### PR TITLE
test: add regression for section-end table separator capture

### DIFF
--- a/src/formatters/helpers/getEndOfSection.test.ts
+++ b/src/formatters/helpers/getEndOfSection.test.ts
@@ -204,6 +204,25 @@ test("getEndOfSection - capture to end of section with a leading tag, should not
 	expect(result).toBe(5);
 });
 
+test("getEndOfSection - heading section with markdown table separators", () => {
+	const lines = [
+		"# Notes",
+		"",
+		"## Time", // target (2)
+		"| Price | Account | receiver | Name |",
+		"| --- | --- | --- | --- |",
+		"| 22 | boc | rstr | breakfast |",
+		"| 45 | boc | rstr | lunch |", // result (6)
+		"## Next",
+		"content",
+	];
+
+	const targetLine = 2;
+
+	const result = getEndOfSection(lines, targetLine, false);
+	expect(result).toBe(6);
+});
+
 test("getEndOfSection - target is heading, should consider subsections", () => {
 	const lines = [
 		"# Notes", // target (0)


### PR DESCRIPTION
## Summary
- Investigated issue #365 in the dev vault using the Obsidian CLI.
- Current behavior already inserts at the end of the section correctly for markdown tables with separator rows (`| --- |`).
- Added regression coverage so this behavior is preserved.

## Reproduction Evidence
- Configured a capture choice with:
  - `Insert after`: `## Time`
  - `Insert at end of section`: enabled
- Ran the choice against a note containing a table separator row.
- Verified the captured text is inserted after the table rows (not before the separator row).

## Changes
- Added regression test:
  - `src/formatters/helpers/getEndOfSection.test.ts:207`
- New test asserts a heading section containing markdown table separator rows resolves to the true section end.

## Validation
- `bun run build-with-lint`
- `bun run test`

## Impact
- No runtime behavior change introduced.
- Locks in the current correct behavior for issue #365.

Closes #365

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case to verify correct section parsing when markdown table formatting is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->