### PR TITLE
refactor(utils): extract shared set-based dedupe helper

### DIFF
--- a/src/utils/FieldValueDeduplicator.ts
+++ b/src/utils/FieldValueDeduplicator.ts
@@ -57,7 +57,7 @@ export class FieldValueDeduplicator {
 	 * Simple Set-based deduplication
 	 */
 	private static deduplicateExact(values: string[]): string[] {
-		return Array.from(new Set(values));
+		return this.deduplicateWithSet(values);
 	}
 
 	/**
@@ -72,6 +72,10 @@ export class FieldValueDeduplicator {
 				return true;
 			});
 		}
+		return this.deduplicateWithSet(values);
+	}
+
+	private static deduplicateWithSet(values: string[]): string[] {
 		return Array.from(new Set(values));
 	}
 


### PR DESCRIPTION
Extracts duplicated Set-based deduplication into a single helper in `FieldValueDeduplicator`.

Both `deduplicateExact` and the non-preserve-first path in `deduplicateCaseSensitive` now reuse `deduplicateWithSet`, keeping behavior unchanged while reducing duplication.

No functional behavior changes are intended; this is a small maintainability refactor.

Validation note: local `bun run test src/utils/FieldValueDeduplicator.test.ts` is currently blocked in this environment because `vitest` is unavailable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and maintainability through restructured utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->