### PR TITLE
feat(ai): model directory, provider presets, and responsive modals

### DIFF
--- a/docs/docs/AIAssistant.md
+++ b/docs/docs/AIAssistant.md
@@ -48,7 +48,7 @@ Here are a few providers that are known to work with QuickAdd:
 
 Paid providers expose their own API, which you can use with QuickAdd. Free providers, such as Ollama, are also supported.
 
-By default, QuickAdd will add the OpenAI and Gemini providers. You can add more providers by clicking the "Add Provider" button in the AI Assistant settings.
+By default, QuickAdd will add the OpenAI and Gemini providers. You can add more providers by clicking the "Add Provider" button in the AI Assistant settings. This now opens a preset picker with common providers (OpenAI, Gemini, Groq, Together, OpenRouter, etc.). Paste your API key and click Connect to add the provider. You can also add a custom provider.
 
 Here's a video showcasing adding Groq as a provider:
 
@@ -94,6 +94,12 @@ Notes:
 
 - Use only supported parameters for Gemini (temperature, top_p). Frequency/presence penalties are not sent to Gemini.
 - Make sure "Disable AI & Online features" is turned off in QuickAdd settings to enable requests.
+
+### Importing and syncing models
+
+- Use the "Browse models" button inside a provider to search and multi-select models from the public models directory (`https://models.dev/api.json`).
+- Choose Add-only to merge or Replace to overwrite the provider's model list.
+- Enable Auto-sync to keep your model list updated; use Sync now for a manual refresh.
 
 ## AI Assistant Settings
 

--- a/src/ai/Provider.ts
+++ b/src/ai/Provider.ts
@@ -3,6 +3,8 @@ export interface AIProvider {
 	endpoint: string;
 	apiKey: string;
 	models: Model[];
+    /** If true, QuickAdd may auto-sync models from models.dev for this provider. */
+    autoSyncModels?: boolean;
 }
 
 export interface Model {
@@ -56,6 +58,7 @@ const OpenAIProvider: AIProvider = {
 			maxTokens: 128000,
 		},
 	],
+    autoSyncModels: false,
 };
 
 const GeminiProvider: AIProvider = {
@@ -76,6 +79,7 @@ const GeminiProvider: AIProvider = {
             maxTokens: 1000000,
         },
     ],
+    autoSyncModels: false,
 };
 
 

