### PR TITLE
fix: encode spaces in advanced uri docs

### DIFF
--- a/docs/docs/Misc/AHK_OpenQuickAddFromDesktop.md
+++ b/docs/docs/Misc/AHK_OpenQuickAddFromDesktop.md
@@ -36,7 +36,7 @@ SetTitleMatchMode, RegEx
 !^+g::
     WinActivate, i) Obsidian
 
-    Run "obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd: Run QuickAdd"
+    Run "obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd"
 Return
 ```
 
@@ -56,7 +56,7 @@ So, you can replace the `!^+g` with any hotkey of your choosing.
 
 You can trigger QuickAdd via the Advanced URI using any launcher or automation tool you prefer:
 
-- Open URL: `obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd: Run QuickAdd`
+- Open URL: `obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd`
 
 Examples:
 - macOS Shortcuts: add an “Open URLs” action with the URI; assign a keyboard shortcut.

--- a/docs/versioned_docs/version-2.9.4/Misc/AHK_OpenQuickAddFromDesktop.md
+++ b/docs/versioned_docs/version-2.9.4/Misc/AHK_OpenQuickAddFromDesktop.md
@@ -36,7 +36,7 @@ SetTitleMatchMode, RegEx
 !^+g::
     WinActivate, i) Obsidian
 
-    Run "obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd: Run QuickAdd"
+    Run "obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd"
 Return
 ```
 
@@ -56,7 +56,7 @@ So, you can replace the `!^+g` with any hotkey of your choosing.
 
 You can trigger QuickAdd via the Advanced URI using any launcher or automation tool you prefer:
 
-- Open URL: `obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd: Run QuickAdd`
+- Open URL: `obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd`
 
 Examples:
 - macOS Shortcuts: add an “Open URLs” action with the URI; assign a keyboard shortcut.


### PR DESCRIPTION
## Summary
- Encode spaces in the Advanced URI QuickAdd command example in docs
- Apply the same fix to the current versioned docs

## Testing
- Not run (docs-only change)

## UI Changes
- N/A

## Issues
- Fixes #282

## Release / Migration Impact
- None (docs only)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1092">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Obsidian Advanced URI examples to properly encode spaces in QuickAdd command paths across both current and legacy documentation versions for correct command execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->