### PR TITLE
fix: close type hygiene user testing gaps

### DIFF
--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -95,7 +95,7 @@ function serialize(response: CliResponse): string {
 	return JSON.stringify(response);
 }
 
-function isTruthy(value: string | "true" | undefined): boolean {
+function isTruthy(value: string | undefined): boolean {
 	if (value === undefined) return false;
 	const normalized = value.toLowerCase();
 	return (

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -327,7 +327,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					defaultReason: "Capture aborted",
 				})
 			) {
-				this.choiceExecutor.signalAbort?.(err as MacroAbortError);
+				this.choiceExecutor.signalAbort?.(err);
 				return;
 			}
 			reportError(err, `Error running capture choice "${this.choice.name}"`);

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -59,6 +59,42 @@ type UserScriptFunction = (
 	params: MacroChoiceEngine["params"],
 	settings: Record<string, unknown>
 ) => Promise<unknown>;
+
+function isObsidianCommand(command: ICommand): command is IObsidianCommand {
+	return command.type === CommandType.Obsidian;
+}
+
+function isUserScriptCommand(command: ICommand): command is IUserScript {
+	return command.type === CommandType.UserScript;
+}
+
+function isChoiceCommand(command: ICommand): command is IChoiceCommand {
+	return command.type === CommandType.Choice;
+}
+
+function isWaitCommand(command: ICommand): command is IWaitCommand {
+	return command.type === CommandType.Wait;
+}
+
+function isNestedChoiceCommand(command: ICommand): command is INestedChoiceCommand {
+	return command.type === CommandType.NestedChoice;
+}
+
+function isEditorCommand(command: ICommand): command is IEditorCommand {
+	return command.type === CommandType.EditorCommand;
+}
+
+function isAIAssistantCommand(command: ICommand): command is IAIAssistantCommand {
+	return command.type === CommandType.AIAssistant;
+}
+
+function isOpenFileCommand(command: ICommand): command is IOpenFileCommand {
+	return command.type === CommandType.OpenFile;
+}
+
+function isConditionalCommand(command: ICommand): command is IConditionalCommand {
+	return command.type === CommandType.Conditional;
+}
 type UserScriptObjectExport = Record<string, unknown> & {
 	entry?: UserScriptFunction;
 	settings?: Record<string, unknown>;
@@ -223,30 +259,29 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 	protected async executeCommands(commands: ICommand[]) {
 		try {
 			for (const command of commands) {
-				if (command?.type === CommandType.Obsidian)
-					this.executeObsidianCommand(command as IObsidianCommand);
-				if (command?.type === CommandType.UserScript)
-					await this.executeUserScript(command as IUserScript);
-				if (command?.type === CommandType.Choice)
-					await this.executeChoice(command as IChoiceCommand);
-				if (command?.type === CommandType.Wait) {
-					const waitCommand: IWaitCommand = command as IWaitCommand;
-					await waitFor(waitCommand.time);
+				if (isObsidianCommand(command))
+					this.executeObsidianCommand(command);
+				if (isUserScriptCommand(command))
+					await this.executeUserScript(command);
+				if (isChoiceCommand(command))
+					await this.executeChoice(command);
+				if (isWaitCommand(command)) {
+					await waitFor(command.time);
 				}
-				if (command?.type === CommandType.NestedChoice) {
-					await this.executeNestedChoice(command as INestedChoiceCommand);
+				if (isNestedChoiceCommand(command)) {
+					await this.executeNestedChoice(command);
 				}
-				if (command?.type === CommandType.EditorCommand) {
-					await this.executeEditorCommand(command as IEditorCommand);
+				if (isEditorCommand(command)) {
+					await this.executeEditorCommand(command);
 				}
-				if (command?.type === CommandType.AIAssistant) {
-					await this.executeAIAssistant(command as IAIAssistantCommand);
+				if (isAIAssistantCommand(command)) {
+					await this.executeAIAssistant(command);
 				}
-				if (command?.type === CommandType.OpenFile) {
-					await this.executeOpenFile(command as IOpenFileCommand);
+				if (isOpenFileCommand(command)) {
+					await this.executeOpenFile(command);
 				}
-				if (command?.type === CommandType.Conditional) {
-					await this.executeConditional(command as IConditionalCommand);
+				if (isConditionalCommand(command)) {
+					await this.executeConditional(command);
 				}
 			}
 		} catch (error) {
@@ -257,7 +292,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 					defaultReason: "Macro execution aborted",
 				})
 			) {
-				this.choiceExecutor.signalAbort?.(error as MacroAbortError);
+				this.choiceExecutor.signalAbort?.(error);
 				return;
 			}
 			throw error;
@@ -267,19 +302,19 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 	// Slightly modified from Templater's user script engine:
 	// https://github.com/SilentVoid13/Templater/blob/master/src/UserTemplates/UserTemplateParser.ts
 	protected async executeUserScript(command: IUserScript) {
-	const cacheKey = command.path ?? command.id;
-	let userScript: unknown | undefined;
-	if (cacheKey !== undefined) {
-		const cached = this.preloadedUserScripts.get(cacheKey);
-		if (cached !== undefined) {
-			userScript = cached;
-			this.preloadedUserScripts.delete(cacheKey);
+		const cacheKey = command.path ?? command.id;
+		let userScript: unknown;
+		if (cacheKey !== undefined) {
+			const cached = this.preloadedUserScripts.get(cacheKey);
+			if (cached !== undefined) {
+				userScript = cached;
+				this.preloadedUserScripts.delete(cacheKey);
+			}
 		}
-	}
 
-	if (userScript === undefined) {
-		userScript = await getUserScript(command, this.app);
-	}
+		if (userScript === undefined) {
+			userScript = await getUserScript(command, this.app);
+		}
 
 		if (!userScript) {
 			log.logError(`failed to load user script ${command.path}.`);

--- a/src/engine/SingleMacroEngine.ts
+++ b/src/engine/SingleMacroEngine.ts
@@ -278,7 +278,7 @@ export class SingleMacroEngine {
 					defaultReason: "Macro execution aborted",
 				})
 			) {
-				this.choiceExecutor.signalAbort?.(error as MacroAbortError);
+				this.choiceExecutor.signalAbort?.(error);
 				throw error;
 			}
 			throw error;

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -167,7 +167,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					defaultReason: "Template execution aborted",
 				})
 			) {
-				this.choiceExecutor.signalAbort?.(err as MacroAbortError);
+				this.choiceExecutor.signalAbort?.(err);
 				return;
 			}
 			reportError(err, `Error running template choice "${this.choice.name}"`);

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -142,7 +142,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		}
 
 		if (this.choice.insertAfter.enabled) {
-			return (await this.insertAfterHandler(formatted)) as string;
+			return await this.insertAfterHandler(formatted);
 		}
 
 		const frontmatterEndPosition = this.file

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,7 +6,7 @@ import type {
 
 declare module "obsidian" {
 	interface CliData {
-		[key: string]: string | "true";
+		[key: string]: string;
 	}
 
 	interface CliFlag {

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -73,7 +73,9 @@ export class AIAssistantCommandSettingsModal extends Modal {
 					this.settings.name = newName;
 					this.reload();
 				}
-			} catch {} // no new name, don't need exceptional state for that
+			} catch {
+				// No new name, so the modal keeps the current command name.
+			}
 		});
 
 		this.addPromptTemplateSetting(this.contentEl);

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -68,7 +68,9 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 					this.settings.name = newName;
 					this.reload();
 				}
-			} catch {} // no new name, don't need exceptional state for that
+			} catch {
+				// No new name, so the modal keeps the current command name.
+			}
 		});
 
 		this.addResultJoinerSetting(this.contentEl);

