### PR TITLE
test(preflight): lock in dropdown VALUE fix for issue #1180

### DIFF
--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { App } from "obsidian";
 import type { FieldRequirement } from "./RequirementCollector";
 import { OnePageInputModal } from "./OnePageInputModal";
+import { buildValueVariableKey } from "src/utils/valueSyntax";
 
 vi.mock("obsidian", () => {
 	class Modal {
@@ -269,6 +270,82 @@ describe("OnePageInputModal", () => {
 
 		await expect(modal.waitForClose).resolves.toEqual({
 			[id]: "#BF616A",
+		});
+	});
+
+	// Regression: issue #1180 — One-page input dropped VALUE dropdown
+	// selections for labeled tokens like {{VALUE:option-a,option-b|label:Pick one}},
+	// resulting in an empty captured value instead of the first option.
+	describe("labeled VALUE dropdown (issue #1180)", () => {
+		it("submits the first option when the labeled dropdown is untouched", async () => {
+			const id = buildValueVariableKey(
+				"option-a,option-b",
+				"Pick one",
+				true,
+			);
+			const requirements: FieldRequirement[] = [
+				{
+					id,
+					label: "Pick one",
+					type: "dropdown",
+					options: ["option-a", "option-b"],
+				},
+			];
+
+			const modal = new OnePageInputModal(
+				{} as App,
+				requirements,
+				new Map(),
+			);
+			const submitButton = Array.from(
+				(modal as any).contentEl.querySelectorAll(
+					"button",
+				) as NodeListOf<HTMLButtonElement>,
+			).find(
+				(button) => button.textContent === "Submit",
+			) as HTMLButtonElement;
+
+			submitButton.click();
+
+			await expect(modal.waitForClose).resolves.toEqual({
+				[id]: "option-a",
+			});
+		});
+
+		it("normalizes a stale empty initial value to the first option", async () => {
+			const id = buildValueVariableKey(
+				"option-a,option-b",
+				"Pick one",
+				true,
+			);
+			const requirements: FieldRequirement[] = [
+				{
+					id,
+					label: "Pick one",
+					type: "dropdown",
+					options: ["option-a", "option-b"],
+				},
+			];
+
+			const initialValues = new Map<string, unknown>([[id, ""]]);
+			const modal = new OnePageInputModal(
+				{} as App,
+				requirements,
+				initialValues,
+			);
+			const submitButton = Array.from(
+				(modal as any).contentEl.querySelectorAll(
+					"button",
+				) as NodeListOf<HTMLButtonElement>,
+			).find(
+				(button) => button.textContent === "Submit",
+			) as HTMLButtonElement;
+
+			submitButton.click();
+
+			await expect(modal.waitForClose).resolves.toEqual({
+				[id]: "option-a",
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds regression coverage that locks in the existing fix for issue #1180 — labeled `{{VALUE:...|label:...}}` dropdowns in the One-page input modal must produce the selected option (or first option when untouched), not an empty value.

## Background

- **Reproduced** at `v2.12.0` against the repro setup from #1180:
  - `onePageInput: "always"`, `useSelectionAsCaptureValue: false`, format `- {{DATE:HH:mm}} | case: single-dropdown-opi | value: {{VALUE:option-a,option-b|label:Pick one}}`.
  - Captured file showed `value: ` (empty) instead of `value: option-a`.
- **Verified fixed** on current `master` HEAD via the same scenario in the dev vault (writes `value: option-a`).
- The runtime fix landed in PR #1175 (`fix(preflight): preserve mapped dropdown defaults in capture`), which introduced `resolveDropdownInitialValue` and the missing `setValue(req.id, selectedValue)` call inside `OnePageInputModal.renderField`. That PR ships unreleased on `master`.
- Existing tests covered the unlabeled `id = "#BF616A,#8CC570,#42A5F5"` shape only, not the labeled-id case (`buildValueVariableKey(...)` with the `\u001F` delimiter) that the issue specifically reports.

## What this PR does

Adds two tests in `src/preflight/OnePageInputModal.test.ts`:

1. `submits the first option when the labeled dropdown is untouched` — labeled id, empty initial values, click Submit, expect `{ [id]: "option-a" }`.
2. `normalizes a stale empty initial value to the first option` — labeled id, initial value `""`, click Submit, expect `{ [id]: "option-a" }`.

Both tests exercise `buildValueVariableKey("option-a,option-b", "Pick one", true)` so we cover the actual key shape produced by `{{VALUE:...|label:...}}`.

## Verification

- `bun run test src/preflight/OnePageInputModal.test.ts` — 4/4 pass on this branch.
- Confirmed both new tests **fail** when applied at tag `2.12.0` (received `""` instead of `"option-a"`).
- `bun run test` — full suite passes (105 files, 1047 tests on this branch).
- `bun run build-with-lint` — green, `main.js` regenerated.
- Manual end-to-end verification via Obsidian CLI on the `dev` vault: at 2.12.0 capture writes `value: " "`; on master HEAD capture writes `value: option-a`.

## Release impact

- No production code changes — test-only PR.
- Locks in unreleased fix #1175 ahead of the next release so the issue cannot regress.

Closes #1180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved labeled dropdown behavior to properly normalize empty or untouched states to the first available option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->