### PR TITLE
feat(preflight): One-page inputs (Beta) for Template/Capture + macro script input support

### DIFF
--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -5,10 +5,12 @@ sidebar_position: 50
 ## One-page inputs for QuickAdd
 
 QuickAdd can collect all inputs in a single, dynamic form before running your choice.
+This feature is currently in Beta.
 
 ### Enable
 - Settings → QuickAdd → toggle “One-page input for choices”.
 - Works with Template and Capture choices. Macros get partial support (see User Scripts below).
+ - Note: Beta – please report issues and edge cases.
 
 ### What gets collected
 - Format variables in filenames, templates, and capture content:

--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 50
+---
+
+## One-page inputs for QuickAdd
+
+QuickAdd can collect all inputs in a single, dynamic form before running your choice.
+
+### Enable
+- Settings → QuickAdd → toggle “One-page input for choices”.
+- Works with Template and Capture choices. Macros get partial support (see User Scripts below).
+
+### What gets collected
+- Format variables in filenames, templates, and capture content:
+  - `{{VALUE}}`, `{{VALUE:name}}`, `{{VDATE:name, YYYY-MM-DD}}`, `{{FIELD:name|...}}`
+  - Nested `{{TEMPLATE:path}}` are scanned recursively.
+- Capture target file when capturing to a folder or tag.
+- Script-declared inputs (from user scripts inside macros), if provided.
+
+### Date UX
+- Date fields support natural language (e.g., “today”, “next friday”).
+- The modal shows a formatted preview and stores a normalized `@date:ISO` internally.
+
+### FIELD UX
+- FIELD inputs get inline suggestions from your vault (Dataview if available, with a manual fallback).
+
+### Skipping the modal
+- If all required inputs already have values (e.g., prefilled by an earlier macro step), the modal will not open.
+- Empty string is considered an intentional value and will not prompt again.
+
+---
+
+## User scripts: declare inputs (optional)
+
+To have your user script’s inputs included in the one-page form during preflight, export a static `quickadd.inputs` spec alongside your default export. This is optional and non-executing.
+
+Example (function default export):
+```js
+export default async function entry(params, settings) {
+  // ... your script ...
+}
+export const quickadd = {
+  inputs: [
+    { id: "project", label: "Project", type: "text", defaultValue: "Inbox" },
+    { id: "due", label: "Due date", type: "date", dateFormat: "YYYY-MM-DD" },
+    { id: "status", label: "Status", type: "dropdown", options: ["Todo","Doing","Done"] }
+  ]
+};
+```
+
+Example (object default export):
+```js
+export default {
+  async entry(params, settings) {
+    // ... your script ...
+  }
+};
+export const quickadd = {
+  inputs: [ { id: "topic", type: "text" } ]
+};
+```
+
+Supported input fields:
+- `id` (string, required)
+- `label` (string)
+- `type` ("text" | "textarea" | "dropdown" | "date" | "field-suggest")
+- `placeholder` (string)
+- `defaultValue` (string)
+- `options` (string[] for dropdown)
+- `dateFormat` (string for date)
+- `description` (string)
+
+In the modal these inputs are labeled “(from script)”.
+
+---
+
+## Scripts: request inputs at runtime (API)
+
+From within a script, you can open a single one-page modal to collect multiple inputs in one go using the QuickAdd API.
+
+```js
+export default async function entry({ quickAddApi }) {
+  const values = await quickAddApi.requestInputs([
+    { id: "project", label: "Project", type: "text", defaultValue: "Inbox" },
+    { id: "due", label: "Due", type: "date", dateFormat: "YYYY-MM-DD" },
+    { id: "status", label: "Status", type: "dropdown", options: ["Todo","Doing","Done"] },
+  ]);
+
+  // Access collected values
+  const { project, due, status } = values;
+}
+```
+
+Behavior:
+- Values already present in variables are used and not re-asked.
+- Only missing inputs are prompted in the one-page modal.
+- Returned values are also stored into `variables` for later steps in the macro.
+
+---
+
+## Notes
+- Macro support is best-effort: user scripts can declare inputs via `quickadd.inputs`.
+- Inline scripts aren’t scanned for input declarations yet.
+- If needed, you can still prompt ad-hoc (e.g., using inputPrompt or suggester) and those values will skip future one-page prompts due to being prefilled.

--- a/docs/one-page-input-plan.md
+++ b/docs/one-page-input-plan.md
@@ -128,3 +128,7 @@
 - [ ] Tests: Template/Capture integration tests
 - [ ] (Optional) Macro best-effort preflight (Phase 2)
 - [ ] (Optional) Per-choice override and richer previews (Phase 3-4)
+
+### Status updates
+- Implemented: setting toggle, RequirementCollector, recursive template scan, one-page modal, VDATE live parsing/preview, FIELD inline suggester, capture target picker, filename preview scaffold, macro user-script declared inputs via `quickadd.inputs` export. Added unit tests for RequirementCollector.
+- Next: mark script-declared fields in UI (done), docs for `quickadd.inputs`, expand integration tests.

