### PR TITLE
fix: remove script suffix from request inputs

### DIFF
--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -95,10 +95,6 @@ Supported input fields:
   - Supports multi-select mode via `suggesterConfig.multiSelect: true`
   - Multi-select: Select multiple items, separated by commas. Suggestions stay open after each selection.
 
-In the modal these inputs are labeled “(from script)”.
-
----
-
 ## Scripts: request inputs at runtime (API)
 
 From within a script, you can open a single one-page modal to collect multiple inputs in one go using the QuickAdd API.

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -291,9 +291,6 @@ export class OnePageInputModal extends Modal {
 	}
 
 	private decorateLabel(req: FieldRequirement): string {
-		if (req.source === "script") {
-			return `${req.label} (from script)`;
-		}
 		return req.label;
 	}
 


### PR DESCRIPTION
## Summary
- stop appending "(from script)" to script-provided input labels so the prompts match author intent
- update the advanced guide to reflect the simpler labeling

## Testing
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect current input field labeling behavior.

* **Changes**
  * Removed the "(from script)" label suffix from input fields in the modal interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->