### PR TITLE
docs: redesign landing page with Obsidian-native aesthetic

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -26,8 +26,13 @@
   --qa-ink-subtle: #71717a;
   --qa-line: rgba(24, 24, 27, 0.08);
   --qa-line-strong: rgba(24, 24, 27, 0.14);
-  --qa-accent: #7c6ef2;
+  /* Text/icon accent — darker shade for AA contrast on cream canvas (~5.4:1) */
+  --qa-accent: #5a4aec;
   --qa-accent-soft: rgba(124, 110, 242, 0.1);
+  /* Dedicated CTA tokens — white on #5a4aec passes AA at 5.68:1 */
+  --qa-cta-bg: #5a4aec;
+  --qa-cta-bg-hover: #4a38e9;
+  --qa-cta-fg: #ffffff;
 
   --ifm-font-family-base: 'InterVariable', 'Inter', system-ui, -apple-system,
     'Segoe UI', Roboto, Ubuntu, Cantarell, 'Noto Sans', sans-serif,
@@ -60,6 +65,10 @@
   --qa-ink-muted: #a1a1aa;
   --qa-ink-subtle: #71717a;
   --qa-line: rgba(244, 244, 245, 0.08);
+  /* Button: keep #5a4aec so white text still passes AA; lighter on hover */
+  --qa-cta-bg: #5a4aec;
+  --qa-cta-bg-hover: #6b5cef;
+  --qa-cta-fg: #ffffff;
   --qa-line-strong: rgba(244, 244, 245, 0.14);
   --qa-accent: #a195f7;
   --qa-accent-soft: rgba(161, 149, 247, 0.14);

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,186 +1,105 @@
 /**
  * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
+ * bundles Infima by default.
  */
 
-/* You can override the default Infima variables here. */
+@import url('https://rsms.me/inter/inter.css');
+
 :root {
-  /* Sophisticated blue-based color scheme */
-  --ifm-color-primary: #3b82f6;
-  --ifm-color-primary-dark: #2563eb;
-  --ifm-color-primary-darker: #1d4ed8;
-  --ifm-color-primary-darkest: #1e40af;
-  --ifm-color-primary-light: #60a5fa;
-  --ifm-color-primary-lighter: #93bbfd;
-  --ifm-color-primary-lightest: #dbeafe;
+  /* Obsidian-ish purple-blue accent */
+  --ifm-color-primary: #7c6ef2;
+  --ifm-color-primary-dark: #6b5cef;
+  --ifm-color-primary-darker: #5a4aec;
+  --ifm-color-primary-darkest: #4a38e9;
+  --ifm-color-primary-light: #8d80f5;
+  --ifm-color-primary-lighter: #a195f7;
+  --ifm-color-primary-lightest: #e6e3fd;
+
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.05);
-  
-  /* Custom properties for QuickAdd */
-  --qa-accent: #3b82f6;
-  --qa-success: #10b981;
-  --qa-info: #0ea5e9;
-  
-  /* Typography */
-  --ifm-font-family-base: system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+
+  /* Landing-page tokens (scoped via .landing class to avoid affecting docs chrome) */
+  --qa-canvas: #f7f5f0;
+  --qa-canvas-raised: #ffffff;
+  --qa-ink: #18181b;
+  --qa-ink-muted: #52525b;
+  --qa-ink-subtle: #71717a;
+  --qa-line: rgba(24, 24, 27, 0.08);
+  --qa-line-strong: rgba(24, 24, 27, 0.14);
+  --qa-accent: #7c6ef2;
+  --qa-accent-soft: rgba(124, 110, 242, 0.1);
+
+  --ifm-font-family-base: 'InterVariable', 'Inter', system-ui, -apple-system,
+    'Segoe UI', Roboto, Ubuntu, Cantarell, 'Noto Sans', sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --ifm-heading-font-family: var(--ifm-font-family-base);
-  --ifm-font-family-monospace: 'SF Mono', Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --ifm-font-family-monospace: 'JetBrains Mono', 'SF Mono', Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
+@supports (font-variation-settings: normal) {
+  :root {
+    --ifm-font-family-base: 'InterVariable', system-ui, -apple-system,
+      'Segoe UI', Roboto, sans-serif;
+  }
+}
+
 [data-theme='dark'] {
-  --ifm-color-primary: #60a5fa;
-  --ifm-color-primary-dark: #3b82f6;
-  --ifm-color-primary-darker: #2563eb;
-  --ifm-color-primary-darkest: #1d4ed8;
-  --ifm-color-primary-light: #93bbfd;
-  --ifm-color-primary-lighter: #bfdbfe;
-  --ifm-color-primary-lightest: #dbeafe;
+  --ifm-color-primary: #a195f7;
+  --ifm-color-primary-dark: #8d80f5;
+  --ifm-color-primary-darker: #7c6ef2;
+  --ifm-color-primary-darkest: #6b5cef;
+  --ifm-color-primary-light: #b5abf9;
+  --ifm-color-primary-lighter: #c9c1fb;
+  --ifm-color-primary-lightest: #e6e3fd;
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.05);
-  
-  /* Custom properties for QuickAdd dark mode */
-  --qa-accent: #60a5fa;
-  --qa-success: #34d399;
-  --qa-info: #38bdf8;
-  
-  /* Better dark mode backgrounds */
-  --ifm-background-color: #0f172a;
-  --ifm-background-surface-color: #1e293b;
+
+  --qa-canvas: #17181c;
+  --qa-canvas-raised: #1f2126;
+  --qa-ink: #f4f4f5;
+  --qa-ink-muted: #a1a1aa;
+  --qa-ink-subtle: #71717a;
+  --qa-line: rgba(244, 244, 245, 0.08);
+  --qa-line-strong: rgba(244, 244, 245, 0.14);
+  --qa-accent: #a195f7;
+  --qa-accent-soft: rgba(161, 149, 247, 0.14);
+
+  --ifm-background-color: #0f1013;
+  --ifm-background-surface-color: #17181c;
 }
 
