### PR TITLE
Add option to set default behavior if file already exists for template

### DIFF
--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -74,7 +74,6 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			let userChoice = this.choice.fileExistsMode;
 
 			if(!this.choice.setFileExistsBehavior) {
-
 				userChoice = await GenericSuggester.Suggest(
 					this.app,
 					fileExistsChoices,

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -70,11 +70,17 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			}
 
 			await this.app.workspace.getLeaf("tab").openFile(file);
-			const userChoice: string = await GenericSuggester.Suggest(
-				this.app,
-				fileExistsChoices,
-				fileExistsChoices
-			);
+
+			let userChoice = this.choice.fileExistsMode;
+
+			if(!this.choice.setFileExistsBehavior) {
+
+				userChoice = await GenericSuggester.Suggest(
+					this.app,
+					fileExistsChoices,
+					fileExistsChoices
+				);
+			}
 
 			switch (userChoice) {
 				case fileExistsAppendToTop:

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -17,6 +17,7 @@ import type { FileViewMode } from "../../types/fileViewMode";
 import { GenericTextSuggester } from "../suggesters/genericTextSuggester";
 import { FormatSyntaxSuggester } from "../suggesters/formatSyntaxSuggester";
 import { ExclusiveSuggester } from "../suggesters/exclusiveSuggester";
+import { fileExistsAppendToBottom, fileExistsAppendToTop, fileExistsDoNothing, fileExistsOverwriteFile } from "src/constants";
 
 export class TemplateChoiceBuilder extends ChoiceBuilder {
 	choice: ITemplateChoice;
@@ -36,6 +37,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 		this.addFolderSetting();
 		this.addAppendLinkSetting();
 		this.addIncrementFileNameSetting();
+		this.addFileAlreadyExistsSetting();
 		this.addOpenFileSetting();
 		if (this.choice.openFile) this.addOpenFileInNewTabSetting();
 	}
@@ -268,6 +270,36 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 				toggle.onChange(
 					(value) => (this.choice.incrementFileName = value)
 				);
+			});
+	}
+
+	private addFileAlreadyExistsSetting(): void {
+		const fileAlreadyExistsSetting: Setting = new Setting(this.contentEl);
+		fileAlreadyExistsSetting
+			.setName("Set default behavior if file already exists")
+			.setDesc("Set default behavior rather then prompting what to do if a file already exists set the default behavior.")
+			.addToggle((toggle) => {
+				toggle.setValue(this.choice.setFileExistsBehavior);
+				toggle.onChange((value) => {
+					this.choice.setFileExistsBehavior = value;
+				});
+			})
+			.addDropdown((dropdown) => {
+				dropdown.selectEl.style.marginLeft = "10px";
+
+				if (!this.choice.fileExistsMode)
+					this.choice.fileExistsMode = fileExistsDoNothing;
+
+				dropdown
+					.addOption(fileExistsAppendToBottom, fileExistsAppendToBottom)
+					.addOption(fileExistsAppendToTop, fileExistsAppendToTop)
+					.addOption(fileExistsOverwriteFile, fileExistsOverwriteFile)
+					.addOption(fileExistsDoNothing, fileExistsDoNothing)
+					.setValue(this.choice.fileExistsMode)
+					.onChange(
+						(value) =>
+							(this.choice.fileExistsMode = value as string)
+					);
 			});
 	}
 

--- a/src/types/choices/ITemplateChoice.ts
+++ b/src/types/choices/ITemplateChoice.ts
@@ -1,6 +1,7 @@
 import type IChoice from "./IChoice";
 import type { NewTabDirection } from "../newTabDirection";
 import type { FileViewMode } from "../fileViewMode";
+import {fileExistsAppendToBottom} from "../../constants";
 
 export default interface ITemplateChoice extends IChoice {
 	templatePath: string;
@@ -21,4 +22,6 @@ export default interface ITemplateChoice extends IChoice {
 		focus: boolean;
 	};
 	openFileInMode: FileViewMode;
+	fileExistsMode: string;
+	setFileExistsBehavior: boolean;
 }

--- a/src/types/choices/TemplateChoice.ts
+++ b/src/types/choices/TemplateChoice.ts
@@ -23,6 +23,9 @@ export class TemplateChoice extends Choice implements ITemplateChoice {
 	openFile: boolean;
 	openFileInMode: FileViewMode;
 	templatePath: string;
+	fileExistsMode: string;
+	setFileExistsBehavior: boolean;
+
 
 	constructor(name: string) {
 		super(name, ChoiceType.Template);


### PR DESCRIPTION
Added an option to define the default behaviour if a file already exists at the creation path for a template.

If the behaviour is set then the user won't be prompted when the macro etc runs.

It's highly likely that the increment setting should be rolled into this but I wasn't entirely sure how to go about migrating settings etc 