### PR TITLE
refactor(ai): deduplicate provider secret storage reads

### DIFF
--- a/src/ai/providerSecrets.test.ts
+++ b/src/ai/providerSecrets.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type { AIProvider } from "./Provider";
+
+const { logWarningMock } = vi.hoisted(() => ({
+	logWarningMock: vi.fn(),
+}));
+
+vi.mock("src/logger/logManager", () => ({
+	log: {
+		logWarning: logWarningMock,
+	},
+}));
+
+const {
+	resolveProviderApiKey,
+	storeProviderApiKeyInSecretStorage,
+} = await import("./providerSecrets");
+
+function createProvider(overrides: Partial<AIProvider> = {}): AIProvider {
+	return {
+		name: "OpenAI",
+		endpoint: "https://api.openai.com/v1",
+		apiKey: "legacy-key",
+		models: [],
+		modelSource: "providerApi",
+		...overrides,
+	};
+}
+
+function createApp(secretStorage: {
+	getSecret?: (name: string) => Promise<string | null> | string | null;
+	setSecret?: (name: string, value: string) => Promise<void> | void;
+}): App {
+	return { secretStorage } as unknown as App;
+}
+
+describe("providerSecrets", () => {
+	beforeEach(() => {
+		logWarningMock.mockReset();
+	});
+
+	it("resolveProviderApiKey returns SecretStorage value when available", async () => {
+		const getSecret = vi.fn().mockResolvedValue("secret-key");
+		const app = createApp({ getSecret });
+		const provider = createProvider({ apiKeyRef: "provider-secret" });
+
+		const value = await resolveProviderApiKey(app, provider);
+
+		expect(value).toBe("secret-key");
+		expect(getSecret).toHaveBeenCalledWith("provider-secret");
+	});
+
+	it("resolveProviderApiKey falls back to provider apiKey and logs read errors", async () => {
+		const getSecret = vi.fn().mockRejectedValue(new Error("boom"));
+		const app = createApp({ getSecret });
+		const provider = createProvider({ apiKeyRef: "missing-secret" });
+
+		const value = await resolveProviderApiKey(app, provider);
+
+		expect(value).toBe("legacy-key");
+		expect(logWarningMock).toHaveBeenCalledWith(
+			expect.stringContaining('Failed to read SecretStorage entry "missing-secret"'),
+		);
+	});
+
+	it("storeProviderApiKeyInSecretStorage reuses existing matching secret", async () => {
+		const getSecret = vi.fn().mockResolvedValue("stored-key");
+		const setSecret = vi.fn();
+		const app = createApp({ getSecret, setSecret });
+		const provider = createProvider({ name: "OpenAI" });
+
+		const secretName = await storeProviderApiKeyInSecretStorage(
+			app,
+			provider,
+			"stored-key",
+		);
+
+		expect(secretName).toBe("quickadd-ai-openai");
+		expect(setSecret).not.toHaveBeenCalled();
+	});
+
+	it("storeProviderApiKeyInSecretStorage appends suffix when base is occupied", async () => {
+		const getSecret = vi
+			.fn()
+			.mockResolvedValueOnce("different-key")
+			.mockResolvedValueOnce(null);
+		const setSecret = vi.fn().mockResolvedValue(undefined);
+		const app = createApp({ getSecret, setSecret });
+		const provider = createProvider({ name: "OpenAI" });
+
+		const secretName = await storeProviderApiKeyInSecretStorage(
+			app,
+			provider,
+			"new-key",
+		);
+
+		expect(secretName).toBe("quickadd-ai-openai-2");
+		expect(setSecret).toHaveBeenCalledWith("quickadd-ai-openai-2", "new-key");
+	});
+
+	it("storeProviderApiKeyInSecretStorage logs write errors and returns null", async () => {
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const setSecret = vi.fn().mockRejectedValue(new Error("write failed"));
+		const app = createApp({ getSecret, setSecret });
+		const provider = createProvider();
+
+		const secretName = await storeProviderApiKeyInSecretStorage(
+			app,
+			provider,
+			"new-key",
+		);
+
+		expect(secretName).toBeNull();
+		expect(logWarningMock).toHaveBeenCalledWith(
+			expect.stringContaining('Failed to write SecretStorage entry "quickadd-ai-openai"'),
+		);
+	});
+});

--- a/src/ai/providerSecrets.ts
+++ b/src/ai/providerSecrets.ts
@@ -17,22 +17,30 @@ function buildSecretBase(provider: AIProvider): string {
 	return `${SECRET_PREFIX}-${toSecretId(name)}`;
 }
 
+async function readSecretStorageEntry(
+	app: App | undefined,
+	secretName: string,
+): Promise<string | null> {
+	if (!app?.secretStorage?.getSecret) return null;
+
+	try {
+		return await Promise.resolve(app.secretStorage.getSecret(secretName));
+	} catch (err) {
+		log.logWarning(
+			`Failed to read SecretStorage entry "${secretName}": ${(err as Error).message ?? err}`,
+		);
+		return null;
+	}
+}
+
 export async function resolveProviderApiKey(
 	app: App | undefined,
 	provider: AIProvider,
 ): Promise<string> {
 	const secretName = provider.apiKeyRef?.trim();
-	if (secretName && app?.secretStorage?.getSecret) {
-		try {
-			const secret = await Promise.resolve(
-				app.secretStorage.getSecret(secretName),
-			);
-			if (secret) return secret;
-		} catch (err) {
-			log.logWarning(
-				`Failed to read SecretStorage entry "${secretName}": ${(err as Error).message ?? err}`,
-			);
-		}
+	if (secretName) {
+		const secret = await readSecretStorageEntry(app, secretName);
+		if (secret) return secret;
 	}
 
 	return provider.apiKey ?? "";
@@ -52,16 +60,7 @@ export async function storeProviderApiKeyInSecretStorage(
 	let suffix = 1;
 
 	while (true) {
-		let existing: string | null = null;
-		try {
-			existing = await Promise.resolve(
-				app.secretStorage.getSecret(candidate),
-			);
-		} catch (err) {
-			log.logWarning(
-				`Failed to read SecretStorage entry "${candidate}": ${(err as Error).message ?? err}`,
-			);
-		}
+		const existing = await readSecretStorageEntry(app, candidate);
 
 		if (!existing) break;
 		if (existing === trimmed) return candidate;


### PR DESCRIPTION
Extract duplicated SecretStorage read-and-log handling in provider API key utilities and add focused regression coverage.

Both `resolveProviderApiKey` and `storeProviderApiKeyInSecretStorage` had near-identical `getSecret` try/catch blocks with the same warning behavior. This change centralizes that behavior in `readSecretStorageEntry`, keeping runtime behavior the same while reducing duplication and making future maintenance safer.

A dedicated test file now covers:
- resolving from SecretStorage vs legacy fallback
- warning + fallback on read failure
- reusing an existing matching secret
- suffix allocation when base key is occupied
- warning + null return on write failure

Reviewer notes:
- Scope is intentionally small and behavior-preserving.
- Local test execution in this environment was blocked (`bun` tempdir permission issue), so CI is the source of truth for verification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for AI provider secrets functionality, including retrieval, storage, conflict handling, and error scenarios.

* **Refactor**
  * Enhanced secret storage access patterns with centralized error handling and improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->