### PR TITLE
Fix: Choice names not updating in macro lists

### DIFF
--- a/src/gui/MacroGUIs/Components/StandardCommand.svelte
+++ b/src/gui/MacroGUIs/Components/StandardCommand.svelte
@@ -3,6 +3,7 @@
     import ObsidianIcon from "../../components/ObsidianIcon.svelte";
     import {createEventDispatcher} from "svelte";
     import type {DndEvent} from "svelte-dnd-action";
+    import {getCommandDisplayName} from "../../../utils/macroHelpers";
 
     export let command: ICommand;
     export let startDrag: (e: CustomEvent<DndEvent>) => void;
@@ -15,7 +16,7 @@
 </script>
 
 <div class="quickAddCommandListItem">
-    <li>{command.name}</li>
+    <li>{getCommandDisplayName(command)}</li>
     <div>
         <span 
             role="button"

--- a/src/utils/macroHelpers.ts
+++ b/src/utils/macroHelpers.ts
@@ -1,0 +1,17 @@
+import QuickAdd from "src/main";
+import { CommandType } from "src/types/macros/CommandType";
+import type { IChoiceCommand } from "src/types/macros/IChoiceCommand";
+import type { ICommand } from "src/types/macros/ICommand";
+
+export function getCommandDisplayName(cmd: ICommand): string {
+    if (cmd.type === CommandType.Choice) {
+        try {
+            return QuickAdd.instance.getChoiceById((cmd as IChoiceCommand).choiceId)
+                .name;
+        } catch {
+            return "(missing choice)";
+        }
+    }
+
+    return cmd.name;
+}


### PR DESCRIPTION
## Summary
Fixes issue where choice names don't update in macro lists when choices are renamed.

## Changes
- Created  helper function that dynamically resolves choice names using choice IDs
- Updated  to use the helper instead of static 
- Maintains backward compatibility and doesn't affect macro execution

## Testing
- Compiled successfully with TypeScript
- Solution follows Oracle's recommended approach of deriving names on demand
- Works retroactively for all existing macros

Fixes #152