### PR TITLE
Adding option to be prompt in which of the subfolders of the folderset we want to create the new note

### DIFF
--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -115,6 +115,13 @@ export class TemplateChoiceEngine extends TemplateEngine {
             return this.getOrCreateFolder([activeFile.parent.path]);
         }
 
+		if (this.choice.folder?.chooseFromSubfolders)
+		{
+            const allSubfolders: string[] = getAllFolderPathsInVault(this.app).filter(folder => {
+				return folders.some(choiceFolder => folder.startsWith(choiceFolder));
+			});
+			return await this.getOrCreateFolder(allSubfolders);
+		}
         return await this.getOrCreateFolder(folders);
     }
 }

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -108,6 +108,14 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
                     });
 
                 if (!this.choice.folder?.chooseWhenCreatingNote) {
+					const chooseFolderFromSubfolderContainer: HTMLDivElement = this.contentEl.createDiv('chooseFolderFromSubfolderContainer');
+					chooseFolderFromSubfolderContainer.createEl('span', {text: "Be prompt in which subfolder you want the new note to be create"});
+					const chooseFolderFromSubfolder: ToggleComponent = new ToggleComponent(chooseFolderFromSubfolderContainer);
+					chooseFolderFromSubfolder.setValue(this.choice.folder?.chooseFromSubfolders)
+						.onChange(value => {
+							this.choice.folder.chooseFromSubfolders = value;
+							this.reload();
+						});
                     this.addFolderSelector();
                 }
             }

--- a/src/types/choices/ITemplateChoice.ts
+++ b/src/types/choices/ITemplateChoice.ts
@@ -4,7 +4,7 @@ import type {FileViewMode} from "../fileViewMode";
 
 export default interface ITemplateChoice extends IChoice {
     templatePath: string;
-    folder: { enabled: boolean, folders: string[], chooseWhenCreatingNote: boolean, createInSameFolderAsActiveFile: boolean }
+    folder: { enabled: boolean, folders: string[], chooseWhenCreatingNote: boolean, createInSameFolderAsActiveFile: boolean, chooseFromSubfolders: boolean}
     fileNameFormat: { enabled: boolean, format: string };
     appendLink: boolean;
     incrementFileName: boolean;

--- a/styles.css
+++ b/styles.css
@@ -167,6 +167,13 @@
     margin-bottom: 10px;
 }
 
+.chooseFolderFromSubfolderContainer {
+    display: flex;
+    align-content: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
 .clickable:hover {
     cursor: pointer;
 }


### PR DESCRIPTION
Hi chhoumann :)
I really like your plugins but it felt like it was missing one little feature to really match what I needed:
I'm storing all my references (films, radio podcast, books, ...) in a folder called "ref" using subfolders.
e.g. : folders like "ref/film/documentary/foo.md", "ref/film/videoclip/foo.md" or "ref/book/essai/bar.md".
I wanted to be prompt in which of the subfolders of "ref" I want to create my new note when setting only "ref" as the folder path.
e.g. : 
- ref/
- ref/film/
- ref/film/documentary/
- ref/film/videoclip/
- ref/
- ref/book/
- ref/book/essai