--- a/src/ai/modelsDirectory.ts
+++ b/src/ai/modelsDirectory.ts
@@ -1,0 +1,107 @@
+import { requestUrl } from "obsidian";
+import type { AIProvider, Model } from "./Provider";
+import { settingsStore } from "src/settingsStore";
+
+export type ModelsDevModel = {
+  id: string;
+  name?: string;
+  limit?: { context?: number; output?: number };
+};
+
+export type ModelsDevProvider = {
+  id: string;
+  api?: string;
+  name: string;
+  models: Record<string, ModelsDevModel>;
+};
+
+export type ModelsDevDirectory = Record<string, ModelsDevProvider>;
+
+let cachedDirectory: { data: ModelsDevDirectory; fetchedAt: number } | null = null;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export async function fetchModelsDevDirectory(): Promise<ModelsDevDirectory> {
+  if (
+    cachedDirectory &&
+    Date.now() - cachedDirectory.fetchedAt < ONE_DAY_MS
+  ) {
+    return cachedDirectory.data;
+  }
+
+  if (settingsStore.getState().disableOnlineFeatures) {
+    throw new Error(
+      "Fetching models directory is disabled: Online features are turned off."
+    );
+  }
+
+  const response = await requestUrl({
+    url: "https://models.dev/api.json",
+    method: "GET",
+  });
+
+  const data = (await response.json) as ModelsDevDirectory;
+  cachedDirectory = { data, fetchedAt: Date.now() };
+  return data;
+}
+
+export function mapEndpointToModelsDevKey(endpoint: string): string | null {
+  const url = endpoint.toLowerCase();
+  if (url.includes("openai.com")) return "openai";
+  if (url.includes("openrouter.ai")) return "openrouter";
+  if (url.includes("generativelanguage.googleapis.com")) return "google";
+  if (url.includes("anthropic.com") || url.includes("anthropic"))
+    return "anthropic";
+  if (url.includes("groq.com")) return "groq";
+  if (url.includes("together.ai")) return "togetherai";
+  if (url.includes("huggingface.co") || url.includes("huggingface"))
+    return "huggingface";
+  if (url.includes("github") && url.includes("models")) return "github-models";
+  if (url.includes("bedrock") || url.includes("aws")) return "amazon-bedrock";
+  if (url.includes("modelscope")) return "modelscope";
+  if (url.includes("dashscope")) return "alibaba";
+  if (url.includes("fireworks.ai")) return "fireworks-ai";
+  if (url.includes("vercel")) return "vercel";
+  if (url.includes("inference.net")) return "inference";
+  if (url.includes("z.ai") || url.includes("zhipu")) return "zhipuai";
+  if (url.includes("deepseek.com")) return "deepseek";
+  if (url.includes("cerebras")) return "cerebras";
+  if (url.includes("venice.ai")) return "venice";
+  if (url.includes("upstage.ai")) return "upstage";
+  if (url.includes("llama.com") || url.includes("api.llama.com")) return "llama";
+  if (url.includes("morphllm")) return "morph";
+  if (url.includes("inceptionlabs.ai")) return "inception";
+  if (url.includes("deepinfra")) return "deepinfra";
+  if (url.includes("gateway.opencode.ai")) return "opencode";
+  if (url.includes("router.huggingface.co")) return "huggingface";
+  if (url.includes("inference.wandb.ai")) return "wandb";
+  if (url.includes("api.githubcopilot.com")) return "github-copilot";
+  if (url.includes("api.openai.com")) return "openai";
+  return null;
+}
+
+export async function getModelsForProvider(
+  provider: AIProvider
+): Promise<ModelsDevModel[]> {
+  const dir = await fetchModelsDevDirectory();
+  const key = mapEndpointToModelsDevKey(provider.endpoint);
+  if (!key || !(key in dir)) {
+    throw new Error(
+      `Could not determine models.dev provider for endpoint: ${provider.endpoint}`
+    );
+  }
+  const mdp = dir[key];
+  return Object.values(mdp.models);
+}
+
+export function mapModelsDevToQuickAdd(models: ModelsDevModel[]): Model[] {
+  return models.map((m) => ({
+    name: m.id,
+    maxTokens: Math.max(1, Math.floor(m.limit?.context ?? 128000)),
+  }));
+}
+
+export function dedupeModels(existing: Model[], incoming: Model[]): Model[] {
+  const existingNames = new Set(existing.map((m) => m.name));
+  const filtered = incoming.filter((m) => !existingNames.has(m.name));
+  return existing.concat(filtered);
+}

--- a/src/ai/providerPresets.ts
+++ b/src/ai/providerPresets.ts
@@ -1,0 +1,54 @@
+export interface ProviderPreset {
+  name: string;
+  endpoint: string;
+  doc?: string;
+  note?: string;
+}
+
+export const PROVIDER_PRESETS: ProviderPreset[] = [
+  {
+    name: "OpenAI",
+    endpoint: "https://api.openai.com/v1",
+    doc: "https://platform.openai.com/docs/models",
+  },
+  {
+    name: "Gemini",
+    endpoint: "https://generativelanguage.googleapis.com",
+    doc: "https://ai.google.dev/gemini-api/docs",
+  },
+  {
+    name: "Anthropic",
+    endpoint: "https://api.anthropic.com",
+    doc: "https://docs.anthropic.com/",
+  },
+  {
+    name: "Groq",
+    endpoint: "https://api.groq.com/openai/v1",
+    doc: "https://console.groq.com/docs/models",
+  },
+  {
+    name: "TogetherAI",
+    endpoint: "https://api.together.xyz/v1",
+    doc: "https://docs.together.ai/docs/serverless-models",
+  },
+  {
+    name: "OpenRouter",
+    endpoint: "https://openrouter.ai/api/v1",
+    doc: "https://openrouter.ai/models",
+  },
+  {
+    name: "Hugging Face",
+    endpoint: "https://router.huggingface.co/v1",
+    doc: "https://huggingface.co/docs/inference-providers",
+  },
+  {
+    name: "Mistral",
+    endpoint: "https://api.mistral.ai/v1",
+    doc: "https://docs.mistral.ai/getting-started/models/",
+  },
+  {
+    name: "DeepSeek",
+    endpoint: "https://api.deepseek.com",
+    doc: "https://platform.deepseek.com/api-docs/",
+  },
+];

