### PR TITLE
fix: close type hygiene scrutiny gaps

### DIFF
--- a/src/engine/MacroChoiceEngine.entry.test.ts
+++ b/src/engine/MacroChoiceEngine.entry.test.ts
@@ -193,6 +193,65 @@ describe("MacroChoiceEngine user script entry handling", () => {
 		expect(engine["output"]).toBe("entry-result");
 	});
 
+	it("initializes user script settings only from object-shaped settings exports", async () => {
+		const entryFn = vi.fn().mockResolvedValue("entry-result");
+		const settings = {
+			apiKey: {
+				type: "text",
+				defaultValue: "abc123",
+			},
+		};
+
+		mockGetUserScript.mockResolvedValue({
+			entry: entryFn,
+			settings,
+		});
+
+		const engine = new MacroChoiceEngine(
+			app,
+			plugin,
+			macroChoice,
+			choiceExecutor,
+			variables,
+		);
+
+		await engine["executeUserScript"](userScriptCommand);
+
+		expect(mockInitializeUserScriptSettings).toHaveBeenCalledWith(
+			userScriptCommand.settings,
+			settings,
+		);
+		expect(entryFn).toHaveBeenCalledWith(
+			expect.objectContaining({ variables: expect.any(Object) }),
+			userScriptCommand.settings,
+		);
+	});
+
+	it("ignores malformed primitive settings exports at the user-script boundary", async () => {
+		const entryFn = vi.fn().mockResolvedValue("entry-result");
+
+		mockGetUserScript.mockResolvedValue({
+			entry: entryFn,
+			settings: "not-settings",
+		});
+
+		const engine = new MacroChoiceEngine(
+			app,
+			plugin,
+			macroChoice,
+			choiceExecutor,
+			variables,
+		);
+
+		await engine["executeUserScript"](userScriptCommand);
+
+		expect(mockInitializeUserScriptSettings).not.toHaveBeenCalled();
+		expect(entryFn).toHaveBeenCalledWith(
+			expect.objectContaining({ variables: expect.any(Object) }),
+			userScriptCommand.settings,
+		);
+	});
+
 	it("prompts the user when no entry export is defined", async () => {
 		const optionFn = vi.fn().mockResolvedValue("option-result");
 

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -63,7 +63,27 @@ type UserScriptObjectExport = Record<string, unknown> & {
 	entry?: UserScriptFunction;
 	settings?: Record<string, unknown>;
 };
-type UserScriptExport = UserScriptFunction | UserScriptObjectExport | unknown;
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function isUserScriptFunction(value: unknown): value is UserScriptFunction {
+	return typeof value === "function";
+}
+
+function isUserScriptObjectExport(
+	value: unknown
+): value is UserScriptObjectExport {
+	return isRecord(value);
+}
+
+function getUserScriptSettings(
+	value: unknown
+): Record<string, unknown> | undefined {
+	if (!isUserScriptObjectExport(value)) return undefined;
+	const { settings } = value;
+	return isRecord(settings) ? settings : undefined;
+}
 
 function getConditionalScriptCacheKey(condition: ScriptCondition): string {
 	return `${condition.scriptPath}::${condition.exportName ?? "default"}`;
@@ -272,11 +292,10 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 
 		this.userScriptCommand = command;
 
-		// @ts-ignore
-		if (userScript.settings) {
+		const userScriptSettings = getUserScriptSettings(userScript);
+		if (userScriptSettings) {
 			// Initialize default values for settings before executing the script
-			// @ts-ignore
-			initializeUserScriptSettings(command.settings, userScript.settings);
+			initializeUserScriptSettings(command.settings, userScriptSettings);
 		}
 
 		try {
@@ -324,23 +343,24 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 	}
 
 	 
-	protected async userScriptDelegator(userScript: UserScriptExport) {
+	protected async userScriptDelegator(userScript: unknown) {
 		switch (typeof userScript) {
 			case "function":
+				if (!isUserScriptFunction(userScript)) {
+					break;
+				}
 				if (this.userScriptCommand) {
 					await this.runScriptWithSettings(
-						 
-						userScript as UserScriptFunction,
+						userScript,
 						this.userScriptCommand
 					);
 				} else {
-					 
-					await this.onExportIsFunction(userScript as UserScriptFunction);
+					await this.onExportIsFunction(userScript);
 				}
 				break;
 			case "object":
-				if (userScript !== null) {
-					await this.onExportIsObject(userScript as UserScriptObjectExport);
+				if (isUserScriptObjectExport(userScript)) {
+					await this.onExportIsObject(userScript);
 				}
 				break;
 			case "bigint":

--- a/src/engine/conditionalEvaluator.test.ts
+++ b/src/engine/conditionalEvaluator.test.ts
@@ -109,6 +109,23 @@ describe("evaluateCondition", () => {
 		expect(falsyResult).toBe(true);
 	});
 
+	it("preserves object containment through safe formatting", async () => {
+		const condition: VariableCondition = {
+			mode: "variable",
+			variableName: "payload",
+			operator: "contains",
+			valueType: "string",
+			expectedValue: '"needle":true',
+		};
+
+		const result = await evaluateCondition(condition, {
+			variables: { payload: { needle: true } },
+			evaluateScriptCondition: noopScriptEvaluator,
+		});
+
+		expect(result).toBe(true);
+	});
+
 	it("delegates script conditions", async () => {
 		const condition: ScriptCondition = {
 			mode: "script",

--- a/src/engine/helpers/conditionalEvaluator.ts
+++ b/src/engine/helpers/conditionalEvaluator.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../types/macros/Conditional/types";
 import {
 	normalizeExpectedValue,
+	formatUnknownValue,
 	normalizeVariableValue,
 	requiresExpectedValue,
 } from "../../utils/conditionalHelpers";
@@ -50,9 +51,9 @@ function evaluateVariableCondition(
 
 	switch (condition.operator) {
 		case "isTruthy":
-			return Boolean(rawValue);
+			return !!rawValue;
 		case "isFalsy":
-			return !Boolean(rawValue);
+			return !rawValue;
 	}
 
 	if (requiresExpectedValue(condition.operator)) {
@@ -100,14 +101,17 @@ function evaluateContains(
 	}
 
 	if (typeof rawValue === "string") {
-		return rawValue.includes(String(expected));
+		return rawValue.includes(formatUnknownValue(expected));
 	}
 
 	if (typeof rawValue === "number" && typeof expected === "number") {
 		return rawValue === expected;
 	}
 
-	return String(rawValue).includes(String(expected));
+	const formattedValue = formatUnknownValue(rawValue);
+	const formattedExpected = formatUnknownValue(expected);
+	return typeof formattedValue === "string"
+		&& formattedValue.includes(formattedExpected);
 }
 
 function evaluateComparable(

--- a/src/formatters/formatter-text-mapping.test.ts
+++ b/src/formatters/formatter-text-mapping.test.ts
@@ -27,8 +27,16 @@ class TextMappingFormatter extends Formatter {
 		this.hasExplicitSuggestionResult = true;
 	}
 
+	public setVariable(name: string, value: unknown): void {
+		this.variables.set(name, value);
+	}
+
 	public async testFormat(input: string): Promise<string> {
 		return await this.format(input);
+	}
+
+	public async testValueFormat(input: string): Promise<string> {
+		return await this.replaceValueInString(input);
 	}
 
 	protected async format(input: string): Promise<string> {
@@ -174,5 +182,13 @@ describe("Formatter VALUE text mapping", () => {
 		await expect(
 			formatter.testFormat("{{VALUE:a,b|text:Same,Same}}"),
 		).rejects.toThrow(/duplicate text entries/i);
+	});
+
+	it("formats injected object VALUE variables without default object stringification", async () => {
+		formatter.setVariable("value", { title: "Project", count: 2 });
+
+		const result = await formatter.testValueFormat("{{VALUE}}");
+
+		expect(result).toBe('{"title":"Project","count":2}');
 	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -35,6 +35,7 @@ import {
 	type ValueInputType,
 } from "../utils/valueSyntax";
 import { parseMacroToken } from "../utils/macroSyntax";
+import { formatUnknownValue } from "../utils/conditionalHelpers";
 
 export type LinkToCurrentFileBehavior = "required" | "optional";
 
@@ -161,7 +162,7 @@ export abstract class Formatter {
 		// Preserve programmatic VALUE injection via reserved variable name `value`.
 		if (this.hasConcreteVariable("value")) {
 			const existingValue = this.variables.get("value");
-			this.value = existingValue === null ? "" : String(existingValue);
+			this.value = formatUnknownValue(existingValue);
 		}
 
 		// Prompt only once per formatter run (empty string is a valid value).
@@ -639,7 +640,7 @@ export abstract class Formatter {
 					formattedDate = storedValue;
 				} else if (storedValue != null) {
 					// Fallback: avoid throwing if a non-string value is stored.
-					formattedDate = `${storedValue}`;
+					formattedDate = formatUnknownValue(storedValue);
 				}
 
 				// Replace the specific match rather than using regex again

--- a/src/formatters/vdate-default.test.ts
+++ b/src/formatters/vdate-default.test.ts
@@ -115,6 +115,10 @@ class TestFormatter extends Formatter {
     public async testReplaceDateVariableInString(input: string): Promise<string> {
         return await this.replaceDateVariableInString(input);
     }
+
+    public setVariable(name: string, value: unknown): void {
+        this.variables.set(name, value);
+    }
 }
 
 describe('VDATE Default Value Support', () => {
@@ -277,6 +281,16 @@ describe('VDATE Default Value Support', () => {
 
             expect(formatter.testDateParser.parseDate).toHaveBeenCalledWith("2026-05-04");
             expect(result).toBe("Date: YYYY-MM-DD-formatted");
+        });
+
+        it('formats malformed non-string stored values without object default stringification', async () => {
+            formatter.setVariable('date', { unexpected: 'shape' });
+
+            const result = await formatter.testReplaceDateVariableInString(
+                "Date: {{VDATE:date,YYYY-MM-DD}}",
+            );
+
+            expect(result).toBe('Date: {"unexpected":"shape"}');
         });
     });
 

--- a/src/utils/conditionalHelpers.ts
+++ b/src/utils/conditionalHelpers.ts
@@ -22,7 +22,7 @@ const OPERATORS_REQUIRING_EXPECTED: ConditionalOperator[] = [
 const BOOLEAN_TRUE_VALUES = new Set(["true", "1", "yes", "on"]);
 const BOOLEAN_FALSE_VALUES = new Set(["false", "0", "no", "off"]);
 
-function formatUnknownValue(value: unknown): string {
+export function formatUnknownValue(value: unknown): string {
 	if (value === null || value === undefined) return "";
 	if (typeof value === "string") return value;
 	if (typeof value === "number" || typeof value === "boolean") return String(value);


### PR DESCRIPTION
Add targeted fixes and tests for the type-hygiene scrutiny follow-up.

Validation found remaining edge cases around macro entry handling, conditional evaluation, formatter text mapping, and VDATE defaults. This PR closes those gaps with focused implementation changes and regression tests.

Review focus:
- Macro choice entry behavior and tests.
- Conditional evaluator handling of typed values.
- Formatter/VDATE regression coverage.

Stack position: 7/17, based on `scorecard/06-type-hygiene`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.