### PR TITLE
fix(gui): reduce choice builder full-reload usage

### DIFF
--- a/plans/issue-1130-fsm-modal-reload.md
+++ b/plans/issue-1130-fsm-modal-reload.md
@@ -20,6 +20,7 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
 - [x] (2026-03-05 06:44Z) Hardened reload queue handling by replacing recursive pending-reload replay with iterative draining and added two regression tests for re-entrant/coalesced reload requests.
 - [x] (2026-03-05 07:56Z) Implemented phase-2 in-place UI updates for AI command settings modals so `Show advanced settings` no longer triggers full modal reload, and removed non-infinite model-change/name-edit reloads by refreshing UI elements directly.
 - [x] (2026-03-05 08:06Z) Implemented phase-3 in-place subsection rendering for `OpenFileCommandSettingsModal` and `ConditionalCommandSettingsModal`, removing full reload dependency for location/type/operator/value-type UI pivots.
+- [x] (2026-03-05 08:11Z) Implemented phase-4 shared `ChoiceBuilder` in-place section rendering for open-file controls, removing full reload dependency for `Open` toggle and `File Opening Location` changes in Template/Capture builders.
 
 ## Surprises & Discoveries
 
@@ -46,6 +47,9 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
 
 - Observation: split-direction and conditional-form pivots can be isolated to dedicated subsection containers without redrawing the full modal.
   Evidence: both modals now update only their dynamic containers (`openFileCommandSettingsModal__splitDirection`, `conditionalSettingsModal__conditionConfig`) while keeping static controls mounted.
+
+- Observation: Template/Capture builders share open-file UI through `ChoiceBuilder`, so one base-class in-place migration removes multiple full reload paths at once.
+  Evidence: both `TemplateChoiceBuilder` and `CaptureChoiceBuilder` now call `addOpenFileSetting(..., contextLabel)` and rely on `choiceBuilder__fileOpeningSection` local rerenders.
 
 ## Decision Log
 
