### PR TITLE
feat: add paste with format command for rich clipboard content

### DIFF
--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -24,6 +24,7 @@ import { EditorCommandType } from "../types/macros/EditorCommands/EditorCommandT
 import { CutCommand } from "../types/macros/EditorCommands/CutCommand";
 import { CopyCommand } from "../types/macros/EditorCommands/CopyCommand";
 import { PasteCommand } from "../types/macros/EditorCommands/PasteCommand";
+import { PasteWithFormatCommand } from "../types/macros/EditorCommands/PasteWithFormatCommand";
 import { SelectActiveLineCommand } from "../types/macros/EditorCommands/SelectActiveLineCommand";
 import { SelectLinkOnActiveLineCommand } from "../types/macros/EditorCommands/SelectLinkOnActiveLineCommand";
 import { waitFor } from "src/utility";
@@ -289,6 +290,9 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 				break;
 			case EditorCommandType.Paste:
 				await PasteCommand.run(this.app);
+				break;
+			case EditorCommandType.PasteWithFormat:
+				await PasteWithFormatCommand.run(this.app);
 				break;
 			case EditorCommandType.SelectActiveLine:
 				SelectActiveLineCommand.run(this.app);

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -23,6 +23,7 @@ import { EditorCommandType } from "../../types/macros/EditorCommands/EditorComma
 import { CopyCommand } from "../../types/macros/EditorCommands/CopyCommand";
 import { CutCommand } from "../../types/macros/EditorCommands/CutCommand";
 import { PasteCommand } from "../../types/macros/EditorCommands/PasteCommand";
+import { PasteWithFormatCommand } from "../../types/macros/EditorCommands/PasteWithFormatCommand";
 import { log } from "../../logger/logManager";
 import { SelectActiveLineCommand } from "../../types/macros/EditorCommands/SelectActiveLineCommand";
 import { SelectLinkOnActiveLineCommand } from "../../types/macros/EditorCommands/SelectLinkOnActiveLineCommand";
@@ -220,6 +221,9 @@ export class MacroBuilder extends Modal {
 				case EditorCommandType.Paste:
 					command = new PasteCommand();
 					break;
+				case EditorCommandType.PasteWithFormat:
+					command = new PasteWithFormatCommand();
+					break;
 				case EditorCommandType.SelectActiveLine:
 					command = new SelectActiveLineCommand();
 					break;
@@ -244,6 +248,7 @@ export class MacroBuilder extends Modal {
 					.addOption(EditorCommandType.Copy, EditorCommandType.Copy)
 					.addOption(EditorCommandType.Cut, EditorCommandType.Cut)
 					.addOption(EditorCommandType.Paste, EditorCommandType.Paste)
+					.addOption(EditorCommandType.PasteWithFormat, EditorCommandType.PasteWithFormat)
 					.addOption(
 						EditorCommandType.SelectActiveLine,
 						EditorCommandType.SelectActiveLine

--- a/src/types/macros/EditorCommands/EditorCommandType.ts
+++ b/src/types/macros/EditorCommands/EditorCommandType.ts
@@ -2,6 +2,7 @@ export enum EditorCommandType {
 	Cut = "Cut",
 	Copy = "Copy",
 	Paste = "Paste",
+	PasteWithFormat = "Paste with format",
 	SelectActiveLine = "Select active line",
 	SelectLinkOnActiveLine = "Select link on active line",
 }

--- a/src/types/macros/EditorCommands/PasteWithFormatCommand.ts
+++ b/src/types/macros/EditorCommands/PasteWithFormatCommand.ts
@@ -1,0 +1,59 @@
+import { type App, htmlToMarkdown } from "obsidian";
+import { log } from "../../../logger/logManager";
+import { EditorCommand } from "./EditorCommand";
+import { EditorCommandType } from "./EditorCommandType";
+
+export class PasteWithFormatCommand extends EditorCommand {
+	constructor() {
+		super(EditorCommandType.PasteWithFormat);
+	}
+
+	static async run(app: App) {
+		const activeView = EditorCommand.getActiveMarkdownView(app);
+
+		if (!activeView) {
+			log.logError("no active markdown view.");
+			return;
+		}
+
+		let content = "";
+
+		try {
+			// Check if advanced clipboard API is available
+			if ('read' in navigator.clipboard && navigator.clipboard.read) {
+				const clipboardItems = await navigator.clipboard.read();
+				let foundHtml = false;
+
+				// Look for HTML content in clipboard
+				for (const item of clipboardItems) {
+					if (item.types.includes("text/html")) {
+						const htmlBlob = await item.getType("text/html");
+						const htmlContent = await htmlBlob.text();
+						content = await htmlToMarkdown(htmlContent);
+						foundHtml = true;
+						break;
+					}
+				}
+
+				// If no HTML found, fall back to plain text
+				if (!foundHtml) {
+					content = await navigator.clipboard.readText();
+				}
+			} else {
+				// Fallback for older Electron versions
+				content = await navigator.clipboard.readText();
+			}
+
+			activeView.editor.replaceSelection(content);
+		} catch (error) {
+			// Fallback to regular text paste if formatted clipboard reading fails
+			log.logWarning(`Formatted paste failed. Falling back to plain text: ${error}`);
+			try {
+				const textContent = await navigator.clipboard.readText();
+				activeView.editor.replaceSelection(textContent);
+			} catch (textError) {
+				log.logError(`Failed to read clipboard text: ${textError}`);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new "Paste with format" macro command that preserves rich formatting from clipboard content.

## Changes

- **New Command**: Added EditorCommandType.PasteWithFormat and PasteWithFormatCommand class
- **Rich Clipboard Support**: Uses navigator.clipboard.read() to access HTML content and converts to Markdown using Obsidian's htmlToMarkdown() function
- **Graceful Fallbacks**: Falls back to plain text when HTML is unavailable or on older Electron versions
- **UI Integration**: Added dropdown option in macro builder alongside existing editor commands
- **Cross-Platform**: Feature detection ensures compatibility with different Obsidian/Electron versions

## Behavior

1. **HTML Content**: When rich content (like formatted text with links) is copied, it reads the HTML and converts to proper Markdown
2. **Plain Text Fallback**: When only plain text is available, behaves like the regular paste command
3. **Error Handling**: Logs warnings on clipboard access failures and gracefully falls back to text

## Fixes

Closes #93

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint passes
- ✅ All existing tests pass
- ✅ Build completes successfully

## Examples

**Before**: Copying a link from browser would paste as plain text
**After**: Same copy operation now preserves format as proper Markdown links