### PR TITLE
fix(gui): eliminate ghost gap after drag in Settings Choice list (#882)

### DIFF
--- a/src/gui/choiceList/ChoiceItemRightButtons.svelte
+++ b/src/gui/choiceList/ChoiceItemRightButtons.svelte
@@ -81,8 +81,7 @@
          aria-label="Drag-handle"
          style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
          class="alignIconInDivInMiddle"
-         on:mousedown
-         on:touchstart
+         on:pointerdown={() => dispatcher('dragHandleDown')}
     >
         <ObsidianIcon iconId="grip-vertical" size={16} />
     </div>

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -20,24 +20,33 @@
         let {items: newItems, info: {id}} = e.detail;
         collapseId = id;
 
-        choices = newItems as IChoice[];
+        // Remove internal placeholder item from state to avoid ghost gaps
+        const sanitized = (newItems as IChoice[]).filter(
+            (it) => it.id !== SHADOW_PLACEHOLDER_ITEM_ID
+        );
+        choices = sanitized;
     }
 
     function handleSort(e: CustomEvent<DndEvent>) {
-        let {items: newItems, info: {source}} = e.detail;
+        let {items: newItems} = e.detail;
         collapseId = "";
 
-        choices = newItems as IChoice[];
+        // Remove internal placeholder item from state to avoid ghost gaps
+        const sanitized = (newItems as IChoice[]).filter(
+            (it) => it.id !== SHADOW_PLACEHOLDER_ITEM_ID
+        );
+        choices = sanitized;
 
-        if (source === SOURCES.POINTER) {
-            dragDisabled = true;
-        }
+        // Always re-disable dragging when the sort finalizes
+        dragDisabled = true;
 
         emitChoicesReordered();
     }
 
-    function startDrag(e: CustomEvent<DndEvent>) {
-        e.preventDefault();
+    function startDrag(e: Event) {
+        // prevent focus/selection side-effects before enabling drag
+        // @ts-ignore
+        if (typeof e?.preventDefault === 'function') e.preventDefault();
         dragDisabled = false;
     }
 </script>
@@ -52,23 +61,21 @@
         {#if choice.type !== "Multi"}
             <ChoiceListItem
                     bind:dragDisabled={dragDisabled}
-                    on:mousedown={startDrag}
-                    on:touchstart={startDrag}
                     on:deleteChoice
                     on:configureChoice
                     on:toggleCommand
                     on:duplicateChoice
+                    startDrag={startDrag}
                     bind:choice
             />
         {:else}
             <MultiChoiceListItem
                     bind:dragDisabled={dragDisabled}
-                    on:mousedown={startDrag}
-                    on:touchstart={startDrag}
                     on:deleteChoice
                     on:configureChoice
                     on:toggleCommand
                     on:duplicateChoice
+                    startDrag={startDrag}
                     bind:collapseId
                     bind:choice
             />

--- a/src/gui/choiceList/ChoiceListItem.svelte
+++ b/src/gui/choiceList/ChoiceListItem.svelte
@@ -6,6 +6,7 @@
 
 	export let choice: IChoice;
 	export let dragDisabled: boolean;
+	export let startDrag: (e: Event) => void;
 	let showConfigureButton: boolean = true;
 	const dispatcher = createEventDispatcher();
 
@@ -46,8 +47,7 @@
 	<span class="choiceListItemName" bind:this={nameElement} />
 
 	<RightButtons
-		on:mousedown
-		on:touchstart
+		on:dragHandleDown={startDrag}
 		on:deleteChoice={deleteChoice}
 		on:configureChoice={configureChoice}
 		on:toggleCommand={toggleCommandForChoice}

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -9,6 +9,7 @@
     export let choice: IMultiChoice;
     export let collapseId: string;
     export let dragDisabled: boolean;
+    export let startDrag: (e: Event) => void;
     let showConfigureButton: boolean = true;
 
     const dispatcher = createEventDispatcher();
@@ -62,8 +63,7 @@
         </div>
 
         <RightButtons
-            on:mousedown
-            on:touchstart
+            on:dragHandleDown={startDrag}
             on:deleteChoice={deleteChoice}
             on:configureChoice={configureChoice}
             on:toggleCommand={toggleCommandForChoice}


### PR DESCRIPTION
Root cause
- svelte-dnd-action placeholder was being persisted into state during/after drag, leaving a blank slot in the list

Fix
- Filter out SHADOW_PLACEHOLDER_ITEM_ID in both consider and finalize before assigning to choices
- Restrict drag start to the handle; call preventDefault() before enabling drag
- Always re-disable dragDisabled on finalize

Impact
- Affects both top-level Choices and nested Choices in Multi; no behavior change outside drag-and-drop

QA
- Drag items at top level and inside Multi; confirm no lingering blank space after drop
- Build and test suite pass

Fixes #882
