### PR TITLE
fix(gui): reduce macro command modal full-reload usage

### DIFF
--- a/plans/issue-1130-fsm-modal-reload.md
+++ b/plans/issue-1130-fsm-modal-reload.md
@@ -19,6 +19,7 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
 - [x] (2026-03-05 06:16Z) Verified with `bun run test`, `bun run build`, `bun run build-with-lint`, and Obsidian CLI runtime probes in `vault=dev`.
 - [x] (2026-03-05 06:44Z) Hardened reload queue handling by replacing recursive pending-reload replay with iterative draining and added two regression tests for re-entrant/coalesced reload requests.
 - [x] (2026-03-05 07:56Z) Implemented phase-2 in-place UI updates for AI command settings modals so `Show advanced settings` no longer triggers full modal reload, and removed non-infinite model-change/name-edit reloads by refreshing UI elements directly.
+- [x] (2026-03-05 08:06Z) Implemented phase-3 in-place subsection rendering for `OpenFileCommandSettingsModal` and `ConditionalCommandSettingsModal`, removing full reload dependency for location/type/operator/value-type UI pivots.
 
 ## Surprises & Discoveries
 
@@ -42,6 +43,9 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
 
 - Observation: `Show advanced settings` can be updated as a local section re-render without changing surrounding settings rows.
   Evidence: CLI probe in `quickadd:testQuickAdd` showed `scrollTop` remained `220` and active element stayed `TEXTAREA` while modal height increased after toggle.
+
+- Observation: split-direction and conditional-form pivots can be isolated to dedicated subsection containers without redrawing the full modal.
+  Evidence: both modals now update only their dynamic containers (`openFileCommandSettingsModal__splitDirection`, `conditionalSettingsModal__conditionConfig`) while keeping static controls mounted.
 
 ## Decision Log
 
@@ -69,6 +73,10 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
   Rationale: this is a high-frequency interaction and does not require rebuilding unrelated controls; local re-render removes unnecessary modal churn.
   Date/Author: 2026-03-05 / Codex
 
+- Decision: remove `ModalReloadController` from `OpenFileCommandSettingsModal` and `ConditionalCommandSettingsModal` after converting their dynamic sections to in-place rendering.
+  Rationale: these flows no longer require full modal redraw for their conditional UI, so keeping reload orchestration adds complexity without value.
+  Date/Author: 2026-03-05 / Codex
+
 ## Outcomes & Retrospective
 
 Implemented outcome matches purpose: reload-driven modal jumps are now handled through an FSM-based controller that captures and restores UI position. Scoped modal classes no longer call direct full-refresh reload logic without restoration.
@@ -81,8 +89,9 @@ Validation results:
 - Obsidian CLI runtime probe (`vault=dev`) confirms preserved scroll/focus on model-change reload in the test modal.
 - Post-merge hardening: `modalReloadMachine` now has 6 passing tests, including queued and coalesced reload behavior during render re-entrancy.
 - Phase-2 follow-up: `Show advanced settings` in both AI command settings modals now updates in place (no full reload); CLI probe confirms stable scroll/focus with non-zero scroll range.
+- Phase-3 follow-up: `OpenFileCommandSettingsModal` and `ConditionalCommandSettingsModal` now re-render only dynamic subsections rather than full modal content for conditional UI changes.
 
-Remaining gap: this change reduces reload frequency in AI command settings flows but does not eliminate reloads across all modal classes. Further follow-up can convert additional conditional UI paths (for example `CaptureChoiceBuilder`, `TemplateChoiceBuilder`, and provider/model editors) to fine-grained section updates.
+Remaining gap: this change reduces reload frequency in AI and macro command settings flows but does not eliminate reloads across all modal classes. Further follow-up can convert additional conditional UI paths (for example `CaptureChoiceBuilder`, `TemplateChoiceBuilder`, and provider/model editors) to fine-grained section updates.
 
 ## Context and Orientation
 
@@ -284,3 +293,4 @@ Revision Note (2026-03-05): Initial ExecPlan created in response to issue #1130 
 Revision Note (2026-03-05): Updated after implementation to reflect completed milestones, final validation evidence, and runtime probe adjustments needed to distinguish true preservation from expected scroll clamping.
 Revision Note (2026-03-05): Updated after merge with queue-drain hardening and additional controller regression tests for re-entrant reload requests.
 Revision Note (2026-03-05): Updated for phase-2 partial migration that removes full reloads from advanced-settings toggles in AI command settings modals and records new CLI evidence.
+Revision Note (2026-03-05): Updated for phase-3 partial migration that replaces reload-driven conditional sections in Open File and Conditional command settings modals with in-place container rerenders.

