### PR TITLE
fix: prevent double hashtag in tag completion

### DIFF
--- a/src/gui/suggesters/tagSuggester.ts
+++ b/src/gui/suggesters/tagSuggester.ts
@@ -72,7 +72,7 @@ export class TagSuggester extends TextInputSuggest<string> {
 
 		const tagInput: string = tagMatch[1];
 		this.lastInput = tagInput;
-		this.lastInputStart = tagMatch.index! + 1; // +1 to skip the #
+		this.lastInputStart = tagMatch.index!;
 
 		// Prefix matches first
 		const prefixMatches = this.sortedTags.filter(tag =>
@@ -106,14 +106,20 @@ export class TagSuggester extends TextInputSuggest<string> {
 	}
 
 	selectSuggestion(item: string): void {
-		if (this.inputEl.selectionStart === null) return;
+		const input = this.inputEl;
+		if (input.selectionStart === null) return;
 
-		const cursorPosition: number = this.inputEl.selectionStart;
-		const replaceStart = this.lastInputStart;
-		const replaceEnd = cursorPosition;
+		const cursor = input.selectionStart;
+		const value = input.value;
 
-		// Replace the partial tag with the complete tag
-		replaceRange(this.inputEl, replaceStart, replaceEnd, item);
+		// Find the actual '#' position by walking backwards from cursor
+		const hashPos = value.lastIndexOf("#", cursor - 1);
+		if (hashPos === -1) return; // Should not happen, but be safe
+
+		// Ensure exactly one '#' in replacement
+		const replacement = item.startsWith("#") ? item : `#${item}`;
+
+		replaceRange(input, hashPos, cursor, replacement, { dispatchInput: false });
 		this.close();
 	}
 }

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -25,12 +25,16 @@ export function replaceRange(
 	input: HTMLInputElement | HTMLTextAreaElement,
 	start: number,
 	end: number,
-	replacement: string
+	replacement: string,
+	options: { dispatchInput?: boolean } = {}
 ): void {
+	const { dispatchInput = true } = options;
 	const value = input.value;
 	input.value = value.slice(0, start) + replacement + value.slice(end);
 	input.setSelectionRange(start + replacement.length, start + replacement.length);
-	input.trigger("input");
+	if (dispatchInput) {
+		input.trigger("input");
+	}
 }
 
 /**


### PR DESCRIPTION
- Fix double hashtag bug when selecting tag completions
- Replace stale cached position logic with dynamic calculation
- Add dispatchInput option to replaceRange for cleaner event control
- Prevent suggestion popup from reappearing after tag completion

Fixes #847