### PR TITLE
Add Sidebar Ribbon Icon

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,12 @@ export default class QuickAdd extends Plugin {
 
 		log.register(new ConsoleErrorLogger()).register(new GuiLogger(this));
 
+		if (this.settings.enableRibbonIcon) {
+			this.addRibbonIcon("file-plus", "QuickAdd", () => {
+				ChoiceSuggester.Open(this, this.settings.choices);
+			});
+		}
+		
 		this.addSettingTab(new QuickAddSettingsTab(this.app, this));
 
 		this.app.workspace.onLayoutReady(() =>

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -22,6 +22,7 @@ export interface QuickAddSettings {
 	 * Users _can_ still use User Scripts to do so by executing arbitrary JavaScript, but that is not something the plugin controls.
 	 */
 	disableOnlineFeatures: boolean;
+	enableRibbonIcon: boolean;
 	ai: {
 		defaultModel: Model["name"] | "Ask me";
 		defaultSystemPrompt: string;
@@ -48,6 +49,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	announceUpdates: true,
 	version: "0.0.0",
 	disableOnlineFeatures: true,
+	enableRibbonIcon: false,
 	ai: {
 		defaultModel: "Ask me",
 		defaultSystemPrompt: `As an AI assistant within Obsidian, your primary goal is to help users manage their ideas and knowledge more effectively. Format your responses using Markdown syntax. Please use the [[Obsidian]] link format. You can write aliases for the links by writing [[Obsidian|the alias after the pipe symbol]]. To use mathematical notation, use LaTeX syntax. LaTeX syntax for larger equations should be on separate lines, surrounded with double dollar signs ($$). You can also inline math expressions by wrapping it in $ symbols. For example, use $$w_{ij}^{\text{new}}:=w_{ij}^{\text{current}}+\eta\cdot\delta_j\cdot x_{ij}$$ on a separate line, but you can write "($\eta$ = learning rate, $\delta_j$ = error term, $x_{ij}$ = input)" inline.`,
@@ -84,6 +86,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.addTemplateFolderPathSetting();
 		this.addAnnounceUpdatesSetting();
 		this.addDisableOnlineFeaturesSetting();
+		this.addEnableRibbonIconSetting();
 	}
 
 	addAnnounceUpdatesSetting() {
@@ -193,5 +196,22 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 						this.display();
 					})
 			);
+	}
+	
+	private addEnableRibbonIconSetting() {
+		new Setting(this.containerEl)
+			.setName("Show icon in sidebar")
+			.setDesc("Add QuickAdd icon to the sidebar ribbon. Requires a reload.")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(settingsStore.getState().enableRibbonIcon)
+					.onChange((value:boolean) => {
+						settingsStore.setState({
+							enableRibbonIcon: value,
+						});
+
+						this.display();
+					})
+			});
 	}
 }


### PR DESCRIPTION
Related to #575

### Description
This PR introduces a new quick add icon in the sidebar ribbon. The option can be configured in the settings page and defaults to hidden.

I wanted this feature for easier access to quick add on mobile.

### Screenshots
<img width="586" alt="image" src="https://github.com/chhoumann/quickadd/assets/561902/d79a25df-6cc2-4936-9350-62cde1594bbe">

![IMG_5035](https://github.com/chhoumann/quickadd/assets/561902/c584498e-47f1-4120-afd6-6414b985a1aa)

