### PR TITLE
fix(preflight): restore One Page Input modal by avoiding mutation of executor variables during requirements scan

### DIFF
--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -45,7 +45,10 @@ export class RequirementCollector extends Formatter {
 		super();
 		this.dateParser = NLDParser;
 		if (choiceExecutor) {
-			this.variables = choiceExecutor.variables;
+			// Use a shallow copy to avoid mutating the executor's live variables
+			// during preflight scanning. This ensures unresolved detection works
+			// and the One Page Input modal is shown when needed.
+			this.variables = new Map(choiceExecutor.variables);
 		}
 	}
 


### PR DESCRIPTION
Clone the executor variables map in `RequirementCollector` so preflight scanning does not prefill empty strings into the live variables store.

- Problem: `RequirementCollector` wrote empty values to `choiceExecutor.variables` during preflight, causing the unresolved check to treat inputs as resolved and skip the One Page Input modal.
- Fix: Use a shallow copy of the executor variables during preflight so scanning is side‑effect free.
- Impact: Restores the one‑page form for Capture/Template choices that include tokens like `{{VALUE:alpha}}` and `{{VALUE:bravo}}`. No behavior change outside preflight.

Closes #916.
