### PR TITLE
Fix {{FIELD:tags}} suggestions from vault tag index

### DIFF
--- a/src/utils/FieldValueCollector.issue671.test.ts
+++ b/src/utils/FieldValueCollector.issue671.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { FieldSuggestionCache } from "./FieldSuggestionCache";
+import { collectFieldValuesProcessed } from "./FieldValueCollector";
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: () => null,
+}));
+
+describe("Issue #671 - {{FIELD:tags}} suggestions", () => {
+	beforeEach(() => {
+		FieldSuggestionCache.getInstance().clear();
+	});
+
+	it("includes tags from the vault tag index", async () => {
+		const app = new App();
+
+		// @ts-expect-error - getTags exists in Obsidian but is not typed
+		app.metadataCache.getTags = () => ({
+			"#ai/technology": 1,
+			"#cook/hoven": 1,
+		});
+
+		app.vault.getMarkdownFiles = () => [];
+
+		const values = await collectFieldValuesProcessed(app, "tags", {});
+
+		expect(values).toEqual(
+			expect.arrayContaining(["ai/technology", "cook/hoven"]),
+		);
+	});
+});


### PR DESCRIPTION
Fixes #671.

### What changed
- `{{FIELD:tags}}` / `{{FIELD:tag}}` now suggests existing tags from Obsidian's vault-wide tag index (`metadataCache.getTags()`), so tags show up even when they're not present as a frontmatter field.
- When FIELD filters are present (e.g. `|folder:`, `|tag:`, exclusions), we fall back to scanning the filtered file set to preserve filtering semantics.

### Tests
- Added a regression test: `src/utils/FieldValueCollector.issue671.test.ts`.
- `bun run test` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tag collection to properly retrieve tags from the vault's metadata cache, including both frontmatter and inline tags in field value suggestions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->