### PR TITLE
fix: clear choice markdown render target

### DIFF
--- a/src/gui/choiceList/renderChoiceName.test.ts
+++ b/src/gui/choiceList/renderChoiceName.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { App, Component, MarkdownRenderer } from "obsidian";
+import { renderChoiceName } from "./renderChoiceName";
+
+describe("renderChoiceName", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("replaces existing rendered markdown instead of appending stale content", () => {
+		const app = new App();
+		const component = new Component();
+		const element = document.createElement("span");
+		const renderSpy = vi
+			.spyOn(MarkdownRenderer, "render")
+			.mockImplementation((_app, source, el) => {
+				const rendered = document.createElement("strong");
+				rendered.textContent = source;
+				el.appendChild(rendered);
+				return Promise.resolve();
+			});
+
+		renderChoiceName("First choice", element, component, app);
+		renderChoiceName("Second choice", element, component, app);
+
+		expect(renderSpy).toHaveBeenCalledTimes(2);
+		expect(element.textContent).toBe("Second choice");
+		expect(element.querySelectorAll("strong")).toHaveLength(1);
+		expect(element.textContent).not.toContain("First choice");
+	});
+});

--- a/src/gui/choiceList/renderChoiceName.ts
+++ b/src/gui/choiceList/renderChoiceName.ts
@@ -6,5 +6,6 @@ export function renderChoiceName(
 	component: Component,
 	app: App,
 ): void {
+	element.replaceChildren();
 	void MarkdownRenderer.render(app, choiceName, element, "/", component);
 }


### PR DESCRIPTION
Ensure choice markdown rendering replaces content instead of appending duplicates.

This fixes the focused regression found during API-modernization review: repeated rendering into the same choice-name target must clear prior markdown output before rendering again.

Review focus:
- The one-line render-target clear in `renderChoiceName`.
- Regression coverage proving duplicate markdown is not appended.
- Interaction with the preceding deprecated-API modernization PR.

Stack position: 14/17, based on `scorecard/13-deprecated-api-modernization`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.