### PR TITLE
Add 'insert after' support for active file captures

### DIFF
--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -145,20 +145,17 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
         }
 
         let content: string = await this.getCaptureContent();
-        content = await this.formatter.formatContent(content, this.choice);
-
-        if (this.choice.format.enabled) {
-            content = await templaterParseTemplate(this.app, content, activeFile);
-        }
-
         if (!content) return;
 
-        if (this.choice.prepend) {
+        if (this.choice.prepend || this.choice?.insertAfter?.enabled) {
             const fileContent: string = await this.app.vault.cachedRead(activeFile);
-            const newFileContent: string = `${fileContent}${content}`
-
+            const newFileContent = await this.formatter.formatContentWithFile(content, this.choice, fileContent, activeFile);
             await this.app.vault.modify(activeFile, newFileContent);
         } else {
+            content = await this.formatter.formatContent(content, this.choice);
+            if (this.choice.format.enabled) {
+                content = await templaterParseTemplate(this.app, content, activeFile);
+            }
             appendToCurrentLine(content, this.app);
         }
     }

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -41,10 +41,10 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 
         this.addTaskSetting();
         this.addPrependSetting();
+        this.addInsertAfterSetting();
 
         if (!this.choice.captureToActiveFile) {
             this.addAppendLinkSetting();
-            this.addInsertAfterSetting();
             this.addOpenFileSetting();
             if (this.choice.openFile)
                 this.addOpenFileInNewTabSetting();


### PR DESCRIPTION
Adds "insert after line" functionality when capturing to the active file (fix/implementation of #73)