### PR TITLE
fix: prevent creating new tab when openInNewTab is not set

### DIFF
--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -139,8 +139,10 @@ export async function openFile(
 
 	if (optional.openInNewTab && optional.direction) {
 		leaf = app.workspace.getLeaf("split", optional.direction);
-	} else {
+	} else if (optional.openInNewTab) {
 		leaf = app.workspace.getLeaf("tab");
+	} else {
+		leaf = app.workspace.getLeaf(false);
 	}
 
 	await leaf.openFile(file);


### PR DESCRIPTION
Fixes #634, #583, #530, #401, #338.

As per API docs:

> If newLeaf is false (or not set) then an existing leaf which can be navigated
> is returned, or a new leaf will be created if there was no leaf available.

Note that settings must be enhanced to support an additional state (option 3):

1. Current tab (when open in new tab is unchecked) - fixed in this PR
2. New tab with split (vertical/horizontal) - exists
3. New tab without split - handled if `direction` is not set. Current settings do not support this.

I guess most people would like 1 and 3. 2 is a bit niche, as splits are annoying.