### PR TITLE
citationsManager imports keywords as tags

### DIFF
--- a/docs/Examples/Attachments/citationsManager.js
+++ b/docs/Examples/Attachments/citationsManager.js
@@ -69,6 +69,7 @@ async function handleCitationsPlugin(params, citationsPlugin, settings) {
         zoteroSelectURI: entry.zoteroSelectURI,
         type: entry.type,
         issuedDate: entry.issuedDate,
+        keywords:  importAllKeywordsAsTags(entry.data.fields.keywords),
     };
 
     if (settings[ignoreEmpty]) {
@@ -81,5 +82,10 @@ async function handleCitationsPlugin(params, citationsPlugin, settings) {
 }
 
 function replaceIllegalFileNameCharactersInString(string) {
-    return string.replace(/[\\,#%&\{\}\/*<>$\'\":@]*/g, '');
+    return string.replace(/[\\,#%&\{\}\/*<>$\'\":@]/g, '');
+}
+
+function importAllKeywordsAsTags(keywords) {
+    keywords.forEach((element , index) => keywords[index] = (" #" + element.replace(" ","_")))
+    return(keywords)
 }

--- a/docs/Examples/Attachments/citationsManager.js
+++ b/docs/Examples/Attachments/citationsManager.js
@@ -82,7 +82,7 @@ async function handleCitationsPlugin(params, citationsPlugin, settings) {
 }
 
 function replaceIllegalFileNameCharactersInString(string) {
-    return string.replace(/[\\,#%&\{\}\/*<>$\'\":@]/g, '');
+    return string.replace(/[\\,#%&\{\}\/*<>$\'\":@]*/g, '');
 }
 
 function importAllKeywordsAsTags(keywords) {


### PR DESCRIPTION
I am not a JS or TS developer, But I managed to add a few lines so the keywords of a citation can be imported as tags.
This might require an option to disable this feature if one does not need it.

Also in your guide in [here](https://bagerbach.com/blog/how-i-read-research-papers-with-obsidian-and-zotero#creating-notes-in-obsidian-from-papers-in-zotero) need to add the keywords to the template.

p.s. in the guide the tag for naming the new note should be {{VALUE:fileName}} while it is {{VALUE:title}} as causes issue with invalid characters.