### PR TITLE
fix: migrate ai macro modal styles

### DIFF
--- a/src/gui/AIAssistantProvidersModal.ts
+++ b/src/gui/AIAssistantProvidersModal.ts
@@ -44,7 +44,8 @@ export class AIAssistantProvidersModal extends Modal {
 
 		this.contentEl.createEl("h2", {
 			text: modalName,
-		}).style.textAlign = "center";
+			cls: "qa-modal-title",
+		});
 
 		if (this.selectedProvider) {
 			this.addProviderSetting(this.contentEl);
@@ -74,13 +75,9 @@ export class AIAssistantProvidersModal extends Modal {
                 button.setCta();
             });
 
-		const providersContainer = container.createDiv("providers-container");
-		providersContainer.style.display = "flex";
-		providersContainer.style.flexDirection = "column";
-		providersContainer.style.gap = "10px";
-		providersContainer.style.overflowY = "auto";
-		providersContainer.style.maxHeight = "400px";
-		providersContainer.style.padding = "10px";
+		const providersContainer = container.createDiv({
+			cls: "providers-container qa-ai-list-container",
+		});
 
 		this.providers.forEach((provider, i) => {
 			new Setting(providersContainer)
@@ -199,13 +196,9 @@ export class AIAssistantProvidersModal extends Modal {
 	}
 
     addProviderModelsSetting(container: HTMLElement) {
-        const modelsContainer = container.createDiv("models-container");
-        modelsContainer.style.display = "flex";
-        modelsContainer.style.flexDirection = "column";
-        modelsContainer.style.gap = "10px";
-        modelsContainer.style.overflowY = "auto";
-        modelsContainer.style.maxHeight = "400px";
-        modelsContainer.style.padding = "10px";
+        const modelsContainer = container.createDiv({
+			cls: "models-container qa-ai-list-container",
+		});
 
         this.selectedProvider!.models.forEach((model, i) => {
             new Setting(modelsContainer)
@@ -319,11 +312,9 @@ export class AIAssistantProvidersModal extends Modal {
 	}
 
 	addProviderSettingButtonRow(container: HTMLElement) {
-		const buttonRow = container.createDiv("button-row");
-		buttonRow.style.display = "flex";
-		buttonRow.style.justifyContent = "space-between";
-		buttonRow.style.marginTop = "20px";
-		buttonRow.style.gap = "0.5rem";
+		const buttonRow = container.createDiv({
+			cls: "button-row qa-ai-provider-button-row",
+		});
 
 		const CancelButton = new ButtonComponent(buttonRow);
 		CancelButton.setButtonText("Cancel");

--- a/src/gui/AIAssistantSettingsModal.ts
+++ b/src/gui/AIAssistantSettingsModal.ts
@@ -34,15 +34,13 @@ export class AIAssistantSettingsModal extends Modal {
 	}
 
 	private display(): void {
-		// Responsive sizing (desktop and mobile)
-		this.modalEl.style.width = `min(100vw - 32px, 980px)`;
-		this.modalEl.style.maxWidth = `980px`;
-		this.contentEl.style.maxHeight = `min(85vh, 800px)`;
-		this.contentEl.style.overflowY = "auto";
+		this.modalEl.addClass("qa-ai-wide-modal");
+		this.contentEl.addClass("qa-ai-scroll-content");
 
 		this.contentEl.createEl("h2", {
 			text: "AI Assistant Settings",
-		}).style.textAlign = "center";
+			cls: "qa-modal-title",
+		});
 
 		this.addProvidersSetting(this.contentEl);
 		this.addDefaultModelSetting(this.contentEl);
@@ -142,10 +140,7 @@ export class AIAssistantSettingsModal extends Modal {
 			QuickAdd.instance
 		);
 
-		textAreaComponent.inputEl.style.width = "100%";
-		textAreaComponent.inputEl.style.height = "100px";
-		textAreaComponent.inputEl.style.minHeight = "100px";
-		textAreaComponent.inputEl.style.marginBottom = "1em";
+		textAreaComponent.inputEl.addClass("qa-ai-prompt-textarea");
 
 		const formatDisplay = this.contentEl.createEl("span");
 

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -56,9 +56,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			text: `${this.settings.name} Settings`,
 		});
 
-		header.style.textAlign = "center";
-		header.style.cursor = "pointer";
-		header.style.userSelect = "none";
+		header.addClass("qa-clickable-modal-title");
 		 
 		header.addEventListener("click", async () => {
 			try {
@@ -179,13 +177,13 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			.setDesc("The system prompt for the AI Assistant");
 
 		const container = this.contentEl.createEl("div");
-		const tokenCount = container.createEl("span");
-		tokenCount.style.color = "var(--text-muted-color)";
+		const tokenCount = container.createEl("span", {
+			cls: "qa-ai-token-count",
+		});
 		const tokenCountNote = container.createEl("div", {
 			text: "Exact for OpenAI models; estimates for others.",
+			cls: "qa-ai-token-note",
 		});
-		tokenCountNote.style.color = "var(--text-muted-color)";
-		tokenCountNote.style.fontSize = "var(--font-ui-smaller)";
 
 		container.appendChild(tokenCount);
 		container.appendChild(tokenCountNote);
@@ -210,10 +208,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			QuickAdd.instance
 		);
 
-		textAreaComponent.inputEl.style.width = "100%";
-		textAreaComponent.inputEl.style.height = "100px";
-		textAreaComponent.inputEl.style.minHeight = "100px";
-		textAreaComponent.inputEl.style.marginBottom = "1em";
+		textAreaComponent.inputEl.addClass("qa-ai-prompt-textarea");
 
 		const formatDisplay = this.contentEl.createEl("span");
 		const updateTokenCount = debounce(() => {

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -51,9 +51,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			text: `${this.settings.name} Settings`,
 		});
 
-		header.style.textAlign = "center";
-		header.style.cursor = "pointer";
-		header.style.userSelect = "none";
+		header.addClass("qa-clickable-modal-title");
 		 
 		header.addEventListener("click", async () => {
 			try {
@@ -143,13 +141,13 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			.setDesc("The system prompt for the AI Assistant");
 
 		const container = this.contentEl.createEl("div");
-		const tokenCount = container.createEl("span");
-		tokenCount.style.color = "var(--text-muted-color)";
+		const tokenCount = container.createEl("span", {
+			cls: "qa-ai-token-count",
+		});
 		const tokenCountNote = container.createEl("div", {
 			text: "Exact for OpenAI models; estimates for others.",
+			cls: "qa-ai-token-note",
 		});
-		tokenCountNote.style.color = "var(--text-muted-color)";
-		tokenCountNote.style.fontSize = "var(--font-ui-smaller)";
 
 		container.appendChild(tokenCount);
 		container.appendChild(tokenCountNote);
@@ -174,10 +172,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			QuickAdd.instance
 		);
 
-		textAreaComponent.inputEl.style.width = "100%";
-		textAreaComponent.inputEl.style.height = "100px";
-		textAreaComponent.inputEl.style.minHeight = "100px";
-		textAreaComponent.inputEl.style.marginBottom = "1em";
+		textAreaComponent.inputEl.addClass("qa-ai-prompt-textarea");
 
 		const formatDisplay = this.contentEl.createEl("span");
 		const updateTokenCount = debounce(() => {

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -244,7 +244,7 @@ export class CommandSequenceEditor {
 			.setDesc("Add an Obsidian command")
 			.addText((textComponent) => {
 				input = textComponent;
-				textComponent.inputEl.style.marginRight = "1em";
+				textComponent.inputEl.addClass("qa-command-sequence-input");
 				textComponent.setPlaceholder("Obsidian command");
 				new GenericTextSuggester(
 					this.app,
@@ -319,7 +319,7 @@ export class CommandSequenceEditor {
 			.setDesc("Add editor command")
 			.addDropdown((dropdown) => {
 				dropdownComponent = dropdown;
-				dropdown.selectEl.style.marginRight = "1em";
+				dropdown.selectEl.addClass("qa-command-sequence-input");
 				dropdown
 					.addOption("", "Select command")
 					.addOption(EditorCommandType.Copy, EditorCommandType.Copy)
@@ -376,7 +376,7 @@ export class CommandSequenceEditor {
 
 			input.setValue("");
 			if (addButton) {
-				addButton.buttonEl.style.display = "none";
+				addButton.buttonEl.addClass("qa-hidden");
 			}
 		};
 
@@ -385,7 +385,7 @@ export class CommandSequenceEditor {
 			.setDesc("Add user script - type the name or click Browse")
 			.addText((textComponent) => {
 				input = textComponent;
-				textComponent.inputEl.style.marginRight = "1em";
+				textComponent.inputEl.addClass("qa-command-sequence-input");
 				textComponent.setPlaceholder("Start typing script name...");
 
 				new GenericTextSuggester(
@@ -417,14 +417,12 @@ export class CommandSequenceEditor {
 			.addButton((button) => {
 				addButton = button;
 				button.setButtonText("Add").setCta().onClick(addUserScriptFromInput);
-				button.buttonEl.style.display = "none";
+				button.buttonEl.addClass("qa-hidden");
 			});
 
 		input.onChange((value) => {
 			if (!addButton) return;
-			addButton.buttonEl.style.display = value.trim()
-				? "inline-block"
-				: "none";
+			addButton.buttonEl.toggleClass("qa-hidden", value.trim().length === 0);
 		});
 	}
 
@@ -446,7 +444,7 @@ export class CommandSequenceEditor {
 			.setDesc("Add existing choice")
 			.addText((textComponent) => {
 				input = textComponent;
-				textComponent.inputEl.style.marginRight = "1em";
+				textComponent.inputEl.addClass("qa-command-sequence-input");
 				textComponent.setPlaceholder("Choice");
 				new GenericTextSuggester(
 					this.app,

--- a/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
+++ b/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
@@ -44,7 +44,8 @@
               on:mousedown={startDrag} 
               on:touchstart={startDrag}
               aria-label="Drag-handle"
-              style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
+              class:qa-drag-handle-ready={dragDisabled}
+              class:qa-drag-handle-active={!dragDisabled}
               tabindex={dragDisabled ? 0 : -1}
         >
             <ObsidianIcon iconId="grip-vertical" size={16} />

--- a/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
+++ b/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
@@ -78,7 +78,8 @@
 			role="button"
 			on:mousedown={startDrag}
 			on:touchstart={startDrag}
-			style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
+			class:qa-drag-handle-ready={dragDisabled}
+			class:qa-drag-handle-active={!dragDisabled}
 			tabindex={dragDisabled ? 0 : -1}
 			aria-label="Drag command"
 		>

--- a/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
+++ b/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
@@ -44,7 +44,8 @@
               on:mousedown={startDrag} 
               on:touchstart={startDrag}
               aria-label="Drag-handle"
-              style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
+              class:qa-drag-handle-ready={dragDisabled}
+              class:qa-drag-handle-active={!dragDisabled}
               tabindex={dragDisabled ? 0 : -1}
         >
             <ObsidianIcon iconId="grip-vertical" size={16} />

--- a/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
+++ b/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
@@ -45,7 +45,8 @@
 			on:mousedown={startDrag} 
 			on:touchstart={startDrag}
 			aria-label="Drag-handle"
-			style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
+			class:qa-drag-handle-ready={dragDisabled}
+			class:qa-drag-handle-active={!dragDisabled}
 			tabindex={dragDisabled ? 0 : -1}
 		>
 			<ObsidianIcon iconId="grip-vertical" size={16} />

--- a/src/gui/MacroGUIs/Components/StandardCommand.svelte
+++ b/src/gui/MacroGUIs/Components/StandardCommand.svelte
@@ -32,7 +32,8 @@
               on:mousedown={startDrag} 
               on:touchstart={startDrag}
               aria-label="Drag-handle"
-              style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
+              class:qa-drag-handle-ready={dragDisabled}
+              class:qa-drag-handle-active={!dragDisabled}
               tabindex={dragDisabled ? 0 : -1}
         >
             <ObsidianIcon iconId="grip-vertical" size={16} />

--- a/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
+++ b/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
@@ -46,7 +46,8 @@
               on:mousedown={startDrag} 
               on:touchstart={startDrag}
               aria-label="Drag-handle"
-              style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
+              class:qa-drag-handle-ready={dragDisabled}
+              class:qa-drag-handle-active={!dragDisabled}
               tabindex={dragDisabled ? 0 : -1}
         >
             <ObsidianIcon iconId="grip-vertical" size={16} />

--- a/src/gui/MacroGUIs/Components/WaitCommand.svelte
+++ b/src/gui/MacroGUIs/Components/WaitCommand.svelte
@@ -17,7 +17,7 @@
 
     function resizeInput() {
         const length: number = inputEl.value.length;
-        inputEl.style.width = (length === 0 ? 2 : length) + 'ch';
+        inputEl.style.setProperty("--qa-wait-input-width", `${length === 0 ? 2 : length}ch`);
     }
 
     onMount(resizeInput);
@@ -40,7 +40,8 @@
               on:mousedown={startDrag} 
               on:touchstart={startDrag}
               aria-label="Drag-handle"
-              style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
+              class:qa-drag-handle-ready={dragDisabled}
+              class:qa-drag-handle-active={!dragDisabled}
               tabindex={dragDisabled ? 0 : -1}
         >
             <ObsidianIcon iconId="grip-vertical" size={16} />
@@ -56,6 +57,7 @@
     font-size: inherit;
     padding: 0;
     width: 0;
+    width: var(--qa-wait-input-width, 2ch);
     text-decoration: underline dotted;
     background-color: transparent;
 }

--- a/src/gui/MacroGUIs/ConditionalBranchEditorModal.ts
+++ b/src/gui/MacroGUIs/ConditionalBranchEditorModal.ts
@@ -62,7 +62,7 @@ export class ConditionalBranchEditorModal extends Modal {
 		this.contentEl.empty();
 
 		const headerEl = this.contentEl.createEl("h2", { text: title });
-		headerEl.style.textAlign = "center";
+		headerEl.addClass("qa-modal-title");
 
 		const editorContainer = this.contentEl.createDiv("branchCommandEditor");
 		this.commandEditor = new CommandSequenceEditor({
@@ -81,11 +81,9 @@ export class ConditionalBranchEditorModal extends Modal {
 	}
 
 	private renderButtonBar() {
-		const buttonContainer = this.contentEl.createDiv();
-		buttonContainer.style.display = "flex";
-		buttonContainer.style.justifyContent = "flex-end";
-		buttonContainer.style.gap = "12px";
-		buttonContainer.style.marginTop = "20px";
+		const buttonContainer = this.contentEl.createDiv({
+			cls: "qa-command-button-row",
+		});
 
 		new ButtonComponent(buttonContainer)
 			.setButtonText("Cancel")

--- a/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
@@ -94,7 +94,7 @@ export class ConditionalCommandSettingsModal extends Modal {
 		const headerEl = this.contentEl.createEl("h2", {
 			text: "Configure Conditional Command",
 		});
-		headerEl.style.textAlign = "center";
+		headerEl.addClass("qa-modal-title");
 
 		this.renderModeSelector();
 		if (this.workingCommand.condition.mode === "variable") {
@@ -298,11 +298,9 @@ export class ConditionalCommandSettingsModal extends Modal {
 	}
 
 	private renderButtonBar() {
-		const buttonContainer = this.contentEl.createDiv();
-		buttonContainer.style.display = "flex";
-		buttonContainer.style.justifyContent = "flex-end";
-		buttonContainer.style.gap = "12px";
-		buttonContainer.style.marginTop = "20px";
+		const buttonContainer = this.contentEl.createDiv({
+			cls: "qa-command-button-row",
+		});
 
 		new ButtonComponent(buttonContainer)
 			.setButtonText("Cancel")

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -75,9 +75,8 @@ export class MacroBuilder extends Modal {
 
 	protected addCenteredHeader(header: string): void {
 		const headerEl = this.contentEl.createEl("h2");
-		headerEl.style.textAlign = "center";
 		headerEl.setText(header);
-		headerEl.addClass("clickable");
+		headerEl.addClass("clickable", "qa-clickable-modal-title");
 
 		 
 		headerEl.addEventListener("click", async () => {

--- a/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
@@ -51,7 +51,7 @@ export class OpenFileCommandSettingsModal extends Modal {
 
 		const headerEl = this.contentEl.createEl("h2");
 		headerEl.textContent = "Open File Command Settings";
-		headerEl.style.textAlign = "center";
+		headerEl.addClass("qa-modal-title");
 
 		this.addFilePathSetting();
 		this.addOpenLocationSetting();
@@ -167,11 +167,9 @@ export class OpenFileCommandSettingsModal extends Modal {
 
 
 	private addButtonBar() {
-		const buttonContainer = this.contentEl.createDiv();
-		buttonContainer.style.display = "flex";
-		buttonContainer.style.justifyContent = "flex-end";
-		buttonContainer.style.gap = "8px";
-		buttonContainer.style.marginTop = "20px";
+		const buttonContainer = this.contentEl.createDiv({
+			cls: "qa-command-button-row qa-command-button-row-compact",
+		});
 
 		const cancelButton = new ButtonComponent(buttonContainer);
 		cancelButton

--- a/src/gui/MacroGUIs/UserScriptSettingsModal.ts
+++ b/src/gui/MacroGUIs/UserScriptSettingsModal.ts
@@ -168,16 +168,7 @@ export class UserScriptSettingsModal extends Modal {
 				})
 				.setPlaceholder(placeholder ?? "");
 
-			textArea.inputEl.style.width = "100%";
-			textArea.inputEl.style.maxWidth = "15rem";
-			textArea.inputEl.style.boxSizing = "border-box";
-			textArea.inputEl.style.minHeight = "100px";
-			textArea.inputEl.style.maxHeight = "300px";
-			textArea.inputEl.style.resize = "vertical";
-			textArea.inputEl.style.overflowY = "auto";
-			textArea.inputEl.style.overflowX = "hidden";
-			textArea.inputEl.style.overflowWrap = "anywhere";
-			textArea.inputEl.style.setProperty("field-sizing", "content");
+			textArea.inputEl.addClass("qa-user-script-argument-textarea");
 		});
 	}
 
@@ -227,9 +218,7 @@ export class UserScriptSettingsModal extends Modal {
 			})
 			.setPlaceholder(placeholder ?? "");
 
-		input.inputEl.style.width = "100%";
-		input.inputEl.style.height = "100px";
-		input.inputEl.style.marginBottom = "1em";
+		input.inputEl.addClass("qa-user-script-format-textarea");
 
 		void (async () =>
 			(formatDisplay.innerText = await displayFormatter.format(value)))();

--- a/src/gui/MacroGUIs/noScriptsFoundNotice.ts
+++ b/src/gui/MacroGUIs/noScriptsFoundNotice.ts
@@ -34,6 +34,5 @@ export function showNoScriptsFoundNotice(): void {
 	});
 	link.target = "_blank";
 	link.rel = "noopener noreferrer";
-	link.style.color = "var(--interactive-accent)";
-	link.style.textDecoration = "underline";
+	link.addClass("quickadd-notice-link");
 }

--- a/src/gui/ModelDirectoryModal.ts
+++ b/src/gui/ModelDirectoryModal.ts
@@ -42,13 +42,13 @@ export class ModelDirectoryModal extends Modal {
 
   private display() {
     this.contentEl.empty();
-    // Responsive sizing
-    this.modalEl.style.width = `min(100vw - 32px, 980px)`;
-    this.modalEl.style.maxWidth = `980px`;
-    this.contentEl.style.maxHeight = `min(85vh, 800px)`;
-    this.contentEl.style.overflowY = "auto";
+    this.modalEl.addClass("qa-ai-wide-modal");
+    this.contentEl.addClass("qa-ai-scroll-content");
 
-    this.contentEl.createEl("h2", { text: `Browse models for ${this.provider.name}` }).style.textAlign = "center";
+    this.contentEl.createEl("h2", {
+      text: `Browse models for ${this.provider.name}`,
+      cls: "qa-modal-title",
+    });
 
     // Search/filter
     new Setting(this.contentEl)
@@ -92,10 +92,7 @@ export class ModelDirectoryModal extends Modal {
       });
 
     // List container
-    const list = this.contentEl.createDiv({ cls: "qa-model-directory" });
-    list.style.maxHeight = window.innerWidth < 640 ? "55vh" : "60vh";
-    list.style.overflowY = "auto";
-    list.style.padding = "6px";
+    this.contentEl.createDiv({ cls: "qa-model-directory" });
 
     this.renderList();
   }
@@ -107,9 +104,6 @@ export class ModelDirectoryModal extends Modal {
 
     for (const m of this.filtered) {
       const row = list.createDiv({ cls: "qa-model-row" });
-      row.style.display = "flex";
-      row.style.alignItems = "center";
-      row.style.gap = "8px";
 
       const cb = this.contentEl.ownerDocument.createElement("input");
       cb.type = "checkbox";
@@ -120,12 +114,12 @@ export class ModelDirectoryModal extends Modal {
       };
       row.appendChild(cb);
 
-      const title = row.createDiv({ text: m.name });
-      title.style.flex = "1";
+      row.createDiv({ text: m.name, cls: "qa-model-row-title" });
 
-      const meta = row.createDiv({ text: `${m.maxTokens.toLocaleString()} tokens max` });
-      meta.style.opacity = "0.7";
-      meta.style.fontSize = "0.9em";
+      row.createDiv({
+        text: `${m.maxTokens.toLocaleString()} tokens max`,
+        cls: "qa-model-row-meta",
+      });
     }
   }
 

--- a/src/gui/ProviderPickerModal.ts
+++ b/src/gui/ProviderPickerModal.ts
@@ -25,41 +25,29 @@ export class ProviderPickerModal extends Modal {
   }
 
   private addHeader(container: HTMLElement) {
-    container.createEl("h2", { text: "Add a provider" }).style.textAlign = "center";
+    container.createEl("h2", {
+      text: "Add a provider",
+      cls: "qa-modal-title",
+    });
   }
 
   private display() {
     this.contentEl.empty();
-    // Responsive modal sizing for desktop and mobile
-    this.modalEl.style.width = `min(100vw - 32px, 980px)`;
-    this.modalEl.style.maxWidth = `980px`;
-    this.contentEl.style.maxHeight = `min(85vh, 800px)`;
-    this.contentEl.style.overflowY = "auto";
+    this.modalEl.addClass("qa-ai-wide-modal");
+    this.contentEl.addClass("qa-ai-scroll-content");
     this.addHeader(this.contentEl);
 
-    const grid = this.contentEl.createDiv();
-    grid.style.display = "grid";
-    const isMobile = window.innerWidth < 640;
-    grid.style.gridTemplateColumns = isMobile
-      ? "1fr"
-      : "repeat(auto-fill, minmax(260px, 1fr))";
-    grid.style.gap = "12px";
+    const grid = this.contentEl.createDiv({ cls: "qa-provider-grid" });
 
     for (const preset of PROVIDER_PRESETS) {
       const card = grid.createDiv({ cls: "qa-provider-card" });
-      card.style.border = "1px solid var(--background-modifier-border)";
-      card.style.borderRadius = "8px";
-      card.style.padding = window.innerWidth < 640 ? "10px" : "12px";
-      card.style.display = "flex";
-      card.style.flexDirection = "column";
-      card.style.gap = "8px";
 
-      const title = card.createEl("div", { text: preset.name });
-      title.style.fontWeight = "600";
+      card.createEl("div", { text: preset.name, cls: "qa-provider-card-title" });
 
-      const endpoint = card.createEl("div", { text: preset.endpoint });
-      endpoint.style.fontSize = "0.9em";
-      endpoint.style.opacity = "0.8";
+      card.createEl("div", {
+        text: preset.endpoint,
+        cls: "qa-provider-card-endpoint",
+      });
 
       if (preset.doc) {
         const doc = card.createEl("a", { text: "Docs", href: preset.doc });
@@ -77,10 +65,7 @@ export class ProviderPickerModal extends Modal {
             apiKeyRef = value;
           }));
 
-      // Make the API key input stack vertically to avoid squishing on narrow screens
-      apiSetting.settingEl.style.display = "flex";
-      apiSetting.settingEl.style.flexDirection = "column";
-      apiSetting.settingEl.style.gap = "6px";
+      apiSetting.settingEl.addClass("qa-provider-api-setting");
 
       apiSetting.addButton((b) => {
           b.setButtonText("Connect").setCta().onClick(() => {

--- a/src/gui/choiceList/ChoiceItemRightButtons.svelte
+++ b/src/gui/choiceList/ChoiceItemRightButtons.svelte
@@ -32,9 +32,9 @@
         tabindex="0"
         on:click={emitToggleCommand}
         on:keypress={(e) => (e.key === 'Enter' || e.key === ' ') && emitToggleCommand()}
+        class:command-enabled={commandEnabled}
         class="alignIconInDivInMiddle clickable" 
         aria-label={`${commandEnabled ? "Disable in Command Palette" : "Enable in Command Palette"}${choiceName ? ": " + choiceName : ""}`} 
-        style={commandEnabled ? "color: #FDD023;" : ""}
     >
         <ObsidianIcon iconId="zap" size={16} />
     </div>
@@ -79,8 +79,9 @@
          role="button"
          tabindex={dragDisabled ? 0 : -1}
          aria-label="Drag-handle"
-         style="{dragDisabled ? 'cursor: grab' : 'cursor: grabbing'};"
          class="alignIconInDivInMiddle"
+         class:qa-drag-handle-ready={dragDisabled}
+         class:qa-drag-handle-active={!dragDisabled}
          on:pointerdown={() => dispatcher('dragHandleDown')}
     >
         <ObsidianIcon iconId="grip-vertical" size={16} />
@@ -101,5 +102,9 @@
 .alignIconInDivInMiddle {
     display: flex;
     align-items: center;
+}
+
+.command-enabled {
+    color: var(--text-accent);
 }
 </style>

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -78,7 +78,10 @@
             on:click={() => choice.collapsed = !choice.collapsed}
             on:keypress={(e) => (e.key === 'Enter' || e.key === ' ') && (choice.collapsed = !choice.collapsed)}
         >
-            <div style={`transform:rotate(${choice.collapsed ? -180 : 0}deg); transition: transform 0.2s ease-in-out; display: inline-flex;`}>
+            <div
+                class="multiChoiceCollapseIcon"
+                class:is-collapsed={choice.collapsed}
+            >
                 <ObsidianIcon iconId="chevron-down" size={16} />
             </div>
             <span class="choiceListItemName" bind:this={nameElement}></span>
@@ -125,6 +128,15 @@
         font-size: 16px;
         align-items: center;
         margin: 12px 0 0 0;
+    }
+
+    .multiChoiceCollapseIcon {
+        display: inline-flex;
+        transition: transform 0.2s ease-in-out;
+    }
+
+    .multiChoiceCollapseIcon.is-collapsed {
+        transform: rotate(-180deg);
     }
 
     .clickable:hover {

--- a/src/gui/components/ObsidianIcon.svelte
+++ b/src/gui/components/ObsidianIcon.svelte
@@ -24,9 +24,14 @@
     }
 </script>
 
-<span bind:this={iconEl} class="quickadd-icon" style="display: inline-flex; align-items: center;"></span>
+<span bind:this={iconEl} class="quickadd-icon"></span>
 
 <style>
+    .quickadd-icon {
+        display: inline-flex;
+        align-items: center;
+    }
+
     .quickadd-icon :global(svg) {
         display: inline-block;
         vertical-align: middle;

--- a/src/gui/components/validatedInput.ts
+++ b/src/gui/components/validatedInput.ts
@@ -71,10 +71,10 @@ export function createValidatedInput(
 	const inputEl = component.inputEl;
 	const activeWindow = getOwnerWindow(inputEl);
 
-	if (fullWidth) inputEl.style.width = "100%";
-	inputEl.style.marginBottom = `${marginBottomPx}px`;
+	if (fullWidth) inputEl.addClass("qa-validated-input-full-width");
+	inputEl.addClass(`qa-validated-input-margin-${marginBottomPx}`);
 	if (inputKind === "textarea") {
-		inputEl.style.minHeight = "10rem";
+		inputEl.addClass("qa-validated-input-textarea");
 	}
 	if (placeholder) component.setPlaceholder(placeholder);
 	component.setValue(initialValue);

--- a/src/styles.css
+++ b/src/styles.css
@@ -218,6 +218,200 @@
 	white-space: nowrap;
 }
 
+.quickAddModal .qa-modal-title,
+.quickAddModal .qa-clickable-modal-title,
+.qa-modal-title,
+.qa-clickable-modal-title {
+	text-align: center;
+}
+
+.qa-clickable-modal-title {
+	cursor: pointer;
+	user-select: none;
+}
+
+.qa-ai-wide-modal {
+	width: min(100vw - 32px, 980px);
+	max-width: 980px;
+}
+
+.qa-ai-scroll-content {
+	max-height: min(85vh, 800px);
+	overflow-y: auto;
+}
+
+.qa-provider-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	gap: 12px;
+}
+
+.qa-provider-card {
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 8px;
+	padding: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.qa-provider-card-title {
+	font-weight: 600;
+}
+
+.qa-provider-card-endpoint {
+	font-size: 0.9em;
+	opacity: 0.8;
+	overflow-wrap: anywhere;
+}
+
+.qa-provider-api-setting {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.qa-model-directory {
+	max-height: 60vh;
+	overflow-y: auto;
+	padding: 6px;
+}
+
+.qa-model-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.qa-model-row-title {
+	flex: 1;
+	overflow-wrap: anywhere;
+}
+
+.qa-model-row-meta,
+.qa-provider-card-endpoint {
+	color: var(--text-muted);
+}
+
+.qa-model-row-meta {
+	font-size: 0.9em;
+	white-space: nowrap;
+}
+
+.qa-ai-list-container {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	overflow-y: auto;
+	max-height: 400px;
+	padding: 10px;
+}
+
+.qa-ai-provider-button-row {
+	display: flex;
+	justify-content: space-between;
+	margin-top: 20px;
+	gap: 0.5rem;
+}
+
+.qa-ai-prompt-textarea,
+.qa-user-script-format-textarea {
+	width: 100%;
+	height: 100px;
+	min-height: 100px;
+	margin-bottom: 1em;
+	box-sizing: border-box;
+}
+
+.qa-ai-token-count,
+.qa-ai-token-note {
+	color: var(--text-muted);
+}
+
+.qa-ai-token-note {
+	font-size: var(--font-ui-smaller);
+}
+
+.qa-command-button-row {
+	display: flex;
+	justify-content: flex-end;
+	gap: 12px;
+	margin-top: 20px;
+}
+
+.qa-command-button-row-compact {
+	gap: 8px;
+}
+
+.qa-command-sequence-input {
+	margin-right: 1em;
+}
+
+.qa-hidden {
+	display: none;
+}
+
+.qa-user-script-argument-textarea {
+	width: 100%;
+	max-width: 15rem;
+	box-sizing: border-box;
+	min-height: 100px;
+	max-height: 300px;
+	resize: vertical;
+	overflow-y: auto;
+	overflow-x: hidden;
+	overflow-wrap: anywhere;
+	field-sizing: content;
+}
+
+.qa-validated-input-full-width {
+	width: 100%;
+}
+
+.qa-validated-input-margin-8 {
+	margin-bottom: 8px;
+}
+
+.qa-validated-input-textarea {
+	min-height: 10rem;
+}
+
+.quickadd-notice-link {
+	color: var(--interactive-accent);
+	text-decoration: underline;
+}
+
+.qa-drag-handle-ready {
+	cursor: grab;
+}
+
+.qa-drag-handle-active {
+	cursor: grabbing;
+}
+
+@media screen and (max-width: 639px) {
+	.qa-provider-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.qa-provider-card {
+		padding: 10px;
+	}
+
+	.qa-model-directory {
+		max-height: 55vh;
+	}
+
+	.qa-model-row {
+		align-items: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.qa-model-row-meta {
+		white-space: normal;
+	}
+}
+
 .quickAddModal .qa-canvas-node-helper {
 	margin: 8px 0 4px;
 	font-size: 12px;


### PR DESCRIPTION
Move AI, provider, macro, and command-modal static styles into CSS classes.

This is the second UI-style remediation batch, focused on AI assistant settings/providers, macro command editors, provider picker/model directory modals, choice-list buttons, icon components, and related modal surfaces.

Review focus:
- Visual and interaction parity in the migrated modal surfaces.
- CSS class organization in `src/styles.css`.
- Svelte component class usage replacing static inline styles.

Stack position: 12/17, based on `scorecard/11-ui-styling-batch-a`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.