### PR TITLE
Macros QoL upgrade 18/03/23 - easier configure & adding macros from choices

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -72,7 +72,7 @@ esbuild
 		],
 		format: "cjs",
 		watch: !prod,
-		target: "es2018",
+		target: "ES2020",
 		logLevel: "info",
 		sourcemap: prod ? false : "inline",
 		treeShaking: true,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "builtin-modules": "^3.3.0",
-    "fuse.js": "6.6.2"
+    "fuse.js": "6.6.2",
+    "zustand": "^4.3.6"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,10 +33,12 @@ specifiers:
   uuid: 9.0.0
   vite: ^4.1.4
   vitest: ^0.28.5
+  zustand: ^4.3.6
 
 dependencies:
   builtin-modules: 3.3.0
   fuse.js: 6.6.2
+  zustand: 4.3.6
 
 devDependencies:
   '@fortawesome/free-regular-svg-icons': 6.2.1
@@ -5210,6 +5212,12 @@ packages:
       requires-port: 1.0.0
     dev: true
 
+  /use-sync-external-store/1.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dev: false
+
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -5555,3 +5563,18 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zustand/4.3.6:
+    resolution: {integrity: sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      immer: '>=9.0'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      immer:
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      use-sync-external-store: 1.2.0
+    dev: false

--- a/src/MacrosManager.ts
+++ b/src/MacrosManager.ts
@@ -8,12 +8,12 @@ import {
 	ToggleComponent,
 } from "obsidian";
 import { MacroBuilder } from "./gui/MacroGUIs/MacroBuilder";
-import { QuickAddMacro } from "./types/macros/QuickAddMacro";
 import { log } from "./logger/logManager";
 import type IChoice from "./types/choices/IChoice";
 import { ChoiceType } from "./types/choices/choiceType";
 import type IMultiChoice from "./types/choices/IMultiChoice";
 import type QuickAdd from "./main";
+import { settingsStore } from "./settingsStore";
 
 export class MacrosManager extends Modal {
 	public waitForClose: Promise<IMacro[]>;
@@ -207,22 +207,15 @@ export class MacrosManager extends Modal {
 			.onClick(() => {
 				const inputValue = nameInput.getValue();
 
-				if (
-					inputValue !== "" &&
-					!this.macros.find((m) => m.name === inputValue)
-				) {
-					const macro = new QuickAddMacro(inputValue);
-					if (!macro) {
-						log.logError("macro invalid - will not be added");
-						return;
-					}
-
-					this.macros.push(macro);
+				try {
+					settingsStore.createMacro(inputValue);
 					this.reload();
 					this.macroContainer.scrollTo(
 						0,
 						this.macroContainer.scrollHeight
 					);
+				} catch (error) {
+					log.logError(error);
 				}
 			});
 	}

--- a/src/MacrosManager.ts
+++ b/src/MacrosManager.ts
@@ -20,6 +20,7 @@ export class MacrosManager extends Modal {
 	private resolvePromise: (macros: IMacro[]) => void;
 	private rejectPromise: (reason?: unknown) => void;
 	private updateMacroContainer: () => void;
+	private unsubscribe: () => void;
 
 	private macroContainer: HTMLDivElement;
 	private plugin: QuickAdd;
@@ -36,6 +37,13 @@ export class MacrosManager extends Modal {
 		this.waitForClose = new Promise<IMacro[]>((resolve, reject) => {
 			this.rejectPromise = reject;
 			this.resolvePromise = resolve;
+		});
+
+		this.unsubscribe = settingsStore.subscribe((newSettings) => {
+			this.macros = newSettings.macros;
+			this.choices = newSettings.choices;
+
+			this.reload();
 		});
 
 		this.open();
@@ -222,6 +230,7 @@ export class MacrosManager extends Modal {
 
 	onClose() {
 		super.onClose();
+		this.unsubscribe();
 		this.resolvePromise(this.macros);
 	}
 }

--- a/src/gui/ChoiceBuilder/macroChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/macroChoiceBuilder.ts
@@ -1,15 +1,24 @@
 import { ChoiceBuilder } from "./choiceBuilder";
 import type IMacroChoice from "../../types/choices/IMacroChoice";
-import type { App } from "obsidian";
+import { App, ButtonComponent } from "obsidian";
 import { DropdownComponent } from "obsidian";
 import type { IMacro } from "../../types/macros/IMacro";
+import { MacroBuilder } from "../MacroGUIs/MacroBuilder";
+import QuickAdd from "src/main";
+import { settingsStore } from "src/settingsStore";
+import IChoice from "src/types/choices/IChoice";
+import { log } from "src/logger/logManager";
 
 export class MacroChoiceBuilder extends ChoiceBuilder {
 	choice: IMacroChoice;
+	private macros: IMacro[];
+	private choices: IChoice[];
 
-	constructor(app: App, choice: IMacroChoice, private macros: IMacro[]) {
+	constructor(app: App, choice: IMacroChoice, macros: IMacro[], choices: IChoice[]) {
 		super(app);
 		this.choice = choice;
+		this.macros = macros;
+		this.choices = choices;
 
 		this.display();
 	}
@@ -17,12 +26,32 @@ export class MacroChoiceBuilder extends ChoiceBuilder {
 	protected display() {
 		this.containerEl.addClass("macroChoiceBuilder");
 		this.addCenteredChoiceNameHeader(this.choice);
-		this.addSelectMacroSearch();
+		const macroDropdownContainer = this.contentEl.createDiv();
+		macroDropdownContainer.addClass("macroDropdownContainer");
+		this.addSelectMacroSearch(macroDropdownContainer);
+		this.addConfigureMacroButton(macroDropdownContainer);
 	}
 
-	private addSelectMacroSearch() {
+	private addConfigureMacroButton(container: HTMLElement) {
+		const configureMacroButtonContainer = container.createDiv();
+		const configureMacroButton = new ButtonComponent(
+			configureMacroButtonContainer
+		);
+		configureMacroButton.setIcon("cog")
+			.onClick(async () => { 
+				const macro = this.macros.find((m) => m.id === this.choice.macroId);
+				if (!macro) return log.logError("Could not find macro to configure");
+
+				const builder = new MacroBuilder(app, QuickAdd.instance, macro, this.choices);
+				const newMacro = await builder.waitForClose;
+
+				settingsStore.setMacro(this.choice.macroId, newMacro);
+			});
+	}
+
+	private addSelectMacroSearch(container: HTMLElement) {
 		const selectMacroDropdownContainer: HTMLDivElement =
-			this.contentEl.createDiv("selectMacroDropdownContainer");
+			container.createDiv("selectMacroDropdownContainer");
 		const dropdown: DropdownComponent = new DropdownComponent(
 			selectMacroDropdownContainer
 		);

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -22,6 +22,7 @@
     import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
 	import { excludeKeys, getChoiceType } from "src/utility";
 	import { settingsStore } from "src/settingsStore";
+	import { onMount } from "svelte";
 
     export let choices: IChoice[] = [];
     export let macros: IMacro[] = [];
@@ -30,6 +31,17 @@
     export let saveMacros: (macros: IMacro[]) => void;
     export let app: App;
     export let plugin: QuickAdd;
+
+    onMount(() => {
+        const unsubSettingsStore = settingsStore.subscribe(settings => {
+            choices = settings.choices;
+            macros = settings.macros;
+        });
+
+        return () => {
+            unsubSettingsStore();
+        }
+    });
 
     function addChoiceToList(event: any): void {
         const {name, type} = event.detail;

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -21,6 +21,7 @@
     import QuickAdd from "../../main";
     import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
 	import { excludeKeys, getChoiceType } from "src/utility";
+	import { settingsStore } from "src/settingsStore";
 
     export let choices: IChoice[] = [];
     export let macros: IMacro[] = [];
@@ -176,7 +177,7 @@
             case ChoiceType.Capture:
                 return new CaptureChoiceBuilder(app, choice as ICaptureChoice, plugin);
             case ChoiceType.Macro:
-                return new MacroChoiceBuilder(app, choice as IMacroChoice, macros);
+                return new MacroChoiceBuilder(app, choice as IMacroChoice, macros, settingsStore.getState().choices);
             case ChoiceType.Multi:
             default:
                 break;

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -97,7 +97,7 @@
     async function configureChoice(e: any) {
         const {choice: oldChoice} = e.detail;
 
-        let updatedChoice;
+        let updatedChoice: MultiChoice | TemplateChoice | CaptureChoice | MacroChoice;
         if (oldChoice.type === ChoiceType.Multi) {
             updatedChoice = oldChoice;
 
@@ -106,7 +106,12 @@
 
             updatedChoice.name = name;
         } else {
-            updatedChoice = await getChoiceBuilder(oldChoice).waitForClose;
+            const builder = getChoiceBuilder(oldChoice);
+            if (!builder) {
+                throw new Error('Invalid choice type');
+            }
+            
+            updatedChoice = await builder.waitForClose as typeof updatedChoice;
         }
 
         if (!updatedChoice) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,8 @@ export default class QuickAdd extends Plugin {
 	static instance: QuickAdd;
 	settings: QuickAddSettings;
 
+	private unsubscribeSettingsStore: () => void;
+
 	get api(): ReturnType<typeof QuickAddApi.GetApi> {
 		return QuickAddApi.GetApi(app, this, new ChoiceExecutor(app, this));
 	}
@@ -29,7 +31,7 @@ export default class QuickAdd extends Plugin {
 
 		await this.loadSettings();
 		settingsStore.setState(this.settings);
-		settingsStore.subscribe((settings) => {	
+		this.unsubscribeSettingsStore = settingsStore.subscribe((settings) => {	
 			this.settings = settings;
 			this.saveSettings();
 		});
@@ -100,6 +102,7 @@ export default class QuickAdd extends Plugin {
 
 	onunload() {
 		console.log("Unloading QuickAdd");
+		this.unsubscribeSettingsStore?.call(this);
 	}
 
 	async loadSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { deleteObsidianCommand } from "./utility";
 import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
 import { QuickAddApi } from "./quickAddApi";
 import migrate from "./migrations/migrate";
+import { settingsStore } from "./settingsStore";
 
 export default class QuickAdd extends Plugin {
 	static instance: QuickAdd;
@@ -27,6 +28,11 @@ export default class QuickAdd extends Plugin {
 		QuickAdd.instance = this;
 
 		await this.loadSettings();
+		settingsStore.setState(this.settings);
+		settingsStore.subscribe((settings) => {	
+			this.settings = settings;
+			this.saveSettings();
+		});
 
 		this.addCommand({
 			id: "runQuickAdd",

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -1,14 +1,10 @@
-import {
-	App,
-	PluginSettingTab,
-	Setting,
-	TFolder,
-} from "obsidian";
+import { App, PluginSettingTab, Setting, TFolder } from "obsidian";
 import type QuickAdd from "./main";
 import type IChoice from "./types/choices/IChoice";
 import ChoiceView from "./gui/choiceList/ChoiceView.svelte";
 import type { IMacro } from "./types/macros/IMacro";
 import { GenericTextSuggester } from "./gui/suggesters/genericTextSuggester";
+import { settingsStore } from "./settingsStore";
 
 export interface QuickAddSettings {
 	choices: IChoice[];
@@ -17,11 +13,11 @@ export interface QuickAddSettings {
 	devMode: boolean;
 	templateFolderPath: string;
 	migrations: {
-		migrateToMacroIDFromEmbeddedMacro: boolean,
-		useQuickAddTemplateFolder: boolean,
+		migrateToMacroIDFromEmbeddedMacro: boolean;
+		useQuickAddTemplateFolder: boolean;
 		incrementFileNameSettingMoveToDefaultBehavior: boolean;
 		mutualExclusionInsertAfterAndWriteToBottomOfFile: boolean;
-	}
+	};
 }
 
 export const DEFAULT_SETTINGS: QuickAddSettings = {
@@ -34,8 +30,8 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 		migrateToMacroIDFromEmbeddedMacro: false,
 		useQuickAddTemplateFolder: false,
 		incrementFileNameSettingMoveToDefaultBehavior: false,
-		mutualExclusionInsertAfterAndWriteToBottomOfFile: false
-	}
+		mutualExclusionInsertAfterAndWriteToBottomOfFile: false,
+	},
 };
 
 export class QuickAddSettingsTab extends PluginSettingTab {
@@ -71,15 +67,13 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			props: {
 				app: this.app,
 				plugin: this.plugin,
-				choices: this.plugin.settings.choices,
+				choices: settingsStore.getState().choices,
 				saveChoices: async (choices: IChoice[]) => {
-					this.plugin.settings.choices = choices;
-					await this.plugin.saveSettings();
+					settingsStore.setState({ choices });
 				},
-				macros: this.plugin.settings.macros,
+				macros: settingsStore.getState().macros,
 				saveMacros: async (macros: IMacro[]) => {
-					this.plugin.settings.macros = macros;
-					await this.plugin.saveSettings();
+					settingsStore.setState({ macros });
 				},
 			},
 		});
@@ -97,12 +91,14 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					.setTooltip("Use multi-line input prompt")
 					.onChange((value) => {
 						if (value) {
-							this.plugin.settings.inputPrompt = "multi-line";
+							settingsStore.setState({
+								inputPrompt: "multi-line",
+							});
 						} else {
-							this.plugin.settings.inputPrompt = "single-line";
+							settingsStore.setState({
+								inputPrompt: "single-line",
+							});
 						}
-
-						this.plugin.saveSettings();
 					})
 			);
 	}
@@ -116,13 +112,10 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		);
 
 		setting.addText((text) => {
-			text.setPlaceholder(
-				"templates/"
-			)
-				.setValue(this.plugin.settings.templateFolderPath)
+			text.setPlaceholder("templates/")
+				.setValue(settingsStore.getState().templateFolderPath)
 				.onChange(async (value) => {
-					this.plugin.settings.templateFolderPath = value;
-					await this.plugin.saveSettings();
+					settingsStore.setState({ templateFolderPath: value });
 				});
 
 			new GenericTextSuggester(
@@ -130,7 +123,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 				text.inputEl,
 				app.vault
 					.getAllLoadedFiles()
-					.filter((f) => f instanceof TFolder && f.path !== '/')
+					.filter((f) => f instanceof TFolder && f.path !== "/")
 					.map((f) => f.path)
 			);
 		});

--- a/src/settingsStore.ts
+++ b/src/settingsStore.ts
@@ -1,6 +1,7 @@
 import { createStore } from "zustand/vanilla";
 import { DEFAULT_SETTINGS, QuickAddSettings } from "./quickAddSettingsTab";
 import { IMacro } from "./types/macros/IMacro";
+import { QuickAddMacro } from "./types/macros/QuickAddMacro";
 
 // Define the state shape and actions for your store.
 type SettingsState = QuickAddSettings & {
@@ -25,15 +26,26 @@ export const settingsStore = (function () {
 		},
 		setMacro: (macroId: IMacro["id"], macro: IMacro) => {
 			setState((state) => {
-				const macros = state.macros.map((m) => {
-					if (m.id === macroId) {
-						return macro;
-					}
-					
-					return m;
-				});
+				const macroIdx = state.macros.findIndex((m) => m.id === macroId);
+				if (macroIdx === -1) {
+					throw new Error("Macro not found");
+				}
 
-				return { ...state, macros };
+				state.macros[macroIdx] = macro;
+
+				return state;
+			});
+		},
+		createMacro: (name: string) => {
+			if (name === "" || getState().macros.some((m) => m.name === name)) {
+				throw new Error("Invalid macro name");
+			}
+
+			setState((state) => {
+				const macro = new QuickAddMacro(name);
+				state.macros.push(macro);
+
+				return state;
 			});
 		},
 	};

--- a/src/settingsStore.ts
+++ b/src/settingsStore.ts
@@ -29,6 +29,7 @@ export const settingsStore = (function () {
 					if (m.id === macroId) {
 						return macro;
 					}
+					
 					return m;
 				});
 

--- a/src/settingsStore.ts
+++ b/src/settingsStore.ts
@@ -21,19 +21,23 @@ export const settingsStore = (function () {
 		getState,
 		setState,
 		subscribe,
-		getChoices: () => {
-			return getState().choices;
-		},
 		setMacro: (macroId: IMacro["id"], macro: IMacro) => {
 			setState((state) => {
-				const macroIdx = state.macros.findIndex((m) => m.id === macroId);
+				const macroIdx = state.macros.findIndex(
+					(m) => m.id === macroId
+				);
 				if (macroIdx === -1) {
 					throw new Error("Macro not found");
 				}
 
-				state.macros[macroIdx] = macro;
+				const newState = {
+					...state,
+					macros: [...state.macros],
+				};
 
-				return state;
+				newState.macros[macroIdx] = macro;
+
+				return newState;
 			});
 		},
 		createMacro: (name: string) => {
@@ -41,12 +45,18 @@ export const settingsStore = (function () {
 				throw new Error("Invalid macro name");
 			}
 
-			setState((state) => {
-				const macro = new QuickAddMacro(name);
-				state.macros.push(macro);
+			const macro = new QuickAddMacro(name);
+			console.log("macros length", getState().macros.length);
+			setState((state) => ({
+				...state,
+				macros: [...state.macros, macro],
+			}));
+			console.log("macros length", getState().macros.length);
 
-				return state;
-			});
+			return macro;
+		},
+		getMacro: (macroId: IMacro["id"]) => {
+			return getState().macros.find((m) => m.id === macroId);
 		},
 	};
 })();

--- a/src/settingsStore.ts
+++ b/src/settingsStore.ts
@@ -1,0 +1,39 @@
+import { createStore } from "zustand/vanilla";
+import { DEFAULT_SETTINGS, QuickAddSettings } from "./quickAddSettingsTab";
+import { IMacro } from "./types/macros/IMacro";
+
+// Define the state shape and actions for your store.
+type SettingsState = QuickAddSettings & {
+	setSettings: (settings: Partial<QuickAddSettings>) => void;
+};
+
+export const settingsStore = (function () {
+	const useSettingsStore = createStore<SettingsState>((set, get) => ({
+		...DEFAULT_SETTINGS,
+		setSettings: (settings: Partial<QuickAddSettings>) =>
+			set((state) => ({ ...state, ...settings })),
+	}));
+
+	const { getState, setState, subscribe } = useSettingsStore;
+
+	return {
+		getState,
+		setState,
+		subscribe,
+		getChoices: () => {
+			return getState().choices;
+		},
+		setMacro: (macroId: IMacro["id"], macro: IMacro) => {
+			setState((state) => {
+				const macros = state.macros.map((m) => {
+					if (m.id === macroId) {
+						return macro;
+					}
+					return m;
+				});
+
+				return { ...state, macros };
+			});
+		},
+	};
+})();

--- a/src/settingsStore.ts
+++ b/src/settingsStore.ts
@@ -46,12 +46,10 @@ export const settingsStore = (function () {
 			}
 
 			const macro = new QuickAddMacro(name);
-			console.log("macros length", getState().macros.length);
 			setState((state) => ({
 				...state,
 				macros: [...state.macros, macro],
 			}));
-			console.log("macros length", getState().macros.length);
 
 			return macro;
 		},

--- a/src/styles.css
+++ b/src/styles.css
@@ -241,9 +241,28 @@
 
 /* macroChoiceBuilder.ts */
 .macroDropdownContainer {
-	display: flex;
-	align-content: center;
-	justify-content: center;
-	margin-bottom: 10px;
-	gap: 10px;
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  margin-bottom: 10px;
+  gap: 10px;
+}
+
+.macro-choice-buttonsContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
+
+@media only screen and (max-width: 600px) {
+  .macroDropdownContainer {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .macroDropdownContainer .macro-choice-buttonsContainer {
+    gap: 20px;
+  }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -238,3 +238,12 @@
 .quickadd-choice-suggestion p {
 	margin: 0;
 }
+
+/* macroChoiceBuilder.ts */
+.macroDropdownContainer {
+	display: flex;
+	align-content: center;
+	justify-content: center;
+	margin-bottom: 10px;
+	gap: 10px;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"inlineSourceMap": true,
 		"inlineSources": true,
 		"module": "ESNext",
-		"target": "ES6",
+		"target": "ES2020",
 		"allowJs": true,
 		"noImplicitAny": true,
 		"moduleResolution": "node",


### PR DESCRIPTION
- refactor: use settingsStore with Zustand
- refactor: use settingsStore in settings
- feat: button to access macro configuration from macro choice settings
- refactor: move macro creation to store
- refactor: unsubscribe from settings store
- fix: update references by explicitly returning new obj to update state
- fix: ensure choiceView has latest choices & macros
- feat: add macro from macro choice - no need to open macros manager
- refactor: fix type issue
- feat: macro choices with an associated macro (same name) will now delete the macro when deleting the choice
- fix: macros manager adding macros

## Demo
![Obsidian_c1w5DpFn8W](https://user-images.githubusercontent.com/29108628/226095091-d3db72cf-f0b5-40b0-94de-c60158e5853d.gif)
