### PR TITLE
fix: guard nullish macro commands

### DIFF
--- a/src/engine/MacroChoiceEngine.entry.test.ts
+++ b/src/engine/MacroChoiceEngine.entry.test.ts
@@ -681,6 +681,65 @@ describe("MacroChoiceEngine choice command cancellation", () => {
 	});
 });
 
+describe("MacroChoiceEngine malformed saved command entries", () => {
+	const executeCommandById = vi.fn();
+	const app = {
+		commands: {
+			executeCommandById,
+		},
+	} as unknown as App;
+	const plugin = {} as unknown as QuickAdd;
+
+	let choiceExecutor: IChoiceExecutor;
+	let variables: Map<string, unknown>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		executeCommandById.mockReset();
+		variables = new Map<string, unknown>();
+		choiceExecutor = {
+			execute: vi.fn(),
+			variables,
+		};
+	});
+
+	it("skips nullish persisted macro command entries without blocking valid commands", async () => {
+		const macroChoice: IMacroChoice = {
+			id: "macro-nullish-commands",
+			name: "Macro with nullish commands",
+			type: "Macro",
+			command: false,
+			runOnStartup: false,
+			macro: {
+				id: "macro-nullish-commands",
+				name: "Macro with nullish commands",
+				commands: [
+					null,
+					undefined,
+					{
+						id: "obsidian-command",
+						name: "Run Obsidian command",
+						type: CommandType.Obsidian,
+						commandId: "app:valid-command",
+					},
+				] as unknown as IMacro["commands"],
+			} as IMacro,
+		};
+
+		const engine = new MacroChoiceEngine(
+			app,
+			plugin,
+			macroChoice,
+			choiceExecutor,
+			variables,
+		);
+
+		await expect(engine.run()).resolves.toBeUndefined();
+		expect(executeCommandById).toHaveBeenCalledTimes(1);
+		expect(executeCommandById).toHaveBeenCalledWith("app:valid-command");
+	});
+});
+
 describe("QuickAddApi prompt cancellation", () => {
 	const app = {} as App;
 

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -60,40 +60,53 @@ type UserScriptFunction = (
 	settings: Record<string, unknown>
 ) => Promise<unknown>;
 
-function isObsidianCommand(command: ICommand): command is IObsidianCommand {
-	return command.type === CommandType.Obsidian;
+function hasCommandType(
+	command: unknown,
+	type: CommandType
+): command is ICommand {
+	return isRecord(command) && command.type === type;
 }
 
-function isUserScriptCommand(command: ICommand): command is IUserScript {
-	return command.type === CommandType.UserScript;
+function isObsidianCommand(command: unknown): command is IObsidianCommand {
+	return hasCommandType(command, CommandType.Obsidian);
 }
 
-function isChoiceCommand(command: ICommand): command is IChoiceCommand {
-	return command.type === CommandType.Choice;
+function isUserScriptCommand(command: unknown): command is IUserScript {
+	return hasCommandType(command, CommandType.UserScript);
 }
 
-function isWaitCommand(command: ICommand): command is IWaitCommand {
-	return command.type === CommandType.Wait;
+function isChoiceCommand(command: unknown): command is IChoiceCommand {
+	return hasCommandType(command, CommandType.Choice);
 }
 
-function isNestedChoiceCommand(command: ICommand): command is INestedChoiceCommand {
-	return command.type === CommandType.NestedChoice;
+function isWaitCommand(command: unknown): command is IWaitCommand {
+	return hasCommandType(command, CommandType.Wait);
 }
 
-function isEditorCommand(command: ICommand): command is IEditorCommand {
-	return command.type === CommandType.EditorCommand;
+function isNestedChoiceCommand(
+	command: unknown
+): command is INestedChoiceCommand {
+	return hasCommandType(command, CommandType.NestedChoice);
 }
 
-function isAIAssistantCommand(command: ICommand): command is IAIAssistantCommand {
-	return command.type === CommandType.AIAssistant;
+function isEditorCommand(command: unknown): command is IEditorCommand {
+	return hasCommandType(command, CommandType.EditorCommand);
 }
 
-function isOpenFileCommand(command: ICommand): command is IOpenFileCommand {
-	return command.type === CommandType.OpenFile;
+function isAIAssistantCommand(
+	command: unknown
+): command is IAIAssistantCommand {
+	return hasCommandType(command, CommandType.AIAssistant);
 }
 
-function isConditionalCommand(command: ICommand): command is IConditionalCommand {
-	return command.type === CommandType.Conditional;
+function isOpenFileCommand(command: unknown): command is IOpenFileCommand {
+	return hasCommandType(command, CommandType.OpenFile);
+}
+
+function isConditionalCommand(
+	command: unknown
+): command is IConditionalCommand {
+	return hasCommandType(command, CommandType.Conditional);
 }
 type UserScriptObjectExport = Record<string, unknown> & {
 	entry?: UserScriptFunction;


### PR DESCRIPTION
Guard macro command execution against nullish command results.

This fixes a concrete macro-engine edge case found during the type-hygiene pass: macro commands may resolve through nullable paths, and those should be handled deliberately rather than assuming a command object is always present.

Review focus:
- Macro command lookup and execution guard behavior.
- New macro entry tests for nullish command handling.
- Preservation of normal macro command execution.

Stack position: 10/17, based on `scorecard/09-type-hygiene-user-testing`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.