### PR TITLE
Fix VALUE variables from scripts reaching templates

### DIFF
--- a/src/formatters/formatter-issue929-integration.test.ts
+++ b/src/formatters/formatter-issue929-integration.test.ts
@@ -170,12 +170,12 @@ describe('Issue #929 Integration Test: Full Macro Flow', () => {
     });
 
     it('should handle edge case: null/undefined from script', async () => {
-        // Script sets null (which should be treated as "no value set")
+        // Script sets null (treated as explicit value)
         formatter.simulateScriptSetVariable('title', null);
         formatter.setTitle('File Basename');
         
         const result = await formatter.formatCapture('{{VALUE:title}}');
-        expect(result).toBe('File Basename'); // Should fall back to file basename
+        expect(result).toBe(''); // Null is intentional -> empty string
         
         // Reset and test undefined
         formatter = new CaptureFormatterTest();

--- a/src/formatters/formatter.test.ts
+++ b/src/formatters/formatter.test.ts
@@ -10,12 +10,11 @@ class TestFormatter {
         return (this.variables.get(variableName) as string) ?? "";
     }
 
-    /** Returns true when a variable is present AND its value is neither undefined nor null.  
-     *  An empty string is considered a valid, intentional value. */
+    /** Returns true when a variable is present AND its value is not undefined.
+     *  Null and empty string are considered intentional values. */
     protected hasConcreteVariable(name: string): boolean {
         if (!this.variables.has(name)) return false;
-        const v = this.variables.get(name);
-        return v !== undefined && v !== null;
+        return this.variables.get(name) !== undefined;
     }
 
     protected async promptForVariable(variableName: string): Promise<string> {
@@ -172,11 +171,11 @@ describe('Formatter - Variable Handling', () => {
             expect(formatter.wasPromptCalled()).toBe(true);
         });
 
-        it('should prompt when variable is null', async () => {
+        it('should not prompt when variable is null', async () => {
             formatter.setVariable('nullVar', null);
             const result = await formatter.testReplaceVariableInString('Rating: {{VALUE:nullVar}}');
-            expect(result).toBe('Rating: prompted_value');
-            expect(formatter.wasPromptCalled()).toBe(true);
+            expect(result).toBe('Rating: ');
+            expect(formatter.wasPromptCalled()).toBe(false);
         });
 
         it('should preserve non-empty string values without prompting', async () => {

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -25,6 +25,7 @@ import {
 	RequirementCollector,
 	type FieldRequirement,
 } from "./RequirementCollector";
+import { resolveExistingVariableKey } from "src/utils/valueSyntax";
 
 async function readTemplate(app: App, path: string): Promise<string> {
 	const addExt =
@@ -234,10 +235,13 @@ export async function runOnePagePreflight(
 		if (requirements.length === 0) return false; // Nothing to collect
 
 		// Only prompt for unresolved inputs (variables missing or null). Empty string is intentional.
-		const unresolved: FieldRequirement[] = requirements.filter((req) => {
-			const v = choiceExecutor.variables.get(req.id) as unknown;
-			return v === undefined || v === null;
-		});
+		const unresolved: FieldRequirement[] = requirements.filter(
+			(req) =>
+				!resolveExistingVariableKey(
+					choiceExecutor.variables,
+					req.id,
+				),
+		);
 
 		if (unresolved.length === 0) return false; // Everything prefilled, skip modal
 

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildValueVariableKey,
 	parseValueToken,
+	resolveExistingVariableKey,
 } from "./valueSyntax";
 
 describe("parseValueToken", () => {
@@ -40,5 +41,44 @@ describe("parseValueToken", () => {
 		const parsed = parseValueToken("a,b|custom|default:High");
 		expect(parsed?.allowCustomInput).toBe(true);
 		expect(parsed?.defaultValue).toBe("High");
+	});
+});
+
+describe("resolveExistingVariableKey", () => {
+	it("returns exact key when present", () => {
+		const vars = new Map<string, unknown>([["title", "Hello"]]);
+		expect(resolveExistingVariableKey(vars, "title")).toBe("title");
+	});
+
+	it("falls back to base key for labeled tokens", () => {
+		const vars = new Map<string, unknown>([["low,med,high", "med"]]);
+		const key = buildValueVariableKey(
+			"low,med,high",
+			"Priority",
+			true,
+		);
+		expect(resolveExistingVariableKey(vars, key)).toBe("low,med,high");
+	});
+
+	it("uses case-insensitive match when unique", () => {
+		const vars = new Map<string, unknown>([["Title", "Value"]]);
+		expect(resolveExistingVariableKey(vars, "title")).toBe("Title");
+	});
+
+	it("returns null for ambiguous case-insensitive matches", () => {
+		const vars = new Map<string, unknown>([
+			["Title", "One"],
+			["TITLE", "Two"],
+		]);
+		expect(resolveExistingVariableKey(vars, "title")).toBeNull();
+	});
+
+	it("treats undefined as missing but allows null", () => {
+		const vars = new Map<string, unknown>([
+			["missing", undefined],
+			["nullable", null],
+		]);
+		expect(resolveExistingVariableKey(vars, "missing")).toBeNull();
+		expect(resolveExistingVariableKey(vars, "nullable")).toBe("nullable");
 	});
 });

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -30,6 +30,45 @@ export function getValueVariableBaseName(variableKey: string): string {
 	return variableKey.slice(0, delimiterIndex);
 }
 
+function findCaseInsensitiveMatch(
+	vars: Map<string, unknown>,
+	candidate: string,
+): string | null {
+	const lower = candidate.toLowerCase();
+	let match: string | null = null;
+
+	for (const key of vars.keys()) {
+		if (key.toLowerCase() !== lower) continue;
+		if (vars.get(key) === undefined) continue;
+		if (match) return null;
+		match = key;
+	}
+
+	return match;
+}
+
+export function resolveExistingVariableKey(
+	vars: Map<string, unknown>,
+	variableKey: string,
+): string | null {
+	if (!variableKey) return null;
+
+	const candidates = [variableKey];
+	const baseKey = getValueVariableBaseName(variableKey);
+	if (baseKey !== variableKey) candidates.push(baseKey);
+
+	for (const candidate of candidates) {
+		if (vars.has(candidate) && vars.get(candidate) !== undefined) {
+			return candidate;
+		}
+
+		const match = findCaseInsensitiveMatch(vars, candidate);
+		if (match) return match;
+	}
+
+	return null;
+}
+
 type ParsedOptions = {
 	label?: string;
 	defaultValue: string;


### PR DESCRIPTION
## Summary
- Preserve script-provided VALUE variables through formatting and preflight resolution.
- Make VALUE lookup tolerant of label-scoped keys and case-only mismatches (unique only).
- Stop quickAddApi.format() from wiping preexisting variables by restoring snapshots instead of clearing.

## Problem
Scripts can set QuickAdd.variables/params.variables correctly, but subsequent Template steps still prompt for {{VALUE:...}} placeholders. Two failure modes were observed:
1) Key mismatches introduced by label-scoped VALUE tokens (and occasional case drift).
2) Helper formatting calls (quickAddApi.format) clearing the shared variables map.

## Fix
- VALUE lookup now resolves an existing variable key by trying:
  - exact key
  - base key for label-scoped VALUE lists
  - case-insensitive unique match
- VALUE "concreteness" treats null as intentional; only undefined is considered missing.
- One-page preflight uses the same resolver so it won’t re-ask already-provided values.
- quickAddApi.format() snapshots variables and restores them when shouldClearVariables is true (preserves pre-existing script values while still cleaning up format-local additions).

## Behavior changes / Notes
- null is now treated as an explicit value (no prompt). To force prompting, set the variable to undefined or delete it.
- Case-insensitive fallback only applies when there is a single unique match; ambiguous matches still prompt.

## Test Plan
- bun run test

## Issue
Fixes #1059


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Variables with null values no longer trigger input prompts; they are now treated as valid concrete values.
  * Improved variable key resolution with case-insensitive matching and base key fallback support.
  * Enhanced variable state preservation during quick add formatting operations.

* **Tests**
  * Updated test expectations for null value handling in formatter.
  * Added comprehensive test coverage for variable key resolution scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->