### PR TITLE
Fix macro variable reassignment

### DIFF
--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -106,7 +106,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 
 				const entries =
 					next instanceof Map
-						? Array.from(next.entries())
+						? Array.from(next.entries()).filter(([key]) => typeof key === "string")
 						: next && typeof next === "object"
 							? Object.entries(next as Record<string, unknown>)
 							: null;


### PR DESCRIPTION
Fixes #1014. Fixes #1010.

Both issues report user scripts populating variables, but Templater behaves as if the values were never set (prompting for missing `{{VALUE:*}}` fields).

This PR makes `params.variables` a getter/setter backed by the shared variables `Map`:
- Assigning an object or `Map` (`QuickAdd.variables = {...}` / `params.variables = {...}`) replaces the backing store so downstream templating sees the new values.
- Self-assignment (assigning the same backing `Map` / `params.variables = params.variables`) is treated as a no-op to avoid clearing variables.
- Invalid assignments (e.g. numbers/strings) are ignored to avoid wiping the backing store.

Tests: `bun run test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests covering how user scripts read, replace, or modify the variables object during macro execution.

* **Bug Fixes**
  * Improved variable handling so replacing the variables object swaps stored entries, assigning the same map preserves existing keys, and invalid reassignments are ignored — while preserving backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->