### PR TITLE
fix: render DOM safety surfaces as text

### DIFF
--- a/src/gui/suggesters/fileSuggester.test.ts
+++ b/src/gui/suggesters/fileSuggester.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { App, TFile, Vault, MetadataCache, Workspace, Plugin } from 'obsidian';
+import { TFile as RuntimeTFile } from 'obsidian';
 import { FileIndex } from './FileIndex';
+import { FileSuggester } from './fileSuggester';
+import { renderExactHighlight } from './utils';
+
+vi.mock("../../main", () => ({
+    default: {
+        instance: {
+            registerEvent: vi.fn(),
+        },
+    },
+}));
 
 // Mock Plugin
 const mockPlugin = {
@@ -40,6 +51,28 @@ function createMockFile(path: string, basename: string): TFile {
             size: 100,
         },
     } as TFile;
+}
+
+function createIndexedFile(path: string, basename: string) {
+    return {
+        path,
+        pathNormalized: path.toLowerCase(),
+        basename,
+        basenameNormalized: basename.toLowerCase(),
+        aliases: [],
+        aliasesNormalized: [],
+        headings: [],
+        blockIds: [],
+        tags: [],
+        modified: Date.now(),
+        folder: path.includes('/') ? path.split('/').slice(0, -1).join('/') : '',
+    };
+}
+
+function expectNoPayloadDom(el: HTMLElement): void {
+    expect(el.querySelector('img, script, svg')).toBeNull();
+    expect((globalThis as typeof globalThis & { __qaXss?: number }).__qaXss)
+        .toBeUndefined();
 }
 
 describe('FileSuggester - Issue #838 and #839', () => {
@@ -246,6 +279,134 @@ describe('FileSuggester - Issue #838 and #839', () => {
             expect(doctorMatches.some(r => r.file.basename === 'Caleb')).toBe(true);
             expect(doctorMatches.some(r => r.file.basename === 'Zeb')).toBe(true);
         });
+    });
+});
+
+describe('FileSuggester DOM XSS safety', () => {
+    beforeEach(() => {
+        delete (globalThis as typeof globalThis & { __qaXss?: number }).__qaXss;
+    });
+
+    it('renders malicious file paths and basenames as text', () => {
+        const payload = '<img src=x onerror=globalThis.__qaXss=1>';
+        const el = document.createElement('div');
+
+        FileSuggester.prototype.renderSuggestion.call(
+            {
+                addHoverTooltip: vi.fn(),
+            },
+            {
+                file: createIndexedFile(`Notes/${payload}.md`, payload),
+                score: 0,
+                matchType: 'exact',
+                displayText: payload,
+            },
+            el,
+        );
+
+        expect(el.textContent).toContain(payload);
+        expect(el.textContent).toContain(`Notes/${payload}.md`);
+        expectNoPayloadDom(el);
+    });
+
+    it('renders malicious heading text safely while preserving highlighting', () => {
+        const payload = '<svg onload=globalThis.__qaXss=1>Danger</svg>';
+        const el = document.createElement('div');
+
+        FileSuggester.prototype.renderSuggestion.call(
+            {
+                lastInput: `Source#Danger`,
+                addHoverTooltip: vi.fn(),
+                renderMatch: renderExactHighlight,
+            },
+            {
+                file: createIndexedFile('Source.md', 'Source'),
+                score: 0,
+                matchType: 'heading',
+                displayText: `Source#${payload}`,
+            },
+            el,
+        );
+
+        expect(el.textContent).toContain(payload);
+        expect(el.querySelector('mark.qa-highlight')?.textContent).toBe('Danger');
+        expectNoPayloadDom(el);
+    });
+
+    it('renders alias, unresolved, block, and attachment fields as text', () => {
+        const payload = '<img src=x onerror=globalThis.__qaXss=1>';
+        const cases = [
+            {
+                matchType: 'alias' as const,
+                displayText: payload,
+                expectedText: payload,
+            },
+            {
+                matchType: 'unresolved' as const,
+                displayText: payload,
+                expectedText: payload,
+            },
+            {
+                matchType: 'block' as const,
+                displayText: `Block Source#^${payload}`,
+                expectedText: payload,
+            },
+            {
+                matchType: 'fuzzy' as const,
+                displayText: payload,
+                expectedText: payload,
+            },
+        ];
+
+        for (const testCase of cases) {
+            const el = document.createElement('div');
+            FileSuggester.prototype.renderSuggestion.call(
+                {
+                    addHoverTooltip: vi.fn(),
+                },
+                {
+                    file: createIndexedFile(`Notes/${payload}.md`, payload),
+                    score: 0,
+                    ...testCase,
+                },
+                el,
+            );
+
+            expect(el.textContent).toContain(testCase.expectedText);
+            expectNoPayloadDom(el);
+        }
+    });
+
+    it('renders tooltip metadata as text', () => {
+        const payload = '<img src=x onerror=globalThis.__qaXss=1>';
+        const obsidianFile = new RuntimeTFile();
+        obsidianFile.basename = payload;
+        obsidianFile.path = `Notes/${payload}.md`;
+        (obsidianFile as TFile).stat = {
+            ctime: 0,
+            mtime: new Date('2024-01-01T00:00:00Z').getTime(),
+            size: 1,
+        };
+
+        const tooltip = (
+            FileSuggester.prototype as unknown as {
+                createTooltip(this: unknown, file: { path: string }): HTMLElement | null;
+            }
+        ).createTooltip.call(
+            {
+                app: {
+                    vault: {
+                        getAbstractFileByPath: vi.fn(() => obsidianFile),
+                    },
+                },
+            },
+            { path: obsidianFile.path },
+        );
+
+        expect(tooltip).not.toBeNull();
+        expect(tooltip?.textContent).toContain(payload);
+        expect(tooltip?.textContent).toContain(`Path: Notes/${payload}.md`);
+        expectNoPayloadDom(tooltip!);
     });
 });
 

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -12,6 +12,32 @@ interface HTMLElementWithTooltipCleanup extends HTMLElement {
 	_tooltipCleanup?: () => void;
 }
 
