### PR TITLE
test: cover DOM safety scrutiny gaps

### DIFF
--- a/src/gui/suggesters/fileSuggester.test.ts
+++ b/src/gui/suggesters/fileSuggester.test.ts
@@ -5,6 +5,190 @@ import { FileIndex } from './FileIndex';
 import { FileSuggester } from './fileSuggester';
 import { renderExactHighlight } from './utils';
 
+vi.mock('./suggest', () => {
+    function getOwnerDocument(node: Node): Document {
+        if (node.nodeType === Node.DOCUMENT_NODE) {
+            return node as Document;
+        }
+        return node.ownerDocument ?? document;
+    }
+
+    class TestScope {
+        private callbacks = new Map<string, (event: any) => unknown>();
+
+        register(_hotkeys: any[], key: string, callback: (event: any) => unknown) {
+            this.callbacks.set(key, callback);
+        }
+
+        trigger(key: string, event: any = { isComposing: false }): unknown {
+            return this.callbacks.get(key)?.(event);
+        }
+    }
+
+    class TestSuggest<T> {
+        private values: T[] = [];
+        private suggestions: HTMLDivElement[] = [];
+        private selectedItem = 0;
+        private isOpen = false;
+
+        constructor(
+            private owner: {
+                renderSuggestion(item: T, el: HTMLElement): void;
+                selectSuggestion(item: T, event: MouseEvent | KeyboardEvent): unknown;
+            },
+            private containerEl: HTMLElement,
+            private scope: TestScope,
+        ) {
+            scope.register([], 'ArrowUp', (event: KeyboardEvent) => {
+                if (!event.isComposing && this.isOpen) {
+                    this.setSelectedItem(this.selectedItem - 1, true);
+                    return false;
+                }
+            });
+            scope.register([], 'ArrowDown', (event: KeyboardEvent) => {
+                if (!event.isComposing && this.isOpen) {
+                    this.setSelectedItem(this.selectedItem + 1, true);
+                    return false;
+                }
+            });
+            scope.register([], 'Enter', (event: KeyboardEvent) => {
+                if (!event.isComposing && this.isOpen) {
+                    return this.useSelectedItem(event);
+                }
+            });
+            scope.register([], 'PageUp', (event: KeyboardEvent) => {
+                if (!event.isComposing && this.isOpen) {
+                    this.setSelectedItem(Math.max(0, this.selectedItem - 5), true);
+                    return false;
+                }
+            });
+            scope.register([], 'PageDown', (event: KeyboardEvent) => {
+                if (!event.isComposing && this.isOpen) {
+                    this.setSelectedItem(
+                        Math.min(this.suggestions.length - 1, this.selectedItem + 5),
+                        true,
+                    );
+                    return false;
+                }
+            });
+        }
+
+        setSuggestions(values: T[]) {
+            this.containerEl.replaceChildren();
+            this.values = values;
+            this.suggestions = values.map((value, index) => {
+                const suggestionEl = this.containerEl.ownerDocument.createElement('div');
+                suggestionEl.className = 'suggestion-item';
+                suggestionEl.setAttribute('role', 'option');
+                suggestionEl.setAttribute('aria-selected', 'false');
+                suggestionEl.setAttribute('id', `suggestion-${index}`);
+                this.owner.renderSuggestion(value, suggestionEl);
+                this.containerEl.appendChild(suggestionEl);
+                return suggestionEl;
+            });
+            this.setSelectedItem(0, false);
+            this.isOpen = values.length > 0;
+        }
+
+        private useSelectedItem(event: KeyboardEvent): unknown {
+            const currentValue = this.values[this.selectedItem];
+            if (!currentValue) return undefined;
+            return this.owner.selectSuggestion(currentValue, event);
+        }
+
+        private setSelectedItem(selectedIndex: number, scrollIntoView: boolean) {
+            if (!this.suggestions.length) return;
+
+            const normalizedIndex = ((selectedIndex % this.suggestions.length)
+                + this.suggestions.length) % this.suggestions.length;
+            const prevSelectedSuggestion = this.suggestions[this.selectedItem];
+            const selectedSuggestion = this.suggestions[normalizedIndex];
+
+            prevSelectedSuggestion?.classList.remove('is-selected');
+            selectedSuggestion?.classList.add('is-selected');
+            prevSelectedSuggestion?.setAttribute('aria-selected', 'false');
+            selectedSuggestion?.setAttribute('aria-selected', 'true');
+            this.selectedItem = normalizedIndex;
+
+            if (scrollIntoView) {
+                selectedSuggestion.scrollIntoView?.(false);
+            }
+        }
+    }
+
+    class TextInputSuggest<T> {
+        protected renderMatch = (el: HTMLElement, text: string, query: string) => {
+            if (!query) {
+                el.textContent = text;
+                return;
+            }
+
+            const index = text.toLowerCase().indexOf(query.toLowerCase());
+            if (index === -1) {
+                el.textContent = text;
+                return;
+            }
+
+            const ownerDocument = el.ownerDocument;
+            el.append(
+                ownerDocument.createTextNode(text.slice(0, index)),
+                Object.assign(ownerDocument.createElement('mark'), {
+                    className: 'qa-highlight',
+                    textContent: text.slice(index, index + query.length),
+                }),
+                ownerDocument.createTextNode(text.slice(index + query.length)),
+            );
+        };
+        private scope: TestScope;
+        private suggest: TestSuggest<T>;
+        private suggestEl: HTMLElement;
+
+        constructor(
+            protected app: unknown,
+            protected inputEl: HTMLInputElement | HTMLTextAreaElement,
+        ) {
+            this.scope = new TestScope();
+            const ownerDocument = this.inputEl.ownerDocument;
+            this.suggestEl = ownerDocument.createElement('div');
+            this.suggestEl.className = 'suggestion-container';
+            const suggestion = ownerDocument.createElement('div');
+            suggestion.className = 'suggestion';
+            suggestion.setAttribute('role', 'listbox');
+            suggestion.setAttribute('aria-label', 'Suggestions');
+            this.suggestEl.appendChild(suggestion);
+            this.suggest = new TestSuggest<T>(
+                this as unknown as {
+                    renderSuggestion(item: T, el: HTMLElement): void;
+                    selectSuggestion(item: T, event: MouseEvent | KeyboardEvent): unknown;
+                },
+                suggestion,
+                this.scope,
+            );
+        }
+
+        open(container: HTMLElement, inputEl: HTMLElement = this.inputEl): void {
+            const inputDocument = getOwnerDocument(inputEl);
+            const containerDocument = getOwnerDocument(container);
+            const ownerCompatibleContainer =
+                containerDocument === inputDocument ? container : inputDocument.body;
+            ownerCompatibleContainer.appendChild(this.suggestEl);
+            this.inputEl.setAttribute('aria-expanded', 'true');
+        }
+
+        close(): void {
+            this.suggest.setSuggestions([]);
+            this.suggestEl.remove();
+            this.inputEl.setAttribute('aria-expanded', 'false');
+        }
+
+        destroy(): void {
+            this.close();
+        }
+    }
+
+    return { TextInputSuggest };
+});
+
 vi.mock("../../main", () => ({
     default: {
         instance: {
@@ -67,6 +251,21 @@ function createIndexedFile(path: string, basename: string) {
         modified: Date.now(),
         folder: path.includes('/') ? path.split('/').slice(0, -1).join('/') : '',
     };
+}
+
+function createRuntimeFile(path: string, basename: string): TFile {
+    const file = new RuntimeTFile();
+    file.path = path;
+    file.basename = basename;
+    file.name = path.split('/').pop() ?? basename;
+    file.extension = path.split('.').pop() ?? 'md';
+    file.parent = null;
+    (file as TFile).stat = {
+        ctime: 0,
+        mtime: new Date('2024-01-01T00:00:00Z').getTime(),
+        size: 1,
+    };
+    return file as TFile;
 }
 
 function expectNoPayloadDom(el: HTMLElement): void {
@@ -379,14 +578,7 @@ describe('FileSuggester DOM XSS safety', () => {
 
     it('renders tooltip metadata as text', () => {
         const payload = '<img src=x onerror=globalThis.__qaXss=1>';
-        const obsidianFile = new RuntimeTFile();
-        obsidianFile.basename = payload;
-        obsidianFile.path = `Notes/${payload}.md`;
-        (obsidianFile as TFile).stat = {
-            ctime: 0,
-            mtime: new Date('2024-01-01T00:00:00Z').getTime(),
-            size: 1,
-        };
+        const obsidianFile = createRuntimeFile(`Notes/${payload}.md`, payload);
 
         const tooltip = (
             FileSuggester.prototype as unknown as {
@@ -407,6 +599,182 @@ describe('FileSuggester DOM XSS safety', () => {
         expect(tooltip?.textContent).toContain(payload);
         expect(tooltip?.textContent).toContain(`Path: Notes/${payload}.md`);
         expectNoPayloadDom(tooltip!);
+    });
+
+    it('keeps malicious suggestions selectable by keyboard navigation', async () => {
+        const payload = '<img src=x onerror=globalThis.__qaXss=1>';
+        const insertedValues: string[] = [];
+        const runtimeFiles = new Map([
+            [
+                `Notes/${payload}.md`,
+                createRuntimeFile(`Notes/${payload}.md`, payload),
+            ],
+            [
+                `Fuzzy/${payload} attachment.png`,
+                createRuntimeFile(`Fuzzy/${payload} attachment.png`, `${payload} attachment`),
+            ],
+            [
+                `Aliases/${payload}.md`,
+                createRuntimeFile(`Aliases/${payload}.md`, payload),
+            ],
+        ]);
+        const inputEl = document.createElement('input');
+        inputEl.value = `before [[${payload}]] after`;
+        inputEl.setSelectionRange(
+            `before [[${payload}`.length,
+            `before [[${payload}`.length,
+        );
+        inputEl.trigger = vi.fn();
+
+        const app = {
+            dom: { appContainerEl: document.body },
+            keymap: {
+                pushScope: vi.fn(),
+                popScope: vi.fn(),
+            },
+            workspace: {
+                getActiveFile: vi.fn(() => null),
+            },
+            fileManager: {
+                getNewFileParent: vi.fn(() => ({ path: '' })),
+                generateMarkdownLink: vi.fn((file: TFile, _source: string, _sub: string, alias: string) => {
+                    const link = alias ? `[[${file.basename}|${alias}]]` : `[[${file.basename}]]`;
+                    insertedValues.push(link);
+                    return link;
+                }),
+            },
+            vault: {
+                getAbstractFileByPath: vi.fn((path: string) => runtimeFiles.get(path) ?? null),
+                getFiles: vi.fn(() => Array.from(runtimeFiles.values())),
+            },
+        };
+        const suggestions = [
+            {
+                kind: 'exact',
+                expectedValue: `[[${payload}]]`,
+                item: {
+                    file: createIndexedFile(`Notes/${payload}.md`, payload),
+                    score: 0,
+                    matchType: 'exact' as const,
+                    displayText: payload,
+                },
+            },
+            {
+                kind: 'fuzzy',
+                expectedValue: `[[${payload} attachment]]`,
+                item: {
+                    file: createIndexedFile(`Fuzzy/${payload} attachment.png`, `${payload} attachment`),
+                    score: 1,
+                    matchType: 'fuzzy' as const,
+                    displayText: `${payload} attachment.png`,
+                },
+            },
+            {
+                kind: 'alias',
+                expectedValue: `[[${payload}|${payload} alias]]`,
+                item: {
+                    file: createIndexedFile(`Aliases/${payload}.md`, payload),
+                    score: 0,
+                    matchType: 'alias' as const,
+                    displayText: `${payload} alias`,
+                },
+            },
+            {
+                kind: 'heading',
+                expectedValue: `Source#${payload} Heading`,
+                item: {
+                    file: createIndexedFile('Source.md', 'Source'),
+                    score: 0,
+                    matchType: 'heading' as const,
+                    displayText: `Source#${payload} Heading`,
+                },
+            },
+            {
+                kind: 'block',
+                expectedValue: `Source#^${payload}-block`,
+                item: {
+                    file: createIndexedFile('Source.md', 'Source'),
+                    score: 0,
+                    matchType: 'block' as const,
+                    displayText: `Source#^${payload}-block`,
+                },
+            },
+            {
+                kind: 'unresolved',
+                expectedValue: `before [[${payload}]]]] after`,
+                item: {
+                    file: createIndexedFile(`${payload}.md`, payload),
+                    score: 0,
+                    matchType: 'unresolved' as const,
+                    displayText: payload,
+                },
+            },
+            {
+                kind: 'attachment',
+                expectedValue: `${payload} attachment.png`,
+                item: {
+                    file: createIndexedFile(`Attachments/${payload} attachment.png`, `${payload} attachment`),
+                    score: 0,
+                    matchType: 'exact' as const,
+                    displayText: `${payload} attachment.png`,
+                },
+            },
+        ];
+
+        for (const { kind, item, expectedValue } of suggestions) {
+            const suggester = new FileSuggester(app as unknown as App, inputEl);
+            (suggester as unknown as { lastInput: string }).lastInput = payload;
+            (suggester as unknown as {
+                suggest: { setSuggestions(values: unknown[]): void };
+            }).suggest.setSuggestions(suggestions.map(({ item }) => item));
+            suggester.open(document.body, inputEl);
+
+            const scope = (suggester as unknown as {
+                scope: { trigger(key: string): unknown };
+            }).scope;
+            const items = Array.from(
+                document.querySelectorAll<HTMLElement>('.suggestion-item'),
+            );
+
+            expect(items).toHaveLength(suggestions.length);
+            for (const el of items) {
+                expect(el.textContent).toContain(payload);
+                expectNoPayloadDom(el);
+            }
+
+            expect(items[0].getAttribute('aria-selected')).toBe('true');
+            scope.trigger('ArrowDown');
+            expect(items[1].getAttribute('aria-selected')).toBe('true');
+            expect(items[0].getAttribute('aria-selected')).toBe('false');
+            scope.trigger('ArrowUp');
+            expect(items[0].getAttribute('aria-selected')).toBe('true');
+            scope.trigger('PageDown');
+            expect(items[5].getAttribute('aria-selected')).toBe('true');
+            scope.trigger('PageUp');
+            expect(items[0].getAttribute('aria-selected')).toBe('true');
+
+            const targetIndex = suggestions.findIndex((candidate) => candidate.item === item);
+            for (let i = 0; i < targetIndex; i += 1) {
+                scope.trigger('ArrowDown');
+            }
+
+            expect(items[targetIndex].getAttribute('aria-selected')).toBe('true');
+            await scope.trigger('Enter');
+
+            if (kind === 'exact' || kind === 'fuzzy' || kind === 'alias') {
+                expect(insertedValues.at(-1)).toBe(expectedValue);
+            } else {
+                expect(inputEl.value).toContain(expectedValue);
+            }
+            expectNoPayloadDom(document.body);
+
+            suggester.destroy();
+            inputEl.value = `before [[${payload}]] after`;
+            inputEl.setSelectionRange(
+                `before [[${payload}`.length,
+                `before [[${payload}`.length,
+            );
+        }
     });
 });
 

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Component } from "obsidian";
+import { renderChoiceName } from "./gui/choiceList/renderChoiceName";
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
+import { formatDateAliasLines } from "./utils/dateAliases";
 
 function expectNoPayloadDom(el: HTMLElement): void {
 	expect(el.querySelector("img, script, svg")).toBeNull();
@@ -43,5 +48,76 @@ describe("renderDevelopmentInfo", () => {
 
 		expect(container.textContent).toContain("Uncommitted changes: No");
 		expect(container.querySelector(".qa-dev-clean-status")).not.toBeNull();
+	});
+});
+
+describe("settings user-authored DOM XSS safety", () => {
+	beforeEach(() => {
+		delete (globalThis as typeof globalThis & { __qaXss?: number }).__qaXss;
+	});
+
+	it("renders malicious choice and multi names through sanitized markdown", async () => {
+		const payload = "<img src=x onerror=globalThis.__qaXss=1>";
+		const container = document.createElement("span");
+
+		renderChoiceName(`**Visible** ${payload}`, container, new Component());
+		await Promise.resolve();
+
+		expect(container.textContent).toContain("Visible");
+		expect(container.textContent).toContain(payload);
+		expect(container.querySelector("strong")?.textContent).toBe("Visible");
+		expectNoPayloadDom(container);
+
+		const multiContainer = document.createElement("span");
+		renderChoiceName(`Multi ${payload}`, multiContainer, new Component());
+		await Promise.resolve();
+
+		expect(multiContainer.textContent).toContain(`Multi ${payload}`);
+		expectNoPayloadDom(multiContainer);
+	});
+
+	it("keeps malicious date alias text in textarea values, not parsed DOM", () => {
+		const payload = "<svg onload=globalThis.__qaXss=1>date</svg>";
+		const container = document.createElement("div");
+		const textarea = document.createElement("textarea");
+		textarea.value = formatDateAliasLines({
+			[payload]: `next ${payload}`,
+		});
+		container.appendChild(textarea);
+
+		expect(textarea?.value).toContain(`${payload} = next ${payload}`);
+		expect(container.textContent).not.toContain(payload);
+		expectNoPayloadDom(container);
+	});
+
+	it("source settings surfaces use escaped bindings for globals and package conflicts", () => {
+		const srcRoot = join(__dirname);
+		const surfaces = [
+			"gui/GlobalVariables/GlobalVariablesView.svelte",
+			"gui/PackageManager/ImportPackageModal.svelte",
+			"gui/PackageManager/ExportPackageModal.svelte",
+			"gui/choiceList/ChoiceListItem.svelte",
+			"gui/choiceList/MultiChoiceListItem.svelte",
+		];
+
+		for (const relativePath of surfaces) {
+			const source = readFileSync(join(srcRoot, relativePath), "utf8");
+			expect(source, relativePath).not.toContain("{@html");
+		}
+
+		const globalVariablesSource = readFileSync(
+			join(srcRoot, "gui/GlobalVariables/GlobalVariablesView.svelte"),
+			"utf8",
+		);
+		expect(globalVariablesSource).toContain("bind:value={it.name}");
+		expect(globalVariablesSource).toContain("bind:value={it.value}");
+
+		const packageImportSource = readFileSync(
+			join(srcRoot, "gui/PackageManager/ImportPackageModal.svelte"),
+			"utf8",
+		);
+		expect(packageImportSource).toContain("{conflict.name}");
+		expect(packageImportSource).toContain("{conflict.originalPath}");
+		expectNoPayloadDom(document.body);
 	});
 });

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -30,6 +30,13 @@ export class BaseComponent {
   }
 }
 
+export class Component extends BaseComponent {
+  load() {}
+  onload() {}
+  unload() {}
+  onunload() {}
+}
+
 export class ButtonComponent extends BaseComponent {
   buttonEl: HTMLButtonElement;
 
@@ -168,6 +175,31 @@ export class SecretComponent extends BaseComponent {
   }
 }
 
+export class TextAreaComponent extends BaseComponent {
+  inputEl: HTMLTextAreaElement;
+
+  constructor(containerEl: HTMLElement) {
+    super();
+    this.inputEl = document.createElement("textarea");
+    containerEl.appendChild(this.inputEl);
+  }
+
+  setPlaceholder(value: string): this {
+    this.inputEl.placeholder = value;
+    return this;
+  }
+
+  setValue(value: string): this {
+    this.inputEl.value = value;
+    return this;
+  }
+
+  onChange(cb: (value: string) => void): this {
+    this.inputEl.addEventListener("input", () => cb(this.inputEl.value));
+    return this;
+  }
+}
+
 export class Setting {
   settingEl: HTMLElement;
   infoEl: HTMLElement;
@@ -235,6 +267,11 @@ export class Setting {
 
   addText(cb: (component: TextComponent) => any): this {
     cb(new TextComponent(this.controlEl));
+    return this;
+  }
+
+  addTextArea(cb: (component: TextAreaComponent) => any): this {
+    cb(new TextAreaComponent(this.controlEl));
     return this;
   }
 
@@ -478,7 +515,48 @@ export const Modal = class {
 };
 
 export const Scope = class {
-  register(hotkeys: any, callback: any) {}
+  callbacks = new Map<string, (event: any) => unknown>();
+
+  register(_hotkeys: any, key: any, callback?: any) {
+    if (typeof key === "string" && typeof callback === "function") {
+      this.callbacks.set(key, callback);
+    } else if (typeof key === "function") {
+      this.callbacks.set("", key);
+    }
+  }
+
+  trigger(key: string, event: any = { isComposing: false }): unknown {
+    return this.callbacks.get(key)?.(event);
+  }
+};
+
+export const MarkdownRenderer = {
+  async renderMarkdown(
+    source: string,
+    el: HTMLElement,
+    _sourcePath: string,
+    _component: unknown,
+  ): Promise<void> {
+    el.replaceChildren();
+    const strongPattern = /\*\*([^*]+)\*\*/g;
+    let cursor = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = strongPattern.exec(source)) !== null) {
+      if (match.index > cursor) {
+        el.appendChild(document.createTextNode(source.slice(cursor, match.index)));
+      }
+
+      const strong = document.createElement("strong");
+      strong.textContent = match[1];
+      el.appendChild(strong);
+      cursor = match.index + match[0].length;
+    }
+
+    if (cursor < source.length) {
+      el.appendChild(document.createTextNode(source.slice(cursor)));
+    }
+  },
 };
 
 export class Notice {
@@ -523,11 +601,13 @@ export function debounce<T extends (...args: any[]) => any>(
 // Default export for compatibility
 export default {
   App,
+  Component,
   BaseComponent,
   ButtonComponent,
   ToggleComponent,
   DropdownComponent,
   TextComponent,
+  TextAreaComponent,
   Plugin,
   PluginSettingTab,
   Setting,
@@ -540,6 +620,7 @@ export default {
   FuzzySuggestModal,
   Modal,
   Scope,
+  MarkdownRenderer,
   Notice,
   moment,
   normalizePath,


### PR DESCRIPTION
Add the DOM safety evidence that the initial remediation needed for review confidence.

This PR expands tests around malicious file-suggester inputs, keyboard selection, and settings rendering so the preceding DOM-safety changes are covered by concrete regression cases rather than relying only on implementation inspection.

The test harness intentionally avoids modifying shared browser/Obsidian globals or DOM prototypes. Instead of patching `HTMLElement.prototype`/`globalThis`, it uses local test doubles that create Obsidian-like suggestion DOM in the relevant owner document.

Review focus:
- The malicious-input fixtures and expected text-only behavior.
- Keyboard interaction coverage in the suggester tests.
- Local, non-invasive test doubles for Obsidian suggestion behavior.
- Obsidian stub additions needed to exercise these flows.

Stack position: 2/17, based on `master` now that the first DOM-safety PR has landed.

Validated with `bun run test -- src/gui/suggesters/fileSuggester.test.ts src/quickAddSettingsTab.test.ts` and `bun run lint` after restacking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added XSS safety tests to ensure suggestion rendering and user-authored setting content are preserved as text, do not create executable DOM payloads, and remain selectable via keyboard.
  * Enhanced test infrastructure and stubs for components, text areas, scope handling, and markdown rendering for more reliable, deterministic tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1188)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->