--- a/src/gui/AIAssistantProvidersModal.ts
+++ b/src/gui/AIAssistantProvidersModal.ts
@@ -6,6 +6,7 @@ import { dedupeModels, fetchModelsDevDirectory, getModelsForProvider, mapModelsD
 import { ModelDirectoryModal } from "./ModelDirectoryModal";
 import { setPasswordOnBlur } from "src/utils/setPasswordOnBlur";
 import GenericInputPrompt from "./GenericInputPrompt/GenericInputPrompt";
+import { ProviderPickerModal } from "./ProviderPickerModal";
 import GenericYesNoPrompt from "./GenericYesNoPrompt/GenericYesNoPrompt";
 import type { IconType } from "src/types/IconType";
 
@@ -62,25 +63,14 @@ export class AIAssistantProvidersModal extends Modal {
 		new Setting(container)
 			.setName("Providers")
 			.setDesc("Providers for the AI Assistant")
-			.addButton((button) => {
-				button.setButtonText("Add Provider").onClick(async () => {
-					const providerName = await GenericInputPrompt.Prompt(
-						this.app,
-						"Provider Name"
-					);
+            .addButton((button) => {
+                button.setButtonText("Add Provider").onClick(async () => {
+                    await new ProviderPickerModal(this.app, this.providers).waitForClose;
+                    this.reload();
+                });
 
-					this.providers.push({
-						name: providerName,
-						endpoint: "",
-						apiKey: "",
-						models: [],
-					});
-
-					this.reload();
-				});
-
-				button.setCta();
-			});
+                button.setCta();
+            });
 
 		const providersContainer = container.createDiv("providers-container");
 		providersContainer.style.display = "flex";

--- a/src/gui/AIAssistantSettingsModal.ts
+++ b/src/gui/AIAssistantSettingsModal.ts
@@ -34,6 +34,12 @@ export class AIAssistantSettingsModal extends Modal {
 	}
 
 	private display(): void {
+		// Responsive sizing (desktop and mobile)
+		this.modalEl.style.width = `min(100vw - 32px, 980px)`;
+		this.modalEl.style.maxWidth = `980px`;
+		this.contentEl.style.maxHeight = `min(85vh, 800px)`;
+		this.contentEl.style.overflowY = "auto";
+
 		this.contentEl.createEl("h2", {
 			text: "AI Assistant Settings",
 		}).style.textAlign = "center";

--- a/src/gui/ModelDirectoryModal.ts
+++ b/src/gui/ModelDirectoryModal.ts
@@ -1,0 +1,146 @@
+import { Modal, Setting, Notice } from "obsidian";
+import type { AIProvider, Model } from "src/ai/Provider";
+import {
+  fetchModelsDevDirectory,
+  getModelsForProvider,
+  mapModelsDevToQuickAdd,
+  type ModelsDevModel,
+} from "src/ai/modelsDirectory";
+
+export class ModelDirectoryModal extends Modal {
+  public waitForClose: Promise<{ imported: Model[]; mode: "add" | "replace" } | null>;
+
+  private resolvePromise: (result: { imported: Model[]; mode: "add" | "replace" } | null) => void;
+  private rejectPromise: (reason?: unknown) => void;
+
+  private provider: AIProvider;
+  private allModels: ModelsDevModel[] = [];
+  private filtered: ModelsDevModel[] = [];
+  private selectedIds = new Set<string>();
+  private mode: "add" | "replace" = "add";
+
+  constructor(app: import("obsidian").App, provider: AIProvider) {
+    super(app);
+    this.provider = provider;
+
+    this.waitForClose = new Promise((resolve, reject) => {
+      this.resolvePromise = resolve;
+      this.rejectPromise = reject;
+    });
+
+    this.open();
+    void this.loadData().then(() => this.display());
+  }
+
+  private async loadData() {
+    try {
+      await fetchModelsDevDirectory();
+      this.allModels = await getModelsForProvider(this.provider);
+      this.filtered = this.allModels.slice();
+    } catch (err) {
+      new Notice(`Failed to load model directory: ${(err as { message?: string }).message ?? err}`);
+    }
+  }
+
+  private display() {
+    this.contentEl.empty();
+
+    this.contentEl.createEl("h2", { text: `Browse models for ${this.provider.name}` }).style.textAlign = "center";
+
+    // Search/filter
+    new Setting(this.contentEl)
+      .setName("Search")
+      .addText((text) => {
+        text.setPlaceholder("Filter by name or id").onChange((value) => {
+          const q = value.trim().toLowerCase();
+          this.filtered = this.allModels.filter((m) => m.id.toLowerCase().includes(q) || (m.name ?? "").toLowerCase().includes(q));
+          this.renderList();
+        });
+      })
+      .addExtraButton((btn) => {
+        btn.setIcon("check");
+        btn.setTooltip("Select all");
+        btn.onClick(() => {
+          this.filtered.forEach((m) => this.selectedIds.add(m.id));
+          this.renderList();
+        });
+      })
+      .addExtraButton((btn) => {
+        btn.setIcon("x");
+        btn.setTooltip("Clear selection");
+        btn.onClick(() => {
+          this.selectedIds.clear();
+          this.renderList();
+        });
+      });
+
+    // Mode toggle
+    new Setting(this.contentEl)
+      .setName("Import mode")
+      .setDesc("Add will append new models. Replace will overwrite existing models with the selected list.")
+      .addDropdown((dd) => {
+        dd.addOption("add", "Add only");
+        dd.addOption("replace", "Replace existing");
+        dd.setValue(this.mode);
+        dd.onChange((v) => (this.mode = v as "add" | "replace"));
+      })
+      .addButton((b) => {
+        b.setButtonText("Import selected").setCta().onClick(() => this.importSelected());
+      });
+
+    // List container
+    const list = this.contentEl.createDiv({ cls: "qa-model-directory" });
+    list.style.maxHeight = "400px";
+    list.style.overflowY = "auto";
+    list.style.padding = "6px";
+
+    this.renderList();
+  }
+
+  private renderList() {
+    const list = this.contentEl.querySelector(".qa-model-directory");
+    if (!list) return;
+    list.empty();
+
+    for (const m of this.filtered) {
+      const row = list.createDiv({ cls: "qa-model-row" });
+      row.style.display = "flex";
+      row.style.alignItems = "center";
+      row.style.gap = "8px";
+
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.checked = this.selectedIds.has(m.id);
+      cb.onchange = () => {
+        if (cb.checked) this.selectedIds.add(m.id);
+        else this.selectedIds.delete(m.id);
+      };
+      row.appendChild(cb);
+
+      const title = row.createDiv({ text: m.name ?? m.id });
+      title.style.flex = "1";
+
+      const meta = row.createDiv({ text: `${m.limit?.context ?? "?"} tokens ctx` });
+      meta.style.opacity = "0.7";
+      meta.style.fontSize = "0.9em";
+    }
+  }
+
+  private importSelected() {
+    if (this.selectedIds.size === 0) {
+      new Notice("Select at least one model.");
+      return;
+    }
+    const selection = this.allModels.filter((m) => this.selectedIds.has(m.id));
+    const qaModels = mapModelsDevToQuickAdd(selection);
+    this.resolvePromise({ imported: qaModels, mode: this.mode });
+    this.close();
+  }
+
+  onClose(): void {
+    if (!this.selectedIds || this.selectedIds.size === 0) {
+      this.resolvePromise(null);
+    }
+    super.onClose();
+  }
+}

--- a/src/gui/ModelDirectoryModal.ts
+++ b/src/gui/ModelDirectoryModal.ts
@@ -136,10 +136,18 @@ export class ModelDirectoryModal extends Modal {
       new Notice("Select at least one model.");
       return;
     }
-    const selection = this.allModels.filter((m) => this.selectedIds.has(m.id));
-    const qaModels = mapModelsDevToQuickAdd(selection);
-    this.resolvePromise({ imported: qaModels, mode: this.mode });
-    this.close();
+    try {
+      const selection = this.allModels.filter((m) => this.selectedIds.has(m.id));
+      const qaModels = mapModelsDevToQuickAdd(selection);
+      if (!qaModels.length) {
+        new Notice("No models selected to import.");
+        return;
+      }
+      this.resolvePromise({ imported: qaModels, mode: this.mode });
+      this.close();
+    } catch (err) {
+      new Notice(`Import failed: ${(err as { message?: string }).message ?? err}`);
+    }
   }
 
   onClose(): void {

--- a/src/gui/ModelDirectoryModal.ts
+++ b/src/gui/ModelDirectoryModal.ts
@@ -44,6 +44,11 @@ export class ModelDirectoryModal extends Modal {
 
   private display() {
     this.contentEl.empty();
+    // Responsive sizing
+    this.modalEl.style.width = `min(100vw - 32px, 980px)`;
+    this.modalEl.style.maxWidth = `980px`;
+    this.contentEl.style.maxHeight = `min(85vh, 800px)`;
+    this.contentEl.style.overflowY = "auto";
 
     this.contentEl.createEl("h2", { text: `Browse models for ${this.provider.name}` }).style.textAlign = "center";
 
@@ -90,7 +95,7 @@ export class ModelDirectoryModal extends Modal {
 
     // List container
     const list = this.contentEl.createDiv({ cls: "qa-model-directory" });
-    list.style.maxHeight = "400px";
+    list.style.maxHeight = window.innerWidth < 640 ? "55vh" : "60vh";
     list.style.overflowY = "auto";
     list.style.padding = "6px";
 

--- a/src/gui/ProviderPickerModal.ts
+++ b/src/gui/ProviderPickerModal.ts
@@ -81,16 +81,49 @@ export class ProviderPickerModal extends Modal {
 
       apiSetting.addButton((b) => {
           b.setButtonText("Connect").setCta().onClick(() => {
-            const apiKey = (card.querySelector("input") as HTMLInputElement)?.dataset?.["qa_key"] ?? "";
-            const provider: AIProvider = {
-              name: preset.name,
-              endpoint: preset.endpoint,
-              apiKey,
-              models: [],
-            };
-            this.providers.push(provider);
-            new Notice(`${preset.name} added. Click Edit to configure models.`);
-            this.display();
+            try {
+              const apiKey = (card.querySelector("input") as HTMLInputElement)?.dataset?.["qa_key"] ?? "";
+
+              // Basic validation
+              try {
+                // Validate endpoint URL format
+                // eslint-disable-next-line no-new
+                new URL(preset.endpoint);
+              } catch {
+                new Notice(`Invalid endpoint URL for ${preset.name}.`);
+                return;
+              }
+
+              const lower = preset.endpoint.toLowerCase();
+              const likelyRequiresKey = [
+                "openai.com",
+                "generativelanguage.googleapis.com",
+                "anthropic",
+                "api.groq.com",
+                "together.xyz",
+                "openrouter.ai",
+                "router.huggingface.co",
+                "api.mistral.ai",
+                "api.deepseek.com",
+              ].some((s) => lower.includes(s));
+
+              if (likelyRequiresKey && !apiKey) {
+                new Notice(`${preset.name} requires an API key.`);
+                return;
+              }
+
+              const provider: AIProvider = {
+                name: preset.name,
+                endpoint: preset.endpoint,
+                apiKey,
+                models: [],
+              };
+              this.providers.push(provider);
+              new Notice(`${preset.name} added. Click Edit to configure models.`);
+              this.display();
+            } catch (err) {
+              new Notice(`Failed to add provider: ${(err as { message?: string }).message ?? err}`);
+            }
           });
         });
     }

--- a/src/gui/ProviderPickerModal.ts
+++ b/src/gui/ProviderPickerModal.ts
@@ -1,0 +1,100 @@
+import { Modal, Setting, Notice } from "obsidian";
+import type { AIProvider } from "src/ai/Provider";
+import { PROVIDER_PRESETS } from "src/ai/providerPresets";
+
+export class ProviderPickerModal extends Modal {
+  public waitForClose: Promise<AIProvider[] | null>;
+
+  private resolvePromise: (providers: AIProvider[] | null) => void;
+  private rejectPromise: (reason?: unknown) => void;
+
+  private providers: AIProvider[];
+
+  constructor(app: import("obsidian").App, providers: AIProvider[]) {
+    super(app);
+    this.providers = providers;
+
+    this.waitForClose = new Promise((resolve, reject) => {
+      this.resolvePromise = resolve;
+      this.rejectPromise = reject;
+    });
+
+    this.open();
+    this.display();
+  }
+
+  private addHeader(container: HTMLElement) {
+    container.createEl("h2", { text: "Add a provider" }).style.textAlign = "center";
+  }
+
+  private display() {
+    this.contentEl.empty();
+    this.addHeader(this.contentEl);
+
+    const grid = this.contentEl.createDiv();
+    grid.style.display = "grid";
+    grid.style.gridTemplateColumns = "repeat(auto-fill, minmax(220px, 1fr))";
+    grid.style.gap = "12px";
+
+    for (const preset of PROVIDER_PRESETS) {
+      const card = grid.createDiv({ cls: "qa-provider-card" });
+      card.style.border = "1px solid var(--background-modifier-border)";
+      card.style.borderRadius = "8px";
+      card.style.padding = "12px";
+      card.style.display = "flex";
+      card.style.flexDirection = "column";
+      card.style.gap = "8px";
+
+      const title = card.createEl("div", { text: preset.name });
+      title.style.fontWeight = "600";
+
+      const endpoint = card.createEl("div", { text: preset.endpoint });
+      endpoint.style.fontSize = "0.9em";
+      endpoint.style.opacity = "0.8";
+
+      if (preset.doc) {
+        const doc = card.createEl("a", { text: "Docs", href: preset.doc });
+        doc.target = "_blank";
+        doc.rel = "noopener noreferrer";
+      }
+
+      new Setting(card)
+        .setName("API Key")
+        .addText((text) => {
+          text.setPlaceholder("paste key...");
+          text.onChange((v) => (text.inputEl.dataset["qa_key"] = v));
+        })
+        .addButton((b) => {
+          b.setButtonText("Connect").setCta().onClick(() => {
+            const apiKey = (card.querySelector("input") as HTMLInputElement)?.dataset?.["qa_key"] ?? "";
+            const provider: AIProvider = {
+              name: preset.name,
+              endpoint: preset.endpoint,
+              apiKey,
+              models: [],
+            };
+            this.providers.push(provider);
+            new Notice(`${preset.name} added. Click Edit to configure models.`);
+            this.display();
+          });
+        });
+    }
+
+    new Setting(this.contentEl)
+      .setName("Custom provider")
+      .setDesc("Create any custom endpoint (OpenAI-compatible or otherwise)")
+      .addButton((b) => {
+        b.setButtonText("Add custom...").onClick(() => {
+          const provider: AIProvider = { name: "Custom", endpoint: "", apiKey: "", models: [] };
+          this.providers.push(provider);
+          new Notice("Custom provider added. Click Edit to configure.");
+          this.display();
+        });
+      });
+  }
+
+  onClose(): void {
+    this.resolvePromise(this.providers ?? null);
+    super.onClose();
+  }
+}

--- a/src/gui/ProviderPickerModal.ts
+++ b/src/gui/ProviderPickerModal.ts
@@ -66,13 +66,20 @@ export class ProviderPickerModal extends Modal {
         doc.rel = "noopener noreferrer";
       }
 
-      new Setting(card)
+      const apiSetting = new Setting(card)
         .setName("API Key")
         .addText((text) => {
           text.setPlaceholder("paste key...");
+          text.inputEl.style.width = "100%";
           text.onChange((v) => (text.inputEl.dataset["qa_key"] = v));
-        })
-        .addButton((b) => {
+        });
+
+      // Make the API key input stack vertically to avoid squishing on narrow screens
+      apiSetting.settingEl.style.display = "flex";
+      apiSetting.settingEl.style.flexDirection = "column";
+      apiSetting.settingEl.style.gap = "6px";
+
+      apiSetting.addButton((b) => {
           b.setButtonText("Connect").setCta().onClick(() => {
             const apiKey = (card.querySelector("input") as HTMLInputElement)?.dataset?.["qa_key"] ?? "";
             const provider: AIProvider = {

--- a/src/gui/ProviderPickerModal.ts
+++ b/src/gui/ProviderPickerModal.ts
@@ -29,18 +29,26 @@ export class ProviderPickerModal extends Modal {
 
   private display() {
     this.contentEl.empty();
+    // Responsive modal sizing for desktop and mobile
+    this.modalEl.style.width = `min(100vw - 32px, 980px)`;
+    this.modalEl.style.maxWidth = `980px`;
+    this.contentEl.style.maxHeight = `min(85vh, 800px)`;
+    this.contentEl.style.overflowY = "auto";
     this.addHeader(this.contentEl);
 
     const grid = this.contentEl.createDiv();
     grid.style.display = "grid";
-    grid.style.gridTemplateColumns = "repeat(auto-fill, minmax(220px, 1fr))";
+    const isMobile = window.innerWidth < 640;
+    grid.style.gridTemplateColumns = isMobile
+      ? "1fr"
+      : "repeat(auto-fill, minmax(260px, 1fr))";
     grid.style.gap = "12px";
 
     for (const preset of PROVIDER_PRESETS) {
       const card = grid.createDiv({ cls: "qa-provider-card" });
       card.style.border = "1px solid var(--background-modifier-border)";
       card.style.borderRadius = "8px";
-      card.style.padding = "12px";
+      card.style.padding = window.innerWidth < 640 ? "10px" : "12px";
       card.style.display = "flex";
       card.style.flexDirection = "column";
       card.style.gap = "8px";


### PR DESCRIPTION
## Summary
- Model Directory: browse/filter and multi-select models from models.dev; add-only or replace import modes; notices and error handling
- Provider Picker: preset cards for common providers; API key field with validation; one-click Connect; custom provider
- Auto-sync models: toggle per provider and Sync now button
- Responsive UX: wider modals, mobile-friendly grids; AI Assistant settings modal now responsive
- Docs updated for presets, model browsing/import, and auto-sync

## Test plan
- Open AI Assistant settings → Add Provider: verify preset cards, full-width key input, validation, mobile layout
- Edit a provider → Browse models: search, select, import (add/replace), notices on empty or failure
- Test Auto-sync toggle and Sync now
- Confirm AI Assistant settings modal uses responsive sizing
- Build + tests pass}