+function createSuggestionPill(matchType: SearchResult["matchType"]): HTMLElement | null {
+	const pill = document.createElement("span");
+	pill.classList.add("qa-suggestion-pill");
+
+	switch (matchType) {
+		case "alias":
+			pill.classList.add("qa-alias-pill");
+			pill.textContent = "alias";
+			return pill;
+		case "heading":
+			pill.classList.add("qa-heading-pill");
+			pill.textContent = "H";
+			return pill;
+		case "block":
+			pill.classList.add("qa-block-pill");
+			pill.textContent = "^";
+			return pill;
+		case "unresolved":
+			pill.classList.add("qa-unresolved-pill");
+			pill.textContent = "unresolved";
+			return pill;
+		default:
+			return null;
+	}
+}
+
 export class FileSuggester extends TextInputSuggest<SearchResult> {
 	private lastInput = "";
 	private fileIndex: FileIndex;
@@ -254,7 +280,8 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 
 		let mainText = displayText;
 		let subText = "";
-		let pill = "";
+		let shouldHighlightMainText = false;
+		let highlightQuery = "";
 
 		switch (matchType) {
 			case 'exact':
@@ -264,7 +291,6 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 			case 'alias':
 				mainText = displayText;
 				subText = file.path;
-				pill = '<span class="qa-suggestion-pill qa-alias-pill">alias</span>';
 				break;
 			case 'fuzzy':
 				mainText = file.basename;
@@ -278,14 +304,13 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 					: '';
 				const headingQueryNormalized = normalizeForSearch(headingQuery ?? "");
 				if (headingQuery && normalizeForSearch(heading).includes(headingQueryNormalized)) {
-					const tempEl = document.createElement('span');
-					this.renderMatch(tempEl, heading, headingQuery);
-					mainText = tempEl.innerHTML;
+					mainText = heading;
+					shouldHighlightMainText = true;
+					highlightQuery = headingQuery;
 				} else {
 					mainText = heading;
 				}
 				subText = fileName; // Show source file name
-				pill = '<span class="qa-suggestion-pill qa-heading-pill">H</span>';
 				break;
 			}
 			case 'block': {
@@ -293,23 +318,34 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 				const [fileName, blockId] = displayText.split('#^');
 				mainText = blockId; // Show only the block ID
 				subText = fileName; // Show source file name without '#'
-				pill = '<span class="qa-suggestion-pill qa-block-pill">^</span>';
 				break;
 			}
 			case 'unresolved':
 				mainText = displayText;
 				subText = "Unresolved link";
-				pill = '<span class="qa-suggestion-pill qa-unresolved-pill">unresolved</span>';
 				break;
 		}
 