--- a/src/gui/components/validatedInput.ts
+++ b/src/gui/components/validatedInput.ts
@@ -68,13 +68,13 @@ export function createValidatedInput(
 			? new TextAreaComponent(parent)
 			: new TextComponent(parent);
 
-	const inputEl = component.inputEl as HTMLInputElement | HTMLTextAreaElement;
+	const inputEl = component.inputEl;
 	const activeWindow = getOwnerWindow(inputEl);
 
 	if (fullWidth) inputEl.style.width = "100%";
 	inputEl.style.marginBottom = `${marginBottomPx}px`;
 	if (inputKind === "textarea") {
-		(inputEl as HTMLTextAreaElement).style.minHeight = "10rem";
+		inputEl.style.minHeight = "10rem";
 	}
 	if (placeholder) component.setPlaceholder(placeholder);
 	component.setValue(initialValue);

--- a/src/gui/suggesters/LaTeXSuggester.ts
+++ b/src/gui/suggesters/LaTeXSuggester.ts
@@ -8,21 +8,19 @@ const LATEX_REGEX = new RegExp(/\\([a-z{}A-Z0-9]*)$/);
 
 export class LaTeXSuggester extends TextInputSuggest<string> {
 	private lastInput = "";
-	private symbols;
-	private elementsRendered;
+	private symbols: string[];
+	private elementsRendered: Record<string, HTMLElement>;
 
 	constructor(public inputEl: HTMLInputElement | HTMLTextAreaElement) {
 		super(QuickAdd.instance.app, inputEl);
 		this.symbols = Object.assign([], LaTeXSymbols);
 
-		this.elementsRendered = this.symbols.reduce((elements, symbol) => {
+		this.elementsRendered = this.symbols.reduce<Record<string, HTMLElement>>((elements, symbol) => {
 			try {
-				//@ts-ignore
-				 
 				elements[symbol.toString()] = renderMath(symbol, true);
-			
-						// Ignoring symbols that we can't use
-			} catch {} 	 
+			} catch {
+				// Ignore symbols that Obsidian's math renderer cannot render.
+			}
 
 			return elements;
 		}, {});

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -698,19 +698,20 @@ export class QuickAddApi {
 		options?: { renderItem?: (value: string, el: HTMLElement) => void; },
 	) {
 		try {
-			let displayedItems;
+			let displayedItems: string[];
 
 			if (typeof displayItems === "function") {
-				displayedItems = actualItems.map(displayItems);
+				displayedItems = actualItems.map((value, index, arr) =>
+					normalizeDisplayItem(displayItems(value, index, arr)),
+				);
 			} else {
-				displayedItems = displayItems;
+				displayedItems = displayItems.map((item) => normalizeDisplayItem(item));
 			}
-			displayedItems = displayedItems.map((item) => normalizeDisplayItem(item));
 
 			if (allowCustomInput) {
 				return await InputSuggester.Suggest(
 					app,
-					displayedItems as string[],
+					displayedItems,
 					actualItems,
 					{
 						...(placeholder ? { placeholder } : {}),
@@ -723,7 +724,7 @@ export class QuickAddApi {
 
 			return await GenericSuggester.Suggest(
 				app,
-				displayedItems as string[],
+				displayedItems,
 				actualItems,
 				placeholder,
 				options?.renderItem,

--- a/src/utils/FieldValueCollector.ts
+++ b/src/utils/FieldValueCollector.ts
@@ -189,7 +189,9 @@ async function collectTagValuesFromFiles(
 						if (tag) values.add(tag);
 					}
 				}
-			} catch {}
+			} catch {
+				// Ignore unreadable metadata for this file and continue collecting.
+			}
 			return values;
 		});
 
@@ -254,9 +256,13 @@ async function collectFieldValuesManually(
 							const t = String(s).trim();
 							if (t) values.add(t);
 						});
-					} catch {}
+					} catch {
+						// Ignore files whose contents cannot be read for inline fields.
+					}
 				}
-			} catch {}
+			} catch {
+				// Ignore unreadable metadata for this file and continue collecting.
+			}
 			return values;
 		});
 

