### PR TITLE
fix: format VDATE values passed via API/URL params (#1074)

### DIFF
--- a/src/formatters/vdate-default.test.ts
+++ b/src/formatters/vdate-default.test.ts
@@ -244,6 +244,19 @@ describe('VDATE Default Value Support', () => {
             expect(formatter.testDateParser.parseDate).toHaveBeenCalledWith("today");
             expect(result).toBe("Date1: YYYY-MM-DD-formatted Date2: MM/DD/YYYY-formatted");
         });
+
+        it('should parse and format pre-seeded string variables used in VDATE', async () => {
+            // Mirrors issue #1074: variables passed via API/URL are plain strings.
+            formatter.variables.set('date', '2026-12-31');
+
+            const result = await formatter.testReplaceDateVariableInString(
+                "Test {{VDATE:date,YYYY-MM-DD}}",
+            );
+
+            // The formatter should attempt to parse the existing string into a date.
+            expect(formatter.testDateParser.parseDate).toHaveBeenCalledWith("2026-12-31");
+            expect(result).toBe("Test YYYY-MM-DD-formatted");
+        });
     });
 
     describe('Edge Cases', () => {


### PR DESCRIPTION
## What
Fixes VDATE formatting when template variables are provided via the QuickAdd JS API or `obsidian://quickadd` URL params. Previously, passing a date like `2026-12-31` would be rendered as the raw string (e.g. `2026-12-31`) even when the template used a formatted VDATE token like `{{VDATE:date,DD MMMM YYYY}}`.

Fixes #1074

## Why
VDATE formatting only kicked in when a variable was stored in QuickAdd’s internal date encoding (`@date:<ISO>`), which is normally created when the user is prompted for a date. Values passed in via API/URL are plain strings, so they never got parsed/coerced into the date form and the formatter fell back to echoing the original value.

## How
When a VDATE token is processed and the variable already exists:
- If it’s a plain string (and not `@date:`), normalize + parse it using the date parser and, if successful, coerce it into `@date:<ISO>` so the existing formatting path is used.
- If it’s a `Date` object, coerce it into `@date:<ISO>` as well.
- If parsing fails, keep the original value (backwards-compatible behavior).

## Validation
- Added a regression unit test covering the API/URL scenario (pre-seeded string variable used by `{{VDATE:...}}` is parsed + formatted).
- `bun run test`
- `bun run lint`
- `bun run build`
