### PR TITLE
fix: preserve folder path suggester clicks

### DIFF
--- a/src/gui/suggesters/suggest.test.ts
+++ b/src/gui/suggesters/suggest.test.ts
@@ -1,0 +1,55 @@
+import type { App } from "obsidian";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GenericTextSuggester } from "./genericTextSuggester";
+
+function createApp(): App {
+	return {
+		dom: {
+			appContainerEl: document.body,
+		},
+		keymap: {
+			pushScope: vi.fn(),
+			popScope: vi.fn(),
+		},
+	} as unknown as App;
+}
+
+describe("TextInputSuggest", () => {
+	afterEach(() => {
+		document.body.replaceChildren();
+	});
+
+	it("keeps focus during suggestion mousedown so click selection can run", async () => {
+		const input = document.createElement("input");
+		input.trigger = (eventName: string) => {
+			input.dispatchEvent(new Event(eventName, { bubbles: true }));
+		};
+		document.body.appendChild(input);
+
+		new GenericTextSuggester(createApp(), input, ["Adventure"]);
+
+		input.focus();
+		input.value = "Adv";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		await Promise.resolve();
+
+		const suggestion = document.querySelector<HTMLElement>(".suggestion-item");
+		expect(suggestion?.textContent).toBe("Adventure");
+
+		const mouseDown = new MouseEvent("mousedown", {
+			bubbles: true,
+			cancelable: true,
+		});
+		suggestion?.dispatchEvent(mouseDown);
+
+		if (!mouseDown.defaultPrevented) {
+			input.blur();
+		}
+
+		suggestion?.dispatchEvent(
+			new MouseEvent("click", { bubbles: true, cancelable: true }),
+		);
+
+		expect(input.value).toBe("Adventure");
+	});
+});

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -264,7 +264,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		this.inputEl.setAttribute("aria-expanded", "false");
 
 		this.suggestEl.addEventListener("mousedown", (event: MouseEvent) => {
-			if (event.target === this.suggestEl) event.preventDefault();
+			event.preventDefault();
 		});
 
 		// Setup global listeners


### PR DESCRIPTION
Prevent suggestion popups from closing on mousedown before their click handler can select an item. This restores the folder-path picker in template settings on Obsidian 1.12.x, where clicking a folder suggestion blurred the input and left the typed query in place.

The fix keeps focus while mousing down inside the suggester popup, matching the pre-2.12.1 behavior. I added a regression test for the mousedown/blur/click ordering that previously dropped the selection.

Validation:
- Reproduced in the `dev` vault before the fix: CDP click on `Adventure` left the folder path input as `Adv`, focused `BODY`, and the folder list stayed empty.
- `bun run test`
- `bun run build-with-lint`
- Reloaded QuickAdd in the `dev` vault and reran the same CDP path: clicking `Adventure` changed the input to `Adventure`; clicking Add rendered `Adventure` in the folder list; `obsidian vault=dev dev:errors` reported no captured errors.

Fixes #1210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for text suggestion functionality.

* **Bug Fixes**
  * Improved suggestion selection behavior to prevent unintended input focus loss during interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->