### PR TITLE
fix: preserve capture-format spacing for insert-at-end

### DIFF
--- a/src/formatters/captureChoiceFormatter-frontmatter.test.ts
+++ b/src/formatters/captureChoiceFormatter-frontmatter.test.ts
@@ -386,7 +386,7 @@ describe('CaptureChoiceFormatter insert after end-of-section spacing', () => {
     const formatter = new CaptureChoiceFormatter(app, plugin);
     const file = createTFile('EndOfSection.md');
 
-    return { formatter, file };
+    return { app, formatter, file };
   };
 
   const createInsertAfterChoice = (
@@ -492,6 +492,32 @@ describe('CaptureChoiceFormatter insert after end-of-section spacing', () => {
 
     expect(result).toBe(
       ['# Journal', '', '18:13', 'Test5', '', '10:00', 'Some data', ''].join('\n'),
+    );
+  });
+
+  it('uses EOF spacing logic when create-if-not-found inserts at cursor with insert-at-end', async () => {
+    const { app, formatter, file } = createFormatter();
+    const choice = createInsertAfterChoice('# Missing', {
+      createIfNotFound: true,
+      createIfNotFoundLocation: 'cursor',
+    });
+    (app.workspace.getActiveViewOfType as any).mockReturnValue({
+      editor: {
+        getCursor: vi.fn().mockReturnValue({ line: 0, ch: 0 }),
+        getSelection: vi.fn().mockReturnValue(''),
+      },
+    });
+    const initial = ['# Journal', '', '10:00', 'Some data', '', ''].join('\n');
+
+    const result = await formatter.formatContentWithFile(
+      '18:14\nTest6\n\n',
+      choice,
+      initial,
+      file,
+    );
+
+    expect(result).toBe(
+      ['# Journal', '', '10:00', 'Some data', '', '# Missing', '18:14', 'Test6', '', ''].join('\n'),
     );
   });
 });

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -466,7 +466,11 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 						!!this.choice.insertAfter.considerSubsections,
 					);
 
-					targetPosition = endOfSectionIndex ?? fileContentLines.length - 1;
+					targetPosition = this.findInsertAfterPositionAtSectionEnd(
+						fileContentLines,
+						endOfSectionIndex ?? fileContentLines.length - 1,
+						this.fileContent,
+					);
 				}
 
 				const newFileContent = this.insertTextAfterPositionInBody(


### PR DESCRIPTION
## Summary
- fix Capture insertAfter + insertAtEnd insertion positioning so trailing blank lines at EOF are preserved instead of collapsing entries
- keep existing behavior unchanged when blank lines are followed by content (for example before the next heading)
- add regression tests for repeated insert-at-end captures, leading-newline formats, non-heading targets, and insertAtEnd=false guard behavior

## Testing
- bun run test
- bun run lint
- bun run build-with-lint
- Obsidian CLI (vault=dev) verification: repeated command-triggered captures now preserve the blank line between entries; dev:errors reported no runtime errors

Closes #712


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined insertion behavior at section ends to better preserve trailing blank lines and final-newline spacing when adding content.

* **Tests**
  * Added comprehensive tests covering various section-end insertion scenarios, including EOF and cursor-based create/insert flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->