### PR TITLE
chore(types): resolve all svelte-check errors and enforce svelte-check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
               run: bun install --frozen-lockfile
             - name: Run build with lint
               run: bun run build-with-lint
+            - name: Svelte check
+              run: bun run check
 
     dependency-review:
         name: Dependency Review

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "build-with-lint": "tsc -noEmit -skipLibCheck && bun lint && node esbuild.config.mjs production",
+    "check": "svelte-check --threshold error",
     "test": "vitest run --config vitest.config.mts --passWithNoTests",
     "test:e2e": "vitest run --config vitest.e2e.config.mts"
   },

--- a/src/gui/GlobalVariables/GlobalVariablesView.svelte
+++ b/src/gui/GlobalVariables/GlobalVariablesView.svelte
@@ -39,7 +39,7 @@
   function addVariable() {
     const names = new Set(items.map((i) => i.name));
     const name = uniqueName("NewVar", names);
-    items = [...items, { id: name, name, value: "" }];
+    items = [...items, { name, value: "" }];
     persistToSettings();
   }
 

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -31,6 +31,8 @@ import { createEventDispatcher } from "svelte";
 import { OpenFileCommandSettingsModal } from "./OpenFileCommandSettingsModal";
 import ConditionalCommand from "./Components/ConditionalCommand.svelte";
 import type { IConditionalCommand } from "../../types/macros/Conditional/IConditionalCommand";
+import type { IWaitCommand } from "../../types/macros/QuickCommands/IWaitCommand";
+import type { INestedChoiceCommand } from "../../types/macros/QuickCommands/INestedChoiceCommand";
 
 	export let commands: ICommand[];
 export let deleteCommand: (commandId: string) => Promise<void>;
@@ -39,6 +41,16 @@ export let app: App;
 export let plugin: QuickAdd;
 let dragDisabled: boolean = true;
 const dispatch = createEventDispatcher();
+
+// Narrowing helpers: the {#each} discriminates on command.type, so each child
+// receives the matching subtype. Passed one-way — children report edits via the
+// on:updateCommand event, not via two-way bind:command.
+const asWait = (c: ICommand) => c as IWaitCommand;
+const asNested = (c: ICommand) => c as INestedChoiceCommand;
+const asUserScript = (c: ICommand) => c as IUserScript;
+const asAI = (c: ICommand) => c as IAIAssistantCommand;
+const asOpenFile = (c: ICommand) => c as IOpenFileCommand;
+const asConditional = (c: ICommand) => c as IConditionalCommand;
 
 	export const updateCommandList: (newCommands: ICommand[]) => void = (
 		newCommands: ICommand[]
@@ -66,7 +78,7 @@ const dispatch = createEventDispatcher();
 		saveCommands(commands);
 	}
 
-	let startDrag = (e: CustomEvent<DndEvent>) => {
+	let startDrag = (e: MouseEvent | TouchEvent) => {
 		e.preventDefault();
 		dragDisabled = false;
 	};
@@ -135,23 +147,13 @@ function editConditionalElse(e: CustomEvent<IConditionalCommand>) {
 			return;
 		}
 
+		const scriptSettings =
+			(userScript as { settings?: { [key: string]: unknown } }).settings ?? {};
+
 		new UserScriptSettingsModal(
 			app,
 			command,
-			(userScript.settings ?? {}) as {
-				[key: string]: unknown;
-				options?: {
-					[key: string]: {
-						description?: string;
-						type: string;
-						value: string | boolean;
-						placeholder?: string;
-						secret?: boolean;
-						defaultValue: string | boolean;
-						options?: string[];
-					};
-				};
-			},
+			scriptSettings as ConstructorParameters<typeof UserScriptSettingsModal>[2],
 			() => saveCommands([...commands]),
 		).open();
 	}
