### PR TITLE
fix(ai): match provider endpoints by hostname (resolves 11 CodeQL alerts)

### DIFF
--- a/docs/static/scripts/EzImport.js
+++ b/docs/static/scripts/EzImport.js
@@ -350,6 +350,6 @@ async function apiGet(url, data) {
 function replaceIllegalFileNameCharactersInString(string) {
 	return string
 		.replace(/[\\,#%&\{\}\/*<>$\'\":@\u2023\|\?]*/g, "") // Replace illegal file name characters with empty string
-		.replace(/\n/, " ") // replace newlines with spaces
-		.replace("  ", " "); // replace multiple spaces with single space to make sure we don't have double spaces in the file name
+		.replace(/\n/g, " ") // replace all newlines with spaces
+		.replace(/ {2,}/g, " "); // collapse runs of spaces into a single space in the file name
 }

--- a/src/ai/modelsDirectory.test.ts
+++ b/src/ai/modelsDirectory.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+	mapEndpointToModelsDevKey,
+	mapModelsDevToQuickAdd,
+	dedupeModels,
+	type ModelsDevModel,
+} from "./modelsDirectory";
+
+describe("mapEndpointToModelsDevKey", () => {
+	// Realistic provider base URLs should map to the right models.dev key.
+	it.each([
+		["https://api.openai.com/v1", "openai"],
+		["https://openrouter.ai/api/v1", "openrouter"],
+		["https://generativelanguage.googleapis.com/v1beta", "google"],
+		["https://api.anthropic.com", "anthropic"],
+		["https://api.groq.com/openai/v1", "groq"],
+		["https://api.together.xyz/v1", "togetherai"],
+		["https://together.ai/v1", "togetherai"],
+		["https://router.huggingface.co/v1", "huggingface"],
+		["https://models.github.ai/inference", "github-models"],
+		["https://bedrock-runtime.us-east-1.amazonaws.com", "amazon-bedrock"],
+		["https://api-inference.modelscope.cn/v1", "modelscope"],
+		["https://dashscope.aliyuncs.com/compatible-mode/v1", "alibaba"],
+		["https://api.fireworks.ai/inference/v1", "fireworks-ai"],
+		["https://api.inference.net/v1", "inference"],
+		["https://api.z.ai/api/paas/v4", "zhipuai"],
+		["https://api.deepseek.com", "deepseek"],
+		["https://api.cerebras.ai/v1", "cerebras"],
+		["https://api.venice.ai/api/v1", "venice"],
+		["https://api.upstage.ai/v1", "upstage"],
+		["https://api.llama.com/v1", "llama"],
+		["https://api.morphllm.com/v1", "morph"],
+		["https://api.inceptionlabs.ai/v1", "inception"],
+		["https://api.deepinfra.com/v1/openai", "deepinfra"],
+		["https://gateway.opencode.ai/v1", "opencode"],
+		["https://inference.wandb.ai/v1", "wandb"],
+		["https://api.githubcopilot.com", "github-copilot"],
+	])("maps %s -> %s", (endpoint, expected) => {
+		expect(mapEndpointToModelsDevKey(endpoint)).toBe(expected);
+	});
+
+	it("matches the bare provider host without an api subdomain", () => {
+		expect(mapEndpointToModelsDevKey("https://openai.com/v1")).toBe("openai");
+	});
+
+	it("accepts endpoints without a scheme", () => {
+		expect(mapEndpointToModelsDevKey("api.openai.com/v1")).toBe("openai");
+	});
+
+	it("is case-insensitive", () => {
+		expect(mapEndpointToModelsDevKey("https://API.OpenAI.COM/v1")).toBe("openai");
+	});
+
+	// Spoofing: a provider domain appearing in the path or in a different host
+	// must NOT be classified as that provider (the CodeQL finding).
+	it.each([
+		"https://evil.com/api.openai.com/v1",
+		"https://openai.com.evil.com/v1",
+		"https://deepseek.com.attacker.example/v1",
+		"https://api.openai.com@evil.com/v1",
+	])("does not classify spoofed URL %s as any provider", (endpoint) => {
+		expect(mapEndpointToModelsDevKey(endpoint)).toBeNull();
+	});
+
+	it("returns null for unknown or unparseable endpoints", () => {
+		expect(mapEndpointToModelsDevKey("https://example.com/v1")).toBeNull();
+		expect(mapEndpointToModelsDevKey("not a url")).toBeNull();
+		expect(mapEndpointToModelsDevKey("")).toBeNull();
+	});
+
+	// Providers reached via proxy/custom URLs are intentionally matched by loose
+	// keyword (these checks are deliberately not hostname-scoped).
+	it.each([
+		["https://my-anthropic-proxy.internal/v1", "anthropic"],
+		["https://cerebras.internal.example/v1", "cerebras"],
+		["https://my-huggingface-proxy.internal/v1", "huggingface"],
+		["https://gateway.internal/deepinfra", "deepinfra"],
+		["https://internal-bedrock.example/v1", "amazon-bedrock"],
+		["https://zhipu-proxy.internal/v1", "zhipuai"],
+	])("identifies %s via keyword/proxy fallback -> %s", (endpoint, expected) => {
+		expect(mapEndpointToModelsDevKey(endpoint)).toBe(expected);
+	});
+
+	it("handles scheme-less endpoints that include a port", () => {
+		expect(mapEndpointToModelsDevKey("api.openai.com:8443/v1")).toBe("openai");
+	});
+});
+
+describe("mapModelsDevToQuickAdd", () => {
+	it("maps id + context limit, flooring and clamping to >= 1", () => {
+		const models: ModelsDevModel[] = [
+			{ id: "gpt-x", limit: { context: 200000 } },
+			{ id: "no-limit" },
+			{ id: "tiny", limit: { context: 0.5 } },
+		];
+		expect(mapModelsDevToQuickAdd(models)).toEqual([
+			{ name: "gpt-x", maxTokens: 200000 },
+			{ name: "no-limit", maxTokens: 128000 },
+			{ name: "tiny", maxTokens: 1 },
+		]);
+	});
+});
+
+describe("dedupeModels", () => {
+	it("appends only incoming models whose name isn't already present", () => {
+		const existing = [{ name: "a", maxTokens: 1 }];
+		const incoming = [
+			{ name: "a", maxTokens: 2 },
+			{ name: "b", maxTokens: 3 },
+		];
+		expect(dedupeModels(existing, incoming)).toEqual([
+			{ name: "a", maxTokens: 1 },
+			{ name: "b", maxTokens: 3 },
+		]);
+	});
+});

--- a/src/ai/modelsDirectory.ts
+++ b/src/ai/modelsDirectory.ts
@@ -44,38 +44,63 @@ export async function fetchModelsDevDirectory(): Promise<ModelsDevDirectory> {
   return data;
 }
 
+// Extract the lowercased hostname from an endpoint, tolerating a missing
+// scheme (e.g. "api.openai.com/v1"). Returns "" when it can't be parsed.
+function endpointHost(endpoint: string): string {
+  for (const candidate of [endpoint, `https://${endpoint}`]) {
+    try {
+      // A scheme-less "host:port/path" parses as an opaque scheme with an empty
+      // hostname; require a real hostname so such inputs fall through to the
+      // https://-prefixed candidate instead of resolving to "".
+      const host = new URL(candidate).hostname.toLowerCase();
+      if (host) return host;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return "";
+}
+
 export function mapEndpointToModelsDevKey(endpoint: string): string | null {
   const url = endpoint.toLowerCase();
-  if (url.includes("openai.com")) return "openai";
-  if (url.includes("openrouter.ai")) return "openrouter";
-  if (url.includes("generativelanguage.googleapis.com")) return "google";
-  if (url.includes("anthropic.com") || url.includes("anthropic"))
-    return "anthropic";
-  if (url.includes("groq.com")) return "groq";
-  if (url.includes("together.ai")) return "togetherai";
-  if (url.includes("huggingface.co") || url.includes("huggingface"))
-    return "huggingface";
+  const host = endpointHost(endpoint);
+
+  // Match a provider domain against the URL's hostname (or a subdomain of it)
+  // so it can't be spoofed by the domain appearing elsewhere in the URL — e.g.
+  // "https://evil.com/api.openai.com" or "https://openai.com.evil.com"
+  // (CodeQL js/incomplete-url-substring-sanitization). Bare-keyword checks
+  // below stay as loose substring matches on purpose (they identify providers
+  // reached via proxy/custom URLs).
+  const hostMatches = (domain: string): boolean =>
+    host === domain || host.endsWith(`.${domain}`);
+
+  if (hostMatches("openai.com")) return "openai";
+  if (hostMatches("openrouter.ai")) return "openrouter";
+  if (hostMatches("generativelanguage.googleapis.com")) return "google";
+  if (url.includes("anthropic")) return "anthropic";
+  if (hostMatches("groq.com")) return "groq";
+  if (hostMatches("together.ai") || hostMatches("together.xyz"))
+    return "togetherai";
+  if (url.includes("huggingface")) return "huggingface";
   if (url.includes("github") && url.includes("models")) return "github-models";
   if (url.includes("bedrock") || url.includes("aws")) return "amazon-bedrock";
   if (url.includes("modelscope")) return "modelscope";
   if (url.includes("dashscope")) return "alibaba";
-  if (url.includes("fireworks.ai")) return "fireworks-ai";
+  if (hostMatches("fireworks.ai")) return "fireworks-ai";
   if (url.includes("vercel")) return "vercel";
-  if (url.includes("inference.net")) return "inference";
-  if (url.includes("z.ai") || url.includes("zhipu")) return "zhipuai";
-  if (url.includes("deepseek.com")) return "deepseek";
+  if (hostMatches("inference.net")) return "inference";
+  if (hostMatches("z.ai") || url.includes("zhipu")) return "zhipuai";
+  if (hostMatches("deepseek.com")) return "deepseek";
   if (url.includes("cerebras")) return "cerebras";
-  if (url.includes("venice.ai")) return "venice";
-  if (url.includes("upstage.ai")) return "upstage";
-  if (url.includes("llama.com") || url.includes("api.llama.com")) return "llama";
+  if (hostMatches("venice.ai")) return "venice";
+  if (hostMatches("upstage.ai")) return "upstage";
+  if (hostMatches("llama.com")) return "llama";
   if (url.includes("morphllm")) return "morph";
-  if (url.includes("inceptionlabs.ai")) return "inception";
+  if (hostMatches("inceptionlabs.ai")) return "inception";
   if (url.includes("deepinfra")) return "deepinfra";
-  if (url.includes("gateway.opencode.ai")) return "opencode";
-  if (url.includes("router.huggingface.co")) return "huggingface";
-  if (url.includes("inference.wandb.ai")) return "wandb";
-  if (url.includes("api.githubcopilot.com")) return "github-copilot";
-  if (url.includes("api.openai.com")) return "openai";
+  if (hostMatches("opencode.ai")) return "opencode";
+  if (hostMatches("inference.wandb.ai")) return "wandb";
+  if (hostMatches("githubcopilot.com")) return "github-copilot";
   return null;
 }
 


### PR DESCRIPTION
Resolves all **11 open CodeQL high alerts** ([code scanning](https://github.com/chhoumann/quickadd/security/code-scanning)).

## What & why
**10× `js/incomplete-url-substring-sanitization`** in `src/ai/modelsDirectory.ts` — provider detection used `url.includes("openai.com")`-style substring checks on the full URL, which a crafted URL can spoof (`https://evil.com/api.openai.com`, `https://openai.com.evil.com`).
- Now parses the endpoint **hostname** (tolerating a missing scheme; requires a real hostname so scheme-less `host:port/path` still resolves) and matches provider domains via `host === domain || host.endsWith("."+domain)`.
- Bare-keyword checks (`anthropic`, `huggingface`, `github`+`models`, …) stay loose **on purpose** — they identify providers behind proxy/custom URLs (not a CodeQL-flagged pattern).
- Removes 3 now-redundant checks (`api.openai.com`, `api.llama.com`, `router.huggingface.co`).
- Bonus: also detects Together's real endpoint `api.together.xyz` (was only `together.ai`, so the preset mapped to **null** before).

**1× `js/incomplete-sanitization`** in `docs/static/scripts/EzImport.js` — the filename sanitizer's non-global `.replace(/\\n/, " ")` (and `.replace("  ", " ")`) only fixed the first match; both are now global.

## Tests
Adds the **first real unit test** for `mapEndpointToModelsDevKey` (it was mocked everywhere): 43 cases — every provider endpoint, spoof rejection (asserts `null`), scheme-less/port/case handling, and keyword-proxy fallbacks.

## Verification
Behavior preserved for every realistic provider endpoint (old-vs-new diff'd). `bun run build-with-lint` clean; **1126 tests pass**. **Adversarially verified across 4 review lenses** (CodeQL coverage, behavior preservation, bypass/false-positive+negative, test adequacy) — which is how the scheme-less-port regression and the Together gap were caught and fixed before pushing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file name normalization to consistently handle all newline characters and collapse multiple consecutive spaces into single spaces.

* **Improvements**
  * Enhanced provider endpoint recognition with stricter hostname-based matching to reduce spoofing risks and expand support for additional providers.

* **Tests**
  * Added comprehensive test coverage for endpoint mapping and model deduplication functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->