### PR TITLE
fix: nested choice reordering not persisting

### DIFF
--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -2,7 +2,7 @@
     import type IChoice from "../../types/choices/IChoice";
     import ChoiceListItem from "./ChoiceListItem.svelte";
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
-    import {dndzone, SHADOW_PLACEHOLDER_ITEM_ID, SOURCES} from "svelte-dnd-action";
+    import {dndzone, SHADOW_PLACEHOLDER_ITEM_ID} from "svelte-dnd-action";
     import type {DndEvent} from "svelte-dnd-action";
     import {createEventDispatcher} from "svelte";
     import type { App } from "obsidian";
@@ -87,6 +87,7 @@
                     on:toggleCommand
                     on:duplicateChoice
                     on:moveChoice
+                    on:reorderChoices
                     startDrag={startDrag}
                     bind:collapseId
                     bind:choice

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -59,6 +59,12 @@
             onMove: (targetId) => dispatcher('moveChoice', { choice, targetId }),
         });
     }
+
+    function handleNestedReorder() {
+        // Nested choices were reordered; bubble up event with cloned root choices
+        // Shallow clone creates new array reference to trigger settingsStore subscription
+        dispatcher('reorderChoices', {choices: [...roots]});
+    }
 </script>
 
 <div>
@@ -108,6 +114,7 @@
                         on:toggleCommand
                         on:duplicateChoice
                         on:moveChoice
+                        on:reorderChoices={handleNestedReorder}
                         bind:multiChoice={choice}
                         bind:choices={choice.choices}
                 />


### PR DESCRIPTION
Fixes #142

## Problem
When users reordered choices inside Multi/folder choices, the UI updated correctly but changes weren't persisted on plugin reload. The choices would revert to their previous arrangement after restarting Obsidian.

## Root Cause
The `reorderChoices` event from nested ChoiceLists wasn't bubbling up to ChoiceView where `saveChoices()` is called to persist changes. The event chain was incomplete.

## Solution
- Added `on:reorderChoices` handler in MultiChoiceListItem that re-dispatches the event with a shallow clone of the roots array
- Added `on:reorderChoices` forwarding in ChoiceList for MultiChoiceListItem components
- The shallow clone `[...roots]` creates a new array reference that triggers the settingsStore subscription, which persists changes via `saveSettings()`

## Additional Cleanup
- Removed unused `SOURCES` import from ChoiceList.svelte

## Testing
- Verified nested choice reordering now persists across plugin reloads
- Confirmed top-level choice reordering still works correctly
- Build passes with no errors