### PR TITLE
fix: insert-at-end-of-section appends correctly

### DIFF
--- a/src/formatters/helpers/getEndOfSection.test.ts
+++ b/src/formatters/helpers/getEndOfSection.test.ts
@@ -311,6 +311,21 @@ test("getEndOfSection - capture to last line, shouldConsiderSubsections OFF", ()
 	expect(result).toBe(2);
 });
 
+test("getEndOfSection - target heading with only subsections, should not consider subsections", () => {
+	const lines = [
+		"## Insert", // target (0)
+		"1",
+		"2", // result (2)
+		"### Subsection",
+		"sub content",
+	];
+
+	const targetLine = 0;
+
+	const result = getEndOfSection(lines, targetLine, false);
+	expect(result).toBe(2);
+});
+
 
 test("getMarkdownHeadings - correctly identifies headings", () => {
 	const lines = [

--- a/src/formatters/helpers/getEndOfSection.ts
+++ b/src/formatters/helpers/getEndOfSection.ts
@@ -177,11 +177,9 @@ function findNextHeading(
 	fromIdxInBody: number,
 	headings: Heading[],
 ): number | null {
-	const nextheading = headings.findIndex(
-		(heading) => heading.line > fromIdxInBody,
-	);
+	const nextHeading = headings.find((heading) => heading.line > fromIdxInBody);
 
-	return nextheading === -1 ? null : nextheading;
+	return nextHeading ? nextHeading.line : null;
 }
 
 function findPriorIdx<T>(


### PR DESCRIPTION
Fixes #593

Corrects end-of-section detection so captures configured with “Insert at end of section” append in-order instead of stacking under the header.

Adds a regression test for headings with only subsections.
