### PR TITLE
fix: templater commands not executing correctly with QuickAdd

### DIFF
--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -284,7 +284,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		}
 
 		const file: TFile = await this.createFileWithInput(filePath, fileContent);
-		await replaceTemplaterTemplatesInCreatedFile(this.app, file);
+		await replaceTemplaterTemplatesInCreatedFile(this.app, file, true);
 
 		const updatedFileContent: string = await this.app.vault.cachedRead(file);
 		const newFileContent: string = await this.formatter.formatContentWithFile(

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -106,7 +106,8 @@ export abstract class TemplateEngine extends QuickAddEngine {
 				formattedTemplateContent
 			);
 
-			await replaceTemplaterTemplatesInCreatedFile(this.app, createdFile);
+			// Always force processing of Templater commands for template choices
+			await replaceTemplaterTemplatesInCreatedFile(this.app, createdFile, true);
 
 			return createdFile;
 		} catch (e) {
@@ -132,6 +133,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 				await this.formatter.formatFileContent(templateContent);
 			await this.app.vault.modify(file, formattedTemplateContent);
 
+			// Already forcing Templater processing, keep this as-is
 			await replaceTemplaterTemplatesInCreatedFile(this.app, file, true);
 
 			return file;
@@ -160,6 +162,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 					: `${fileContent}\n${formattedTemplateContent}`;
 			await this.app.vault.modify(file, newFileContent);
 
+			// Already forcing Templater processing, keep this as-is
 			await replaceTemplaterTemplatesInCreatedFile(this.app, file, true);
 
 			return file;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -25,14 +25,16 @@ export async function replaceTemplaterTemplatesInCreatedFile(
 	force = false,
 ) {
 	const templater = getTemplater(app);
-
-	if (
-		templater &&
-		(force ||
-			!(templater.settings as Record<string, unknown>)[
-				"trigger_on_file_creation"
-			])
-	) {
+	
+	if (!templater) return;
+	
+	// Process Templater commands in these cases:
+	// 1. force=true (explicitly requested processing, e.g., for Template choices)
+	// 2. Templater's trigger_on_file_creation=false (manual processing required)
+	const shouldProcess = force || 
+		!(templater.settings as Record<string, unknown>)["trigger_on_file_creation"];
+	
+	if (shouldProcess) {
 		const impl = templater?.templater as {
 			overwrite_file_commands?: (file: TFile) => Promise<void>;
 		};


### PR DESCRIPTION
## Summary
- Fixes an issue where Templater commands weren't executing properly when using QuickAdd's Template and Capture choices
- Ensures consistent behavior across both choice types regardless of Templater settings

## Root Cause
This issue was introduced as a side effect of fixing issue #533 in PR #783 (version 1.13.0), which addressed duplicate prompts in Capture choices. The fix modified how Templater commands are processed but inadvertently affected Templater command execution.

## Changes
- Modified `CaptureChoiceEngine.ts` to always force Templater processing
- Updated `TemplateEngine.ts` to ensure consistent behavior across all choice types
- Improved `replaceTemplaterTemplatesInCreatedFile` in `utilityObsidian.ts` for better readability

## Related Issues
- Fixes #787
- Maintains fix for #533