### PR TITLE
fix: close platform compatibility scrutiny gaps

### DIFF
--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -319,12 +319,12 @@ export async function runAIAssistant(
 			[`${outputVariable}-quoted`]: outputInMarkdownBlockQuote,
 		};
 
-		setTimeout(() => notice.hide(), 5000);
+		window.setTimeout(() => notice.hide(), 5000);
 
 		return variables;
 	} catch (error) {
 		notice.setMessage("dead", (error as { message: string }).message);
-		setTimeout(() => notice.hide(), 5000);
+		window.setTimeout(() => notice.hide(), 5000);
 		// Always abort on cancelled input
 		if (isCancellationError(error)) {
 			throw new MacroAbortError("Input cancelled by user");
@@ -427,12 +427,12 @@ export async function Prompt(
 			[`${outputVariable}-quoted`]: outputInMarkdownBlockQuote,
 		};
 
-		setTimeout(() => notice.hide(), 5000);
+		window.setTimeout(() => notice.hide(), 5000);
 
 		return variables;
 	} catch (error) {
 		notice.setMessage("dead", (error as { message: string }).message);
-		setTimeout(() => notice.hide(), 5000);
+		window.setTimeout(() => notice.hide(), 5000);
 		// No user input in this function - re-throw original error
 		throw error;
 	}
@@ -477,7 +477,7 @@ class RateLimiter {
 			);
 			this.schedule();
 		});
-		setTimeout(() => this.schedule(), this.intervalMs);
+		window.setTimeout(() => this.schedule(), this.intervalMs);
 	}
 }
 
@@ -653,12 +653,12 @@ export async function ChunkedPrompt(
 			[`${outputVariable}-quoted`]: outputInMarkdownBlockQuote,
 		};
 
-		setTimeout(() => notice.hide(), 5000);
+		window.setTimeout(() => notice.hide(), 5000);
 
 		return variables;
 	} catch (error) {
 		notice.setMessage("dead", (error as { message: string }).message);
-		setTimeout(() => notice.hide(), 5000);
+		window.setTimeout(() => notice.hide(), 5000);
 		// No user input in this function - re-throw original error
 		throw error;
 	}

--- a/src/gui/suggesters/fileSuggester.test.ts
+++ b/src/gui/suggesters/fileSuggester.test.ts
@@ -613,7 +613,7 @@ describe('FileSuggester DOM XSS safety', () => {
 
         const obsidianFile = createRuntimeFile('Popout.md', 'Popout');
         const app = {
-            dom: { appContainerEl: popoutDocument.body },
+            dom: { appContainerEl: document.body },
             keymap: {
                 pushScope: vi.fn(),
                 popScope: vi.fn(),
@@ -656,7 +656,7 @@ describe('FileSuggester DOM XSS safety', () => {
                     displayText: 'Popout',
                 },
             ]);
-            suggester.open(popoutDocument.body, inputEl);
+            suggester.open(document.body, inputEl);
 
             const suggestion = popoutDocument.querySelector<HTMLElement>('.suggestion-item')!;
             expect(suggestion).not.toBeNull();

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -369,7 +369,11 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		// Update accessibility attributes
 		this.inputEl.setAttribute("aria-expanded", "true");
 
-		container.appendChild(this.suggestEl);
+		const inputDocument = getOwnerDocument(inputEl);
+		const containerDocument = getOwnerDocument(container);
+		const ownerCompatibleContainer =
+			containerDocument === inputDocument ? container : inputDocument.body;
+		ownerCompatibleContainer.appendChild(this.suggestEl);
 
 		// Create Popper only when needed
 		this.popper = createPopper(inputEl, this.suggestEl, {
@@ -408,7 +412,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		});
 
 		// Add global listeners (idempotent due to capture true)
-		const activeDocument = getOwnerDocument(inputEl);
+		const activeDocument = inputDocument;
 		const activeWindow = getOwnerWindow(inputEl);
 		activeDocument.addEventListener("pointerdown", this.globalClickListener, true);
 		activeDocument.addEventListener("wheel", this.globalWheelListener, true);


### PR DESCRIPTION
Close the remaining platform-scrutiny gaps after the popout DOM pass.

This tightens follow-up findings from validation: it removes the lingering raw timer usage in the AI assistant path and strengthens ownership handling in the suggest infrastructure so popout/main-window behavior is explicit.

Review focus:
- Timer usage in `AIAssistant`.
- TextInputSuggest ownership handling in `suggest.ts`.
- The small test adjustment proving the intended owner-document path.

Stack position: 4/17, based on `scorecard/03-popout-owned-dom`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.