@@ -77,6 +81,10 @@ The user-visible proof is simple: in a dev modal that currently jumps (the exist
   Rationale: these flows no longer require full modal redraw for their conditional UI, so keeping reload orchestration adds complexity without value.
   Date/Author: 2026-03-05 / Codex
 
+- Decision: add optional context-aware in-place rendering to `ChoiceBuilder.addOpenFileSetting` instead of introducing separate template/capture-specific logic.
+  Rationale: centralizing this behavior in the shared base keeps both builders aligned and reduces duplication while preserving legacy fallback (`reload()`) when no context is provided.
+  Date/Author: 2026-03-05 / Codex
+
 ## Outcomes & Retrospective
 
 Implemented outcome matches purpose: reload-driven modal jumps are now handled through an FSM-based controller that captures and restores UI position. Scoped modal classes no longer call direct full-refresh reload logic without restoration.
@@ -90,8 +98,9 @@ Validation results:
 - Post-merge hardening: `modalReloadMachine` now has 6 passing tests, including queued and coalesced reload behavior during render re-entrancy.
 - Phase-2 follow-up: `Show advanced settings` in both AI command settings modals now updates in place (no full reload); CLI probe confirms stable scroll/focus with non-zero scroll range.
 - Phase-3 follow-up: `OpenFileCommandSettingsModal` and `ConditionalCommandSettingsModal` now re-render only dynamic subsections rather than full modal content for conditional UI changes.
+- Phase-4 follow-up: Template/Capture open-file settings now update in place through `ChoiceBuilder` shared section rendering; no full modal reload is required for open toggle/location pivots in that shared path.
 
-Remaining gap: this change reduces reload frequency in AI and macro command settings flows but does not eliminate reloads across all modal classes. Further follow-up can convert additional conditional UI paths (for example `CaptureChoiceBuilder`, `TemplateChoiceBuilder`, and provider/model editors) to fine-grained section updates.
+Remaining gap: this change reduces reload frequency in AI, macro command settings, and shared open-file choice builder flows, but does not eliminate reloads across all modal classes. Further follow-up can convert additional conditional UI paths (for example folder/capture destination pivots in `CaptureChoiceBuilder`, file-exists/folder paths in `TemplateChoiceBuilder`, and provider/model editors) to fine-grained section updates.
 
 ## Context and Orientation
 
@@ -294,3 +303,4 @@ Revision Note (2026-03-05): Updated after implementation to reflect completed mi
 Revision Note (2026-03-05): Updated after merge with queue-drain hardening and additional controller regression tests for re-entrant reload requests.
 Revision Note (2026-03-05): Updated for phase-2 partial migration that removes full reloads from advanced-settings toggles in AI command settings modals and records new CLI evidence.
 Revision Note (2026-03-05): Updated for phase-3 partial migration that replaces reload-driven conditional sections in Open File and Conditional command settings modals with in-place container rerenders.
+Revision Note (2026-03-05): Updated for phase-4 shared ChoiceBuilder migration that replaces reload-driven open-file section changes with in-place section rerendering in Template/Capture flows.

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -66,11 +66,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 		// Behavior
 		new Setting(this.contentEl).setName("Behavior").setHeading();
 		if (!this.choice.captureToActiveFile) {
-			this.addOpenFileSetting("Open the captured file.");
-
-			if (this.choice.openFile) {
-				this.addFileOpeningSetting("captured");
-			}
+			this.addOpenFileSetting("Open the captured file.", "captured");
 		}
 		this.addSelectionAsValueSetting();
 		this.addTemplaterAfterCaptureSetting();

--- a/src/gui/ChoiceBuilder/choiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/choiceBuilder.ts
@@ -16,6 +16,7 @@ export abstract class ChoiceBuilder extends Modal {
 	abstract choice: IChoice;
 	protected svelteElements: SvelteComponent[] = [];
 	private readonly reloadController: ModalReloadController;
+	private fileOpeningSectionContainer: HTMLElement | null = null;
 
 	protected constructor(app: App) {
 		super(app);
@@ -111,7 +112,10 @@ export abstract class ChoiceBuilder extends Modal {
 	 * Adds a toggle that controls whether the resulting file should be opened.
 	 * @param description Description explaining what file will be opened (e.g. "Open the file that is captured to.")
 	 */
-	protected addOpenFileSetting(description: string): void {
+	protected addOpenFileSetting(
+		description: string,
+		contextLabel?: string,
+	): void {
 		// We intentionally cast to `any` because not all IChoice implementations have openFile.
 		const choice: any = this.choice as any;
 		if (choice.openFile === undefined) return; // Guard: nothing to configure
@@ -119,13 +123,38 @@ export abstract class ChoiceBuilder extends Modal {
 		new Setting(this.contentEl)
 			.setName("Open")
 			.setDesc(description)
-			.addToggle((toggle) => {
-				toggle.setValue(choice.openFile);
-				toggle.onChange((value) => {
-					choice.openFile = value;
-					this.reload();
+				.addToggle((toggle) => {
+					toggle.setValue(choice.openFile);
+					toggle.onChange((value) => {
+						choice.openFile = value;
+						if (!contextLabel) {
+							this.reload();
+							return;
+						}
+
+						this.renderFileOpeningSection(contextLabel);
+					});
 				});
-			});
+
+		if (!contextLabel) return;
+
+		this.fileOpeningSectionContainer = this.contentEl.createDiv(
+			"choiceBuilder__fileOpeningSection",
+		);
+		this.renderFileOpeningSection(contextLabel);
+	}
+
+	private renderFileOpeningSection(contextLabel: string): void {
+		if (!this.fileOpeningSectionContainer) return;
+
+		this.fileOpeningSectionContainer.empty();
+		const choice: any = this.choice as any;
+		if (!choice.openFile) return;
+
+		this.addFileOpeningSettingsToContainer(
+			this.fileOpeningSectionContainer,
+			contextLabel,
+		);
 	}
 
 	/**
@@ -135,13 +164,20 @@ export abstract class ChoiceBuilder extends Modal {
 	 * @param contextLabel Text to use in descriptions (e.g. "captured" | "created")
 	 */
 	protected addFileOpeningSetting(contextLabel: string): void {
+		this.addFileOpeningSettingsToContainer(this.contentEl, contextLabel);
+	}
+
+	private addFileOpeningSettingsToContainer(
+		container: HTMLElement,
+		contextLabel: string,
+	): void {
 		const choice: any = this.choice as any;
 		choice.fileOpening = normalizeFileOpening(choice.fileOpening);
 
 		const fileOpening = choice.fileOpening as FileOpeningSettings;
 
 		// Location selector
-		new Setting(this.contentEl)
+		new Setting(container)
 			.setName("File Opening Location")
 			.setDesc(`Where to open the ${contextLabel} file`)
 			.addDropdown((dropdown) => {
@@ -156,13 +192,18 @@ export abstract class ChoiceBuilder extends Modal {
 				dropdown.setValue(fileOpening.location);
 				dropdown.onChange((value: any) => {
 					fileOpening.location = value as OpenLocation;
+					if (this.fileOpeningSectionContainer) {
+						this.renderFileOpeningSection(contextLabel);
+						return;
+					}
+
 					this.reload();
 				});
 			});
 
 		// Split direction – only if location === "split"
 		if (fileOpening.location === "split") {
-			new Setting(this.contentEl)
+			new Setting(container)
 				.setName("Split Direction")
 				.setDesc("How to arrange the new pane relative to the current one")
 				.addDropdown((dropdown) => {
@@ -178,7 +219,7 @@ export abstract class ChoiceBuilder extends Modal {
 		}
 
 		// View mode selector
-		new Setting(this.contentEl)
+		new Setting(container)
 			.setName("View Mode")
 			.setDesc("How to display the opened file")
 			.addDropdown((dropdown) => {
@@ -200,7 +241,7 @@ export abstract class ChoiceBuilder extends Modal {
 
 		// Focus toggle – only show for non-reuse locations
 		if (fileOpening.location !== "reuse") {
-			new Setting(this.contentEl)
+			new Setting(container)
 				.setName("Focus new pane")
 				.setDesc("Focus the opened tab immediately after opening")
 				.addToggle((toggle) =>

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -63,10 +63,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 		// Behavior
 		new Setting(this.contentEl).setName("Behavior").setHeading();
 		this.addFileAlreadyExistsSetting();
-		this.addOpenFileSetting("Open the created file.");
-		if (this.choice.openFile) {
-			this.addFileOpeningSetting("created");
-		}
+		this.addOpenFileSetting("Open the created file.", "created");
 		this.addOnePageOverrideSetting(this.choice);
 	}
 


### PR DESCRIPTION
Reduce remaining full modal reload usage in shared ChoiceBuilder open-file controls by rerendering only the file-opening section in place.

This is phase 4 of the FSM/reload stabilization stream after #1132, #1133, #1134, and #1135.

What changed:
- ChoiceBuilder
  - addOpenFileSetting now supports context-aware in-place section updates
  - introduced local section container `choiceBuilder__fileOpeningSection`
  - open toggle and file-opening location changes rerender only that section
  - legacy fallback remains: when context is not provided, existing reload behavior is unchanged
- TemplateChoiceBuilder and CaptureChoiceBuilder
  - switched to shared context-aware call: addOpenFileSetting(..., "created" / "captured")
  - removed duplicate conditional call pattern that depended on full modal reload
- updated living ExecPlan with phase-4 progress, decisions, and evidence

Why:
- open-file and location controls are high-frequency pivots that only affect a narrow subsection of UI.
- rerendering only that section reduces modal churn and preserves user editing context more naturally.

Validation:
- bun run test
- bun run build-with-lint
- Obsidian CLI smoke in dev vault:
  - obsidian vault=dev plugin:reload id=quickadd
  - obsidian vault=dev command id=quickadd:testQuickAdd
  - obsidian vault=dev dev:errors (no runtime errors)

Refs #1130
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced file-opening settings rendering to eliminate unnecessary full modal reloads when toggling open-file options or changing file-opening locations in template and capture builders. File-opening settings now update in place for immediate feedback, providing a faster and more responsive experience when configuring file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->