### PR TITLE
fix: support popout-owned DOM surfaces

### DIFF
--- a/src/gui/GlobalVariables/GlobalVariablesView.svelte
+++ b/src/gui/GlobalVariables/GlobalVariablesView.svelte
@@ -61,10 +61,10 @@
     };
   }
 
-  let debounceTimer: any;
+  let debounceTimer: number | undefined;
   function debouncedPersist(it: GV) {
-    clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
+    if (debounceTimer !== undefined) window.clearTimeout(debounceTimer);
+    debounceTimer = window.setTimeout(() => {
       persistToSettings();
     }, 200);
   }
@@ -73,7 +73,10 @@
     unsubscribe = settingsStore.subscribe(() => loadFromSettings());
     loadFromSettings();
   });
-  onDestroy(() => unsubscribe && unsubscribe());
+  onDestroy(() => {
+    if (debounceTimer !== undefined) window.clearTimeout(debounceTimer);
+    unsubscribe && unsubscribe();
+  });
 </script>
 
 <div class="qa-gv">

--- a/src/gui/ModelDirectoryModal.ts
+++ b/src/gui/ModelDirectoryModal.ts
@@ -111,7 +111,7 @@ export class ModelDirectoryModal extends Modal {
       row.style.alignItems = "center";
       row.style.gap = "8px";
 
-      const cb = document.createElement("input");
+      const cb = this.contentEl.ownerDocument.createElement("input");
       cb.type = "checkbox";
       cb.checked = this.selectedIds.has(m.name);
       cb.onchange = () => {

--- a/src/gui/components/validatedInput.ts
+++ b/src/gui/components/validatedInput.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
 import { TextAreaComponent, TextComponent } from "obsidian";
+import { getOwnerWindow } from "src/utils/activeWindow";
 import { GenericTextSuggester } from "../suggesters/genericTextSuggester";
 
 type ValidatorResult = boolean | string | { valid: boolean; message?: string };
@@ -68,6 +69,7 @@ export function createValidatedInput(
 			: new TextComponent(parent);
 
 	const inputEl = component.inputEl as HTMLInputElement | HTMLTextAreaElement;
+	const activeWindow = getOwnerWindow(inputEl);
 
 	if (fullWidth) inputEl.style.width = "100%";
 	inputEl.style.marginBottom = `${marginBottomPx}px`;
@@ -144,8 +146,8 @@ export function createValidatedInput(
 	const handleChange = (value: string) => {
 		if (onChange) onChange(value);
 		if (debounceMs > 0) {
-			if (timer) window.clearTimeout(timer);
-			timer = window.setTimeout(() => void runValidator(value), debounceMs);
+			if (timer) activeWindow.clearTimeout(timer);
+			timer = activeWindow.setTimeout(() => void runValidator(value), debounceMs);
 		} else {
 			void runValidator(value);
 		}
@@ -185,7 +187,7 @@ export function createValidatedInput(
 		validateNow: () => runValidator(inputEl.value),
 		destroy: () => {
 			disposed = true;
-			if (timer) window.clearTimeout(timer);
+			if (timer) activeWindow.clearTimeout(timer);
 			hint.detach();
 		},
 	};

--- a/src/gui/suggesters/FileIndex.ts
+++ b/src/gui/suggesters/FileIndex.ts
@@ -117,8 +117,8 @@ export class FileIndex {
 	private unresolvedLinks: Set<string> = new Set();
 	private isIndexing = false;
 	private indexPromise: Promise<void> | null = null;
-	private reindexTimeout: ReturnType<typeof setTimeout> | null = null;
-	private fuseUpdateTimeout: ReturnType<typeof setTimeout> | null = null;
+	private reindexTimeout: number | null = null;
+	private fuseUpdateTimeout: number | null = null;
 	private pendingFuseUpdates: Map<string, 'add' | 'update' | 'remove'> = new Map();
 	private effectiveWeights: SearchWeightsConfig = SearchWeights;
 
@@ -236,10 +236,10 @@ export class FileIndex {
 	private scheduleReindex(): void {
 		// Debounce reindexing
 		if (this.reindexTimeout !== null) {
-			clearTimeout(this.reindexTimeout);
+			window.clearTimeout(this.reindexTimeout);
 		}
-		this.reindexTimeout = globalThis.setTimeout(() => {
-			this.reindex();
+		this.reindexTimeout = window.setTimeout(() => {
+			void this.reindex();
 		}, 500);
 	}
 
@@ -272,7 +272,7 @@ export class FileIndex {
 				}
 
 				// Yield control back to the event loop
-				await new Promise(resolve => setTimeout(resolve, 0));
+				await new Promise(resolve => window.setTimeout(resolve, 0));
 			}
 		};
 
@@ -410,11 +410,11 @@ export class FileIndex {
 
 		// Clear existing timeout
 		if (this.fuseUpdateTimeout !== null) {
-			clearTimeout(this.fuseUpdateTimeout);
+			window.clearTimeout(this.fuseUpdateTimeout);
 		}
 
-		// Debounce updates - use globalThis for cross-platform compatibility
-		this.fuseUpdateTimeout = globalThis.setTimeout(() => {
+		// Debounce updates on the renderer window for Obsidian popout compatibility.
+		this.fuseUpdateTimeout = window.setTimeout(() => {
 			this.processPendingFuseUpdates();
 		}, FUSE_UPDATE_DEBOUNCE_MS);
 	}

--- a/src/gui/suggesters/fileSuggester.test.ts
+++ b/src/gui/suggesters/fileSuggester.test.ts
@@ -586,6 +586,7 @@ describe('FileSuggester DOM XSS safety', () => {
             }
         ).createTooltip.call(
             {
+                inputEl: document.createElement('input'),
                 app: {
                     vault: {
                         getAbstractFileByPath: vi.fn(() => obsidianFile),
@@ -599,6 +600,85 @@ describe('FileSuggester DOM XSS safety', () => {
         expect(tooltip?.textContent).toContain(payload);
         expect(tooltip?.textContent).toContain(`Path: Notes/${payload}.md`);
         expectNoPayloadDom(tooltip!);
+    });
+
+    it('uses the input owner document for suggestions, tooltips, timers, and cleanup', () => {
+        vi.useFakeTimers();
+        const frame = document.createElement('iframe');
+        document.body.appendChild(frame);
+        const popoutDocument = frame.contentDocument!;
+        const popoutWindow = frame.contentWindow!;
+        const inputEl = popoutDocument.createElement('input');
+        popoutDocument.body.appendChild(inputEl);
+
+        const obsidianFile = createRuntimeFile('Popout.md', 'Popout');
+        const app = {
+            dom: { appContainerEl: popoutDocument.body },
+            keymap: {
+                pushScope: vi.fn(),
+                popScope: vi.fn(),
+            },
+            workspace: {
+                getActiveFile: vi.fn(() => null),
+                on: vi.fn(() => ({})),
+            },
+            fileManager: {
+                getNewFileParent: vi.fn(() => ({ path: '' })),
+            },
+            vault: {
+                getAbstractFileByPath: vi.fn(() => obsidianFile),
+                getFiles: vi.fn(() => []),
+                getMarkdownFiles: vi.fn(() => []),
+                on: vi.fn(),
+            },
+            metadataCache: {
+                on: vi.fn(),
+                getFileCache: vi.fn(),
+                unresolvedLinks: {},
+            },
+        };
+
+        const plugin = { registerEvent: vi.fn() };
+        (FileIndex as unknown as { instance?: FileIndex }).instance = new (
+            FileIndex as unknown as new (app: App, plugin: unknown) => FileIndex
+        )(app as unknown as App, plugin);
+
+        try {
+            const suggester = new FileSuggester(app as unknown as App, inputEl);
+            (suggester as unknown as { lastInput: string }).lastInput = 'Pop';
+            (suggester as unknown as {
+                suggest: { setSuggestions(values: unknown[]): void };
+            }).suggest.setSuggestions([
+                {
+                    file: createIndexedFile('Popout.md', 'Popout'),
+                    score: 0,
+                    matchType: 'exact' as const,
+                    displayText: 'Popout',
+                },
+            ]);
+            suggester.open(popoutDocument.body, inputEl);
+
+            const suggestion = popoutDocument.querySelector<HTMLElement>('.suggestion-item')!;
+            expect(suggestion).not.toBeNull();
+            expect(document.querySelector('.suggestion-item')).toBeNull();
+
+            suggestion.dispatchEvent(new MouseEvent('mouseenter', {
+                bubbles: true,
+                view: popoutWindow,
+            }));
+            vi.advanceTimersByTime(200);
+
+            const tooltip = popoutDocument.querySelector('.qa-file-tooltip');
+            expect(tooltip).not.toBeNull();
+            expect(document.querySelector('.qa-file-tooltip')).toBeNull();
+
+            suggester.destroy();
+            expect(popoutDocument.querySelector('.suggestion-container')).toBeNull();
+            expect(popoutDocument.querySelector('.qa-file-tooltip')).toBeNull();
+        } finally {
+            frame.remove();
+            vi.useRealTimers();
+        }
     });
 
     it('keeps malicious suggestions selectable by keyboard navigation', async () => {

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -7,13 +7,17 @@ import { FILE_LINK_REGEX } from "../../constants";
 import { FileIndex, type SearchResult, type SearchContext, type IndexedFile } from "./FileIndex";
 import { normalizeForSearch } from "./utils";
 import QuickAdd from "../../main";
+import { createOwnedElement, getOwnerDocument, getOwnerWindow } from "../../utils/activeWindow";
 
 interface HTMLElementWithTooltipCleanup extends HTMLElement {
 	_tooltipCleanup?: () => void;
 }
 
-function createSuggestionPill(matchType: SearchResult["matchType"]): HTMLElement | null {
-	const pill = document.createElement("span");
+function createSuggestionPill(
+	owner: Node,
+	matchType: SearchResult["matchType"],
+): HTMLElement | null {
+	const pill = createOwnedElement(owner, "span");
 	pill.classList.add("qa-suggestion-pill");
 
 	switch (matchType) {
@@ -326,10 +330,10 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 				break;
 		}
 
-		const content = document.createElement("div");
+		const content = createOwnedElement(el, "div");
 		content.className = "qa-suggestion-content";
 
-		const mainTextEl = document.createElement("span");
+		const mainTextEl = createOwnedElement(el, "span");
 		mainTextEl.className = "suggestion-main-text";
 		if (shouldHighlightMainText) {
 			this.renderMatch(mainTextEl, mainText, highlightQuery);
@@ -338,10 +342,10 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		}
 		content.appendChild(mainTextEl);
 
-		const pill = createSuggestionPill(matchType);
+		const pill = createSuggestionPill(el, matchType);
 		if (pill) content.appendChild(pill);
 
-		const subTextEl = document.createElement("span");
+		const subTextEl = createOwnedElement(el, "span");
 		subTextEl.className = "suggestion-sub-text";
 		subTextEl.textContent = subText;
 
@@ -352,20 +356,25 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 	}
 
 	private addHoverTooltip(el: HTMLElement, file: { path: string; }): void {
-		let tooltipTimeout: NodeJS.Timeout;
+		let tooltipTimeout: number | undefined;
+		const activeDocument = getOwnerDocument(el);
+		const activeWindow = getOwnerWindow(el);
 
 		const cleanup = () => {
-			clearTimeout(tooltipTimeout);
-			const existingTooltip = document.querySelector('.qa-file-tooltip');
+			if (tooltipTimeout !== undefined) {
+				activeWindow.clearTimeout(tooltipTimeout);
+				tooltipTimeout = undefined;
+			}
+			const existingTooltip = activeDocument.querySelector('.qa-file-tooltip');
 			existingTooltip?.remove();
 		};
 
 		el.addEventListener('mouseenter', () => {
 			cleanup(); // Remove any existing tooltips
-			tooltipTimeout = setTimeout(async () => {
+			tooltipTimeout = activeWindow.setTimeout(() => {
 				const tooltip = this.createTooltip(file);
 				if (tooltip) {
-					document.body.appendChild(tooltip);
+					activeDocument.body.appendChild(tooltip);
 					this.positionTooltip(tooltip, el);
 				}
 			}, 200);
@@ -377,34 +386,35 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 
 		// Clean up on scroll to prevent misplaced tooltips
 		const cleanupOnScroll = () => cleanup();
-		document.addEventListener('scroll', cleanupOnScroll, { passive: true });
+		activeDocument.addEventListener('scroll', cleanupOnScroll, { passive: true });
 
 		// Store cleanup function for later removal
 		(el as HTMLElementWithTooltipCleanup)._tooltipCleanup = () => {
 			cleanup();
-			document.removeEventListener('scroll', cleanupOnScroll);
+			activeDocument.removeEventListener('scroll', cleanupOnScroll);
 		};
 	}
 
 	private createTooltip(file: { path: string; }): HTMLElement | null {
 		const obsidianFile = this.app.vault.getAbstractFileByPath(file.path);
 		if (!obsidianFile || !(obsidianFile instanceof TFile)) return null;
+		const owner = this.inputEl;
 
-		const tooltip = document.createElement('div');
+		const tooltip = createOwnedElement(owner, 'div');
 		tooltip.className = 'qa-file-tooltip';
 
 		// For now, just show basic info - content preview can be added later
-		const header = document.createElement("div");
+		const header = createOwnedElement(owner, "div");
 		header.className = "qa-tooltip-header";
 		header.textContent = obsidianFile.basename;
 
-		const content = document.createElement("div");
+		const content = createOwnedElement(owner, "div");
 		content.className = "qa-tooltip-content";
 
-		const path = document.createElement("div");
+		const path = createOwnedElement(owner, "div");
 		path.textContent = `Path: ${obsidianFile.path}`;
 
-		const modified = document.createElement("div");
+		const modified = createOwnedElement(owner, "div");
 		modified.textContent = `Modified: ${new Date(obsidianFile.stat.mtime).toLocaleDateString()}`;
 
 		content.append(path, modified);
@@ -423,7 +433,8 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 
 	close(): void {
 		// Clean up any tooltip listeners before closing
-		const tooltipElements = document.querySelectorAll('.qaFileSuggestionItem');
+		const activeDocument = getOwnerDocument(this.inputEl);
+		const tooltipElements = activeDocument.querySelectorAll('.qaFileSuggestionItem');
 		tooltipElements.forEach(el => {
 			const elementWithCleanup = el as HTMLElementWithTooltipCleanup;
 			if (elementWithCleanup._tooltipCleanup) {
@@ -432,7 +443,7 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		});
 
 		// Remove any existing tooltips
-		const existingTooltips = document.querySelectorAll('.qa-file-tooltip');
+		const existingTooltips = activeDocument.querySelectorAll('.qa-file-tooltip');
 		existingTooltips.forEach(tooltip => tooltip.remove());
 
 		super.close();

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -3,6 +3,7 @@ import { createPopper } from "@popperjs/core";
 import type { App, ISuggestOwner } from "obsidian";
 import { debounce, Scope } from "obsidian";
 import { log } from "src/logger/logManager";
+import { getOwnerDocument, getOwnerWindow } from "src/utils/activeWindow";
 import { renderExactHighlight } from "./utils";
 
 const wrapAround = (value: number, size: number): number => {
@@ -16,21 +17,23 @@ class Suggest<T> {
 	private selectedItem: number;
 	private containerEl: HTMLElement;
 	private isOpen = false;
+	private clickListener: (event: MouseEvent) => void;
+	private mousemoveListener: (event: MouseEvent) => void;
 
 	constructor(owner: ISuggestOwner<T>, containerEl: HTMLElement, scope: Scope) {
 		this.owner = owner;
 		this.containerEl = containerEl;
 
-		containerEl.on(
-			"click",
-			".suggestion-item",
-			this.onSuggestionClick.bind(this),
-		);
-		containerEl.on(
-			"mousemove",
-			".suggestion-item",
-			this.onSuggestionMouseover.bind(this),
-		);
+		this.clickListener = (event: MouseEvent) => {
+			const item = this.findSuggestionItem(event.target);
+			if (item) this.onSuggestionClick(event, item);
+		};
+		this.mousemoveListener = (event: MouseEvent) => {
+			const item = this.findSuggestionItem(event.target);
+			if (item) this.onSuggestionMouseover(event, item);
+		};
+		containerEl.addEventListener("click", this.clickListener);
+		containerEl.addEventListener("mousemove", this.mousemoveListener);
 
 		// Enhanced keyboard navigation
 		scope.register([], "ArrowUp", (event) => {
@@ -73,6 +76,15 @@ class Suggest<T> {
 		});
 	}
 
+	private findSuggestionItem(target: EventTarget | null): HTMLDivElement | null {
+		const ownerWindow = this.containerEl.ownerDocument.defaultView;
+		if (!ownerWindow || !(target instanceof ownerWindow.Element)) {
+			return null;
+		}
+		const item = target.closest<HTMLDivElement>(".suggestion-item");
+		return item && this.containerEl.contains(item) ? item : null;
+	}
+
 	onSuggestionClick(event: MouseEvent, el: HTMLDivElement): void {
 		event.preventDefault();
 
@@ -87,11 +99,13 @@ class Suggest<T> {
 	}
 
 	setSuggestions(values: T[]) {
-		this.containerEl.empty();
+		this.containerEl.replaceChildren();
 		const suggestionEls: HTMLDivElement[] = [];
 
 		values.forEach((value, index) => {
-			const suggestionEl = this.containerEl.createDiv("suggestion-item");
+			const suggestionEl = this.containerEl.ownerDocument.createElement("div");
+			suggestionEl.classList.add("suggestion-item");
+			this.containerEl.appendChild(suggestionEl);
 			// Add accessibility attributes
 			suggestionEl.setAttribute("role", "option");
 			suggestionEl.setAttribute("aria-selected", "false");
@@ -122,8 +136,8 @@ class Suggest<T> {
 		const selectedSuggestion = this.suggestions[normalizedIndex];
 
 		// Update visual selection
-		prevSelectedSuggestion?.removeClass("is-selected");
-		selectedSuggestion?.addClass("is-selected");
+		prevSelectedSuggestion?.classList.remove("is-selected");
+		selectedSuggestion?.classList.add("is-selected");
 
 		// Update accessibility attributes
 		prevSelectedSuggestion?.setAttribute("aria-selected", "false");
@@ -183,6 +197,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	private globalWheelListener: (event: WheelEvent) => void;
 	private globalResizeListener: () => void;
 	private globalBlurListener: () => void;
+	private inputBlurListener: () => void;
 
 	// Debounced input handler and bound event listeners
 	private debouncedOnInputChanged: (event?: Event) => void;
@@ -213,8 +228,11 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		this.inputEl = inputEl;
 		this.scope = new Scope();
 
-		this.suggestEl = createDiv("suggestion-container");
-		const suggestion = this.suggestEl.createDiv("suggestion");
+		this.suggestEl = this.inputEl.ownerDocument.createElement("div");
+		this.suggestEl.classList.add("suggestion-container");
+		const suggestion = this.inputEl.ownerDocument.createElement("div");
+		suggestion.classList.add("suggestion");
+		this.suggestEl.appendChild(suggestion);
 
 		// Add accessibility attributes to the suggestion container
 		suggestion.setAttribute("role", "listbox");
@@ -230,22 +248,19 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		// Store bound event listeners for proper cleanup
 		this.inputEventListener = (event: Event) => this.debouncedOnInputChanged(event);
 		this.focusEventListener = () => this.debouncedOnInputChanged();
+		this.inputBlurListener = this.close.bind(this);
 
 		this.inputEl.addEventListener("input", this.inputEventListener);
 		this.inputEl.addEventListener("focus", this.focusEventListener);
-		this.inputEl.addEventListener("blur", this.close.bind(this));
+		this.inputEl.addEventListener("blur", this.inputBlurListener);
 
 		// Set up accessibility relationship
 		this.inputEl.setAttribute("aria-autocomplete", "list");
 		this.inputEl.setAttribute("aria-expanded", "false");
 
-		this.suggestEl.on(
-			"mousedown",
-			".suggestion-container",
-			(event: MouseEvent) => {
-				event.preventDefault();
-			},
-		);
+		this.suggestEl.addEventListener("mousedown", (event: MouseEvent) => {
+			if (event.target === this.suggestEl) event.preventDefault();
+		});
 
 		// Setup global listeners
 		this.globalClickListener = this.onGlobalClick.bind(this);
@@ -337,7 +352,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	private showNoResultsAndClose(): void {
 		// Clear any existing timeout
 		if (this.noResultsTimeout) {
-			window.clearTimeout(this.noResultsTimeout);
+			getOwnerWindow(this.inputEl).clearTimeout(this.noResultsTimeout);
 		}
 
 		// Close immediately for now - could add "No matches" placeholder here
@@ -393,10 +408,12 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		});
 
 		// Add global listeners (idempotent due to capture true)
-		document.addEventListener("pointerdown", this.globalClickListener, true);
-		document.addEventListener("wheel", this.globalWheelListener, true);
-		window.addEventListener("resize", this.globalResizeListener);
-		window.addEventListener("blur", this.globalBlurListener);
+		const activeDocument = getOwnerDocument(inputEl);
+		const activeWindow = getOwnerWindow(inputEl);
+		activeDocument.addEventListener("pointerdown", this.globalClickListener, true);
+		activeDocument.addEventListener("wheel", this.globalWheelListener, true);
+		activeWindow.addEventListener("resize", this.globalResizeListener);
+		activeWindow.addEventListener("blur", this.globalBlurListener);
 	}
 
 	close(): void {
@@ -417,19 +434,21 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 			this.popper = null;
 		}
 
-		this.suggestEl.detach();
+		this.suggestEl.remove();
 
 		// Clear no results timeout
 		if (this.noResultsTimeout) {
-			window.clearTimeout(this.noResultsTimeout);
+			getOwnerWindow(this.inputEl).clearTimeout(this.noResultsTimeout);
 			this.noResultsTimeout = null;
 		}
 
 		// Remove global listeners
-		document.removeEventListener("pointerdown", this.globalClickListener, true);
-		document.removeEventListener("wheel", this.globalWheelListener, true);
-		window.removeEventListener("resize", this.globalResizeListener);
-		window.removeEventListener("blur", this.globalBlurListener);
+		const activeDocument = getOwnerDocument(this.inputEl);
+		const activeWindow = getOwnerWindow(this.inputEl);
+		activeDocument.removeEventListener("pointerdown", this.globalClickListener, true);
+		activeDocument.removeEventListener("wheel", this.globalWheelListener, true);
+		activeWindow.removeEventListener("resize", this.globalResizeListener);
+		activeWindow.removeEventListener("blur", this.globalBlurListener);
 
 		const classKey = this.constructor.name;
 		const byClass = instanceMap.get(this.inputEl);
@@ -446,7 +465,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		// Remove input listeners
 		this.inputEl.removeEventListener("input", this.inputEventListener);
 		this.inputEl.removeEventListener("focus", this.focusEventListener);
-		this.inputEl.removeEventListener("blur", this.close.bind(this));
+		this.inputEl.removeEventListener("blur", this.inputBlurListener);
 
 		// Remove from instance map
 		const classKey = this.constructor.name;

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -1,3 +1,5 @@
+import { createOwnedElement, createOwnedTextNode } from "src/utils/activeWindow";
+
 /**
  * Utility functions for text manipulation in suggesters
  */
@@ -86,9 +88,9 @@ export function renderExactHighlight(el: HTMLElement, text: string, query: strin
 	let idx = lower.indexOf(q, from);
 
 	while (idx !== -1) {
-		if (idx > from) el.append(document.createTextNode(text.slice(from, idx)));
+		if (idx > from) el.append(createOwnedTextNode(el, text.slice(from, idx)));
 
-		const mark = document.createElement('mark');
+		const mark = createOwnedElement(el, 'mark');
 		mark.className = 'qa-highlight';
 		mark.textContent = text.slice(idx, idx + query.length);
 		el.append(mark);
@@ -97,7 +99,7 @@ export function renderExactHighlight(el: HTMLElement, text: string, query: strin
 		idx = lower.indexOf(q, from);
 	}
 
-	if (from < text.length) el.append(document.createTextNode(text.slice(from)));
+	if (from < text.length) el.append(createOwnedTextNode(el, text.slice(from)));
 }
 
 /**
@@ -115,13 +117,13 @@ export function renderFuzzyHighlight(el: HTMLElement, text: string, query: strin
 
 	for (const ch of text) {
 		if (qi < q.length && ch.toLowerCase() === q[qi]) {
-			const mark = document.createElement('mark');
+			const mark = createOwnedElement(el, 'mark');
 			mark.className = 'qa-highlight';
 			mark.textContent = ch;
 			el.append(mark);
 			qi++;
 		} else {
-			el.append(document.createTextNode(ch));
+			el.append(createOwnedTextNode(el, ch));
 		}
 	}
 }

--- a/src/quickAddSettingsDevelopmentInfo.ts
+++ b/src/quickAddSettingsDevelopmentInfo.ts
@@ -1,3 +1,5 @@
+import { createOwnedElement, createOwnedTextNode } from "./utils/activeWindow";
+
 export type DevelopmentInfo = {
 	branch: string | null;
 	commit: string | null;
@@ -10,11 +12,11 @@ function appendDevelopmentInfoRow(
 	value: string,
 	options?: { className?: string },
 ): HTMLElement {
-	const row = document.createElement("div");
-	const labelEl = document.createElement("strong");
+	const row = createOwnedElement(container, "div");
+	const labelEl = createOwnedElement(container, "strong");
 	labelEl.textContent = label;
 	row.appendChild(labelEl);
-	row.appendChild(document.createTextNode(` ${value}`));
+	row.appendChild(createOwnedTextNode(container, ` ${value}`));
 	if (options?.className) row.classList.add(options.className);
 	row.style.marginBottom = "5px";
 	container.appendChild(row);

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,5 +1,5 @@
 export function waitFor(ms: number): Promise<unknown> {
-	return new Promise((res) => setTimeout(res, ms));
+	return new Promise((res) => window.setTimeout(res, ms));
 }
 
 export function getLinesInString(input: string) {

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -99,7 +99,7 @@ export function isTemplaterTriggerOnCreateEnabled(app: App): boolean {
 }
 
 function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 export async function waitForTemplaterTriggerOnCreateToComplete(

--- a/src/utils/activeWindow.ts
+++ b/src/utils/activeWindow.ts
@@ -1,0 +1,29 @@
+export function getOwnerDocument(node: Node): Document {
+	if (node.nodeType === Node.DOCUMENT_NODE) {
+		return node as Document;
+	}
+	const ownerDocument = node.ownerDocument;
+	if (!ownerDocument) {
+		throw new Error("Unable to resolve owner document for DOM node.");
+	}
+	return ownerDocument;
+}
+
+export function getOwnerWindow(node: Node): Window {
+	const ownerWindow = getOwnerDocument(node).defaultView;
+	if (!ownerWindow) {
+		throw new Error("Unable to resolve owner window for DOM node.");
+	}
+	return ownerWindow;
+}
+
+export function createOwnedElement<K extends keyof HTMLElementTagNameMap>(
+	owner: Node,
+	tagName: K,
+): HTMLElementTagNameMap[K] {
+	return getOwnerDocument(owner).createElement(tagName);
+}
+
+export function createOwnedTextNode(owner: Node, text: string): Text {
+	return getOwnerDocument(owner).createTextNode(text);
+}

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -8,8 +8,10 @@ function hasWindowFunction(name: "btoa" | "atob"): boolean {
 }
 
 function getGlobalBuffer(): undefined | { from(input: string, encoding: string): { toString(encoding: string): string } } {
-	if (typeof globalThis === "undefined") return undefined;
-	const buffer = (globalThis as Record<string, unknown>).Buffer as
+	const runtime = typeof window !== "undefined"
+		? (window as unknown as Record<string, unknown>)
+		: (globalThis as unknown as Record<string, unknown>);
+	const buffer = runtime.Buffer as
 		| { from(input: string, encoding: string): { toString(encoding: string): string } }
 		| undefined;
 	return buffer;

--- a/src/utils/deepClone.ts
+++ b/src/utils/deepClone.ts
@@ -1,5 +1,8 @@
 export function deepClone<T>(value: T): T {
-	const structuredCloneFn = (globalThis as any).structuredClone as
+	const runtime = typeof window !== "undefined" ? window : globalThis;
+	const structuredCloneFn = (runtime as typeof globalThis & {
+		structuredClone?: (value: unknown) => unknown;
+	}).structuredClone as
 		| ((value: unknown) => unknown)
 		| undefined;
 


### PR DESCRIPTION
Make DOM creation respect the owning Obsidian window/document.

This fixes platform compatibility findings where suggester and modal UI could be created against the wrong document in popout windows. It introduces owner-document/window helpers and threads that ownership through affected suggesters and GUI utilities.

Review focus:
- `activeWindow`/owner-document helper behavior.
- Popout-owned file suggester tests.
- Call sites that now create elements through the owning document instead of global `document`.

Stack position: 3/17, based on `scorecard/02-dom-safety-evidence`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOM context handling in multi-document scenarios (modals, popouts, iframes)
  * Fixed timer, tooltip and suggester rendering so elements and cleanup stay confined to the correct document/window
  * Enhanced teardown to clear lingering timers and subscriptions

* **New Features**
  * Added debounced persistence for settings to reduce repeated writes

* **Chores**
  * Refactored DOM utilities and runtime/window detection for consistent owner-document handling across components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1189)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->