### PR TITLE
fix: close decision bucket findings

### DIFF
--- a/src/commandLabels.ts
+++ b/src/commandLabels.ts
@@ -1,0 +1,5 @@
+export const QUICK_ADD_COMMAND_LABELS = {
+	run: "Run",
+	reloadDev: "Reload (dev)",
+	testDev: "Test (dev)",
+} as const;

--- a/src/main.commandLabels.test.ts
+++ b/src/main.commandLabels.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
+
+describe("QuickAdd command labels", () => {
+	it("keeps built-in command labels free of the plugin name", () => {
+		expect(QUICK_ADD_COMMAND_LABELS).toEqual({
+			run: "Run",
+			reloadDev: "Reload (dev)",
+			testDev: "Test (dev)",
+		});
+
+		for (const label of Object.values(QUICK_ADD_COMMAND_LABELS)) {
+			expect(label).not.toContain("QuickAdd");
+		}
+	});
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssis
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { isMajorUpdate } from "./utils/semver";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
+import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
 
 // Parameters prefixed with `value-` get used as named values for the executed choice
 type CaptureValueParameters = { [key in `value-${string}`]?: string };
@@ -60,7 +61,7 @@ export default class QuickAdd extends Plugin {
 
 		this.addCommand({
 			id: "runQuickAdd",
-			name: "Run QuickAdd",
+			name: QUICK_ADD_COMMAND_LABELS.run,
 			callback: () => {
 				ChoiceSuggester.Open(this, this.settings.choices);
 			},
@@ -68,7 +69,7 @@ export default class QuickAdd extends Plugin {
 
 		this.addCommand({
 			id: "reloadQuickAdd",
-			name: "Reload QuickAdd (dev)",
+			name: QUICK_ADD_COMMAND_LABELS.reloadDev,
 			checkCallback: (checking) => {
 				if (checking) {
 					return this.settings.devMode;
@@ -88,13 +89,13 @@ export default class QuickAdd extends Plugin {
 
 		this.addCommand({
 			id: "testQuickAdd",
-			name: "Test QuickAdd (dev)",
+			name: QUICK_ADD_COMMAND_LABELS.testDev,
 			checkCallback: (checking) => {
 				if (checking) {
 					return this.settings.devMode;
 				}
 
-				log.logMessage("Test QuickAdd (dev)");
+				log.logMessage(QUICK_ADD_COMMAND_LABELS.testDev);
 
 				const fn = () => {
 					new InfiniteAIAssistantCommandSettingsModal(this.app, {

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -1,7 +1,7 @@
 import {
 	TFolder,
 	type App,
-	type TFile,
+	TFile,
 	type WorkspaceLeaf,
 	type WorkspaceParent,
 } from "obsidian";
@@ -10,10 +10,13 @@ import {
 	__test,
 	areSameVaultFilePath,
 	getAllFolderPathsInVault,
+	getUserScript,
 	normalizeVaultFilePath,
 	getOpenFileOriginLeaf,
 	openFile,
 } from "./utilityObsidian";
+import type { IUserScript } from "./types/macros/IUserScript";
+import { CommandType } from "./types/macros/CommandType";
 
 const { convertLinkToEmbed, extractMarkdownLinkTarget } = __test;
 
@@ -40,7 +43,12 @@ function createLeaf(id: string, pinned = false): FakeLeaf {
 }
 
 function createFile(path = "target.md"): TFile {
-	return { path } as TFile;
+	const file = new TFile();
+	file.path = path;
+	file.name = path.split("/").pop() ?? path;
+	file.extension = path.split(".").pop() ?? "";
+	file.basename = file.name.replace(/\.[^.]+$/, "");
+	return file;
 }
 
 function createFolder(path: string): TFolder {
@@ -202,6 +210,104 @@ describe("getAllFolderPathsInVault", () => {
 		} as unknown as App;
 
 		expect(getAllFolderPathsInVault(app)).toEqual(["B", "A", "A/C"]);
+	});
+});
+
+describe("getUserScript", () => {
+	function createUserScriptCommand(
+		options: Partial<IUserScript> = {},
+	): IUserScript {
+		return {
+			id: "script",
+			name: "Script",
+			type: CommandType.UserScript,
+			path: "Scripts/script.js",
+			settings: {},
+			...options,
+		};
+	}
+
+	function createUserScriptApp(fileContent: string) {
+		const file = createFile("Scripts/script.js");
+		return {
+			vault: {
+				getAbstractFileByPath: vi.fn(() => file),
+				read: vi.fn(async () => fileContent),
+			},
+		} as unknown as App;
+	}
+
+	it("executes CommonJS user scripts with Obsidian globals available", async () => {
+		const app = createUserScriptApp(`
+			module.exports = {
+				globalType: typeof globalThis,
+				globalValue: globalThis.__quickAddEvalCompatibilityGlobal,
+			};
+		`);
+		const previousGlobal = (
+			globalThis as { __quickAddEvalCompatibilityGlobal?: string }
+		).__quickAddEvalCompatibilityGlobal;
+		(
+			globalThis as { __quickAddEvalCompatibilityGlobal?: string }
+		).__quickAddEvalCompatibilityGlobal = "visible";
+
+		try {
+			const script = await getUserScript(createUserScriptCommand(), app);
+
+			expect(script).toEqual({
+				globalType: "object",
+				globalValue: "visible",
+			});
+		} finally {
+			if (previousGlobal === undefined) {
+				delete (
+					globalThis as { __quickAddEvalCompatibilityGlobal?: string }
+				).__quickAddEvalCompatibilityGlobal;
+			} else {
+				(
+					globalThis as { __quickAddEvalCompatibilityGlobal?: string }
+				).__quickAddEvalCompatibilityGlobal = previousGlobal;
+			}
+		}
+	});
+
+	it("preserves argument passing, return values, sensitive strings, and async errors", async () => {
+		const app = createUserScriptApp(`
+			module.exports = {
+				settings: { mode: "private" },
+				run: async (params, settings) => {
+					if (params.shouldReject) throw new Error("script rejected");
+					return {
+						receivedToken: params.token,
+						mode: settings.mode,
+					};
+				},
+			};
+		`);
+		const command = createUserScriptCommand({
+			name: "Script::run",
+			settings: { mode: "user" },
+		});
+
+		const script = await getUserScript(command, app);
+		expect(typeof script).toBe("function");
+
+		await expect(
+			(script as (params: unknown, settings: Record<string, unknown>) => unknown)(
+				{ token: "sensitive-token" },
+				command.settings,
+			),
+		).resolves.toEqual({
+			receivedToken: "sensitive-token",
+			mode: "user",
+		});
+
+		await expect(
+			(script as (params: unknown, settings: Record<string, unknown>) => unknown)(
+				{ shouldReject: true },
+				command.settings,
+			),
+		).rejects.toThrow("script rejected");
 	});
 });
 


### PR DESCRIPTION
Document and encode the final decision-bucket remediations.

This handles findings that required product judgment rather than mechanical cleanup: command label text is centralized while preserving command IDs, and utility tests cover the intentionally retained user-script/eval behavior and related waiver decisions.

Review focus:
- Command label changes versus stable command IDs.
- User-script/eval decision coverage in `utilityObsidian.test.ts`.
- Whether the centralized label helper matches expected UI wording.

Stack position: 16/17, based on `scorecard/15-build-release-hygiene`.

Validated as part of the completed scorecard mission with `bun run build-with-lint`, `bun run test`, `bun run build`, `bun run test:e2e`, and Obsidian `dev` vault reload/smoke checks.