### PR TITLE
fix: prevent duplicated destination prefixes for template filename paths

### DIFF
--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
 import { TFile } from "obsidian";
+import { TFolder } from "obsidian";
 import invariant from "src/utils/invariant";
 import {
 	fileExistsAppendToBottom,
@@ -342,12 +343,14 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		const normalizedFileName = formattedName.trim();
 		if (!normalizedFileName.includes("/")) return false;
 		if (normalizedFileName.startsWith("./")) return false;
+
 		if (normalizedFileName.startsWith("/")) return true;
 
-		const slashCount = normalizedFileName.split("/").length - 1;
-		// Keep one-level subpaths (e.g. "tasks/note") relative to Obsidian's
-		// default folder, while treating deeper paths as vault-relative.
-		return slashCount >= 2;
+		const [firstSegment] = this.stripLeadingSlash(normalizedFileName).split("/");
+		if (!firstSegment) return false;
+
+		const rootEntry = this.app.vault.getAbstractFileByPath(firstSegment);
+		return rootEntry instanceof TFolder;
 	}
 
 	private getCurrentFolderSuggestion():


### PR DESCRIPTION
## Summary
Fix template choice destination path resolution when `Create in folder` is disabled and `File name format` already includes folders.

QuickAdd was always prepending Obsidian's resolved default note folder (`getNewFileParent`) to the formatted filename. If the formatted name was already a vault-relative path, this produced duplicated/incorrect prefixes.

This change:
- strips exact duplicate folder prefixes from formatted names
- treats slash-separated formatted names as explicit vault-relative paths when their first segment exists at vault root
- preserves existing default-folder behavior for plain filenames and relative subpaths

Closes #1116.

## Before / After Repro Evidence
### Before fix (confirmed)
- Active note in `03_Aufgabenmanagement/ToDos/W-Tanso/...`
- File name format: `03_Aufgabenmanagement/ToDos/W-Work/this_is_a_task/Issue1116-before-{{DATE:YYYY-MM-DD}}.excalidraw`
- Created path:
  - `03_Aufgabenmanagement/ToDos/W-Tanso/03_Aufgabenmanagement/ToDos/W-Work/this_is_a_task/Issue1116-before-2026-02-23.excalidraw.md`
- Console log showed same duplicated destination in `TemplateEngine.createFileWithTemplate`.

### After fix (confirmed)
Same setup now creates:
- `03_Aufgabenmanagement/ToDos/W-Work/this_is_a_task/Issue1116-after-current-2026-02-23.excalidraw.md`

With Obsidian default note location set to fixed folder (`00_Journaling/Daily_Notes`), same format now creates:
- `03_Aufgabenmanagement/ToDos/W-Work/this_is_a_task/Issue1116-after-daily-2026-02-23.excalidraw.md`

No runtime errors were captured via `obsidian vault=dev dev:errors`.

## Tests
Added regression coverage in `src/engine/TemplateChoiceEngine.notice.test.ts`:
- full-path filename format is treated correctly (no duplicate prefix)
- plain filename still follows Obsidian default new-note location
- relative subpaths remain under default location

Executed:
- `bun run test src/engine/TemplateChoiceEngine.notice.test.ts`
- `bun run test`
- `bun run build-with-lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for template destination path resolution covering vault-relative paths, leading-slash and deep subpaths, plain filenames, default-folder interactions, create-in-folder behavior, and root-edge cases.

* **Bug Fixes**
  * Improved template file path resolution so vault-relative names, duplicate-folder prefixes, relative subpaths, and create-in-folder scenarios produce correct destination paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->