### PR TITLE
fix(file-suggester): prevent crash on "[[@" by guarding Fuse results (closes #892)

### DIFF
--- a/src/gui/suggesters/FileIndex.ts
+++ b/src/gui/suggesters/FileIndex.ts
@@ -565,6 +565,11 @@ export class FileIndex {
 		}
 
 		for (const result of fuseResults) {
+			// Defensive: skip malformed Fuse results
+			if (!result || !result.item || !result.item.path) {
+				continue;
+			}
+
 			// Skip if already added
 			if (addedPaths.has(result.item.path)) {
 				continue;
@@ -852,6 +857,11 @@ export class FileIndex {
 		}
 
 		for (const result of fuseResults) {
+			// Defensive: skip malformed Fuse results
+			if (!result || !result.item || !result.item.path) {
+				continue;
+			}
+
 			if (addedPaths.has(result.item.path)) {
 				continue;
 			}


### PR DESCRIPTION
This fixes a crash when typing "[[@" in QuickAdd’s link suggester.

Root cause
- In , the Fuse.js result loops immediately read . Under some edge cases (e.g., during incremental index updates) Fuse can yield a transient result with a missing , leading to .

Fix
- Add defensive guards in both Fuse result loops to skip malformed results (check , , and ).

Impact
- No change to ranking or behavior for valid results. The suggester closes gracefully when there are no valid matches instead of throwing.

References
- Closes #892
