### PR TITLE
fix(docs): clarify how to add user scripts to macros

### DIFF
--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -69,6 +69,28 @@ In the Macro Builder, you can add different types of commands:
    - Run custom scripts that return a boolean to choose a branch
    - Configure "then" and optional "else" command sequences from the builder
 
+### Add a User Script Command
+
+Macros do not contain JavaScript code directly. Your code lives in a `.js` file
+inside your vault, and the macro simply runs that file.
+
+Create a new script file such as `scripts/my-macro.js` and make sure it is not
+inside `.obsidian` or any folder whose name starts with a dot. QuickAdd ignores
+scripts in those locations, so they will not show up in the script picker.
+
+Open the Macro Builder, add a **User Script** command, and select your script
+file. If the script exports multiple functions, QuickAdd will ask which export
+to run. You can also set an output variable name so later commands can reuse the
+result.
+
+If your goal is to insert text into a note, use a **Template** or **Capture**
+choice and run it from the macro using a **Nested Choice** command. This is the
+intended way to write content. No YAML frontmatter is required.
+
+If your script calls APIs from other plugins, those plugins must be installed
+and enabled in your vault. You do not need any extra plugins just to run user
+scripts in macros.
+
 ### Conditional Commands
 
 Conditional commands let you branch your macro without writing boilerplate JavaScript. Each conditional includes:


### PR DESCRIPTION
Fixes #341.

This adds a short prose section to the Macros docs that explains where macro JavaScript lives, how to add a User Script command, and what to use when the goal is to insert text.

Testing:
- bun run test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for User Script Commands in Macro Builder, covering script storage locations, setup procedures, handling multiple exports, optional output variable configuration, recommended alternative approaches for text insertion tasks, and plugin compatibility information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->