### PR TITLE
doc: inlinescript: Add sentence about parsing

### DIFF
--- a/docs/docs/InlineScripts.md
+++ b/docs/docs/InlineScripts.md
@@ -2,6 +2,7 @@
 QuickAdd supports the usage of inline scripts in [Template choices](./Choices/TemplateChoice.md) and [Capture choices](./Choices/CaptureChoice.md).
 
 Inline scripts allow you to execute any JavaScript code you want.
+They are parsed and executed before anything else. Accessing of `{{VALUE}}`-Template isn't possible. But you can askk for a Userinput via `this.quickAddApi.inputPrompt`. See [QuickAdd API](./QuickAddAPI.md).
 
 You are given the [QuickAdd API](./QuickAddAPI.md), just as with user scripts. In inline scripts, it is passed in as ``this``, as can be seen in the example below.
 


### PR DESCRIPTION
A bit more explanation why access to `{{VALUE}}` is not possible.

See #377.