### PR TITLE
fix: default update announcements to major

### DIFF
--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -6,7 +6,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		inputPrompt: "single-line",
 		devMode: false,
 		templateFolderPath: "",
-		announceUpdates: "all",
+		announceUpdates: "major",
 		version: "0.0.0",
 		globalVariables: {},
 		onePageInputEnabled: false,

--- a/src/engine/CaptureChoiceEngine.template-property-types.test.ts
+++ b/src/engine/CaptureChoiceEngine.template-property-types.test.ts
@@ -11,7 +11,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		inputPrompt: "single-line",
 		devMode: false,
 		templateFolderPath: "",
-		announceUpdates: "all",
+		announceUpdates: "major",
 		version: "0.0.0",
 		globalVariables: {},
 		onePageInputEnabled: false,

--- a/src/engine/MacroChoiceEngine.notice.test.ts
+++ b/src/engine/MacroChoiceEngine.notice.test.ts
@@ -6,7 +6,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		inputPrompt: "single-line",
 		devMode: false,
 		templateFolderPath: "",
-		announceUpdates: "all",
+		announceUpdates: "major",
 		version: "0.0.0",
 		globalVariables: {},
 		onePageInputEnabled: false,

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -6,7 +6,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		inputPrompt: "single-line",
 		devMode: false,
 		templateFolderPath: "",
-		announceUpdates: "all",
+		announceUpdates: "major",
 		version: "0.0.0",
 		globalVariables: {},
 		onePageInputEnabled: false,

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -64,7 +64,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	inputPrompt: "single-line",
 	devMode: false,
 	templateFolderPath: "",
-	announceUpdates: "all",
+	announceUpdates: "major",
 	version: "0.0.0",
 	globalVariables: {},
 	onePageInputEnabled: false,


### PR DESCRIPTION
## Summary
- default update announcements to major releases

## Related Issues
- #1038

## Testing
- not run (not requested)

## Release / Migration Notes
- No migration required. Existing users keep their setting; new installs default to "major".
