### PR TITLE
fix(migrations): traverse nested template choices

### DIFF
--- a/src/migrations/consolidateFileExistsBehavior.test.ts
+++ b/src/migrations/consolidateFileExistsBehavior.test.ts
@@ -1,3 +1,4 @@
+import { CommandType } from "../types/macros/CommandType";
 import { describe, expect, it } from "vitest";
 import migration from "./consolidateFileExistsBehavior";
 
@@ -51,7 +52,46 @@ describe("consolidateFileExistsBehavior migration", () => {
 		});
 	});
 
-	it("normalizes nested macro command template choices", async () => {
+	it("normalizes template choices nested inside Macro choice commands", async () => {
+		const plugin = {
+			settings: {
+				choices: [
+					{
+						id: "macro-choice",
+						name: "Macro Choice",
+						type: "Macro",
+						macro: {
+							id: "macro-1",
+							name: "Macro",
+							commands: [
+								{
+									type: CommandType.NestedChoice,
+									choice: {
+										id: "template-choice",
+										name: "Template",
+										type: "Template",
+										setFileExistsBehavior: true,
+										fileExistsMode: "Append duplicate suffix",
+									},
+								},
+							],
+						},
+					},
+				],
+				macros: [],
+			},
+		} as any;
+
+		await migration.migrate(plugin);
+
+		expect(
+			plugin.settings.choices[0].macro.commands[0].choice,
+		).toMatchObject({
+			fileExistsBehavior: { kind: "apply", mode: "duplicateSuffix" },
+		});
+	});
+
+	it("normalizes nested macro command template choices in legacy macros", async () => {
 		const plugin = {
 			settings: {
 				choices: [],
@@ -80,6 +120,62 @@ describe("consolidateFileExistsBehavior migration", () => {
 		await migration.migrate(plugin);
 
 		expect(plugin.settings.macros[0].commands[0].choice).toMatchObject({
+			fileExistsBehavior: { kind: "prompt" },
+		});
+	});
+
+	it("normalizes template choices nested in conditional macro branches", async () => {
+		const plugin = {
+			settings: {
+				choices: [],
+				macros: [
+					{
+						id: "macro-1",
+						name: "Macro",
+						commands: [
+							{
+								type: CommandType.Conditional,
+								thenCommands: [
+									{
+										type: CommandType.NestedChoice,
+										choice: {
+											id: "template-then",
+											name: "Then Template",
+											type: "Template",
+											setFileExistsBehavior: true,
+											fileExistsMode: "Append duplicate suffix",
+										},
+									},
+								],
+								elseCommands: [
+									{
+										type: CommandType.NestedChoice,
+										choice: {
+											id: "template-else",
+											name: "Else Template",
+											type: "Template",
+											setFileExistsBehavior: false,
+											fileExistsMode: "Overwrite the file",
+										},
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		} as any;
+
+		await migration.migrate(plugin);
+
+		expect(
+			plugin.settings.macros[0].commands[0].thenCommands[0].choice,
+		).toMatchObject({
+			fileExistsBehavior: { kind: "apply", mode: "duplicateSuffix" },
+		});
+		expect(
+			plugin.settings.macros[0].commands[0].elseCommands[0].choice,
+		).toMatchObject({
 			fileExistsBehavior: { kind: "prompt" },
 		});
 	});

--- a/src/migrations/consolidateFileExistsBehavior.test.ts
+++ b/src/migrations/consolidateFileExistsBehavior.test.ts
@@ -89,6 +89,12 @@ describe("consolidateFileExistsBehavior migration", () => {
 		).toMatchObject({
 			fileExistsBehavior: { kind: "apply", mode: "duplicateSuffix" },
 		});
+		expect(
+			plugin.settings.choices[0].macro.commands[0].choice.fileExistsMode,
+		).toBeUndefined();
+		expect(
+			plugin.settings.choices[0].macro.commands[0].choice.setFileExistsBehavior,
+		).toBeUndefined();
 	});
 
 	it("normalizes nested macro command template choices in legacy macros", async () => {
@@ -122,6 +128,12 @@ describe("consolidateFileExistsBehavior migration", () => {
 		expect(plugin.settings.macros[0].commands[0].choice).toMatchObject({
 			fileExistsBehavior: { kind: "prompt" },
 		});
+		expect(
+			plugin.settings.macros[0].commands[0].choice.fileExistsMode,
+		).toBeUndefined();
+		expect(
+			plugin.settings.macros[0].commands[0].choice.setFileExistsBehavior,
+		).toBeUndefined();
 	});
 
 	it("normalizes template choices nested in conditional macro branches", async () => {
@@ -174,9 +186,39 @@ describe("consolidateFileExistsBehavior migration", () => {
 			fileExistsBehavior: { kind: "apply", mode: "duplicateSuffix" },
 		});
 		expect(
+			plugin.settings.macros[0].commands[0].thenCommands[0].choice
+				.fileExistsMode,
+		).toBeUndefined();
+		expect(
+			plugin.settings.macros[0].commands[0].thenCommands[0].choice
+				.setFileExistsBehavior,
+		).toBeUndefined();
+		expect(
 			plugin.settings.macros[0].commands[0].elseCommands[0].choice,
 		).toMatchObject({
 			fileExistsBehavior: { kind: "prompt" },
 		});
+		expect(
+			plugin.settings.macros[0].commands[0].elseCommands[0].choice
+				.fileExistsMode,
+		).toBeUndefined();
+		expect(
+			plugin.settings.macros[0].commands[0].elseCommands[0].choice
+				.setFileExistsBehavior,
+		).toBeUndefined();
+	});
+
+	it("treats malformed persisted choice and macro collections as empty arrays", async () => {
+		const plugin = {
+			settings: {
+				choices: { invalid: true },
+				macros: "invalid",
+			},
+		} as any;
+
+		await migration.migrate(plugin);
+
+		expect(plugin.settings.choices).toEqual([]);
+		expect(plugin.settings.macros).toEqual([]);
 	});
 });

--- a/src/migrations/consolidateFileExistsBehavior.ts
+++ b/src/migrations/consolidateFileExistsBehavior.ts
@@ -1,53 +1,27 @@
 import type QuickAdd from "src/main";
-import type IChoice from "src/types/choices/IChoice";
-import type { IMacro } from "src/types/macros/IMacro";
 import { deepClone } from "src/utils/deepClone";
 import {
 	isTemplateChoice,
 	normalizeTemplateChoice,
 } from "./helpers/normalizeTemplateFileExistsBehavior";
-import { isMultiChoice } from "./helpers/isMultiChoice";
-import { isNestedChoiceCommand } from "./helpers/isNestedChoiceCommand";
+import { walkAllChoices } from "./helpers/choice-traversal";
 import type { Migration } from "./Migrations";
-
-function normalizeChoices(choices: IChoice[]): IChoice[] {
-	for (const choice of choices) {
-		if (isMultiChoice(choice)) {
-			choice.choices = normalizeChoices(choice.choices);
-		}
-
-		if (isTemplateChoice(choice)) {
-			normalizeTemplateChoice(choice);
-		}
-	}
-
-	return choices;
-}
-
-function normalizeMacros(macros: IMacro[]): IMacro[] {
-	for (const macro of macros) {
-		if (!Array.isArray(macro.commands)) continue;
-
-		for (const command of macro.commands) {
-			if (isNestedChoiceCommand(command) && isTemplateChoice(command.choice)) {
-				normalizeTemplateChoice(command.choice);
-			}
-		}
-	}
-
-	return macros;
-}
 
 const consolidateFileExistsBehavior: Migration = {
 	description:
 		"Re-run template file collision normalization for users with older migration state",
 
 	migrate: async (plugin: QuickAdd): Promise<void> => {
-		const choicesCopy = deepClone(plugin.settings.choices);
-		const macrosCopy = deepClone((plugin.settings as any).macros || []);
+		plugin.settings.choices = deepClone(plugin.settings.choices);
+		(plugin.settings as any).macros = deepClone(
+			(plugin.settings as any).macros || [],
+		);
 
-		plugin.settings.choices = deepClone(normalizeChoices(choicesCopy));
-		(plugin.settings as any).macros = normalizeMacros(macrosCopy);
+		walkAllChoices(plugin, (choice) => {
+			if (isTemplateChoice(choice)) {
+				normalizeTemplateChoice(choice);
+			}
+		});
 	},
 };
 

--- a/src/migrations/consolidateFileExistsBehavior.ts
+++ b/src/migrations/consolidateFileExistsBehavior.ts
@@ -12,10 +12,15 @@ const consolidateFileExistsBehavior: Migration = {
 		"Re-run template file collision normalization for users with older migration state",
 
 	migrate: async (plugin: QuickAdd): Promise<void> => {
-		plugin.settings.choices = deepClone(plugin.settings.choices);
-		(plugin.settings as any).macros = deepClone(
-			(plugin.settings as any).macros || [],
-		);
+		const choices = Array.isArray(plugin.settings.choices)
+			? plugin.settings.choices
+			: [];
+		const macros = Array.isArray((plugin.settings as any).macros)
+			? (plugin.settings as any).macros
+			: [];
+
+		plugin.settings.choices = deepClone(choices);
+		(plugin.settings as any).macros = deepClone(macros);
 
 		walkAllChoices(plugin, (choice) => {
 			if (isTemplateChoice(choice)) {


### PR DESCRIPTION
Handle nested Template choices during \ by reusing the shared choice traversal helper.

The previous migration only normalized top-level Template choices, Multi children, and direct legacy macro commands. That missed Template choices embedded inside Macro choice command lists and inside Conditional then/else branches, which left legacy file-exists settings behind and degraded runtime behavior to prompt mode.

This switches the migration to use \, which already traverses Multi choices, Macro choice commands, legacy macros, and Conditional branches in one place. The tests now cover nested Macro-choice templates, legacy macros, and Conditional branches.

This came from follow-up review comments on #1151 after the original PR was merged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for normalization of file-existence choices in nested macro and conditional scenarios; adds cases for malformed persisted data and asserts obsolete file-existence fields are removed.

* **Refactor**
  * Streamlined migration logic to a single traversal-driven normalization pass for template choices, improving efficiency and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->