### PR TITLE
feat: add allowCustomInput parameter to suggester API

### DIFF
--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -111,15 +111,16 @@ await quickAddApi.infoDialog(
 );
 ```
 
-### `suggester(displayItems: string[] | Function, actualItems: string[], placeholder?: string): Promise<string>`
-Opens a selection prompt with searchable options.
+### `suggester(displayItems: string[] | Function, actualItems: string[], placeholder?: string, allowCustomInput?: boolean): Promise<string>`
+Opens a selection prompt with searchable options. Can optionally allow custom input not in the predefined list.
 
 **Parameters:**
 - `displayItems`: Array of display strings OR a map function
 - `actualItems`: Array of actual values to return
 - `placeholder`: (Optional) Placeholder text shown in the suggester
+- `allowCustomInput`: (Optional) When `true`, allows users to enter custom text not in `actualItems`. Defaults to `false`
 
-**Returns:** Promise resolving to the selected value, or `null` if cancelled
+**Returns:** Promise resolving to the selected value or custom input, or `null` if cancelled
 
 **Examples:**
 
@@ -161,6 +162,19 @@ const selectedTask = await quickAddApi.suggester(
     tasks,
     "Select a task to edit"
 );
+```
+
+Allow custom input (like quick switcher):
+```javascript
+// User can select from existing tags or type a new one
+const existingTags = ["#project", "#personal", "#work"];
+const selectedTag = await quickAddApi.suggester(
+    existingTags,
+    existingTags,
+    "Select existing tag or type new one",
+    true  // allowCustomInput = true
+);
+// Returns either an existing tag or the user's custom input
 ```
 
 ### `checkboxPrompt(items: string[], selectedItems?: string[]): Promise<string[]>`

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -2,6 +2,7 @@ import GenericInputPrompt from "./gui/GenericInputPrompt/GenericInputPrompt";
 import GenericYesNoPrompt from "./gui/GenericYesNoPrompt/GenericYesNoPrompt";
 import GenericInfoDialog from "./gui/GenericInfoDialog/GenericInfoDialog";
 import GenericSuggester from "./gui/GenericSuggester/genericSuggester";
+import InputSuggester from "./gui/InputSuggester/inputSuggester";
 import type { App } from "obsidian";
 import GenericCheckboxPrompt from "./gui/GenericCheckboxPrompt/genericCheckboxPrompt";
 import type { IChoiceExecutor } from "./IChoiceExecutor";
@@ -62,9 +63,10 @@ export class QuickAddApi {
 							arr?: string[]
 					  ) => string[]),
 				actualItems: string[],
-				placeholder?: string
+				placeholder?: string,
+				allowCustomInput = false
 			) => {
-				return this.suggester(app, displayItems, actualItems, placeholder);
+				return this.suggester(app, displayItems, actualItems, placeholder, allowCustomInput);
 			},
 			checkboxPrompt: (items: string[], selectedItems?: string[]) => {
 				return this.checkboxPrompt(app, items, selectedItems);
@@ -454,7 +456,8 @@ export class QuickAddApi {
 			| string[]
 			| ((value: string, index?: number, arr?: string[]) => string[]),
 		actualItems: string[],
-		placeholder?: string
+		placeholder?: string,
+		allowCustomInput = false
 	) {
 		try {
 			let displayedItems;
@@ -463,6 +466,15 @@ export class QuickAddApi {
 				displayedItems = actualItems.map(displayItems);
 			} else {
 				displayedItems = displayItems;
+			}
+
+			if (allowCustomInput) {
+				return await InputSuggester.Suggest(
+					app,
+					displayedItems as string[],
+					actualItems,
+					placeholder ? { placeholder } : {}
+				);
 			}
 
 			return await GenericSuggester.Suggest(


### PR DESCRIPTION
## Summary

Adds an optional `allowCustomInput` parameter to the suggester API that allows users to enter custom text not present in the predefined suggestions list, similar to Obsidian's quick switcher behavior.

## Changes

- Added `allowCustomInput` parameter (defaults to `false` for backward compatibility)
- When `true`, uses existing `InputSuggester` internally to allow custom input
- When `false`, uses existing `GenericSuggester` (current behavior)
- Updated API documentation with new parameter and usage examples

## Example Usage

```javascript
// User can select from existing tags or type a new one
const existingTags = ["#project", "#personal", "#work"];
const selectedTag = await quickAddApi.suggester(
    existingTags,
    existingTags,
    "Select existing tag or type new one",
    true  // allowCustomInput = true
);
```

## Testing

- ✅ Build passes without errors
- ✅ Linting passes
- ✅ Type checking passes  
- ✅ Backward compatibility maintained (all existing code works unchanged)

Closes #219