### PR TITLE
fix(capture): preserve canvas tab indentation on configured writes

### DIFF
--- a/src/engine/canvasCapture.test.ts
+++ b/src/engine/canvasCapture.test.ts
@@ -285,6 +285,8 @@ describe("canvasCapture", () => {
 		};
 		expect(updated.nodes[0].id).toBe("t1");
 		expect(updated.nodes[0].text).toBe("Updated");
+		expect(modified).toContain('\t"nodes": [');
+		expect(modified).not.toContain('  "nodes": [');
 	});
 
 	it("aborts configured text-node write when canvas changed concurrently", async () => {

--- a/src/engine/canvasCapture.ts
+++ b/src/engine/canvasCapture.ts
@@ -455,6 +455,6 @@ export async function setCanvasTextCaptureContent(
 	target.canvasData.nodes[target.nodeIndex] = target.nodeData;
 	await app.vault.modify(
 		target.canvasFile,
-		JSON.stringify(target.canvasData, null, 2),
+		JSON.stringify(target.canvasData, null, "\t"),
 	);
 }


### PR DESCRIPTION
Preserve Obsidian-style tab indentation when QuickAdd updates configured Canvas text nodes.

Configured Canvas writes currently serialize JSON with 2-space indentation, which rewrites whole `.canvas` files with whitespace-only diffs. This follow-up keeps serialization aligned with Obsidian’s tab-indented format to reduce diff noise and avoid unnecessary formatting churn.

Changes made:
- switch configured canvas serialization from `JSON.stringify(..., null, 2)` to `JSON.stringify(..., null, \"\t\")`
- add a regression assertion in `canvasCapture.test.ts` to ensure persisted output keeps tab indentation

Alternative considered:
- preserving original file formatting dynamically (more complex and brittle for this targeted follow-up)

Reviewer context:
- this is a narrow post-merge follow-up to late review feedback on #1124 (`discussion_r2866132800`)
- behavior change is limited to configured Canvas text-node write formatting; content semantics are unchanged

Refs #1124
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated JSON indentation format in canvas data files to use tabs instead of spaces.

* **Tests**
  * Added test assertions to validate the updated indentation format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->