### PR TITLE
Fix omdbapi protocol

### DIFF
--- a/docs/docs/Examples/Attachments/movies.js
+++ b/docs/docs/Examples/Attachments/movies.js
@@ -2,7 +2,7 @@ const notice = msg => new Notice(msg, 5000);
 const log = msg => console.log(msg);
 
 const API_KEY_OPTION = "OMDb API Key";
-const API_URL = "https://www.omdbapi.com/";
+const API_URL = "http://www.omdbapi.com/";
 
 module.exports = {
     entry: start,


### PR DESCRIPTION
As per documentation on https://www.omdbapi.com the protocol for the API is HTTP not HTTPS.

Even with a correct API key requests against https://... are returning 401. 

```
curl -s -o /dev/null -w "%{http_code}" "https://www.omdbapi.com/?i=tt3896198&apikey=cafecafe"
401
```

where as 

```
curl -s -o /dev/null -w "%{http_code}" "http://www.omdbapi.com/?i=tt3896198&apikey=cafecafe"
200
```

one could argue that https should work as well, so I emailed the owner of OMDB as well.