### PR TITLE
Make the text capture element multiline

### DIFF
--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -1,4 +1,4 @@
-import {App, ButtonComponent, Modal, TextComponent} from "obsidian";
+import {App, ButtonComponent, Modal, TextAreaComponent} from "obsidian";
 import {SilentFileAndTagSuggester} from "../silentFileAndTagSuggester";
 
 export default class GenericInputPrompt extends Modal {
@@ -7,7 +7,7 @@ export default class GenericInputPrompt extends Modal {
     private resolvePromise: (input: string) => void;
     private rejectPromise: (reason?: any) => void;
     private didSubmit: boolean = false;
-    private inputComponent: TextComponent;
+    private inputComponent: TextAreaComponent;
     private input: string;
     private readonly placeholder: string;
     private suggester: SilentFileAndTagSuggester;
@@ -46,15 +46,16 @@ export default class GenericInputPrompt extends Modal {
     }
 
     protected createInputField(container: HTMLElement, placeholder?: string, value?: string) {
-        const textComponent = new TextComponent(container);
+        const textAreaComponent = new TextAreaComponent(container);
 
-        textComponent.inputEl.style.width = "100%";
-        textComponent.setPlaceholder(placeholder ?? "")
+        textAreaComponent.inputEl.style.width = "100%";
+        textAreaComponent.inputEl.rows = 6;
+        textAreaComponent.setPlaceholder(placeholder ?? "")
             .setValue(value ?? "")
             .onChange(value => this.input = value)
             .inputEl.addEventListener('keydown', this.submitEnterCallback);
 
-        return textComponent;
+        return textAreaComponent;
     }
 
     private createButton(container: HTMLElement, text: string, callback: (evt: MouseEvent) => any) {
@@ -81,7 +82,7 @@ export default class GenericInputPrompt extends Modal {
     private cancelClickCallback = (evt: MouseEvent) => this.cancel();
 
     private submitEnterCallback = (evt: KeyboardEvent) => {
-        if (evt.key === "Enter") {
+        if ((evt.ctrlKey || evt.metaKey) && evt.key === "Enter") {
             evt.preventDefault();
             this.submit();
         }

--- a/src/gui/silentFileAndTagSuggester.ts
+++ b/src/gui/silentFileAndTagSuggester.ts
@@ -15,7 +15,7 @@ export class SilentFileAndTagSuggester extends TextInputSuggest<string> {
     private unresolvedLinkNames: string[];
     private tags: string[];
 
-    constructor(public app: App, public inputEl: HTMLInputElement) {
+    constructor(public app: App, public inputEl: HTMLTextAreaElement) {
         super(app, inputEl);
         this.files = app.vault.getMarkdownFiles();
         this.unresolvedLinkNames = this.getUnresolvedLinkNames(app);


### PR DESCRIPTION
This is a suggestion of a change to resolve #114. Seems to work for me but:

- IDK if sometimes single-line input may be preferable?
- This is the first time I interact with TypeScript and this repo so I may have missed something, please check.
- I didn't test it on mobile.
- The text area element should probably be wider, but in order to achieve this, ideally, the window itself needs to be wider. I could do smth like `textAreaComponent.inputEl.cols = 60;` but not sure if this is a one-size-fits-all solution.