### PR TITLE
fix: route QuickAdd opens away from pinned origin leaf

### DIFF
--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -1,4 +1,4 @@
-import type { App } from "obsidian";
+import type { App, WorkspaceLeaf } from "obsidian";
 import type QuickAdd from "./main";
 import type IChoice from "./types/choices/IChoice";
 import type ITemplateChoice from "./types/choices/ITemplateChoice";
@@ -14,6 +14,7 @@ import { settingsStore } from "./settingsStore";
 import { runOnePagePreflight } from "./preflight/runOnePagePreflight";
 import { MacroAbortError } from "./errors/MacroAbortError";
 import { isCancellationError } from "./utils/errorUtils";
+import { getOpenFileOriginLeaf } from "./utilityObsidian";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
@@ -33,6 +34,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 
 	async execute(choice: IChoice): Promise<void> {
 		this.pendingAbort = null;
+		const originLeaf = getOpenFileOriginLeaf(this.app);
 		// One-page preflight honoring per-choice override.
 		const globalEnabled = settingsStore.getState().onePageInputEnabled;
 		const override = choice.onePageInput;
@@ -63,17 +65,17 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			case "Template": {
 				const templateChoice: ITemplateChoice =
 					choice as ITemplateChoice;
-				await this.onChooseTemplateType(templateChoice);
+				await this.onChooseTemplateType(templateChoice, originLeaf);
 				break;
 			}
 			case "Capture": {
 				const captureChoice: ICaptureChoice = choice as ICaptureChoice;
-				await this.onChooseCaptureType(captureChoice);
+				await this.onChooseCaptureType(captureChoice, originLeaf);
 				break;
 			}
 			case "Macro": {
 				const macroChoice: IMacroChoice = choice as IMacroChoice;
-				await this.onChooseMacroType(macroChoice);
+				await this.onChooseMacroType(macroChoice, originLeaf);
 				break;
 			}
 			case "Multi": {
@@ -87,32 +89,44 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	}
 
 	private async onChooseTemplateType(
-		templateChoice: ITemplateChoice
+		templateChoice: ITemplateChoice,
+		originLeaf: WorkspaceLeaf | null,
 	): Promise<void> {
 		await new TemplateChoiceEngine(
 			this.app,
 			this.plugin,
 			templateChoice,
-			this
+			this,
+			originLeaf,
 		).run();
 	}
 
-	private async onChooseCaptureType(captureChoice: ICaptureChoice) {
+	private async onChooseCaptureType(
+		captureChoice: ICaptureChoice,
+		originLeaf: WorkspaceLeaf | null,
+	) {
 		await new CaptureChoiceEngine(
 			this.app,
 			this.plugin,
 			captureChoice,
-			this
+			this,
+			originLeaf,
 		).run();
 	}
 
-	private async onChooseMacroType(macroChoice: IMacroChoice) {
+	private async onChooseMacroType(
+		macroChoice: IMacroChoice,
+		originLeaf: WorkspaceLeaf | null,
+	) {
 		const macroEngine = new MacroChoiceEngine(
 			this.app,
 			this.plugin,
 			macroChoice,
 			this,
-			this.variables
+			this.variables,
+			undefined,
+			undefined,
+			originLeaf,
 		);
 		await macroEngine.run();
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -1,4 +1,10 @@
-import { MarkdownView, Notice, type App, type TFile } from "obsidian";
+import {
+	MarkdownView,
+	Notice,
+	type App,
+	type TFile,
+	type WorkspaceLeaf,
+} from "obsidian";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
 import invariant from "src/utils/invariant";
 import merge from "three-way-merge";
@@ -63,6 +69,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		plugin: QuickAdd,
 		choice: ICaptureChoice,
 		private choiceExecutor: IChoiceExecutor,
+		private readonly originLeaf: WorkspaceLeaf | null = null,
 	) {
 		super(app);
 		this.choice = choice;
@@ -304,7 +311,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				const openExistingTab = openExistingFileTab(this.app, file, focus);
 
 				if (!openExistingTab) {
-					await openFile(this.app, file, fileOpening);
+					await openFile(this.app, file, {
+						...fileOpening,
+						originLeaf: this.originLeaf,
+					});
 				}
 
 				await jumpToNextTemplaterCursorIfPossible(this.app, file);
@@ -381,7 +391,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			const openExistingTab = openExistingFileTab(this.app, file, focus);
 
 			if (!openExistingTab) {
-				await openFile(this.app, file, fileOpening);
+				await openFile(this.app, file, {
+					...fileOpening,
+					originLeaf: this.originLeaf,
+				});
 			}
 
 			await jumpToNextTemplaterCursorIfPossible(this.app, file);

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -1,5 +1,5 @@
 import type IMacroChoice from "../types/choices/IMacroChoice";
-import type { App } from "obsidian";
+import type { App, WorkspaceLeaf } from "obsidian";
 import * as obsidian from "obsidian";
 import type { IUserScript } from "../types/macros/IUserScript";
 import type { IObsidianCommand } from "../types/macros/IObsidianCommand";
@@ -159,6 +159,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		variables: Map<string, unknown>,
 		preloadedUserScripts?: Map<string, unknown>,
 		promptLabel?: string,
+		private readonly originLeaf: WorkspaceLeaf | null = null,
 	) {
 		super(app);
 		this.choice = choice;
@@ -671,7 +672,10 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 
 			const openOptions = buildOpenFileOptions(command);
 
-			await openFile(this.app, file, openOptions);
+			await openFile(this.app, file, {
+				...openOptions,
+				originLeaf: this.originLeaf,
+			});
 		} catch (error) {
 			log.logError(`OpenFile: Failed to open file '${command.filePath}': ${error.message}`);
 		}

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -1,4 +1,4 @@
-import type { App } from "obsidian";
+import type { App, WorkspaceLeaf } from "obsidian";
 import { TFile } from "obsidian";
 import { TFolder } from "obsidian";
 import invariant from "src/utils/invariant";
@@ -37,6 +37,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		plugin: QuickAdd,
 		choice: ITemplateChoice,
 		choiceExecutor: IChoiceExecutor,
+		private readonly originLeaf: WorkspaceLeaf | null = null,
 	) {
 		super(app, plugin, choiceExecutor);
 		this.choiceExecutor = choiceExecutor;
@@ -146,7 +147,10 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				);
 
 				if (!openExistingTab) {
-					await openFile(this.app, createdFile, fileOpening);
+					await openFile(this.app, createdFile, {
+						...fileOpening,
+						originLeaf: this.originLeaf,
+					});
 				}
 
 				await jumpToNextTemplaterCursorIfPossible(this.app, createdFile);

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -284,6 +284,32 @@ describe("openFile", () => {
 		expect(getLeaf).not.toHaveBeenCalledWith(false);
 	});
 
+	it("treats nested view-state pinning as pinned navigation state", async () => {
+		const pinnedOriginLeaf = createLeaf("pinned-origin");
+		pinnedOriginLeaf.getViewState.mockReturnValue({
+			type: "markdown",
+			state: { file: "pinned-origin.md", pinned: true },
+		});
+		const unpinnedSiblingLeaf = createLeaf("unpinned-sibling");
+		const tabLeaf = createLeaf("tab");
+		const file = createFile();
+		const { app, getLeaf } = createApp({
+			rootLeaves: [pinnedOriginLeaf, unpinnedSiblingLeaf],
+			originLeaf: pinnedOriginLeaf,
+			tabLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "tab",
+			originLeaf: pinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(unpinnedSiblingLeaf);
+		expect(unpinnedSiblingLeaf.openFile).toHaveBeenCalledWith(file);
+		expect(tabLeaf.openFile).not.toHaveBeenCalled();
+		expect(getLeaf).not.toHaveBeenCalledWith("tab");
+	});
+
 	it("preserves normal tab behavior when the origin is not pinned", async () => {
 		const unpinnedOriginLeaf = createLeaf("origin");
 		const tabLeaf = createLeaf("tab");

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -352,15 +352,17 @@ describe("openFile", () => {
 		expect(tabLeaf.openFile).toHaveBeenCalledWith(file);
 	});
 
-	it("falls back to normal reuse behavior when no unpinned sibling exists", async () => {
+	it("falls back to a new tab for reuse when no unpinned sibling exists", async () => {
 		const pinnedOriginLeaf = createLeaf("pinned-origin", true);
 		const pinnedSiblingLeaf = createLeaf("pinned-sibling", true);
 		const reuseLeaf = createLeaf("reuse");
+		const tabLeaf = createLeaf("tab");
 		const file = createFile();
 		const { app, getLeaf } = createApp({
 			rootLeaves: [pinnedOriginLeaf, pinnedSiblingLeaf],
 			originLeaf: pinnedOriginLeaf,
 			reuseLeaf,
+			tabLeaf,
 		});
 
 		const leaf = await openFile(app, file, {
@@ -368,9 +370,11 @@ describe("openFile", () => {
 			originLeaf: pinnedOriginLeaf,
 		});
 
-		expect(leaf).toBe(reuseLeaf);
-		expect(getLeaf).toHaveBeenCalledWith(false);
-		expect(reuseLeaf.openFile).toHaveBeenCalledWith(file);
+		expect(leaf).toBe(tabLeaf);
+		expect(getLeaf).toHaveBeenCalledWith("tab");
+		expect(getLeaf).not.toHaveBeenCalledWith(false);
+		expect(tabLeaf.openFile).toHaveBeenCalledWith(file);
+		expect(reuseLeaf.openFile).not.toHaveBeenCalled();
 	});
 
 	it("leaves explicit split behavior unchanged for pinned origins", async () => {

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -1,11 +1,109 @@
-import { describe, expect, it } from "vitest";
+import type { App, TFile, WorkspaceLeaf, WorkspaceParent } from "obsidian";
+import { describe, expect, it, vi } from "vitest";
 import {
 	__test,
 	areSameVaultFilePath,
 	normalizeVaultFilePath,
+	getOpenFileOriginLeaf,
+	openFile,
 } from "./utilityObsidian";
 
 const { convertLinkToEmbed, extractMarkdownLinkTarget } = __test;
+
+type FakeLeaf = WorkspaceLeaf & {
+	id: string;
+	pinned?: boolean;
+	openFile: ReturnType<typeof vi.fn>;
+	getViewState: ReturnType<typeof vi.fn>;
+	setViewState: ReturnType<typeof vi.fn>;
+};
+
+function createLeaf(id: string, pinned = false): FakeLeaf {
+	const leaf = { id, pinned } as FakeLeaf;
+
+	leaf.openFile = vi.fn(async () => undefined);
+	leaf.getViewState = vi.fn(() => ({
+		type: "markdown",
+		state: { file: `${id}.md` },
+		...(leaf.pinned ? { pinned: true } : {}),
+	}));
+	leaf.setViewState = vi.fn(async () => undefined);
+
+	return leaf;
+}
+
+function createFile(path = "target.md"): TFile {
+	return { path } as TFile;
+}
+
+function setParent(leaf: FakeLeaf, parent: { id: string }): FakeLeaf {
+	(leaf as unknown as { parent: { id: string } }).parent = parent;
+	return leaf;
+}
+
+function createApp({
+	rootLeaves,
+	originLeaf,
+	activeLeaf = originLeaf,
+	mostRecentLeaf = originLeaf,
+	tabLeaf = createLeaf("tab"),
+	reuseLeaf = activeLeaf ?? tabLeaf,
+	splitLeaf = createLeaf("split"),
+	windowLeaf = createLeaf("window"),
+	leftSidebarLeaf = createLeaf("left-sidebar"),
+	rightSidebarLeaf = createLeaf("right-sidebar"),
+	rootSplit = { id: "root-split" } as unknown as WorkspaceParent,
+}: {
+	rootLeaves: FakeLeaf[];
+	originLeaf: FakeLeaf | null;
+	activeLeaf?: FakeLeaf | null;
+	mostRecentLeaf?: FakeLeaf | null;
+	tabLeaf?: FakeLeaf;
+	reuseLeaf?: FakeLeaf;
+	splitLeaf?: FakeLeaf;
+	windowLeaf?: FakeLeaf;
+	leftSidebarLeaf?: FakeLeaf;
+	rightSidebarLeaf?: FakeLeaf;
+	rootSplit?: WorkspaceParent | null;
+}) {
+	const getLeaf = vi.fn((location?: unknown) => {
+		if (location === "tab") return tabLeaf;
+		if (location === false) return reuseLeaf;
+		if (location === "split") return splitLeaf;
+		if (location === "window") return windowLeaf;
+		return reuseLeaf;
+	});
+	const setActiveLeaf = vi.fn();
+	const getMostRecentLeaf = vi.fn(() => mostRecentLeaf);
+	const iterateRootLeaves = vi.fn((callback: (leaf: WorkspaceLeaf) => void) => {
+		rootLeaves.forEach(callback);
+	});
+
+	const app = {
+		workspace: {
+			activeLeaf,
+			rootSplit,
+			getMostRecentLeaf,
+			getLeaf,
+			getLeftLeaf: vi.fn(() => leftSidebarLeaf),
+			getRightLeaf: vi.fn(() => rightSidebarLeaf),
+			iterateRootLeaves,
+			setActiveLeaf,
+		},
+		vault: {
+			getAbstractFileByPath: vi.fn(),
+		},
+	} as unknown as App;
+
+	return {
+		app,
+		getLeaf,
+		getMostRecentLeaf,
+		rootSplit,
+		iterateRootLeaves,
+		setActiveLeaf,
+	};
+}
 
 describe("convertLinkToEmbed", () => {
 	it("converts wiki links to embeds", () => {
@@ -73,6 +171,204 @@ describe("extractMarkdownLinkTarget", () => {
 
 	it("returns null for empty targets", () => {
 		expect(extractMarkdownLinkTarget("[Label]()")).toBeNull();
+	});
+});
+
+describe("getOpenFileOriginLeaf", () => {
+	it("captures the most recent root-split leaf before tab creation", () => {
+		const activeLeaf = createLeaf("active");
+		const originLeaf = createLeaf("source");
+		const { app, getMostRecentLeaf, rootSplit } = createApp({
+			rootLeaves: [originLeaf],
+			originLeaf: activeLeaf,
+			mostRecentLeaf: originLeaf,
+		});
+
+		expect(getOpenFileOriginLeaf(app)).toBe(originLeaf);
+		expect(getMostRecentLeaf).toHaveBeenCalledWith(rootSplit);
+	});
+
+	it("falls back to the most recent leaf when rootSplit is unavailable", () => {
+		const activeLeaf = createLeaf("active");
+		const originLeaf = createLeaf("source");
+		const { app, getMostRecentLeaf } = createApp({
+			rootLeaves: [originLeaf],
+			originLeaf: activeLeaf,
+			mostRecentLeaf: originLeaf,
+			rootSplit: null,
+		});
+
+		expect(getOpenFileOriginLeaf(app)).toBe(originLeaf);
+		expect(getMostRecentLeaf).toHaveBeenCalledWith();
+	});
+});
+
+describe("openFile", () => {
+	it("routes tab opens from a pinned origin into an unpinned sibling", async () => {
+		const pinnedOriginLeaf = createLeaf("pinned-origin", true);
+		const unpinnedSiblingLeaf = createLeaf("unpinned-sibling");
+		const tabLeaf = createLeaf("tab");
+		const file = createFile();
+		const { app, getLeaf, setActiveLeaf } = createApp({
+			rootLeaves: [pinnedOriginLeaf, unpinnedSiblingLeaf],
+			originLeaf: pinnedOriginLeaf,
+			tabLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "tab",
+			originLeaf: pinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(unpinnedSiblingLeaf);
+		expect(unpinnedSiblingLeaf.openFile).toHaveBeenCalledWith(file);
+		expect(tabLeaf.openFile).not.toHaveBeenCalled();
+		expect(getLeaf).not.toHaveBeenCalledWith("tab");
+		expect(setActiveLeaf).toHaveBeenCalledWith(unpinnedSiblingLeaf, {
+			focus: true,
+		});
+	});
+
+	it("routes away from a transient leaf in the pinned origin's tab group", async () => {
+		const lockedGroup = { id: "locked-group" };
+		const rightGroup = { id: "right-group" };
+		const pinnedOriginLeaf = setParent(
+			createLeaf("pinned-origin", true),
+			lockedGroup,
+		);
+		const transientLeaf = setParent(createLeaf("transient"), lockedGroup);
+		const unpinnedSiblingLeaf = setParent(
+			createLeaf("unpinned-sibling"),
+			rightGroup,
+		);
+		const tabLeaf = createLeaf("tab");
+		const file = createFile();
+		const { app, getLeaf } = createApp({
+			rootLeaves: [transientLeaf, unpinnedSiblingLeaf],
+			originLeaf: pinnedOriginLeaf,
+			activeLeaf: transientLeaf,
+			mostRecentLeaf: transientLeaf,
+			tabLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "tab",
+			originLeaf: pinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(unpinnedSiblingLeaf);
+		expect(transientLeaf.openFile).not.toHaveBeenCalled();
+		expect(unpinnedSiblingLeaf.openFile).toHaveBeenCalledWith(file);
+		expect(getLeaf).not.toHaveBeenCalledWith("tab");
+	});
+
+	it("routes reuse opens from a pinned origin into an unpinned sibling", async () => {
+		const pinnedOriginLeaf = createLeaf("pinned-origin", true);
+		const unpinnedSiblingLeaf = createLeaf("unpinned-sibling");
+		const reuseLeaf = createLeaf("reuse");
+		const file = createFile();
+		const { app, getLeaf } = createApp({
+			rootLeaves: [pinnedOriginLeaf, unpinnedSiblingLeaf],
+			originLeaf: pinnedOriginLeaf,
+			reuseLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "reuse",
+			originLeaf: pinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(unpinnedSiblingLeaf);
+		expect(unpinnedSiblingLeaf.openFile).toHaveBeenCalledWith(file);
+		expect(reuseLeaf.openFile).not.toHaveBeenCalled();
+		expect(getLeaf).not.toHaveBeenCalledWith(false);
+	});
+
+	it("preserves normal tab behavior when the origin is not pinned", async () => {
+		const unpinnedOriginLeaf = createLeaf("origin");
+		const tabLeaf = createLeaf("tab");
+		const file = createFile();
+		const { app, getLeaf } = createApp({
+			rootLeaves: [unpinnedOriginLeaf],
+			originLeaf: unpinnedOriginLeaf,
+			tabLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "tab",
+			originLeaf: unpinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(tabLeaf);
+		expect(getLeaf).toHaveBeenCalledWith("tab");
+		expect(tabLeaf.openFile).toHaveBeenCalledWith(file);
+		expect(unpinnedOriginLeaf.openFile).not.toHaveBeenCalled();
+	});
+
+	it("falls back to normal tab creation when no unpinned sibling exists", async () => {
+		const pinnedOriginLeaf = createLeaf("pinned-origin", true);
+		const pinnedSiblingLeaf = createLeaf("pinned-sibling", true);
+		const tabLeaf = createLeaf("tab");
+		const file = createFile();
+		const { app, getLeaf } = createApp({
+			rootLeaves: [pinnedOriginLeaf, pinnedSiblingLeaf],
+			originLeaf: pinnedOriginLeaf,
+			tabLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "tab",
+			originLeaf: pinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(tabLeaf);
+		expect(getLeaf).toHaveBeenCalledWith("tab");
+		expect(tabLeaf.openFile).toHaveBeenCalledWith(file);
+	});
+
+	it("falls back to normal reuse behavior when no unpinned sibling exists", async () => {
+		const pinnedOriginLeaf = createLeaf("pinned-origin", true);
+		const pinnedSiblingLeaf = createLeaf("pinned-sibling", true);
+		const reuseLeaf = createLeaf("reuse");
+		const file = createFile();
+		const { app, getLeaf } = createApp({
+			rootLeaves: [pinnedOriginLeaf, pinnedSiblingLeaf],
+			originLeaf: pinnedOriginLeaf,
+			reuseLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "reuse",
+			originLeaf: pinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(reuseLeaf);
+		expect(getLeaf).toHaveBeenCalledWith(false);
+		expect(reuseLeaf.openFile).toHaveBeenCalledWith(file);
+	});
+
+	it("leaves explicit split behavior unchanged for pinned origins", async () => {
+		const pinnedOriginLeaf = createLeaf("pinned-origin", true);
+		const unpinnedSiblingLeaf = createLeaf("unpinned-sibling");
+		const splitLeaf = createLeaf("split");
+		const file = createFile();
+		const { app, getLeaf, iterateRootLeaves } = createApp({
+			rootLeaves: [pinnedOriginLeaf, unpinnedSiblingLeaf],
+			originLeaf: pinnedOriginLeaf,
+			splitLeaf,
+		});
+
+		const leaf = await openFile(app, file, {
+			location: "split",
+			direction: "horizontal",
+			originLeaf: pinnedOriginLeaf,
+		});
+
+		expect(leaf).toBe(splitLeaf);
+		expect(getLeaf).toHaveBeenCalledWith("split", "horizontal");
+		expect(iterateRootLeaves).not.toHaveBeenCalled();
+		expect(unpinnedSiblingLeaf.openFile).not.toHaveBeenCalled();
+		expect(splitLeaf.openFile).toHaveBeenCalledWith(file);
 	});
 });
 

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -813,7 +813,11 @@ function isLeafPinnedForNavigation(
 		| PinnedLeafViewState
 		| undefined;
 
-	return !!pinnedLeaf.pinned || !!viewState?.pinned;
+	return (
+		!!pinnedLeaf.pinned ||
+		!!viewState?.pinned ||
+		!!viewState?.state?.pinned
+	);
 }
 
 export function getOpenFileOriginLeaf(app: App): WorkspaceLeaf | null {

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -879,7 +879,7 @@ function resolveLeafForOpenFileLocation(
 			getRootLeaves(app),
 			originLeaf,
 		);
-		if (siblingLeaf) return siblingLeaf;
+		return siblingLeaf ?? app.workspace.getLeaf("tab");
 	}
 
 	switch (location) {

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -3,6 +3,7 @@ import type {
 	CachedMetadata,
 	TAbstractFile,
 	WorkspaceLeaf,
+	WorkspaceParent,
 } from "obsidian";
 import { FileView, MarkdownView, normalizePath, TFile, TFolder } from "obsidian";
 import { log } from "./logger/logManager";
@@ -779,7 +780,121 @@ export type OpenLocation = FileOpenLocation;
 export type FileViewMode2 = FileViewModeNew;
 export type OpenFileOptions = FileOpenOptions;
 
+export type OpenFileRuntimeOptions = FileOpenOptions & {
+	/**
+	 * Transient origin leaf captured before Obsidian creates a new tab.
+	 * This is intentionally not persisted in choice settings.
+	 */
+	originLeaf?: WorkspaceLeaf | null;
+};
 
+type PinnedLeafViewState = {
+	pinned?: boolean;
+	state?: { pinned?: boolean };
+};
+
+type PinnedLeaf = WorkspaceLeaf & {
+	pinned?: boolean;
+};
+
+type WorkspaceWithOriginLeaf = App["workspace"] & {
+	activeLeaf?: WorkspaceLeaf | null;
+	rootSplit?: WorkspaceParent;
+	getMostRecentLeaf?: (root?: WorkspaceParent) => WorkspaceLeaf | null;
+};
+
+function isLeafPinnedForNavigation(
+	leaf: WorkspaceLeaf | null | undefined,
+): boolean {
+	if (!leaf) return false;
+
+	const pinnedLeaf = leaf as PinnedLeaf;
+	const viewState = pinnedLeaf.getViewState?.() as
+		| PinnedLeafViewState
+		| undefined;
+
+	return !!pinnedLeaf.pinned || !!viewState?.pinned;
+}
+
+export function getOpenFileOriginLeaf(app: App): WorkspaceLeaf | null {
+	const workspace = app.workspace as WorkspaceWithOriginLeaf;
+	const rootLeaf = workspace.rootSplit
+		? workspace.getMostRecentLeaf?.(workspace.rootSplit)
+		: null;
+
+	return rootLeaf ?? workspace.getMostRecentLeaf?.() ?? workspace.activeLeaf ?? null;
+}
+
+function getRootLeaves(app: App): WorkspaceLeaf[] {
+	const leaves: WorkspaceLeaf[] = [];
+	app.workspace.iterateRootLeaves((leaf: WorkspaceLeaf) => {
+		if (!leaves.includes(leaf)) leaves.push(leaf);
+	});
+	return leaves;
+}
+
+function getLeafParentId(leaf: WorkspaceLeaf): unknown {
+	return (leaf.parent as { id?: unknown } | undefined)?.id ?? leaf.parent ?? null;
+}
+
+function findUnpinnedNavigableSibling(
+	rootLeaves: WorkspaceLeaf[],
+	originLeaf: WorkspaceLeaf,
+): WorkspaceLeaf | null {
+	const originParentId = getLeafParentId(originLeaf);
+	const candidates = rootLeaves.filter((leaf) => {
+		if (leaf === originLeaf || isLeafPinnedForNavigation(leaf)) return false;
+		return originParentId === null || getLeafParentId(leaf) !== originParentId;
+	});
+	if (candidates.length === 0) return null;
+
+	const originIndex = rootLeaves.indexOf(originLeaf);
+	const orderedLeaves =
+		originIndex === -1
+			? rootLeaves
+			: [
+					...rootLeaves.slice(originIndex + 1),
+					...rootLeaves.slice(0, originIndex),
+				];
+
+	return orderedLeaves.find((leaf) => candidates.includes(leaf)) ?? candidates[0];
+}
+
+function resolveLeafForOpenFileLocation(
+	app: App,
+	location: FileOpenLocation,
+	direction: FileOpenOptions["direction"],
+	originLeaf: WorkspaceLeaf | null,
+): WorkspaceLeaf | null {
+	if (
+		originLeaf &&
+		(location === "tab" || location === "reuse") &&
+		isLeafPinnedForNavigation(originLeaf)
+	) {
+		const siblingLeaf = findUnpinnedNavigableSibling(
+			getRootLeaves(app),
+			originLeaf,
+		);
+		if (siblingLeaf) return siblingLeaf;
+	}
+
+	switch (location) {
+		case "reuse":
+			return app.workspace.getLeaf(false);
+		case "tab":
+			return app.workspace.getLeaf("tab");
+		case "split":
+			return app.workspace.getLeaf("split", direction);
+		case "window":
+			return app.workspace.getLeaf("window");
+		case "left-sidebar":
+			return app.workspace.getLeftLeaf(true);
+		case "right-sidebar":
+			return app.workspace.getRightLeaf(true);
+		default:
+			return app.workspace.getLeaf("tab");
+	}
+}
 
 /**
  * Open a file (by TFile or vault path) with precise control over location and mode.
@@ -808,7 +923,7 @@ export type OpenFileOptions = FileOpenOptions;
 export async function openFile(
 	app: App,
 	fileOrPath: TFile | string,
-	options: FileOpenOptions = {}
+	options: OpenFileRuntimeOptions = {}
 ): Promise<WorkspaceLeaf> {
 	const {
 		location = "tab",
@@ -816,6 +931,7 @@ export async function openFile(
 		mode,
 		focus = true,
 		eState,
+		originLeaf,
 	} = options;
 
 	const file =
@@ -825,30 +941,13 @@ export async function openFile(
 
 	if (!file) throw new Error(`File not found: ${String(fileOrPath)}`);
 
-	// Resolve a target leaf for all supported locations
-	let leaf: WorkspaceLeaf | null;
-	switch (location) {
-		case "reuse":
-			leaf = app.workspace.getLeaf(false);
-			break;
-		case "tab":
-			leaf = app.workspace.getLeaf("tab");
-			break;
-		case "split":
-			leaf = app.workspace.getLeaf("split", direction);
-			break;
-		case "window":
-			leaf = app.workspace.getLeaf("window");
-			break;
-		case "left-sidebar":
-			leaf = app.workspace.getLeftLeaf(true);
-			break;
-		case "right-sidebar":
-			leaf = app.workspace.getRightLeaf(true);
-			break;
-		default:
-			leaf = app.workspace.getLeaf("tab");
-	}
+	const openOriginLeaf = originLeaf ?? getOpenFileOriginLeaf(app);
+	const leaf = resolveLeafForOpenFileLocation(
+		app,
+		location,
+		direction,
+		openOriginLeaf,
+	);
 	if (!leaf) throw new Error("Could not obtain a workspace leaf.");
 
 	// Open the file

--- a/tests/e2e/locked-leaf-file-opening.test.ts
+++ b/tests/e2e/locked-leaf-file-opening.test.ts
@@ -1,0 +1,338 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	acquireVaultRunLock,
+	captureFailureArtifacts,
+	clearVaultRunLockMarker,
+	createObsidianClient,
+	createSandboxApi,
+} from "obsidian-e2e";
+import type {
+	ObsidianClient,
+	PluginHandle,
+	SandboxApi,
+	VaultRunLock,
+} from "obsidian-e2e";
+
+const VAULT = "dev";
+const PLUGIN_ID = "quickadd";
+const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
+const TEST_PREFIX = "__qa-test-1165-";
+
+let obsidian: ObsidianClient;
+let sandbox: SandboxApi;
+let qa: PluginHandle;
+let lock: VaultRunLock | undefined;
+
+type QuickAddData = {
+	choices: Record<string, unknown>[];
+	migrations: Record<string, boolean>;
+};
+
+type LayoutResult = {
+	ok?: boolean;
+	error?: string;
+	leftLeafId?: string;
+	leftParentId?: string | null;
+	leftPinned?: boolean;
+	rightLeafId?: string;
+};
+
+type OpenResult = {
+	activeFile: string | null;
+	activeLeafId: string | null;
+	origin: {
+		id: string | null;
+		pinned: boolean;
+		parentId: string | null;
+	};
+	targetLeaf: {
+		id: string | null;
+		file: string | null;
+		pinned: boolean;
+		parentId: string | null;
+	} | null;
+	targetTabsInOriginGroup: number;
+};
+
+function macroOpenFileChoice(id: string, targetPath: string, location: "tab" | "reuse") {
+	return {
+		id,
+		name: id,
+		type: "Macro",
+		command: true,
+		runOnStartup: false,
+		macro: {
+			id,
+			name: id,
+			commands: [
+				{
+					id: `${id}-open-file`,
+					name: `Open ${targetPath}`,
+					type: "OpenFile",
+					filePath: targetPath,
+					location,
+					focus: true,
+					openInNewTab: false,
+				},
+			],
+		},
+	};
+}
+
+function clearTestChoices(data: QuickAddData) {
+	data.choices = data.choices.filter(
+		(choice) => !String(choice.id ?? "").startsWith(TEST_PREFIX),
+	);
+}
+
+async function seedFile(path: string, content: string) {
+	await sandbox.write(path, content, {
+		waitForContent: true,
+		waitOptions: WAIT_OPTS,
+	});
+}
+
+async function waitForEvalResult<T extends { ok?: boolean; error?: string }>(
+	globalName: string,
+): Promise<T> {
+	const result = await obsidian.waitFor(async () => {
+		const value = await obsidian.dev.evalJson<T | null>(
+			`window.${globalName} ?? null`,
+		);
+		return value?.ok || value?.error ? value : false;
+	}, WAIT_OPTS);
+
+	if (result.error) throw new Error(result.error);
+	return result;
+}
+
+function setupPinnedOriginLayoutCode({
+	leftPath,
+	rightPath,
+	globalName,
+}: {
+	leftPath: string;
+	rightPath: string;
+	globalName: string;
+}) {
+	return `
+window.${globalName} = { ok: false };
+(async () => {
+	try {
+		const getFile = (path) => {
+			const file = app.vault.getAbstractFileByPath(path);
+			if (!file) throw new Error(\`Missing file: \${path}\`);
+			return file;
+		};
+
+		const leftFile = getFile(${JSON.stringify(leftPath)});
+		const rightFile = getFile(${JSON.stringify(rightPath)});
+
+		const leftLeaf = app.workspace.getLeaf(false);
+		await leftLeaf.openFile(leftFile);
+		leftLeaf.setPinned(true);
+		app.workspace.setActiveLeaf(leftLeaf, { focus: true });
+
+		const rightLeaf = app.workspace.getLeaf("split", "vertical");
+		await rightLeaf.openFile(rightFile);
+		rightLeaf.setPinned(false);
+
+		app.workspace.setActiveLeaf(leftLeaf, { focus: true });
+		window.${globalName} = {
+			ok: true,
+			leftLeafId: leftLeaf.id ?? null,
+			leftParentId: leftLeaf.parent?.id ?? null,
+			leftPinned: !!leftLeaf.pinned || !!leftLeaf.getViewState?.()?.pinned,
+			rightLeafId: rightLeaf.id ?? null,
+		};
+	} catch (error) {
+		window.${globalName} = {
+			ok: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+})();
+"started";
+`;
+}
+
+function inspectOpenResultCode({
+	originLeafId,
+	originParentId,
+	originPinned,
+	targetPath,
+}: {
+	originLeafId: string;
+	originParentId: string | null;
+	originPinned: boolean;
+	targetPath: string;
+}) {
+	return `
+(() => {
+	const leafInfo = (leaf) => {
+		if (!leaf) return null;
+		const viewState = leaf.getViewState?.();
+		return {
+			id: leaf.id ?? null,
+			file: leaf.view?.file?.path ?? viewState?.state?.file ?? null,
+			pinned: !!leaf.pinned || !!viewState?.pinned,
+			parentId: leaf.parent?.id ?? null,
+		};
+	};
+	const leaves = [];
+	app.workspace.iterateAllLeaves((leaf) => leaves.push(leaf));
+	const originParentId = ${JSON.stringify(originParentId)};
+	const targetPath = ${JSON.stringify(targetPath)};
+	const targetLeaves = leaves.filter((leaf) => {
+		const viewState = leaf.getViewState?.();
+		return leaf.view?.file?.path === targetPath || viewState?.state?.file === targetPath;
+	});
+	const activeLeaf = app.workspace.activeLeaf ?? null;
+	const activeViewState = activeLeaf?.getViewState?.();
+	const activeLeafShowsTarget =
+		activeLeaf?.view?.file?.path === targetPath || activeViewState?.state?.file === targetPath;
+	const targetLeaf =
+		targetLeaves.find((leaf) => (leaf.parent?.id ?? null) !== originParentId) ??
+		targetLeaves[0] ??
+		(activeLeafShowsTarget ? activeLeaf : null);
+
+	return {
+		activeFile: app.workspace.getActiveFile()?.path ?? null,
+		activeLeafId: app.workspace.activeLeaf?.id ?? null,
+		origin: {
+			id: ${JSON.stringify(originLeafId)},
+			pinned: ${JSON.stringify(originPinned)},
+			parentId: originParentId,
+		},
+		targetLeaf: leafInfo(targetLeaf),
+		targetTabsInOriginGroup: targetLeaves.filter((leaf) => (leaf.parent?.id ?? null) === originParentId).length,
+	};
+})()
+`;
+}
+
+async function runOpenFileScenario(location: "tab" | "reuse") {
+	const id = `${TEST_PREFIX}${location}`;
+	const leftPath = sandbox.path(`${location}-left-locked.md`);
+	const rightPath = sandbox.path(`${location}-right-unlocked.md`);
+	const targetPath = sandbox.path(`${location}-target.md`);
+	const layoutGlobal = `__qa1165Layout_${location}`;
+
+	await seedFile(`${location}-left-locked.md`, `${location.toUpperCase()} LEFT`);
+	await seedFile(`${location}-right-unlocked.md`, `${location.toUpperCase()} RIGHT`);
+	await seedFile(`${location}-target.md`, `${location.toUpperCase()} TARGET`);
+
+	await qa.data<QuickAddData>().patch((data) => {
+		clearTestChoices(data);
+		data.choices.push(macroOpenFileChoice(id, targetPath, location));
+	});
+	await qa.reload({ waitUntilReady: true });
+
+	await obsidian.dev.evalRaw(
+		setupPinnedOriginLayoutCode({ leftPath, rightPath, globalName: layoutGlobal }),
+	);
+	const layout = await waitForEvalResult<LayoutResult>(layoutGlobal);
+	expect(layout.leftLeafId).toBeTruthy();
+	expect(layout.leftPinned).toBe(true);
+
+	await obsidian.command(`quickadd:choice:${id}`).run();
+	await obsidian.waitFor(async () => {
+		const result = await obsidian.dev.evalJson<OpenResult>(
+			inspectOpenResultCode({
+				originLeafId: layout.leftLeafId as string,
+				originParentId: layout.leftParentId ?? null,
+				originPinned: layout.leftPinned ?? false,
+				targetPath,
+			}),
+		);
+		return result.activeFile === targetPath ? result : false;
+	}, WAIT_OPTS);
+
+	return await obsidian.dev.evalJson<OpenResult>(
+		inspectOpenResultCode({
+			originLeafId: layout.leftLeafId as string,
+			originParentId: layout.leftParentId ?? null,
+			originPinned: layout.leftPinned ?? false,
+			targetPath,
+		}),
+	);
+}
+
+async function runTeardownStep(
+	label: string,
+	step: () => Promise<unknown> | unknown,
+	errors: unknown[],
+) {
+	try {
+		await step();
+	} catch (error) {
+		errors.push(error);
+		console.warn(`locked-leaf-file-opening teardown failed during ${label}`, error);
+	}
+}
+
+beforeAll(async () => {
+	obsidian = createObsidianClient({ vault: VAULT });
+	await obsidian.verify();
+
+	lock = await acquireVaultRunLock({
+		vaultName: VAULT,
+		vaultPath: await obsidian.vaultPath(),
+	});
+	await lock.publishMarker(obsidian);
+
+	qa = obsidian.plugin(PLUGIN_ID);
+	sandbox = await createSandboxApi({
+		obsidian,
+		sandboxRoot: "__obsidian_e2e__",
+		testName: "locked-leaf-file-opening",
+	});
+}, 30_000);
+
+afterAll(async () => {
+	const errors: unknown[] = [];
+
+	await runTeardownStep("restoreData", () => qa?.restoreData?.(), errors);
+	await runTeardownStep("reload", () => qa?.reload?.(), errors);
+	await runTeardownStep("sandbox cleanup", () => sandbox?.cleanup?.(), errors);
+	await runTeardownStep(
+		"clear vault run lock marker",
+		() => (obsidian ? clearVaultRunLockMarker(obsidian) : undefined),
+		errors,
+	);
+	await runTeardownStep("release vault lock", () => lock?.release(), errors);
+
+	if (errors.length > 0) {
+		throw errors[0];
+	}
+}, 15_000);
+
+beforeEach((ctx) => {
+	ctx.onTestFailed(async () => {
+		await captureFailureArtifacts(
+			{ id: ctx.task.id, name: ctx.task.name },
+			obsidian,
+			{ plugin: qa, captureOnFailure: true },
+		);
+	});
+});
+
+describe("issue 1165: file opening from locked split panes", () => {
+	it("routes tab opens from a pinned origin into the unlocked split", async () => {
+		const result = await runOpenFileScenario("tab");
+
+		expect(result.origin).toMatchObject({ pinned: true });
+		expect(result.targetLeaf).toMatchObject({ pinned: false });
+		expect(result.targetLeaf?.parentId).not.toBe(result.origin.parentId);
+		expect(result.targetTabsInOriginGroup).toBe(0);
+	});
+
+	it("routes reuse opens from a pinned origin into the unlocked split", async () => {
+		const result = await runOpenFileScenario("reuse");
+
+		expect(result.origin).toMatchObject({ pinned: true });
+		expect(result.targetLeaf).toMatchObject({ pinned: false });
+		expect(result.targetLeaf?.parentId).not.toBe(result.origin.parentId);
+		expect(result.targetTabsInOriginGroup).toBe(0);
+	});
+});

--- a/tests/e2e/locked-leaf-file-opening.test.ts
+++ b/tests/e2e/locked-leaf-file-opening.test.ts
@@ -35,6 +35,7 @@ type LayoutResult = {
 	leftParentId?: string | null;
 	leftPinned?: boolean;
 	rightLeafId?: string;
+	rightParentId?: string | null;
 };
 
 type OpenResult = {
@@ -52,6 +53,10 @@ type OpenResult = {
 		parentId: string | null;
 	} | null;
 	targetTabsInOriginGroup: number;
+};
+
+type ScenarioResult = OpenResult & {
+	rightParentId: string | null;
 };
 
 function macroOpenFileChoice(id: string, targetPath: string, location: "tab" | "reuse") {
@@ -144,6 +149,7 @@ window.${globalName} = { ok: false };
 			leftParentId: leftLeaf.parent?.id ?? null,
 			leftPinned: !!leftLeaf.pinned || !!leftLeaf.getViewState?.()?.pinned,
 			rightLeafId: rightLeaf.id ?? null,
+			rightParentId: rightLeaf.parent?.id ?? null,
 		};
 	} catch (error) {
 		window.${globalName} = {
@@ -191,10 +197,11 @@ function inspectOpenResultCode({
 	const activeViewState = activeLeaf?.getViewState?.();
 	const activeLeafShowsTarget =
 		activeLeaf?.view?.file?.path === targetPath || activeViewState?.state?.file === targetPath;
-	const targetLeaf =
-		targetLeaves.find((leaf) => (leaf.parent?.id ?? null) !== originParentId) ??
-		targetLeaves[0] ??
-		(activeLeafShowsTarget ? activeLeaf : null);
+	const targetLeaf = activeLeafShowsTarget
+		? activeLeaf
+		: targetLeaves.find((leaf) => (leaf.parent?.id ?? null) !== originParentId) ??
+			targetLeaves[0] ??
+			null;
 
 	return {
 		activeFile: app.workspace.getActiveFile()?.path ?? null,
@@ -211,7 +218,9 @@ function inspectOpenResultCode({
 `;
 }
 
-async function runOpenFileScenario(location: "tab" | "reuse") {
+async function runOpenFileScenario(
+	location: "tab" | "reuse",
+): Promise<ScenarioResult> {
 	const id = `${TEST_PREFIX}${location}`;
 	const leftPath = sandbox.path(`${location}-left-locked.md`);
 	const rightPath = sandbox.path(`${location}-right-unlocked.md`);
@@ -234,6 +243,7 @@ async function runOpenFileScenario(location: "tab" | "reuse") {
 	const layout = await waitForEvalResult<LayoutResult>(layoutGlobal);
 	expect(layout.leftLeafId).toBeTruthy();
 	expect(layout.leftPinned).toBe(true);
+	expect(layout.rightParentId).toBeTruthy();
 
 	await obsidian.command(`quickadd:choice:${id}`).run();
 	await obsidian.waitFor(async () => {
@@ -248,7 +258,7 @@ async function runOpenFileScenario(location: "tab" | "reuse") {
 		return result.activeFile === targetPath ? result : false;
 	}, WAIT_OPTS);
 
-	return await obsidian.dev.evalJson<OpenResult>(
+	const result = await obsidian.dev.evalJson<OpenResult>(
 		inspectOpenResultCode({
 			originLeafId: layout.leftLeafId as string,
 			originParentId: layout.leftParentId ?? null,
@@ -256,6 +266,11 @@ async function runOpenFileScenario(location: "tab" | "reuse") {
 			targetPath,
 		}),
 	);
+
+	return {
+		...result,
+		rightParentId: layout.rightParentId ?? null,
+	};
 }
 
 async function runTeardownStep(
@@ -323,6 +338,7 @@ describe("issue 1165: file opening from locked split panes", () => {
 
 		expect(result.origin).toMatchObject({ pinned: true });
 		expect(result.targetLeaf).toMatchObject({ pinned: false });
+		expect(result.targetLeaf?.parentId).toBe(result.rightParentId);
 		expect(result.targetLeaf?.parentId).not.toBe(result.origin.parentId);
 		expect(result.targetTabsInOriginGroup).toBe(0);
 	});
@@ -332,6 +348,7 @@ describe("issue 1165: file opening from locked split panes", () => {
 
 		expect(result.origin).toMatchObject({ pinned: true });
 		expect(result.targetLeaf).toMatchObject({ pinned: false });
+		expect(result.targetLeaf?.parentId).toBe(result.rightParentId);
 		expect(result.targetLeaf?.parentId).not.toBe(result.origin.parentId);
 		expect(result.targetTabsInOriginGroup).toBe(0);
 	});


### PR DESCRIPTION
Capture the originating workspace leaf before QuickAdd runs preflight or opens files, then pass that transient origin leaf through Capture, Template, and Macro file-opening paths. When the captured origin is pinned, tab-like opens now route to an existing unpinned root sibling instead of letting Obsidian create a tab in the pinned source group.

This fixes the split-pane workflow from #1165 where a newly created/opened note should replace the right/unlocked pane rather than opening beside the locked left note.

The implementation avoids new persisted settings or migrations. It keeps explicit split/window/sidebar destinations unchanged and only applies the pinned-origin reroute for tab/reuse-style opens.

Verification:
- `bun run test`
- `bun run build`
- `bun run build-with-lint`
- `bunx vitest run tests/e2e/locked-leaf-file-opening.test.ts --config vitest.e2e.config.mts`
- Obsidian dev vault: reloaded QuickAdd and verified real Macro command paths for both `location: "tab"` and `location: "reuse"`; both routed from a pinned source leaf to the unlocked/right tab group.
- `obsidian vault=dev dev:errors` reported no errors.

Fixes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-opening now respects the originating tab context: avoids opening into pinned tabs and selects appropriate sibling, split, or reuse targets to preserve workspace layout.
  * Actions (templates, captures, macros) now carry origin context so opened files appear relative to where the action started.

* **Tests**
  * Expanded unit and end-to-end tests covering origin selection, pinned-tab routing, split/tab/reuse behaviors, and locked-origin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->