### PR TITLE
refactor(packages): share ensureParentFolders helper

### DIFF
--- a/src/services/packageExportService.ts
+++ b/src/services/packageExportService.ts
@@ -17,6 +17,7 @@ import {
 import { log } from "../logger/logManager";
 import { encodeToBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
+import { ensureParentFolders } from "../utils/ensureParentFolders";
 
 export interface BuildPackageOptions {
 	choices: IChoice[];
@@ -208,23 +209,4 @@ export async function writePackageToVault(
 	await ensureParentFolders(app, normalizedPath);
 	const serialized = JSON.stringify(pkg, null, 2);
 	await app.vault.adapter.write(normalizedPath, serialized);
-}
-
-async function ensureParentFolders(app: App, filePath: string): Promise<void> {
-	const lastSlash = filePath.lastIndexOf("/");
-	if (lastSlash < 0) return;
-
-	const folderPath = filePath.slice(0, lastSlash);
-	if (!folderPath) return;
-
-	const segments = folderPath.split("/").filter(Boolean);
-	let current = "";
-
-	for (const segment of segments) {
-		current = current ? `${current}/${segment}` : segment;
-		const exists = await app.vault.adapter.exists(current);
-		if (!exists) {
-			await app.vault.createFolder(current);
-		}
-	}
 }

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -21,6 +21,7 @@ import { CommandType } from "../types/macros/CommandType";
 import { log } from "../logger/logManager";
 import { decodeFromBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
+import { ensureParentFolders } from "../utils/ensureParentFolders";
 
 export interface LoadedQuickAddPackage {
 	pkg: QuickAddPackage;
@@ -560,23 +561,6 @@ function findMultiByPath(
 	}
 
 	return currentMulti;
-}
-
-async function ensureParentFolders(app: App, filePath: string): Promise<void> {
-	const lastSlash = filePath.lastIndexOf("/");
-	if (lastSlash < 0) return;
-	const folderPath = filePath.slice(0, lastSlash);
-	if (!folderPath) return;
-
-	const segments = folderPath.split("/").filter(Boolean);
-	let current = "";
-	for (const segment of segments) {
-		current = current ? `${current}/${segment}` : segment;
-		const exists = await app.vault.adapter.exists(current);
-		if (!exists) {
-			await app.vault.createFolder(current);
-		}
-	}
 }
 
 function applyAssetPathOverrides(

--- a/src/utils/ensureParentFolders.ts
+++ b/src/utils/ensureParentFolders.ts
@@ -1,0 +1,23 @@
+import type { App } from "obsidian";
+
+export async function ensureParentFolders(
+	app: App,
+	filePath: string,
+): Promise<void> {
+	const lastSlash = filePath.lastIndexOf("/");
+	if (lastSlash < 0) return;
+
+	const folderPath = filePath.slice(0, lastSlash);
+	if (!folderPath) return;
+
+	const segments = folderPath.split("/").filter(Boolean);
+	let current = "";
+
+	for (const segment of segments) {
+		current = current ? `${current}/${segment}` : segment;
+		const exists = await app.vault.adapter.exists(current);
+		if (!exists) {
+			await app.vault.createFolder(current);
+		}
+	}
+}


### PR DESCRIPTION
Extract duplicated parent-folder creation logic used by package import/export into a shared utility.

Both `packageExportService` and `packageImportService` had the same `ensureParentFolders` implementation. This centralizes that logic in `src/utils/ensureParentFolders.ts` and updates both services to import it.

Behavior is intended to remain unchanged. This is a small maintainability refactor that reduces duplicate code paths for future fixes.

In this sandbox, targeted tests could not be executed because `vitest` is unavailable (`vitest: command not found`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->