### PR TITLE
fix(preflight): preserve one-page FIELD values

### DIFF
--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -300,13 +300,15 @@ describe("Format Syntax documentation examples", () => {
 			displayOptions: ["Low", "Normal", "High"],
 		});
 		expect(
-			collector.requirements.get("status|default:Draft|default-always:true"),
+			collector.requirements.get(
+				"FIELD:status|default:Draft|default-always:true",
+			),
 		).toMatchObject({
 			type: "field-suggest",
 		});
 		expect(
 			collector.requirements.get(
-				"Id|inline:true|inline-code-blocks:ad-note",
+				"FIELD:Id|inline:true|inline-code-blocks:ad-note",
 			),
 		).toMatchObject({
 			type: "field-suggest",

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -35,6 +35,7 @@ import {
 	type ValueInputType,
 } from "../utils/valueSyntax";
 import { parseMacroToken } from "../utils/macroSyntax";
+import { getFieldVariableKey } from "../utils/fieldVariableKey";
 
 export type LinkToCurrentFileBehavior = "required" | "optional";
 
@@ -54,7 +55,6 @@ export abstract class Formatter {
 	protected variables: Map<string, unknown> = new Map<string, unknown>();
 	protected dateParser: IDateParser | undefined;
 	private linkToCurrentFileBehavior: LinkToCurrentFileBehavior = "required";
-	private static readonly FIELD_VARIABLE_PREFIX = "FIELD:";
 	protected valuePromptContext?: PromptContext;
 
 	// Tracks variables collected for YAML property post-processing
@@ -443,7 +443,7 @@ export abstract class Formatter {
 			const fullMatch = match[1] + (match[2] || "");
 
 			if (fullMatch) {
-				const fieldVariableKey = this.getFieldVariableKey(fullMatch);
+				const fieldVariableKey = getFieldVariableKey(fullMatch);
 
 				if (!this.hasConcreteVariable(fieldVariableKey)) {
 					this.variables.set(
@@ -467,10 +467,6 @@ export abstract class Formatter {
 		}
 
 		return output;
-	}
-
-	private getFieldVariableKey(fieldSpecifier: string): string {
-		return `${Formatter.FIELD_VARIABLE_PREFIX}${fieldSpecifier}`;
 	}
 
 	protected abstract promptForMathValue(): Promise<string>;

--- a/src/gui/suggesters/FieldValueInputSuggest.ts
+++ b/src/gui/suggesters/FieldValueInputSuggest.ts
@@ -3,9 +3,8 @@ import {
 	FieldSuggestionParser,
 	type FieldFilter,
 } from "src/utils/FieldSuggestionParser";
-import {
-	collectFieldValuesProcessed
-} from "src/utils/FieldValueCollector";
+import { collectFieldValuesProcessed } from "src/utils/FieldValueCollector";
+import { stripFieldVariableKeyPrefix } from "src/utils/fieldVariableKey";
 import { TextInputSuggest } from "./suggest";
 
 export class FieldValueInputSuggest extends TextInputSuggest<string> {
@@ -16,8 +15,8 @@ export class FieldValueInputSuggest extends TextInputSuggest<string> {
 
 	constructor(app: App, inputEl: HTMLInputElement, fieldInput: string) {
 		super(app, inputEl);
-		this.fieldInput = fieldInput;
-		const parsed = FieldSuggestionParser.parse(fieldInput);
+		this.fieldInput = stripFieldVariableKeyPrefix(fieldInput);
+		const parsed = FieldSuggestionParser.parse(this.fieldInput);
 		this.fieldName = parsed.fieldName;
 		this.filters = parsed.filters;
 	}

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -273,6 +273,35 @@ describe("OnePageInputModal", () => {
 		});
 	});
 
+	it("submits FIELD values under the prefixed runtime key", async () => {
+		const id = "FIELD:People";
+		const requirements: FieldRequirement[] = [
+			{
+				id,
+				label: "People",
+				type: "field-suggest",
+			},
+		];
+
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		const input = (modal as any).contentEl.querySelector(
+			"input",
+		) as HTMLInputElement;
+		input.value = "Alice";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		const submitButton = Array.from(
+			(modal as any).contentEl.querySelectorAll(
+				"button",
+			) as NodeListOf<HTMLButtonElement>,
+		).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+
+		submitButton.click();
+
+		await expect(modal.waitForClose).resolves.toEqual({
+			[id]: "Alice",
+		});
+	});
+
 	// Regression: issue #1180 — One-page input dropped VALUE dropdown
 	// selections for labeled tokens like {{VALUE:option-a,option-b|label:Pick one}},
 	// resulting in an empty captured value instead of the first option.

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -218,4 +218,32 @@ Body`);
     const requirement = rc.requirements.get("title");
     expect(requirement?.type).toBe("textarea");
   });
+
+  it("collects FIELD requirements with runtime-compatible ids and raw labels", async () => {
+    const app = makeApp();
+    const plugin = makePlugin();
+    const rc = new RequirementCollector(app, plugin);
+    await rc.scanString("Person: {{FIELD:People}}");
+
+    expect(rc.requirements.get("People")).toBeUndefined();
+    expect(rc.requirements.get("FIELD:People")).toMatchObject({
+      id: "FIELD:People",
+      label: "People",
+      type: "field-suggest",
+    });
+  });
+
+  it("preserves filtered FIELD syntax in the prefixed runtime id", async () => {
+    const app = makeApp();
+    const plugin = makePlugin();
+    const rc = new RequirementCollector(app, plugin);
+    await rc.scanString("Person: {{FIELD:People|folder:Contacts}}");
+
+    expect(rc.requirements.get("People|folder:Contacts")).toBeUndefined();
+    expect(rc.requirements.get("FIELD:People|folder:Contacts")).toMatchObject({
+      id: "FIELD:People|folder:Contacts",
+      label: "People|folder:Contacts",
+      type: "field-suggest",
+    });
+  });
 });

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -4,6 +4,7 @@ import { Formatter, type PromptContext } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import type QuickAdd from "src/main";
 import { NLDParser } from "src/parsers/NLDParser";
+import { getFieldVariableKey } from "src/utils/fieldVariableKey";
 import { parseValueToken } from "src/utils/valueSyntax";
 
 export type FieldType =
@@ -284,9 +285,10 @@ export class RequirementCollector extends Formatter {
 
 	protected async suggestForField(variableName: string): Promise<string> {
 		// Store as a field-suggest requirement; actual suggestions are provided by UI
-		if (!this.requirements.has(variableName)) {
-			this.requirements.set(variableName, {
-				id: variableName,
+		const key = getFieldVariableKey(variableName);
+		if (!this.requirements.has(key)) {
+			this.requirements.set(key, {
+				id: key,
 				label: variableName,
 				type: "field-suggest",
 				source: "collected",

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -5,7 +5,10 @@ import type ICaptureChoice from "src/types/choices/ICaptureChoice";
 import type IMacroChoice from "src/types/choices/IMacroChoice";
 import { CommandType } from "src/types/macros/CommandType";
 import type { IUserScript } from "src/types/macros/IUserScript";
-import { collectChoiceRequirements } from "./collectChoiceRequirements";
+import {
+	collectChoiceRequirements,
+	getUnresolvedRequirements,
+} from "./collectChoiceRequirements";
 
 const {
 	getMarkdownFilesInFolderMock,
@@ -263,5 +266,20 @@ describe("collectChoiceRequirements - capture targets", () => {
 					requirement.id === "QA_INTERNAL_CAPTURE_TARGET_FILE_PATH",
 			),
 		).toBe(false);
+	});
+});
+
+describe("getUnresolvedRequirements - FIELD keys", () => {
+	it("considers prefixed FIELD values resolved", () => {
+		const requirements = [
+			{
+				id: "FIELD:People",
+				label: "People",
+				type: "field-suggest" as const,
+			},
+		];
+		const variables = new Map<string, unknown>([["FIELD:People", "Alice"]]);
+
+		expect(getUnresolvedRequirements(requirements, variables)).toEqual([]);
 	});
 });

--- a/src/utils/fieldVariableKey.test.ts
+++ b/src/utils/fieldVariableKey.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+	getFieldVariableKey,
+	stripFieldVariableKeyPrefix,
+} from "./fieldVariableKey";
+
+describe("fieldVariableKey", () => {
+	it("builds FIELD-prefixed runtime keys", () => {
+		expect(getFieldVariableKey("People|folder:Contacts")).toBe(
+			"FIELD:People|folder:Contacts",
+		);
+	});
+
+	it("strips FIELD prefixes before field suggestion parsing", () => {
+		expect(stripFieldVariableKeyPrefix("FIELD:People|folder:Contacts")).toBe(
+			"People|folder:Contacts",
+		);
+	});
+
+	it("leaves raw field suggestion inputs unchanged", () => {
+		expect(stripFieldVariableKeyPrefix("People|folder:Contacts")).toBe(
+			"People|folder:Contacts",
+		);
+	});
+});

--- a/src/utils/fieldVariableKey.ts
+++ b/src/utils/fieldVariableKey.ts
@@ -1,0 +1,11 @@
+const FIELD_VARIABLE_PREFIX = "FIELD:";
+
+export function getFieldVariableKey(fieldSpecifier: string): string {
+	return `${FIELD_VARIABLE_PREFIX}${fieldSpecifier}`;
+}
+
+export function stripFieldVariableKeyPrefix(fieldInput: string): string {
+	return fieldInput.startsWith(FIELD_VARIABLE_PREFIX)
+		? fieldInput.slice(FIELD_VARIABLE_PREFIX.length)
+		: fieldInput;
+}


### PR DESCRIPTION
Preserve one-page input values for `{{FIELD:...}}` tokens by using the runtime-compatible `FIELD:` key during preflight collection. This prevents Template choices from prompting a second time after the one-page modal has already collected the FIELD value.

The field suggestion UI still displays raw labels and strips the internal prefix before parsing, so vault suggestions continue to work for both plain and filtered FIELD syntax.

Validation performed:
- `bun run test`
- `bun run lint`
- `bun run build`
- Obsidian dev-vault CLI check/run flow for `{{FIELD:People}}` and `{{FIELD:People|folder:Contacts}}`, confirming prefixed variables resolve and generated output contains the provided values with no dev errors.

Fixes #1184