### PR TITLE
chore: add repo governance (SECURITY, CODEOWNERS, templates, PR-title lint)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repository.
+# Automatically requests review from the owner on every pull request.
+* @chhoumann

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussions
+    url: https://github.com/chhoumann/quickadd/discussions
+    about: Ask questions, share workflows, and get help from the community here.
+  - name: QuickAdd documentation
+    url: https://quickadd.obsidian.guide
+    about: Guides and reference for QuickAdd's features before filing an issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this change, and why? -->
+
+## Changes
+
+<!-- Bullet the key changes. -->
+
+## Testing / validation
+
+<!-- How did you verify this? e.g. `bun run build-with-lint`, `bun run test`, and
+     manual checks in Obsidian (include the Obsidian version; screenshots for UI). -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
+      — it becomes the squash-merge commit and drives the released version.
+- [ ] Linked any related issue(s).
+- [ ] Noted release/migration impact, if any.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,42 @@
+name: PR Title
+
+# Releases are driven by semantic-release from the squash-merge commit, which is
+# the PR title. Validate it as a Conventional Commit so a bad title can't produce
+# a wrong (or missing) release.
+on:
+    pull_request_target:
+        types: [opened, edited, synchronize, reopened]
+
+permissions:
+    pull-requests: read
+
+concurrency:
+    group: pr-title-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    validate:
+        name: Validate PR title
+        runs-on: ubuntu-latest
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+              with:
+                  egress-policy: audit
+            - name: Lint PR title
+              uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  types: |
+                      feat
+                      fix
+                      perf
+                      docs
+                      style
+                      refactor
+                      test
+                      build
+                      ci
+                      chore
+                      revert

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported versions
+
+QuickAdd is an Obsidian community plugin; only the latest released version
+(see the [releases page](https://github.com/chhoumann/quickadd/releases)) is
+supported. Please update to the latest version before reporting an issue.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately** using GitHub's
+[Private Vulnerability Reporting](https://github.com/chhoumann/quickadd/security/advisories/new).
+Do **not** open a public issue, discussion, or pull request for a security
+problem.
+
+When reporting, please include:
+
+- a description of the vulnerability and its impact,
+- steps to reproduce (or a proof of concept), and
+- the QuickAdd and Obsidian versions affected.
+
+We aim to acknowledge reports within a few days. Once a fix is available it will
+be released and the advisory published with credit to the reporter (unless you
+prefer to remain anonymous). Thank you for helping keep QuickAdd and its users
+safe.


### PR DESCRIPTION
Adds the governance pieces a popular public plugin should have. Low-risk additions only.

- **SECURITY.md** — security policy using GitHub **Private Vulnerability Reporting** (enabled out-of-band), supported versions, and what to include in a report.
- **CODEOWNERS** (`* @chhoumann`) — auto-requests review.
- **PULL_REQUEST_TEMPLATE.md** — summary / changes / validation + a Conventional-Commit reminder (the squash title drives the released version).
- **ISSUE_TEMPLATE/config.yml** — disables blank issues; routes questions to Discussions + the docs site.
- **pr-title.yml** — validates PR titles as Conventional Commits (amannn/action-semantic-pull-request, SHA-pinned, harden-runner, `pull-requests: read`). Protects semantic-release from a malformed squash title. Non-blocking (not a required check).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy with vulnerability reporting guidelines; users should report security issues privately rather than publicly.
  * Updated issue templates to guide users toward discussions and documentation resources.

* **Chores**
  * Established pull request validation standards and repository code ownership configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->