### PR TITLE
Fix: Standardize multi-line input font size across themes

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -9,6 +9,7 @@
         min-width: 100%;
         max-width: 100%;
 		height: 6rem;
+		font-size: 16px;
 		direction: inherit;
 		text-align: inherit;
 	}
@@ -20,6 +21,7 @@
 		width: 40rem;
 		max-width: 100%;
 		height: 20rem;
+		font-size: 16px;
 		direction: inherit;
 		text-align: inherit;
 	}


### PR DESCRIPTION
## Summary
Fixes #270

This PR adds an explicit `font-size: 16px` to the `.wideInputPromptInputEl` class to ensure consistent font sizing across all Obsidian themes.

## Problem
The multi-line input box was inheriting font-size from theme-specific textarea styles, causing overlarge text in some themes (e.g., Shimmering Focus) while working fine in others (e.g., Minimal).

## Solution
Added explicit `font-size: 16px` to both mobile and desktop media queries for `.wideInputPromptInputEl` in `src/styles.css`. This:
- Prevents theme-specific inheritance issues
- Ensures consistent appearance across all themes
- Matches the font-size used in other UI elements (16px is also used in `.checkboxRow span` and `.choiceListItem`)

## Changes
- Added `font-size: 16px;` to mobile media query (lines 12)
- Added `font-size: 16px;` to desktop media query (lines 24)

## Testing
The plugin has been rebuilt successfully. Users should see consistent font sizing in the multi-line input box regardless of their active theme.