### PR TITLE
fix: add newline when appending tasks

### DIFF
--- a/src/formatters/captureChoiceFormatter-frontmatter.test.ts
+++ b/src/formatters/captureChoiceFormatter-frontmatter.test.ts
@@ -534,3 +534,40 @@ describe('CaptureChoiceFormatter insert after inline', () => {
     expect(reportError).toHaveBeenCalled();
   });
 });
+
+describe('CaptureChoiceFormatter append task newline regression (issue #124)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (global as any).navigator = {
+      clipboard: {
+        readText: vi.fn().mockResolvedValue(''),
+      },
+    };
+  });
+
+  it('inserts a newline before an appended task when the file does not end with a newline', async () => {
+    const app = createMockApp();
+    const plugin = {
+      settings: {
+        enableTemplatePropertyTypes: false,
+        globalVariables: {},
+        showCaptureNotification: false,
+        showInputCancellationNotification: true,
+      },
+    } as any;
+    const formatter = new CaptureChoiceFormatter(app, plugin);
+
+    const choice = createChoice({ prepend: true, task: true });
+    const file = createTFile('Test.md');
+    const fileContent = '- [ ] Old task';
+
+    const result = await formatter.formatContentWithFile(
+      '- [ ] New task\n',
+      choice,
+      fileContent,
+      file,
+    );
+
+    expect(result).toBe('- [ ] Old task\n- [ ] New task\n');
+  });
+});

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -120,9 +120,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		if (formattedContentIsEmpty) return this.fileContent;
 
 		if (this.choice.prepend) {
+			// When appending to the end of a file, ensure the capture starts on a new line.
+			// Notes are not guaranteed to end with a trailing newline (see issue #124).
 			const shouldInsertLinebreak = !this.choice.task;
-			return `${this.fileContent}${shouldInsertLinebreak ? "\n" : ""
-				}${formatted}`;
+			const needsLeadingNewline =
+				this.fileContent.length > 0 &&
+				!this.fileContent.endsWith("\n") &&
+				!formatted.startsWith("\n");
+			const separator = shouldInsertLinebreak || needsLeadingNewline ? "\n" : "";
+
+			return `${this.fileContent}${separator}${formatted}`;
 		}
 
 		if (this.choice.insertAfter.enabled) {


### PR DESCRIPTION
Fixes #124.

This addresses a missing newline when appending a *task* capture to the bottom of a note that does not end with a trailing newline.

Repro
- Existing note ends without a final newline
- Capture appends a task to bottom
- Before: `- [ ] Old task- [ ] New task` (same line)
- After: tasks land on separate lines

Changes
- Ensure a separator newline is inserted when needed in the CaptureChoiceFormatter append-to-bottom path.
- Add a regression test for the no-trailing-newline case.

Verification
- `bun run test`
- `bun run build-with-lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved newline handling when appending tasks to files, ensuring proper separation between existing content and newly formatted content, particularly for files without trailing newlines.

* **Tests**
  * Added test suite validating correct newline formatting behavior when appending tasks to existing file content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->