### PR TITLE
fix: Fix description for file already exisiting setting

### DIFF
--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -277,7 +277,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 		const fileAlreadyExistsSetting: Setting = new Setting(this.contentEl);
 		fileAlreadyExistsSetting
 			.setName("Set default behavior if file already exists")
-			.setDesc("Set default behavior rather then prompting what to do if a file already exists set the default behavior.")
+			.setDesc("Set default behavior rather then prompting user on what to do if a file already exists.")
 			.addToggle((toggle) => {
 				toggle.setValue(this.choice.setFileExistsBehavior);
 				toggle.onChange((value) => {


### PR DESCRIPTION
Followup from #391 I noted that my description field was poorly worded.