### PR TITLE
feat: add Browse button for user script selection

### DIFF
--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -31,6 +31,7 @@ import type { MultiChoice } from "src/types/choices/MultiChoice";
 import type { IconType } from "src/types/IconType";
 import { AIAssistantCommand } from "src/types/macros/QuickCommands/AIAssistantCommand";
 import { settingsStore } from "src/settingsStore";
+import InputSuggester from "../InputSuggester/inputSuggester";
 
 function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 	const arr: IChoice[] = [];
@@ -239,6 +240,7 @@ export class MacroBuilder extends Modal {
 
 	private addAddUserScriptSetting() {
 		let input: TextComponent;
+		let addButton: ButtonComponent;
 
 		const addUserScriptFromInput = () => {
 			const value: string = input.getValue();
@@ -252,15 +254,23 @@ export class MacroBuilder extends Modal {
 			this.addCommandToMacro(new UserScript(value, file.path));
 
 			input.setValue("");
+			// Ensure Add button is hidden after clearing input
+			addButton.buttonEl.style.display = 'none';
 		};
 
 		new Setting(this.contentEl)
 			.setName("User Scripts")
-			.setDesc("Add user script")
+			.setDesc("Add user script - type the name or click Browse")
 			.addText((textComponent) => {
 				input = textComponent;
 				textComponent.inputEl.style.marginRight = "1em";
-				textComponent.setPlaceholder("User script");
+				textComponent.setPlaceholder("Start typing script name...");
+				
+				// Show/hide Add button based on input
+				textComponent.onChange((value) => {
+					addButton.buttonEl.style.display = value.trim() ? 'inline-block' : 'none';
+				});
+				
 				new GenericTextSuggester(
 					this.app,
 					textComponent.inputEl,
@@ -276,12 +286,26 @@ export class MacroBuilder extends Modal {
 					}
 				);
 			})
-			.addButton((button) =>
+			.addButton((button) => {
+				button
+					.setButtonText("Browse")
+					.setTooltip("Browse and select a script file")
+					.onClick(async () => {
+						const selected = await this.showScriptPicker();
+						if (selected) {
+							this.addCommandToMacro(new UserScript(selected.basename, selected.path));
+						}
+					});
+			})
+			.addButton((button) => {
+				addButton = button;
 				button
 					.setButtonText("Add")
 					.setCta()
-					.onClick(addUserScriptFromInput)
-			);
+					.onClick(addUserScriptFromInput);
+				// Initially hidden
+				button.buttonEl.style.display = 'none';
+			});
 	}
 
 	private addAddChoiceSetting() {
@@ -437,6 +461,27 @@ export class MacroBuilder extends Modal {
 				);
 				this.addCommandToMacro(new NestedChoiceCommand(captureChoice));
 			});
+	}
+
+	private async showScriptPicker(): Promise<TFile | null> {
+		if (this.javascriptFiles.length === 0) {
+			return null;
+		}
+
+		const scriptNames = this.javascriptFiles.map(f => f.basename);
+		const selected = await InputSuggester.Suggest(
+			this.app,
+			scriptNames,
+			scriptNames,
+			{ 
+				placeholder: "Select a JavaScript file",
+				emptyStateText: "No .js files found in your vault"
+			}
+		);
+		
+		if (!selected) return null;
+		
+		return this.javascriptFiles.find(f => f.basename === selected) ?? null;
 	}
 
 	private addCommandToMacro(command: ICommand) {

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -258,18 +258,13 @@ export class MacroBuilder extends Modal {
 			addButton.buttonEl.style.display = 'none';
 		};
 
-		new Setting(this.contentEl)
+		const setting = new Setting(this.contentEl)
 			.setName("User Scripts")
 			.setDesc("Add user script - type the name or click Browse")
 			.addText((textComponent) => {
 				input = textComponent;
 				textComponent.inputEl.style.marginRight = "1em";
 				textComponent.setPlaceholder("Start typing script name...");
-				
-				// Show/hide Add button based on input
-				textComponent.onChange((value) => {
-					addButton.buttonEl.style.display = value.trim() ? 'inline-block' : 'none';
-				});
 				
 				new GenericTextSuggester(
 					this.app,
@@ -306,6 +301,11 @@ export class MacroBuilder extends Modal {
 				// Initially hidden
 				button.buttonEl.style.display = 'none';
 			});
+
+		// Set up onChange handler after both input and addButton are initialized
+		input!.onChange((value) => {
+			addButton!.buttonEl.style.display = value.trim() ? 'inline-block' : 'none';
+		});
 	}
 
 	private addAddChoiceSetting() {


### PR DESCRIPTION
## Summary

Implements Solution 2 from the UX improvements analysis - a dual-action interface that provides both quick typing workflow and discoverable browse functionality for adding user scripts to macros.

## Changes

- **Browse Button**: Opens modal file picker using existing InputSuggester
- **Dynamic Add Button**: Only appears when user types, hides when input is empty
- **Enhanced UX**: Clear placeholder text and improved descriptions  
- **Progressive Disclosure**: Clean initial state with actions appearing as needed
- **Consistent Behavior**: Add button hides after successful script addition

## UX Improvements

- **New Users**: Clear Browse button makes script selection discoverable
- **Power Users**: Preserved quick typing workflow with autocomplete
- **Visual Feedback**: Dynamic button visibility provides clear affordances
- **Clean Interface**: No clutter when input is empty

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint passes with no new warnings
- ✅ All existing tests pass
- ✅ Build completes successfully

Resolves the user script selection UX issues identified in discussion #841.