### PR TITLE
fix(macros): commands no longer disappear when reordering in the macro editor

### DIFF
--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -60,7 +60,12 @@ const asConditional = (c: ICommand) => c as IConditionalCommand;
 
 	function handleConsider(e: CustomEvent<DndEvent>) {
 		let { items: newItems } = e.detail;
-		commands = newItems as ICommand[];
+		// Drop svelte-dnd-action's internal shadow placeholder so a command can't
+		// linger in state and vanish on reorder (ghost gap) — mirrors the Settings
+		// choice list fix (#883).
+		commands = (newItems as ICommand[]).filter(
+			(c) => c.id !== SHADOW_PLACEHOLDER_ITEM_ID
+		);
 	}
 
 	function handleSort(e: CustomEvent<DndEvent>) {
@@ -69,7 +74,9 @@ const asConditional = (c: ICommand) => c as IConditionalCommand;
 			info: { source },
 		} = e.detail;
 
-		commands = newItems as ICommand[];
+		commands = (newItems as ICommand[]).filter(
+			(c) => c.id !== SHADOW_PLACEHOLDER_ITEM_ID
+		);
 
 		if (source === SOURCES.POINTER) {
 			dragDisabled = true;


### PR DESCRIPTION
## Bug
In the macro editor, dragging to reorder a command could make **another command disappear** (most visibly with 2 commands).

## Cause
`CommandList`'s `handleConsider`/`handleSort` assigned svelte-dnd-action's raw `e.detail.items` — including the library's internal **shadow placeholder** — directly to `commands`, and only filtered the placeholder out of the `{#each}`. With few items, a command could end up retained in state as the placeholder and then be filtered out of the render, so it vanished.

## Fix
Strip `SHADOW_PLACEHOLDER_ITEM_ID` in both handlers before assigning to `commands` — the exact fix already applied to the Settings choice list in #883. CommandList was the only dndzone list still missing it (pre-existing; unrelated to the recent CI/type work).

## Verification
Manually verified in the dev vault: reordering with 2+ commands no longer drops an item and the order persists. `bun run build` + `bun run check` (svelte-check 0/0) clean; unit tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where placeholder items would persist during command list reordering, improving the drag-and-drop user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->