### PR TITLE
refactor(choice-builder): deduplicate canvas target path check

### DIFF
--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -992,7 +992,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 	private addCanvasModeCompatibilityNotice(isActiveFile: boolean) {
 		const obviousCanvasTarget =
 			typeof this.choice.captureTo === "string" &&
-			this.choice.captureTo.trim().toLowerCase().endsWith(".canvas");
+			this.isCanvasTargetPath(this.choice.captureTo);
 		const hasActiveCanvasView =
 			this.app.workspace.activeLeaf?.view?.getViewType?.() === "canvas";
 		const usesCursorMode =


### PR DESCRIPTION
Use the existing `isCanvasTargetPath(...)` helper in `CaptureChoiceBuilder` where canvas target detection was previously duplicated inline.

This keeps the `.canvas` detection logic in one place in the class and reduces risk of subtle drift if the check changes in the future. Behavior is unchanged.

Alternative considered: leave the duplication in place due its small size, but centralizing the check is clearer and lower maintenance.

Reviewer context: this PR is intentionally tiny (1-line functional change) and limited to `addCanvasModeCompatibilityNotice(...)` in the choice builder.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code organization and logic flow to enhance maintainability and code consistency. These improvements strengthen the overall codebase quality while ensuring all existing features and functionality remain fully intact. The modifications focus exclusively on code quality enhancements with no impact on end-user experience, application behavior, or any user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->