### PR TITLE
refactor(engine): deduplicate open file options mapping

### DIFF
--- a/src/engine/helpers/openFileOptions.ts
+++ b/src/engine/helpers/openFileOptions.ts
@@ -1,6 +1,25 @@
 import type { OpenFileOptions } from "../../types/fileOpening";
 import type { IOpenFileCommand } from "../../types/macros/QuickCommands/IOpenFileCommand";
 
+function getSplitDirection(
+	direction: IOpenFileCommand["direction"],
+	fallback: "vertical" | undefined = undefined
+): "horizontal" | "vertical" | undefined {
+	return direction === "horizontal" || direction === "vertical"
+		? direction
+		: fallback;
+}
+
+function createOpenFileOptions(
+	location: NonNullable<OpenFileOptions["location"]>,
+	focus: boolean,
+	direction?: OpenFileOptions["direction"]
+): OpenFileOptions {
+	return direction
+		? { location, direction, focus, mode: "default" }
+		: { location, focus, mode: "default" };
+}
+
 export function buildOpenFileOptions(
 	command: IOpenFileCommand
 ): OpenFileOptions {
@@ -9,49 +28,36 @@ export function buildOpenFileOptions(
 	if (command.location) {
 		switch (command.location) {
 			case "reuse":
-				return { location: "reuse", focus, mode: "default" };
+				return createOpenFileOptions("reuse", focus);
 			case "tab":
-				return { location: "tab", focus, mode: "default" };
+				return createOpenFileOptions("tab", focus);
 			case "split": {
-				const direction =
-					command.direction === "horizontal" || command.direction === "vertical"
-						? command.direction
-						: "vertical";
-				return {
-					location: "split",
-					direction,
+				return createOpenFileOptions(
+					"split",
 					focus,
-					mode: "default",
-				};
+					getSplitDirection(command.direction, "vertical")
+				);
 			}
 			case "window":
-				return { location: "window", focus, mode: "default" };
+				return createOpenFileOptions("window", focus);
 			case "left-sidebar":
-				return { location: "left-sidebar", focus, mode: "default" };
+				return createOpenFileOptions("left-sidebar", focus);
 			case "right-sidebar":
-				return { location: "right-sidebar", focus, mode: "default" };
+				return createOpenFileOptions("right-sidebar", focus);
 			default:
 				break; // fall back to legacy fields
 		}
 	}
 
 	const openInNewTab = command.openInNewTab ?? false;
-	const legacyDirection =
-		command.direction === "horizontal" || command.direction === "vertical"
-			? command.direction
-			: undefined;
+	const legacyDirection = getSplitDirection(command.direction);
 
 	// Legacy mapping (pre-location field):
 	// openInNewTab === false -> reuse the current tab
 	// openInNewTab === true without direction -> split (default vertical)
 	if (!openInNewTab) {
-		return { location: "reuse", focus, mode: "default" };
+		return createOpenFileOptions("reuse", focus);
 	}
 
-	return {
-		location: "split",
-		direction: legacyDirection ?? "vertical",
-		focus,
-		mode: "default",
-	};
+	return createOpenFileOptions("split", focus, legacyDirection ?? "vertical");
 }


### PR DESCRIPTION
Refactors open-file option building to remove small but repeated mapping logic in the macro engine helper.

The helper previously repeated split-direction normalization and repeated object construction of `{ focus, mode: "default" }` across multiple branches. This change extracts those behaviors into `getSplitDirection()` and `createOpenFileOptions()` and reuses them from both explicit-location and legacy `openInNewTab` paths.

Behavior is unchanged; this is a targeted internal cleanup to reduce duplication and make future option changes less error-prone.

Verification note: `bun run test -- src/engine/MacroChoiceEngine.openFileOptions.test.ts` could not be executed in this environment because `vitest` is not installed (`vitest: command not found`).

Areas to review: `src/engine/helpers/openFileOptions.ts`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to code organization and logic consolidation in file handling operations. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->