@@ -197,7 +199,7 @@ function editConditionalElse(e: CustomEvent<IConditionalCommand>) {
 	{#each commands.filter((c) => c.id !== SHADOW_PLACEHOLDER_ITEM_ID) as command (command.id)}
 		{#if command.type === CommandType.Wait}
 			<WaitCommand
-				bind:command
+				command={asWait(command)}
 				bind:dragDisabled
 				bind:startDrag
 				on:deleteCommand={async (e) => await deleteCommand(e.detail)}
@@ -205,7 +207,7 @@ function editConditionalElse(e: CustomEvent<IConditionalCommand>) {
 			/>
 		{:else if command.type === CommandType.NestedChoice}
 			<NestedChoiceCommand
-				bind:command
+				command={asNested(command)}
 				bind:dragDisabled
 				bind:startDrag
 				on:deleteCommand={async (e) => await deleteCommand(e.detail)}
@@ -214,7 +216,7 @@ function editConditionalElse(e: CustomEvent<IConditionalCommand>) {
 			/>
 		{:else if command.type === CommandType.UserScript}
 			<UserScriptCommand
-				bind:command
+				command={asUserScript(command)}
 				bind:dragDisabled
 				bind:startDrag
 				on:deleteCommand={async (e) => await deleteCommand(e.detail)}
@@ -223,7 +225,7 @@ function editConditionalElse(e: CustomEvent<IConditionalCommand>) {
 			/>
 		{:else if command.type === CommandType.AIAssistant}
 			<AIAssistantCommand
-				bind:command
+				command={asAI(command)}
 				bind:dragDisabled
 				bind:startDrag
 				on:deleteCommand={async (e) => await deleteCommand(e.detail)}
@@ -232,7 +234,7 @@ function editConditionalElse(e: CustomEvent<IConditionalCommand>) {
 			/>
 		{:else if command.type === CommandType.OpenFile}
 			<OpenFileCommand
-				bind:command
+				command={asOpenFile(command)}
 				bind:dragDisabled
 				bind:startDrag
 				on:deleteCommand={async (e) => await deleteCommand(e.detail)}
@@ -241,7 +243,7 @@ function editConditionalElse(e: CustomEvent<IConditionalCommand>) {
 			/>
 		{:else if command.type === CommandType.Conditional}
 			<ConditionalCommand
-				bind:command
+				command={asConditional(command)}
 				bind:dragDisabled
 				bind:startDrag
 				on:deleteCommand={async (e) => await deleteCommand(e.detail)}

--- a/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
+++ b/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import ObsidianIcon from "../../components/ObsidianIcon.svelte";
     import {createEventDispatcher} from "svelte";
-    import type {DndEvent} from "svelte-dnd-action";
 	import type { IAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
 
     export let command: IAIAssistantCommand;
-    export let startDrag: (e: CustomEvent<DndEvent>) => void;
+    export let startDrag: (e: MouseEvent | TouchEvent) => void;
     export let dragDisabled: boolean;
     const dispatch = createEventDispatcher();
 

--- a/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
+++ b/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 	import { createEventDispatcher } from "svelte";
-	import type { DndEvent } from "svelte-dnd-action";
 	import ObsidianIcon from "../../components/ObsidianIcon.svelte";
 	import type { IConditionalCommand } from "../../../types/macros/Conditional/IConditionalCommand";
 	import { getConditionSummary } from "../../../utils/conditionalHelpers";
 
 	export let command: IConditionalCommand;
-	export let startDrag: (e: CustomEvent<DndEvent>) => void;
+	export let startDrag: (e: MouseEvent | TouchEvent) => void;
 	export let dragDisabled: boolean;
 
 	const dispatch = createEventDispatcher();

--- a/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
+++ b/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import ObsidianIcon from "../../components/ObsidianIcon.svelte";
     import {createEventDispatcher} from "svelte";
-    import type {DndEvent} from "svelte-dnd-action";
     import type {INestedChoiceCommand} from "../../../types/macros/QuickCommands/INestedChoiceCommand";
 
     export let command: INestedChoiceCommand;
-    export let startDrag: (e: CustomEvent<DndEvent>) => void;
+    export let startDrag: (e: MouseEvent | TouchEvent) => void;
     export let dragDisabled: boolean;
     const dispatch = createEventDispatcher();
 

--- a/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
+++ b/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
@@ -2,11 +2,10 @@
 	import type { IOpenFileCommand } from "../../../types/macros/QuickCommands/IOpenFileCommand";
 	import ObsidianIcon from "../../components/ObsidianIcon.svelte";
 	import { createEventDispatcher } from "svelte";
-	import type { DndEvent } from "svelte-dnd-action";
 
 	export let command: IOpenFileCommand;
 	export let dragDisabled: boolean;
-	export let startDrag: (e: CustomEvent<DndEvent>) => void;
+	export let startDrag: (e: MouseEvent | TouchEvent) => void;
 
 	const dispatch = createEventDispatcher();
 

--- a/src/gui/MacroGUIs/Components/StandardCommand.svelte
+++ b/src/gui/MacroGUIs/Components/StandardCommand.svelte
@@ -2,11 +2,10 @@
     import type {ICommand} from "../../../types/macros/ICommand";
     import ObsidianIcon from "../../components/ObsidianIcon.svelte";
     import {createEventDispatcher} from "svelte";
-    import type {DndEvent} from "svelte-dnd-action";
     import {getCommandDisplayName} from "../../../utils/macroHelpers";
 
     export let command: ICommand;
-    export let startDrag: (e: CustomEvent<DndEvent>) => void;
+    export let startDrag: (e: MouseEvent | TouchEvent) => void;
     export let dragDisabled: boolean;
     const dispatch = createEventDispatcher();
 

--- a/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
+++ b/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import ObsidianIcon from "../../components/ObsidianIcon.svelte";
     import {createEventDispatcher} from "svelte";
-    import type {DndEvent} from "svelte-dnd-action";
     import type {IUserScript} from "../../../types/macros/IUserScript";
 
     export let command: IUserScript;
-    export let startDrag: (e: CustomEvent<DndEvent>) => void;
+    export let startDrag: (e: MouseEvent | TouchEvent) => void;
     export let dragDisabled: boolean;
     const dispatch = createEventDispatcher();
 

--- a/src/gui/MacroGUIs/Components/WaitCommand.svelte
+++ b/src/gui/MacroGUIs/Components/WaitCommand.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import ObsidianIcon from "../../components/ObsidianIcon.svelte";
     import {createEventDispatcher, onMount} from "svelte";
-    import type {DndEvent} from "svelte-dnd-action";
     import type {IWaitCommand} from "../../../types/macros/QuickCommands/IWaitCommand";
 
     export let command: IWaitCommand;
-    export let startDrag: (e: CustomEvent<DndEvent>) => void;
+    export let startDrag: (e: MouseEvent | TouchEvent) => void;
     export let dragDisabled: boolean;
     const dispatch = createEventDispatcher();
 

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
     import type IChoice from "../../types/choices/IChoice";
     import ChoiceListItem from "./ChoiceListItem.svelte";
-    import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
+    import MultiChoiceListItemRaw from "./MultiChoiceListItem.svelte";
+    // `as any` breaks the recursive ChoiceList <-> MultiChoiceListItem type cycle (svelte-check); runtime is unchanged.
+    const MultiChoiceListItem = MultiChoiceListItemRaw as any;
     import {dndzone, SHADOW_PLACEHOLDER_ITEM_ID} from "svelte-dnd-action";
     import type {DndEvent} from "svelte-dnd-action";
     import {createEventDispatcher} from "svelte";

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -5,7 +5,6 @@
 	import { onMount } from "svelte";
 	import type QuickAdd from "../../main";
 	import {
-		type ChoiceType,
 		CommandRegistry,
 		configureChoice,
 		createChoice,
@@ -13,6 +12,7 @@
 		deleteChoiceWithConfirmation,
 		duplicateChoice,
 	} from "../../services/choiceService";
+	import type { ChoiceType } from "../../types/choices/choiceType";
 	import type IChoice from "../../types/choices/IChoice";
 	import { AIAssistantSettingsModal } from "../AIAssistantSettingsModal";
 	import ObsidianIcon from "../components/ObsidianIcon.svelte";
@@ -23,6 +23,10 @@
 
 	export let choices: IChoice[] = [];
 	export let saveChoices: (choices: IChoice[]) => void;
+
+	function handleReorderChoices(e: CustomEvent<{ choices: IChoice[] }>) {
+		saveChoices(e.detail.choices);
+	}
 	export let app: App;
 	export let plugin: QuickAdd;
 
@@ -217,7 +221,6 @@
 
 	{#if filterQuery.trim().length === 0}
 		<ChoiceList
-			type="main"
 			app={app}
 			roots={choices}
 			bind:choices
@@ -227,11 +230,10 @@
 			on:duplicateChoice={handleDuplicateChoice}
 			on:renameChoice={handleRenameChoice}
 			on:moveChoice={handleMoveChoice}
-			on:reorderChoices={(e) => saveChoices(e.detail.choices)}
+			on:reorderChoices={handleReorderChoices}
 		/>
 	{:else}
 		<ChoiceList
-			type="main"
 			app={app}
 			roots={choices}
 			choices={filterChoices(choices, filterQuery)}

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import ObsidianIcon from "../components/ObsidianIcon.svelte";
-    import ChoiceList from "./ChoiceList.svelte";
+    import ChoiceListRaw from "./ChoiceList.svelte";
+    // `as any` breaks the recursive ChoiceList <-> MultiChoiceListItem type cycle (svelte-check); runtime is unchanged.
+    const ChoiceList = ChoiceListRaw as any;
     import type IMultiChoice from "../../types/choices/IMultiChoice";
     import RightButtons from "./ChoiceItemRightButtons.svelte";
     import {createEventDispatcher} from "svelte";

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -16,10 +16,7 @@ type ChoiceSuggesterOptions = {
 	placeholderStack?: Array<string | undefined>;
 };
 export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
-	private choiceExecutor: IChoiceExecutor = new ChoiceExecutor(
-		this.app,
-		this.plugin
-	);
+	private choiceExecutor: IChoiceExecutor;
 	private placeholderStack: Array<string | undefined> = [];
 	private currentPlaceholder?: string;
 
@@ -37,6 +34,9 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		options?: ChoiceSuggesterOptions
 	) {
 		super(plugin.app);
+		// Initialize here (not as a field initializer) so the `plugin` parameter
+		// property is already assigned; a field initializer runs before it.
+		this.choiceExecutor = new ChoiceExecutor(this.app, this.plugin);
 		if (options?.choiceExecutor) this.choiceExecutor = options.choiceExecutor;
 		this.placeholderStack = options?.placeholderStack ?? [];
 		this.currentPlaceholder = options?.placeholder?.trim() || undefined;

--- a/src/types/macros/ObsidianCommand.ts
+++ b/src/types/macros/ObsidianCommand.ts
@@ -4,10 +4,10 @@ import type { IObsidianCommand } from "./IObsidianCommand";
 import { v4 as uuidv4 } from "uuid";
 
 export class ObsidianCommand extends Command implements IObsidianCommand {
-	name: string;
-	id: string;
+	declare name: string;
+	declare id: string;
 	commandId: string;
-	type: CommandType;
+	declare type: CommandType;
 
 	constructor(name: string, commandId: string) {
 		super(name, CommandType.Obsidian);

--- a/src/types/macros/QuickCommands/AIAssistantCommand.ts
+++ b/src/types/macros/QuickCommands/AIAssistantCommand.ts
@@ -6,9 +6,9 @@ import type { OpenAIModelParameters } from "src/ai/OpenAIModelParameters";
 import { DEFAULT_FREQUENCY_PENALTY, DEFAULT_PRESENCE_PENALTY, DEFAULT_TEMPERATURE, DEFAULT_TOP_P } from "src/ai/OpenAIModelParameters";
 
 export class AIAssistantCommand extends Command implements IAIAssistantCommand {
-	id: string;
-	name: string;
-	type: CommandType;
+	declare id: string;
+	declare name: string;
+	declare type: CommandType;
 
 	model: string;
 	systemPrompt: string;

--- a/src/types/macros/QuickCommands/WaitCommand.ts
+++ b/src/types/macros/QuickCommands/WaitCommand.ts
@@ -3,10 +3,10 @@ import { CommandType } from "../CommandType";
 import type { IWaitCommand } from "./IWaitCommand";
 
 export class WaitCommand extends Command implements IWaitCommand {
-	id: string;
-	name: string;
+	declare id: string;
+	declare name: string;
 	time: number;
-	type: CommandType;
+	declare type: CommandType;
 
 	constructor(time: number) {
 		super("Wait", CommandType.Wait);

--- a/src/types/macros/UserScript.ts
+++ b/src/types/macros/UserScript.ts
@@ -3,9 +3,9 @@ import { CommandType } from "./CommandType";
 import type { IUserScript } from "./IUserScript";
 
 export class UserScript extends Command implements IUserScript {
-	name: string;
+	declare name: string;
 	path: string;
-	type: CommandType;
+	declare type: CommandType;
 	settings: { [key: string]: unknown };
 
 	constructor(name: string, path: string) {


### PR DESCRIPTION
Resolves the 40 svelte-check errors (17 files) and wires svelte-check into CI. **Every fix is type-only / behavior-preserving** — no Svelte version or bundling change (we share the Obsidian runtime with other plugins).

## Fixes by category
- **dnd drag handles (14)** — `startDrag` was mis-typed `(e: CustomEvent<DndEvent>)` but is bound to `on:mousedown`/`on:touchstart`; retyped to `(e: MouseEvent | TouchEvent)` in the 7 command components + `CommandList` (kept the parent's `DndEvent` import — still used by consider/finalize; dropped the unused child imports).
- **Command subclasses (11)** — `declare` on inherited `name`/`id`/`type` (TS2612; emission-free under ES2020, and prevents field-clobbering if the target is ever raised).
- **CommandList narrowing (8)** — `ICommand` → specific types via `<script>` cast helpers passed **one-way** (`command={asWait(command)}`); children report edits via `on:updateCommand` events (verified none reassign `command`), so behavior is unchanged. `ConstructorParameters<...>` for the settings-modal arg.
- **choiceList (4)** — broke the `ChoiceList ↔ MultiChoiceListItem` recursive type cycle with `as any` cross-imports; imported `ChoiceType` from its canonical source; typed reorder handler; removed the dead `type="main"` prop.
- **choiceSuggester (1)** — initialize `choiceExecutor` in the constructor body (after `super()`) so `plugin` is defined (TS2729).
- **GlobalVariables (2)** — dropped a dead `id` field never present on `GV` (confirmed unused; `{#each}` is index-based).

## CI
Adds a `check` script (`svelte-check --threshold error`) and runs it in the **Build + Lint** job, so Svelte component type regressions are caught going forward.

## Verification
- svelte-check **0 errors / 0 warnings** (was 40); `build-with-lint` clean; **1126 tests pass**.
- The provider/endpoint detection and other logic untouched.
- **Dev-vault smoke test**: plugin reloads with no errors; the choice suggester (exercises the `choiceSuggester` init reorder) opens with no errors; settings render with no errors.

> Investigated + cross-checked via a multi-agent workflow (each fix got a runtime-safety assessment); the agent that consolidated the plan empirically drove it to 0 svelte-check + 0 tsc errors.
> Note: I couldn't fully drive the macro-editor *modal* (drag-reorder/edit a command) headlessly — that change is event-driven and compiles/loads clean, but a quick manual check there is worthwhile.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type-checking to continuous integration workflow via new `check` script.

* **Bug Fixes**
  * Resolved circular type reference issues in choice list components.
  * Fixed initialization timing in choice suggester.

* **Refactor**
  * Updated command drag-handler event types across components.
  * Modified class property type declarations for consistency.
  * Streamlined global variable creation structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->