### PR TITLE
feat: add macro selection helper

### DIFF
--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -188,6 +188,20 @@ module.exports = async (params) => {
 };
 ```
 
+### Getting the current selection
+
+Use the utility helper to read the active editor selection. It returns an empty
+string when nothing is selected or no editor is active.
+
+```javascript
+module.exports = async (params) => {
+    const selection = params.quickAddApi.utility.getSelection();
+    if (selection) {
+        params.variables.selectedText = selection;
+    }
+};
+```
+
 ### Accessing Other Plugins
 
 Scripts can interact with other Obsidian plugins:

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -426,6 +426,18 @@ Sets the clipboard contents.
 await quickAddApi.utility.setClipboard("Hello, World!");
 ```
 
+### `getSelection(): string`
+Gets the currently selected text in the active editor. Returns an empty string if
+there is no active editor or no selection.
+
+**Example:**
+```javascript
+const selection = quickAddApi.utility.getSelection();
+if (selection) {
+    console.log("Selected:", selection);
+}
+```
+
 Combined example:
 ```javascript
 // Transform clipboard contents

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -461,6 +461,15 @@ export class QuickAddApi {
 				setClipboard: async (text: string) => {
 					return await navigator.clipboard.writeText(text);
 				},
+				getSelection: () => {
+					const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+
+					if (!activeView) {
+						return "";
+					}
+
+					return activeView.editor.getSelection() ?? "";
+				},
 				getSelectedText: () => {
 					const activeView = app.workspace.getActiveViewOfType(MarkdownView);
 


### PR DESCRIPTION
## Summary
- add quickAddApi.utility.getSelection for safe selection access in macros
- document the helper in QuickAdd API and Macro docs

## Testing
- not run (not requested)

## Issue
Closes #483

## Release/Migration
- additive API; no migration required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `getSelection()` method to the QuickAdd API's utility object, allowing retrieval of the currently selected text in the active editor.

* **Documentation**
  * Added usage examples demonstrating how to access and store the active editor's text selection within macros.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->