### PR TITLE
fix: preserve blank lines after insert after match

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -57,6 +57,17 @@ If you have a tag called `#people`, and you type `#people` in the _Capture To_ f
 ## Insert after
 
 Insert After will allow you to insert the text after some line with the specified text.
+If the matched line is followed by one or more blank lines (including whitespace-only
+lines), QuickAdd inserts after those blank lines to preserve spacing under headings.
+
+Example (Insert After `# H` with content `X`):
+
+```markdown
+# H
+
+X
+A
+```
 
 With Insert After, you can also enable `Insert at end of section` and `Consider subsections`.
 You can see an explanation of these below.

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -408,7 +408,9 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 
 	private addInsertAfterFields() {
 		const descText =
-			"Insert capture after specified line. Accepts format syntax. Tip: use a heading (starts with #) to target a section.";
+			"Insert capture after specified line. Accepts format syntax. " +
+			"Tip: use a heading (starts with #) to target a section. " +
+			"If the matched line is followed by blank lines, QuickAdd inserts after them to preserve spacing.";
 
 		new Setting(this.contentEl)
 			.setName("Insert after")


### PR DESCRIPTION
## Summary
- add per-choice blank-line mode (auto/skip/none) for Insert After
- default auto skips blank lines only for ATX headings
- update insert-after logic, tests, and docs/UI copy

## Testing
- bun run test