### PR TITLE
fix: honor Open File toggle for reuse

### DIFF
--- a/src/engine/MacroChoiceEngine.openFileOptions.test.ts
+++ b/src/engine/MacroChoiceEngine.openFileOptions.test.ts
@@ -26,12 +26,12 @@ describe("buildOpenFileOptions", () => {
 		expect(options.location).toBe("right-sidebar");
 	});
 
-	it("keeps legacy default behavior: new tab when openInNewTab is false", () => {
+	it("opens in the current tab when openInNewTab is false", () => {
 		const options = buildOpenFileOptions(
 			createCommand({ openInNewTab: false, location: undefined })
 		);
 
-		expect(options.location).toBe("tab");
+		expect(options.location).toBe("reuse");
 		expect(options.direction).toBeUndefined();
 	});
 

--- a/src/engine/helpers/openFileOptions.ts
+++ b/src/engine/helpers/openFileOptions.ts
@@ -42,10 +42,10 @@ export function buildOpenFileOptions(
 			: undefined;
 
 	// Legacy mapping (pre-location field):
-	// openInNewTab === false -> open in a new tab (not reuse)
+	// openInNewTab === false -> reuse the current tab
 	// openInNewTab === true without direction -> split (default vertical)
 	if (!openInNewTab) {
-		return { location: "tab", focus, mode: "default" };
+		return { location: "reuse", focus, mode: "default" };
 	}
 
 	return {

--- a/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
@@ -161,7 +161,7 @@ export class OpenFileCommandSettingsModal extends Modal {
 		if (this.command.openInNewTab) {
 			return "split";
 		}
-		return "tab";
+		return "reuse";
 	}
 
 


### PR DESCRIPTION
## Summary
- map legacy openInNewTab=false to reuse the active tab
- align Open File settings modal default to reuse when toggle is off
- add regression test for legacy open-file mapping

## Testing
- bun run test

Closes #1001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated file opening behavior: when the "open in new tab" option is disabled, files now correctly reuse the current tab instead of opening in a new tab. This change applies across file opening functionality and ensures consistent behavior in the file command settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->