### PR TITLE
feat(api): custom renderer for suggester (closes #898)

### DIFF
--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -119,6 +119,7 @@ export class QuickAddApi {
 				actualItems: string[],
 				placeholder?: string,
 				allowCustomInput = false,
+				options?: { renderItem?: (value: string, el: HTMLElement) => void },
 			) => {
 				return QuickAddApi.suggester(
 					app,
@@ -126,6 +127,7 @@ export class QuickAddApi {
 					actualItems,
 					placeholder,
 					allowCustomInput,
+					options,
 				);
 			},
 			checkboxPrompt: (items: string[], selectedItems?: string[]) => {
@@ -520,6 +522,7 @@ export class QuickAddApi {
 		actualItems: string[],
 		placeholder?: string,
 		allowCustomInput = false,
+		options?: { renderItem?: (value: string, el: HTMLElement) => void },
 	) {
 		try {
 			let displayedItems;
@@ -535,7 +538,12 @@ export class QuickAddApi {
 					app,
 					displayedItems as string[],
 					actualItems,
-					placeholder ? { placeholder } : {},
+					{
+						...(placeholder ? { placeholder } : {}),
+						...(options?.renderItem
+							? { renderItem: options.renderItem }
+							: {}),
+					},
 				);
 			}
 
@@ -544,6 +552,7 @@ export class QuickAddApi {
 				displayedItems as string[],
 				actualItems,
 				placeholder,
+				options?.renderItem,
 			);
 		} catch {
 			return undefined;


### PR DESCRIPTION
This PR implements an optional custom renderer for the QuickAdd API suggester.

Summary
- Add `options.renderItem?: (value: string, el: HTMLElement) => void` to `quickAddApi.suggester(...)`
- Thread the renderer to both `GenericSuggester` and `InputSuggester`
- Override `renderSuggestion` to call the custom renderer, and safely fall back to default if it throws
- Update docs with usage examples (two runnable user scripts)

Motivation (from issue #898)
> Is your feature request related to a problem? Please describe.
> I want to be able to custom render my suggestions when using the API.
>
> Describe the solution you'd like
> The suggest API endpoint takes an optional render function which then passes the value & HTML Element and lets us define / render it ourselves.
>
> Describe alternatives you've considered
> I thought about just building my own class to take care of this but I can't extend base Obsidian classes in user scripts.
>
> Additional context
> I'm happy to do this myself but just want to know if it'd be accepted.

Implementation details
- `src/gui/GenericSuggester/genericSuggester.ts`: add optional `renderItem` and call it inside `renderSuggestion`
- `src/gui/InputSuggester/inputSuggester.ts`: extend options with `renderItem` and call inside `renderSuggestion`
- `src/quickAddApi.ts`: extend `suggester` to accept `options.renderItem` and forward accordingly
- Docs updated in `docs/docs/QuickAddAPI.md` and `docs/docs/SuggesterSystem.md`

Backwards compatibility
- Existing API calls are unchanged and continue to use default fuzzy-highlight rendering when no renderer is provided.

Docs
- Added two runnable examples to QuickAdd API docs: one custom-rendered list and one allowing custom input with tailored rendering.

Closes #898
