### PR TITLE
fix(docs): move feature icon inside <dt> for valid <dl> content model

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -275,7 +275,6 @@
   justify-content: center;
   width: 2.25rem;
   height: 2.25rem;
-  margin-bottom: 0.75rem;
   background: var(--qa-accent-soft);
   color: var(--qa-accent);
   border-radius: 9px;
@@ -287,11 +286,18 @@
 }
 
 .featureTitle {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.featureTitleText {
   font-size: 1.0625rem;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--qa-ink);
-  margin: 0;
 }
 
 .featureDesc {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -280,8 +280,12 @@ function Features(): React.JSX.Element {
         <dl className={styles.features}>
           {features.map((f) => (
             <div className={styles.feature} key={f.title}>
-              <span className={styles.featureIcon}>{f.icon}</span>
-              <dt className={styles.featureTitle}>{f.title}</dt>
+              <dt className={styles.featureTitle}>
+                <span className={styles.featureIcon} aria-hidden="true">
+                  {f.icon}
+                </span>
+                <span className={styles.featureTitleText}>{f.title}</span>
+              </dt>
               <dd className={styles.featureDesc}>{f.description}</dd>
             </div>
           ))}


### PR DESCRIPTION
## Summary

Follow-up to [#1168](https://github.com/chhoumann/quickadd/pull/1168). Post-merge review from Devin flagged that the feature grid in [docs/src/pages/index.tsx:280-288](docs/src/pages/index.tsx) places a `<span className={styles.featureIcon}>` as a direct child of the `<div>` that wraps each `<dt>`/`<dd>` pair.

Per the HTML spec, when `<div>` is a child of `<dl>` its content model is restricted to `<dt>` and `<dd>` (plus script-supporting elements). The icon span violates that, fails validation, and can confuse assistive tech that relies on strict term/description pairing.

## Fix

Moved the icon span inside `<dt>`. The icon is semantically part of the term, so this is the natural home for it. The visual layout is unchanged — the `<dt>` is now a small flex column (icon chip above title text, 0.75rem gap), and the `<div>` now contains exactly `<dt>` + `<dd>`.

## Test plan

- [x] DOM inspection: `<div>` inside `<dl>` has zero `<span>` children; `<dt>` contains icon span + title span
- [x] Visual regression check: title text is still 17px/600, icon chip is still 36×36 with soft-purple background, spacing matches pre-fix layout
- [x] `aria-hidden="true"` on the icon span so screen readers read the term as just the title text
- [ ] Eyeball in a browser before merging
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved feature title layout with refined spacing and visual hierarchy in the documentation.
  * Enhanced accessibility by properly handling decorative icons in feature listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->