### PR TITLE
fix: migrate ui styling batch a

### DIFF
--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -135,8 +135,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 		const formatInput = new TextComponent(this.contentEl);
 		formatInput.setPlaceholder("File name format");
 		textField = formatInput;
-		formatInput.inputEl.style.width = "100%";
-		formatInput.inputEl.style.marginBottom = "8px";
+		formatInput.inputEl.addClass("qa-template-format-input");
 
 		formatInput
 			.setValue(this.choice.fileNameFormat.format)
@@ -260,7 +259,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 			"folderInputContainer",
 		);
 		const folderInput = new TextComponent(inputContainer);
-		folderInput.inputEl.style.width = "100%";
+		folderInput.inputEl.addClass("qa-folder-path-input");
 		folderInput.setPlaceholder("Folder path");
 		const allFolders: string[] = sortFolderPathsByTree(
 			getAllFolderPathsInVault(this.app),

--- a/src/gui/MultiChoiceSettingsModal.ts
+++ b/src/gui/MultiChoiceSettingsModal.ts
@@ -60,10 +60,7 @@ export class MultiChoiceSettingsModal extends Modal {
 		new ButtonComponent(buttonRow)
 			.setButtonText("Cancel")
 			.onClick(() => this.cancel());
-		buttonRow.style.display = "flex";
-		buttonRow.style.justifyContent = "flex-end";
-		buttonRow.style.gap = "0.5rem";
-		buttonRow.style.marginTop = "1rem";
+		buttonRow.addClass("qa-modal-button-row");
 	}
 
 	private submit() {

--- a/src/gui/VDateInputPrompt/VDateInputPrompt.ts
+++ b/src/gui/VDateInputPrompt/VDateInputPrompt.ts
@@ -73,7 +73,7 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 		// Create TextComponent directly to avoid duplicate onChange listeners
 		const textComponent = new TextComponent(container);
 		
-		textComponent.inputEl.style.width = "100%";
+		textComponent.inputEl.addClass("qa-vdate-input");
 		textComponent
 			.setPlaceholder(placeholder ?? "")
 			.setValue(value ?? "")
@@ -113,26 +113,16 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 
 	private createPreviewElement(container: HTMLElement) {
 		const previewContainer = container.createDiv("vdate-preview-container");
-		previewContainer.style.marginTop = "0.5rem";
-		previewContainer.style.padding = "0.5rem";
-		previewContainer.style.backgroundColor = "var(--background-modifier-form-field)";
-		previewContainer.style.borderRadius = "4px";
-		previewContainer.style.fontSize = "0.9em";
 		
-		const previewLabel = previewContainer.createEl("div", {
+		previewContainer.createEl("div", {
 			text: "Preview:",
 			cls: "vdate-preview-label"
 		});
-		previewLabel.style.fontWeight = "600";
-		previewLabel.style.marginBottom = "0.25rem";
-		previewLabel.style.color = "var(--text-muted)";
 		
 		this.previewEl = previewContainer.createEl("div", {
 			cls: "vdate-preview-text"
 		});
-		this.previewEl.style.fontFamily = "var(--font-monospace)";
 		this.previewEl.textContent = VDateInputPrompt.PREVIEW_PLACEHOLDER;
-		this.previewEl.style.color = "var(--text-normal)";
 
 		const aliasEntries = getOrderedDateAliases(
 			settingsStore.getState().dateAliases,
@@ -141,13 +131,11 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 			const aliasDetails = previewContainer.createEl("details", {
 				cls: "vdate-alias-details",
 			});
-			aliasDetails.style.marginTop = "0.25rem";
 
 			const aliasSummary = aliasDetails.createEl("summary", {
 				text: `Aliases (${aliasEntries.length})`,
 			});
-			aliasSummary.style.fontSize = "0.85em";
-			aliasSummary.style.color = "var(--text-muted)";
+			aliasSummary.addClass("vdate-alias-summary");
 
 			const aliasList = aliasDetails.createEl("div", {
 				cls: "vdate-alias-list",
@@ -155,10 +143,6 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 			aliasList.textContent = formatDateAliasInline(
 				settingsStore.getState().dateAliases,
 			);
-			aliasList.style.marginTop = "0.25rem";
-			aliasList.style.fontSize = "0.85em";
-			aliasList.style.color = "var(--text-muted)";
-			aliasList.style.fontFamily = "var(--font-monospace)";
 		}
 	}
 
@@ -267,12 +251,7 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 
 	private setPreviewText(text: string, isError: boolean) {
 		this.previewEl.textContent = text;
-
-		if (isError) {
-			this.previewEl.style.color = "var(--text-error)";
-		} else {
-			this.previewEl.style.color = "var(--text-normal)";
-		}
+		this.previewEl.toggleClass("is-error", isError);
 	}
 
 	onOpen() {

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -78,22 +78,16 @@ export class OnePageInputModal extends Modal {
 		this.contentEl.empty();
 
 		const title = this.contentEl.createEl("h2", { text: "Provide inputs" });
-		title.style.textAlign = "center";
+		title.addClass("qa-onepage-title");
 
 		// Optional live preview area
 		if (this.computePreview) {
 			this.previewContainerEl = this.contentEl.createDiv();
 			this.previewContainerEl.addClass("qa-onepage-preview");
-			this.previewContainerEl.style.padding = "0.5rem";
-			this.previewContainerEl.style.marginBottom = "0.75rem";
-			this.previewContainerEl.style.backgroundColor =
-				"var(--background-modifier-form-field)";
-			this.previewContainerEl.style.borderRadius = "4px";
 			const label = this.previewContainerEl.createEl("div", {
 				text: "Preview",
 			});
-			label.style.fontWeight = "600";
-			label.style.marginBottom = "0.25rem";
+			label.addClass("qa-onepage-preview-label");
 			this.updatePreviews();
 		}
 
@@ -132,8 +126,7 @@ export class OnePageInputModal extends Modal {
 					.setPlaceholder(req.placeholder ?? "")
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
-				input.inputEl.style.width = "100%";
-				input.inputEl.style.height = "120px";
+				input.inputEl.addClass("qa-onepage-textarea");
 				break;
 			}
 			case "text": {
@@ -170,8 +163,7 @@ export class OnePageInputModal extends Modal {
 					const note = setting.controlEl.createDiv({
 						text: req.placeholder || "No options available",
 					});
-					note.style.marginLeft = "0.5rem";
-					note.style.color = "var(--text-muted)";
+					note.addClass("qa-onepage-dropdown-note");
 				}
 				break;
 			}
@@ -214,31 +206,25 @@ export class OnePageInputModal extends Modal {
 				});
 
 				const preview = container.createDiv();
-				preview.style.marginTop = "0.25rem";
-				preview.style.fontSize = "0.9em";
-				preview.style.fontFamily = "var(--font-monospace)";
+				preview.addClass("qa-date-preview-text");
 
 				const aliasEntries = getOrderedDateAliases(
 					settingsStore.getState().dateAliases,
 				);
 				if (aliasEntries.length > 0) {
 					const aliasDetails = container.createEl("details");
-					aliasDetails.style.marginTop = "0.25rem";
+					aliasDetails.addClass("qa-date-alias-details");
 
 					const aliasSummary = aliasDetails.createEl("summary", {
 						text: `Aliases (${aliasEntries.length})`,
 					});
-					aliasSummary.style.fontSize = "0.85em";
-					aliasSummary.style.color = "var(--text-muted)";
+					aliasSummary.addClass("qa-date-alias-summary");
 
 					const aliasList = aliasDetails.createEl("div");
 					aliasList.textContent = formatDateAliasInline(
 						settingsStore.getState().dateAliases,
 					);
-					aliasList.style.marginTop = "0.25rem";
-					aliasList.style.fontSize = "0.85em";
-					aliasList.style.color = "var(--text-muted)";
-					aliasList.style.fontFamily = "var(--font-monospace)";
+					aliasList.addClass("qa-date-alias-list");
 				}
 
 				const formatIsoForDisplay = (iso: string) => {
@@ -251,9 +237,7 @@ export class OnePageInputModal extends Modal {
 
 				const renderPreview = (text: string, isError: boolean) => {
 					preview.setText(text);
-					preview.style.color = isError
-						? "var(--text-error)"
-						: "var(--text-normal)";
+					preview.toggleClass("is-error", isError);
 				};
 
 				const syncSelection = (iso?: string) => {
@@ -478,13 +462,13 @@ export class OnePageInputModal extends Modal {
 				children[i].remove();
 			}
 			Object.entries(preview).forEach(([k, v]) => {
-				const row = this.previewContainerEl!.createDiv();
-				row.style.display = "flex";
-				row.style.gap = "0.5rem";
+				const row = this.previewContainerEl!.createDiv({
+					cls: "qa-onepage-preview-row",
+				});
 				row.createEl("div", {
 					text: `${k}:`,
 					cls: "qa-preview-key",
-				}).style.fontWeight = "600";
+				});
 				row.createEl("div", { text: String(v), cls: "qa-preview-val" });
 			});
 		} catch {

--- a/src/quickAddSettingsDevelopmentInfo.ts
+++ b/src/quickAddSettingsDevelopmentInfo.ts
@@ -18,7 +18,7 @@ function appendDevelopmentInfoRow(
 	row.appendChild(labelEl);
 	row.appendChild(createOwnedTextNode(container, ` ${value}`));
 	if (options?.className) row.classList.add(options.className);
-	row.style.marginBottom = "5px";
+	row.classList.add("qa-dev-info-row");
 	container.appendChild(row);
 	return row;
 }

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -117,14 +117,8 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 
 	private prepareFullWidthSetting(setting: Setting): void {
 		setting.infoEl.remove();
-		setting.settingEl.style.display = "block";
-		setting.controlEl.style.width = "100%";
-		setting.controlEl.style.flex = "1 1 auto";
-		setting.controlEl.style.display = "block";
-		setting.controlEl.style.marginLeft = "0";
-		setting.controlEl.style.justifyContent = "flex-start";
-		setting.controlEl.style.alignItems = "stretch";
-		setting.controlEl.style.textAlign = "left";
+		setting.settingEl.addClass("qa-setting-full-width");
+		setting.controlEl.addClass("qa-setting-full-width-control");
 	}
 
 	private addDevelopmentInfoSetting(group: SettingGroupLike) {
@@ -133,9 +127,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			setting.setDesc("Git information for developers.");
 
 			const infoContainer = setting.settingEl.createDiv();
-			infoContainer.style.marginTop = "10px";
-			infoContainer.style.fontFamily = "var(--font-monospace)";
-			infoContainer.style.fontSize = "0.9em";
+			infoContainer.addClass("qa-dev-info");
 
 			renderDevelopmentInfo(infoContainer, {
 				branch: __DEV_GIT_BRANCH__,
@@ -428,13 +420,8 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 				"Shortcodes for natural language date parsing. " +
 					"One per line: alias = phrase. Example: tm = tomorrow.",
 			);
-			setting.settingEl.style.alignItems = "flex-start";
-			setting.controlEl.style.display = "flex";
-			setting.controlEl.style.flexWrap = "wrap";
-			setting.controlEl.style.gap = "0.5rem";
-			setting.controlEl.style.alignItems = "flex-start";
-			setting.controlEl.style.flex = "1 1 320px";
-			setting.controlEl.style.minWidth = "240px";
+			setting.settingEl.addClass("qa-date-alias-setting");
+			setting.controlEl.addClass("qa-date-alias-control");
 
 			let textAreaRef: TextAreaComponent | null = null;
 
@@ -450,11 +437,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 							dateAliases: parseDateAliasLines(value),
 						});
 					});
-				textArea.inputEl.style.width = "100%";
-				textArea.inputEl.style.minHeight = "6rem";
-				textArea.inputEl.style.flex = "1 1 280px";
-				textArea.inputEl.style.maxWidth = "100%";
-				textArea.inputEl.style.boxSizing = "border-box";
+				textArea.inputEl.addClass("qa-date-alias-input");
 			});
 
 			setting.addButton((button) => {
@@ -470,8 +453,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 							);
 						}
 					});
-				button.buttonEl.style.alignSelf = "flex-start";
-				button.buttonEl.style.whiteSpace = "nowrap";
+				button.buttonEl.addClass("qa-date-alias-reset");
 			});
 		});
 	}

