### PR TITLE
fix(docs): avoid duplicate background warning

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -153,7 +153,12 @@
 
 .previewSidebar {
   background: var(--qa-canvas);
-  background: color-mix(in srgb, var(--qa-canvas) 72%, var(--qa-canvas-raised));
+}
+
+@supports (background: color-mix(in srgb, white, black)) {
+  .previewSidebar {
+    background: color-mix(in srgb, var(--qa-canvas) 72%, var(--qa-canvas-raised));
+  }
 }
 
 .previewSidebarTitle,


### PR DESCRIPTION
Avoid the duplicate `background` warning in the docs homepage CSS.

The preview sidebar used a plain `background` fallback followed by a `color-mix()` enhancement in the same rule, which triggered an unexpected duplicate property warning. This keeps the fallback as the base declaration and moves the enhanced color into an `@supports` block so unsupported browsers still get the fallback while supported browsers apply the mixed background.

Verification:
- `bun run build` from `docs/`
- Obsidian dev vault CSS runtime check with `obsidian vault=dev eval`, confirming `CSS.supports(...)` is true, the mixed computed background applies, and `dev:errors` reports no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved preview sidebar styling with enhanced browser compatibility support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->