### PR TITLE
feat(settings): add fuzzy filter to Choices list

### DIFF
--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -10,6 +10,8 @@
     export let choices: IChoice[] = [];
     export let roots: IChoice[] | undefined;
     export let app: App;
+    // When true, keeps drag disabled regardless of user action
+    export let forceDragDisabled: boolean = false;
     let collapseId: string;
     let dragDisabled: boolean = true;
 
@@ -47,6 +49,7 @@
     }
 
     function startDrag(e: Event) {
+        if (forceDragDisabled) return; // Do not enable drag while forcing disabled (e.g., during filtering)
         // prevent focus/selection side-effects before enabling drag
         // @ts-ignore
         if (typeof e?.preventDefault === 'function') e.preventDefault();


### PR DESCRIPTION
Adds a fuzzy filter to the Choices list in Settings.

- Uses Obsidian's `prepareFuzzySearch` for matching.
- Auto-expands Multi choices that match or contain matching descendants while filtering (original collapse state is preserved and restored when the filter is cleared).
- Disables drag-and-drop and reordering during filtering to avoid corrupting order when viewing a filtered subset.
- Adds a clear button and ESC-to-clear in the filter input.

This does not persist the filter, does not add regex mode, and does not highlight matches.

Closes #744.
