### PR TITLE
skip entry and settings from macro choice

### DIFF
--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -141,10 +141,12 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
             await this.runScriptWithSettings(obj, this.userScriptCommand)
 
         try {
-            const keys = Object.keys(obj);
-            const selected: string = await GenericSuggester.Suggest(this.app, keys, keys);
+            const keys = Object.keys(obj).filter(k => k !== 'entry' && k !== 'settings');
+            if (keys.length > 0) {
+                const selected: string = await GenericSuggester.Suggest(this.app, keys, keys);
 
-            await this.userScriptDelegator(obj[selected]);
+                await this.userScriptDelegator(obj[selected]);
+            }
         } catch (e) {
             log.logMessage(e);
         }


### PR DESCRIPTION
Fixes #94

Obviously, you'd want to remove settings from suggester. As for `entry` (default entry point), I'm not sure. Perhaps you might want to keep it; in this case, `if` should be different.