-/* Custom styles for enhanced homepage */
-
-.feature-card {
-  padding: 2rem;
-  margin: 1rem 0;
-  border-radius: 8px;
-  background: var(--ifm-card-background-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  transition: all 0.2s ease;
-  height: 100%;
-}
-
-.feature-card:hover {
-  transform: translateY(-2px);
-  border-color: var(--ifm-color-emphasis-300);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-[data-theme='dark'] .feature-card {
-  border-color: var(--ifm-color-emphasis-200);
-}
-
-[data-theme='dark'] .feature-card:hover {
-  box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05);
-}
-
-/* Fix spacing for feature grid */
-.col {
-  padding: 0.75rem !important;
-}
-
-.row {
-  margin-left: -0.75rem !important;
-  margin-right: -0.75rem !important;
-}
-
-.hero-button {
-  font-size: 1.05rem;
-  padding: 0.75rem 2rem;
-  margin: 0.5rem;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-  font-weight: 500;
-}
-
-.hero-button:hover {
-  transform: translateY(-1px);
-  text-decoration: none;
-}
-
-.hero-button--primary {
-  background: var(--ifm-color-primary);
-  color: white;
-  border: none;
-}
-
-.hero-button--primary:hover {
-  background: var(--ifm-color-primary-dark);
-  color: white;
-}
-
-.button--outline {
-  border: 2px solid var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
-  background: var(--ifm-background-color);
-}
-
-.button--outline:hover {
-  background: var(--ifm-color-primary);
-  color: white;
-  border-color: var(--ifm-color-primary);
-}
-
-.section-dark {
-  background-color: var(--ifm-background-surface-color);
-  border-top: 1px solid var(--ifm-color-emphasis-200);
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-}
-
-.code-example {
-  background-color: var(--ifm-pre-background);
-  border-radius: 8px;
-  padding: 1rem;
-  margin: 1rem 0;
-  font-family: var(--ifm-font-family-monospace);
-  overflow-x: auto;
-}
-
-/* Improve navbar appearance */
-.navbar {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-[data-theme='dark'] .navbar {
-  box-shadow: 0 1px 3px rgba(255, 255, 255, 0.1);
-}
-
-/* Better code blocks */
+/* Better code blocks across the whole site */
 pre {
-  border-radius: 8px;
+  border-radius: 10px;
 }
 
-/* Improved documentation sidebar */
+/* Docs sidebar polish */
 .menu__link {
   border-radius: 6px;
-  transition: all 0.2s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .menu__link:hover {
-  background-color: var(--ifm-color-emphasis-200);
+  background-color: var(--ifm-color-emphasis-100);
   text-decoration: none;
 }
 
 .menu__link--active {
-  background-color: var(--ifm-color-emphasis-200);
-  color: var(--ifm-font-color-base);
+  background-color: var(--qa-accent-soft);
+  color: var(--ifm-color-primary);
   font-weight: 600;
 }
 
-/* Feature icons styling */
-.feature-icon {
-  width: 60px;
-  height: 60px;
-  margin-bottom: 1rem;
-  color: var(--ifm-color-primary);
+.navbar {
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow: none;
 }
 
 /* GitHub icon in navbar */
 .header-github-link::before {
   content: '';
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   display: flex;
   background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E") no-repeat;
 }
@@ -190,5 +109,5 @@ pre {
 }
 
 .header-github-link:hover {
-  opacity: 0.6;
+  opacity: 0.7;
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -1,47 +1,478 @@
 /**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
+ * QuickAdd docs landing page.
+ * Scoped under .landing so styles don't leak into /docs pages.
  */
 
-.heroBanner {
-  padding: 6rem 0;
+.landing {
+  background: var(--qa-canvas);
+  color: var(--qa-ink);
+  font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11', 'ss01';
+  letter-spacing: -0.003em;
+}
+
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding-inline: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .container {
+    padding-inline: 2rem;
+  }
+}
+
+/* ──────────────────────────────────────────────────────────
+   Hero
+   ────────────────────────────────────────────────────────── */
+
+.hero {
+  padding: clamp(5rem, 10vw, 8rem) 0 clamp(4rem, 8vw, 6.5rem);
   text-align: center;
   position: relative;
   overflow: hidden;
-  background: var(--ifm-background-color);
-  border-bottom: 1px solid var(--ifm-toc-border-color);
 }
 
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 3rem 1rem;
-  }
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: -40% 0 auto 0;
+  height: 70%;
+  background: radial-gradient(
+    ellipse 60% 50% at 50% 0%,
+    var(--qa-accent-soft),
+    transparent 70%
+  );
+  pointer-events: none;
+  z-index: 0;
 }
 
-.buttons {
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--qa-accent);
+  letter-spacing: 0.02em;
+  margin: 0 0 1.25rem;
+}
+
+.heroTitle {
+  font-size: clamp(2.5rem, 5.5vw + 0.5rem, 4rem);
+  line-height: 1.05;
+  font-weight: 600;
+  letter-spacing: -0.028em;
+  color: var(--qa-ink);
+  max-width: 22ch;
+  margin: 0 auto 1.25rem;
+  text-wrap: balance;
+}
+
+.heroSubtitle {
+  font-size: clamp(1.125rem, 1vw + 0.875rem, 1.3125rem);
+  line-height: 1.55;
+  color: var(--qa-ink-muted);
+  max-width: 52ch;
+  margin: 0 auto;
+  text-wrap: pretty;
+}
+
+.heroActions {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  margin-top: 2rem;
+  gap: 0.75rem;
+  margin-top: 2.25rem;
   flex-wrap: wrap;
 }
 
-.hero__title {
-  font-size: 3rem;
-  margin-bottom: 1rem;
-  font-weight: 700;
+.heroChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 2.5rem;
+  padding: 0.5rem 0.875rem;
+  background: var(--qa-canvas-raised);
+  border: 1px solid var(--qa-line);
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  color: var(--qa-ink-muted);
 }
 
-@media screen and (max-width: 996px) {
-  .hero__title {
-    font-size: 2.25rem;
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.375rem;
+  background: var(--qa-canvas);
+  border: 1px solid var(--qa-line-strong);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--qa-ink);
+  line-height: 1;
+}
+
+.chipArrow {
+  color: var(--qa-ink-subtle);
+}
+
+.chipLabel {
+  font-weight: 500;
+  color: var(--qa-ink);
+}
+
+/* ──────────────────────────────────────────────────────────
+   Buttons
+   ────────────────────────────────────────────────────────── */
+
+.buttonPrimary,
+.buttonPrimary:hover,
+.buttonPrimary:visited {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.25rem;
+  background: var(--qa-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9375rem;
+  border-radius: 10px;
+  border: none;
+  text-decoration: none;
+  transition: transform 0.15s ease, background-color 0.15s ease,
+    box-shadow 0.15s ease;
+  box-shadow: 0 1px 2px rgba(24, 24, 27, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.buttonPrimary:hover {
+  background: var(--ifm-color-primary-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(124, 110, 242, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+
+.buttonSecondary,
+.buttonSecondary:hover,
+.buttonSecondary:visited {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.125rem;
+  background: transparent;
+  color: var(--qa-ink);
+  font-weight: 500;
+  font-size: 0.9375rem;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.buttonSecondary:hover {
+  background: var(--qa-line);
+  color: var(--qa-ink);
+}
+
+/* ──────────────────────────────────────────────────────────
+   Generic section
+   ────────────────────────────────────────────────────────── */
+
+.section {
+  padding-block: clamp(4rem, 8vw, 6rem);
+  border-top: 1px solid var(--qa-line);
+}
+
+.sectionHead {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  margin-bottom: 3rem;
+  max-width: 780px;
+}
+
+.sectionHead .eyebrow {
+  margin: 0;
+}
+
+.sectionTitle {
+  font-size: clamp(1.75rem, 2.25vw + 0.5rem, 2.5rem);
+  line-height: 1.15;
+  font-weight: 600;
+  letter-spacing: -0.022em;
+  color: var(--qa-ink);
+  max-width: 28ch;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.sectionSubtitle {
+  font-size: 1.125rem;
+  line-height: 1.55;
+  color: var(--qa-ink-muted);
+  max-width: 56ch;
+  margin: 0;
+  text-wrap: pretty;
+}
+
+/* ──────────────────────────────────────────────────────────
+   Features
+   ────────────────────────────────────────────────────────── */
+
+.features {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width: 640px) {
+  .features {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
-.features {
+@media (min-width: 1024px) {
+  .features {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.feature {
   display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 1.75rem;
+  background: var(--qa-canvas-raised);
+  border: 1px solid var(--qa-line);
+  border-radius: 14px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.feature:hover {
+  border-color: var(--qa-line-strong);
+  transform: translateY(-2px);
+}
+
+.featureIcon {
+  display: inline-flex;
   align-items: center;
-  padding: 4rem 0;
-  width: 100%;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-bottom: 0.75rem;
+  background: var(--qa-accent-soft);
+  color: var(--qa-accent);
+  border-radius: 9px;
+}
+
+.featureIcon svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.featureTitle {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--qa-ink);
+  margin: 0;
+}
+
+.featureDesc {
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--qa-ink-muted);
+  margin: 0;
+  text-wrap: pretty;
+}
+
+/* ──────────────────────────────────────────────────────────
+   Examples
+   ────────────────────────────────────────────────────────── */
+
+.examples {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .examples {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.example {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.75rem;
+  background: var(--qa-canvas-raised);
+  border: 1px solid var(--qa-line);
+  border-radius: 14px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.example:hover {
+  border-color: var(--qa-line-strong);
+  transform: translateY(-2px);
+}
+
+.exampleIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  background: var(--qa-accent-soft);
+  color: var(--qa-accent);
+  border-radius: 9px;
+}
+
+.exampleIcon svg {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.exampleTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--qa-ink);
+  margin: 0.5rem 0 0;
+}
+
+.exampleDesc {
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--qa-ink-muted);
+  margin: 0;
+  flex: 1;
+  text-wrap: pretty;
+}
+
+.exampleLink,
+.exampleLink:hover,
+.exampleLink:visited {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.375rem;
+  color: var(--qa-accent);
+  font-weight: 500;
+  font-size: 0.9375rem;
+  text-decoration: none;
+}
+
+.exampleLink:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* ──────────────────────────────────────────────────────────
+   Quick start
+   ────────────────────────────────────────────────────────── */
+
+.quickStart {
+  padding-block: clamp(4rem, 8vw, 6rem);
+  border-top: 1px solid var(--qa-line);
+  text-align: center;
+}
+
+.quickStart .sectionHead {
+  margin-inline: auto;
+  align-items: center;
+  text-align: center;
+}
+
+.quickStart .sectionTitle {
+  margin-inline: auto;
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  margin-top: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .steps {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2.5rem;
+  }
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding-inline: 0.5rem;
+}
+
+.stepNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: var(--qa-canvas-raised);
+  border: 1px solid var(--qa-line-strong);
+  border-radius: 999px;
+  font-family: var(--ifm-font-family-monospace);
+  font-feature-settings: 'tnum';
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--qa-accent);
+}
+
+.stepTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--qa-ink);
+  margin: 0.25rem 0 0;
+}
+
+.stepDesc {
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--qa-ink-muted);
+  max-width: 32ch;
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.quickStartCta {
+  margin-top: 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+/* ──────────────────────────────────────────────────────────
+   Reduced motion
+   ────────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .feature,
+  .example,
+  .buttonPrimary {
+    transition: none;
+  }
+  .feature:hover,
+  .example:hover,
+  .buttonPrimary:hover {
+    transform: none;
+  }
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -140,8 +140,8 @@
   align-items: center;
   justify-content: center;
   padding: 0.75rem 1.25rem;
-  background: var(--qa-accent);
-  color: #fff;
+  background: var(--qa-cta-bg);
+  color: var(--qa-cta-fg);
   font-weight: 600;
   font-size: 0.9375rem;
   border-radius: 10px;
@@ -154,9 +154,9 @@
 }
 
 .buttonPrimary:hover {
-  background: var(--ifm-color-primary-dark);
+  background: var(--qa-cta-bg-hover);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(124, 110, 242, 0.28),
+  box-shadow: 0 4px 12px rgba(90, 74, 236, 0.28),
     inset 0 1px 0 rgba(255, 255, 255, 0.22);
 }
 
@@ -402,7 +402,9 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: 2rem;
-  margin-top: 0.5rem;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
 }
 
 @media (min-width: 768px) {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
@@ -7,122 +6,309 @@ import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
 
-type FeatureItem = {
+// ──────────────────────────────────────────────────────────
+// Icons (Lucide-style, 24×24, currentColor stroke)
+// ──────────────────────────────────────────────────────────
+
+type IconProps = React.SVGProps<SVGSVGElement>;
+
+const Svg = ({children, ...props}: React.PropsWithChildren<IconProps>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.75"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}>
+    {children}
+  </svg>
+);
+
+const ZapIcon = () => (
+  <Svg>
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+  </Svg>
+);
+
+const FileTextIcon = () => (
+  <Svg>
+    <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+    <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+    <path d="M10 9H8" />
+    <path d="M16 13H8" />
+    <path d="M16 17H8" />
+  </Svg>
+);
+
+const WorkflowIcon = () => (
+  <Svg>
+    <rect width="8" height="8" x="3" y="3" rx="2" />
+    <path d="M7 11v4a2 2 0 0 0 2 2h4" />
+    <rect width="8" height="8" x="13" y="13" rx="2" />
+  </Svg>
+);
+
+const SparklesIcon = () => (
+  <Svg>
+    <path d="M9.94 15.5A2 2 0 0 0 8.5 14.06l-6.13-1.58a.5.5 0 0 1 0-.96L8.5 9.94A2 2 0 0 0 9.94 8.5l1.58-6.13a.5.5 0 0 1 .96 0L14.06 8.5A2 2 0 0 0 15.5 9.94l6.13 1.58a.5.5 0 0 1 0 .96L15.5 14.06a2 2 0 0 0-1.44 1.44l-1.58 6.13a.5.5 0 0 1-.96 0z" />
+    <path d="M20 3v4" />
+    <path d="M22 5h-4" />
+    <path d="M4 17v2" />
+    <path d="M5 18H3" />
+  </Svg>
+);
+
+const FolderTreeIcon = () => (
+  <Svg>
+    <path d="M20 10a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2.5a1 1 0 0 1-.8-.4l-.9-1.2A1 1 0 0 0 15 3h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z" />
+    <path d="M20 21a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-2.9a1 1 0 0 1-.88-.55l-.42-.85a1 1 0 0 0-.92-.6H13a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z" />
+    <path d="M3 5a2 2 0 0 0 2 2h3" />
+    <path d="M3 3v13a2 2 0 0 0 2 2h3" />
+  </Svg>
+);
+
+const RocketIcon = () => (
+  <Svg>
+    <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+    <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+    <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+    <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+  </Svg>
+);
+
+const BookIcon = () => (
+  <Svg>
+    <path d="M12 7v14" />
+    <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+  </Svg>
+);
+
+const PenIcon = () => (
+  <Svg>
+    <path d="M12 20h9" />
+    <path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z" />
+  </Svg>
+);
+
+const FilmIcon = () => (
+  <Svg>
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="M7 3v18" />
+    <path d="M3 7.5h4" />
+    <path d="M3 12h18" />
+    <path d="M3 16.5h4" />
+    <path d="M17 3v18" />
+    <path d="M17 7.5h4" />
+    <path d="M17 16.5h4" />
+  </Svg>
+);
+
+const ListChecksIcon = () => (
+  <Svg>
+    <path d="m3 17 2 2 4-4" />
+    <path d="m3 7 2 2 4-4" />
+    <path d="M13 6h8" />
+    <path d="M13 12h8" />
+    <path d="M13 18h8" />
+  </Svg>
+);
+
+// ──────────────────────────────────────────────────────────
+// Content
+// ──────────────────────────────────────────────────────────
+
+type Feature = {
   title: string;
-  icon: string;
-  description: JSX.Element;
+  icon: React.JSX.Element;
+  description: string;
 };
 
-const FeatureList: FeatureItem[] = [
+const features: Feature[] = [
   {
-    title: 'Lightning Fast Capture',
-    icon: '⚡',
-    description: (
-      <>
-        Capture thoughts, ideas, and information instantly. No more context switching - 
-        just hit your hotkey and start typing.
-      </>
-    ),
+    title: 'Lightning-fast capture',
+    icon: <ZapIcon />,
+    description:
+      'Hit one hotkey and drop content into any note. No file picker, no friction — just type and it lands where you want.',
   },
   {
-    title: 'Powerful Templates',
-    icon: '📄',
-    description: (
-      <>
-        Create complex templates with variables, dates, and dynamic content. 
-        Works seamlessly with Obsidian templates and Templater.
-      </>
-    ),
+    title: 'Powerful templates',
+    icon: <FileTextIcon />,
+    description:
+      'Compose notes with dynamic variables, dates, and inline prompts. Plays well with Obsidian Templates and Templater.',
   },
   {
-    title: 'Automation with Macros',
-    icon: '🤖',
-    description: (
-      <>
-        Build powerful automation workflows with JavaScript. Chain commands, 
-        integrate with APIs, and supercharge your vault management.
-      </>
-    ),
+    title: 'Macro automations',
+    icon: <WorkflowIcon />,
+    description:
+      'Chain choices and user scripts into one-key workflows. Scrape metadata, update a log, open a file — all in sequence.',
   },
   {
-    title: 'AI Integration',
-    icon: '🧠',
-    description: (
-      <>
-        Connect to OpenAI, Anthropic, and other AI providers. Generate content, 
-        summarize notes, and enhance your knowledge management.
-      </>
-    ),
+    title: 'Built-in AI',
+    icon: <SparklesIcon />,
+    description:
+      'Talk to OpenAI, Anthropic, or a local model. Summarize, expand, and rewrite notes without leaving Obsidian.',
   },
   {
-    title: 'Flexible Organization',
-    icon: '📁',
-    description: (
-      <>
-        Organize your choices into folders with Multi-Choice. Create custom 
-        workflows that match your unique note-taking style.
-      </>
-    ),
+    title: 'Organize with Multis',
+    icon: <FolderTreeIcon />,
+    description:
+      'Group related choices into nested folders. Build your own menu for your own workflows.',
   },
   {
-    title: 'Active Development',
-    icon: '🚀',
-    description: (
-      <>
-        Regular updates, active community, and continuous improvements. 
-        Your feedback shapes the future of QuickAdd.
-      </>
-    ),
+    title: 'Actively maintained',
+    icon: <RocketIcon />,
+    description:
+      'Regular updates shaped by real community feedback. Battle-tested in thousands of vaults.',
   },
 ];
 
-function Feature({title, icon, description}: FeatureItem) {
-  return (
-    <div className={clsx('col col--4')}>
-      <div className="feature-card text--center padding--lg">
-        <div className="feature-icon" style={{fontSize: '3rem'}}>{icon}</div>
-        <Heading as="h3">{title}</Heading>
-        <p>{description}</p>
-      </div>
-    </div>
-  );
-}
+type Example = {
+  title: string;
+  icon: React.JSX.Element;
+  description: string;
+  href: string;
+};
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+const examples: Example[] = [
+  {
+    title: 'Book database',
+    icon: <BookIcon />,
+    description:
+      'Fetch metadata from APIs and generate rich book notes. Track ratings, quotes, and reading progress with one command.',
+    href: '/docs/Examples/Macro_BookFinder',
+  },
+  {
+    title: 'Daily journaling',
+    icon: <PenIcon />,
+    description:
+      'Capture entries with timestamps, weather, and mood. Never miss a day with guided prompts.',
+    href: '/docs/Examples/Capture_AddJournalEntry',
+  },
+  {
+    title: 'Media tracker',
+    icon: <FilmIcon />,
+    description:
+      'Log movies and shows with auto-fetched metadata. Curate watchlists and reviews without friction.',
+    href: '/docs/Examples/Macro_MovieAndSeriesScript',
+  },
+  {
+    title: 'Task management',
+    icon: <ListChecksIcon />,
+    description:
+      'Send tasks to Todoist, populate Kanban boards, and run projects. Make Obsidian your productivity hub.',
+    href: '/docs/Examples/Capture_AddTaskToKanbanBoard',
+  },
+];
+
+const steps = [
+  {
+    title: 'Install',
+    description:
+      "Find QuickAdd in Obsidian's Community Plugins browser and enable it.",
+  },
+  {
+    title: 'Create a choice',
+    description:
+      'Open settings and add a Template, Capture, or Macro — or combine them into a Multi.',
+  },
+  {
+    title: 'Hit your hotkey',
+    description:
+      'Trigger QuickAdd with ⌘/Ctrl-P and pick your choice. That\u2019s it.',
+  },
+];
+
+// ──────────────────────────────────────────────────────────
+// Sections
+// ──────────────────────────────────────────────────────────
+
+function Hero(): React.JSX.Element {
   return (
-    <header className={clsx('hero', styles.heroBanner)}>
-      <div className="container">
-        <Heading as="h1" className="hero__title">
-          QuickAdd for Obsidian
+    <header className={styles.hero}>
+      <div className={styles.container}>
+        <div className={styles.eyebrow}>For Obsidian</div>
+        <Heading as="h1" className={styles.heroTitle}>
+          Supercharge Obsidian with one hotkey.
         </Heading>
-        <p className="hero__subtitle" style={{fontSize: '1.3rem', maxWidth: '600px', margin: '0 auto'}}>
-          {siteConfig.tagline}
+        <p className={styles.heroSubtitle}>
+          Templates, captures, macros, and AI — bound to a single command.
+          QuickAdd turns repetitive note-taking tasks into keystrokes.
         </p>
-        <div className={styles.buttons}>
-          <Link
-            className="button hero-button hero-button--primary"
-            to="/docs/">
-            Get Started →
+        <div className={styles.heroActions}>
+          <Link className={styles.buttonPrimary} to="/docs/">
+            Read the docs
           </Link>
           <Link
-            className="button button--outline hero-button"
+            className={styles.buttonSecondary}
             to="https://obsidian.md/plugins?id=quickadd">
-            Install Plugin
+            Install from Obsidian →
           </Link>
+        </div>
+        <div className={styles.heroChip} aria-hidden="true">
+          <kbd className={styles.kbd}>⌘</kbd>
+          <kbd className={styles.kbd}>P</kbd>
+          <span className={styles.chipArrow}>→</span>
+          <span className={styles.chipLabel}>QuickAdd: Run Choice</span>
         </div>
       </div>
     </header>
   );
 }
 
-function HomepageFeatures(): JSX.Element {
+function Features(): React.JSX.Element {
   return (
-    <section className={styles.features}>
-      <div className="container">
-        <div className="row">
-          {FeatureList.map((props, idx) => (
-            <Feature key={idx} {...props} />
+    <section className={styles.section}>
+      <div className={styles.container}>
+        <div className={styles.sectionHead}>
+          <div className={styles.eyebrow}>Features</div>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Four composable choices. Endless workflows.
+          </Heading>
+          <p className={styles.sectionSubtitle}>
+            Templates, Captures, Macros, and Multis combine into whatever
+            automation your vault needs — with AI on tap.
+          </p>
+        </div>
+        <dl className={styles.features}>
+          {features.map((f) => (
+            <div className={styles.feature} key={f.title}>
+              <span className={styles.featureIcon}>{f.icon}</span>
+              <dt className={styles.featureTitle}>{f.title}</dt>
+              <dd className={styles.featureDesc}>{f.description}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+function Examples(): React.JSX.Element {
+  return (
+    <section className={styles.section}>
+      <div className={styles.container}>
+        <div className={styles.sectionHead}>
+          <div className={styles.eyebrow}>Examples</div>
+          <Heading as="h2" className={styles.sectionTitle}>
+            What can you build?
+          </Heading>
+          <p className={styles.sectionSubtitle}>
+            A few things people actually ship with QuickAdd. Every example ships
+            with a walkthrough.
+          </p>
+        </div>
+        <div className={styles.examples}>
+          {examples.map((e) => (
+            <article className={styles.example} key={e.title}>
+              <span className={styles.exampleIcon}>{e.icon}</span>
+              <h3 className={styles.exampleTitle}>{e.title}</h3>
+              <p className={styles.exampleDesc}>{e.description}</p>
+              <Link className={styles.exampleLink} to={e.href}>
+                Learn how →
+              </Link>
+            </article>
           ))}
         </div>
       </div>
@@ -130,85 +316,30 @@ function HomepageFeatures(): JSX.Element {
   );
 }
 
-function ExampleSection(): JSX.Element {
+function QuickStart(): React.JSX.Element {
   return (
-    <section className="section-dark padding-vert--lg">
-      <div className="container">
-        <Heading as="h2" className="text--center margin-bottom--lg">
-          What Can You Build?
-        </Heading>
-        <div className="row">
-          <div className="col col--6">
-            <div className="feature-card">
-              <h3>📚 Book Database</h3>
-              <p>Automatically create book notes with metadata fetched from APIs. Add ratings, quotes, and reading progress with a single command.</p>
-              <Link to="/docs/Examples/Macro_BookFinder">Learn how →</Link>
-            </div>
-          </div>
-          <div className="col col--6">
-            <div className="feature-card">
-              <h3>📝 Daily Journaling</h3>
-              <p>Capture journal entries with timestamps, mood tracking, and weather data. Never miss a day with automated prompts.</p>
-              <Link to="/docs/Examples/Capture_AddJournalEntry">Learn how →</Link>
-            </div>
-          </div>
+    <section className={styles.quickStart}>
+      <div className={styles.container}>
+        <div className={styles.sectionHead}>
+          <div className={styles.eyebrow}>Get started</div>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Up and running in three steps.
+          </Heading>
         </div>
-        <div className="row margin-top--md">
-          <div className="col col--6">
-            <div className="feature-card">
-              <h3>🎬 Media Tracker</h3>
-              <p>Track movies and TV shows with automatic metadata. Create watchlists, reviews, and recommendations.</p>
-              <Link to="/docs/Examples/Macro_MovieAndSeriesScript">Learn how →</Link>
-            </div>
-          </div>
-          <div className="col col--6">
-            <div className="feature-card">
-              <h3>✅ Task Management</h3>
-              <p>Integrate with Todoist, create Kanban boards, and manage projects. Turn Obsidian into your productivity hub.</p>
-              <Link to="/docs/Examples/Capture_AddTaskToKanbanBoard">Learn how →</Link>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function QuickStartSection(): JSX.Element {
-  return (
-    <section className="padding-vert--lg">
-      <div className="container">
-        <Heading as="h2" className="text--center margin-bottom--lg">
-          Quick Start
-        </Heading>
-        <div className="row">
-          <div className="col col--4">
-            <div className="text--center">
-              <div style={{fontSize: '2rem', marginBottom: '1rem'}}>1️⃣</div>
-              <h3>Install QuickAdd</h3>
-              <p>Find QuickAdd in Obsidian's Community Plugins browser and enable it.</p>
-            </div>
-          </div>
-          <div className="col col--4">
-            <div className="text--center">
-              <div style={{fontSize: '2rem', marginBottom: '1rem'}}>2️⃣</div>
-              <h3>Create Your First Choice</h3>
-              <p>Open settings and create a Template, Capture, or Macro choice.</p>
-            </div>
-          </div>
-          <div className="col col--4">
-            <div className="text--center">
-              <div style={{fontSize: '2rem', marginBottom: '1rem'}}>3️⃣</div>
-              <h3>Start Automating</h3>
-              <p>Trigger QuickAdd with Cmd/Ctrl+P and select your choice. That's it!</p>
-            </div>
-          </div>
-        </div>
-        <div className="text--center margin-top--lg">
-          <Link
-            className="button button--primary button--lg hero-button hero-button--primary"
-            to="/docs/">
-            Read the Documentation
+        <ol className={styles.steps} role="list">
+          {steps.map((s, i) => (
+            <li className={styles.step} key={s.title}>
+              <span className={styles.stepNumber} aria-hidden="true">
+                {String(i + 1).padStart(2, '0')}
+              </span>
+              <h3 className={styles.stepTitle}>{s.title}</h3>
+              <p className={styles.stepDesc}>{s.description}</p>
+            </li>
+          ))}
+        </ol>
+        <div className={styles.quickStartCta}>
+          <Link className={styles.buttonPrimary} to="/docs/">
+            Read the documentation
           </Link>
         </div>
       </div>
@@ -216,18 +347,24 @@ function QuickStartSection(): JSX.Element {
   );
 }
 
-export default function Home(): JSX.Element {
+// ──────────────────────────────────────────────────────────
+// Page
+// ──────────────────────────────────────────────────────────
+
+export default function Home(): React.JSX.Element {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`QuickAdd - Supercharge Your Obsidian Workflow`}
-      description={`${siteConfig.tagline} Create templates, capture ideas, and automate your vault with powerful macros and AI integration.`}>
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
-        <ExampleSection />
-        <QuickStartSection />
-      </main>
+      title="QuickAdd — Supercharge your Obsidian workflow"
+      description={`${siteConfig.tagline} Templates, captures, macros, and AI, bound to one hotkey.`}>
+      <div className={styles.landing}>
+        <Hero />
+        <main>
+          <Features />
+          <Examples />
+          <QuickStart />
+        </main>
+      </div>
     </Layout>
   );
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -305,7 +305,10 @@ function Examples(): React.JSX.Element {
               <span className={styles.exampleIcon}>{e.icon}</span>
               <h3 className={styles.exampleTitle}>{e.title}</h3>
               <p className={styles.exampleDesc}>{e.description}</p>
-              <Link className={styles.exampleLink} to={e.href}>
+              <Link
+                className={styles.exampleLink}
+                to={e.href}
+                aria-label={`Learn how: ${e.title}`}>
                 Learn how →
               </Link>
             </article>


### PR DESCRIPTION
## Summary

Refreshes the docs landing page using fundamental UI principles — hierarchy, repetition, contrast, whitespace. The old page was centered-everything, emoji-heavy, and visually flat. The new page is warm and typographic, sits comfortably next to obsidian.md, and uses one consistent card treatment throughout.

- **Emoji → SVG icons.** Six Lucide-style inline icons for features, four for examples, numbered step badges (`01` `02` `03`) — no more ⚡📄🤖🧠📁🚀 or 1️⃣2️⃣3️⃣.
- **New accent color.** Flat `#3B82F6` blue → `#7C6EF2` purple-blue, applied via `--ifm-color-primary` so links, the sidebar, and the navbar all pick it up consistently.
- **Typography.** Inter variable font with OpenType features enabled (`cv02`, `cv03`, `ss01`). Clamp-scaled display type (~59px hero → 30–40px section → 17px feature). `text-wrap: balance` on headings, `text-wrap: pretty` on body.
- **Layout.** Centered hero + left-aligned feature/example/section heads (matches the landing-page rule: never more centered heading groups than left-aligned). Consistent `clamp(4rem, 8vw, 6rem)` section rhythm.
- **Surfaces.** Single card style: 14px radius, 1px hairline border at 8% opacity, no shadows. Reused across features and examples.
- **Hero keyboard chip.** Subtle visual cue — `⌘ P → QuickAdd: Run Choice` — showing what triggering the plugin looks like.
- **Copy rewrite.** Specific over generic (e.g. "Hit one hotkey and drop content into any note" vs "Capture thoughts, ideas, and information instantly").
- **Dark mode.** Deep warm slate canvas (`#17181C`) with raised card background, tuned token set.

## Files

- `docs/src/css/custom.css` — Inter font import, new primary palette, scoped landing tokens, minor sidebar/navbar polish
- `docs/src/pages/index.module.css` — Full rewrite (hero, sections, feature grid, example cards, quick-start steps, buttons, kbd chip)
- `docs/src/pages/index.tsx` — New structure with inline SVG icons, eyebrow kickers, numbered steps, rewritten copy; React 19 JSX namespace fix

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` produces the site cleanly
- [x] Computed styles verified in light mode (cream `#F7F5F0` canvas, white cards, purple CTA) and dark mode (`#17181C` canvas, raised cards)
- [x] Responsive grids verified: mobile 1-col, tablet 2-col features / 3-col steps, desktop 3-col features
- [x] `prefers-reduced-motion` removes transform transitions
- [ ] Visually eyeball on localhost — reviewer please run `cd docs && bun run start` and click through on a real browser
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated typography to Inter and JetBrains Mono, refreshed color palette with a purple-blue accent, adjusted code block radius, navbar and sidebar visuals, and hover/transition behavior.
* **New Features**
  * Full landing redesign: new hero, feature cards, examples, and quick-start sections with responsive layouts and inline SVG icons.
* **Accessibility**
  * Honors prefers-reduced-motion to disable nonessential animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->