-		el.innerHTML = `
-			<div class="qa-suggestion-content">
-				<span class="suggestion-main-text">${mainText}</span>
-				${pill}
-			</div>
-			<span class="suggestion-sub-text">${subText}</span>
-		`;
+		const content = document.createElement("div");
+		content.className = "qa-suggestion-content";
+
+		const mainTextEl = document.createElement("span");
+		mainTextEl.className = "suggestion-main-text";
+		if (shouldHighlightMainText) {
+			this.renderMatch(mainTextEl, mainText, highlightQuery);
+		} else {
+			mainTextEl.textContent = mainText;
+		}
+		content.appendChild(mainTextEl);
+
+		const pill = createSuggestionPill(matchType);
+		if (pill) content.appendChild(pill);
+
+		const subTextEl = document.createElement("span");
+		subTextEl.className = "suggestion-sub-text";
+		subTextEl.textContent = subText;
+
+		el.replaceChildren(content, subTextEl);
 
 		// Add hover tooltip for content preview
 		this.addHoverTooltip(el, file);
@@ -358,13 +394,21 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		tooltip.className = 'qa-file-tooltip';
 
 		// For now, just show basic info - content preview can be added later
-		tooltip.innerHTML = `
-			<div class="qa-tooltip-header">${obsidianFile.basename}</div>
-			<div class="qa-tooltip-content">
-				<div>Path: ${obsidianFile.path}</div>
-				<div>Modified: ${new Date(obsidianFile.stat.mtime).toLocaleDateString()}</div>
-			</div>
-		`;
+		const header = document.createElement("div");
+		header.className = "qa-tooltip-header";
+		header.textContent = obsidianFile.basename;
+
+		const content = document.createElement("div");
+		content.className = "qa-tooltip-content";
+
+		const path = document.createElement("div");
+		path.textContent = `Path: ${obsidianFile.path}`;
+
+		const modified = document.createElement("div");
+		modified.textContent = `Modified: ${new Date(obsidianFile.stat.mtime).toLocaleDateString()}`;
+
+		content.append(path, modified);
+		tooltip.append(header, content);
 
 		return tooltip;
 	}

--- a/src/quickAddSettingsDevelopmentInfo.ts
+++ b/src/quickAddSettingsDevelopmentInfo.ts
@@ -1,0 +1,48 @@
+export type DevelopmentInfo = {
+	branch: string | null;
+	commit: string | null;
+	dirty: boolean | null;
+};
+
+function appendDevelopmentInfoRow(
+	container: HTMLElement,
+	label: string,
+	value: string,
+	options?: { className?: string },
+): HTMLElement {
+	const row = document.createElement("div");
+	const labelEl = document.createElement("strong");
+	labelEl.textContent = label;
+	row.appendChild(labelEl);
+	row.appendChild(document.createTextNode(` ${value}`));
+	if (options?.className) row.classList.add(options.className);
+	row.style.marginBottom = "5px";
+	container.appendChild(row);
+	return row;
+}
+
+export function renderDevelopmentInfo(
+	container: HTMLElement,
+	info: DevelopmentInfo,
+): void {
+	if (info.branch !== null) {
+		appendDevelopmentInfoRow(container, "Branch:", info.branch);
+	}
+
+	if (info.commit !== null) {
+		appendDevelopmentInfoRow(container, "Commit:", info.commit);
+	}
+
+	if (info.dirty !== null) {
+		const statusText = info.dirty ? "Yes (uncommitted changes)" : "No";
+		const statusClass = info.dirty
+			? "qa-dev-dirty-status"
+			: "qa-dev-clean-status";
+		appendDevelopmentInfoRow(
+			container,
+			"Uncommitted changes:",
+			statusText,
+			{ className: statusClass },
+		);
+	}
+}

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
+
+function expectNoPayloadDom(el: HTMLElement): void {
+	expect(el.querySelector("img, script, svg")).toBeNull();
+	expect((globalThis as typeof globalThis & { __qaXss?: number }).__qaXss)
+		.toBeUndefined();
+}
+
+describe("renderDevelopmentInfo", () => {
+	beforeEach(() => {
+		delete (globalThis as typeof globalThis & { __qaXss?: number }).__qaXss;
+	});
+
+	it("renders malicious git metadata as text while preserving labels", () => {
+		const payload = "<img src=x onerror=globalThis.__qaXss=1>";
+		const container = document.createElement("div");
+
+		renderDevelopmentInfo(container, {
+			branch: `feature/${payload}`,
+			commit: `abc123${payload}`,
+			dirty: true,
+		});
+
+		expect(container.textContent).toContain("Branch:");
+		expect(container.textContent).toContain(`feature/${payload}`);
+		expect(container.textContent).toContain("Commit:");
+		expect(container.textContent).toContain(`abc123${payload}`);
+		expect(container.textContent).toContain("Uncommitted changes:");
+		expect(container.textContent).toContain("Yes (uncommitted changes)");
+		expect(container.querySelector(".qa-dev-dirty-status")).not.toBeNull();
+		expectNoPayloadDom(container);
+	});
+
+	it("uses clean status class for clean dev builds", () => {
+		const container = document.createElement("div");
+
+		renderDevelopmentInfo(container, {
+			branch: null,
+			commit: null,
+			dirty: false,
+		});
+
+		expect(container.textContent).toContain("Uncommitted changes: No");
+		expect(container.querySelector(".qa-dev-clean-status")).not.toBeNull();
+	});
+});

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -22,6 +22,7 @@ import {
 	formatDateAliasLines,
 	parseDateAliasLines,
 } from "./utils/dateAliases";
