### PR TITLE
fix: preserve selection when appending link in capture choices

### DIFF
--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -132,9 +132,21 @@ export function appendToCurrentLine(toAppend: string, app: App) {
 			return;
 		}
 
-		activeView.editor.replaceSelection(toAppend);
-	} catch {
-		log.logError(`unable to append '${toAppend}' to current line.`);
+		const editor = activeView.editor;
+
+		/**
+		 * We want to keep any selected text and add the link straight
+		 * after the selection (or, if nothing is selected, at the cursor).
+		 *
+		 * 1. Get the end‐position (`"to"`) of the current selection/caret.
+		 * 2. Insert the link there with replaceRange().
+		 *    – replaceRange() with only the "from" position works as
+		 *      an insert and does **not** touch the existing text.
+		 */
+		const insertionPos = editor.getCursor("to");
+		editor.replaceRange(toAppend, insertionPos);
+	} catch (e) {
+		log.logError(`unable to append '${toAppend}' to current line. ${(e as Error).message}`);
 	}
 }
 

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -146,7 +146,7 @@ export function appendToCurrentLine(toAppend: string, app: App) {
 		const insertionPos = editor.getCursor("to");
 		editor.replaceRange(toAppend, insertionPos);
 	} catch (e) {
-		log.logError(`unable to append '${toAppend}' to current line. ${(e as Error).message}`);
+		log.logError(`unable to append '${toAppend}' to current line. ${e instanceof Error ? e.message : String(e)}`);
 	}
 }
 


### PR DESCRIPTION
Fixes #166 where 'Append link' option was replacing selected text instead of appending after it.

## Changes
- Changed appendToCurrentLine to use editor.getCursor and replaceRange
- Preserves selected text and inserts link at end of selection  
- Maintains backward compatibility for cases with no selection

## Testing
- TypeScript compilation passes
- ESLint passes
- Handles edge cases (multi-line selections, empty selections)

## Root Cause
The previous implementation used editor.replaceSelection which replaces any selected text with the link, causing data loss and contradicting the feature name Append link.

## Solution
Uses editor.getCursor to get the end position of the selection, then editor.replaceRange to insert the link at that position without overwriting existing text.