### PR TITLE
Refactor package import status caching

### DIFF
--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -166,6 +166,12 @@ export async function applyPackageImport(
 	const importableVisiting = new Set<string>();
 
 	const isChoiceImportable = (choiceId: string): boolean => {
+		const finalizeImportable = (isImportable: boolean): boolean => {
+			importableCache.set(choiceId, isImportable);
+			importableVisiting.delete(choiceId);
+			return isImportable;
+		};
+
 		if (importableCache.has(choiceId)) {
 			return importableCache.get(choiceId) as boolean;
 		}
@@ -179,42 +185,30 @@ export async function applyPackageImport(
 
 		const decision = choiceDecisionMap.get(choiceId);
 		if (decision === "skip") {
-			importableCache.set(choiceId, false);
-			importableVisiting.delete(choiceId);
-			return false;
+			return finalizeImportable(false);
 		}
 
 		const entry = catalog.get(choiceId);
 		if (!entry) {
-			importableCache.set(choiceId, false);
-			importableVisiting.delete(choiceId);
-			return false;
+			return finalizeImportable(false);
 		}
 
 		const parentId = entry.parentChoiceId;
 		if (!parentId) {
-			importableCache.set(choiceId, true);
-			importableVisiting.delete(choiceId);
-			return true;
+			return finalizeImportable(true);
 		}
 
 		if (!catalog.has(parentId)) {
-			importableCache.set(choiceId, true);
-			importableVisiting.delete(choiceId);
-			return true;
+			return finalizeImportable(true);
 		}
 
 		const parentDecision = choiceDecisionMap.get(parentId);
 		if (parentDecision === "skip") {
-			importableCache.set(choiceId, true);
-			importableVisiting.delete(choiceId);
-			return true;
+			return finalizeImportable(true);
 		}
 
 		const result = isChoiceImportable(parentId);
-		importableCache.set(choiceId, result);
-		importableVisiting.delete(choiceId);
-		return result;
+		return finalizeImportable(result);
 	};
 
 	for (const entry of pkg.choices) {
@@ -227,27 +221,29 @@ export async function applyPackageImport(
 	const idMap = new Map<string, string>();
 
 	const isDuplicated = (choiceId: string): boolean => {
+		const markDuplicated = (): true => {
+			duplicatedOriginalIds.add(choiceId);
+			return true;
+		};
+
 		if (!importableChoiceIds.has(choiceId)) return false;
 		const cached = duplicatedOriginalIds.has(choiceId);
 		if (cached) return true;
 
 		const decision = choiceDecisionMap.get(choiceId);
 		if (decision === "duplicate") {
-			duplicatedOriginalIds.add(choiceId);
-			return true;
+			return markDuplicated();
 		}
 
 		const parentId = catalog.get(choiceId)?.parentChoiceId ?? null;
 		if (!parentId) return false;
 		const parentDecision = choiceDecisionMap.get(parentId);
 		if (parentDecision === "duplicate") {
-			duplicatedOriginalIds.add(choiceId);
-			return true;
+			return markDuplicated();
 		}
 		if (!importableChoiceIds.has(parentId)) return false;
 		if (isDuplicated(parentId)) {
-			duplicatedOriginalIds.add(choiceId);
-			return true;
+			return markDuplicated();
 		}
 
 		return false;

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -218,35 +218,49 @@ export async function applyPackageImport(
 	}
 
 	const duplicatedOriginalIds = new Set<string>();
+	const nonDuplicatedOriginalIds = new Set<string>();
+	const visitingIds = new Set<string>();
 	const idMap = new Map<string, string>();
 
 	const isDuplicated = (choiceId: string): boolean => {
 		const markDuplicated = (): true => {
 			duplicatedOriginalIds.add(choiceId);
+			nonDuplicatedOriginalIds.delete(choiceId);
 			return true;
+		};
+		const markNotDuplicated = (): false => {
+			nonDuplicatedOriginalIds.add(choiceId);
+			return false;
 		};
 
 		if (!importableChoiceIds.has(choiceId)) return false;
 		const cached = duplicatedOriginalIds.has(choiceId);
 		if (cached) return true;
+		if (nonDuplicatedOriginalIds.has(choiceId)) return false;
+		if (visitingIds.has(choiceId)) return markNotDuplicated();
 
-		const decision = choiceDecisionMap.get(choiceId);
-		if (decision === "duplicate") {
-			return markDuplicated();
-		}
+		visitingIds.add(choiceId);
+		try {
+			const decision = choiceDecisionMap.get(choiceId);
+			if (decision === "duplicate") {
+				return markDuplicated();
+			}
 
-		const parentId = catalog.get(choiceId)?.parentChoiceId ?? null;
-		if (!parentId) return false;
-		const parentDecision = choiceDecisionMap.get(parentId);
-		if (parentDecision === "duplicate") {
-			return markDuplicated();
-		}
-		if (!importableChoiceIds.has(parentId)) return false;
-		if (isDuplicated(parentId)) {
-			return markDuplicated();
-		}
+			const parentId = catalog.get(choiceId)?.parentChoiceId ?? null;
+			if (!parentId) return markNotDuplicated();
+			const parentDecision = choiceDecisionMap.get(parentId);
+			if (parentDecision === "duplicate") {
+				return markDuplicated();
+			}
+			if (!importableChoiceIds.has(parentId)) return markNotDuplicated();
+			if (isDuplicated(parentId)) {
+				return markDuplicated();
+			}
 
-		return false;
+			return markNotDuplicated();
+		} finally {
+			visitingIds.delete(choiceId);
+		}
 	};
 
 	for (const entry of pkg.choices) {


### PR DESCRIPTION
## Summary
- simplify `isChoiceImportable` by consolidating cache cleanup into a helper that finalizes decisions
- avoid repeated `duplicatedOriginalIds` insertions with a dedicated helper in `isDuplicated`

## Testing
- Not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal import and duplicate-detection logic consolidated and simplified for better reliability and maintainability.
  * Improved handling of cyclical references to avoid edge-case recursion and ensure consistent outcomes.
  * State-tracking and cleanup made more robust to reduce intermittent errors.
  * No changes to public APIs or visible behavior for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->