### PR TITLE
fix(gui): reduce AI settings modal full-reload usage

### DIFF
--- a/plans/issue-1130-fsm-modal-reload.md
+++ b/plans/issue-1130-fsm-modal-reload.md
@@ -18,6 +18,7 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
 - [x] (2026-03-05 06:15Z) Integrated reload controller into scoped modals (`ChoiceBuilder`, Macro settings modals, AI settings modals) and replaced direct full-refresh `reload()` implementations.
 - [x] (2026-03-05 06:16Z) Verified with `bun run test`, `bun run build`, `bun run build-with-lint`, and Obsidian CLI runtime probes in `vault=dev`.
 - [x] (2026-03-05 06:44Z) Hardened reload queue handling by replacing recursive pending-reload replay with iterative draining and added two regression tests for re-entrant/coalesced reload requests.
+- [x] (2026-03-05 07:56Z) Implemented phase-2 in-place UI updates for AI command settings modals so `Show advanced settings` no longer triggers full modal reload, and removed non-infinite model-change/name-edit reloads by refreshing UI elements directly.
 
 ## Surprises & Discoveries
 
@@ -38,6 +39,9 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
 
 - Observation: `requestReload()` can be called re-entrantly during `render()`, so pending replay should avoid recursion.
   Evidence: added tests where render triggers queued reload(s), asserting two render passes and latest-reason coalescing.
+
+- Observation: `Show advanced settings` can be updated as a local section re-render without changing surrounding settings rows.
+  Evidence: CLI probe in `quickadd:testQuickAdd` showed `scrollTop` remained `220` and active element stayed `TEXTAREA` while modal height increased after toggle.
 
 ## Decision Log
 
@@ -61,6 +65,10 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
   Rationale: iterative draining preserves behavior while removing recursive call chains during re-entrant reload scenarios.
   Date/Author: 2026-03-05 / Codex
 
+- Decision: convert advanced-settings visibility in AI command settings modals from full reload to in-place section rendering.
+  Rationale: this is a high-frequency interaction and does not require rebuilding unrelated controls; local re-render removes unnecessary modal churn.
+  Date/Author: 2026-03-05 / Codex
+
 ## Outcomes & Retrospective
 
 Implemented outcome matches purpose: reload-driven modal jumps are now handled through an FSM-based controller that captures and restores UI position. Scoped modal classes no longer call direct full-refresh reload logic without restoration.
@@ -72,8 +80,9 @@ Validation results:
 - `bun run build-with-lint`: passed.
 - Obsidian CLI runtime probe (`vault=dev`) confirms preserved scroll/focus on model-change reload in the test modal.
 - Post-merge hardening: `modalReloadMachine` now has 6 passing tests, including queued and coalesced reload behavior during render re-entrancy.
+- Phase-2 follow-up: `Show advanced settings` in both AI command settings modals now updates in place (no full reload); CLI probe confirms stable scroll/focus with non-zero scroll range.
 
-Remaining gap: this change stabilizes reload behavior, but does not yet eliminate reloads entirely. Follow-up work can convert high-churn sections to fine-grained updates to reduce rerenders further.
+Remaining gap: this change reduces reload frequency in AI command settings flows but does not eliminate reloads across all modal classes. Further follow-up can convert additional conditional UI paths (for example `CaptureChoiceBuilder`, `TemplateChoiceBuilder`, and provider/model editors) to fine-grained section updates.
 
 ## Context and Orientation
 
@@ -274,3 +283,4 @@ Integration rule for every migrated modal:
 Revision Note (2026-03-05): Initial ExecPlan created in response to issue #1130 and user request to pursue an FSM-based solution rather than ad-hoc `reload()` calls.
 Revision Note (2026-03-05): Updated after implementation to reflect completed milestones, final validation evidence, and runtime probe adjustments needed to distinguish true preservation from expected scroll clamping.
 Revision Note (2026-03-05): Updated after merge with queue-drain hardening and additional controller regression tests for re-entrant reload requests.