--- a/src/styles.css
+++ b/src/styles.css
@@ -74,6 +74,150 @@
 	font-weight: 600;
 }
 
+.quickAddModal .qa-onepage-title {
+	text-align: center;
+}
+
+.quickAddModal .qa-onepage-preview,
+.quickAddModal .vdate-preview-container {
+	padding: 0.5rem;
+	margin-bottom: 0.75rem;
+	background-color: var(--background-modifier-form-field);
+	border-radius: 4px;
+}
+
+.quickAddModal .vdate-preview-container {
+	margin-top: 0.5rem;
+	font-size: 0.9em;
+}
+
+.quickAddModal .qa-onepage-preview-label,
+.quickAddModal .vdate-preview-label,
+.quickAddModal .qa-preview-key {
+	font-weight: 600;
+}
+
+.quickAddModal .qa-onepage-preview-label,
+.quickAddModal .vdate-preview-label {
+	margin-bottom: 0.25rem;
+	color: var(--text-muted);
+}
+
+.quickAddModal .qa-onepage-textarea {
+	width: 100%;
+	height: 120px;
+}
+
+.quickAddModal .qa-onepage-dropdown-note {
+	margin-left: 0.5rem;
+	color: var(--text-muted);
+}
+
+.quickAddModal .qa-date-preview-text,
+.quickAddModal .vdate-preview-text {
+	margin-top: 0.25rem;
+	font-size: 0.9em;
+	font-family: var(--font-monospace);
+	color: var(--text-normal);
+}
+
+.quickAddModal .qa-date-preview-text.is-error,
+.quickAddModal .vdate-preview-text.is-error {
+	color: var(--text-error);
+}
+
+.quickAddModal .qa-date-alias-details,
+.quickAddModal .vdate-alias-details,
+.quickAddModal .qa-date-alias-list,
+.quickAddModal .vdate-alias-list {
+	margin-top: 0.25rem;
+}
+
+.quickAddModal .qa-date-alias-summary,
+.quickAddModal .vdate-alias-summary,
+.quickAddModal .qa-date-alias-list,
+.quickAddModal .vdate-alias-list {
+	font-size: 0.85em;
+	color: var(--text-muted);
+}
+
+.quickAddModal .qa-date-alias-list,
+.quickAddModal .vdate-alias-list {
+	font-family: var(--font-monospace);
+}
+
+.quickAddModal .qa-onepage-preview-row {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.quickAddModal .qa-vdate-input,
+.quickAddModal .qa-template-format-input,
+.quickAddModal .qa-folder-path-input {
+	width: 100%;
+}
+
+.quickAddModal .qa-template-format-input {
+	margin-bottom: 8px;
+}
+
+.quickAddModal .qa-modal-button-row {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.5rem;
+	margin-top: 1rem;
+}
+
+.qa-setting-full-width {
+	display: block;
+}
+
+.qa-setting-full-width .qa-setting-full-width-control {
+	width: 100%;
+	flex: 1 1 auto;
+	display: block;
+	margin-left: 0;
+	justify-content: flex-start;
+	align-items: stretch;
+	text-align: left;
+}
+
+.qa-dev-info {
+	margin-top: 10px;
+	font-family: var(--font-monospace);
+	font-size: 0.9em;
+}
+
+.qa-dev-info-row {
+	margin-bottom: 5px;
+}
+
+.qa-date-alias-setting {
+	align-items: flex-start;
+}
+
+.qa-date-alias-setting .qa-date-alias-control {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: flex-start;
+	flex: 1 1 320px;
+	min-width: 240px;
+}
+
+.qa-date-alias-input {
+	width: 100%;
+	min-height: 6rem;
+	flex: 1 1 280px;
+	max-width: 100%;
+	box-sizing: border-box;
+}
+
+.qa-date-alias-reset {
+	align-self: flex-start;
+	white-space: nowrap;
+}
+
 .quickAddModal .qa-canvas-node-helper {
 	margin: 8px 0 4px;
 	font-size: 12px;


### PR DESCRIPTION
Move the first batch of static UI styling out of inline style assignments.

This addresses scorecard UI-style findings for template choice settings, multi-choice settings, VDATE prompts, one-page preflight, settings metadata, and settings tab surfaces by moving static presentation into CSS classes.

Review focus:
- Visual equivalence of migrated settings/preflight/VDATE surfaces.
- CSS class names and scope in `src/styles.css`.
- Avoiding behavior changes while removing static inline styling.

Stack position: 11/17, based on `scorecard/10-nullish-macro-commands`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.