+import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 
 type SettingGroupLike = {
 	addSetting(cb: (setting: Setting) => void): void;
@@ -136,28 +137,11 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			infoContainer.style.fontFamily = "var(--font-monospace)";
 			infoContainer.style.fontSize = "0.9em";
 
-			if (__DEV_GIT_BRANCH__ !== null) {
-				const branchDiv = infoContainer.createDiv();
-				branchDiv.innerHTML = `<strong>Branch:</strong> ${__DEV_GIT_BRANCH__}`;
-				branchDiv.style.marginBottom = "5px";
-			}
-
-			if (__DEV_GIT_COMMIT__ !== null) {
-				const commitDiv = infoContainer.createDiv();
-				commitDiv.innerHTML = `<strong>Commit:</strong> ${__DEV_GIT_COMMIT__}`;
-				commitDiv.style.marginBottom = "5px";
-			}
-
-			if (__DEV_GIT_DIRTY__ !== null) {
-				const statusDiv = infoContainer.createDiv();
-				const statusText = __DEV_GIT_DIRTY__
-					? "Yes (uncommitted changes)"
-					: "No";
-				const statusColor = __DEV_GIT_DIRTY__
-					? "var(--text-warning)"
-					: "var(--text-success)";
-				statusDiv.innerHTML = `<strong>Uncommitted changes:</strong> <span style="color: ${statusColor}">${statusText}</span>`;
-			}
+			renderDevelopmentInfo(infoContainer, {
+				branch: __DEV_GIT_BRANCH__,
+				commit: __DEV_GIT_COMMIT__,
+				dirty: __DEV_GIT_DIRTY__,
+			});
 		});
 	}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -579,6 +579,14 @@
   margin-bottom: 2px;
 }
 
+.qa-dev-dirty-status {
+  color: var(--text-warning);
+}
+
+.qa-dev-clean-status {
+  color: var(--text-success);
+}
+
 /* Performance optimization - GPU acceleration for smooth animations */
 .qaFileSuggestionItem {
   will-change: transform, background-color;


### PR DESCRIPTION
Render scorecard-sensitive DOM surfaces as text instead of HTML.

This closes the first DOM safety layer by replacing unsafe rendering paths in file suggestions and settings/development metadata with explicit text/DOM construction. The goal is to preserve the visible UI while ensuring user- or vault-controlled strings cannot be interpreted as markup.

Review focus:
- File suggester display construction and keyboard-selection behavior.
- Settings/development metadata rendering for user-authored content.
- Regression coverage for malicious filenames and settings strings.

Stack position: 1/17, based on `master`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.