+Revision Note (2026-03-05): Updated for phase-2 partial migration that removes full reloads from advanced-settings toggles in AI command settings modals and records new CLI evidence.

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -27,6 +27,8 @@ export class AIAssistantCommandSettingsModal extends Modal {
 	private settings: IAIAssistantCommand;
 	private showAdvancedSettings = false;
 	private readonly reloadController: ModalReloadController;
+	private advancedSettingsContainer: HTMLElement | null = null;
+	private refreshTokenCountText: (() => void) | null = null;
 
 	private get systemPromptTokenLength(): number {
 		if (this.settings.model === "Ask me") return Number.POSITIVE_INFINITY;
@@ -52,7 +54,6 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			modalEl: this.modalEl,
 			contentEl: this.contentEl,
 			render: () => {
-				this.contentEl.empty();
 				this.display();
 			},
 		});
@@ -62,6 +63,10 @@ export class AIAssistantCommandSettingsModal extends Modal {
 	}
 
 	private display(): void {
+		this.contentEl.empty();
+		this.advancedSettingsContainer = null;
+		this.refreshTokenCountText = null;
+
 		const header = this.contentEl.createEl("h2", {
 			text: `${this.settings.name} Settings`,
 		});
@@ -81,7 +86,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 
 				if (newName && newName !== this.settings.name) {
 					this.settings.name = newName;
-					this.reload();
+					header.setText(`${this.settings.name} Settings`);
 				}
 			} catch {} // no new name, don't need exceptional state for that
 		});
@@ -92,15 +97,10 @@ export class AIAssistantCommandSettingsModal extends Modal {
 		this.addOutputVariableNameSetting(this.contentEl);
 
 		this.addShowAdvancedSettingsToggle(this.contentEl);
-
-		if (this.showAdvancedSettings) {
-			if (!this.settings.modelParameters)
-				this.settings.modelParameters = {};
-			this.addTemperatureSetting(this.contentEl);
-			this.addTopPSetting(this.contentEl);
-			this.addFrequencyPenaltySetting(this.contentEl);
-			this.addPresencePenaltySetting(this.contentEl);
-		}
+		this.advancedSettingsContainer = this.contentEl.createDiv(
+			"qa-ai-advanced-settings"
+		);
+		this.renderAdvancedSettingsSection();
 
 		this.addSystemPromptSetting(this.contentEl);
 	}
@@ -158,8 +158,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 				dropdown.setValue(this.settings.model);
 				dropdown.onChange((value) => {
 					this.settings.model = value;
-
-					this.reload();
+					this.refreshTokenCountText?.();
 				});
 			});
 	}
