### PR TITLE
fix: respect Obsidian's default location for new notes

### DIFF
--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -59,8 +59,14 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			let folderPath = "";
 
 			if (this.choice.folder.enabled) {
-				folderPath = await this.getFolderPath();
-			}
+			folderPath = await this.getFolderPath();
+			} else {
+			// Respect Obsidian's "Default location for new notes" setting
+			const parent = this.app.fileManager.getNewFileParent(
+				this.app.workspace.getActiveFile()?.path ?? ""
+			);
+			folderPath = parent === this.app.vault.getRoot() ? "" : parent.path;
+		}
 
 			const format = this.choice.fileNameFormat.enabled
 				? this.choice.fileNameFormat.format


### PR DESCRIPTION
Fixes #613

When 'Create in folder' is disabled in template choices, QuickAdd now respects Obsidian's global 'Default location for new notes' setting instead of always creating files in vault root.

**Changes:**
- Uses `app.fileManager.getNewFileParent()` to determine the correct folder when folder setting is disabled
- Properly detects vault root using object identity comparison

**Breaking Changes:**
None. This fixes a bug where user expectations were not met. Users who want files in vault root can set that as their Obsidian default.