### PR TITLE
test: gate perf tests behind env flag

### DIFF
--- a/src/gui/suggesters/FileIndex.test.ts
+++ b/src/gui/suggesters/FileIndex.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { itPerf } from '../../../tests/perfUtils';
 import { FileIndex } from './FileIndex';
 import { normalizeForSearch } from './utils';
 import type { App, TFile, Vault, MetadataCache, Workspace } from 'obsidian';
@@ -423,7 +424,7 @@ describe('FileIndex', () => {
 	});
 
 	describe('performance', () => {
-		it.skip('should handle large vaults efficiently', async () => {
+		itPerf('should handle large vaults efficiently', async () => {
 			// Mock a large number of files
 			const mockFiles = Array.from({ length: 1000 }, (_, i) => ({
 				path: `file-${i}.md`,

--- a/src/gui/suggesters/headingSanitizer.test.ts
+++ b/src/gui/suggesters/headingSanitizer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { itPerf } from '../../../tests/perfUtils';
 import { sanitizeHeading } from './utils';
 
 describe('sanitizeHeading', () => {
@@ -50,7 +51,7 @@ describe('sanitizeHeading', () => {
 	});
 	
 	// Performance test - ensure regex caching works
-	it('performs well with many calls', () => {
+	itPerf('performs well with many calls', () => {
 		const heading = '**Important** [[Note|Alias]] with ![[image.png]]';
 		const start = performance.now();
 		

--- a/src/template-property-types-performance.test.ts
+++ b/src/template-property-types-performance.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, vi, type MockedFunction } from 'vitest';
+import { describePerf } from '../tests/perfUtils';
 import type { TFile } from 'obsidian';
 import type QuickAdd from '../src/main';
 
@@ -177,7 +178,7 @@ class MockTemplateEngine {
 	}
 }
 
-describe('Template Property Types Performance Tests', () => {
+describePerf('Template Property Types Performance Tests', () => {
 	let mockPlugin: QuickAdd;
 	let mockApp: any;
 	let templateEngine: MockTemplateEngine;

--- a/src/utils/FieldValueDeduplicator.test.ts
+++ b/src/utils/FieldValueDeduplicator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { describePerf } from "../../tests/perfUtils";
 import { FieldValueDeduplicator } from "./FieldValueDeduplicator";
 
 describe("FieldValueDeduplicator", () => {
@@ -152,7 +153,7 @@ describe("FieldValueDeduplicator", () => {
 		});
 	});
 
-	describe("performance with large datasets", () => {
+	describePerf("performance with large datasets", () => {
 		it("should handle 1000+ values efficiently", () => {
 			const values: string[] = [];
 			for (let i = 0; i < 1000; i++) {

--- a/tests/perfUtils.ts
+++ b/tests/perfUtils.ts
@@ -1,0 +1,11 @@
+import { describe, it, test } from 'vitest';
+
+const runPerfTests =
+	process.env.RUN_PERF_TESTS === '1' ||
+	process.env.RUN_PERF_TESTS === 'true';
+
+const describePerf = runPerfTests ? describe : describe.skip;
+const itPerf = runPerfTests ? it : it.skip;
+const testPerf = runPerfTests ? test : test.skip;
+
+export { runPerfTests, describePerf, itPerf, testPerf };


### PR DESCRIPTION
## Summary
- gate perf tests behind RUN_PERF_TESTS to stop flaky unit runs
- keep large-data functional coverage in regular tests and move timing checks to opt-in
- add shared perf test helpers and make large vault perf test opt-in

## Testing
- not run (not requested)