### PR TITLE
fix: keep insert-at-end order for non-newline captures

### DIFF
--- a/src/formatters/captureChoiceFormatter-frontmatter.test.ts
+++ b/src/formatters/captureChoiceFormatter-frontmatter.test.ts
@@ -478,6 +478,28 @@ describe('CaptureChoiceFormatter insert after end-of-section spacing', () => {
     expect(second).toBe(['Target', 'Existing', 'One', '', 'Two', '', ''].join('\n'));
   });
 
+  it('preserves insertion order when format has no trailing newline and EOF blanks exist', async () => {
+    const { formatter, file } = createFormatter();
+    const choice = createInsertAfterChoice('# H');
+    const initial = ['# H', 'A', '', ''].join('\n');
+
+    const first = await formatter.formatContentWithFile(
+      'X',
+      choice,
+      initial,
+      file,
+    );
+
+    const second = await formatter.formatContentWithFile(
+      'Y',
+      choice,
+      first,
+      file,
+    );
+
+    expect(second).toBe(['# H', 'A', 'X', 'Y'].join('\n'));
+  });
+
   it('does not change behavior when insert-at-end is disabled', async () => {
     const { formatter, file } = createFormatter();
     const choice = createInsertAfterChoice('# Journal', { insertAtEnd: false });

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -266,7 +266,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	private findInsertAfterPositionAtSectionEnd(
 		lines: string[],
 		sectionEndIndex: number,
-		body: string,
+		fileContent: string,
+		insertedText: string,
 	): number {
 		if (sectionEndIndex < 0) return sectionEndIndex;
 
@@ -284,10 +285,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			return sectionEndIndex;
 		}
 
+		// For entries without trailing newline, keep insertion anchored at the
+		// section end so repeated captures preserve order.
+		if (!insertedText.endsWith("\n")) {
+			return sectionEndIndex;
+		}
+
 		// split("\n") keeps a trailing empty string when content ends in "\n".
 		// We keep one trailing slot so the next insertion preserves capture spacing
 		// without introducing an extra blank line before the inserted text.
-		if (body.endsWith("\n")) {
+		if (fileContent.endsWith("\n")) {
 			return Math.max(sectionEndIndex, position - 1);
 		}
 
@@ -334,6 +341,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 				fileContentLines,
 				endOfSectionIndex ?? fileContentLines.length - 1,
 				this.fileContent,
+				formatted,
 			);
 		} else {
 			const blankLineMode =
@@ -470,8 +478,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 						fileContentLines,
 						endOfSectionIndex ?? fileContentLines.length - 1,
 						this.fileContent,
+						insertAfterLineAndFormatted,
 					);
-				}
+					}
 
 				const newFileContent = this.insertTextAfterPositionInBody(
 					insertAfterLineAndFormatted,


### PR DESCRIPTION
## Summary
- fix a regression in `insertAfter.insertAtEnd` when the capture text does **not** end with a newline and the file has trailing EOF blank lines
- avoid shifting insertion into trailing EOF blank lines for non-newline entries, preserving append order across repeated captures
- keep existing spacing-preservation behavior for newline-terminated capture formats
- add regression coverage for `# H\nA\n\n` + `X` then `Y` (no trailing newline), asserting order remains `X` then `Y`

## Validation
- bun run test -- src/formatters/captureChoiceFormatter-frontmatter.test.ts
- bun run test
- bun run lint
- bun run build-with-lint
- Obsidian CLI (`vault=dev`) repro check: `# H\nA\n\n` with format `{{value}}` now yields `# H\nA\nX\nY` after two captures

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed insertion order preservation for repeated captures when content lacks trailing newlines, ensuring consistent behavior across successive operations.

* **Tests**
  * Added test coverage verifying insertion order preservation when formatting has no trailing newline and end-of-file blanks are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->