### PR TITLE
Prevent submit if press enter in composition session

### DIFF
--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -123,7 +123,7 @@ export default class GenericInputPrompt extends Modal {
 	private cancelClickCallback = (evt: MouseEvent) => this.cancel();
 
 	private submitEnterCallback = (evt: KeyboardEvent) => {
-		if (evt.key === "Enter") {
+		if (!evt.isComposing && evt.key === "Enter") {
 			evt.preventDefault();
 			this.submit();
 		}


### PR DESCRIPTION
Thanks for a very nice plugin!

I'm a Japanese user.
This plugin had a problem in the Capture input modal where the value being typed was being sent when a Japanese Kanji conversion was confirmed with the enter key. 
So I have fixed it.

![CleanShot 2022-12-31 at 11 04 58](https://user-images.githubusercontent.com/11070996/210121888-fd17cd4c-fc65-436f-ad55-59b31c6f0c7d.png)

reference: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing

