### PR TITLE
fix: clarify split direction labels to match actual behavior

### DIFF
--- a/src/gui/ChoiceBuilder/choiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/choiceBuilder.ts
@@ -162,11 +162,11 @@ export abstract class ChoiceBuilder extends Modal {
 		if (fileOpening.location === "split") {
 			new Setting(this.contentEl)
 				.setName("Split Direction")
-				.setDesc("Direction for split panes")
+				.setDesc("How to arrange the new pane relative to the current one")
 				.addDropdown((dropdown) => {
 					dropdown.addOptions({
-						vertical: "Vertical",
-						horizontal: "Horizontal",
+						vertical: "Split right",
+						horizontal: "Split down",
 					});
 					dropdown.setValue(fileOpening.direction);
 					dropdown.onChange((value: any) => {

--- a/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
@@ -131,11 +131,11 @@ export class OpenFileCommandSettingsModal extends Modal {
 	private addDirectionSetting() {
 		new Setting(this.contentEl)
 			.setName("Split direction")
-			.setDesc("Which direction to split when opening")
+			.setDesc("How to arrange the new pane relative to the current one")
 			.addDropdown((dropdown) => {
 				dropdown
-					.addOption(NewTabDirection.vertical, "Vertical")
-					.addOption(NewTabDirection.horizontal, "Horizontal")
+					.addOption(NewTabDirection.vertical, "Split right")
+					.addOption(NewTabDirection.horizontal, "Split down")
 					.setValue(this.command.direction ?? NewTabDirection.vertical)
 					.onChange((value) => {
 						this.command.direction = value as NewTabDirection;


### PR DESCRIPTION
## Summary
- Renamed confusing "Horizontal"/"Vertical" split direction labels to "Split down"/"Split right"
- Labels now describe where the new pane appears, matching user expectations
- Updated description to clarify what the setting controls

## Root Cause
Obsidian's `SplitDirection` refers to divider orientation, not pane placement:
- `"vertical"` = vertical divider = panes side by side (split right)
- `"horizontal"` = horizontal divider = panes stacked (split down)

The old labels caused users to select "Horizontal" expecting stacked panes, but getting side-by-side instead.

## Test plan
- [x] Create a Template Choice with "Split pane" location
- [x] Select "Split right" → verify new pane opens to the right
- [x] Select "Split down" → verify new pane opens below
- [x] Test same in Macro "Open File" command settings

Fixes #1081
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1089">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved clarity in File Opening UI by updating dropdown labels and descriptions. Split direction options now use "Split right" and "Split down" terminology with enhanced descriptive guidance for better user understanding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->