### PR TITLE
feat: add helpful notice when no scripts found and clarify hidden folder restrictions

### DIFF
--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -97,20 +97,24 @@ User scripts are JavaScript files that extend macro functionality. They have acc
 
 :::warning Script Placement Requirements
 
-User scripts (.js files) must be placed in your Obsidian vault, but **NOT** in the `.obsidian` directory.
+User scripts (.js files) must be placed in your Obsidian vault, but **NOT** in the `.obsidian` directory or in hidden folders (folders starting with a dot).
 
 ✅ **Valid locations:**
 - `/scripts/myScript.js`
+- `/_quickadd/scripts/myScript.js`
 - `/macros/utilities/helper.js`
 - `/my-custom-folder/script.js`
-- Any folder in your vault except `.obsidian`
+- Any folder in your vault except `.obsidian` or hidden folders
 
 ❌ **Invalid locations:**
 - `/.obsidian/plugins/quickadd/scripts/myScript.js`
 - `/.obsidian/scripts/myScript.js`
+- `/.quickadd/scripts/myScript.js` (hidden folder - use `_quickadd` instead)
+- `/.scripts/myScript.js` (hidden folder - use `_scripts` instead)
 - Any path within the `.obsidian` directory
+- Any path within folders starting with a dot (.)
 
-Scripts placed in the `.obsidian` directory are intentionally ignored and will not appear in the script selection dialog.
+Scripts placed in the `.obsidian` directory or hidden folders are intentionally ignored and will not appear in the script selection dialog.
 
 :::
 

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -35,6 +35,7 @@ import { AIAssistantCommand } from "src/types/macros/QuickCommands/AIAssistantCo
 import { settingsStore } from "src/settingsStore";
 import InputSuggester from "../InputSuggester/inputSuggester";
 import { OpenFileCommand } from "../../types/macros/QuickCommands/OpenFileCommand";
+import { showNoScriptsFoundNotice } from "./noScriptsFoundNotice";
 
 function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 	const arr: IChoice[] = [];
@@ -508,6 +509,7 @@ export class MacroBuilder extends Modal {
 
 	private async showScriptPicker(): Promise<TFile | null> {
 		if (this.javascriptFiles.length === 0) {
+			showNoScriptsFoundNotice();
 			return null;
 		}
 

--- a/src/gui/MacroGUIs/noScriptsFoundNotice.ts
+++ b/src/gui/MacroGUIs/noScriptsFoundNotice.ts
@@ -1,0 +1,36 @@
+import { Notice } from "obsidian";
+
+/**
+ * Shows a notice to the user when no JavaScript files are found in their vault.
+ * Provides helpful guidance on where to place scripts and links to documentation.
+ */
+export function showNoScriptsFoundNotice(): void {
+	const notice = new Notice("", 10000);
+	notice.noticeEl.empty();
+	notice.noticeEl.createEl("div", {
+		text: "No JavaScript files found",
+		cls: "quickadd-notice-title",
+	});
+
+	const content = notice.noticeEl.createDiv();
+	content.createEl("div", {
+		text: "QuickAdd cannot find any .js files in your vault.",
+	});
+	content.createEl("br");
+	content.createEl("div", { text: "Please make sure your scripts are:" });
+	content.createEl("div", {
+		text: "✓ In your vault (not in .obsidian folder)",
+	});
+	content.createEl("div", {
+		text: "✓ Not in hidden folders (starting with a dot)",
+	});
+	content.createEl("div", { text: "✓ Have a .js extension" });
+	content.createEl("br");
+
+	const link = content.createEl("a", {
+		text: "View documentation",
+		href: "https://quickadd.obsidian.guide/docs/Choices/MacroChoice#user-scripts",
+	});
+	link.style.color = "var(--interactive-accent)";
+	link.style.textDecoration = "underline";
+}

--- a/src/gui/MacroGUIs/noScriptsFoundNotice.ts
+++ b/src/gui/MacroGUIs/noScriptsFoundNotice.ts
@@ -31,6 +31,8 @@ export function showNoScriptsFoundNotice(): void {
 		text: "View documentation",
 		href: "https://quickadd.obsidian.guide/docs/Choices/MacroChoice#user-scripts",
 	});
+	link.target = "_blank";
+	link.rel = "noopener noreferrer";
 	link.style.color = "var(--interactive-accent)";
 	link.style.textDecoration = "underline";
 }


### PR DESCRIPTION
## Changes

This PR addresses user confusion reported in #895 by providing clear guidance when no JavaScript files are found in the vault.

### What's Changed

- **Added informative notice**: When users click the Browse button and no .js files are found, they now see a helpful notice explaining:
  - Scripts must be in the vault (not in .obsidian folder)
  - Scripts cannot be in hidden folders (folders starting with a dot)
  - Files must have a .js extension
  - Includes a clickable link to the documentation

- **Updated documentation**: Clarified in MacroChoice.md that hidden folders (dot-prefixed like `.quickadd`) are not supported, with clear examples of valid vs invalid locations

- **Code organization**: Extracted notice logic to `noScriptsFoundNotice.ts` for better maintainability

### Related Issue

Related to #895 (provides better user guidance, though doesn't fully resolve the underlying detection issues some users are experiencing)

### Testing

- Build passes ✅
- All tests pass ✅
- No breaking changes