### PR TITLE
fix: adjust mobile styles for multi-line input prompt and clean up me…

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -39,6 +39,10 @@
 
 /* Mobile */
 @media screen and (max-width: 540px) {
+    .qaWideInputPrompt .modal {
+        bottom: 10vh;
+    }
+
 	.macroContainer1 {
 		grid-template-columns: repeat(1, 1fr);
 	}
@@ -52,39 +56,17 @@
 	}
 
 	.wideInputPromptInputEl {
-		width: 20rem;
-		max-width: 100%;
-		height: 3rem;
-		direction: inherit;
-		text-align: inherit;
-	}
-}
-
-/* Tablet */
-@media screen and (max-width: 540px) and (max-width: 780px) {
-	.macroContainer1 {
-		grid-template-columns: repeat(1, 1fr);
-	}
-
-	.macroContainer2 {
-		grid-template-columns: repeat(2, 1fr);
-	}
-
-	.macroContainer3 {
-		grid-template-columns: repeat(2, 1fr);
-	}
-
-	.wideInputPromptInputEl {
-		width: 30rem;
-		max-width: 100%;
-		height: 20rem;
+		width: 100%;
+        min-width: 100%;
+        max-width: 100%;
+		height: 6rem;
 		direction: inherit;
 		text-align: inherit;
 	}
 }
 
 /* Everything else */
-@media screen and (min-width: 781px) {
+@media screen and (min-width: 541px) {
 	.macroContainer1 {
 		grid-template-columns: repeat(1, 1fr);
 	}


### PR DESCRIPTION
### Motivation

When the "Use Multi-line Input Prompt" option was enabled, the input dialog was displayed incorrectly:

- On mobile devices, the intended styles were overridden by the faulty “tablet” media query. The input happened to take the full width only by accident, but the mobile-specific layout was broken. The input field had too large a height and was positioned too low, so it slid under the on-screen keyboard.
- On tablets, styles did not apply at all due to the incorrect media query::

```
@media screen and (max-width: 540px) and (max-width: 780px) { ... }
```

As a result, the dialog looked broken.

In addition, the tablet-specific block only differed from desktop by setting a fixed input width, which was unnecessary and actually degraded the layout.

### Changes

- Fixed the mobile media query so that mobile-specific styles are now correctly applied.
- On mobile devices:
  - the modal is shifted above the keyboard (bottom: 10vh),
  - the input field height was increased (6rem), while keeping the correct width behavior.
- Removed the tablet-specific block: tablets now use desktop styles, which simplifies the layout and improves usability (input takes full width).

### Screenshots

Before (mobile):  
<img src="https://github.com/user-attachments/assets/79ee6991-e5cf-4e28-8424-0701d7ed9e73" width="300" />

After (mobile):  
<img src="https://github.com/user-attachments/assets/50e62aec-002e-404d-854c-aa97f0897277" width="300" />

Before (tablet):  
<img src="https://github.com/user-attachments/assets/3f070984-0d77-440f-944b-6f38062ce155" width="400" />

After (tablet):  
<img src="https://github.com/user-attachments/assets/61f9aa20-8429-45ff-9d80-83265202a6d7" width="400" />