### PR TITLE
feat: add multi-select support to suggester field type

### DIFF
--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -83,7 +83,7 @@ Supported input fields:
 - `options` (string[] for dropdown and suggester)
 - `dateFormat` (string for date)
 - `description` (string)
-- `suggesterConfig` (object for suggester: `{ allowCustomInput?: boolean, caseSensitive?: boolean }`)
+- `suggesterConfig` (object for suggester: `{ allowCustomInput?: boolean, caseSensitive?: boolean, multiSelect?: boolean }`)
 
 **Field Type Details:**
 - `text`: Single-line text input
@@ -92,6 +92,8 @@ Supported input fields:
 - `date`: Date input with natural language support
 - `field-suggest`: Vault field suggestions (uses `{{FIELD:...}}` syntax)
 - `suggester`: **NEW** - Searchable autocomplete with custom options (allows typing custom values)
+  - Supports multi-select mode via `suggesterConfig.multiSelect: true`
+  - Multi-select: Select multiple items, separated by commas. Suggestions stay open after each selection.
 
 In the modal these inputs are labeled “(from script)”.
 
@@ -132,16 +134,41 @@ export default async function entry({ quickAddApi, app }) {
     .array() ?? ["Inbox"];
 
   const values = await quickAddApi.requestInputs([
-    { 
-      id: "project", 
-      label: "Select Project", 
+    {
+      id: "project",
+      label: "Select Project",
       type: "suggester",
       options: projectNames,
       placeholder: "Start typing project name..."
     },
   ]);
-  
+
   const { project } = values;
+}
+```
+
+**Example with Multi-Select:**
+```js
+export default async function entry({ quickAddApi }) {
+  const values = await quickAddApi.requestInputs([
+    {
+      id: "tags",
+      label: "Select Tags",
+      type: "suggester",
+      options: ["#work", "#personal", "#project", "#urgent", "#review"],
+      suggesterConfig: {
+        multiSelect: true,
+        caseSensitive: false
+      },
+      placeholder: "Type or select multiple tags..."
+    },
+  ]);
+
+  // Result: values.tags = "#work, #project, #urgent"
+  const { tags } = values;
+
+  // Split into array if needed
+  const tagArray = tags.split(', ').filter(Boolean);
 }
 ```
 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -32,7 +32,7 @@ tR += result;
 
 ## User Input Methods
 
-### `requestInputs(inputs: Array<{ id: string; label?: string; type: "text" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester"; placeholder?: string; defaultValue?: string; options?: string[]; dateFormat?: string; description?: string; suggesterConfig?: { allowCustomInput?: boolean; caseSensitive?: boolean; } }>): Promise<Record<string, string>>`
+### `requestInputs(inputs: Array<{ id: string; label?: string; type: "text" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester"; placeholder?: string; defaultValue?: string; options?: string[]; dateFormat?: string; description?: string; suggesterConfig?: { allowCustomInput?: boolean; caseSensitive?: boolean; multiSelect?: boolean; } }>): Promise<Record<string, string>>`
 Opens a one-page modal to collect multiple inputs in one go. Values already present in `variables` are used and not re-asked. Returned values are also stored into `variables`.
 
 **Behavior:**
@@ -46,6 +46,7 @@ Opens a one-page modal to collect multiple inputs in one go. Values already pres
 - `date`: Date input with natural language support
 - `field-suggest`: Vault field suggestions (uses `{{FIELD:...}}` syntax)
 - `suggester`: **NEW** - Searchable autocomplete with custom options (allows custom input)
+  - Supports multi-select mode via `suggesterConfig.multiSelect: true` for comma-separated selections
 
 **Example:**
 ```javascript
@@ -74,14 +75,36 @@ const projectNames = dv?.pages()
   .array() ?? ["Inbox"];
 
 const values = await quickAddApi.requestInputs([
-  { 
-    id: "project", 
-    label: "Select Project", 
+  {
+    id: "project",
+    label: "Select Project",
     type: "suggester",
     options: projectNames,
     placeholder: "Start typing project name..."
   }
 ]);
+```
+
+**Multi-Select Suggester:**
+```javascript
+// Select multiple tags, comma-separated
+const values = await quickAddApi.requestInputs([
+  {
+    id: "tags",
+    label: "Select Tags",
+    type: "suggester",
+    options: ["#work", "#personal", "#project", "#urgent", "#review"],
+    suggesterConfig: {
+      multiSelect: true,
+      caseSensitive: false
+    },
+    placeholder: "Type or select multiple tags..."
+  }
+]);
+
+// Result: values.tags = "#work, #project, #urgent"
+// Split into array if needed:
+const tagArray = values.tags.split(', ').filter(Boolean);
 ```
 
 ### `inputPrompt(header: string, placeholder?: string, value?: string): Promise<string>`

--- a/src/gui/suggesters/SuggesterInputSuggest.ts
+++ b/src/gui/suggesters/SuggesterInputSuggest.ts
@@ -4,26 +4,53 @@ import { TextInputSuggest } from "./suggest";
 export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	private options: string[];
 	private caseSensitive: boolean;
+	private multiSelect: boolean;
 
 	constructor(
 		app: App,
 		inputEl: HTMLInputElement,
 		options: string[],
 		caseSensitive = false,
+		multiSelect = false,
 	) {
 		super(app, inputEl);
 		this.options = options;
 		this.caseSensitive = caseSensitive;
+		this.multiSelect = multiSelect;
+
+		// Add accessibility attribute for multi-select mode
+		if (this.multiSelect) {
+			this.inputEl.setAttribute("aria-multiselectable", "true");
+		}
+	}
+
+	private parseMultiSelectInput(input: string): {
+		alreadySelected: string[];
+		activeTerm: string;
+	} {
+		if (!this.multiSelect) {
+			return { alreadySelected: [], activeTerm: input };
+		}
+
+		const parts = input.split(",").map((s) => s.trim());
+		return {
+			alreadySelected: parts.slice(0, -1).filter(Boolean),
+			activeTerm: parts[parts.length - 1] || "",
+		};
 	}
 
 	getSuggestions(query: string): string[] {
-		const searchQuery = this.caseSensitive ? query : query.toLowerCase();
+		const { alreadySelected, activeTerm } = this.parseMultiSelectInput(query);
+		const searchQuery = this.caseSensitive ? activeTerm : activeTerm.toLowerCase();
+
+		// Filter out already-selected items
+		const available = this.options.filter((opt) => !alreadySelected.includes(opt));
 
 		if (!searchQuery) {
-			return this.options.slice(0, 200);
+			return available.slice(0, 200);
 		}
 
-		return this.options
+		return available
 			.filter((opt) => {
 				const optStr = this.caseSensitive ? opt : opt.toLowerCase();
 				return optStr.includes(searchQuery);
@@ -36,10 +63,41 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	}
 
 	selectSuggestion(item: string): void {
+		if (this.multiSelect) {
+			this.selectMultipleItem(item);
+		} else {
+			this.selectSingleItem(item);
+		}
+	}
+
+	private selectSingleItem(item: string): void {
 		this.inputEl.value = item;
 		const event = new Event("input", { bubbles: true });
 		(event as any).fromCompletion = true;
 		this.inputEl.dispatchEvent(event);
 		this.close();
+	}
+
+	private selectMultipleItem(item: string): void {
+		const { alreadySelected } = this.parseMultiSelectInput(this.inputEl.value);
+		alreadySelected.push(item);
+
+		// Set value with trailing comma and space for next entry
+		this.inputEl.value = alreadySelected.join(", ") + ", ";
+
+		// Move cursor to end
+		this.inputEl.setSelectionRange(
+			this.inputEl.value.length,
+			this.inputEl.value.length,
+		);
+
+		// Trigger input event with special flag to keep open
+		const event = new Event("input", { bubbles: true });
+		(event as any).fromCompletion = true;
+		(event as any).keepOpen = true;
+		this.inputEl.dispatchEvent(event);
+
+		// Force re-focus to trigger suggestions
+		this.inputEl.focus();
 	}
 }

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -281,11 +281,16 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 
 			try {
 				const suggestions = await this.getSuggestions(inputStr);
-				if (requestId === this.currentRequestId && suggestions?.length) {
-					this.suggest.setSuggestions(suggestions);
-					// Already open, just update suggestions
-					if (!this.isOpen) {
-						this.open(this.app.dom.appContainerEl, this.inputEl);
+				if (requestId === this.currentRequestId) {
+					if (suggestions?.length) {
+						this.suggest.setSuggestions(suggestions);
+						// Already open, just update suggestions
+						if (!this.isOpen) {
+							this.open(this.app.dom.appContainerEl, this.inputEl);
+						}
+					} else {
+						// No more items available to select, close the dropdown
+						this.close();
 					}
 				}
 			} catch (error) {

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -248,11 +248,13 @@ export class OnePageInputModal extends Modal {
 				if (options.length > 0) {
 					try {
 						const caseSensitive = req.suggesterConfig?.caseSensitive ?? false;
+						const multiSelect = req.suggesterConfig?.multiSelect ?? false;
 						new SuggesterInputSuggest(
 							this.app,
 							input.inputEl,
 							options,
 							caseSensitive,
+							multiSelect,
 						);
 					} catch {
 						// Non-fatal; falls back to plain text input

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -29,6 +29,7 @@ export interface FieldRequirement {
 	suggesterConfig?: {
 		allowCustomInput?: boolean;
 		caseSensitive?: boolean;
+		multiSelect?: boolean;
 	};
 }
 

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -39,8 +39,9 @@ export class QuickAddApi {
 			 * Open a single one-page modal to collect multiple inputs at once from a script.
 			 * Any values already present in variables will be used as defaults and not re-asked.
 			 *
-			 * Example spec item:
+			 * Example spec items:
 			 * { id: "project", label: "Project", type: "text", defaultValue: "Inbox" }
+			 * { id: "tags", label: "Tags", type: "suggester", options: ["#work", "#personal"], suggesterConfig: { multiSelect: true } }
 			 */
 			requestInputs: async (
 				inputs: Array<{
@@ -55,6 +56,7 @@ export class QuickAddApi {
 					suggesterConfig?: {
 						allowCustomInput?: boolean;
 						caseSensitive?: boolean;
+						multiSelect?: boolean;
 					};
 				}>,
 			): Promise<Record<string, string>> => {


### PR DESCRIPTION
Closes #934

Implements multi-select functionality for the suggester field type in one-page inputs.

## Features
- Users can select multiple items from a suggester, separated by commas
- Suggestions stay open after each selection in multi-select mode
- Already-selected items are filtered from suggestions
- Supports both typing and selecting from dropdown
- ARIA accessibility attributes for screen reader support

## Configuration
```javascript
{
  id: "tags",
  type: "suggester",
  options: ["#work", "#personal", "#urgent"],
  suggesterConfig: {
    multiSelect: true
  }
}
```

## Usage Example
```javascript
const values = await quickAddApi.requestInputs([
  {
    id: "tags",
    label: "Select Tags",
    type: "suggester",
    options: ["#work", "#personal", "#project", "#urgent", "#review"],
    suggesterConfig: {
      multiSelect: true,
      caseSensitive: false
    }
  }
]);

// Result: values.tags = "#work, #project, #urgent"
const tagArray = values.tags.split(', ').filter(Boolean);
```

## Documentation
- Updated onePageInputs.md with multi-select examples
- Updated QuickAddAPI.md with API documentation
- Added examples for splitting comma-separated results

## Testing
Tested manually in Obsidian with the suggester field type in both single-select (default) and multi-select modes. Backward compatibility verified - existing suggesters work unchanged.