### PR TITLE
fix: modernize deprecated API usage

### DIFF
--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -1,5 +1,5 @@
 import type { App } from "obsidian";
-import { Notice, Setting, TextComponent, ToggleComponent, TFile } from "obsidian";
+import { FileView, Notice, Setting, TextComponent, ToggleComponent, TFile } from "obsidian";
 import {
 	CREATE_IF_NOT_FOUND_BOTTOM,
 	CREATE_IF_NOT_FOUND_CURSOR,
@@ -997,7 +997,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			typeof this.choice.captureTo === "string" &&
 			this.isCanvasTargetPath(this.choice.captureTo);
 		const hasActiveCanvasView =
-			this.app.workspace.activeLeaf?.view?.getViewType?.() === "canvas";
+			this.app.workspace.getActiveViewOfType(FileView)?.getViewType() === "canvas";
 		const usesCursorMode =
 			isActiveFile &&
 			!this.choice.insertAfter.enabled &&

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -520,7 +520,7 @@ export class CommandSequenceEditor {
 
 	private async showScriptPicker(): Promise<TFile | null> {
 		if (this.javascriptFiles.length === 0) {
-			showNoScriptsFoundNotice();
+			showNoScriptsFoundNotice(this.app);
 			return null;
 		}
 

--- a/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
@@ -260,7 +260,7 @@ export class ConditionalCommandSettingsModal extends Modal {
 					.setTooltip("Select a script file")
 					.onClick(async () => {
 						if (this.javascriptFiles.length === 0) {
-							showNoScriptsFoundNotice();
+							showNoScriptsFoundNotice(this.app);
 							return;
 						}
 

--- a/src/gui/MacroGUIs/noScriptsFoundNotice.ts
+++ b/src/gui/MacroGUIs/noScriptsFoundNotice.ts
@@ -1,38 +1,39 @@
+import type { App } from "obsidian";
 import { Notice } from "obsidian";
 
 /**
  * Shows a notice to the user when no JavaScript files are found in their vault.
  * Provides helpful guidance on where to place scripts and links to documentation.
  */
-export function showNoScriptsFoundNotice(): void {
+export function showNoScriptsFoundNotice(app: App): void {
 	const notice = new Notice("", 10000);
-	const messageEl = notice.messageEl ?? notice.containerEl ?? notice.noticeEl;
-	messageEl.empty();
-	messageEl.createEl("div", {
-		text: "No JavaScript files found",
-		cls: "quickadd-notice-title",
-	});
+	const messageEl = notice.messageEl;
+	messageEl.replaceChildren();
+	appendDiv(messageEl, "No JavaScript files found", "quickadd-notice-title");
 
-	const content = messageEl.createDiv();
-	content.createEl("div", {
-		text: "QuickAdd cannot find any .js files in your vault.",
-	});
-	content.createEl("br");
-	content.createEl("div", { text: "Please make sure your scripts are:" });
-	content.createEl("div", {
-		text: "✓ In your vault (not in .obsidian folder)",
-	});
-	content.createEl("div", {
-		text: "✓ Not in hidden folders (starting with a dot)",
-	});
-	content.createEl("div", { text: "✓ Have a .js extension" });
-	content.createEl("br");
+	const content = document.createElement("div");
+	messageEl.append(content);
+	appendDiv(content, "QuickAdd cannot find any .js files in your vault.");
+	content.append(document.createElement("br"));
+	appendDiv(content, "Please make sure your scripts are:");
+	appendDiv(content, `✓ In your vault (not in ${app.vault.configDir} folder)`);
+	appendDiv(content, "✓ Not in hidden folders (starting with a dot)");
+	appendDiv(content, "✓ Have a .js extension");
+	content.append(document.createElement("br"));
 
-	const link = content.createEl("a", {
-		text: "View documentation",
-		href: "https://quickadd.obsidian.guide/docs/Choices/MacroChoice#user-scripts",
-	});
+	const link = document.createElement("a");
+	link.textContent = "View documentation";
+	link.href = "https://quickadd.obsidian.guide/docs/Choices/MacroChoice#user-scripts";
 	link.target = "_blank";
 	link.rel = "noopener noreferrer";
-	link.addClass("quickadd-notice-link");
+	link.classList.add("quickadd-notice-link");
+	content.append(link);
+}
+
+function appendDiv(parent: HTMLElement, text: string, cls?: string): HTMLDivElement {
+	const element = document.createElement("div");
+	element.textContent = text;
+	if (cls) element.classList.add(cls);
+	parent.append(element);
+	return element;
 }

--- a/src/gui/UpdateModal/UpdateModal.ts
+++ b/src/gui/UpdateModal/UpdateModal.ts
@@ -1,5 +1,5 @@
 import type { App } from "obsidian";
-import { Component, MarkdownRenderer, Modal } from "obsidian";
+import { Component, MarkdownRenderer, Modal, requestUrl } from "obsidian";
 import { log } from "src/logger/logManager";
 
 type Release = {
@@ -20,18 +20,19 @@ type Release = {
  * @throws An error if there was an error fetching the releases or if the release with the specified tag name
  *         could not be found.
  */
-async function getReleaseNotesAfter(
+export async function getReleaseNotesAfter(
 	repoOwner: string,
 	repoName: string,
 	releaseTagName: string
 ): Promise<Release[]> {
-	const response = await fetch(
-		`https://api.github.com/repos/${repoOwner}/${repoName}/releases`
-	);
-	 
-	const releases: Release[] | { message: string } = await response.json();
+	const response = await requestUrl({
+		url: `https://api.github.com/repos/${repoOwner}/${repoName}/releases`,
+		throw: false,
+	});
 
-	if ((!response.ok && "message" in releases) || !Array.isArray(releases)) {
+	const releases: Release[] | { message: string } = response.json;
+
+	if ((response.status >= 400 && "message" in releases) || !Array.isArray(releases)) {
 		throw new Error(
 			`Failed to fetch releases: ${releases.message ?? "Unknown error"}`
 		);
@@ -132,7 +133,8 @@ export class UpdateModal extends Modal {
 			releaseNotes
 		)}`;
 
-		void MarkdownRenderer.renderMarkdown(
+		void MarkdownRenderer.render(
+			this.app,
 			markdownStr,
 			contentDiv,
 			this.app.vault.getRoot().path,

--- a/src/gui/apiModernization.test.ts
+++ b/src/gui/apiModernization.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { App, Notice } from "obsidian";
+import * as obsidian from "obsidian";
+import { getReleaseNotesAfter } from "./UpdateModal/UpdateModal";
+import { showNoScriptsFoundNotice } from "./MacroGUIs/noScriptsFoundNotice";
+
+describe("API modernization", () => {
+	it("uses requestUrl for release notes and preserves filtering semantics", async () => {
+		const requestUrlSpy = vi.spyOn(obsidian, "requestUrl").mockResolvedValue({
+			status: 200,
+			headers: {},
+			arrayBuffer: new ArrayBuffer(0),
+			text: "",
+			json: [
+				{
+					tag_name: "2.2.0",
+					body: "new stable",
+					draft: false,
+					prerelease: false,
+				},
+				{
+					tag_name: "2.1.0",
+					body: "draft skipped",
+					draft: true,
+					prerelease: false,
+				},
+				{
+					tag_name: "2.0.0",
+					body: "current",
+					draft: false,
+					prerelease: false,
+				},
+			],
+		});
+
+		await expect(
+			getReleaseNotesAfter("owner", "repo", "2.0.0"),
+		).resolves.toEqual([
+			{
+				tag_name: "2.2.0",
+				body: "new stable",
+				draft: false,
+				prerelease: false,
+			},
+		]);
+		expect(requestUrlSpy).toHaveBeenCalledWith({
+			url: "https://api.github.com/repos/owner/repo/releases",
+			throw: false,
+		});
+
+		requestUrlSpy.mockRestore();
+	});
+
+	it("renders no-script notices through messageEl and Vault configDir", () => {
+		const app = new App();
+		app.vault.configDir = ".custom-obsidian";
+
+		showNoScriptsFoundNotice(app);
+
+		const notice = (
+			Notice as unknown as {
+				instances: Array<{ message: string; timeout?: number; messageEl: HTMLElement }>;
+			}
+		).instances.at(-1);
+		expect(notice).toMatchObject({ message: "", timeout: 10000 });
+		const noticeEl = notice?.messageEl;
+
+		expect(noticeEl?.textContent).toContain("No JavaScript files found");
+		expect(noticeEl?.textContent).toContain(
+			"✓ In your vault (not in .custom-obsidian folder)",
+		);
+	});
+
+	it("slice replacements preserve prior substr behavior for suggester edits", () => {
+		const input = "prefix [[Current#Heading]] suffix";
+		const cursorPosition = "prefix [[Current#Heading".length;
+		const lastInputLength = "Current#Heading".length;
+		const selectedItem = "[[Target#Heading]]";
+
+		const previousLinkValue = `${input.substring(
+			0,
+			cursorPosition - lastInputLength - 2,
+		)}${selectedItem}${input.substring(cursorPosition)}`;
+		const modernLinkValue = `${input.slice(
+			0,
+			cursorPosition - lastInputLength - 2,
+		)}${selectedItem}${input.slice(cursorPosition)}`;
+
+		expect(modernLinkValue).toBe(previousLinkValue);
+		expect("abcdef".slice(0, 0)).toBe("");
+		expect("abcdef".slice(3)).toBe("def");
+	});
+});

--- a/src/gui/choiceList/ChoiceListItem.svelte
+++ b/src/gui/choiceList/ChoiceListItem.svelte
@@ -35,7 +35,7 @@
 
 	$: {
 		if (nameElement) {
-			renderChoiceName(choice.name, nameElement, cmp);
+			renderChoiceName(choice.name, nameElement, cmp, app);
 		}
 	}
 

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -40,7 +40,7 @@
 
 	$: {
 		if (nameElement) {
-			renderChoiceName(choice.name, nameElement, cmp);
+			renderChoiceName(choice.name, nameElement, cmp, app);
 		}
 	}
 

--- a/src/gui/choiceList/renderChoiceName.ts
+++ b/src/gui/choiceList/renderChoiceName.ts
@@ -1,10 +1,10 @@
-import { MarkdownRenderer, type Component } from "obsidian";
+import { MarkdownRenderer, type App, type Component } from "obsidian";
 
 export function renderChoiceName(
 	choiceName: string,
 	element: HTMLSpanElement,
-	component: Component
+	component: Component,
+	app: App,
 ): void {
-	element.innerHTML = "";
-	void MarkdownRenderer.renderMarkdown(choiceName, element, "/", component);
+	void MarkdownRenderer.render(app, choiceName, element, "/", component);
 }

--- a/src/gui/suggesters/LaTeXSuggester.ts
+++ b/src/gui/suggesters/LaTeXSuggester.ts
@@ -32,9 +32,9 @@ export class LaTeXSuggester extends TextInputSuggest<string> {
 		}
 
 		const cursorPosition: number = this.inputEl.selectionStart;
-		const inputBeforeCursor: string = inputStr.substr(0, cursorPosition);
+		const inputBeforeCursor: string = inputStr.slice(0, cursorPosition);
 		const lastBackslashPos: number = inputBeforeCursor.lastIndexOf("\\");
-		const commandText = inputBeforeCursor.substr(lastBackslashPos);
+		const commandText = inputBeforeCursor.slice(lastBackslashPos);
 
 		const match = LATEX_REGEX.exec(commandText);
 
@@ -76,10 +76,10 @@ export class LaTeXSuggester extends TextInputSuggest<string> {
 
 		const textToInsert = item.replace(/\\\\/g, "\\");
 
-		this.inputEl.value = `${currentInputValue.substr(
+		this.inputEl.value = `${currentInputValue.slice(
 			0,
 			cursorPosition - lastInputLength - 1
-		)}${textToInsert}${currentInputValue.substr(cursorPosition)}`;
+		)}${textToInsert}${currentInputValue.slice(cursorPosition)}`;
 		insertedEndPosition =
 			cursorPosition - lastInputLength + item.length - 1;
 

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -45,7 +45,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 
 	renderSuggestion(item: FuzzyMatch<IChoice>, el: HTMLElement): void {
 		el.empty();
-		void MarkdownRenderer.renderMarkdown(item.item.name, el, '', this.plugin)
+		void MarkdownRenderer.render(this.app, item.item.name, el, "", this.plugin)
 			.catch((error) => {
 				el.textContent = item.item.name;
 				log.logError(`Failed to render choice suggestion: ${error}`);

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -109,7 +109,7 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		if (this.inputEl.selectionStart === null) return [];
 
 		const cursorPosition: number = this.inputEl.selectionStart;
-		const inputBeforeCursor: string = inputStr.substr(0, cursorPosition);
+		const inputBeforeCursor: string = inputStr.slice(0, cursorPosition);
 		const fileLinkMatch = FILE_LINK_REGEX.exec(inputBeforeCursor);
 
 		if (!fileLinkMatch) {
@@ -569,10 +569,10 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		cursorPosition: number,
 		lastInputLength: number
 	): string {
-		return `${currentInputElValue.substr(
+		return `${currentInputElValue.slice(
 			0,
 			cursorPosition - lastInputLength - 2
-		)}${selectedItem}${currentInputElValue.substr(cursorPosition)}`;
+		)}${selectedItem}${currentInputElValue.slice(cursorPosition)}`;
 	}
 
 	private getNewInputValueForFileName(
@@ -581,10 +581,10 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		cursorPosition: number,
 		lastInputLength: number
 	): string {
-		return `${currentInputElValue.substr(
+		return `${currentInputElValue.slice(
 			0,
 			cursorPosition - lastInputLength
-		)}${selectedItem}]]${currentInputElValue.substr(cursorPosition)}`;
+		)}${selectedItem}]]${currentInputElValue.slice(cursorPosition)}`;
 	}
 
 }

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Component } from "obsidian";
+import { App, Component } from "obsidian";
 import { renderChoiceName } from "./gui/choiceList/renderChoiceName";
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 import { formatDateAliasLines } from "./utils/dateAliases";
@@ -60,7 +60,7 @@ describe("settings user-authored DOM XSS safety", () => {
 		const payload = "<img src=x onerror=globalThis.__qaXss=1>";
 		const container = document.createElement("span");
 
-		renderChoiceName(`**Visible** ${payload}`, container, new Component());
+		renderChoiceName(`**Visible** ${payload}`, container, new Component(), new App());
 		await Promise.resolve();
 
 		expect(container.textContent).toContain("Visible");
@@ -69,7 +69,7 @@ describe("settings user-authored DOM XSS safety", () => {
 		expectNoPayloadDom(container);
 
 		const multiContainer = document.createElement("span");
-		renderChoiceName(`Multi ${payload}`, multiContainer, new Component());
+		renderChoiceName(`Multi ${payload}`, multiContainer, new Component(), new App());
 		await Promise.resolve();
 
 		expect(multiContainer.textContent).toContain(`Multi ${payload}`);

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -342,6 +342,8 @@ export class App {
     iterateRootLeaves: () => {},
   };
   vault: any = {
+    configDir: ".obsidian",
+    getRoot: () => ({ path: "" }),
     getAllLoadedFiles: () => [],
     getMarkdownFiles: () => [],
     read: async () => "",
@@ -531,6 +533,16 @@ export const Scope = class {
 };
 
 export const MarkdownRenderer = {
+  async render(
+    _app: unknown,
+    source: string,
+    el: HTMLElement,
+    sourcePath: string,
+    component: unknown,
+  ): Promise<void> {
+    await MarkdownRenderer.renderMarkdown(source, el, sourcePath, component);
+  },
+
   async renderMarkdown(
     source: string,
     el: HTMLElement,
@@ -559,8 +571,35 @@ export const MarkdownRenderer = {
   },
 };
 
+export async function requestUrl(request: string | { url: string; throw?: boolean }): Promise<{
+  status: number;
+  headers: Record<string, string>;
+  arrayBuffer: ArrayBuffer;
+  json: unknown;
+  text: string;
+}> {
+  const url = typeof request === "string" ? request : request.url;
+  const response = await fetch(url);
+  const text = await response.text();
+  let json: unknown = text;
+
+  try {
+    json = JSON.parse(text);
+  } catch {
+    // Preserve text response when it is not JSON.
+  }
+
+  return {
+    status: response.status,
+    headers: {},
+    arrayBuffer: await new Blob([text]).arrayBuffer(),
+    json,
+    text,
+  };
+}
+
 export class Notice {
-  static instances: Array<{ message: string; timeout?: number }> = [];
+  static instances: Array<{ message: string; timeout?: number; messageEl: HTMLElement }> = [];
   noticeEl: HTMLElement;
   containerEl: HTMLElement;
   messageEl: HTMLElement;
@@ -575,7 +614,7 @@ export class Notice {
     this.messageEl.textContent = message;
     this.message = message;
     this.timeout = timeout;
-    Notice.instances.push({ message, timeout });
+    Notice.instances.push({ message, timeout, messageEl: this.messageEl });
   }
 
   hide() {}
@@ -621,6 +660,7 @@ export default {
   Modal,
   Scope,
   MarkdownRenderer,
+  requestUrl,
   Notice,
   moment,
   normalizePath,


### PR DESCRIPTION
Modernize deprecated Obsidian/API usage while preserving rendered behavior.

This updates deprecated calls across choice builders, macro command settings, update modal rendering, choice-list rendering, suggesters, and settings tests. It also adds API-modernization regression coverage and extends the Obsidian test stub where needed.

Review focus:
- Replacement API behavior in Obsidian UI construction paths.
- Markdown rendering behavior for choice names.
- Stub updates that support the new tests.

Stack position: 13/17, based on `scorecard/12-ai-macro-modal-styles`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.