### PR TITLE
Fix unicode normalization in file suggestions

### DIFF
--- a/src/gui/suggesters/FileIndex.test.ts
+++ b/src/gui/suggesters/FileIndex.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { FileIndex } from './FileIndex';
+import { normalizeForSearch } from './utils';
 import type { App, TFile, Vault, MetadataCache, Workspace } from 'obsidian';
 
 // Test-specific subclass that allows resetting the singleton
@@ -49,6 +50,32 @@ const createMockApp = (): App => {
 	} as App;
 };
 
+const createMockIndexedFile = (overrides: {
+	path: string;
+	basename: string;
+	aliases?: string[];
+	headings?: string[];
+	blockIds?: string[];
+	tags?: string[];
+	modified?: number;
+	folder?: string;
+}) => {
+	const aliases = overrides.aliases ?? [];
+	return {
+		path: overrides.path,
+		pathNormalized: normalizeForSearch(overrides.path),
+		basename: overrides.basename,
+		basenameNormalized: normalizeForSearch(overrides.basename),
+		aliases,
+		aliasesNormalized: aliases.map((alias) => normalizeForSearch(alias)),
+		headings: overrides.headings ?? [],
+		blockIds: overrides.blockIds ?? [],
+		tags: overrides.tags ?? [],
+		modified: overrides.modified ?? Date.now(),
+		folder: overrides.folder ?? ''
+	};
+};
+
 describe('FileIndex', () => {
 	let mockApp: App;
 	let fileIndex: FileIndex;
@@ -66,16 +93,11 @@ describe('FileIndex', () => {
 
 	describe('scoring system', () => {
 		it('should boost same-folder files', () => {
-			const mockFile = {
+			const mockFile = createMockIndexedFile({
 				path: 'folder/test.md',
 				basename: 'test',
-				aliases: [],
-				headings: [],
-				blockIds: [],
-				tags: [],
-				modified: Date.now(),
 				folder: 'folder'
-			};
+			});
 
 			const context = { currentFolder: 'folder' };
 			const score = (fileIndex as any).calculateScore(mockFile, 'test', context, 0.5);
@@ -84,16 +106,11 @@ describe('FileIndex', () => {
 		});
 
 		it('should penalize alias match types', () => {
-			const mockFile = {
+			const mockFile = createMockIndexedFile({
 				path: 'test.md',
 				basename: 'test',
-				aliases: ['exact-match'],
-				headings: [],
-				blockIds: [],
-				tags: [],
-				modified: Date.now(),
-				folder: ''
-			};
+				aliases: ['exact-match']
+			});
 
 			const score = (fileIndex as any).calculateScore(mockFile, 'exact-match', {}, 0.5, 'alias');
 
@@ -101,16 +118,11 @@ describe('FileIndex', () => {
 		});
 
 		it('should rank basename matches better than alias matches', () => {
-			const mockFile = {
+			const mockFile = createMockIndexedFile({
 				path: 'test.md',
 				basename: 'test',
-				aliases: ['my-alias'],
-				headings: [],
-				blockIds: [],
-				tags: [],
-				modified: Date.now(),
-				folder: ''
-			};
+				aliases: ['my-alias']
+			});
 
 			const aliasScore = (fileIndex as any).calculateScore(mockFile, 'my-alias', {}, 0.5, 'alias');
 			const basenameScore = (fileIndex as any).calculateScore(mockFile, 'test', {}, 0.5, 'exact');
@@ -119,27 +131,17 @@ describe('FileIndex', () => {
 		});
 
 		it('should boost files with tag overlap', () => {
-			const currentFile = {
+			const currentFile = createMockIndexedFile({
 				path: 'current.md',
 				basename: 'current',
-				aliases: [],
-				headings: [],
-				blockIds: [],
-				tags: ['#shared-tag'],
-				modified: Date.now(),
-				folder: ''
-			};
+				tags: ['#shared-tag']
+			});
 
-			const testFile = {
+			const testFile = createMockIndexedFile({
 				path: 'test.md',
 				basename: 'test',
-				aliases: [],
-				headings: [],
-				blockIds: [],
-				tags: ['#shared-tag', '#other-tag'],
-				modified: Date.now(),
-				folder: ''
-			};
+				tags: ['#shared-tag', '#other-tag']
+			});
 
 			// Simulate current file in map
 			(fileIndex as any).fileMap.set('current.md', currentFile);

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -228,8 +228,11 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 			.map(file => ({
 				file: {
 					path: file.path,
+					pathNormalized: normalizeForSearch(file.path),
 					basename: file.basename,
+					basenameNormalized: normalizeForSearch(file.basename),
 					aliases: [],
+					aliasesNormalized: [],
 					headings: [],
 					blockIds: [],
 					tags: [],

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -12,10 +12,6 @@ export function normalizeForSearch(value: string): string {
 	return value.normalize("NFC").toLowerCase();
 }
 
-export function normalizeForFuse(value: string): string {
-	return value.normalize("NFC");
-}
-
 /**
  * Insert text at cursor position
  */


### PR DESCRIPTION
## Summary
- normalize search/query strings to NFC for file suggestion matching
- normalize Fuse lookups and attachment/heading filtering
- add regression test for decomposed (NFD) filenames and fix FileIndex singleton reset in tests

Fixes #289.

## Testing
- bun run build-with-lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search reliably matches filenames and headings regardless of Unicode composition (composed vs decomposed), fixing missed results for accented/international characters.

* **Improvements**
  * Consistent normalization for exact, prefix, substring, fuzzy matching and highlighting; normalization utilities added to improve match accuracy.

* **Tests**
  * Added tests for Unicode normalization, ensured indexing completion before assertions, and stabilized singleton reset behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->