### PR TITLE
Make Api public

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,14 +14,18 @@ import type IMacroChoice from "./types/choices/IMacroChoice";
 import {MathModal} from "./gui/MathModal";
 import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
 import ReactExampleView from './gui/ReactExampleView';
+import { QuickAddApi } from './quickAddApi';
 
 export default class QuickAdd extends Plugin {
 	static instance: QuickAdd;
 	settings: QuickAddSettings;
+	api: ReturnType<typeof QuickAddApi.GetApi>;
 
 	async onload() {
 		console.log('Loading QuickAdd');
 		QuickAdd.instance = this;
+
+		this.api = QuickAddApi.GetApi(this.app, this, new ChoiceExecutor(this.app, this));
 
 		await this.loadSettings();
 


### PR DESCRIPTION
close #138

I made Api public so that it can be used from dataviewjs etc.

### Example
```js
const quickAddApi = this.app.plugins.plugins['quickadd'].api;
const btn = this.container.createEl('button', {text: 'Execute Capture Choice'});
const data = {/* ... */};

btn.addEventListener('click', () => {
  quickAddApi.executeChoice('Capture Choice', {
    X: data.x,
    Y: data.y,
    Z: data.z,
    // ...
  });
});

dv.paragraph(btn);
```