### PR TITLE
fix: harden suggester filtering on Android

### DIFF
--- a/src/gui/GenericSuggester/genericSuggester.test.ts
+++ b/src/gui/GenericSuggester/genericSuggester.test.ts
@@ -18,4 +18,13 @@ describe("GenericSuggester", () => {
 		expect(() => suggester.getSuggestions("1")).not.toThrow();
 	});
 
+	it("tolerates undefined query input", () => {
+		const items = ["Alpha", "Beta"];
+		const suggester = new GenericSuggester(app, items, items);
+
+		expect(() =>
+			suggester.getSuggestions(undefined as unknown as string),
+		).not.toThrow();
+	});
+
 });

--- a/src/gui/GenericSuggester/genericSuggester.ts
+++ b/src/gui/GenericSuggester/genericSuggester.ts
@@ -1,7 +1,7 @@
 import { FuzzySuggestModal } from "obsidian";
 import type { FuzzyMatch, App } from "obsidian";
 import { log, toError } from "src/logger/logManager";
-import { normalizeDisplayItem } from "../suggesters/utils";
+import { normalizeDisplayItem, normalizeQuery } from "../suggesters/utils";
 
 type SuggestRender<T> = (value: T, el: HTMLElement) => void;
 
@@ -84,6 +84,11 @@ export default class GenericSuggester<T> extends FuzzySuggestModal<T> {
 
 	getItems(): T[] {
 		return this.items;
+	}
+
+	getSuggestions(query: string): FuzzyMatch<T>[] {
+		const safeQuery = normalizeQuery(query);
+		return super.getSuggestions(safeQuery);
 	}
 
 	selectSuggestion(

--- a/src/gui/InputSuggester/inputSuggester.test.ts
+++ b/src/gui/InputSuggester/inputSuggester.test.ts
@@ -42,6 +42,18 @@ describe("InputSuggester", () => {
 		expect(matchingEntries).toHaveLength(1);
 	});
 
+	it("tolerates undefined query input", () => {
+		const suggester = new InputSuggester(
+			app,
+			["Alpha file", "Beta note"],
+			["Alpha file", "Beta note"]
+		);
+
+		expect(() =>
+			suggester.getSuggestions(undefined as unknown as string),
+		).not.toThrow();
+	});
+
 	it("aligns displayItems length with items length", () => {
 		const shortDisplay = ["Alpha"];
 		const shortItems = ["Alpha", "Beta", "Gamma"];

--- a/src/gui/InputSuggester/inputSuggester.ts
+++ b/src/gui/InputSuggester/inputSuggester.ts
@@ -1,7 +1,7 @@
 import { FuzzySuggestModal } from "obsidian";
 import type { FuzzyMatch, App } from "obsidian";
 import { log, toError } from "src/logger/logManager";
-import { normalizeDisplayItem } from "../suggesters/utils";
+import { normalizeDisplayItem, normalizeQuery } from "../suggesters/utils";
 
 type SuggestRender<T> = (value: T, el: HTMLElement) => void;
 
@@ -113,8 +113,9 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 	}
 
 	getSuggestions(query: string): FuzzyMatch<string>[] {
-		const suggestions = super.getSuggestions(query);
-		const customValue = this.inputEl.value;
+		const safeQuery = normalizeQuery(query);
+		const suggestions = super.getSuggestions(safeQuery);
+		const customValue = normalizeQuery(this.inputEl.value);
 
 		if (!customValue) return suggestions;
 

--- a/src/gui/suggesters/SuggesterInputSuggest.ts
+++ b/src/gui/suggesters/SuggesterInputSuggest.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
 import { TextInputSuggest } from "./suggest";
+import { normalizeDisplayItem, normalizeQuery } from "./utils";
 
 export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	private options: string[];
@@ -14,7 +15,7 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 		multiSelect = false,
 	) {
 		super(app, inputEl);
-		this.options = options;
+		this.options = options.map((option) => normalizeDisplayItem(option));
 		this.caseSensitive = caseSensitive;
 		this.multiSelect = multiSelect;
 
@@ -44,7 +45,8 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	}
 
 	getSuggestions(query: string): string[] {
-		const { alreadySelected, activeTerm } = this.parseMultiSelectInput(query);
+		const safeQuery = normalizeQuery(query);
+		const { alreadySelected, activeTerm } = this.parseMultiSelectInput(safeQuery);
 		const searchQuery = this.caseSensitive ? activeTerm : activeTerm.toLowerCase();
 
 		const available = this.getRemainingOptions(alreadySelected);

--- a/src/gui/suggesters/genericTextSuggester.ts
+++ b/src/gui/suggesters/genericTextSuggester.ts
@@ -1,5 +1,6 @@
-import { TextInputSuggest } from "./suggest";
 import type { App } from "obsidian";
+import { TextInputSuggest } from "./suggest";
+import { normalizeDisplayItem, normalizeQuery } from "./utils";
 
 export class GenericTextSuggester extends TextInputSuggest<string> {
 	constructor(
@@ -9,10 +10,11 @@ export class GenericTextSuggester extends TextInputSuggest<string> {
 		private maxSuggestions = Infinity
 	) {
 		super(app, inputEl);
+		this.items = items.map((item) => normalizeDisplayItem(item));
 	}
 
 	getSuggestions(inputStr: string): string[] {
-		const inputLowerCase: string = inputStr.toLowerCase();
+		const inputLowerCase = normalizeQuery(inputStr).toLowerCase();
 
 		const filtered = this.items.filter((item) => {
 			return item.toLowerCase().includes(inputLowerCase);

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -8,6 +8,10 @@ export function normalizeDisplayItem(value: unknown): string {
 	return String(value);
 }
 
+export function normalizeQuery(value: unknown): string {
+	return normalizeDisplayItem(value);
+}
+
 export function normalizeForSearch(value: string): string {
 	return value.normalize("NFC").toLowerCase();
 }

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -17,6 +17,7 @@ import GenericWideInputPrompt from "./gui/GenericWideInputPrompt/GenericWideInpu
 import GenericYesNoPrompt from "./gui/GenericYesNoPrompt/GenericYesNoPrompt";
 import InputSuggester from "./gui/InputSuggester/inputSuggester";
 import VDateInputPrompt from "./gui/VDateInputPrompt/VDateInputPrompt";
+import { normalizeDisplayItem } from "./gui/suggesters/utils";
 import type { IChoiceExecutor } from "./IChoiceExecutor";
 import type QuickAdd from "./main";
 import { OnePageInputModal } from "./preflight/OnePageInputModal";
@@ -671,6 +672,7 @@ export class QuickAddApi {
 			} else {
 				displayedItems = displayItems;
 			}
+			displayedItems = displayedItems.map((item) => normalizeDisplayItem(item));
 
 			if (allowCustomInput) {
 				return await InputSuggester.Suggest(


### PR DESCRIPTION
## Summary
- Fix Android WebView crash in QuickAdd suggester filtering when query or options are undefined/non-string
- Normalize suggester inputs at the API boundary and across suggester implementations
- Add regression tests for undefined query handling

## Issue
Closes #1078

## Reproduction
1. On Android (Obsidian 1.11.4), run a QuickAdd script that passes folder children to quickAddApi.suggester (see issue).
2. Start typing to filter results.
3. The suggester crashes with "Cannot read properties of undefined (reading 'toLowerCase')".

## Root Cause
FuzzySuggestModal internally calls query.toLowerCase(). When the input event or options list includes undefined (e.g., folder children without a basename or programmatic updates that pass undefined), the query or option is not a string. This caused the Android WebView to throw at .toLowerCase(), breaking filtering and leaving the suggester unusable.

## Fix
- Introduce a single normalizeQuery helper so every suggester normalizes query values before fuzzy matching.
- Normalize suggester options at the API boundary, so any entry point (including scripts and preflight input) receives safe string display items.
- Ensure input suggesters normalize custom input values before comparisons.

## Tests
- bun run test