@@ -229,6 +228,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 					: "select a model to calculate"
 			}`;
 		}, 50);
+		this.refreshTokenCountText = () => updateTokenCount();
 
 		updateTokenCount();
 
@@ -247,10 +247,26 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			.addToggle((toggle) => {
 				toggle.setValue(this.showAdvancedSettings);
 				toggle.onChange((value) => {
+					if (value === this.showAdvancedSettings) return;
 					this.showAdvancedSettings = value;
-					this.reload();
+					this.renderAdvancedSettingsSection();
 				});
 			});
+	}
+
+	private renderAdvancedSettingsSection(): void {
+		if (!this.advancedSettingsContainer) return;
+
+		this.advancedSettingsContainer.empty();
+		if (!this.showAdvancedSettings) return;
+		if (!this.settings.modelParameters) {
+			this.settings.modelParameters = {};
+		}
+
+		this.addTemperatureSetting(this.advancedSettingsContainer);
+		this.addTopPSetting(this.advancedSettingsContainer);
+		this.addFrequencyPenaltySetting(this.advancedSettingsContainer);
+		this.addPresencePenaltySetting(this.advancedSettingsContainer);
 	}
 
 	addTemperatureSetting(container: HTMLElement) {

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -24,6 +24,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 	private settings: IInfiniteAIAssistantCommand;
 	private showAdvancedSettings = false;
 	private readonly reloadController: ModalReloadController;
+	private advancedSettingsContainer: HTMLElement | null = null;
 
 	private get systemPromptTokenLength(): number {
 		const model = getModelByName(this.settings.model);
@@ -46,7 +47,6 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			modalEl: this.modalEl,
 			contentEl: this.contentEl,
 			render: () => {
-				this.contentEl.empty();
 				this.display();
 			},
 		});
@@ -57,6 +57,8 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 
 	private display(): void {
 		this.contentEl.empty();
+		this.advancedSettingsContainer = null;
+
 		const header = this.contentEl.createEl("h2", {
 			text: `${this.settings.name} Settings`,
 		});
@@ -76,7 +78,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 
 				if (newName && newName !== this.settings.name) {
 					this.settings.name = newName;
-					this.reload();
+					header.setText(`${this.settings.name} Settings`);
 				}
 			} catch {} // no new name, don't need exceptional state for that
 		});
@@ -90,15 +92,10 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 		this.addOutputVariableNameSetting(this.contentEl);
 
 		this.addShowAdvancedSettingsToggle(this.contentEl);
-
-		if (this.showAdvancedSettings) {
-			if (!this.settings.modelParameters)
-				this.settings.modelParameters = {};
-			this.addTemperatureSetting(this.contentEl);
-			this.addTopPSetting(this.contentEl);
-			this.addFrequencyPenaltySetting(this.contentEl);
-			this.addPresencePenaltySetting(this.contentEl);
-		}
+		this.advancedSettingsContainer = this.contentEl.createDiv(
+			"qa-ai-advanced-settings"
+		);
+		this.renderAdvancedSettingsSection();
 
 		this.addSystemPromptSetting(this.contentEl);
 	}
@@ -207,10 +204,26 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			.addToggle((toggle) => {
 				toggle.setValue(this.showAdvancedSettings);
 				toggle.onChange((value) => {
+					if (value === this.showAdvancedSettings) return;
 					this.showAdvancedSettings = value;
-					this.reload();
+					this.renderAdvancedSettingsSection();
 				});
 			});
+	}
+
+	private renderAdvancedSettingsSection(): void {
+		if (!this.advancedSettingsContainer) return;
+
+		this.advancedSettingsContainer.empty();
+		if (!this.showAdvancedSettings) return;
+		if (!this.settings.modelParameters) {
+			this.settings.modelParameters = {};
+		}
+
+		this.addTemperatureSetting(this.advancedSettingsContainer);
+		this.addTopPSetting(this.advancedSettingsContainer);
+		this.addFrequencyPenaltySetting(this.advancedSettingsContainer);
+		this.addPresencePenaltySetting(this.advancedSettingsContainer);
 	}
 
 	addTemperatureSetting(container: HTMLElement) {


### PR DESCRIPTION
Reduce unnecessary full modal reloads in AI settings flows by rendering high-churn sections in place.

This follows the FSM migration in #1132 and queue hardening in #1133. The remaining UX churn in these modals was mostly caused by full reloads for interactions that only affect a small subsection of UI.

What changed:
- AIAssistantCommandSettingsModal
  - show/hide advanced settings now re-renders only the advanced section container (no full modal reload)
  - name edit now updates header text directly (no full modal reload)
  - model dropdown now refreshes token count text directly (no full modal reload)
- InfiniteAIAssistantCommandSettingsModal
  - show/hide advanced settings now re-renders only the advanced section container (no full modal reload)
  - name edit now updates header text directly (no full modal reload)
- Updated the living exec plan with this phase-2 decision/progress/evidence

Why:
- Advanced settings toggle is a frequent interaction and does not require rebuilding unrelated controls.
- In-place updates reduce UI churn and make the modal feel stable even before fallback restoration logic is needed.

Validation:
- bun run test
- bun run build-with-lint
- Obsidian CLI probe in dev vault:
  - open quickadd:testQuickAdd
  - force modal scrollable height
  - toggle Show advanced settings
  - observed before/after scrollTop remain 220 and active element remain TEXTAREA
  - dev:errors reported no runtime errors

Refs #1130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* AI command settings modals now update more efficiently—advanced settings, model changes, and name edits no longer trigger unnecessary full reloads, improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->