### PR TITLE
Fix macro rename prompt prefill

### DIFF
--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -84,6 +84,7 @@ export class MacroBuilder extends Modal {
 			const newName: string = await GenericInputPrompt.Prompt(
 				this.app,
 				`Update name for ${this.choice.name}`,
+				this.choice.name,
 				this.choice.name
 			);
 			if (!newName) return;


### PR DESCRIPTION
## Summary
- prefill Macro Builder rename prompt with the current macro name

## Testing
- not run (not requested)

Fixes #1037
