### PR TITLE
Include windows illegal file name character '?'

### DIFF
--- a/docs/Examples/Attachments/citationsManager.js
+++ b/docs/Examples/Attachments/citationsManager.js
@@ -81,5 +81,5 @@ async function handleCitationsPlugin(params, citationsPlugin, settings) {
 }
 
 function replaceIllegalFileNameCharactersInString(string) {
-    return string.replace(/[\\,#%&\{\}\/*<>$\'\":@]*/g, '');
+    return string.replace(/[\\,#%&\{\}\/*<>$\'\":@\?]*/g, '');
 }


### PR DESCRIPTION
As mentioned in #286 the small addition of the question mark when replacing file names