--- a/src/utils/templatePropertyStringParser.ts
+++ b/src/utils/templatePropertyStringParser.ts
@@ -116,7 +116,7 @@ function supportsCommaList(propertyType: string | null): boolean {
 export function parseStructuredPropertyValueFromString(
 	value: string,
 	options?: ParseOptions,
-): unknown | undefined {
+): unknown {
 	const trimmed = value.trim();
 	if (!trimmed) return undefined;
 

--- a/src/utils/yamlContext.ts
+++ b/src/utils/yamlContext.ts
@@ -26,7 +26,8 @@ export function getYamlContextForMatch(
   matchEnd: number,
   yamlRange: YamlRange,
 ): YamlMatchContext {
-  const isInYaml = yamlRange !== null && matchStart >= yamlRange[0]! && matchStart <= yamlRange[1]!;
+  const [yamlStart, yamlEnd] = yamlRange ?? [Number.NaN, Number.NaN];
+  const isInYaml = yamlRange !== null && matchStart >= yamlStart && matchStart <= yamlEnd;
   if (!isInYaml) {
     return {
       isInYaml: false,


### PR DESCRIPTION
Close type-hygiene issues surfaced during user-testing flows.

This PR applies the type-safety cleanup to CLI handlers, choice engines, formatter plumbing, AI command settings, LaTeX suggestions, API entrypoints, and field collection paths that were exercised during Obsidian-backed validation.

Review focus:
- Macro choice and field collection behavior under real QuickAdd flows.
- CLI/API type boundaries.
- UI settings paths touched by the cleanup.

Stack position: 9/17, based on `scorecard/08-unknown-format-total`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.