### PR TITLE
Linkify director list in movies.js

### DIFF
--- a/docs/Examples/Attachments/movies.js
+++ b/docs/Examples/Attachments/movies.js
@@ -58,7 +58,7 @@ async function start(params, settings) {
     actorLinks: linkifyList(selectedShow.Actors.split(",")),
     genreLinks: linkifyList(selectedShow.Genre.split(",")),
     directorLink:
-      selectedShow.Director === "N/A" ? " " : `[[${selectedShow.Director}]]`,
+      selectedShow.Director === "N/A" ? " " : linkifyList(selectedShow.Director.split(",")),
     fileName: replaceIllegalFileNameCharactersInString(selectedShow.Title),
     typeLink: `[[${selectedShow.Type === "movie" ? "Movies" : "Series"}]]`,
   };


### PR DESCRIPTION
## Summary

This PR resolves a bug in `movies.js` where the `directorLink` is not properly linkified when a movie is directed by multiple people. 

## Example
Query: `The Matrix`

OMDb Response:
```
{
    ...
    "Director": "Lana Wachowski, Lilly Wachowski",
    ...
}
```

Output: 
`{{VALUE.directorLink}}` renders `[[Lana Wachowski, Lilly Wachowski]]`

### Screenshot:

**Current Version Output**
<img width="413" alt="Screen Shot 2022-09-01 at 13 38 49" src="https://user-images.githubusercontent.com/3716415/187978494-1e83d5f3-c1ff-48ab-a597-8bf56a755c82.png">

**Output After PR**
<img width="409" alt="Screen Shot 2022-09-01 at 13 47 43" src="https://user-images.githubusercontent.com/3716415/187979497-a3e98545-6ddf-469e-9db2-8ccfa205482c.png">



