### PR TITLE
fix: make unknown formatting total

### DIFF
--- a/src/utils/conditionalHelpers.test.ts
+++ b/src/utils/conditionalHelpers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatUnknownValue } from "./conditionalHelpers";
+
+describe("formatUnknownValue", () => {
+	it("preserves existing formatting for ordinary values", () => {
+		expect(formatUnknownValue("ready")).toBe("ready");
+		expect(formatUnknownValue(42)).toBe("42");
+		expect(formatUnknownValue(true)).toBe("true");
+		expect(formatUnknownValue(null)).toBe("");
+		expect(formatUnknownValue(undefined)).toBe("");
+		expect(formatUnknownValue(["alpha", "beta"])).toBe('["alpha","beta"]');
+		expect(formatUnknownValue({ status: "ready" })).toBe('{"status":"ready"}');
+	});
+
+	it("uses a fallback when JSON.stringify returns undefined", () => {
+		function namedFormatterFallback() {
+			return "not used";
+		}
+
+		const jsonUndefinedObject = {
+			toJSON: () => undefined,
+		};
+
+		expect(formatUnknownValue(namedFormatterFallback)).toBe("[object Function]");
+		expect(formatUnknownValue(jsonUndefinedObject)).toBe("[object Object]");
+	});
+});

--- a/src/utils/conditionalHelpers.ts
+++ b/src/utils/conditionalHelpers.ts
@@ -29,7 +29,8 @@ export function formatUnknownValue(value: unknown): string {
 	if (typeof value === "bigint" || typeof value === "symbol") return value.toString();
 	if (value instanceof Error) return value.message;
 	try {
-		return JSON.stringify(value);
+		const json = JSON.stringify(value);
+		return json ?? Object.prototype.toString.call(value);
 	} catch {
 		return Object.prototype.toString.call(value);
 	}


### PR DESCRIPTION
Make unknown-value formatting total instead of throwing on difficult inputs.

This small follow-up ensures conditional formatting can produce a safe fallback for unknown values, including values whose normal stringification may fail. It adds regression coverage for the fallback behavior.

Review focus:
- `formatUnknown`/conditional helper fallback behavior.
- The new tests for non-standard stringification paths.
- Whether fallback output remains useful without leaking unsafe assumptions.

Stack position: 8/17, based on `scorecard/07-type-hygiene-scrutiny`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.