--- a/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
@@ -16,7 +16,6 @@ import {
 } from "../../constants";
 import InputSuggester from "../InputSuggester/inputSuggester";
 import { showNoScriptsFoundNotice } from "./noScriptsFoundNotice";
-import { ModalReloadController } from "../utils/modalReloadMachine";
 
 function cloneCondition(condition: ConditionalCondition): ConditionalCondition {
 	return condition.mode === "variable"
@@ -47,7 +46,7 @@ export class ConditionalCommandSettingsModal extends Modal {
 	private workingCommand: IConditionalCommand;
 	private isResolved = false;
 	private javascriptFiles: TFile[] = [];
-	private readonly reloadController: ModalReloadController;
+	private conditionConfigContainer: HTMLElement | null = null;
 
 	constructor(app: App, command: IConditionalCommand) {
 		super(app);
@@ -60,13 +59,6 @@ export class ConditionalCommandSettingsModal extends Modal {
 		this.waitForClose = new Promise<IConditionalCommand | null>((resolve) => {
 			this.resolvePromise = resolve;
 		});
-		this.reloadController = new ModalReloadController({
-			modalEl: this.modalEl,
-			contentEl: this.contentEl,
-			render: () => {
-				this.display();
-			},
-		});
 
 		this.loadJavascriptFiles();
 		this.display();
@@ -74,7 +66,6 @@ export class ConditionalCommandSettingsModal extends Modal {
 	}
 
 	onClose() {
-		this.reloadController.destroy();
 		super.onClose();
 		if (!this.isResolved) {
 			this.resolve(null);
@@ -93,13 +84,10 @@ export class ConditionalCommandSettingsModal extends Modal {
 			.filter((file) => JAVASCRIPT_FILE_EXTENSION_REGEX.test(file.path));
 	}
 
-	private reload() {
-		this.reloadController.requestReload("conditional-settings:reload");
-	}
-
 	private display() {
 		this.containerEl.addClass("quickAddModal", "conditionalSettingsModal");
 		this.contentEl.empty();
+		this.conditionConfigContainer = null;
 
 		const headerEl = this.contentEl.createEl("h2", {
 			text: "Configure Conditional Command",
@@ -107,13 +95,30 @@ export class ConditionalCommandSettingsModal extends Modal {
 		headerEl.style.textAlign = "center";
 
 		this.renderModeSelector();
-		if (this.workingCommand.condition.mode === "variable") {
-			this.renderVariableConfiguration(this.workingCommand.condition);
-		} else {
-			this.renderScriptConfiguration(this.workingCommand.condition);
-		}
+		this.conditionConfigContainer = this.contentEl.createDiv(
+			"conditionalSettingsModal__conditionConfig"
+		);
+		this.renderConditionConfiguration();
 
 		this.renderButtonBar();
+	}
+
+	private renderConditionConfiguration() {
+		if (!this.conditionConfigContainer) return;
+		this.conditionConfigContainer.empty();
+
+		if (this.workingCommand.condition.mode === "variable") {
+			this.renderVariableConfiguration(
+				this.conditionConfigContainer,
+				this.workingCommand.condition
+			);
+			return;
+		}
+
+		this.renderScriptConfiguration(
+			this.conditionConfigContainer,
+			this.workingCommand.condition
+		);
 	}
 
 	private renderModeSelector() {
@@ -131,22 +136,28 @@ export class ConditionalCommandSettingsModal extends Modal {
 							value === "variable"
 								? createDefaultVariableCondition()
 								: createDefaultScriptCondition();
-						this.reload();
+						this.renderConditionConfiguration();
 					});
 			});
 	}
 
-	private renderVariableConfiguration(condition: VariableCondition) {
-		this.renderVariableNameSetting(condition);
-		this.renderOperatorSetting(condition);
-		this.renderValueTypeSetting(condition);
+	private renderVariableConfiguration(
+		container: HTMLElement,
+		condition: VariableCondition
+	) {
+		this.renderVariableNameSetting(container, condition);
+		this.renderOperatorSetting(container, condition);
+		this.renderValueTypeSetting(container, condition);
 		if (requiresExpectedValue(condition.operator)) {
-			this.renderExpectedValueSetting(condition);
+			this.renderExpectedValueSetting(container, condition);
 		}
 	}
 
-	private renderVariableNameSetting(condition: VariableCondition) {
-		new Setting(this.contentEl)
+	private renderVariableNameSetting(
+		container: HTMLElement,
+		condition: VariableCondition
+	) {
+		new Setting(container)
 			.setName("Variable name")
 			.setDesc("Name of the macro variable to inspect (without the $ prefix).")
 			.addText((text) =>
@@ -159,7 +170,10 @@ export class ConditionalCommandSettingsModal extends Modal {
 			);
 	}
 
-	private renderOperatorSetting(condition: VariableCondition) {
+	private renderOperatorSetting(
+		container: HTMLElement,
+		condition: VariableCondition
+	) {
 		const operators: Array<{ value: VariableCondition["operator"]; label: string }> = [
 			{ value: "equals", label: "Equals" },
 			{ value: "notEquals", label: "Does not equal" },
@@ -173,7 +187,7 @@ export class ConditionalCommandSettingsModal extends Modal {
 			{ value: "isFalsy", label: "Is falsy" },
 		];
 
-		new Setting(this.contentEl)
+		new Setting(container)
 			.setName("Operator")
 			.setDesc("How to compare the variable value.")
 			.addDropdown((dropdown: DropdownComponent) => {
@@ -192,13 +206,16 @@ export class ConditionalCommandSettingsModal extends Modal {
 					if (!requiresExpectedValue(condition.operator)) {
 						delete condition.expectedValue;
 					}
-					this.reload();
+					this.renderConditionConfiguration();
 				});
 			});
 	}
 
-	private renderValueTypeSetting(condition: VariableCondition) {
-		new Setting(this.contentEl)
+	private renderValueTypeSetting(
+		container: HTMLElement,
+		condition: VariableCondition
+	) {
+		new Setting(container)
 			.setName("Value type")
 			.setDesc("How to interpret the comparison value.")
 			.addDropdown((dropdown) => {
@@ -209,14 +226,17 @@ export class ConditionalCommandSettingsModal extends Modal {
 					.setValue(condition.valueType)
 					.onChange((value) => {
 						condition.valueType = value as VariableCondition["valueType"];
-						this.reload();
+						this.renderConditionConfiguration();
 					});
 			});
 	}
 
-	private renderExpectedValueSetting(condition: VariableCondition) {
+	private renderExpectedValueSetting(
+		container: HTMLElement,
+		condition: VariableCondition
+	) {
 		if (condition.valueType === "boolean") {
-			new Setting(this.contentEl)
+			new Setting(container)
 				.setName("Expected value")
 				.setDesc("Choose true or false.")
 				.addDropdown((dropdown) => {
@@ -231,7 +251,7 @@ export class ConditionalCommandSettingsModal extends Modal {
 			return;
 		}
 
-		new Setting(this.contentEl)
+		new Setting(container)
 			.setName("Expected value")
 			.setDesc("Value to compare against.")
 			.addText((text: TextComponent) => {
@@ -244,15 +264,21 @@ export class ConditionalCommandSettingsModal extends Modal {
 			});
 	}
 
-	private renderScriptConfiguration(condition: ScriptCondition) {
-		this.renderScriptPathSetting(condition);
-		this.renderScriptExportSetting(condition);
+	private renderScriptConfiguration(
+		container: HTMLElement,
+		condition: ScriptCondition
+	) {
+		this.renderScriptPathSetting(container, condition);
+		this.renderScriptExportSetting(container, condition);
 	}
 
-	private renderScriptPathSetting(condition: ScriptCondition) {
+	private renderScriptPathSetting(
+		container: HTMLElement,
+		condition: ScriptCondition
+	) {
 		let input: TextComponent;
 
-		new Setting(this.contentEl)
+		new Setting(container)
 			.setName("Script path")
 			.setDesc("Vault-relative path to the JavaScript file.")
 			.addText((text) => {
@@ -293,8 +319,11 @@ export class ConditionalCommandSettingsModal extends Modal {
 			);
 	}
 
-	private renderScriptExportSetting(condition: ScriptCondition) {
-		new Setting(this.contentEl)
+	private renderScriptExportSetting(
+		container: HTMLElement,
+		condition: ScriptCondition
+	) {
+		new Setting(container)
 			.setName("Export name")
 			.setDesc("Optional export or member to call (use :: to access nested members).")
 			.addText((text) =>

--- a/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
@@ -4,7 +4,6 @@ import type { IOpenFileCommand } from "../../types/macros/QuickCommands/IOpenFil
 import { NewTabDirection } from "../../types/newTabDirection";
 import type { OpenLocation } from "../../types/fileOpening";
 import { CommandType } from "../../types/macros/CommandType";
-import { ModalReloadController } from "../utils/modalReloadMachine";
 
 export class OpenFileCommandSettingsModal extends Modal {
 	public waitForClose: Promise<IOpenFileCommand | null>;
@@ -12,7 +11,7 @@ export class OpenFileCommandSettingsModal extends Modal {
 	private command: IOpenFileCommand;
 	private originalCommand: IOpenFileCommand;
 	private isResolved = false;
-	private readonly reloadController: ModalReloadController;
+	private directionSettingContainer: HTMLElement | null = null;
 
 	constructor(app: App, command: IOpenFileCommand) {
 		super(app);
@@ -27,20 +26,12 @@ export class OpenFileCommandSettingsModal extends Modal {
 		this.waitForClose = new Promise<IOpenFileCommand | null>((resolve) => {
 			this.resolvePromise = resolve;
 		});
-		this.reloadController = new ModalReloadController({
-			modalEl: this.modalEl,
-			contentEl: this.contentEl,
-			render: () => {
-				this.display();
-			},
-		});
 
 		this.display();
 		this.open();
 	}
 
 	onClose() {
-		this.reloadController.destroy();
 		super.onClose();
 		if (!this.isResolved) {
 			this.resolvePromise(this.command);
@@ -58,6 +49,7 @@ export class OpenFileCommandSettingsModal extends Modal {
 	private display() {
 		this.containerEl.addClass("quickAddModal", "openFileCommandSettingsModal");
 		this.contentEl.empty();
+		this.directionSettingContainer = null;
 
 		const headerEl = this.contentEl.createEl("h2");
 		headerEl.textContent = "Open File Command Settings";
@@ -109,13 +101,14 @@ export class OpenFileCommandSettingsModal extends Modal {
 					.onChange((value: OpenLocation) => {
 						this.command.location = value;
 						this.syncLegacyFlagsFromLocation(value);
-						this.reload();
+						this.renderDirectionSetting();
 					});
 			});
 
-		if (this.deriveLocation() === "split") {
-			this.addDirectionSetting();
-		}
+		this.directionSettingContainer = this.contentEl.createDiv(
+			"openFileCommandSettingsModal__splitDirection"
+		);
+		this.renderDirectionSetting();
 	}
 
 	private syncLegacyFlagsFromLocation(value: OpenLocation) {
@@ -138,8 +131,8 @@ export class OpenFileCommandSettingsModal extends Modal {
 		}
 	}
 
-	private addDirectionSetting() {
-		new Setting(this.contentEl)
+	private addDirectionSetting(container: HTMLElement) {
+		new Setting(container)
 			.setName("Split direction")
 			.setDesc("How to arrange the new pane relative to the current one")
 			.addDropdown((dropdown) => {
@@ -151,6 +144,13 @@ export class OpenFileCommandSettingsModal extends Modal {
 						this.command.direction = value as NewTabDirection;
 					});
 			});
+	}
+
+	private renderDirectionSetting() {
+		if (!this.directionSettingContainer) return;
+		this.directionSettingContainer.empty();
+		if (this.deriveLocation() !== "split") return;
+		this.addDirectionSetting(this.directionSettingContainer);
 	}
 
 	private addFocusSetting() {
@@ -202,7 +202,4 @@ export class OpenFileCommandSettingsModal extends Modal {
 			});
 	}
 
-	private reload() {
-		this.reloadController.requestReload("open-file-command:reload");
-	}
 }


### PR DESCRIPTION
Reduce remaining full-modal reload usage in two macro command settings dialogs by rendering only dynamic subsections in place.

This is phase 3 of the FSM/reload stabilization stream after #1132, #1133, and #1134.

What changed:
- ConditionalCommandSettingsModal
  - removed full-modal reload dependency
  - introduced a dedicated condition config container (`conditionalSettingsModal__conditionConfig`)
  - mode/operator/value-type changes now rerender only that container
- OpenFileCommandSettingsModal
  - removed full-modal reload dependency
  - introduced a dedicated split-direction container (`openFileCommandSettingsModal__splitDirection`)
  - location changes now rerender only split-direction controls
- updated the living ExecPlan (`plans/issue-1130-fsm-modal-reload.md`) with phase-3 progress, discovery, decision, and retrospective notes

Why:
- These interactions change small, isolated parts of UI and do not require tearing down/rebuilding the entire modal.
- In-place updates further reduce modal churn and complement FSM-based restoration fallback.

Validation:
- bun run test
- bun run build-with-lint
- Obsidian CLI smoke in dev vault:
  - obsidian vault=dev plugin:reload id=quickadd
  - obsidian vault=dev command id=quickadd:testQuickAdd
  - obsidian vault=dev dev:errors (no runtime errors)

Refs #1130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Conditional command settings modal now updates condition configuration in-place when adjusting variables, operators, value types, or script settings, eliminating unnecessary reloads and improving responsiveness.
  * File operation command settings modal now refreshes location and split-direction settings in-place, providing faster configuration adjustments without full modal reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->