### PR TITLE
UI: Improve clarity of the main Settings window

### DIFF
--- a/src/gui/choiceList/AddChoiceBox.svelte
+++ b/src/gui/choiceList/AddChoiceBox.svelte
@@ -52,5 +52,6 @@
         font-size: 16px;
         padding: 3px;
         border-radius: 3px;
+        appearance: auto;
     }
 </style>

--- a/src/gui/choiceList/ChoiceListItem.svelte
+++ b/src/gui/choiceList/ChoiceListItem.svelte
@@ -30,9 +30,10 @@
 	$: {
 		if (nameElement) {
 			nameElement.innerHTML = "";
-			const nameHTML = htmlToMarkdown(choice.name);
+			const typeHTML = htmlToMarkdown(choice.type);
+			const nameHTMLWithChoiceType = `**${typeHTML}:** ${choice.name}`;
 			MarkdownRenderer.renderMarkdown(
-				nameHTML,
+				nameHTMLWithChoiceType,
 				nameElement,
 				"/",
 				null as unknown as Component

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -55,50 +55,13 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		containerEl.empty();
 		containerEl.createEl("h2", { text: "QuickAdd Settings" });
 
-		this.addChoicesSetting();
+		containerEl.createEl("h3", { text: "General Settings" });
 		this.addUseMultiLineInputPromptSetting();
 		this.addTemplateFolderPathSetting();
 		this.addAnnounceUpdatesSetting();
-	}
 
-	addAnnounceUpdatesSetting() {
-		const setting = new Setting(this.containerEl);
-		setting.setName("Announce Updates");
-		setting.setDesc(
-			"Display release notes when a new version is installed. This includes new features, demo videos, and bug fixes."
-		);
-		setting.addToggle((toggle) => {
-			toggle.setValue(settingsStore.getState().announceUpdates);
-			toggle.onChange((value) => {
-				settingsStore.setState({ announceUpdates: value });
-			});
-		});
-	}
-
-	hide(): void {
-		if (this.choiceView) this.choiceView.$destroy();
-	}
-
-	private addChoicesSetting(): void {
-		const setting = new Setting(this.containerEl);
-		setting.infoEl.remove();
-		setting.settingEl.style.display = "block";
-
-		this.choiceView = new ChoiceView({
-			target: setting.settingEl,
-			props: {
-				app: this.app,
-				plugin: this.plugin,
-				choices: settingsStore.getState().choices,
-				saveChoices: (choices: IChoice[]) => {
-					settingsStore.setState({ choices });
-				},
-				macros: settingsStore.getState().macros,
-				saveMacros: (macros: IMacro[]) => {
-					settingsStore.setState({ macros });
-				},
-			},
-		});
+		containerEl.createEl("h3", { text: "List of individual Choices (Templates, Captures, Macros)" });
+		this.addChoicesSetting();
 	}
 
 	private addUseMultiLineInputPromptSetting() {
@@ -148,6 +111,46 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					.filter((f) => f instanceof TFolder && f.path !== "/")
 					.map((f) => f.path)
 			);
+		});
+	}
+
+	addAnnounceUpdatesSetting() {
+		const setting = new Setting(this.containerEl);
+		setting.setName("Announce Updates");
+		setting.setDesc(
+			"Display release notes when a new version is installed. This includes new features, demo videos, and bug fixes."
+		);
+		setting.addToggle((toggle) => {
+			toggle.setValue(settingsStore.getState().announceUpdates);
+			toggle.onChange((value) => {
+				settingsStore.setState({ announceUpdates: value });
+			});
+		});
+	}
+
+	hide(): void {
+		if (this.choiceView) this.choiceView.$destroy();
+	}
+
+	private addChoicesSetting(): void {
+		const setting = new Setting(this.containerEl);
+		setting.infoEl.remove();
+		setting.settingEl.style.display = "block";
+
+		this.choiceView = new ChoiceView({
+			target: setting.settingEl,
+			props: {
+				app: this.app,
+				plugin: this.plugin,
+				choices: settingsStore.getState().choices,
+				saveChoices: (choices: IChoice[]) => {
+					settingsStore.setState({ choices });
+				},
+				macros: settingsStore.getState().macros,
+				saveMacros: (macros: IMacro[]) => {
+					settingsStore.setState({ macros });
+				},
+			},
 		});
 	}
 }


### PR DESCRIPTION
Before:
![2023-04-15_Main-window_2-Before](https://user-images.githubusercontent.com/2521942/232181000-991a5dc8-a9df-4226-95fe-88c3b678fac3.png)
After:
![2023-04-15_Main-window_2-After](https://user-images.githubusercontent.com/2521942/232181003-e704060e-80b3-449a-b005-4a9ada3f235e.png)

I think that the changes are self-evidently for the better.

There are a lot of UI changes that should imho be implemented to drastically improve the UI/UX aspect, both for the main Settings view as well as in almost every other window. 

But the problem is that:
1. I don't know if these changes are welcome and thus I don't want to work in vain.
2. Especially because these small changes took an enormous amount of effort from me. My JS/TS skills are not good and I hate JS with a passion anyway. :-)

Therefore if these changes are good and you would like me to continue, I could design the changes and explain them in new Issues, but I will leave the implementation to you/other people. How does this sound?