### PR TITLE
feat(clipboard): support image attachments in note content

### DIFF
--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -80,6 +80,7 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 		openExistingFileTab: vi.fn(() => null),
 		openFile: vi.fn(),
 		overwriteTemplaterOnce: vi.fn(),
+		resolveClipboardForNoteContent: vi.fn(async () => ""),
 		templaterParseTemplate: vi.fn(async (_app, content) => content),
 		getTemplater: vi.fn(() => ({})),
 	}));

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -55,6 +55,7 @@ vi.mock("../utilityObsidian", () => ({
 	openExistingFileTab: vi.fn(() => null),
 	openFile: vi.fn(),
 	overwriteTemplaterOnce: vi.fn(),
+	resolveClipboardForNoteContent: vi.fn(async () => ""),
 	templaterParseTemplate: vi.fn(async (_app, content) => content),
 	waitForTemplaterTriggerOnCreateToComplete: vi.fn(),
 }));

--- a/src/engine/CaptureChoiceEngine.template-property-types.test.ts
+++ b/src/engine/CaptureChoiceEngine.template-property-types.test.ts
@@ -132,6 +132,7 @@ vi.mock("../utilityObsidian", () => ({
 		openExistingFileTab: vi.fn().mockReturnValue(null),
 		openFile: vi.fn(),
 		overwriteTemplaterOnce: vi.fn().mockResolvedValue(undefined),
+		resolveClipboardForNoteContent: vi.fn(async () => ""),
 		templaterParseTemplate: vi.fn(async (_app, content) => content),
 		waitForFileToStopChanging: vi.fn().mockResolvedValue(undefined),
 		getTemplater: vi.fn(() => ({})),

--- a/src/engine/MacroChoiceEngine.conditional.test.ts
+++ b/src/engine/MacroChoiceEngine.conditional.test.ts
@@ -27,6 +27,8 @@ vi.mock("../settingsStore", () => ({
 vi.mock("../formatters/completeFormatter", () => ({
 	CompleteFormatter: class CompleteFormatterMock {
 		constructor() {}
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
 	},
 }));
 vi.mock("../ai/AIAssistant", () => ({

--- a/src/engine/MacroChoiceEngine.editorCommands.test.ts
+++ b/src/engine/MacroChoiceEngine.editorCommands.test.ts
@@ -2,7 +2,10 @@ import type { App } from "obsidian";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../formatters/completeFormatter", () => ({
-	CompleteFormatter: class CompleteFormatterMock {},
+	CompleteFormatter: class CompleteFormatterMock {
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
+	},
 }));
 
 vi.mock("obsidian-dataview", () => ({

--- a/src/engine/MacroChoiceEngine.entry.test.ts
+++ b/src/engine/MacroChoiceEngine.entry.test.ts
@@ -108,7 +108,10 @@ vi.mock("../settingsStore", () => ({
 }));
 
 vi.mock("../formatters/completeFormatter", () => ({
-	CompleteFormatter: class CompleteFormatterMock {},
+	CompleteFormatter: class CompleteFormatterMock {
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
+	},
 }));
 
 vi.mock("../ai/AIAssistant", () => ({

--- a/src/engine/MacroChoiceEngine.notice.test.ts
+++ b/src/engine/MacroChoiceEngine.notice.test.ts
@@ -44,7 +44,10 @@ vi.mock("../quickAddSettingsTab", () => {
 });
 
 vi.mock("../formatters/completeFormatter", () => ({
-	CompleteFormatter: class CompleteFormatterMock {},
+	CompleteFormatter: class CompleteFormatterMock {
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
+	},
 }));
 
 vi.mock("obsidian-dataview", () => ({

--- a/src/engine/SingleMacroEngine.member-access.test.ts
+++ b/src/engine/SingleMacroEngine.member-access.test.ts
@@ -79,7 +79,10 @@ vi.mock("../settingsStore", () => ({
 }));
 
 vi.mock("../formatters/completeFormatter", () => ({
-	CompleteFormatter: class CompleteFormatterMock {},
+	CompleteFormatter: class CompleteFormatterMock {
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
+	},
 }));
 
 vi.mock("../ai/AIAssistant", () => ({

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -62,6 +62,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		setTitle() {}
 		setDestinationFile() {}
 		setDestinationSourcePath() {}
+		clearDestinationContext() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
 		}

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -60,6 +60,8 @@ vi.mock("../formatters/completeFormatter", () => {
 		constructor() {}
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
 		}
@@ -85,6 +87,7 @@ vi.mock("../utilityObsidian", () => ({
 	insertFileLinkToActiveView: vi.fn(),
 	openExistingFileTab: vi.fn(() => null),
 	openFile: vi.fn(),
+	resolveClipboardForNoteContent: vi.fn(async () => ""),
 }));
 
 vi.mock("../gui/GenericSuggester/genericSuggester", () => ({

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -62,6 +62,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		setTitle() {}
 		setDestinationFile() {}
 		setDestinationSourcePath() {}
+		clearDestinationContext() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
 		}

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -60,6 +60,8 @@ vi.mock("../formatters/completeFormatter", () => {
 		constructor() {}
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
 		}
@@ -88,6 +90,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		insertFileLinkToActiveView: vi.fn(),
 		openExistingFileTab: vi.fn(() => null),
 		openFile: vi.fn(),
+		resolveClipboardForNoteContent: vi.fn(async () => ""),
 	}));
 
 vi.mock("../gui/GenericSuggester/genericSuggester", () => ({

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -93,6 +93,24 @@ export abstract class TemplateEngine extends QuickAddEngine {
 		| Promise<string>
 		| Promise<{ file: TFile; content: string }>;
 
+	private setTemplateDestinationContext(filePath: string): void {
+		if (MARKDOWN_FILE_EXTENSION_REGEX.test(filePath)) {
+			this.formatter.setDestinationSourcePath(filePath);
+			return;
+		}
+
+		this.formatter.clearDestinationContext();
+	}
+
+	private setTemplateDestinationContextForFile(file: TFile): void {
+		if (MARKDOWN_FILE_EXTENSION_REGEX.test(file.path)) {
+			this.formatter.setDestinationFile(file);
+			return;
+		}
+
+		this.formatter.clearDestinationContext();
+	}
+
 	protected async getOrCreateFolder(
 		folders: string[],
 		options: FolderChoiceOptions = {},
@@ -478,7 +496,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Extract filename without extension from the full path.
 			const fileBasename = basenameWithoutMdOrCanvas(filePath);
 			this.formatter.setTitle(fileBasename);
-			this.formatter.setDestinationSourcePath(filePath);
+			this.setTemplateDestinationContext(filePath);
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
@@ -538,7 +556,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Use the existing file's basename as the title
 			const fileBasename = file.basename;
 			this.formatter.setTitle(fileBasename);
-			this.formatter.setDestinationFile(file);
+			this.setTemplateDestinationContextForFile(file);
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
@@ -586,7 +604,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Use the existing file's basename as the title
 			const fileBasename = file.basename;
 			this.formatter.setTitle(fileBasename);
-			this.formatter.setDestinationFile(file);
+			this.setTemplateDestinationContextForFile(file);
 
 			let formattedTemplateContent: string =
 				await this.formatter.formatFileContent(templateContent);

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -478,6 +478,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Extract filename without extension from the full path.
 			const fileBasename = basenameWithoutMdOrCanvas(filePath);
 			this.formatter.setTitle(fileBasename);
+			this.formatter.setDestinationSourcePath(filePath);
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
@@ -537,6 +538,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Use the existing file's basename as the title
 			const fileBasename = file.basename;
 			this.formatter.setTitle(fileBasename);
+			this.formatter.setDestinationFile(file);
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
@@ -584,6 +586,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Use the existing file's basename as the title
 			const fileBasename = file.basename;
 			this.formatter.setTitle(fileBasename);
+			this.formatter.setDestinationFile(file);
 
 			let formattedTemplateContent: string =
 				await this.formatter.formatFileContent(templateContent);

--- a/src/engine/templateEngine-title.test.ts
+++ b/src/engine/templateEngine-title.test.ts
@@ -19,9 +19,16 @@ vi.mock('../formatters/completeFormatter', () => {
                 setDestinationSourcePath: vi.fn((path: string) => {
                     destinationSourcePath = path;
                 }),
+                clearDestinationContext: vi.fn(() => {
+                    destinationFile = null;
+                    destinationSourcePath = null;
+                }),
                 getTitle: () => title,
                 getDestinationFile: () => destinationFile,
                 getDestinationSourcePath: () => destinationSourcePath,
+                getAndClearTemplatePropertyVars: vi.fn(
+                    () => new Map<string, unknown>(),
+                ),
                 withTemplatePropertyCollection: vi.fn(
                     async (work: () => Promise<unknown>) => await work(),
                 ),
@@ -39,6 +46,7 @@ vi.mock('../formatters/completeFormatter', () => {
 vi.mock('../utilityObsidian', () => ({
     getTemplater: vi.fn(() => null),
     overwriteTemplaterOnce: vi.fn().mockResolvedValue(undefined),
+    templaterParseTemplate: vi.fn(async (_app, content: string) => content),
     resolveClipboardForNoteContent: vi.fn(async () => ""),
 }));
 
@@ -177,6 +185,13 @@ describe('TemplateEngine - Title Handling', () => {
 
             expect(engine.getFormatterDestinationSourcePath()).toBe('folder/TestDocument.md');
         });
+
+        it('should clear destination context for new non-markdown template output', async () => {
+            await engine.testCreateFileWithTemplate('folder/Kanban.base', 'template.base');
+
+            expect(engine.getFormatterDestinationSourcePath()).toBeNull();
+            expect(engine.getFormatterDestinationFile()).toBeNull();
+        });
     });
 
     describe('existing file template updates', () => {
@@ -201,6 +216,32 @@ describe('TemplateEngine - Title Handling', () => {
             await engine.testAppendToFileWithTemplate(existingFile, 'template.md', 'bottom');
 
             expect(engine.getFormatterDestinationFile()).toBe(existingFile);
+        });
+
+        it('should clear destination context before overwriting non-markdown template output', async () => {
+            const existingBaseFile = {
+                path: 'folder/Kanban.base',
+                basename: 'Kanban',
+                extension: 'base',
+            } as any;
+
+            await engine.testOverwriteFileWithTemplate(existingBaseFile, 'template.base');
+
+            expect(engine.getFormatterDestinationFile()).toBeNull();
+            expect(engine.getFormatterDestinationSourcePath()).toBeNull();
+        });
+
+        it('should clear destination context before appending non-markdown template output', async () => {
+            const existingCanvasFile = {
+                path: 'folder/Board.canvas',
+                basename: 'Board',
+                extension: 'canvas',
+            } as any;
+
+            await engine.testAppendToFileWithTemplate(existingCanvasFile, 'template.canvas', 'bottom');
+
+            expect(engine.getFormatterDestinationFile()).toBeNull();
+            expect(engine.getFormatterDestinationSourcePath()).toBeNull();
         });
     });
 

--- a/src/engine/templateEngine-title.test.ts
+++ b/src/engine/templateEngine-title.test.ts
@@ -9,9 +9,19 @@ vi.mock('../formatters/completeFormatter', () => {
     return {
         CompleteFormatter: vi.fn().mockImplementation(() => {
             let title = '';
+            let destinationFile: unknown = null;
+            let destinationSourcePath: string | null = null;
             return {
                 setTitle: vi.fn((t: string) => { title = t; }),
+                setDestinationFile: vi.fn((file: unknown) => {
+                    destinationFile = file;
+                }),
+                setDestinationSourcePath: vi.fn((path: string) => {
+                    destinationSourcePath = path;
+                }),
                 getTitle: () => title,
+                getDestinationFile: () => destinationFile,
+                getDestinationSourcePath: () => destinationSourcePath,
                 withTemplatePropertyCollection: vi.fn(
                     async (work: () => Promise<unknown>) => await work(),
                 ),
@@ -29,6 +39,7 @@ vi.mock('../formatters/completeFormatter', () => {
 vi.mock('../utilityObsidian', () => ({
     getTemplater: vi.fn(() => null),
     overwriteTemplaterOnce: vi.fn().mockResolvedValue(undefined),
+    resolveClipboardForNoteContent: vi.fn(async () => ""),
 }));
 
 // Test implementation of TemplateEngine
@@ -46,9 +57,25 @@ class TestTemplateEngine extends TemplateEngine {
         return await this.createFileWithTemplate(filePath, templatePath);
     }
 
+    public async testOverwriteFileWithTemplate(file: any, templatePath: string) {
+        return await this.overwriteFileWithTemplate(file, templatePath);
+    }
+
+    public async testAppendToFileWithTemplate(file: any, templatePath: string, section: "top" | "bottom") {
+        return await this.appendToFileWithTemplate(file, templatePath, section);
+    }
+
     public getFormatterTitle(): string {
         // Access the title that was set on the formatter
         return (this.formatter as any).getTitle();
+    }
+
+    public getFormatterDestinationSourcePath(): string | null {
+        return (this.formatter as any).getDestinationSourcePath();
+    }
+
+    public getFormatterDestinationFile(): unknown {
+        return (this.formatter as any).getDestinationFile();
     }
 }
 
@@ -143,6 +170,37 @@ describe('TemplateEngine - Title Handling', () => {
             
             // Verify formatFileContent was called
             expect(mockFormatter.formatFileContent).toHaveBeenCalled();
+        });
+
+        it('should set destination source path before formatting new template content', async () => {
+            await engine.testCreateFileWithTemplate('folder/TestDocument.md', 'template.md');
+
+            expect(engine.getFormatterDestinationSourcePath()).toBe('folder/TestDocument.md');
+        });
+    });
+
+    describe('existing file template updates', () => {
+        const existingFile = {
+            path: 'folder/Existing.md',
+            basename: 'Existing',
+            extension: 'md',
+        } as any;
+
+        beforeEach(() => {
+            mockApp.vault.modify = vi.fn().mockResolvedValue(undefined);
+            mockApp.vault.cachedRead = vi.fn().mockResolvedValue('Existing content');
+        });
+
+        it('should set destination file before overwriting template content', async () => {
+            await engine.testOverwriteFileWithTemplate(existingFile, 'template.md');
+
+            expect(engine.getFormatterDestinationFile()).toBe(existingFile);
+        });
+
+        it('should set destination file before appending template content', async () => {
+            await engine.testAppendToFileWithTemplate(existingFile, 'template.md', 'bottom');
+
+            expect(engine.getFormatterDestinationFile()).toBe(existingFile);
         });
     });
 

--- a/src/formatters/captureChoiceFormatter-frontmatter.test.ts
+++ b/src/formatters/captureChoiceFormatter-frontmatter.test.ts
@@ -4,6 +4,7 @@ import type ICaptureChoice from '../types/choices/ICaptureChoice';
 
 vi.mock('../utilityObsidian', () => ({
   templaterParseTemplate: vi.fn().mockResolvedValue(null),
+  resolveClipboardForNoteContent: vi.fn(async () => ''),
 }));
 
 vi.mock('../gui/InputPrompt', () => ({

--- a/src/formatters/captureChoiceFormatter-write-position.test.ts
+++ b/src/formatters/captureChoiceFormatter-write-position.test.ts
@@ -4,6 +4,7 @@ import type ICaptureChoice from "../types/choices/ICaptureChoice";
 
 vi.mock("../utilityObsidian", () => ({
 	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+	resolveClipboardForNoteContent: vi.fn(async () => ""),
 }));
 
 vi.mock("../gui/InputPrompt", () => ({

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -30,11 +30,13 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	private templaterProcessed = false;
 
 	public setDestinationFile(file: TFile): void {
+		super.setDestinationFile(file);
 		this.file = file;
 		this.sourcePath = file.path;
 	}
 
 	public setDestinationSourcePath(path: string): void {
+		super.setDestinationSourcePath(path);
 		this.sourcePath = path;
 		this.file = null;
 	}

--- a/src/formatters/completeFormatter.clipboard.test.ts
+++ b/src/formatters/completeFormatter.clipboard.test.ts
@@ -86,6 +86,33 @@ describe("CompleteFormatter clipboard handling", () => {
 		expect(app.vault.createBinary).not.toHaveBeenCalled();
 	});
 
+	it("does not resolve clipboard content when the token is absent", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const readText = vi.fn().mockResolvedValue("clipboard text");
+		const read = vi.fn().mockResolvedValue([
+			{
+				types: ["image/png"],
+				getType: vi.fn().mockResolvedValue(
+					new Blob(["image-bytes"], { type: "image/png" }),
+				),
+			},
+		]);
+		setClipboard({
+			read,
+			readText,
+		});
+
+		const result = await formatter.formatFileContent("No clipboard token here");
+
+		expect(result).toBe("No clipboard token here");
+		expect(read).not.toHaveBeenCalled();
+		expect(readText).not.toHaveBeenCalled();
+		expect(app.vault.createBinary).not.toHaveBeenCalled();
+	});
+
 	it("saves a clipboard image attachment and returns an Obsidian embed", async () => {
 		const { app } = createMockApp();
 		const formatter = new CompleteFormatter(app, createPlugin());
@@ -200,6 +227,42 @@ describe("CompleteFormatter clipboard handling", () => {
 		expect(app.vault.createBinary).toHaveBeenCalledWith(
 			"Assets/pasted-image.png",
 			expect.any(ArrayBuffer),
+		);
+	});
+
+	it("imports a local .jpeg clipboard image path as an attachment embed", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const readFile = vi
+			.fn()
+			.mockResolvedValue(new Uint8Array([255, 216, 255, 224]));
+		setClipboard({
+			read: vi.fn().mockResolvedValue([]),
+			readText: vi
+				.fn()
+				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.jpeg"),
+		});
+		setWindowRequire((id: string) => {
+			if (id === "fs") {
+				return {
+					existsSync: vi.fn().mockReturnValue(true),
+					promises: { readFile },
+				};
+			}
+			return undefined;
+		});
+
+		const result = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(result).toBe("![[Assets/pasted-image.png]]");
+		expect(app.fileManager.getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.stringMatching(/^Pasted image \d{8}-\d{6}\.jpeg$/),
+			"Notes/Daily.md",
+		);
+		expect(readFile).toHaveBeenCalledWith(
+			"/Users/christian/Library/Caches/Clop/images/85074.jpeg",
 		);
 	});
 

--- a/src/formatters/completeFormatter.clipboard.test.ts
+++ b/src/formatters/completeFormatter.clipboard.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+
+vi.mock("../gui/choiceList/ChoiceView.svelte", () => ({}));
+vi.mock("../gui/GlobalVariables/GlobalVariablesView.svelte", () => ({}));
+vi.mock("../main", () => ({
+	__esModule: true,
+	default: class QuickAddMock {},
+}));
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+import { CompleteFormatter } from "./completeFormatter";
+
+const createMockApp = () => {
+	const attachmentFile = {
+		path: "Assets/pasted-image.png",
+		name: "pasted-image.png",
+		basename: "pasted-image",
+		extension: "png",
+	} as unknown as TFile;
+
+	return {
+		attachmentFile,
+		app: {
+			workspace: {
+				getActiveFile: vi.fn().mockReturnValue(null),
+				getActiveViewOfType: vi.fn().mockReturnValue(null),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn().mockReturnValue("[[Assets/pasted-image.png]]"),
+				getAvailablePathForAttachment: vi
+					.fn()
+					.mockResolvedValue("Assets/pasted-image.png"),
+			},
+			vault: {
+				createBinary: vi.fn().mockResolvedValue(attachmentFile),
+			},
+		} as unknown as App,
+	};
+};
+
+const createPlugin = () =>
+	({
+		settings: {
+			inputPrompt: "single-line",
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+		},
+	}) as any;
+
+const setClipboard = (clipboard: Record<string, unknown>) => {
+	Object.defineProperty(globalThis, "navigator", {
+		value: { clipboard },
+		configurable: true,
+		writable: true,
+	});
+};
+
+const setWindowRequire = (requireImpl?: (id: string) => unknown) => {
+	Object.defineProperty(window, "require", {
+		value: requireImpl,
+		configurable: true,
+		writable: true,
+	});
+};
+
+describe("CompleteFormatter clipboard handling", () => {
+	beforeEach(() => {
+		vi.useRealTimers();
+		setWindowRequire(undefined);
+		setClipboard({
+			readText: vi.fn().mockResolvedValue("clipboard text"),
+		});
+	});
+
+	it("uses plain text clipboard content for note formatting when no image is present", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const result = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(result).toBe("clipboard text");
+		expect(app.vault.createBinary).not.toHaveBeenCalled();
+	});
+
+	it("saves a clipboard image attachment and returns an Obsidian embed", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const imageBlob = new Blob(["image-bytes"], { type: "image/png" });
+		const read = vi.fn().mockResolvedValue([
+			{
+				types: ["image/png"],
+				getType: vi.fn().mockResolvedValue(imageBlob),
+			},
+		]);
+		setClipboard({
+			read,
+			readText: vi.fn().mockResolvedValue("clipboard text"),
+		});
+
+		const result = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(read).toHaveBeenCalledOnce();
+		expect(result).toBe("![[Assets/pasted-image.png]]");
+		expect(app.fileManager.getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.stringMatching(/^Pasted image \d{8}-\d{6}\.png$/),
+			"Notes/Daily.md",
+		);
+		expect(app.vault.createBinary).toHaveBeenCalledWith(
+			"Assets/pasted-image.png",
+			expect.any(ArrayBuffer),
+		);
+		expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(
+			expect.objectContaining({ path: "Assets/pasted-image.png" }),
+			"Notes/Daily.md",
+		);
+	});
+
+	it("falls back to clipboard text when image inspection fails", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		setClipboard({
+			read: vi.fn().mockRejectedValue(new Error("denied")),
+			readText: vi.fn().mockResolvedValue("clipboard text"),
+		});
+
+		const result = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(result).toBe("clipboard text");
+		expect(app.vault.createBinary).not.toHaveBeenCalled();
+	});
+
+	it("falls back to plain text when no destination note context exists", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+
+		setClipboard({
+			read: vi.fn().mockResolvedValue([
+				{
+					types: ["image/png"],
+					getType: vi.fn().mockResolvedValue(
+						new Blob(["image-bytes"], { type: "image/png" }),
+					),
+				},
+			]),
+			readText: vi.fn().mockResolvedValue("clipboard text"),
+		});
+
+		const result = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(result).toBe("clipboard text");
+		expect(app.vault.createBinary).not.toHaveBeenCalled();
+	});
+
+	it("imports a local clipboard image path as an attachment embed", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const readFile = vi
+			.fn()
+			.mockResolvedValue(new Uint8Array([137, 80, 78, 71]));
+		const existsSync = vi.fn().mockReturnValue(true);
+		setClipboard({
+			read: vi.fn().mockResolvedValue([]),
+			readText: vi
+				.fn()
+				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.png"),
+		});
+		setWindowRequire((id: string) => {
+			if (id === "fs") {
+				return {
+					existsSync,
+					promises: { readFile },
+				};
+			}
+			return undefined;
+		});
+
+		const result = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(result).toBe("![[Assets/pasted-image.png]]");
+		expect(existsSync).toHaveBeenCalledWith(
+			"/Users/christian/Library/Caches/Clop/images/85074.png",
+		);
+		expect(readFile).toHaveBeenCalledWith(
+			"/Users/christian/Library/Caches/Clop/images/85074.png",
+		);
+		expect(app.fileManager.getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.stringMatching(/^Pasted image \d{8}-\d{6}\.png$/),
+			"Notes/Daily.md",
+		);
+		expect(app.vault.createBinary).toHaveBeenCalledWith(
+			"Assets/pasted-image.png",
+			expect.any(ArrayBuffer),
+		);
+	});
+
+	it("reuses the same resolved clipboard embed across repeated content passes", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const readFile = vi
+			.fn()
+			.mockResolvedValue(new Uint8Array([137, 80, 78, 71]));
+		setClipboard({
+			read: vi.fn().mockResolvedValue([]),
+			readText: vi
+				.fn()
+				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.png"),
+		});
+		setWindowRequire((id: string) => {
+			if (id === "fs") {
+				return {
+					existsSync: vi.fn().mockReturnValue(true),
+					promises: { readFile },
+				};
+			}
+			return undefined;
+		});
+
+		const first = await formatter.formatFileContent("{{clipboard}}");
+		const second = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(first).toBe("![[Assets/pasted-image.png]]");
+		expect(second).toBe("![[Assets/pasted-image.png]]");
+		expect(readFile).toHaveBeenCalledOnce();
+		expect(app.vault.createBinary).toHaveBeenCalledOnce();
+	});
+
+	it("leaves plain text untouched when clipboard path is not an existing image", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const existsSync = vi.fn().mockReturnValue(false);
+		setClipboard({
+			read: vi.fn().mockResolvedValue([]),
+			readText: vi
+				.fn()
+				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.png"),
+		});
+		setWindowRequire((id: string) => {
+			if (id === "fs") {
+				return {
+					existsSync,
+					promises: { readFile: vi.fn() },
+				};
+			}
+			return undefined;
+		});
+
+		const result = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(result).toBe(
+			"/Users/christian/Library/Caches/Clop/images/85074.png",
+		);
+		expect(app.vault.createBinary).not.toHaveBeenCalled();
+	});
+
+	it("keeps filename formatting text-only even when clipboard contains an image", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+		formatter.setDestinationSourcePath("Notes/Daily.md");
+
+		const read = vi.fn().mockResolvedValue([
+			{
+				types: ["image/png"],
+				getType: vi.fn().mockResolvedValue(
+					new Blob(["image-bytes"], { type: "image/png" }),
+				),
+			},
+		]);
+		const readText = vi.fn().mockResolvedValue("clipboard text");
+		setClipboard({
+			read,
+			readText,
+		});
+
+		const result = await formatter.formatFileName("{{clipboard}}", "Prompt");
+
+		expect(result).toBe("clipboard text");
+		expect(read).not.toHaveBeenCalled();
+		expect(readText).toHaveBeenCalledOnce();
+		expect(app.vault.createBinary).not.toHaveBeenCalled();
+	});
+});

--- a/src/formatters/completeFormatter.clipboard.test.ts
+++ b/src/formatters/completeFormatter.clipboard.test.ts
@@ -58,18 +58,26 @@ const setClipboard = (clipboard: Record<string, unknown>) => {
 	});
 };
 
-const setWindowRequire = (requireImpl?: (id: string) => unknown) => {
-	Object.defineProperty(window, "require", {
-		value: requireImpl,
-		configurable: true,
-		writable: true,
+const mockFetchForFile = (
+	bytes: Uint8Array,
+	opts?: { reject?: boolean },
+) => {
+	vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.href : (input as Request).url;
+		if (!url.startsWith("file://")) {
+			return new Response(null, { status: 404 });
+		}
+		if (opts?.reject) {
+			return new Response(null, { status: 404, statusText: "Not Found" });
+		}
+		return new Response(bytes, { status: 200 });
 	});
 };
 
 describe("CompleteFormatter clipboard handling", () => {
 	beforeEach(() => {
 		vi.useRealTimers();
-		setWindowRequire(undefined);
+		vi.restoreAllMocks();
 		setClipboard({
 			readText: vi.fn().mockResolvedValue("clipboard text"),
 		});
@@ -212,34 +220,20 @@ describe("CompleteFormatter clipboard handling", () => {
 		const formatter = new CompleteFormatter(app, createPlugin());
 		formatter.setDestinationSourcePath("Notes/Daily.md");
 
-		const readFile = vi
-			.fn()
-			.mockResolvedValue(new Uint8Array([137, 80, 78, 71]));
-		const existsSync = vi.fn().mockReturnValue(true);
+		const imageBytes = new Uint8Array([137, 80, 78, 71]);
+		mockFetchForFile(imageBytes);
 		setClipboard({
 			read: vi.fn().mockResolvedValue([]),
 			readText: vi
 				.fn()
 				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.png"),
 		});
-		setWindowRequire((id: string) => {
-			if (id === "fs") {
-				return {
-					existsSync,
-					promises: { readFile },
-				};
-			}
-			return undefined;
-		});
 
 		const result = await formatter.formatFileContent("{{clipboard}}");
 
 		expect(result).toBe("![[Assets/pasted-image.png]]");
-		expect(existsSync).toHaveBeenCalledWith(
-			"/Users/christian/Library/Caches/Clop/images/85074.png",
-		);
-		expect(readFile).toHaveBeenCalledWith(
-			"/Users/christian/Library/Caches/Clop/images/85074.png",
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"file:///Users/christian/Library/Caches/Clop/images/85074.png",
 		);
 		expect(app.fileManager.getAvailablePathForAttachment).toHaveBeenCalledWith(
 			expect.stringMatching(/^Pasted image \d{8}-\d{6}\.png$/),
@@ -256,23 +250,13 @@ describe("CompleteFormatter clipboard handling", () => {
 		const formatter = new CompleteFormatter(app, createPlugin());
 		formatter.setDestinationSourcePath("Notes/Daily.md");
 
-		const readFile = vi
-			.fn()
-			.mockResolvedValue(new Uint8Array([255, 216, 255, 224]));
+		const imageBytes = new Uint8Array([255, 216, 255, 224]);
+		mockFetchForFile(imageBytes);
 		setClipboard({
 			read: vi.fn().mockResolvedValue([]),
 			readText: vi
 				.fn()
 				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.jpeg"),
-		});
-		setWindowRequire((id: string) => {
-			if (id === "fs") {
-				return {
-					existsSync: vi.fn().mockReturnValue(true),
-					promises: { readFile },
-				};
-			}
-			return undefined;
 		});
 
 		const result = await formatter.formatFileContent("{{clipboard}}");
@@ -282,8 +266,8 @@ describe("CompleteFormatter clipboard handling", () => {
 			expect.stringMatching(/^Pasted image \d{8}-\d{6}\.jpeg$/),
 			"Notes/Daily.md",
 		);
-		expect(readFile).toHaveBeenCalledWith(
-			"/Users/christian/Library/Caches/Clop/images/85074.jpeg",
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"file:///Users/christian/Library/Caches/Clop/images/85074.jpeg",
 		);
 	});
 
@@ -292,23 +276,13 @@ describe("CompleteFormatter clipboard handling", () => {
 		const formatter = new CompleteFormatter(app, createPlugin());
 		formatter.setDestinationSourcePath("Notes/Daily.md");
 
-		const readFile = vi
-			.fn()
-			.mockResolvedValue(new Uint8Array([137, 80, 78, 71]));
+		const imageBytes = new Uint8Array([137, 80, 78, 71]);
+		mockFetchForFile(imageBytes);
 		setClipboard({
 			read: vi.fn().mockResolvedValue([]),
 			readText: vi
 				.fn()
 				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.png"),
-		});
-		setWindowRequire((id: string) => {
-			if (id === "fs") {
-				return {
-					existsSync: vi.fn().mockReturnValue(true),
-					promises: { readFile },
-				};
-			}
-			return undefined;
 		});
 
 		const first = await formatter.formatFileContent("{{clipboard}}");
@@ -316,7 +290,8 @@ describe("CompleteFormatter clipboard handling", () => {
 
 		expect(first).toBe("![[Assets/pasted-image.png]]");
 		expect(second).toBe("![[Assets/pasted-image.png]]");
-		expect(readFile).toHaveBeenCalledOnce();
+		// fetch is called only once; second pass uses cached result
+		expect(globalThis.fetch).toHaveBeenCalledOnce();
 		expect(app.vault.createBinary).toHaveBeenCalledOnce();
 	});
 
@@ -325,27 +300,21 @@ describe("CompleteFormatter clipboard handling", () => {
 		const formatter = new CompleteFormatter(app, createPlugin());
 		formatter.setDestinationSourcePath("Notes/Daily.md");
 
-		const existsSync = vi.fn().mockReturnValue(false);
+		mockFetchForFile(new Uint8Array(), { reject: true });
 		setClipboard({
 			read: vi.fn().mockResolvedValue([]),
 			readText: vi
 				.fn()
 				.mockResolvedValue("/Users/christian/Library/Caches/Clop/images/85074.png"),
 		});
-		setWindowRequire((id: string) => {
-			if (id === "fs") {
-				return {
-					existsSync,
-					promises: { readFile: vi.fn() },
-				};
-			}
-			return undefined;
-		});
 
 		const result = await formatter.formatFileContent("{{clipboard}}");
 
 		expect(result).toBe(
 			"/Users/christian/Library/Caches/Clop/images/85074.png",
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"file:///Users/christian/Library/Caches/Clop/images/85074.png",
 		);
 		expect(app.vault.createBinary).not.toHaveBeenCalled();
 	});

--- a/src/formatters/completeFormatter.clipboard.test.ts
+++ b/src/formatters/completeFormatter.clipboard.test.ts
@@ -186,6 +186,27 @@ describe("CompleteFormatter clipboard handling", () => {
 		expect(app.vault.createBinary).not.toHaveBeenCalled();
 	});
 
+	it("re-reads clipboard text on each call when no destination note context exists", async () => {
+		const { app } = createMockApp();
+		const formatter = new CompleteFormatter(app, createPlugin());
+
+		const readText = vi
+			.fn()
+			.mockResolvedValueOnce("first clipboard text")
+			.mockResolvedValueOnce("second clipboard text");
+		setClipboard({
+			readText,
+		});
+
+		const first = await formatter.formatFileContent("{{clipboard}}");
+		const second = await formatter.formatFileContent("{{clipboard}}");
+
+		expect(first).toBe("first clipboard text");
+		expect(second).toBe("second clipboard text");
+		expect(readText).toHaveBeenCalledTimes(2);
+		expect(app.vault.createBinary).not.toHaveBeenCalled();
+	});
+
 	it("imports a local clipboard image path as an attachment embed", async () => {
 		const { app } = createMockApp();
 		const formatter = new CompleteFormatter(app, createPlugin());

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -24,12 +24,22 @@ import {
 	generateFieldCacheKey,
 } from "../utils/FieldValueCollector";
 import { FieldValueProcessor } from "../utils/FieldValueProcessor";
+import { resolveClipboardForNoteContent } from "../utilityObsidian";
 import { Formatter, type PromptContext } from "./formatter";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { isCancellationError } from "../utils/errorUtils";
+import type { TFile } from "obsidian";
 
 export class CompleteFormatter extends Formatter {
 	private valueHeader: string;
+	private destinationSourcePath: string | null = null;
+	private clipboardContentScopeDepth = 0;
+	private resolvedClipboardContent:
+		| {
+				destinationSourcePath: string | null;
+				value: string;
+		  }
+		| null = null;
 
 	constructor(
 		protected app: App,
@@ -66,6 +76,27 @@ export class CompleteFormatter extends Formatter {
 		return output;
 	}
 
+	public setDestinationFile(file: TFile): void {
+		this.setDestinationSourcePath(file.path);
+	}
+
+	public setDestinationSourcePath(path: string): void {
+		if (this.destinationSourcePath !== path) {
+			this.resolvedClipboardContent = null;
+		}
+		this.destinationSourcePath = path;
+	}
+
+	private async withClipboardContentScope<T>(work: () => Promise<T>): Promise<T> {
+		this.clipboardContentScopeDepth += 1;
+
+		try {
+			return await work();
+		} finally {
+			this.clipboardContentScopeDepth -= 1;
+		}
+	}
+
 	protected async replaceGlobalVarInString(input: string): Promise<string> {
 		let output = input;
 		// Allow nested globals up to a small recursion limit
@@ -98,14 +129,16 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	async formatFileContent(input: string): Promise<string> {
-		let output: string = input;
+		return await this.withClipboardContentScope(async () => {
+			let output: string = input;
 
-		output = await this.format(output);
-		output = await this.replaceLinkToCurrentFileInString(output);
-		output = await this.replaceCurrentFileNameInString(output);
-		output = this.replaceTitleInString(output);
+			output = await this.format(output);
+			output = await this.replaceLinkToCurrentFileInString(output);
+			output = await this.replaceCurrentFileNameInString(output);
+			output = this.replaceTitleInString(output);
 
-		return output;
+			return output;
+		});
 	}
 
 	async formatFolderPath(folderName: string): Promise<string> {
@@ -134,7 +167,7 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected getLinkSourcePath(): string | null {
-		return null;
+		return this.destinationSourcePath;
 	}
 
 	protected getCurrentFileLink(): string | null {
@@ -383,6 +416,26 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async getClipboardContent(): Promise<string> {
+		if (this.clipboardContentScopeDepth > 0) {
+			if (
+				this.resolvedClipboardContent &&
+				this.resolvedClipboardContent.destinationSourcePath ===
+					this.destinationSourcePath
+			) {
+				return this.resolvedClipboardContent.value;
+			}
+
+			const resolvedContent = await resolveClipboardForNoteContent(
+				this.app,
+				this.destinationSourcePath,
+			);
+			this.resolvedClipboardContent = {
+				destinationSourcePath: this.destinationSourcePath,
+				value: resolvedContent,
+			};
+			return resolvedContent;
+		}
+
 		try {
 			return await navigator.clipboard.readText();
 		} catch {

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -87,6 +87,11 @@ export class CompleteFormatter extends Formatter {
 		this.destinationSourcePath = path;
 	}
 
+	public clearDestinationContext(): void {
+		this.destinationSourcePath = null;
+		this.resolvedClipboardContent = null;
+	}
+
 	private async withClipboardContentScope<T>(work: () => Promise<T>): Promise<T> {
 		this.clipboardContentScopeDepth += 1;
 
@@ -416,7 +421,10 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async getClipboardContent(): Promise<string> {
-		if (this.clipboardContentScopeDepth > 0) {
+		if (
+			this.clipboardContentScopeDepth > 0 &&
+			this.destinationSourcePath !== null
+		) {
 			if (
 				this.resolvedClipboardContent &&
 				this.resolvedClipboardContent.destinationSourcePath ===

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -33,13 +33,11 @@ import type { TFile } from "obsidian";
 export class CompleteFormatter extends Formatter {
 	private valueHeader: string;
 	private destinationSourcePath: string | null = null;
-	private clipboardContentScopeDepth = 0;
-	private resolvedClipboardContent:
-		| {
-				destinationSourcePath: string | null;
-				value: string;
-		  }
-		| null = null;
+	private formattingFileContent = false;
+	private resolvedClipboardContent: {
+		destinationSourcePath: string;
+		value: string;
+	} | null = null;
 
 	constructor(
 		protected app: App,
@@ -92,16 +90,6 @@ export class CompleteFormatter extends Formatter {
 		this.resolvedClipboardContent = null;
 	}
 
-	private async withClipboardContentScope<T>(work: () => Promise<T>): Promise<T> {
-		this.clipboardContentScopeDepth += 1;
-
-		try {
-			return await work();
-		} finally {
-			this.clipboardContentScopeDepth -= 1;
-		}
-	}
-
 	protected async replaceGlobalVarInString(input: string): Promise<string> {
 		let output = input;
 		// Allow nested globals up to a small recursion limit
@@ -134,7 +122,9 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	async formatFileContent(input: string): Promise<string> {
-		return await this.withClipboardContentScope(async () => {
+		this.formattingFileContent = true;
+
+		try {
 			let output: string = input;
 
 			output = await this.format(output);
@@ -143,7 +133,9 @@ export class CompleteFormatter extends Formatter {
 			output = this.replaceTitleInString(output);
 
 			return output;
-		});
+		} finally {
+			this.formattingFileContent = false;
+		}
 	}
 
 	async formatFolderPath(folderName: string): Promise<string> {
@@ -421,10 +413,7 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async getClipboardContent(): Promise<string> {
-		if (
-			this.clipboardContentScopeDepth > 0 &&
-			this.destinationSourcePath !== null
-		) {
+		if (this.formattingFileContent && this.destinationSourcePath !== null) {
 			if (
 				this.resolvedClipboardContent &&
 				this.resolvedClipboardContent.destinationSourcePath ===

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -227,6 +227,7 @@ export abstract class Formatter {
 
 	protected async replaceClipboardInString(input: string): Promise<string> {
 		let output: string = input;
+		if (!output.toLowerCase().includes("{{clipboard}}")) return output;
 
 		const clipboardContent = await this.getClipboardContent();
 

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -828,11 +828,12 @@ async function readBlobArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
 	return await new Response(blob).arrayBuffer();
 }
 
-function uint8ArrayToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-	return bytes.buffer.slice(
-		bytes.byteOffset,
-		bytes.byteOffset + bytes.byteLength,
-	);
+function absolutePathToFileUrl(absolutePath: string): string {
+	const forwardSlashPath = absolutePath.replace(/\\/g, "/");
+	const urlPath = forwardSlashPath.startsWith("/")
+		? forwardSlashPath
+		: `/${forwardSlashPath}`;
+	return `file://${urlPath}`;
 }
 
 function parseClipboardLocalImagePath(clipboardText: string): {
@@ -875,30 +876,13 @@ async function readClipboardLocalImagePath(
 	const imagePath = parseClipboardLocalImagePath(clipboardText);
 	if (!imagePath) return null;
 
-	const req =
-		typeof window !== "undefined" && typeof window.require === "function"
-			? window.require
-			: null;
-	if (!req) return null;
-
 	try {
-		const fs = req("fs") as {
-			existsSync?: (path: string) => boolean;
-			promises?: {
-				readFile?: (path: string) => Promise<Uint8Array>;
-			};
-		};
-		if (
-			typeof fs?.existsSync !== "function" ||
-			typeof fs.promises?.readFile !== "function"
-		) {
-			return null;
-		}
-		if (!fs.existsSync(imagePath.path)) return null;
+		const fileUrl = absolutePathToFileUrl(imagePath.path);
+		const response = await fetch(fileUrl);
+		if (!response.ok) return null;
 
-		const bytes = await fs.promises.readFile(imagePath.path);
 		return {
-			bytes: uint8ArrayToArrayBuffer(bytes),
+			bytes: await response.arrayBuffer(),
 			extension: imagePath.extension,
 		};
 	} catch (error) {

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -740,6 +740,244 @@ export function insertFileLinkToActiveView(
 	return true;
 }
 
+const CLIPBOARD_IMAGE_EXTENSIONS: Record<string, string> = {
+	"image/png": "png",
+	"image/jpeg": "jpg",
+	"image/jpg": "jpg",
+	"image/webp": "webp",
+	"image/gif": "gif",
+	"image/svg+xml": "svg",
+	"image/bmp": "bmp",
+	"image/tiff": "tiff",
+};
+
+const CLIPBOARD_IMAGE_FILE_EXTENSIONS = new Set(
+	Object.values(CLIPBOARD_IMAGE_EXTENSIONS),
+);
+
+function getClipboardImageExtension(mimeType: string): string | null {
+	return CLIPBOARD_IMAGE_EXTENSIONS[mimeType.toLowerCase()] ?? null;
+}
+
+function formatClipboardImageTimestamp(date: Date): string {
+	const pad = (value: number) => value.toString().padStart(2, "0");
+
+	return [
+		date.getFullYear(),
+		pad(date.getMonth() + 1),
+		pad(date.getDate()),
+		"-",
+		pad(date.getHours()),
+		pad(date.getMinutes()),
+		pad(date.getSeconds()),
+	].join("");
+}
+
+function getClipboardImageFileName(mimeType: string, now = new Date()): string | null {
+	const extension = getClipboardImageExtension(mimeType);
+	if (!extension) return null;
+
+	return `Pasted image ${formatClipboardImageTimestamp(now)}.${extension}`;
+}
+
+function getClipboardImageFileNameFromExtension(
+	extension: string,
+	now = new Date(),
+): string | null {
+	const normalizedExtension = extension.toLowerCase().replace(/^\./, "");
+	if (!CLIPBOARD_IMAGE_FILE_EXTENSIONS.has(normalizedExtension)) return null;
+
+	return `Pasted image ${formatClipboardImageTimestamp(now)}.${normalizedExtension}`;
+}
+
+async function readClipboardImageItem(): Promise<{
+	blob: Blob;
+	mimeType: string;
+} | null> {
+	if (!("clipboard" in navigator)) return null;
+	const clipboard = navigator.clipboard;
+	if (!("read" in clipboard) || typeof clipboard.read !== "function") return null;
+
+	try {
+		const clipboardItems = await clipboard.read();
+
+		for (const item of clipboardItems) {
+			const imageType = item.types.find((type) => {
+				return type.toLowerCase() in CLIPBOARD_IMAGE_EXTENSIONS;
+			});
+			if (!imageType) continue;
+
+			return {
+				blob: await item.getType(imageType),
+				mimeType: imageType,
+			};
+		}
+	} catch (error) {
+		log.logWarning(`Failed to inspect clipboard image content: ${error}`);
+	}
+
+	return null;
+}
+
+async function readBlobArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+	if (typeof blob.arrayBuffer === "function") {
+		return await blob.arrayBuffer();
+	}
+
+	return await new Response(blob).arrayBuffer();
+}
+
+function uint8ArrayToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(
+		bytes.byteOffset,
+		bytes.byteOffset + bytes.byteLength,
+	);
+}
+
+function parseClipboardLocalImagePath(clipboardText: string): {
+	path: string;
+	extension: string;
+} | null {
+	const trimmedText = clipboardText.trim();
+	if (!trimmedText || /\r|\n/.test(trimmedText)) return null;
+
+	let filePath = trimmedText;
+	if (trimmedText.startsWith("file://")) {
+		try {
+			const parsedUrl = new URL(trimmedText);
+			if (parsedUrl.protocol !== "file:") return null;
+			filePath = decodeURIComponent(parsedUrl.pathname);
+		} catch {
+			return null;
+		}
+	}
+
+	const isUnixAbsolutePath = filePath.startsWith("/");
+	const isWindowsAbsolutePath = /^[a-zA-Z]:[\\/]/.test(filePath);
+	if (!isUnixAbsolutePath && !isWindowsAbsolutePath) return null;
+
+	const extensionMatch = /\.([^.\\/]+)$/.exec(filePath);
+	if (!extensionMatch) return null;
+
+	const extension = extensionMatch[1].toLowerCase();
+	if (!CLIPBOARD_IMAGE_FILE_EXTENSIONS.has(extension)) return null;
+
+	return { path: filePath, extension };
+}
+
+async function readClipboardLocalImagePath(
+	clipboardText: string,
+): Promise<{
+	bytes: ArrayBuffer;
+	extension: string;
+} | null> {
+	const imagePath = parseClipboardLocalImagePath(clipboardText);
+	if (!imagePath) return null;
+
+	const req =
+		typeof window !== "undefined" && typeof window.require === "function"
+			? window.require
+			: null;
+	if (!req) return null;
+
+	try {
+		const fs = req("fs") as {
+			existsSync?: (path: string) => boolean;
+			promises?: {
+				readFile?: (path: string) => Promise<Uint8Array>;
+			};
+		};
+		if (
+			typeof fs?.existsSync !== "function" ||
+			typeof fs.promises?.readFile !== "function"
+		) {
+			return null;
+		}
+		if (!fs.existsSync(imagePath.path)) return null;
+
+		const bytes = await fs.promises.readFile(imagePath.path);
+		return {
+			bytes: uint8ArrayToArrayBuffer(bytes),
+			extension: imagePath.extension,
+		};
+	} catch (error) {
+		log.logWarning(`Failed to read clipboard image path: ${error}`);
+		return null;
+	}
+}
+
+async function saveClipboardImageAttachment(
+	app: App,
+	destinationPath: string,
+	content: {
+		bytes: ArrayBuffer;
+		fileName: string;
+	},
+): Promise<string | null> {
+	try {
+		const attachmentPath = await app.fileManager.getAvailablePathForAttachment(
+			content.fileName,
+			destinationPath,
+		);
+		const attachmentFile = await app.vault.createBinary(
+			attachmentPath,
+			content.bytes,
+		);
+		const link = app.fileManager.generateMarkdownLink(
+			attachmentFile,
+			destinationPath,
+		);
+		return convertLinkToEmbed(link);
+	} catch (error) {
+		log.logWarning(`Failed to save clipboard image attachment: ${error}`);
+		return null;
+	}
+}
+
+export async function resolveClipboardForNoteContent(
+	app: App,
+	destinationPath?: string | null,
+): Promise<string> {
+	let clipboardText = "";
+
+	try {
+		clipboardText = await navigator.clipboard.readText();
+	} catch {
+		clipboardText = "";
+	}
+
+	if (destinationPath) {
+		const imageItem = await readClipboardImageItem();
+
+		if (imageItem) {
+			const fileName = getClipboardImageFileName(imageItem.mimeType);
+			if (fileName) {
+				const embed = await saveClipboardImageAttachment(app, destinationPath, {
+					fileName,
+					bytes: await readBlobArrayBuffer(imageItem.blob),
+				});
+				if (embed) return embed;
+			}
+		}
+
+		const localImagePath = await readClipboardLocalImagePath(clipboardText);
+		if (localImagePath) {
+			const fileName = getClipboardImageFileNameFromExtension(
+				localImagePath.extension,
+			);
+			if (fileName) {
+				const embed = await saveClipboardImageAttachment(app, destinationPath, {
+					fileName,
+					bytes: localImagePath.bytes,
+				});
+				if (embed) return embed;
+			}
+		}
+	}
+
+	return clipboardText;
+}
+
 export function findObsidianCommand(app: App, commandId: string) {
 	return app.commands.findCommand(commandId);
 }
@@ -1077,4 +1315,6 @@ export function getMarkdownFilesWithTag(app: App, tag: string): TFile[] {
 export const __test = {
 	convertLinkToEmbed,
 	extractMarkdownLinkTarget,
+	getClipboardImageExtension,
+	getClipboardImageFileName,
 } as const;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -751,9 +751,10 @@ const CLIPBOARD_IMAGE_EXTENSIONS: Record<string, string> = {
 	"image/tiff": "tiff",
 };
 
-const CLIPBOARD_IMAGE_FILE_EXTENSIONS = new Set(
-	Object.values(CLIPBOARD_IMAGE_EXTENSIONS),
-);
+const CLIPBOARD_IMAGE_FILE_EXTENSIONS = new Set([
+	...Object.values(CLIPBOARD_IMAGE_EXTENSIONS),
+	"jpeg",
+]);
 
 function getClipboardImageExtension(mimeType: string): string | null {
 	return CLIPBOARD_IMAGE_EXTENSIONS[mimeType.toLowerCase()] ?? null;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -830,9 +830,13 @@ async function readBlobArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
 
 function absolutePathToFileUrl(absolutePath: string): string {
 	const forwardSlashPath = absolutePath.replace(/\\/g, "/");
-	const urlPath = forwardSlashPath.startsWith("/")
-		? forwardSlashPath
-		: `/${forwardSlashPath}`;
+	const segments = forwardSlashPath.split("/");
+	const encodedPath = segments
+		.map((segment) => encodeURIComponent(segment))
+		.join("/");
+	const urlPath = encodedPath.startsWith("/")
+		? encodedPath
+		: `/${encodedPath}`;
 	return `file://${urlPath}`;
 }
 


### PR DESCRIPTION
## Summary

Add clipboard image support to note-content `{{clipboard}}` rendering.

This keeps `{{clipboard}}` text-based by default, but when QuickAdd is formatting note content with a destination note context it now detects clipboard images, saves them as Obsidian attachments, and inserts embeds. The resolver also handles desktop clipboard payloads that arrive as local image-file paths, which was necessary to support the live Obsidian clipboard behavior reproduced from issue #1161.

### Changes addressing review comments

**Alternative approach for local image file reading** (`src/utilityObsidian.ts`):
- Replaced `window.require("fs")` with `fetch("file://...")` for reading local clipboard image paths
- Removed `uint8ArrayToArrayBuffer` helper (no longer needed — `fetch` returns `ArrayBuffer` directly)
- Added `absolutePathToFileUrl` helper for cross-platform path→URL conversion
- This eliminates the Node.js `fs` dependency, verbose type casting, and fragile `window.require` detection

**Simplified clipboard handling** (`src/formatters/completeFormatter.ts`):
- Replaced `clipboardContentScopeDepth` counter with a simple `formattingFileContent` boolean flag
- Removed `withClipboardContentScope` wrapper method
- `formatFileContent` now directly sets/unsets the flag in a try/finally block
- Simplified `resolvedClipboardContent` type (removed null union on `destinationSourcePath`)
- Net reduction of ~58 lines across implementation and tests

**Tests** (`src/formatters/completeFormatter.clipboard.test.ts`):
- Replaced `setWindowRequire` helper with `mockFetchForFile` that mocks `globalThis.fetch`
- Updated all local-path tests to assert `fetch` calls with `file://` URLs
- All 1029 tests pass, lint and build clean

Fixes #1161

## Review & Testing Checklist for Human

- [ ] Verify `fetch("file://...")` works in Obsidian's Electron runtime — test with a clipboard manager (e.g. Clop) that puts local image paths in the clipboard. If `fetch` is blocked by Electron security policy, the function gracefully returns `null` and falls back to plain text, but the image import feature would be degraded.
- [ ] Confirm clipboard image embed works end-to-end: copy an image, run a QuickAdd capture/template with `{{clipboard}}`, verify the attachment is created and embed inserted.
- [ ] Verify `formatFileName` with `{{clipboard}}` still returns plain text (not image embeds) even when clipboard contains an image.

### Notes

- The Cloudflare Pages CI failure is pre-existing and unrelated to these changes.
- The `formattingFileContent` boolean replaces the depth counter. Nested `formatFileContent` calls are not expected in practice, so a boolean suffices. If nesting is ever needed, it can be upgraded back to a counter.

Link to Devin session: https://app.devin.ai/sessions/d2e18cb56396423ca07600dfd2facff9
Requested by: @chhoumann

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced clipboard handling with support for embedding images directly from clipboard when creating files from templates.
  * Improved clipboard resolution for template operations, including support for resolving local filesystem image paths.
  * Destination-aware clipboard content resolution for better template formatting.

* **Tests**
  * Added comprehensive test coverage for clipboard image handling in template creation and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->