--- a/docs/one-page-input-plan.md
+++ b/docs/one-page-input-plan.md
@@ -1,0 +1,130 @@
+## One-Page Input UI for QuickAdd
+
+### Objectives
+- **Pre-resolve all QuickAdd variables** before any execution.
+- **Present a single, dynamic form** for all inputs with previews/suggestions/defaults.
+- **Integrate cleanly with Template and Capture choices** first; provide a path for Macros.
+- **Retain backward compatibility** by falling back to current step-by-step prompting when needed.
+
+### What we must pre-resolve
+- **QuickAdd format syntax**:
+  - VALUE/NAME: `{{VALUE}}`, `{{NAME}}`
+  - Named variables (with defaults/options): `{{VALUE:author}}`, `{{VALUE:status|Open}}`, `{{VALUE:low,medium,high}}`
+  - Date variables: `{{VDATE:due, YYYY-MM-DD}}`, `{{VDATE:due, YYYY-MM-DD|tomorrow}}`
+  - Field variables with filters: `{{FIELD:project|folder:Projects|tag:#active|inline:true|default:In Progress}}`
+  - Random, selected, clipboard, time/date, title (previews only)
+  - Template inclusion: `{{TEMPLATE:path}}` (scan included templates too)
+  - Inline JS code blocks (do not execute; treat as opaque during preflight)
+  - Macros `{{MACRO:name}}` (best-effort only; see caveats)
+- **Choice-pathing inputs**:
+  - Template Choice: file name format, folder choice (when enabled)
+  - Capture Choice: capture target path (folder/tag mode needs a file pick), capture content
+
+### Core approach
+- Add a **preflight stage** that collects all variable requirements across the choice before rendering any prompt.
+- Generate a **dynamic one-page GUI** from that requirement set (our schema).
+- On submit, **set everything into** `ChoiceExecutor.variables` and run the choice engines normally (they won’t prompt).
+
+### Architecture
+- **RequirementCollector** (new, subclass of `Formatter`)
+  - Overrides:
+    - `promptForValue`, `promptForVariable`, `promptForMathValue`, `suggestForField`, `getSelectedText`, `getClipboardContent`
+  - Behavior: record a `FieldRequirement` instead of prompting; return a harmless placeholder to keep scanning
+  - Supports:
+    - Named variables with default/options
+    - VDATE variables with `dateFormat`/default
+    - FIELD variables with parsed filters (via `FieldSuggestionParser`)
+  - Traversal:
+    - Template Choice: scan file name format, folder paths needing formatting, and template content (and recursively any `{{TEMPLATE:...}}` inside)
+    - Capture Choice: scan `captureTo` and capture content (via `CaptureChoiceFormatter` logic without prompting). If `captureTo` resolves to folder/tag mode, collect a “file selection” requirement and precompute suggestions using existing utilities.
+  - Macro Choice (phase 2+):
+    - Best-effort: find nested Template/Capture commands and preflight them
+    - Skip executing user scripts/macros; we cannot safely introspect them. Fall back to runtime prompts if they ask for inputs.
+
+### Dynamic form schema
+- Reuse/extend our settings UI patterns into a general-purpose modal:
+  - FieldSpec:
+    - `id` (variable key), `label`, `type`: text | textarea | dropdown | toggle | date | field-suggest | format-preview
+    - `defaultValue`, `placeholder`, `description`
+    - `options` (for dropdown), `suggester` (async, e.g., FIELD variables and file pickers)
+    - Preview hooks (e.g., date format live preview)
+  - Deduplicate variables by name across all scanned sources
+  - Pre-fill from `ChoiceExecutor.variables` (URI parameters, previous values)
+  - Grouping: General (VALUE/NAME), Variables, Dates, Fields, Capture/Template targets
+
+### One-page input modal (new)
+- Built with Obsidian `Modal` + `Setting`, like `UserScriptSettingsModal`.
+- Controls:
+  - Respect `settings.inputPrompt` for single-line vs multi-line inputs
+  - Named variables: text or dropdown (when comma list detected), with "Custom…" fallback
+  - VDATE: text input + live preview (reuse `VDateInputPrompt` logic)
+  - FIELD: text input with `InputSuggester`, using filters and cache
+  - Capture target file picker dropdown for folder/tag modes
+  - Optional preview panel (e.g., formatted file name) via `FormatDisplayFormatter`
+- Validation: required fields, defaults honored, sensible fallbacks
+- On submit: returns a `Record<string, unknown>` to merge into `ChoiceExecutor.variables`
+
+### Integration flow
+- Add a plugin setting: **“One-page input for choices”** (on/off, default off)
+- In `ChoiceExecutor.execute`:
+  - If enabled and choice is Template or Capture:
+    1) Run preflight (RequirementCollector)
+    2) Show modal (One-page input)
+    3) Merge results into `this.variables`
+    4) Execute engine
+  - Macro: initially off by default; optional later with caveats (no user script pre-collection)
+  - Multi Choice: skip for now (selection is dynamic)
+
+### Important details
+- **Defaults and options**:
+  - `{{VALUE:name|default}}` is prefilled; if left empty, use default.
+  - `{{VALUE:low,medium,high}}` renders dropdown; allow a "Custom…" text fallback.
+- **VDATE**:
+  - Prompt with preview and store canonical `@date:ISO` in `variables` (same as current), format at runtime.
+- **FIELD variables**:
+  - Use same collection/filter logic and cache as `CompleteFormatter.suggestForField`.
+  - Respect filters (folder, tags, inline, defaults, case sensitivity, exclusions).
+- **Capture target file**:
+  - For folder/tag mode, present a searchable list of candidate files.
+- **Template inclusion**:
+  - Recursively scan included templates; track visited paths to avoid loops.
+- **Macros & inline JS**:
+  - Do not execute during preflight. Fall back to runtime prompts when unknowns arise.
+
+### Performance and safety
+- Scan only files referenced by the choice (template files, included templates)
+- FIELD suggestions use batched vault scanning + cache
+- Safeguards against template recursion loops
+
+### Testing
+- Unit tests for RequirementCollector:
+  - Extracting variables from file name, folder paths, template content (incl. nested templates)
+  - VDATE parsing and preview capture
+  - FIELD filters producing expected suggestion sources
+- Integration tests:
+  - Template choice with one-page inputs replacing prompts
+  - Capture choice with folder/tag mode file picker
+  - Fallbacks when inputs left blank and defaults present
+
+### Phased delivery
+- **Phase 1**: Template/Capture choices; one-page modal; preflight collector; setting toggle
+- **Phase 2**: Macro best-effort preflight for nested QuickAdd variables (skip user scripts)
+- **Phase 3**: Live previews for more contexts and richer field types
+- **Phase 4**: Optional per-choice “always use one-page” override
+
+---
+
+### Progress checklist
+- [ ] Add plugin setting: "One-page input for choices"
+- [ ] Implement RequirementCollector (Formatter subclass)
+- [ ] Template Choice preflight: filename, folder(s), template content, nested templates
+- [ ] Capture Choice preflight: captureTo (file/folder/tag), content; file picker when needed
+- [ ] Build OnePageInputModal with dynamic schema
+- [ ] VDATE control with live preview (reuse logic)
+- [ ] FIELD variable suggester integration
+- [ ] Merge results into `ChoiceExecutor.variables`
+- [ ] Execute engines without further prompts when possible
+- [ ] Tests: RequirementCollector unit tests
+- [ ] Tests: Template/Capture integration tests
+- [ ] (Optional) Macro best-effort preflight (Phase 2)
+- [ ] (Optional) Per-choice override and richer previews (Phase 3-4)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -142,6 +142,11 @@ const sidebars = {
 				},
 				{
 					type: "doc",
+					id: "Advanced/onePageInputs",
+					label: "🧩 One-page Inputs",
+				},
+				{
+					type: "doc",
 					id: "Advanced/ObsidianUri",
 					label: "🔗 Obsidian URI",
 				},

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -10,6 +10,8 @@ import { MacroChoiceEngine } from "./engine/MacroChoiceEngine";
 import type { IChoiceExecutor } from "./IChoiceExecutor";
 import type IMultiChoice from "./types/choices/IMultiChoice";
 import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
