### PR TITLE
fix: close type hygiene findings

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -171,7 +171,7 @@ export const RANDOM_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[R]?[A]?[N]?[D]?[O]?[M]?[:]?$|{{RANDOM:[^\n\r}]*}}$/i,
 );
 export const GLOBAL_VAR_SYNTAX_SUGGEST_REGEX = new RegExp(
-	/{{[G]?[L]?[O]?[B]?[A]?[L]?[\_]?[V]?[A]?[R]?[:]?$|{{GLOBAL_VAR:[^\n\r}]*}}$/i,
+	/{{[G]?[L]?[O]?[B]?[A]?[L]?[_]?[V]?[A]?[R]?[:]?$|{{GLOBAL_VAR:[^\n\r}]*}}$/i,
 );
 export const TIME_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[T]?[I]?[M]?[E]?[}]?[}]?/i,

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -55,6 +55,15 @@ import { buildOpenFileOptions } from "./helpers/openFileOptions";
 import { createVariablesProxy } from "../utils/variablesProxy";
 
 type ConditionalScriptRunner = () => Promise<unknown>;
+type UserScriptFunction = (
+	params: MacroChoiceEngine["params"],
+	settings: Record<string, unknown>
+) => Promise<unknown>;
+type UserScriptObjectExport = Record<string, unknown> & {
+	entry?: UserScriptFunction;
+	settings?: Record<string, unknown>;
+};
+type UserScriptExport = UserScriptFunction | UserScriptObjectExport | unknown;
 
 function getConditionalScriptCacheKey(condition: ScriptCondition): string {
 	return `${condition.scriptPath}::${condition.exportName ?? "default"}`;
@@ -289,12 +298,12 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 			| ((
 					params: typeof this.params,
 					settings: Record<string, unknown>
-			  ) => Promise<void>)
+			  ) => Promise<unknown>)
 			| {
 					entry: (
 						params: typeof this.params,
 						settings: Record<string, unknown>
-					) => Promise<void>;
+					) => Promise<unknown>;
 			  },
 		command: IUserScript
 	) {
@@ -315,23 +324,24 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 	}
 
 	 
-	protected async userScriptDelegator(userScript: any) {
+	protected async userScriptDelegator(userScript: UserScriptExport) {
 		switch (typeof userScript) {
 			case "function":
 				if (this.userScriptCommand) {
 					await this.runScriptWithSettings(
 						 
-						userScript,
+						userScript as UserScriptFunction,
 						this.userScriptCommand
 					);
 				} else {
 					 
-					await this.onExportIsFunction(userScript);
+					await this.onExportIsFunction(userScript as UserScriptFunction);
 				}
 				break;
 			case "object":
-				 
-				await this.onExportIsObject(userScript);
+				if (userScript !== null) {
+					await this.onExportIsObject(userScript as UserScriptObjectExport);
+				}
 				break;
 			case "bigint":
 			case "boolean":

--- a/src/engine/SingleInlineScriptEngine.ts
+++ b/src/engine/SingleInlineScriptEngine.ts
@@ -3,6 +3,8 @@ import type QuickAdd from "../main";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { MacroChoiceEngine } from "./MacroChoiceEngine";
 
+type AsyncFunctionConstructor = new (code: string) => () => Promise<unknown>;
+
 export class SingleInlineScriptEngine extends MacroChoiceEngine {
 	constructor(
 		app: App,
@@ -15,11 +17,10 @@ export class SingleInlineScriptEngine extends MacroChoiceEngine {
 	}
 
 	 
-	public async runAndGetOutput(code: string): Promise<any> {
-		 
+	public async runAndGetOutput(code: string): Promise<unknown> {
 		const AsyncFunction = Object.getPrototypeOf(
 			async function () {}
-		).constructor;
+		).constructor as AsyncFunctionConstructor;
 		 
 		const userCode = new AsyncFunction(code);
 

--- a/src/engine/SingleMacroEngine.ts
+++ b/src/engine/SingleMacroEngine.ts
@@ -25,6 +25,26 @@ type MemberAccessSelection = {
 	memberAccess: string[];
 };
 
+type UserScriptCallable = () => unknown | Promise<unknown>;
+
+function formatMacroOutput(value: unknown): string {
+	if (value === null || value === undefined) return "";
+	if (typeof value === "string") return value;
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+	if (typeof value === "bigint" || typeof value === "symbol") {
+		return value.toString();
+	}
+	if (value instanceof Error) return value.message;
+
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return Object.prototype.toString.call(value);
+	}
+}
+
 export class SingleMacroEngine {
 	private readonly choiceExecutor: IChoiceExecutor;
 	private readonly variables: Map<string, unknown>;
@@ -135,12 +155,12 @@ export class SingleMacroEngine {
 
 		// Handle functions and objects properly
 		if (typeof result === "function") {
-			result = await (result as (...args: any[]) => any)();
+			result = await (result as UserScriptCallable)();
 		} else if (result && typeof result === "object") {
 			result = JSON.stringify(result);
 		}
 
-		return (result ?? "").toString();
+		return formatMacroOutput(result);
 	}
 
 	public getVariables(): Map<string, unknown> {

--- a/src/engine/helpers/openFileOptions.ts
+++ b/src/engine/helpers/openFileOptions.ts
@@ -1,13 +1,14 @@
 import type { OpenFileOptions } from "../../types/fileOpening";
 import type { IOpenFileCommand } from "../../types/macros/QuickCommands/IOpenFileCommand";
+import { NewTabDirection } from "../../types/newTabDirection";
 
 function getSplitDirection(
 	direction: IOpenFileCommand["direction"],
 	fallback: "vertical" | undefined = undefined
 ): "horizontal" | "vertical" | undefined {
-	return direction === "horizontal" || direction === "vertical"
-		? direction
-		: fallback;
+	if (direction === NewTabDirection.horizontal) return "horizontal";
+	if (direction === NewTabDirection.vertical) return "vertical";
+	return fallback;
 }
 
 function createOpenFileOptions(

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -1,5 +1,5 @@
-import type { App, TFile } from "obsidian";
-import { Notice, Setting, TextComponent, ToggleComponent } from "obsidian";
+import type { App } from "obsidian";
+import { Notice, Setting, TextComponent, ToggleComponent, TFile } from "obsidian";
 import {
 	CREATE_IF_NOT_FOUND_BOTTOM,
 	CREATE_IF_NOT_FOUND_CURSOR,
@@ -558,11 +558,11 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			return null;
 		}
 
-		if (!("extension" in abstractFile) || abstractFile.extension !== "canvas") {
+		if (!(abstractFile instanceof TFile) || abstractFile.extension !== "canvas") {
 			return null;
 		}
 
-		return abstractFile as TFile;
+		return abstractFile;
 	}
 
 	private async readCanvasNodeOptions(

--- a/src/gui/ChoiceBuilder/choiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/choiceBuilder.ts
@@ -9,6 +9,16 @@ import {
 import { GenericTextSuggester } from "../suggesters/genericTextSuggester";
 import { promptRenameChoice } from "../choiceRename";
 
+type OnePageOverride = NonNullable<IChoice["onePageInput"]>;
+type ChoiceWithOpenFile = IChoice & {
+	openFile?: boolean;
+	fileOpening?: FileOpeningSettings;
+};
+
+function isOnePageOverride(value: string): value is OnePageOverride {
+	return value === "always" || value === "never";
+}
+
 export abstract class ChoiceBuilder extends Modal {
 	private resolvePromise: (input: IChoice) => void;
 	public waitForClose: Promise<IChoice>;
@@ -47,7 +57,7 @@ export abstract class ChoiceBuilder extends Modal {
 				});
 				dropdown.setValue((choice.onePageInput ?? "") as string);
 				dropdown.onChange((val: string) => {
-					choice.onePageInput = val === "" ? undefined : (val as any);
+					choice.onePageInput = isOnePageOverride(val) ? val : undefined;
 				});
 			});
 	}
@@ -103,15 +113,14 @@ export abstract class ChoiceBuilder extends Modal {
 	 * @param description Description explaining what file will be opened (e.g. "Open the file that is captured to.")
 	 */
 	protected addOpenFileSetting(description: string): void {
-		// We intentionally cast to `any` because not all IChoice implementations have openFile.
-		const choice: any = this.choice as any;
+		const choice = this.choice as ChoiceWithOpenFile;
 		if (choice.openFile === undefined) return; // Guard: nothing to configure
 
 		new Setting(this.contentEl)
 			.setName("Open")
 			.setDesc(description)
 			.addToggle((toggle) => {
-				toggle.setValue(choice.openFile);
+				toggle.setValue(choice.openFile === true);
 				toggle.onChange((value) => {
 					choice.openFile = value;
 					this.reload();
@@ -126,7 +135,7 @@ export abstract class ChoiceBuilder extends Modal {
 	 * @param contextLabel Text to use in descriptions (e.g. "captured" | "created")
 	 */
 	protected addFileOpeningSetting(contextLabel: string): void {
-		const choice: any = this.choice as any;
+		const choice = this.choice as ChoiceWithOpenFile;
 		choice.fileOpening = normalizeFileOpening(choice.fileOpening);
 
 		const fileOpening = choice.fileOpening as FileOpeningSettings;
@@ -145,7 +154,7 @@ export abstract class ChoiceBuilder extends Modal {
 					"right-sidebar": "Right sidebar",
 				});
 				dropdown.setValue(fileOpening.location);
-				dropdown.onChange((value: any) => {
+				dropdown.onChange((value) => {
 					fileOpening.location = value as OpenLocation;
 					this.reload();
 				});
@@ -162,8 +171,8 @@ export abstract class ChoiceBuilder extends Modal {
 						horizontal: "Split down",
 					});
 					dropdown.setValue(fileOpening.direction);
-					dropdown.onChange((value: any) => {
-						fileOpening.direction = value;
+					dropdown.onChange((value) => {
+						fileOpening.direction = value as FileOpeningSettings["direction"];
 					});
 				});
 		}
@@ -184,7 +193,7 @@ export abstract class ChoiceBuilder extends Modal {
 						? (fileOpening.mode as string)
 						: "default",
 				);
-				dropdown.onChange((value: any) => {
+				dropdown.onChange((value) => {
 					fileOpening.mode = value as FileViewMode2;
 				});
 			});

--- a/src/gui/MacroGUIs/UserScriptSettingsModal.ts
+++ b/src/gui/MacroGUIs/UserScriptSettingsModal.ts
@@ -40,6 +40,19 @@ type Option = { description?: string } & (
 	  }
 );
 
+function formatTitlePart(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value === null || value === undefined) return "";
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value);
+	}
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
 export class UserScriptSettingsModal extends Modal {
 	constructor(
 		app: App,
@@ -63,9 +76,9 @@ export class UserScriptSettingsModal extends Modal {
 		this.containerEl.addClass("quickAddModal", "userScriptSettingsModal");
 		this.contentEl.empty();
 
-		this.titleEl.innerText = `${this.settings?.name ?? this.command.name}${
-			this.settings?.author ? " by " + this.settings?.author : ""
-		}`;
+		const titleName = formatTitlePart(this.settings?.name ?? this.command.name);
+		const author = formatTitlePart(this.settings?.author);
+		this.titleEl.innerText = `${titleName}${author ? ` by ${author}` : ""}`;
 		const options = this.settings.options;
 
 		if (!options) {
@@ -74,7 +87,7 @@ export class UserScriptSettingsModal extends Modal {
 
 		// If there are options, add them to the modal
 		for (const option in options) {
-			if (!options.hasOwnProperty(option)) continue;
+			if (!Object.prototype.hasOwnProperty.call(options, option)) continue;
 			const entry = options[option];
 
 			let value = entry.defaultValue;

--- a/src/gui/suggesters/FieldValueInputSuggest.ts
+++ b/src/gui/suggesters/FieldValueInputSuggest.ts
@@ -8,6 +8,10 @@ import {
 } from "src/utils/FieldValueCollector";
 import { TextInputSuggest } from "./suggest";
 
+type CompletionInputEvent = Event & {
+	fromCompletion?: boolean;
+};
+
 export class FieldValueInputSuggest extends TextInputSuggest<string> {
 	private readonly fieldInput: string;
 	private readonly fieldName: string;
@@ -46,7 +50,7 @@ export class FieldValueInputSuggest extends TextInputSuggest<string> {
 		// Fill input and dispatch a synthetic input event to trigger onChange listeners
 		this.inputEl.value = item;
 		const event = new Event("input", { bubbles: true });
-		(event as any).fromCompletion = true;
+		(event as CompletionInputEvent).fromCompletion = true;
 		this.inputEl.dispatchEvent(event);
 		this.close();
 	}

--- a/src/gui/suggesters/SuggesterInputSuggest.ts
+++ b/src/gui/suggesters/SuggesterInputSuggest.ts
@@ -2,6 +2,11 @@ import type { App } from "obsidian";
 import { TextInputSuggest } from "./suggest";
 import { normalizeDisplayItem, normalizeQuery } from "./utils";
 
+type CompletionInputEvent = Event & {
+	fromCompletion?: boolean;
+	keepOpen?: boolean;
+};
+
 export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	private options: string[];
 	private caseSensitive: boolean;
@@ -78,7 +83,7 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	private selectSingleItem(item: string): void {
 		this.inputEl.value = item;
 		const event = new Event("input", { bubbles: true });
-		(event as any).fromCompletion = true;
+		(event as CompletionInputEvent).fromCompletion = true;
 		this.inputEl.dispatchEvent(event);
 		this.close();
 	}
@@ -102,11 +107,12 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 
 		// Trigger input event
 		const event = new Event("input", { bubbles: true });
-		(event as any).fromCompletion = true;
+		const completionEvent = event as CompletionInputEvent;
+		completionEvent.fromCompletion = true;
 
 		// Only keep open if there are more items to select
 		if (hasMoreItems) {
-			(event as any).keepOpen = true;
+			completionEvent.keepOpen = true;
 			this.inputEl.dispatchEvent(event);
 			// Force re-focus to trigger suggestions
 			this.inputEl.focus();

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -524,7 +524,15 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		// Need to get file again, otherwise it won't be recognized by the link generator. (hotfix, but not a good solution)
 		const file = this.app.vault.getAbstractFileByPath(
 			linkFile.path
-		) as TFile;
+		);
+		if (!(file instanceof TFile)) {
+			return this.makeLinkManually(
+				currentInputValue,
+				linkFile.path,
+				cursorPosition,
+				lastInputLength
+			);
+		}
 		const link = this.app.fileManager.generateMarkdownLink(
 			file,
 			this.getSourcePath(),

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -10,6 +10,11 @@ const wrapAround = (value: number, size: number): number => {
 	return ((value % size) + size) % size;
 };
 
+type CompletionInputEvent = Event & {
+	fromCompletion?: boolean;
+	keepOpen?: boolean;
+};
+
 class Suggest<T> {
 	private owner: ISuggestOwner<T>;
 	private values: T[];
@@ -288,8 +293,9 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	}
 
 	async onInputChanged(event?: Event): Promise<void> {
+		const completionEvent = event as CompletionInputEvent | undefined;
 		// Handle multi-select mode: keep suggestions open after selection
-		if (event && (event as any).fromCompletion && (event as any).keepOpen) {
+		if (completionEvent?.fromCompletion && completionEvent.keepOpen) {
 			const inputStr = this.inputEl.value;
 			const requestId = ++this.currentRequestId;
 			this.currentQuery = inputStr;
@@ -315,7 +321,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		}
 
 		// Ignore programmatic changes from completion selection
-		if (event && (event as any).fromCompletion) {
+		if (completionEvent?.fromCompletion) {
 			return;
 		}
 

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -1,5 +1,9 @@
 import { createOwnedElement, createOwnedTextNode } from "src/utils/activeWindow";
 
+type CompletionInputEvent = Event & {
+	fromCompletion?: boolean;
+};
+
 /**
  * Utility functions for text manipulation in suggesters
  */
@@ -56,7 +60,7 @@ export function replaceRange(
 	const event = new Event("input", { bubbles: true });
 	if (options.fromCompletion) {
 		// Mark this as a programmatic completion change
-		(event as any).fromCompletion = true;
+		(event as CompletionInputEvent).fromCompletion = true;
 	}
 	input.dispatchEvent(event);
 }

--- a/src/logger/logDecorator.ts
+++ b/src/logger/logDecorator.ts
@@ -9,17 +9,24 @@ import { log } from "./logManager";
 * A decorator function that logs the method call with its arguments and return value.
 * Used by writing @logDecorator above a method.
 */
-function logDecorator(target: any, key: string, descriptor: PropertyDescriptor) {
-  const originalMethod = descriptor.value;
+function logDecorator(
+	target: object,
+	key: string,
+	descriptor: PropertyDescriptor,
+) {
+	const originalMethod = descriptor.value as (
+		this: unknown,
+		...args: unknown[]
+	) => unknown;
 
-  descriptor.value = function (...args: any[]) {
-    log.logMessage(`Method ${key} called with arguments: ${JSON.stringify(args)}`);
-    const result = originalMethod.apply(this, args);
-    log.logMessage(`Method ${key} returned: ${JSON.stringify(result)}`);
-    return result;
-  };
+	descriptor.value = function (...args: unknown[]) {
+		log.logMessage(`Method ${key} called with arguments: ${JSON.stringify(args)}`);
+		const result = originalMethod.apply(this, args);
+		log.logMessage(`Method ${key} returned: ${JSON.stringify(result)}`);
+		return result;
+	};
 
-  return descriptor;
+	return descriptor;
 }
 
 export default logDecorator;

--- a/src/migrations/backfillFileOpeningDefaults.ts
+++ b/src/migrations/backfillFileOpeningDefaults.ts
@@ -32,8 +32,13 @@ const backfillFileOpeningDefaults: Migration = {
 					templateOrCaptureChoice.fileOpening !== null
 					? (templateOrCaptureChoice.fileOpening as Partial<FileOpeningSettings>)
 					: undefined;
-			const legacyTabRaw = (templateOrCaptureChoice as any).openFileInNewTab;
-			const legacyMode = (templateOrCaptureChoice as any).openFileInMode;
+			const legacyChoice = templateOrCaptureChoice as
+				| (ITemplateChoice | ICaptureChoice) & {
+						openFileInNewTab?: unknown;
+						openFileInMode?: unknown;
+				  };
+			const legacyTabRaw = legacyChoice.openFileInNewTab;
+			const legacyMode = legacyChoice.openFileInMode;
 			const legacyTab = coerceLegacyOpenFileInNewTab(legacyTabRaw);
 
 			const needsDefaults =

--- a/src/migrations/consolidateFileExistsBehavior.ts
+++ b/src/migrations/consolidateFileExistsBehavior.ts
@@ -6,21 +6,25 @@ import {
 } from "./helpers/normalizeTemplateFileExistsBehavior";
 import { walkAllChoices } from "./helpers/choice-traversal";
 import type { Migration } from "./Migrations";
+import type { IMacro } from "src/types/macros/IMacro";
+
+type SettingsWithLegacyMacros = QuickAdd["settings"] & { macros?: IMacro[] };
 
 const consolidateFileExistsBehavior: Migration = {
 	description:
 		"Re-run template file collision normalization for users with older migration state",
 
 	migrate: async (plugin: QuickAdd): Promise<void> => {
+		const settings = plugin.settings as SettingsWithLegacyMacros;
 		const choices = Array.isArray(plugin.settings.choices)
 			? plugin.settings.choices
 			: [];
-		const macros = Array.isArray((plugin.settings as any).macros)
-			? (plugin.settings as any).macros
+		const macros = Array.isArray(settings.macros)
+			? settings.macros
 			: [];
 
 		plugin.settings.choices = deepClone(choices);
-		(plugin.settings as any).macros = deepClone(macros);
+		settings.macros = deepClone(macros);
 
 		walkAllChoices(plugin, (choice) => {
 			if (isTemplateChoice(choice)) {

--- a/src/migrations/helpers/choice-traversal.ts
+++ b/src/migrations/helpers/choice-traversal.ts
@@ -81,10 +81,14 @@ export function walkAllChoices(plugin: QuickAdd, visitor: ChoiceVisitor): void {
 		walkChoice(choice, visitor, visited);
 	}
 
-	const legacyMacros = (plugin.settings as any).macros;
+	const legacyMacros = (plugin.settings as { macros?: unknown }).macros;
 	if (Array.isArray(legacyMacros)) {
 		for (const macro of legacyMacros) {
-			walkCommands(macro?.commands, visitor, visited);
+			const commands =
+				macro && typeof macro === "object"
+					? (macro as { commands?: ICommand[] }).commands
+					: undefined;
+			walkCommands(commands, visitor, visited);
 		}
 	}
 }

--- a/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
+++ b/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
@@ -12,6 +12,7 @@ type OldTemplateChoice = {
 	setFileExistsBehavior?: boolean;
 	fileExistsMode?: unknown;
 };
+type SettingsWithLegacyMacros = QuickAdd["settings"] & { macros?: IMacro[] };
 
 function isOldTemplateChoice(
 	choice: unknown,
@@ -65,23 +66,19 @@ const incrementFileNameSettingMoveToDefaultBehavior: Migration = {
 		"'Increment file name' setting moved to 'Set default behavior if file already exists' setting",
 	 
 	migrate: async (plugin: QuickAdd): Promise<void> => {
+		const settings = plugin.settings as SettingsWithLegacyMacros;
 		const choicesCopy = deepClone(plugin.settings.choices);
 		const choices = recursiveRemoveIncrementFileName(choicesCopy);
 
-		const macrosCopy = deepClone((plugin.settings as any).macros || []);
+		const macrosCopy = deepClone(settings.macros ?? []);
 		const macros = removeIncrementFileName(macrosCopy);
 
 		plugin.settings.choices = deepClone(choices);
 		
 		// Save the migrated macros back to settings - later migrations still need it
-		(plugin.settings as any).macros = macros;
+		settings.macros = macros;
 		
-		/* DO NOT delete macros here – later migrations still need it
-		// Clean up legacy macros array if it exists
-		if ('macros' in plugin.settings) {
-			delete (plugin.settings as any).macros;
-		}
-		*/
+		// DO NOT delete macros here – later migrations still need it.
 	},
 };
 

--- a/src/migrations/migrateFileOpeningSettings.ts
+++ b/src/migrations/migrateFileOpeningSettings.ts
@@ -10,6 +10,10 @@ import {
 	createFileOpeningFromLegacy,
 } from "./helpers/file-opening-legacy";
 
+type LegacyFileOpeningChoice = (ITemplateChoice | ICaptureChoice) & {
+	openFileInNewTab?: unknown;
+	openFileInMode?: unknown;
+};
 
 const migrateFileOpeningSettings: Migration = {
 	description: "Migrate legacy openFileInNewTab settings to new fileOpening format",
@@ -22,11 +26,11 @@ const migrateFileOpeningSettings: Migration = {
 		const migrateFileOpening = (choice: IChoice) => {
 			if (choice.type !== "Template" && choice.type !== "Capture") return;
 
-			const templateOrCaptureChoice = choice as ITemplateChoice | ICaptureChoice;
+			const templateOrCaptureChoice = choice as LegacyFileOpeningChoice;
 			
 			// Only migrate if new fileOpening doesn't exist but legacy settings do
-			const legacyTabRaw = (templateOrCaptureChoice as any).openFileInNewTab;
-			const legacyMode = (templateOrCaptureChoice as any).openFileInMode;
+			const legacyTabRaw = templateOrCaptureChoice.openFileInNewTab;
+			const legacyMode = templateOrCaptureChoice.openFileInMode;
 			const legacyTab = coerceLegacyOpenFileInNewTab(legacyTabRaw);
 			
 			if (!templateOrCaptureChoice.fileOpening && legacyTab) {

--- a/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
+++ b/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
@@ -5,6 +5,9 @@ import { isMultiChoice } from "./helpers/isMultiChoice";
 import { isNestedChoiceCommand } from "./helpers/isNestedChoiceCommand";
 import type { Migration } from "./Migrations";
 import { deepClone } from "src/utils/deepClone";
+import type QuickAdd from "src/main";
+
+type SettingsWithLegacyMacros = QuickAdd["settings"] & { macros?: IMacro[] };
 
 function recursiveMigrateSettingInChoices(choices: IChoice[]): IChoice[] {
 	for (const choice of choices) {
@@ -49,23 +52,19 @@ const mutualExclusionInsertAfterAndWriteToBottomOfFile: Migration = {
 		"Mutual exclusion of insertAfter and writeToBottomOfFile settings. If insertAfter is enabled, writeToBottomOfFile is disabled. To support changes in settings UI.",
 	 
 	migrate: async (plugin) => {
+		const settings = plugin.settings as SettingsWithLegacyMacros;
 		const choicesCopy = deepClone(plugin.settings.choices);
 		const choices = recursiveMigrateSettingInChoices(choicesCopy);
 
-		const macrosCopy = deepClone((plugin.settings as any).macros || []);
+		const macrosCopy = deepClone(settings.macros ?? []);
 		const macros = migrateSettingsInMacros(macrosCopy);
 
 		plugin.settings.choices = choices;
 		
 		// Save the migrated macros back to settings - later migrations still need it
-		(plugin.settings as any).macros = macros;
+		settings.macros = macros;
 		
-		/* DO NOT delete macros here – later migrations still need it
-		// Clean up legacy macros array if it exists
-		if ('macros' in plugin.settings) {
-			delete (plugin.settings as any).macros;
-		}
-		*/
+		// DO NOT delete macros here – later migrations still need it.
 	},
 };
 

--- a/src/migrations/removeMacroIndirection.ts
+++ b/src/migrations/removeMacroIndirection.ts
@@ -5,14 +5,23 @@ import { MacroChoice } from "src/types/choices/MacroChoice";
 import { flattenChoices } from "src/utils/choiceUtils";
 import type { Migration } from "./Migrations";
 
+type LegacySettings = QuickAdd["settings"] & { macros?: LegacyMacro[] };
+type LegacyMacro = {
+	id: string;
+	name: string;
+	commands?: IMacroChoice["macro"]["commands"];
+	runOnStartup?: boolean;
+};
+type LegacyMacroChoice = IMacroChoice & { macroId?: string };
+
 const removeMacroIndirection: Migration = {
 	description:
 		"Remove macro indirection - embed macros directly in macro choices",
 	migrate: async (plugin: QuickAdd) => {
-		const settings = plugin.settings;
+		const settings = plugin.settings as LegacySettings;
 
 		// Check if we have the old macros array
-		const oldMacros = (settings as any).macros || [];
+		const oldMacros = settings.macros ?? [];
 
 		// Map macroId → all choices that reference it
 		const choicesByMacroId = new Map<string, IMacroChoice[]>();
@@ -20,10 +29,10 @@ const removeMacroIndirection: Migration = {
 
 		for (const choice of allChoices) {
 			if (choice.type === "Macro") {
-				const macroChoice = choice as IMacroChoice;
+				const macroChoice = choice as LegacyMacroChoice;
 				// Check if this has the old macroId property
-				if ((macroChoice as any).macroId) {
-					const macroId = (macroChoice as any).macroId;
+				if (macroChoice.macroId) {
+					const macroId = macroChoice.macroId;
 					if (!choicesByMacroId.has(macroId)) {
 						choicesByMacroId.set(macroId, []);
 					}
@@ -63,7 +72,7 @@ const removeMacroIndirection: Migration = {
 					choice.runOnStartup ??= macro.runOnStartup ?? false;
 
 					// Remove the old macroId property
-					delete (choice as any).macroId;
+					delete (choice as LegacyMacroChoice).macroId;
 				}
 			}
 		}
@@ -72,19 +81,19 @@ const removeMacroIndirection: Migration = {
 		// (in case oldMacros was empty but choices still had macroId)
 		for (const choice of allChoices) {
 			if (choice.type === "Macro") {
-				const macroChoice = choice as IMacroChoice;
-				if ((macroChoice as any).macroId) {
+				const macroChoice = choice as LegacyMacroChoice;
+				if (macroChoice.macroId) {
 					log.logMessage(
-						`Removing orphaned macroId reference: ${(macroChoice as any).macroId}`,
+						`Removing orphaned macroId reference: ${macroChoice.macroId}`,
 					);
-					delete (macroChoice as any).macroId;
+					delete macroChoice.macroId;
 				}
 			}
 		}
 
 		// Remove the old macros array
 		if ("macros" in settings) {
-			delete (settings as any).macros;
+			delete settings.macros;
 		}
 	},
 };

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -16,6 +16,10 @@ import {
 	getOrderedDateAliases,
 } from "src/utils/dateAliases";
 import { settingsStore } from "src/settingsStore";
+type CompletionInputEvent = Event & {
+	fromCompletion?: boolean;
+};
+
 import type { FieldRequirement } from "./RequirementCollector";
 import {
 	mapMappedSuggesterValue,
@@ -374,7 +378,9 @@ export class OnePageInputModal extends Modal {
 					.setValue(startingDisplay)
 					.onChange((v) => setValue(req.id, v));
 				input.inputEl.addEventListener("input", (event) => {
-					const fromCompletion = Boolean((event as any).fromCompletion);
+					const fromCompletion = Boolean(
+						(event as CompletionInputEvent).fromCompletion,
+					);
 					const rawInput = input.inputEl.value;
 					const storedValue = mapMappedSuggesterValue(
 						rawInput,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,7 +73,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	dateAliases: DEFAULT_DATE_ALIASES,
 	ai: {
 		defaultModel: "Ask me",
-		defaultSystemPrompt: `As an AI assistant within Obsidian, your primary goal is to help users manage their ideas and knowledge more effectively. Format your responses using Markdown syntax. Please use the [[Obsidian]] link format. You can write aliases for the links by writing [[Obsidian|the alias after the pipe symbol]]. To use mathematical notation, use LaTeX syntax. LaTeX syntax for larger equations should be on separate lines, surrounded with double dollar signs ($$). You can also inline math expressions by wrapping it in $ symbols. For example, use $$w_{ij}^{\text{new}}:=w_{ij}^{\text{current}}+\eta\cdot\delta_j\cdot x_{ij}$$ on a separate line, but you can write "($\eta$ = learning rate, $\delta_j$ = error term, $x_{ij}$ = input)" inline.`,
+		defaultSystemPrompt: `As an AI assistant within Obsidian, your primary goal is to help users manage their ideas and knowledge more effectively. Format your responses using Markdown syntax. Please use the [[Obsidian]] link format. You can write aliases for the links by writing [[Obsidian|the alias after the pipe symbol]]. To use mathematical notation, use LaTeX syntax. LaTeX syntax for larger equations should be on separate lines, surrounded with double dollar signs ($$). You can also inline math expressions by wrapping it in $ symbols. For example, use $$w_{ij}^{\\text{new}}:=w_{ij}^{\\text{current}}+\\eta\\cdot\\delta_j\\cdot x_{ij}$$ on a separate line, but you can write "($\\eta$ = learning rate, $\\delta_j$ = error term, $x_{ij}$ = input)" inline.`,
 		promptTemplatesFolderPath: "",
 		showAssistant: true,
 		providers: DefaultProviders,

--- a/src/types/fileOpening.ts
+++ b/src/types/fileOpening.ts
@@ -25,5 +25,5 @@ export interface OpenFileOptions {
   mode?: FileViewMode2;              // default: leave as-is
   focus?: boolean;                   // default: true
   /** Optional ephemeral state passed to setViewState */
-  eState?: any;
+  eState?: Record<string, unknown>;
 }

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -864,6 +864,16 @@ function findUnpinnedNavigableSibling(
 	return orderedLeaves.find((leaf) => candidates.includes(leaf)) ?? candidates[0];
 }
 
+function isTFileLike(file: unknown): file is TFile {
+	if (file instanceof TFile) return true;
+	return (
+		typeof file === "object" &&
+		file !== null &&
+		"path" in file &&
+		typeof file.path === "string"
+	);
+}
+
 function resolveLeafForOpenFileLocation(
 	app: App,
 	location: FileOpenLocation,
@@ -940,10 +950,14 @@ export async function openFile(
 
 	const file =
 		typeof fileOrPath === "string"
-			? (app.vault.getAbstractFileByPath(fileOrPath) as TFile | null)
+			? app.vault.getAbstractFileByPath(fileOrPath)
 			: fileOrPath;
 
-	if (!file) throw new Error(`File not found: ${String(fileOrPath)}`);
+	if (!isTFileLike(file)) {
+		const fileLabel =
+			typeof fileOrPath === "string" ? fileOrPath : fileOrPath.path;
+		throw new Error(`File not found: ${fileLabel}`);
+	}
 
 	const openOriginLeaf = originLeaf ?? getOpenFileOriginLeaf(app);
 	const leaf = resolveLeafForOpenFileLocation(
@@ -960,21 +974,21 @@ export async function openFile(
 	// Optionally adjust view mode (Reading / Live Preview / Source)
 	if (mode && mode !== "default" && !(typeof mode === "object" && mode.mode === "default")) {
 		const vs = leaf.getViewState();
-		const next = { ...(vs.state ?? {}) };
+		const next: Record<string, unknown> = { ...(vs.state ?? {}) };
 
 		if (mode === "preview" || (typeof mode === "object" && mode.mode === "preview")) {
 			next.mode = "preview";
-			delete (next as any).source;
+			delete next.source;
 		} else if (mode === "source") {
 			next.mode = "source";
-			(next as any).source = true;
+			next.source = true;
 		} else if (mode === "live" || mode === "live-preview") {
 			next.mode = "source";
-			(next as any).source = false; // Live Preview = source:false
+			next.source = false; // Live Preview = source:false
 		} else if (typeof mode === "object" && mode.mode === "source") {
 			// advanced override
 			next.mode = "source";
-			(next as any).source = mode.source;
+			next.source = mode.source;
 		}
 
 		// Fix eState usage - merge into state rather than passing as second param
@@ -1161,14 +1175,14 @@ function getFileTags(app: App, file: TFile): string[] {
 	}
 
 	if (fileCache.tags && Array.isArray(fileCache.tags)) {
-		tagsInFile.push(...fileCache.tags.map((v) => v.tag.replace(/^\#/, "")));
+		tagsInFile.push(...fileCache.tags.map((v) => v.tag.replace(/^#/, "")));
 	}
 
 	return tagsInFile;
 }
 
 export function getMarkdownFilesWithTag(app: App, tag: string): TFile[] {
-	const targetTag = tag.replace(/^\#/, "");
+	const targetTag = tag.replace(/^#/, "");
 
 	return app.vault.getMarkdownFiles().filter((f: TFile) => {
 		const fileTags = getFileTags(app, f);

--- a/src/utils/DataviewIntegration.ts
+++ b/src/utils/DataviewIntegration.ts
@@ -2,6 +2,17 @@ import type { App } from "obsidian";
 import { getAPI, type DataviewApi } from "obsidian-dataview";
 import { log } from "src/logger/logManager";
 
+type DataviewFileLike = { path: string };
+
+function isDataviewFileLike(value: unknown): value is DataviewFileLike {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"path" in value &&
+		typeof value.path === "string"
+	);
+}
+
 // biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
 export class DataviewIntegration {
 	private static getDataviewAPI(app: App): DataviewApi | null {
@@ -45,14 +56,14 @@ export class DataviewIntegration {
 						fieldValue.forEach(v => {
 							if (v && typeof v === 'string') {
 								values.add(v.trim());
-							} else if (v && typeof v === 'object' && v.path) {
+							} else if (isDataviewFileLike(v)) {
 								// Handle file objects from Dataview
 								values.add(v.path);
 							} else if (v && typeof v !== 'object') {
 								values.add(String(v).trim());
 							}
 						});
-					} else if (fieldValue && typeof fieldValue === 'object' && fieldValue.path) {
+					} else if (isDataviewFileLike(fieldValue)) {
 						// Handle single file object from Dataview
 						values.add(fieldValue.path);
 					} else if (fieldValue && typeof fieldValue === 'string') {
@@ -152,14 +163,14 @@ export class DataviewIntegration {
 						fieldValue.forEach(v => {
 							if (v && typeof v === 'string') {
 								values.add(v.trim());
-							} else if (v && typeof v === 'object' && v.path) {
+							} else if (isDataviewFileLike(v)) {
 								// Handle file objects from Dataview
 								values.add(v.path);
 							} else if (v && typeof v !== 'object') {
 								values.add(String(v).trim());
 							}
 						});
-					} else if (fieldValue && typeof fieldValue === 'object' && fieldValue.path) {
+					} else if (isDataviewFileLike(fieldValue)) {
 						// Handle single file object from Dataview
 						values.add(fieldValue.path);
 					} else if (fieldValue && typeof fieldValue === 'string') {

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -42,7 +42,7 @@ export class FieldSuggestionParser {
 				case "folder":
 					filters.folder = filterValue;
 					break;
-				case "tag":
+				case "tag": {
 					if (!filters.tags) {
 						filters.tags = [];
 					}
@@ -52,6 +52,7 @@ export class FieldSuggestionParser {
 						: filterValue;
 					filters.tags.push(tagName);
 					break;
+				}
 				case "inline":
 					filters.inline = filterValue.toLowerCase() === "true";
 					break;
@@ -84,7 +85,7 @@ export class FieldSuggestionParser {
 					}
 					filters.excludeFolders.push(filterValue);
 					break;
-				case "exclude-tag":
+				case "exclude-tag": {
 					if (!filters.excludeTags) {
 						filters.excludeTags = [];
 					}
@@ -94,6 +95,7 @@ export class FieldSuggestionParser {
 						: filterValue;
 					filters.excludeTags.push(excludeTagName);
 					break;
+				}
 				case "exclude-file":
 					if (!filters.excludeFiles) {
 						filters.excludeFiles = [];

--- a/src/utils/conditionalHelpers.ts
+++ b/src/utils/conditionalHelpers.ts
@@ -22,6 +22,19 @@ const OPERATORS_REQUIRING_EXPECTED: ConditionalOperator[] = [
 const BOOLEAN_TRUE_VALUES = new Set(["true", "1", "yes", "on"]);
 const BOOLEAN_FALSE_VALUES = new Set(["false", "0", "no", "off"]);
 
+function formatUnknownValue(value: unknown): string {
+	if (value === null || value === undefined) return "";
+	if (typeof value === "string") return value;
+	if (typeof value === "number" || typeof value === "boolean") return String(value);
+	if (typeof value === "bigint" || typeof value === "symbol") return value.toString();
+	if (value instanceof Error) return value.message;
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return Object.prototype.toString.call(value);
+	}
+}
+
 export function requiresExpectedValue(operator: ConditionalOperator): boolean {
 	return OPERATORS_REQUIRING_EXPECTED.includes(operator);
 }
@@ -98,7 +111,7 @@ export function normalizeVariableValue(
 		case "string":
 		default:
 			if (value === null || value === undefined) return "";
-			return String(value);
+			return formatUnknownValue(value);
 	}
 }
 


### PR DESCRIPTION
Address the broad type-hygiene scorecard findings across engine, GUI, migrations, and utilities.

This replaces unsafe assumptions with narrower types, safer traversal helpers, and explicit conversions in areas that previously relied on casts or loosely typed values. The intent is behavior preservation with better static guarantees.

Review focus:
- Macro and script engine type narrowing.
- Migration helper/traversal changes.
- Suggester and utility changes that affect user-provided values.

Stack position: 6/17, based on `scorecard/05-async-promise-findings`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.