### PR TITLE
fix(capture): prevent captured content loss on newly created files

### DIFF
--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -394,7 +394,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			await overwriteTemplaterOnce(this.app, file);
 		}
 
-		const updatedFileContent: string = await this.app.vault.cachedRead(file);
+		// Read the file fresh from disk to avoid any potential cached content
+		// after the initial Templater run on newly created files.
+		const updatedFileContent: string = await this.app.vault.read(file);
 		// Second formatting pass: embed the already-resolved capture content into the newly created file
 		const newFileContent: string = await this.formatter.formatContentWithFile(
 			formattedCaptureContent,

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -142,7 +142,13 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				}
 			} else {
 				await this.app.vault.modify(file, newFileContent);
-				await overwriteTemplaterOnce(this.app, file);
+				// Only run a final whole-file Templater pass when the file already existed.
+				// For newly created files, we have already rendered the template once during creation
+				// and inserting the capture afterward. Running Templater again risks clobbering
+				// the just-inserted capture content.
+				if (fileAlreadyExists) {
+					await overwriteTemplaterOnce(this.app, file);
+				}
 			}
 
 			// Show success notification

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -142,13 +142,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				}
 			} else {
 				await this.app.vault.modify(file, newFileContent);
-				// Only run a final whole-file Templater pass when the file already existed.
-				// For newly created files, we have already rendered the template once during creation
-				// and inserting the capture afterward. Running Templater again risks clobbering
-				// the just-inserted capture content.
-				if (fileAlreadyExists) {
-					await overwriteTemplaterOnce(this.app, file);
-				}
+				await overwriteTemplaterOnce(this.app, file);
 			}
 
 			// Show success notification


### PR DESCRIPTION
Summary
- Symptom: In some capture flows that create a file then insert content, the capture line could be lost or moved after a final whole-file Templater pass.

Root Cause
- After creating a new file from a template, we ran Templater on the file and then read it with vault.cachedRead before embedding the capture. cachedRead can return stale content right after a write/render, making us insert into an outdated buffer. A subsequent whole-file Templater pass would then rewrite sections and effectively clobber or relocate the capture.

Fix
- New-file path now reads the file directly from disk with vault.read after the initial Templater run to guarantee fresh content before embedding the capture.
- We retain the final whole-file Templater pass for all captures. Because the capture is now embedded into the actually-rendered file content, the pass no longer clobbers captures. overwriteTemplaterOnce already waits for file mtime stability to mitigate race conditions.

Code Changes
- src/engine/CaptureChoiceEngine.ts: use vault.read after the first Templater run in onCreateFileIfItDoesntExist; always run the final overwriteTemplaterOnce pass in run().

Notes
- Initial investigation considered skipping the final pass for newly created files. With the stale-read fixed, the final pass works reliably and is kept to ensure any file-level Templater logic and capture-introduced tokens are rendered.
- Additional safeguards (e.g., marker-based protection or token heuristics) can be added later if needed.