### PR TITLE
fix: close async promise findings

### DIFF
--- a/src/ai/AIAssistant.async.test.ts
+++ b/src/ai/AIAssistant.async.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RateLimiter } from "./AIAssistant";
+
+describe("RateLimiter async rejection handling", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("rejects queued work with an Error when the original rejection is not Error-like", async () => {
+		vi.useFakeTimers();
+		const rateLimiter = new RateLimiter(1, 100);
+
+		const result = rateLimiter.add(async () => {
+			throw "network failed";
+		});
+		const assertion = expect(result).rejects.toThrow("network failed");
+		await vi.runAllTimersAsync();
+
+		await assertion;
+	});
+
+	it("continues queued work after a rejection without unhandled finally rejections", async () => {
+		vi.useFakeTimers();
+		const rateLimiter = new RateLimiter(1, 100);
+		const first = rateLimiter.add(async () => {
+			throw new Error("first failed");
+		});
+		const second = rateLimiter.add(async () => "second succeeded");
+		const firstAssertion = expect(first).rejects.toThrow("first failed");
+		const secondAssertion = expect(second).resolves.toBe("second succeeded");
+
+		await vi.runAllTimersAsync();
+
+		await firstAssertion;
+		await secondAssertion;
+	});
+});

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -181,15 +181,25 @@ async function repeatUntilResolved(
 	}
 
 	let isDone = false;
-	promise.finally(() => {
-		isDone = true;
-	});
+	void promise.then(
+		() => {
+			isDone = true;
+		},
+		() => {
+			isDone = true;
+		}
+	);
 
 	// Execute the callback function every X milliseconds until the promise is resolved
 	while (!isDone) {
 		callback();
 		await sleep(interval);
 	}
+}
+
+function toError(reason: unknown): Error {
+	if (reason instanceof Error) return reason;
+	return new Error(String(reason));
 }
 
 async function getTargetPromptTemplate(
@@ -438,7 +448,7 @@ export async function Prompt(
 	}
 }
 
-class RateLimiter {
+export class RateLimiter {
 	private queue: (() => Promise<unknown>)[] = [];
 	private pendingPromises: Promise<unknown>[] = [];
 
@@ -450,7 +460,7 @@ class RateLimiter {
 				try {
 					resolve(await promiseFactory());
 				} catch (err) {
-					reject(err);
+					reject(toError(err));
 				}
 			});
 			this.schedule();
@@ -471,12 +481,20 @@ class RateLimiter {
 
 		const promise = promiseFactory();
 		this.pendingPromises.push(promise);
-		promise.finally(() => {
-			this.pendingPromises = this.pendingPromises.filter(
-				(p) => p !== promise
-			);
-			this.schedule();
-		});
+		void promise.then(
+			() => {
+				this.pendingPromises = this.pendingPromises.filter(
+					(p) => p !== promise
+				);
+				this.schedule();
+			},
+			() => {
+				this.pendingPromises = this.pendingPromises.filter(
+					(p) => p !== promise
+				);
+				this.schedule();
+			}
+		);
 		window.setTimeout(() => this.schedule(), this.intervalMs);
 	}
 }

--- a/src/engine/QuickAddEngine.ts
+++ b/src/engine/QuickAddEngine.ts
@@ -36,7 +36,7 @@ export abstract class QuickAddEngine {
 		this.app = app;
 	}
 
-	public abstract run(): void;
+	public abstract run(): void | Promise<unknown>;
 
 	/**
 	 * Validates structured variables to ensure they can be safely processed.

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -6,6 +6,7 @@ import { MultiChoice } from "../../types/choices/MultiChoice";
 import type IMultiChoice from "../../types/choices/IMultiChoice";
 import type QuickAdd from "../../main";
 import type { IChoiceExecutor } from "../../IChoiceExecutor";
+import { log } from "../../logger/logManager";
 
 const backLabel = "← Back";
 
@@ -44,7 +45,11 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 
 	renderSuggestion(item: FuzzyMatch<IChoice>, el: HTMLElement): void {
 		el.empty();
-		void MarkdownRenderer.renderMarkdown(item.item.name, el, '', this.plugin);
+		void MarkdownRenderer.renderMarkdown(item.item.name, el, '', this.plugin)
+			.catch((error) => {
+				el.textContent = item.item.name;
+				log.logError(`Failed to render choice suggestion: ${error}`);
+			});
 		el.classList.add("quickadd-choice-suggestion");
 		if (item.item.name === backLabel)
 			el.classList.add("quickadd-choice-suggestion-back");
@@ -58,13 +63,17 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		return this.choices;
 	}
 
-	async onChooseItem(
+	onChooseItem(
 		item: IChoice,
 		evt: MouseEvent | KeyboardEvent
-	): Promise<void> {
+	): void {
 		if (item.type === "Multi")
 			this.onChooseMultiType(<IMultiChoice>item);
-		else await this.choiceExecutor.execute(item);
+		else {
+			void this.choiceExecutor.execute(item).catch((error) => {
+				log.logError(`Failed to execute selected choice: ${error}`);
+			});
+		}
 	}
 
 	private onChooseMultiType(multi: IMultiChoice) {

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -449,7 +449,7 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		super.close();
 	}
 
-	async selectSuggestion(item: SearchResult): Promise<void> {
+	selectSuggestion(item: SearchResult): void {
 		if (this.inputEl.selectionStart === null) return;
 
 		const cursorPosition: number = this.inputEl.selectionStart;

--- a/src/types/macros/EditorCommands/PasteWithFormatCommand.ts
+++ b/src/types/macros/EditorCommands/PasteWithFormatCommand.ts
@@ -29,7 +29,7 @@ export class PasteWithFormatCommand extends EditorCommand {
 					if (item.types.includes("text/html")) {
 						const htmlBlob = await item.getType("text/html");
 						const htmlContent = await htmlBlob.text();
-						content = await htmlToMarkdown(htmlContent);
+						content = htmlToMarkdown(htmlContent);
 						foundHtml = true;
 						break;
 					}


### PR DESCRIPTION
Resolve scorecard async-promise findings without changing user-visible behavior.

This PR makes promise handling explicit in AI assistant, engine, suggester, and paste-with-format paths so async work is awaited, intentionally detached, or guarded rather than left floating.

Review focus:
- `AIAssistant` async lifecycle and new regression tests.
- QuickAdd engine/suggester callback promise handling.
- Whether the added `void`/await boundaries preserve existing execution order.

Stack position: 5/17, based on `scorecard/04-platform-scrutiny`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.