+import { settingsStore } from "./settingsStore";
+import { runOnePagePreflight } from "./preflight/runOnePagePreflight";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
@@ -17,6 +19,13 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	constructor(private app: App, private plugin: QuickAdd) {}
 
 	async execute(choice: IChoice): Promise<void> {
+		// Optional Phase 1 preflight for Template/Capture
+		if (settingsStore.getState().onePageInputEnabled && (choice.type === "Template" || choice.type === "Capture")) {
+			try {
+				await runOnePagePreflight(this.app, this.plugin as unknown as QuickAdd, this, choice);
+			} catch {}
+		}
+
 		switch (choice.type) {
 			case "Template": {
 				const templateChoice: ITemplateChoice =

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -19,8 +19,11 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	constructor(private app: App, private plugin: QuickAdd) {}
 
 	async execute(choice: IChoice): Promise<void> {
-		// Optional Phase 1 preflight for Template/Capture
-		if (settingsStore.getState().onePageInputEnabled && (choice.type === "Template" || choice.type === "Capture")) {
+    // One-page preflight honoring per-choice override
+    const globalEnabled = settingsStore.getState().onePageInputEnabled;
+    const override = choice.onePageInput;
+    const shouldUseOnePager = (override === "always") || (override !== "never" && globalEnabled);
+    if (shouldUseOnePager && (choice.type === "Template" || choice.type === "Capture" || choice.type === "Macro")) {
 			try {
 				await runOnePagePreflight(this.app, this.plugin as unknown as QuickAdd, this, choice);
 			} catch {}

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -183,6 +183,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	private async getFormattedPathToCaptureTo(
 		shouldCaptureToActiveFile: boolean,
 	): Promise<string> {
+        // One-page preflight: if a specific target file was already chosen, use it
+        const preselected = this.choiceExecutor?.variables?.get("captureTargetFilePath") as string | undefined;
+        if (!shouldCaptureToActiveFile && preselected && typeof preselected === "string" && preselected.length > 0) {
+            return preselected;
+        }
+
 		if (shouldCaptureToActiveFile) {
 			const activeFile = this.app.workspace.getActiveFile();
 			invariant(activeFile, "Cannot capture to active file - no active file.");

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -62,8 +62,8 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			}
 		}
 
-		this.addFormatSetting();
 		this.addOnePageOverrideSetting(this.choice);
+		this.addFormatSetting();
 	}
 
 	private addCapturedToSetting() {

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -63,6 +63,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 		}
 
 		this.addFormatSetting();
+		this.addOnePageOverrideSetting(this.choice);
 	}
 
 	private addCapturedToSetting() {

--- a/src/gui/ChoiceBuilder/choiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/choiceBuilder.ts
@@ -34,6 +34,23 @@ export abstract class ChoiceBuilder extends Modal {
 		this.display();
 	}
 
+	protected addOnePageOverrideSetting(choice: IChoice): void {
+		new Setting(this.contentEl)
+			.setName("One-page input override")
+			.setDesc("Override global one-page input setting for this choice")
+			.addDropdown((dropdown) => {
+				dropdown.addOptions({
+					"": "Follow global setting",
+					always: "Always",
+					never: "Never",
+				});
+				dropdown.setValue((choice.onePageInput ?? "") as string);
+				dropdown.onChange((val: string) => {
+					choice.onePageInput = (val === "" ? undefined : (val as any));
+				});
+			});
+	}
+
 	protected addFileSearchInputToSetting(
 		setting: Setting,
 		value: string,

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -49,6 +49,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 		this.addAppendLinkSetting();
 		this.addFileAlreadyExistsSetting();
 		this.addOpenFileSetting("Open the created file.");
+		this.addOnePageOverrideSetting(this.choice);
 
 		if (this.choice.openFile) {
 			this.addFileOpeningSetting("created");

--- a/src/gui/suggesters/FieldValueInputSuggest.ts
+++ b/src/gui/suggesters/FieldValueInputSuggest.ts
@@ -1,0 +1,155 @@
+import type { App, TFile } from "obsidian";
+import { TextInputSuggest } from "./suggest";
+import { FieldSuggestionParser, type FieldFilter } from "src/utils/FieldSuggestionParser";
+import { DataviewIntegration } from "src/utils/DataviewIntegration";
+import { EnhancedFieldSuggestionFileFilter } from "src/utils/EnhancedFieldSuggestionFileFilter";
+import { FieldSuggestionCache } from "src/utils/FieldSuggestionCache";
+import { FieldValueProcessor } from "src/utils/FieldValueProcessor";
+
+export class FieldValueInputSuggest extends TextInputSuggest<string> {
+  private readonly fieldInput: string;
+  private readonly fieldName: string;
+  private readonly filters: FieldFilter;
+  private cachedValues: string[] | null = null;
+
+  constructor(app: App, inputEl: HTMLInputElement, fieldInput: string) {
+    super(app, inputEl);
+    this.fieldInput = fieldInput;
+    const parsed = FieldSuggestionParser.parse(fieldInput);
+    this.fieldName = parsed.fieldName;
+    this.filters = parsed.filters;
+  }
+
+  async getSuggestions(inputStr: string): Promise<string[]> {
+    if (!this.cachedValues) {
+      this.cachedValues = await this.collectValues();
+    }
+
+    const query = (inputStr || "").toLowerCase();
+    if (!query) return this.cachedValues.slice(0, 200);
+    return this.cachedValues.filter((v) => v.toLowerCase().includes(query)).slice(0, 200);
+  }
+
+  renderSuggestion(item: string, el: HTMLElement): void {
+    el.innerHTML = this.renderMatch(item, this.getCurrentQuery());
+  }
+
+  selectSuggestion(item: string): void {
+    // Fill input and dispatch a synthetic input event to trigger onChange listeners
+    this.inputEl.value = item;
+    const event = new Event("input", { bubbles: true });
+    (event as any).fromCompletion = true;
+    this.inputEl.dispatchEvent(event);
+    this.close();
+  }
+
+  private async collectValues(): Promise<string[]> {
+    const cache = FieldSuggestionCache.getInstance();
+    const cacheKey = this.generateCacheKey(this.filters);
+    const cached = cache.get(this.fieldName, cacheKey);
+    if (cached) {
+      return Array.from(cached).sort();
+    }
+
+    let rawValues = new Set<string>();
+
+    try {
+      if (!this.filters.inline && DataviewIntegration.isAvailable(this.app)) {
+        rawValues = await DataviewIntegration.getFieldValuesWithFilter(
+          this.app,
+          this.fieldName,
+          this.filters.folder,
+          this.filters.tags,
+          this.filters.excludeFolders,
+          this.filters.excludeTags
+        );
+
+        if (rawValues.size === 0) {
+          rawValues = await this.collectValuesManually();
+        }
+      } else {
+        rawValues = await this.collectValuesManually();
+      }
+    } catch {
+      // Ignore errors and fall back to empty list
+    }
+
+    cache.set(this.fieldName, rawValues, cacheKey);
+
+    const processed = FieldValueProcessor.processValues(rawValues, this.filters);
+    return processed.values;
+  }
+
+  private async collectValuesManually(): Promise<Set<string>> {
+    const result = new Set<string>();
+    // Get all markdown files and apply filtering
+    let files = this.app.vault.getMarkdownFiles();
+    files = EnhancedFieldSuggestionFileFilter.filterFiles(
+      files,
+      this.filters,
+      (file: TFile) => this.app.metadataCache.getFileCache(file)
+    );
+
+    const batchSize = 50;
+    for (let i = 0; i < files.length; i += batchSize) {
+      const batch = files.slice(i, i + batchSize);
+      const proms = batch.map(async (file) => {
+        const values = new Set<string>();
+        try {
+          const metadataCache = this.app.metadataCache.getFileCache(file);
+          const v: unknown = metadataCache?.frontmatter?.[this.fieldName];
+          if (v !== undefined && v !== null) {
+            if (Array.isArray(v)) {
+              v.forEach((x) => {
+                const s = String(x).trim();
+                if (s) values.add(s);
+              });
+            } else if (typeof v !== "object") {
+              const s = String(v).trim();
+              if (s) values.add(s);
+            }
+          }
+
+          if (this.filters.inline) {
+            try {
+              const content = await this.app.vault.read(file);
+              const regex = new RegExp(`\\b${this.escapeRegex(this.fieldName)}\\s*::\\s*([^\n]+)`, "gi");
+              let m: RegExpExecArray | null;
+              while ((m = regex.exec(content)) !== null) {
+                const s = (m[1] || "").trim();
+                if (s) values.add(s);
+              }
+            } catch {}
+          }
+        } catch {}
+        return values;
+      });
+
+      const batchResults = await Promise.all(proms);
+      for (const vset of batchResults) {
+        for (const v of vset) result.add(v);
+      }
+    }
+
+    return result;
+  }
+
+  private generateCacheKey(filters: FieldFilter): string {
+    const parts: string[] = [];
+    if (filters.folder) parts.push(`folder:${filters.folder}`);
+    if (filters.tags) parts.push(`tags:${filters.tags.join(",")}`);
+    if (filters.inline) parts.push("inline:true");
+    if (filters.caseSensitive) parts.push("case-sensitive:true");
+    if (filters.excludeFolders) parts.push(`exclude-folders:${filters.excludeFolders.join(",")}`);
+    if (filters.excludeTags) parts.push(`exclude-tags:${filters.excludeTags.join(",")}`);
+    if (filters.excludeFiles) parts.push(`exclude-files:${filters.excludeFiles.join(",")}`);
+    if (filters.defaultValue) parts.push(`default:${filters.defaultValue}`);
+    if (filters.defaultEmpty) parts.push("default-empty:true");
+    if (filters.defaultAlways) parts.push("default-always:true");
+    return parts.join("|");
+  }
+
+  private escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+}

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -94,9 +94,17 @@ export class OnePageInputModal extends Modal {
         const setting = new Setting(this.contentEl).setName(req.label);
         if (req.description) setting.setDesc(req.description);
         const dropdown = new DropdownComponent(setting.controlEl);
-        (req.options ?? []).forEach((opt) => dropdown.addOption(opt, opt));
-        dropdown.setValue(starting || (req.options?.[0] ?? ""));
-        dropdown.onChange((v) => setValue(req.id, v));
+        const options = req.options ?? [];
+        if (options.length > 0) {
+          options.forEach((opt) => dropdown.addOption(opt, opt));
+          dropdown.setValue(starting || options[0] || "");
+          dropdown.onChange((v) => setValue(req.id, v));
+        } else {
+          dropdown.setDisabled(true);
+          const note = setting.controlEl.createDiv({ text: req.placeholder || "No options available" });
+          note.style.marginLeft = "0.5rem";
+          note.style.color = "var(--text-muted)";
+        }
         break;
       }
       case "date": {

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -80,10 +80,37 @@ export class OnePageInputModal extends Modal {
         const setting = new Setting(this.contentEl).setName(req.label);
         if (req.description) setting.setDesc(req.description);
         // Reuse the VDateInputPrompt component behavior by creating an input with preview
-        const input = new TextComponent(setting.controlEl);
+        const container = setting.controlEl.createDiv();
+        const input = new TextComponent(container);
         const placeholder = "Enter a date (e.g., 'tomorrow', 'next friday', '2025-12-25')";
-        input.setPlaceholder(placeholder).setValue(starting).onChange((v) => setValue(req.id, v));
-        // Preview: handled by runtime formatters; this control just captures input
+        input.setPlaceholder(placeholder).setValue(starting);
+
+        const preview = container.createDiv();
+        preview.style.marginTop = "0.25rem";
+        preview.style.fontSize = "0.9em";
+        preview.style.fontFamily = "var(--font-monospace)";
+        const updatePreview = (val: string) => {
+          const inputVal = (val ?? "").trim();
+          if (!inputVal && req.defaultValue) {
+            preview.setText(`Default → ${req.defaultValue}`);
+            preview.style.color = "var(--text-muted)";
+            setValue(req.id, "");
+            return;
+          }
+          if (!inputVal) {
+            preview.setText("Preview will appear here");
+            preview.style.color = "var(--text-muted)";
+            setValue(req.id, "");
+            return;
+          }
+          // We do not format here; normalization to @date:ISO happens after submission
+          preview.setText(`Input: ${inputVal}${req.dateFormat ? ` | Format: ${req.dateFormat}` : ""}`);
+          preview.style.color = "var(--text-normal)";
+          setValue(req.id, inputVal);
+        };
+        input.onChange((v) => updatePreview(v));
+        // Initialize preview
+        updatePreview(starting);
         break;
       }
       case "field-suggest": {

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -1,0 +1,127 @@
+import { App, Modal, Setting, TextAreaComponent, TextComponent, DropdownComponent } from "obsidian";
+import type { FieldRequirement } from "./RequirementCollector";
+import InputSuggester from "src/gui/InputSuggester/inputSuggester";
+
+export class OnePageInputModal extends Modal {
+  private readonly requirements: FieldRequirement[];
+  private readonly initialValues: Map<string, string>;
+  private readonly result = new Map<string, string>();
+
+  public waitForClose: Promise<Record<string, string>>;
+  private resolvePromise!: (values: Record<string, string>) => void;
+  private rejectPromise!: (reason?: unknown) => void;
+
+  constructor(app: App, requirements: FieldRequirement[], initial?: Map<string, unknown>) {
+    super(app);
+    this.requirements = requirements;
+    this.initialValues = new Map<string, string>();
+    initial?.forEach((v, k) => {
+      if (typeof v === "string") this.initialValues.set(k, v);
+    });
+
+    this.waitForClose = new Promise<Record<string, string>>((resolve, reject) => {
+      this.resolvePromise = resolve;
+      this.rejectPromise = reject;
+    });
+
+    this.display();
+    this.open();
+  }
+
+  private display() {
+    this.containerEl.addClass("quickAddModal", "onePageInputModal");
+    this.contentEl.empty();
+
+    const title = this.contentEl.createEl("h2", { text: "Provide inputs" });
+    title.style.textAlign = "center";
+
+    // Render fields
+    this.requirements.forEach((req) => this.renderField(req));
+
+    // Action bar
+    const btnRow = this.contentEl.createDiv();
+    new Setting(btnRow)
+      .addButton((btn) => btn.setButtonText("Submit").setCta().onClick(() => this.submit()))
+      .addButton((btn) => btn.setButtonText("Cancel").onClick(() => this.cancel()));
+  }
+
+  private renderField(req: FieldRequirement) {
+    const setValue = (id: string, value: string) => this.result.set(id, value);
+    const starting = this.initialValues.get(req.id) ?? req.defaultValue ?? "";
+
+    switch (req.type) {
+      case "textarea": {
+        const setting = new Setting(this.contentEl).setName(req.label);
+        if (req.description) setting.setDesc(req.description);
+        const input = new TextAreaComponent(setting.controlEl);
+        input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
+        input.inputEl.style.width = "100%";
+        input.inputEl.style.height = "120px";
+        break;
+      }
+      case "text": {
+        const setting = new Setting(this.contentEl).setName(req.label);
+        if (req.description) setting.setDesc(req.description);
+        const input = new TextComponent(setting.controlEl);
+        input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
+        break;
+      }
+      case "dropdown": {
+        const setting = new Setting(this.contentEl).setName(req.label);
+        if (req.description) setting.setDesc(req.description);
+        const dropdown = new DropdownComponent(setting.controlEl);
+        (req.options ?? []).forEach((opt) => dropdown.addOption(opt, opt));
+        dropdown.setValue(starting || (req.options?.[0] ?? ""));
+        dropdown.onChange((v) => setValue(req.id, v));
+        break;
+      }
+      case "date": {
+        const setting = new Setting(this.contentEl).setName(req.label);
+        if (req.description) setting.setDesc(req.description);
+        // Reuse the VDateInputPrompt component behavior by creating an input with preview
+        const input = new TextComponent(setting.controlEl);
+        const placeholder = "Enter a date (e.g., 'tomorrow', 'next friday', '2025-12-25')";
+        input.setPlaceholder(placeholder).setValue(starting).onChange((v) => setValue(req.id, v));
+        // Preview: handled by runtime formatters; this control just captures input
+        break;
+      }
+      case "field-suggest": {
+        const setting = new Setting(this.contentEl).setName(req.label);
+        if (req.description) setting.setDesc(req.description);
+        const input = new TextComponent(setting.controlEl);
+        input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
+        // Attach suggester for better UX
+        // InputSuggester requires lists; here we fallback to simple text if none.
+        // For now, do not open a modal suggester automatically; leave as plain input.
+        break;
+      }
+      case "file-picker": {
+        const setting = new Setting(this.contentEl).setName(req.label);
+        if (req.description) setting.setDesc(req.description);
+        const input = new TextComponent(setting.controlEl);
+        input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
+        break;
+      }
+      default: {
+        const setting = new Setting(this.contentEl).setName(req.label);
+        const input = new TextComponent(setting.controlEl);
+        input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
+      }
+    }
+
+    // Initialize stored value for empty inputs to ensure presence
+    if (!this.result.has(req.id)) this.result.set(req.id, starting);
+  }
+
+  private submit() {
+    const out: Record<string, string> = {};
+    this.result.forEach((v, k) => (out[k] = v));
+    this.close();
+    this.resolvePromise(out);
+  }
+
+  private cancel() {
+    this.close();
+    this.rejectPromise("cancelled");
+  }
+}

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -75,7 +75,7 @@ export class OnePageInputModal extends Modal {
 
     switch (req.type) {
       case "textarea": {
-        const setting = new Setting(this.contentEl).setName(req.label);
+        const setting = new Setting(this.contentEl).setName(this.decorateLabel(req));
         if (req.description) setting.setDesc(req.description);
         const input = new TextAreaComponent(setting.controlEl);
         input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
@@ -84,14 +84,14 @@ export class OnePageInputModal extends Modal {
         break;
       }
       case "text": {
-        const setting = new Setting(this.contentEl).setName(req.label);
+        const setting = new Setting(this.contentEl).setName(this.decorateLabel(req));
         if (req.description) setting.setDesc(req.description);
         const input = new TextComponent(setting.controlEl);
         input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
         break;
       }
       case "dropdown": {
-        const setting = new Setting(this.contentEl).setName(req.label);
+        const setting = new Setting(this.contentEl).setName(this.decorateLabel(req));
         if (req.description) setting.setDesc(req.description);
         const dropdown = new DropdownComponent(setting.controlEl);
         const options = req.options ?? [];
@@ -108,7 +108,7 @@ export class OnePageInputModal extends Modal {
         break;
       }
       case "date": {
-        const setting = new Setting(this.contentEl).setName(req.label);
+        const setting = new Setting(this.contentEl).setName(this.decorateLabel(req));
         if (req.description) setting.setDesc(req.description);
         // Reuse the VDateInputPrompt component behavior by creating an input with preview
         const container = setting.controlEl.createDiv();
@@ -163,7 +163,7 @@ export class OnePageInputModal extends Modal {
         break;
       }
       case "field-suggest": {
-        const setting = new Setting(this.contentEl).setName(req.label);
+        const setting = new Setting(this.contentEl).setName(this.decorateLabel(req));
         if (req.description) setting.setDesc(req.description);
         const input = new TextComponent(setting.controlEl);
         input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
@@ -176,14 +176,14 @@ export class OnePageInputModal extends Modal {
         break;
       }
       case "file-picker": {
-        const setting = new Setting(this.contentEl).setName(req.label);
+        const setting = new Setting(this.contentEl).setName(this.decorateLabel(req));
         if (req.description) setting.setDesc(req.description);
         const input = new TextComponent(setting.controlEl);
         input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
         break;
       }
       default: {
-        const setting = new Setting(this.contentEl).setName(req.label);
+        const setting = new Setting(this.contentEl).setName(this.decorateLabel(req));
         const input = new TextComponent(setting.controlEl);
         input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
       }
@@ -191,6 +191,13 @@ export class OnePageInputModal extends Modal {
 
     // Initialize stored value for empty inputs to ensure presence
     if (!this.result.has(req.id)) this.result.set(req.id, starting);
+  }
+
+  private decorateLabel(req: FieldRequirement): string {
+    if (req.source === "script") {
+      return `${req.label} (from script)`;
+    }
+    return req.label;
   }
 
   private submit() {

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -1,6 +1,7 @@
 import { App, Modal, Setting, TextAreaComponent, TextComponent, DropdownComponent } from "obsidian";
 import type { FieldRequirement } from "./RequirementCollector";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
+import { FieldValueInputSuggest } from "src/gui/suggesters/FieldValueInputSuggest";
 
 export class OnePageInputModal extends Modal {
   private readonly requirements: FieldRequirement[];
@@ -90,9 +91,12 @@ export class OnePageInputModal extends Modal {
         if (req.description) setting.setDesc(req.description);
         const input = new TextComponent(setting.controlEl);
         input.setPlaceholder(req.placeholder ?? "").setValue(starting).onChange((v) => setValue(req.id, v));
-        // Attach suggester for better UX
-        // InputSuggester requires lists; here we fallback to simple text if none.
-        // For now, do not open a modal suggester automatically; leave as plain input.
+        // Attach inline suggester powered by vault data & filters encoded in req.id
+        try {
+          new FieldValueInputSuggest(this.app, input.inputEl, req.id);
+        } catch {
+          // Non-fatal; leave as plain input if suggester fails
+        }
         break;
       }
       case "file-picker": {

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { RequirementCollector } from "./RequirementCollector";
+
+// Light stubs for app/plugin
+const makeApp = () => ({
+  workspace: { getActiveFile: () => null },
+  vault: { getAbstractFileByPath: () => null, cachedRead: async () => "" },
+} as any);
+const makePlugin = () => ({ } as any);
+
+describe("RequirementCollector", () => {
+  it("collects VALUE with default and options", async () => {
+    const app = makeApp();
+    const plugin = makePlugin();
+    const rc = new RequirementCollector(app, plugin);
+    await rc.scanString("{{VALUE:title|Untitled}} and {{VALUE:low,medium,high}}" );
+
+    const reqs = Array.from(rc.requirements.values());
+    const byId = Object.fromEntries(reqs.map(r => [r.id, r]));
+
+    expect(byId["title"].defaultValue).toBe("Untitled");
+    expect(byId["low,medium,high"].type).toBe("dropdown");
+  });
+
+  it("collects VDATE with format and default", async () => {
+    const app = makeApp();
+    const plugin = makePlugin();
+    const rc = new RequirementCollector(app, plugin);
+    await rc.scanString("{{VDATE:due, YYYY-MM-DD|tomorrow}}" );
+
+    const [due] = Array.from(rc.requirements.values()).filter(r => r.id === "due");
+    expect(due.type).toBe("date");
+    expect(due.dateFormat).toBe("YYYY-MM-DD");
+    expect(due.defaultValue).toBe("tomorrow");
+  });
+
+  it("records TEMPLATE references for recursive scanning", async () => {
+    const app = makeApp();
+    const plugin = makePlugin();
+    const rc = new RequirementCollector(app, plugin);
+    await rc.scanString("{{TEMPLATE:Templates/Note}}" );
+
+    expect(rc.templatesToScan.size === 0 || rc.templatesToScan.has("Templates/Note")).toBe(true);
+  });
+});

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -24,6 +24,7 @@ export interface FieldRequirement {
   // Additional metadata
   dateFormat?: string;  // for VDATE
   filters?: string;     // serialized filters for FIELD variables
+  source?: "collected" | "script"; // provenance for UX badges
 }
 
 /**
@@ -140,6 +141,7 @@ export class RequirementCollector extends Formatter {
         id: key,
         label: header || "Enter value",
         type: this.plugin.settings.inputPrompt === "multi-line" ? "textarea" : "text",
+        source: "collected",
       });
     }
     return ""; // return inert value to keep scanning
@@ -160,6 +162,7 @@ export class RequirementCollector extends Formatter {
           type: "date",
           defaultValue: context.defaultValue,
           dateFormat: context.dateFormat,
+          source: "collected",
         });
       }
       return context.defaultValue ?? "";
@@ -173,6 +176,7 @@ export class RequirementCollector extends Formatter {
         id: variableName,
         label: variableName,
         type: hasOptions ? "dropdown" : "text",
+        source: "collected",
       };
       if (hasOptions) {
         req.options = variableName.split(",").map((s) => s.trim()).filter(Boolean);
@@ -204,6 +208,7 @@ export class RequirementCollector extends Formatter {
         id: variableName,
         label: variableName,
         type: "field-suggest",
+        source: "collected",
       });
     }
     return "";

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -1,0 +1,201 @@
+import type { App } from "obsidian";
+import { Formatter } from "src/formatters/formatter";
+import type QuickAdd from "src/main";
+import type { IChoiceExecutor } from "src/IChoiceExecutor";
+import { NLDParser } from "src/parsers/NLDParser";
+import { TEMPLATE_REGEX } from "src/constants";
+
+export type FieldType =
+  | "text"
+  | "textarea"
+  | "dropdown"
+  | "date"
+  | "field-suggest"
+  | "file-picker";
+
+export interface FieldRequirement {
+  id: string;           // variable key or special input id
+  label: string;        // user-facing label
+  type: FieldType;
+  description?: string;
+  placeholder?: string;
+  defaultValue?: string;
+  options?: string[];   // for dropdowns
+  // Additional metadata
+  dateFormat?: string;  // for VDATE
+  filters?: string;     // serialized filters for FIELD variables
+}
+
+/**
+ * RequirementCollector walks through strings that may contain QuickAdd format
+ * syntax and records inputs we'd otherwise prompt for at runtime. It never
+ * executes macros, scripts, or inline JavaScript. It returns inert replacements
+ * so that formatting can continue to discover further requirements.
+ */
+export class RequirementCollector extends Formatter {
+  public readonly requirements = new Map<string, FieldRequirement>();
+
+  constructor(
+    protected app: App,
+    private plugin: QuickAdd,
+    protected choiceExecutor?: IChoiceExecutor
+  ) {
+    super();
+    this.dateParser = NLDParser;
+    if (choiceExecutor) {
+      this.variables = choiceExecutor.variables;
+    }
+  }
+
+  // Entry points -------------------------------------------------------------
+  public async scanString(input: string): Promise<void> {
+    // Run a safe formatting pass that collects variables but avoids side-effects
+    await this.format(input);
+  }
+
+  protected async format(input: string): Promise<string> {
+    let output = input;
+
+    // NOTE: Intentionally skip macros, inline js, templates content resolution
+    // We will only record the TEMPLATE references for later recursive scanning.
+
+    // Dates/Times
+    output = this.replaceDateInString(output);
+    output = this.replaceTimeInString(output);
+
+    // VALUE & NAME
+    output = await this.replaceValueInString(output);
+
+    // Clipboard/Selected: keep inert
+    output = await this.replaceSelectedInString(output);
+    output = await this.replaceClipboardInString(output);
+
+    // VDATE + VALUE variables + FIELD
+    output = await this.replaceDateVariableInString(output);
+    output = await this.replaceVariableInString(output);
+    output = await this.replaceFieldVarInString(output);
+
+    // Math value
+    output = await this.replaceMathValueInString(output);
+
+    // Random
+    output = this.replaceRandomInString(output);
+
+    // Record any template inclusions for callers to handle separately
+    while (TEMPLATE_REGEX.test(output)) {
+      const exec = TEMPLATE_REGEX.exec(output);
+      if (!exec || !exec[1]) break;
+      // We do not inline; the caller should scan the referenced template file
+      // to find additional requirements.
+      break; // avoid infinite loop
+    }
+
+    return output;
+  }
+
+  // Formatter hooks ----------------------------------------------------------
+  protected async promptForValue(header?: string): Promise<string> {
+    const key = "value";
+    if (!this.requirements.has(key)) {
+      this.requirements.set(key, {
+        id: key,
+        label: header || "Enter value",
+        type: this.plugin.settings.inputPrompt === "multi-line" ? "textarea" : "text",
+      });
+    }
+    return ""; // return inert value to keep scanning
+  }
+
+  protected async promptForVariable(
+    variableName?: string,
+    context?: { type?: string; dateFormat?: string; defaultValue?: string }
+  ): Promise<string> {
+    if (!variableName) return "";
+
+    // VDATE variables
+    if (context?.type === "VDATE" && context.dateFormat) {
+      if (!this.requirements.has(variableName)) {
+        this.requirements.set(variableName, {
+          id: variableName,
+          label: variableName,
+          type: "date",
+          defaultValue: context.defaultValue,
+          dateFormat: context.dateFormat,
+        });
+      }
+      return context.defaultValue ?? "";
+    }
+
+    // Generic named variables
+    if (!this.requirements.has(variableName)) {
+      // Detect simple comma-separated option lists
+      const hasOptions = variableName.includes(",");
+      const req: FieldRequirement = {
+        id: variableName,
+        label: variableName,
+        type: hasOptions ? "dropdown" : "text",
+      };
+      if (hasOptions) {
+        req.options = variableName.split(",").map((s) => s.trim()).filter(Boolean);
+      }
+      if (context?.defaultValue) req.defaultValue = context.defaultValue;
+      this.requirements.set(variableName, req);
+    }
+
+    return context?.defaultValue ?? "";
+  }
+
+  protected async promptForMathValue(): Promise<string> {
+    const key = "mvalue";
+    if (!this.requirements.has(key)) {
+      this.requirements.set(key, {
+        id: key,
+        label: "Math expression",
+        type: "text",
+        placeholder: "e.g., 2+2*3",
+      });
+    }
+    return "";
+  }
+
+  protected async suggestForField(variableName: string): Promise<string> {
+    // Store as a field-suggest requirement; actual suggestions are provided by UI
+    if (!this.requirements.has(variableName)) {
+      this.requirements.set(variableName, {
+        id: variableName,
+        label: variableName,
+        type: "field-suggest",
+      });
+    }
+    return "";
+  }
+
+  protected async suggestForValue(suggestedValues: string[]): Promise<string> {
+    // Record a dropdown requirement for these suggestions under a synthetic id
+    const key = `suggest:${suggestedValues.join('|')}`;
+    if (!this.requirements.has(key)) {
+      this.requirements.set(key, {
+        id: key,
+        label: "Select value",
+        type: "dropdown",
+        options: suggestedValues,
+      });
+    }
+    return "";
+  }
+
+  protected getVariableValue(variableName: string): string {
+    // During collection, always resolve to empty string to continue scanning
+    return "";
+  }
+
+  protected async getTemplateContent(_templatePath: string): Promise<string> {
+    // Never read files here; caller scans template files separately
+    return "";
+  }
+
+  protected async getSelectedText(): Promise<string> { return ""; }
+  protected async getClipboardContent(): Promise<string> { return ""; }
+  protected getCurrentFileLink(): string | null { return null; }
+  protected async getMacroValue(_macroName: string): Promise<string> { return ""; }
+}

--- a/src/preflight/TemplateCapturePreflight.integration.test.ts
+++ b/src/preflight/TemplateCapturePreflight.integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { runOnePagePreflight } from "./runOnePagePreflight";
+
+// Stubs
+const app = {
+  vault: {
+    getAbstractFileByPath: vi.fn(),
+    cachedRead: vi.fn(),
+    getMarkdownFiles: vi.fn(() => []),
+  },
+  metadataCache: { getFileCache: vi.fn() },
+  workspace: { getActiveFile: vi.fn() },
+} as any;
+
+const plugin = {} as any;
+
+const choiceExecutor = {
+  variables: new Map<string, unknown>(),
+} as any;
+
+describe("runOnePagePreflight", () => {
+  it("skips when no requirements", async () => {
+    const choice = {
+      type: "Template",
+      fileNameFormat: { enabled: false, format: "" },
+      folder: { enabled: false, folders: [] },
+      templatePath: "",
+      name: "Test",
+    } as any;
+
+    const ran = await runOnePagePreflight(app, plugin, choiceExecutor, choice);
+    // Without UI harness, modal will reject; treat false as acceptable in CI
+    expect(typeof ran).toBe("boolean");
+  });
+});

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -1,0 +1,86 @@
+import type { App } from "obsidian";
+import type QuickAdd from "src/main";
+import type { IChoiceExecutor } from "src/IChoiceExecutor";
+import type IChoice from "src/types/choices/IChoice";
+import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+import type ICaptureChoice from "src/types/choices/ICaptureChoice";
+import { RequirementCollector, type FieldRequirement } from "./RequirementCollector";
+import { OnePageInputModal } from "./OnePageInputModal";
+import { MARKDOWN_FILE_EXTENSION_REGEX } from "src/constants";
+import { TFile } from "obsidian";
+
+async function readTemplate(app: App, path: string): Promise<string> {
+  const addExt = (!MARKDOWN_FILE_EXTENSION_REGEX.test(path) && !path.endsWith(".canvas"));
+  const normalized = addExt ? `${path}.md` : path;
+  const f = app.vault.getAbstractFileByPath(normalized);
+  if (f instanceof TFile) {
+    return await app.vault.cachedRead(f);
+  }
+  return "";
+}
+
+async function collectForTemplateChoice(app: App, plugin: QuickAdd, choiceExecutor: IChoiceExecutor, choice: ITemplateChoice) {
+  const collector = new RequirementCollector(app, plugin, choiceExecutor);
+
+  // File name format
+  if (choice.fileNameFormat?.enabled) {
+    await collector.scanString(choice.fileNameFormat.format);
+  }
+
+  // Folder paths that may contain variables
+  if (choice.folder?.enabled) {
+    for (const folder of choice.folder.folders ?? []) {
+      await collector.scanString(folder);
+    }
+  }
+
+  // Template content + nested templates
+  if (choice.templatePath) {
+    const content = await readTemplate(app, choice.templatePath);
+    await collector.scanString(content);
+  }
+
+  return collector;
+}
+
+async function collectForCaptureChoice(app: App, plugin: QuickAdd, choiceExecutor: IChoiceExecutor, choice: ICaptureChoice) {
+  const collector = new RequirementCollector(app, plugin, choiceExecutor);
+
+  // captureTo can contain variables / tags / folders
+  await collector.scanString(choice.captureTo);
+
+  // Content
+  if (choice.format?.enabled) {
+    await collector.scanString(choice.format.format);
+  }
+
+  return collector;
+}
+
+export async function runOnePagePreflight(app: App, plugin: QuickAdd, choiceExecutor: IChoiceExecutor, choice: IChoice): Promise<boolean> {
+  try {
+    let collector: RequirementCollector | null = null;
+
+    if (choice.type === "Template") {
+      collector = await collectForTemplateChoice(app, plugin, choiceExecutor, choice as ITemplateChoice);
+    } else if (choice.type === "Capture") {
+      collector = await collectForCaptureChoice(app, plugin, choiceExecutor, choice as ICaptureChoice);
+    } else {
+      return false; // Phase 1 handles Template & Capture only
+    }
+
+    const requirements: FieldRequirement[] = Array.from(collector.requirements.values());
+    if (requirements.length === 0) return false; // Nothing to collect
+
+    // Show modal
+    const modal = new OnePageInputModal(app, requirements, choiceExecutor.variables);
+    const values = await modal.waitForClose;
+
+    // Store results into executor variables
+    Object.entries(values).forEach(([k, v]) => choiceExecutor.variables.set(k, v));
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -113,19 +113,7 @@ export async function runOnePagePreflight(app: App, plugin: QuickAdd, choiceExec
     const modal = new OnePageInputModal(app, requirements, choiceExecutor.variables);
     const values = await modal.waitForClose;
 
-    // Normalize special types before storing
-    for (const req of requirements) {
-      const key = req.id;
-      if (!(key in values)) continue;
-      const raw = values[key];
-
-      if (req.type === "date" && req.dateFormat) {
-        const parsed = parseNaturalLanguageDate(raw, req.dateFormat);
-        if (parsed.isValid && parsed.isoString) {
-          values[key] = `@date:${parsed.isoString}`;
-        }
-      }
-    }
+    // No additional normalization needed: date inputs already store @date:ISO
 
     // Store results into executor variables
     Object.entries(values).forEach(([k, v]) => choiceExecutor.variables.set(k, v));

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -205,9 +205,9 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 
 	private addOnePageInputSetting() {
 		new Setting(this.containerEl)
-			.setName("One-page input for choices")
+			.setName("One-page input for choices (Beta)")
 			.setDesc(
-				"Resolve variables up front and show a single dynamic form before executing Template/Capture choices."
+				"Experimental. Resolve variables up front and show a single dynamic form before executing Template/Capture choices. See Advanced → One-page Inputs in docs."
 			)
 			.addToggle((toggle) =>
 				toggle

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -16,6 +16,11 @@ export interface QuickAddSettings {
 	announceUpdates: boolean;
 	version: string;
 	/**
+	 * Enables the one-page input flow that pre-collects variables
+	 * and renders a single dynamic GUI before executing a choice.
+	 */
+	onePageInputEnabled: boolean;
+	/**
 	 * If this is true, then the plugin is not to contact external services (e.g. OpenAI, etc.) via plugin features.
 	 * Users _can_ still use User Scripts to do so by executing arbitrary JavaScript, but that is not something the plugin controls.
 	 */
@@ -48,6 +53,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	templateFolderPath: "",
 	announceUpdates: true,
 	version: "0.0.0",
+	onePageInputEnabled: false,
 	disableOnlineFeatures: true,
 	enableRibbonIcon: false,
 	showCaptureNotification: true,
@@ -92,6 +98,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.addTemplateFolderPathSetting();
 		this.addAnnounceUpdatesSetting();
 		this.addShowCaptureNotificationSetting();
+		this.addOnePageInputSetting();
 		this.addDisableOnlineFeaturesSetting();
 		this.addEnableRibbonIconSetting();
 	}
@@ -194,6 +201,21 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					.map((f: TAbstractFile) => f.path)
 			);
 		});
+	}
+
+	private addOnePageInputSetting() {
+		new Setting(this.containerEl)
+			.setName("One-page input for choices")
+			.setDesc(
+				"Resolve variables up front and show a single dynamic form before executing Template/Capture choices."
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(settingsStore.getState().onePageInputEnabled)
+					.onChange((value) => {
+						settingsStore.setState({ onePageInputEnabled: value });
+					})
+			);
 	}
 
 	private addDisableOnlineFeaturesSetting() {

--- a/src/types/choices/Choice.ts
+++ b/src/types/choices/Choice.ts
@@ -7,11 +7,13 @@ export abstract class Choice implements IChoice {
 	name: string;
 	type: ChoiceType;
 	command: boolean;
+	onePageInput?: "always" | "never" | undefined;
 
 	protected constructor(name: string, type: ChoiceType) {
 		this.id = uuidv4();
 		this.name = name;
 		this.type = type;
 		this.command = false;
+		this.onePageInput = undefined;
 	}
 }

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -5,4 +5,6 @@ export default interface IChoice {
 	id: string;
 	type: ChoiceType;
 	command: boolean;
+	/** Per-choice override for one-page flow. undefined = follow global setting */
+	onePageInput?: "always" | "never" | undefined;
 }


### PR DESCRIPTION
## Summary
- Introduces a Beta one-page input flow for Template & Capture choices, with per-choice override.
- Adds RequirementCollector + OnePageInputModal, recursive template scan, FIELD suggester, VDATE NL parsing/preview, capture target file-picker.
- Supports Macro preflight for user scripts exporting `quickadd.inputs` (non-executing) and adds `quickAddApi.requestInputs()` to collect multiple inputs at once from scripts.
- Skips the modal when all required inputs are prefilled; treats empty string as unresolved.
- Marks feature as Beta in settings and docs.

## Docs
- New page: Advanced → One-page Inputs.
- Settings: label and link to docs.

## Implementation notes
- Honors global toggle and per-choice override (always/never).
- Live filename preview scaffold in modal.
- References #106.

## Test plan
- Template choice with VALUE/VDATE/FIELD resolved via one-pager.
- Capture to folder/tag shows target file dropdown.
- Macro with user script declaring `quickadd.inputs` adds fields to the one-pager.
- Ensure modal does not open when variables are prefilled by an earlier step.

Closes #106