### PR TITLE
Fix typing error in suggester

### DIFF
--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -52,7 +52,7 @@ export class QuickAddApi {
 							value: string,
 							index?: number,
 							arr?: string[]
-					  ) => string[]),
+					  ) => string),
 				actualItems: string[]
 			) => {
 				return this.suggester(app, displayItems, actualItems);

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -339,7 +339,7 @@ export class QuickAddApi {
 		app: App,
 		displayItems:
 			| string[]
-			| ((value: string, index?: number, arr?: string[]) => string[]),
+			| ((value: string, index?: number, arr?: string[]) => string),
 		actualItems: string[]
 	) {
 		try {


### PR DESCRIPTION
It seems like there was an error in the types of the `suggester` function. The functions seems to be used to map the elements to a string array, so the lambda should return a string, as it is called on every element in the array.