### PR TITLE
Extract choice name renderer helper

### DIFF
--- a/src/gui/choiceList/ChoiceListItem.svelte
+++ b/src/gui/choiceList/ChoiceListItem.svelte
@@ -2,8 +2,9 @@
 	import type IChoice from "../../types/choices/IChoice";
 	import RightButtons from "./ChoiceItemRightButtons.svelte";
 	import { createEventDispatcher } from "svelte";
-	import { Component, htmlToMarkdown, MarkdownRenderer, type App } from "obsidian";
+	import { Component, type App } from "obsidian";
 	import { showChoiceContextMenu } from "./contextMenu";
+	import { renderChoiceName } from "./renderChoiceName";
 
 	export let choice: IChoice;
 	export let app: App;
@@ -34,14 +35,7 @@
 
 	$: {
 		if (nameElement) {
-			nameElement.innerHTML = "";
-			const nameHTML = htmlToMarkdown(choice.name);
-			MarkdownRenderer.renderMarkdown(
-				nameHTML,
-				nameElement,
-				"/",
-				cmp
-			);
+			renderChoiceName(choice.name, nameElement, cmp);
 		}
 	}
 

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -4,9 +4,10 @@
     import type IMultiChoice from "../../types/choices/IMultiChoice";
     import RightButtons from "./ChoiceItemRightButtons.svelte";
     import {createEventDispatcher} from "svelte";
-	import { Component, htmlToMarkdown, MarkdownRenderer, type App } from "obsidian";
+	import { Component, type App } from "obsidian";
     import type IChoice from "src/types/choices/IChoice";
     import { showChoiceContextMenu } from "./contextMenu";
+	import { renderChoiceName } from "./renderChoiceName";
 
     export let choice: IMultiChoice;
     export let roots: IChoice[];
@@ -39,14 +40,7 @@
 
 	$: {
 		if (nameElement) {
-			nameElement.innerHTML = "";
-			const nameHTML = htmlToMarkdown(choice.name);
-			MarkdownRenderer.renderMarkdown(
-				nameHTML,
-				nameElement,
-				"/",
-				cmp
-			);
+			renderChoiceName(choice.name, nameElement, cmp);
 		}
 	}
 

--- a/src/gui/choiceList/renderChoiceName.ts
+++ b/src/gui/choiceList/renderChoiceName.ts
@@ -1,0 +1,11 @@
+import { htmlToMarkdown, MarkdownRenderer, type Component } from "obsidian";
+
+export function renderChoiceName(
+	choiceName: string,
+	element: HTMLSpanElement,
+	component: Component
+): void {
+	element.innerHTML = "";
+	const nameHTML = htmlToMarkdown(choiceName);
+	void MarkdownRenderer.renderMarkdown(nameHTML, element, "/", component);
+}

--- a/src/gui/choiceList/renderChoiceName.ts
+++ b/src/gui/choiceList/renderChoiceName.ts
@@ -1,4 +1,4 @@
-import { htmlToMarkdown, MarkdownRenderer, type Component } from "obsidian";
+import { MarkdownRenderer, type Component } from "obsidian";
 
 export function renderChoiceName(
 	choiceName: string,
@@ -6,6 +6,5 @@ export function renderChoiceName(
 	component: Component
 ): void {
 	element.innerHTML = "";
-	const nameHTML = htmlToMarkdown(choiceName);
-	void MarkdownRenderer.renderMarkdown(nameHTML, element, "/", component);
+	void MarkdownRenderer.renderMarkdown(choiceName, element, "/", component);
 }


### PR DESCRIPTION
Summary
- factor shared markdown rendering logic for choice names into `renderChoiceName`
- use the helper from both `ChoiceListItem` and `MultiChoiceListItem` to keep future updates centralized

Testing
- Not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated choice-name rendering into a shared utility to improve consistency and maintainability across choice lists.
  * No change to user-facing behavior; visual output and interactions remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->