### PR TITLE
fix: handle tp.file.cursor() in template choices

### DIFF
--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -285,7 +285,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		}
 
 		const file: TFile = await this.createFileWithInput(filePath, fileContent);
-		await replaceTemplaterTemplatesInCreatedFile(this.app, file, true);
+		await replaceTemplaterTemplatesInCreatedFile(this.app, file);
 
 		const updatedFileContent: string = await this.app.vault.cachedRead(file);
 		const newFileContent: string = await this.formatter.formatContentWithFile(

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -106,8 +106,8 @@ export abstract class TemplateEngine extends QuickAddEngine {
 				formattedTemplateContent
 			);
 
-			// Always force processing of Templater commands for template choices
-			await replaceTemplaterTemplatesInCreatedFile(this.app, createdFile, true);
+			// Process Templater commands for template choices
+			await replaceTemplaterTemplatesInCreatedFile(this.app, createdFile);
 
 			return createdFile;
 		} catch (err) {
@@ -129,8 +129,8 @@ export abstract class TemplateEngine extends QuickAddEngine {
 				await this.formatter.formatFileContent(templateContent);
 			await this.app.vault.modify(file, formattedTemplateContent);
 
-			// Already forcing Templater processing, keep this as-is
-			await replaceTemplaterTemplatesInCreatedFile(this.app, file, true);
+			// Process Templater commands
+			await replaceTemplaterTemplatesInCreatedFile(this.app, file);
 
 			return file;
 		} catch (err) {
@@ -158,8 +158,8 @@ export abstract class TemplateEngine extends QuickAddEngine {
 					: `${fileContent}\n${formattedTemplateContent}`;
 			await this.app.vault.modify(file, newFileContent);
 
-			// Already forcing Templater processing, keep this as-is
-			await replaceTemplaterTemplatesInCreatedFile(this.app, file, true);
+			// Process Templater commands
+			await replaceTemplaterTemplatesInCreatedFile(this.app, file);
 
 			return file;
 		} catch (err) {

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -22,17 +22,17 @@ export function getTemplater(app: App) {
 export async function replaceTemplaterTemplatesInCreatedFile(
 	app: App,
 	file: TFile,
-	force = false,
 ) {
 	const templater = getTemplater(app);
 	
 	if (!templater) return;
 	
-	// Process Templater commands in these cases:
-	// 1. force=true (explicitly requested processing, e.g., for Template choices)
-	// 2. Templater's trigger_on_file_creation=false (manual processing required)
-	const shouldProcess = force || 
-		!(templater.settings as Record<string, unknown>)["trigger_on_file_creation"];
+	const settings = templater.settings as Record<string, unknown>;
+	const triggerOnFileCreation = settings?.["trigger_on_file_creation"];
+	
+	// Only process if Templater's trigger_on_file_creation is disabled
+	// If it's enabled, Templater will process the file automatically
+	const shouldProcess = !triggerOnFileCreation;
 	
 	if (shouldProcess) {
 		const impl = templater?.templater as {


### PR DESCRIPTION
## Summary
This PR fixes issue #795 where `tp.file.cursor()` was showing as plain text instead of being processed by Templater.

## Root Cause
The issue started in v1.13.1 when we added `force=true` to `replaceTemplaterTemplatesInCreatedFile`. This was causing problems when Templater's `trigger_on_file_creation` setting was enabled, leading to either double processing or incorrect processing of Templater commands.

## Solution
We now only manually trigger Templater processing when `trigger_on_file_creation` is disabled. When it's enabled, we let Templater handle the processing automatically as it normally would.

## Test Plan
- [x] Test with Templater's `trigger_on_file_creation` enabled
- [x] Test with Templater's `trigger_on_file_creation` disabled
- [x] Verify `tp.file.cursor()` is processed correctly and cursor jumps to position
- [x] Verify other Templater commands continue to work

## Additional Notes
This is a follow-up to PR #806 which addressed capture choice issues but inadvertently claimed to fix this template choice issue as well.

🤖 Generated with [Claude Code](https://claude.ai/code)