### PR TITLE
test: core-logic unit tests + coverage tooling (46% -> 54%)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ src/**/*.js
 
 # e2e test failure artifacts
 .obsidian-e2e-artifacts
+# Test coverage output
+coverage/

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@types/node": "24.0.12",
         "@typescript-eslint/eslint-plugin": "^8.60.0",
         "@typescript-eslint/parser": "^8.60.0",
+        "@vitest/coverage-v8": "3.2.4",
         "cz-conventional-changelog": "^3.3.0",
         "esbuild": "0.28",
         "esbuild-svelte": "^0.9.5",
@@ -53,7 +54,15 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -164,6 +173,10 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -295,6 +308,8 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.61.0", "", { "os": "win32", "cpu": "x64" }, "sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw=="],
 
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
     "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
@@ -419,6 +434,8 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
+
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -482,6 +499,8 @@
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
 
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
@@ -615,6 +634,8 @@
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
@@ -703,6 +724,8 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "from2": ["from2@2.3.0", "", { "dependencies": { "inherits": "^2.0.1", "readable-stream": "^2.0.0" } }, "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g=="],
 
     "fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
@@ -721,7 +744,7 @@
 
     "git-log-parser": ["git-log-parser@1.2.1", "", { "dependencies": { "argv-formatter": "~1.0.0", "spawn-error-forwarder": "~1.0.0", "split2": "~1.0.0", "stream-combiner2": "~1.1.1", "through2": "~2.0.0", "traverse": "0.6.8" } }, "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ=="],
 
-    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -737,7 +760,7 @@
 
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
-    "has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
@@ -748,6 +771,8 @@
     "hosted-git-info": ["hosted-git-info@8.1.0", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -821,13 +846,23 @@
 
     "issue-parser": ["issue-parser@7.0.2", "", { "dependencies": { "lodash.capitalize": "^4.2.1", "lodash.escaperegexp": "^4.1.2", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.uniqby": "^4.7.0" } }, "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "java-properties": ["java-properties@1.0.2", "", {}, "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
-    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -915,7 +950,11 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
     "make-asynchronous": ["make-asynchronous@1.1.0", "", { "dependencies": { "p-event": "^6.0.0", "type-fest": "^4.6.0", "web-worker": "^1.5.0" } }, "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
@@ -940,6 +979,8 @@
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.7", "", {}, "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
 
@@ -1025,6 +1066,8 @@
 
     "p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "papaparse": ["papaparse@5.5.3", "", {}, "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -1046,6 +1089,8 @@
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -1171,9 +1216,13 @@
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
@@ -1189,7 +1238,7 @@
 
     "super-regex": ["super-regex@1.1.0", "", { "dependencies": { "function-timeout": "^1.0.1", "make-asynchronous": "^1.0.1", "time-span": "^5.1.0" } }, "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ=="],
 
-    "supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
 
@@ -1206,6 +1255,8 @@
     "temp-dir": ["temp-dir@3.0.0", "", {}, "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw=="],
 
     "tempy": ["tempy@3.2.0", "", { "dependencies": { "is-stream": "^3.0.0", "temp-dir": "^3.0.0", "type-fest": "^2.12.2", "unique-string": "^3.0.0" } }, "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ=="],
+
+    "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -1317,6 +1368,8 @@
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
@@ -1341,9 +1394,19 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@commitlint/config-validator/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@15.0.2", "", { "dependencies": { "@octokit/openapi-types": "^26.0.0" } }, "sha512-rR+5VRjhYSer7sC51krfCctQhVTmjyUMAaShfPB8mscVa8tSoLyon3coxQmXu0ahJoLVWl8dSGD/3OGZlFV44Q=="],
 
@@ -1371,6 +1434,8 @@
 
     "chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
+    "chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1378,6 +1443,8 @@
     "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
+    "commitizen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
@@ -1389,7 +1456,7 @@
 
     "execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
-    "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "global-directory/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
@@ -1787,6 +1854,8 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "pkg-conf/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
@@ -1797,6 +1866,8 @@
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
     "semantic-release/aggregate-error": ["aggregate-error@5.0.0", "", { "dependencies": { "clean-stack": "^5.2.0", "indent-string": "^5.0.0" } }, "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw=="],
 
     "semantic-release/p-reduce": ["p-reduce@3.0.0", "", {}, "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q=="],
@@ -1805,13 +1876,13 @@
 
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
-
-    "supports-hyperlinks/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
-    "supports-hyperlinks/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "svelte/css-tree": ["css-tree@2.3.1", "", { "dependencies": { "mdn-data": "2.0.30", "source-map-js": "^1.0.1" } }, "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw=="],
 
@@ -1829,7 +1900,13 @@
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@26.0.0", "", {}, "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="],
 
@@ -1851,13 +1928,15 @@
 
     "@semantic-release/npm/aggregate-error/indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
-    "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
-    "cli-highlight/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+    "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
+    "commitizen/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "env-ci/execa/get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
 
@@ -1871,19 +1950,15 @@
 
     "env-ci/execa/strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 
     "inquirer/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "inquirer/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "inquirer/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
     "inquirer/figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "log-symbols/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "log-symbols/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -1913,9 +1988,9 @@
 
     "ora/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "ora/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
     "pkg-conf/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
+
+    "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "semantic-release/aggregate-error/clean-stack": ["clean-stack@5.3.0", "", { "dependencies": { "escape-string-regexp": "5.0.0" } }, "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg=="],
 
@@ -1981,6 +2056,8 @@
 
     "vitest/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
+    "wrap-ansi-cjs/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
     "wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "@semantic-release/github/aggregate-error/clean-stack/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -1989,7 +2066,7 @@
 
     "cli-highlight/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "cli-highlight/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+    "commitizen/glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "env-ci/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
@@ -1999,11 +2076,7 @@
 
     "inquirer/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "inquirer/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
     "log-symbols/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "log-symbols/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "npm/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -2023,11 +2096,11 @@
 
     "ora/chalk/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "ora/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
     "pkg-conf/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
     "pkg-conf/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "semantic-release/aggregate-error/clean-stack/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -2135,9 +2208,13 @@
 
     "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "wrap-ansi-cjs/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "cli-highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commitizen/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "inquirer/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
@@ -2146,5 +2223,7 @@
     "ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "pkg-conf/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
+
+    "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build-with-lint": "tsc -noEmit -skipLibCheck && bun lint && node esbuild.config.mjs production",
     "check": "svelte-check --threshold error",
     "test": "vitest run --config vitest.config.mts --passWithNoTests",
+    "test:coverage": "vitest run --config vitest.config.mts --coverage",
     "test:e2e": "vitest run --config vitest.e2e.config.mts"
   },
   "keywords": [],
@@ -22,6 +23,7 @@
     "@types/node": "24.0.12",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
+    "@vitest/coverage-v8": "3.2.4",
     "cz-conventional-changelog": "^3.3.0",
     "esbuild": "0.28",
     "esbuild-svelte": "^0.9.5",

--- a/src/ai/OpenAIRequest.test.ts
+++ b/src/ai/OpenAIRequest.test.ts
@@ -1,0 +1,631 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type { Model } from "./Provider";
+
+const storeState = vi.hoisted(() => ({
+	disableOnlineFeatures: false,
+}));
+
+const mocks = vi.hoisted(() => ({
+	requestUrlMock: vi.fn(),
+	getTokenCountMock: vi.fn(),
+	beginAIRequestLogEntryMock: vi.fn(),
+	finishAIRequestLogEntryMock: vi.fn(),
+	getModelProviderMock: vi.fn(),
+	logMessageMock: vi.fn(),
+	logErrorMock: vi.fn(),
+}));
+
+vi.mock("obsidian", () => ({
+	requestUrl: mocks.requestUrlMock,
+}));
+
+vi.mock("src/settingsStore", () => ({
+	settingsStore: {
+		getState: () => storeState,
+	},
+}));
+
+vi.mock("./AIAssistant", () => ({
+	getTokenCount: mocks.getTokenCountMock,
+	beginAIRequestLogEntry: mocks.beginAIRequestLogEntryMock,
+	finishAIRequestLogEntry: mocks.finishAIRequestLogEntryMock,
+}));
+
+vi.mock("./aiHelpers", () => ({
+	getModelProvider: mocks.getModelProviderMock,
+}));
+
+vi.mock("src/logger/logManager", () => ({
+	log: {
+		logMessage: mocks.logMessageMock,
+		logError: mocks.logErrorMock,
+	},
+}));
+
+const {
+	requestUrlMock,
+	getTokenCountMock,
+	beginAIRequestLogEntryMock,
+	finishAIRequestLogEntryMock,
+	getModelProviderMock,
+	logErrorMock,
+} = mocks;
+
+const { OpenAIRequest } = await import("./OpenAIRequest");
+
+// A minimal app whose activeEditor is undefined so preventCursorChange becomes a no-op.
+function makeApp(): App {
+	return {
+		workspace: {
+			activeEditor: undefined,
+		},
+	} as unknown as App;
+}
+
+// An app whose editor records setCursor/setSelections calls so we can assert
+// preventCursorChange restores cursor state after dispatching the request.
+function makeAppWithEditor() {
+	const calls = {
+		setCursor: vi.fn(),
+		setSelections: vi.fn(),
+	};
+	const cursor = { line: 3, ch: 7 };
+	const selections = [{ anchor: { line: 1, ch: 0 }, head: { line: 2, ch: 4 } }];
+	const app = {
+		workspace: {
+			activeEditor: {
+				editor: {
+					getCursor: () => cursor,
+					listSelections: () => selections,
+					setCursor: calls.setCursor,
+					setSelections: calls.setSelections,
+				},
+			},
+		},
+	} as unknown as App;
+
+	return { app, calls, cursor, selections };
+}
+
+const openAIModel: Model = { name: "gpt-4o", maxTokens: 128000 };
+const anthropicModel: Model = { name: "claude-3-5-sonnet", maxTokens: 200000 };
+const geminiModel: Model = { name: "gemini-1.5-pro", maxTokens: 1000000 };
+
+const openAIProvider = {
+	name: "OpenAI",
+	endpoint: "https://api.openai.com/v1",
+};
+const anthropicProvider = {
+	name: "Anthropic",
+	endpoint: "https://api.anthropic.com",
+};
+const geminiProvider = {
+	name: "Gemini",
+	endpoint: "https://generativelanguage.googleapis.com",
+};
+
+function openAIResponse(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "chatcmpl-123",
+		model: "gpt-4o",
+		object: "chat.completion",
+		usage: {
+			prompt_tokens: 10,
+			completion_tokens: 20,
+			total_tokens: 30,
+		},
+		choices: [
+			{
+				finish_reason: "stop",
+				index: 0,
+				message: { content: "Hello there", role: "assistant" },
+			},
+		],
+		created: 1700000000,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	storeState.disableOnlineFeatures = false;
+	// Default token count keeps every prompt well under any maxTokens limit.
+	getTokenCountMock.mockReturnValue(1);
+	beginAIRequestLogEntryMock.mockReturnValue("log-id-1");
+});
+
+describe("OpenAIRequest", () => {
+	describe("guard clauses", () => {
+		it("throws and does not call requestUrl when online features are disabled", async () => {
+			storeState.disableOnlineFeatures = true;
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				openAIModel,
+				"system"
+			);
+
+			await expect(makeRequest("prompt")).rejects.toThrow(
+				"Online features are disabled in settings."
+			);
+			expect(requestUrlMock).not.toHaveBeenCalled();
+			expect(beginAIRequestLogEntryMock).not.toHaveBeenCalled();
+		});
+
+		it("throws when the combined token count exceeds the model limit", async () => {
+			// prompt + system both contribute; sum (60000+60000) > 100000.
+			getTokenCountMock.mockReturnValue(60000);
+			const model: Model = { name: "gpt-4o", maxTokens: 100000 };
+			const makeRequest = OpenAIRequest(makeApp(), "key", model, "system");
+
+			await expect(makeRequest("prompt")).rejects.toThrow(
+				"The gpt-4o API has a token limit of 100000. Your prompt has 120000 tokens."
+			);
+			expect(requestUrlMock).not.toHaveBeenCalled();
+		});
+
+		it("allows requests exactly at the token limit (boundary)", async () => {
+			// 2 * 50000 = 100000, not strictly greater than the limit.
+			getTokenCountMock.mockReturnValue(50000);
+			const model: Model = { name: "gpt-4o", maxTokens: 100000 };
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
+
+			const makeRequest = OpenAIRequest(makeApp(), "key", model, "system");
+			await expect(makeRequest("prompt")).resolves.toBeDefined();
+			expect(requestUrlMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("throws when no provider is found for the model", async () => {
+			getModelProviderMock.mockReturnValue(undefined);
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				openAIModel,
+				"system"
+			);
+
+			await expect(makeRequest("prompt")).rejects.toThrow(
+				"Model gpt-4o not found with any provider."
+			);
+			expect(requestUrlMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("OpenAI request construction", () => {
+		beforeEach(() => {
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
+		});
+
+		it("posts to the chat/completions endpoint with auth header and JSON content type", async () => {
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"secret-key",
+				openAIModel,
+				"system"
+			);
+			await makeRequest("prompt");
+
+			expect(requestUrlMock).toHaveBeenCalledTimes(1);
+			const arg = requestUrlMock.mock.calls[0][0];
+			expect(arg.url).toBe("https://api.openai.com/v1/chat/completions");
+			expect(arg.method).toBe("POST");
+			expect(arg.headers).toEqual({
+				"Content-Type": "application/json",
+				Authorization: "Bearer secret-key",
+			});
+		});
+
+		it("serializes model name, model params, and system/user messages into the body", async () => {
+			const params = { temperature: 0.5, top_p: 0.9 };
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				openAIModel,
+				"you are helpful",
+				params
+			);
+			await makeRequest("what is 2+2?");
+
+			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
+			expect(body).toEqual({
+				model: "gpt-4o",
+				temperature: 0.5,
+				top_p: 0.9,
+				messages: [
+					{ role: "system", content: "you are helpful" },
+					{ role: "user", content: "what is 2+2?" },
+				],
+			});
+		});
+
+		it("omits extra params when modelParams defaults to empty", async () => {
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				openAIModel,
+				"sys"
+			);
+			await makeRequest("hi");
+
+			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
+			expect(Object.keys(body)).toEqual(["model", "messages"]);
+		});
+
+		it("maps the OpenAI response into the common response shape", async () => {
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				openAIModel,
+				"sys"
+			);
+			const result = await makeRequest("hi");
+
+			expect(result).toEqual({
+				id: "chatcmpl-123",
+				model: "gpt-4o",
+				content: "Hello there",
+				usage: {
+					promptTokens: 10,
+					completionTokens: 20,
+					totalTokens: 30,
+				},
+				stopReason: "stop",
+				stopSequence: null,
+				created: 1700000000,
+			});
+		});
+	});
+
+	describe("Anthropic request construction", () => {
+		beforeEach(() => {
+			getModelProviderMock.mockReturnValue(anthropicProvider);
+		});
+
+		it("posts to /v1/messages with anthropic headers and a user-only message", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: {
+					id: "msg-1",
+					model: "claude-3-5-sonnet",
+					role: "assistant",
+					stop_reason: "end_turn",
+					stop_sequence: null,
+					type: "message",
+					content: [{ text: "Hi from Claude", type: "text" }],
+					usage: { input_tokens: 5, output_tokens: 8 },
+				},
+			});
+
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"anthropic-key",
+				anthropicModel,
+				"system prompt"
+			);
+			await makeRequest("hello claude");
+
+			const arg = requestUrlMock.mock.calls[0][0];
+			expect(arg.url).toBe("https://api.anthropic.com/v1/messages");
+			expect(arg.headers).toEqual({
+				"Content-Type": "application/json",
+				"x-api-key": "anthropic-key",
+				"anthropic-version": "2023-06-01",
+				"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15",
+			});
+
+			const body = JSON.parse(arg.body);
+			expect(body).toEqual({
+				model: "claude-3-5-sonnet",
+				max_tokens: 4096,
+				messages: [{ role: "user", content: "hello claude" }],
+			});
+		});
+
+		it("maps the Anthropic response, summing tokens and preserving stop_sequence", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: {
+					id: "msg-2",
+					model: "claude-3-5-sonnet",
+					role: "assistant",
+					stop_reason: "stop_sequence",
+					stop_sequence: "###",
+					type: "message",
+					content: [{ text: "Answer", type: "text" }],
+					usage: { input_tokens: 11, output_tokens: 4 },
+				},
+			});
+
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				anthropicModel,
+				"sys"
+			);
+			const result = await makeRequest("q");
+
+			expect(result.id).toBe("msg-2");
+			expect(result.content).toBe("Answer");
+			expect(result.usage).toEqual({
+				promptTokens: 11,
+				completionTokens: 4,
+				totalTokens: 15,
+			});
+			expect(result.stopReason).toBe("stop_sequence");
+			expect(result.stopSequence).toBe("###");
+			expect(typeof result.created).toBe("number");
+		});
+	});
+
+	describe("Gemini request construction", () => {
+		beforeEach(() => {
+			getModelProviderMock.mockReturnValue(geminiProvider);
+		});
+
+		it("uses the generateContent URL with the api key as a query param", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: {
+					candidates: [
+						{
+							content: {
+								role: "model",
+								parts: [{ text: "Gemini reply" }],
+							},
+							finishReason: "STOP",
+						},
+					],
+					modelVersion: "gemini-1.5-pro-001",
+					usageMetadata: {
+						promptTokenCount: 7,
+						candidatesTokenCount: 9,
+						totalTokenCount: 16,
+					},
+				},
+			});
+
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"gem ini/key",
+				geminiModel,
+				"system instruction text"
+			);
+			await makeRequest("hi gemini");
+
+			const arg = requestUrlMock.mock.calls[0][0];
+			expect(arg.url).toBe(
+				"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent?key=gem%20ini%2Fkey"
+			);
+			// Gemini does not use the Authorization header.
+			expect(arg.headers).toEqual({ "Content-Type": "application/json" });
+		});
+
+		it("includes a systemInstruction when a non-empty system prompt is provided", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: { candidates: [{ content: { role: "model", parts: [] } }] },
+			});
+
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				geminiModel,
+				"  you are helpful  "
+			);
+			await makeRequest("hi");
+
+			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
+			expect(body.systemInstruction).toEqual({
+				role: "system",
+				parts: [{ text: "  you are helpful  " }],
+			});
+			expect(body.contents).toEqual([
+				{ role: "user", parts: [{ text: "hi" }] },
+			]);
+		});
+
+		it("omits systemInstruction when the system prompt is empty/whitespace", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: { candidates: [{ content: { role: "model", parts: [] } }] },
+			});
+
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "   ");
+			await makeRequest("hi");
+
+			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
+			expect(body.systemInstruction).toBeUndefined();
+		});
+
+		it("maps only temperature and top_p into generationConfig", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: { candidates: [{ content: { role: "model", parts: [] } }] },
+			});
+
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				geminiModel,
+				"sys",
+				{
+					temperature: 0.3,
+					top_p: 0.8,
+					frequency_penalty: 0.5,
+					presence_penalty: 0.5,
+				}
+			);
+			await makeRequest("hi");
+
+			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
+			expect(body.generationConfig).toEqual({
+				temperature: 0.3,
+				topP: 0.8,
+			});
+		});
+
+		it("omits generationConfig when no supported params are provided", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: { candidates: [{ content: { role: "model", parts: [] } }] },
+			});
+
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "sys", {
+				frequency_penalty: 0.5,
+			});
+			await makeRequest("hi");
+
+			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
+			expect(body.generationConfig).toBeUndefined();
+		});
+
+		it("concatenates multiple text parts and reads usage metadata", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: {
+					candidates: [
+						{
+							content: {
+								role: "model",
+								parts: [
+									{ text: "Hello " },
+									{ inlineData: {} },
+									{ text: "world" },
+								],
+							},
+							finishReason: "STOP",
+						},
+					],
+					modelVersion: "gemini-x",
+					usageMetadata: {
+						promptTokenCount: 2,
+						candidatesTokenCount: 3,
+						totalTokenCount: 5,
+					},
+				},
+			});
+
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "sys");
+			const result = await makeRequest("hi");
+
+			expect(result.content).toBe("Hello world");
+			expect(result.model).toBe("gemini-x");
+			expect(result.usage).toEqual({
+				promptTokens: 2,
+				completionTokens: 3,
+				totalTokens: 5,
+			});
+			expect(result.stopReason).toBe("STOP");
+		});
+
+		it("defaults usage and stopReason when metadata is missing", async () => {
+			requestUrlMock.mockResolvedValue({
+				json: { candidates: [{ content: { role: "model", parts: [] } }] },
+			});
+
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "sys");
+			const result = await makeRequest("hi");
+
+			expect(result.content).toBe("");
+			expect(result.model).toBe("gemini");
+			expect(result.usage).toEqual({
+				promptTokens: 0,
+				completionTokens: 0,
+				totalTokens: 0,
+			});
+			expect(result.stopReason).toBe("");
+		});
+	});
+
+	describe("logging lifecycle", () => {
+		it("logs a pending entry then a success entry with usage and duration", async () => {
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
+
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				openAIModel,
+				"sys",
+				{ temperature: 0.2 }
+			);
+			await makeRequest("prompt");
+
+			expect(beginAIRequestLogEntryMock).toHaveBeenCalledWith({
+				provider: "OpenAI",
+				endpoint: "https://api.openai.com/v1",
+				model: "gpt-4o",
+				systemPrompt: "sys",
+				prompt: "prompt",
+				modelOptions: { temperature: 0.2 },
+			});
+
+			expect(finishAIRequestLogEntryMock).toHaveBeenCalledTimes(1);
+			const [id, result] = finishAIRequestLogEntryMock.mock.calls[0];
+			expect(id).toBe("log-id-1");
+			expect(result.status).toBe("success");
+			expect(typeof result.durationMs).toBe("number");
+			expect(result.durationMs).toBeGreaterThanOrEqual(0);
+			expect(result.usage).toEqual({
+				promptTokens: 10,
+				completionTokens: 20,
+				totalTokens: 30,
+			});
+		});
+
+		it("logs an error entry and rethrows a wrapped error when requestUrl rejects", async () => {
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			const networkError = new Error("Network down");
+			requestUrlMock.mockRejectedValue(networkError);
+
+			const makeRequest = OpenAIRequest(
+				makeApp(),
+				"key",
+				openAIModel,
+				"sys"
+			);
+
+			await expect(makeRequest("prompt")).rejects.toThrow(
+				"Error while making request to OpenAI: Network down"
+			);
+
+			expect(finishAIRequestLogEntryMock).toHaveBeenCalledTimes(1);
+			const [, result] = finishAIRequestLogEntryMock.mock.calls[0];
+			expect(result.status).toBe("error");
+			expect(result.errorMessage).toBe("Network down");
+			expect(logErrorMock).toHaveBeenCalledWith(networkError);
+		});
+
+		it("preserves the original error as the cause of the wrapped error", async () => {
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			const networkError = new Error("boom");
+			requestUrlMock.mockRejectedValue(networkError);
+
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+
+			await expect(makeRequest("prompt")).rejects.toMatchObject({
+				cause: networkError,
+			});
+		});
+
+		it("stringifies non-Error rejections in the error message", async () => {
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			requestUrlMock.mockRejectedValue("plain string failure");
+
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+
+			await expect(makeRequest("prompt")).rejects.toThrow(
+				"Error while making request to OpenAI: plain string failure"
+			);
+		});
+	});
+
+	describe("cursor restoration", () => {
+		it("restores the cursor and selection after dispatching the request", async () => {
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
+
+			const { app, calls, cursor, selections } = makeAppWithEditor();
+			const makeRequest = OpenAIRequest(app, "key", openAIModel, "sys");
+			await makeRequest("prompt");
+
+			expect(calls.setCursor).toHaveBeenCalledWith(cursor);
+			expect(calls.setSelections).toHaveBeenCalledWith(selections);
+		});
+	});
+});

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1,0 +1,648 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit tests for the concrete CompleteFormatter.
+ *
+ * The formatter wires together a large number of heavy collaborators (engines,
+ * GUI prompts, field collectors). We mock those modules so the tests stay
+ * deterministic and focus on CompleteFormatter's own behavior: the format
+ * pipeline ordering, the public formatFileName/Content/FolderPath methods, global-variable
+ * expansion, the concrete getter overrides, and the prompt/suggest wrappers
+ * (including their cancellation -> MacroAbortError mapping).
+ */
+
+// --- Hoisted mock handles ------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+	macroRunAndGetOutput: vi.fn(),
+	macroGetVariables: vi.fn(() => new Map()),
+	templateRun: vi.fn(),
+	inlineRunAndGetOutput: vi.fn(),
+	inlineParamsVariables: {} as Record<string, unknown>,
+	inputPromptPrompt: vi.fn(),
+	inputPromptPromptWithContext: vi.fn(),
+	genericInputPromptWithContext: vi.fn(),
+	inputSuggesterSuggest: vi.fn(),
+	genericSuggesterSuggest: vi.fn(),
+	vdatePrompt: vi.fn(),
+	mathPrompt: vi.fn(),
+	fieldParse: vi.fn(),
+	collectProcessedDetailed: vi.fn(),
+	collectRaw: vi.fn(),
+	getSmartDefaults: vi.fn(() => [] as string[]),
+	dateAliases: {} as Record<string, string>,
+}));
+
+// --- Module mocks --------------------------------------------------------
+
+vi.mock("obsidian", () => {
+	// MarkdownView is only referenced as a token passed to getActiveViewOfType.
+	class MarkdownView {}
+	return { MarkdownView };
+});
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+	SingleMacroEngine: class {
+		runAndGetOutput = mocks.macroRunAndGetOutput;
+		getVariables = mocks.macroGetVariables;
+	},
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		run = mocks.templateRun;
+	},
+}));
+
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	SingleInlineScriptEngine: class {
+		params = { variables: mocks.inlineParamsVariables };
+		runAndGetOutput = mocks.inlineRunAndGetOutput;
+	},
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+	default: class {
+		factory() {
+			return {
+				Prompt: mocks.inputPromptPrompt,
+				PromptWithContext: mocks.inputPromptPromptWithContext,
+			};
+		}
+	},
+}));
+
+vi.mock("src/gui/GenericInputPrompt/GenericInputPrompt", () => ({
+	default: { PromptWithContext: mocks.genericInputPromptWithContext },
+}));
+
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
+	default: { Suggest: mocks.inputSuggesterSuggest },
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: { Suggest: mocks.genericSuggesterSuggest },
+}));
+
+vi.mock("src/gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	default: { Prompt: mocks.vdatePrompt },
+}));
+
+vi.mock("../gui/MathModal", () => ({
+	MathModal: { Prompt: mocks.mathPrompt },
+}));
+
+vi.mock("../parsers/NLDParser", () => ({
+	NLDParser: { parseDate: () => null },
+}));
+
+vi.mock("../utils/FieldSuggestionParser", () => ({
+	FieldSuggestionParser: { parse: mocks.fieldParse },
+}));
+
+vi.mock("../utils/FieldValueCollector", () => ({
+	collectFieldValuesProcessedDetailed: mocks.collectProcessedDetailed,
+	collectFieldValuesRaw: mocks.collectRaw,
+	generateFieldCacheKey: (f: unknown) => JSON.stringify(f),
+}));
+
+vi.mock("../utils/FieldValueProcessor", () => ({
+	FieldValueProcessor: { getSmartDefaults: mocks.getSmartDefaults },
+}));
+
+vi.mock("../settingsStore", () => ({
+	settingsStore: { getState: () => ({ dateAliases: mocks.dateAliases }) },
+}));
+
+// Keep the logger silent/deterministic.
+vi.mock("../logger/logManager", () => ({
+	log: {
+		logError: vi.fn(),
+		logWarning: vi.fn(),
+		logMessage: vi.fn(),
+	},
+}));
+
+const { CompleteFormatter } = await import("./completeFormatter");
+const { MacroAbortError } = await import("../errors/MacroAbortError");
+
+// --- Test helpers --------------------------------------------------------
+
+type FakeFile = { basename: string } | null;
+
+interface FakeAppState {
+	activeFile: FakeFile;
+	selection: string | null; // null => no active markdown view
+	generatedLink: string;
+}
+
+function makeApp(state: FakeAppState) {
+	return {
+		workspace: {
+			getActiveFile: () => state.activeFile,
+			getActiveViewOfType: () =>
+				state.selection === null
+					? undefined
+					: { editor: { getSelection: () => state.selection } },
+		},
+		fileManager: {
+			generateMarkdownLink: () => state.generatedLink,
+		},
+	};
+}
+
+function makePlugin(
+	overrides: {
+		globalVariables?: Record<string, string>;
+		enableTemplatePropertyTypes?: boolean;
+	} = {},
+) {
+	return {
+		settings: {
+			globalVariables: overrides.globalVariables ?? {},
+			enableTemplatePropertyTypes:
+				overrides.enableTemplatePropertyTypes ?? false,
+			choices: [],
+			inputPrompt: "single-line",
+		},
+	};
+}
+
+// Default app: no active file, no selection, empty clipboard.
+function defaultFormatter(
+	pluginOverrides: Parameters<typeof makePlugin>[0] = {},
+	appOverrides: Partial<FakeAppState> = {},
+) {
+	const app = makeApp({
+		activeFile: appOverrides.activeFile ?? null,
+		selection: appOverrides.selection ?? null,
+		generatedLink: appOverrides.generatedLink ?? "",
+	});
+	const plugin = makePlugin(pluginOverrides);
+	return new CompleteFormatter(app as any, plugin as any);
+}
+
+beforeEach(() => {
+	for (const key of Object.keys(mocks.inlineParamsVariables)) {
+		delete mocks.inlineParamsVariables[key];
+	}
+	mocks.dateAliases = {};
+	vi.clearAllMocks();
+	mocks.macroGetVariables.mockReturnValue(new Map());
+	mocks.getSmartDefaults.mockReturnValue([]);
+
+	// Deterministic clipboard: empty by default. navigator may not exist in
+	// the jsdom-less environment, so define it.
+	(globalThis as any).navigator = {
+		clipboard: { readText: vi.fn().mockResolvedValue("") },
+	};
+
+	// Deterministic moment used by the base formatter's VDATE formatting.
+	(globalThis as any).window ??= globalThis;
+	(globalThis as any).window.moment = (_input?: unknown) => ({
+		isValid: () => true,
+		format: (fmt?: string) => (fmt === "YYYY-MM-DD" ? "2025-06-21" : "2025-06-21"),
+	});
+});
+
+// =========================================================================
+
+describe("CompleteFormatter - format pipeline (plain text)", () => {
+	it("returns plain input unchanged", async () => {
+		const f = defaultFormatter();
+		await expect(f.formatFileContent("just some text")).resolves.toBe(
+			"just some text",
+		);
+	});
+
+	it("returns empty string for empty input", async () => {
+		const f = defaultFormatter();
+		await expect(f.formatFileContent("")).resolves.toBe("");
+	});
+});
+
+describe("CompleteFormatter - global variable expansion", () => {
+	it("replaces a {{GLOBAL_VAR:name}} token with its configured snippet", async () => {
+		const f = defaultFormatter({ globalVariables: { greeting: "hello" } });
+		await expect(
+			f.formatFolderPath("say {{GLOBAL_VAR:greeting}}"),
+		).resolves.toBe("say hello");
+	});
+
+	it("trims whitespace inside the variable name", async () => {
+		const f = defaultFormatter({ globalVariables: { foo: "bar" } });
+		await expect(
+			f.formatFolderPath("{{GLOBAL_VAR:  foo  }}"),
+		).resolves.toBe("bar");
+	});
+
+	it("replaces an unknown global variable with an empty string", async () => {
+		const f = defaultFormatter({ globalVariables: {} });
+		await expect(
+			f.formatFolderPath("x{{GLOBAL_VAR:missing}}y"),
+		).resolves.toBe("xy");
+	});
+
+	it("expands nested globals (snippet that itself contains a global)", async () => {
+		const f = defaultFormatter({
+			globalVariables: {
+				outer: "[{{GLOBAL_VAR:inner}}]",
+				inner: "deep",
+			},
+		});
+		await expect(f.formatFolderPath("{{GLOBAL_VAR:outer}}")).resolves.toBe(
+			"[deep]",
+		);
+	});
+
+	it("does not loop forever on self-referential globals (recursion guard)", async () => {
+		const f = defaultFormatter({
+			globalVariables: { loop: "x{{GLOBAL_VAR:loop}}" },
+		});
+		// Should terminate (guard caps at 5 expansions) and not hang.
+		const result = await f.formatFolderPath("{{GLOBAL_VAR:loop}}");
+		expect(result.startsWith("xxxxx")).toBe(true);
+		expect(typeof result).toBe("string");
+	});
+});
+
+describe("CompleteFormatter - macro / template / inline-script integration", () => {
+	it("replaces {{MACRO:name}} with the macro engine output", async () => {
+		mocks.macroRunAndGetOutput.mockResolvedValue("MACRO_OUT");
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("a {{MACRO:doThing}} b")).resolves.toBe(
+			"a MACRO_OUT b",
+		);
+		expect(mocks.macroRunAndGetOutput).toHaveBeenCalled();
+	});
+
+	it("uses an empty string when the macro engine returns nullish", async () => {
+		mocks.macroRunAndGetOutput.mockResolvedValue(null);
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("[{{MACRO:noop}}]")).resolves.toBe("[]");
+	});
+
+	it("copies variables produced by the macro engine into the formatter", async () => {
+		mocks.macroRunAndGetOutput.mockResolvedValue("done");
+		mocks.macroGetVariables.mockReturnValue(
+			new Map<string, unknown>([["fromMacro", "value123"]]),
+		);
+		const f = defaultFormatter();
+		// Run a macro, then reference the variable it set via {{VALUE:fromMacro}}.
+		await expect(
+			f.formatFolderPath("{{MACRO:m}}-{{VALUE:fromMacro}}"),
+		).resolves.toBe("done-value123");
+		// The variable was reused; no prompt was needed.
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
+	});
+
+	it("replaces {{TEMPLATE:path}} with the template engine output", async () => {
+		mocks.templateRun.mockResolvedValue("TEMPLATE_BODY");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{TEMPLATE:notes/a.md}}"),
+		).resolves.toBe("TEMPLATE_BODY");
+	});
+
+	it("replaces inline JavaScript with its string output", async () => {
+		mocks.inlineRunAndGetOutput.mockResolvedValue("scripted");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("```js quickadd\nreturn 'x'\n```"),
+		).resolves.toBe("scripted");
+	});
+
+	it("replaces inline JavaScript with empty string when output is non-string", async () => {
+		mocks.inlineRunAndGetOutput.mockResolvedValue(42);
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("[```js quickadd\n1+1\n```]"),
+		).resolves.toBe("[]");
+	});
+
+	it("propagates variables set by the inline script", async () => {
+		// The script block is replaced by its output ("") and the variable it
+		// registered becomes available for the following {{VALUE}} token.
+		mocks.inlineRunAndGetOutput.mockResolvedValue("");
+		mocks.inlineParamsVariables.scriptVar = "fromScript";
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("```js quickadd\nnoop\n```{{VALUE:scriptVar}}"),
+		).resolves.toBe("fromScript");
+	});
+});
+
+describe("CompleteFormatter - getCurrentFileLink / getCurrentFileName", () => {
+	it("replaces {{LINKCURRENT}} with the generated markdown link", async () => {
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "Note" }, generatedLink: "[[Note]]" },
+		);
+		await expect(f.formatFileContent("see {{LINKCURRENT}}")).resolves.toBe(
+			"see [[Note]]",
+		);
+	});
+
+	it("throws (required behavior) when {{LINKCURRENT}} but no active file", async () => {
+		const f = defaultFormatter({}, { activeFile: null });
+		await expect(f.formatFileContent("{{LINKCURRENT}}")).rejects.toThrow(
+			"Unable to get current file path",
+		);
+	});
+
+	it("replaces {{FILENAMECURRENT}} with the active file basename", async () => {
+		const f = defaultFormatter({}, { activeFile: { basename: "My File" } });
+		await expect(
+			f.formatFileContent("name: {{FILENAMECURRENT}}"),
+		).resolves.toBe("name: My File");
+	});
+
+	it("throws when {{FILENAMECURRENT}} but no active file (required behavior)", async () => {
+		const f = defaultFormatter({}, { activeFile: null });
+		await expect(
+			f.formatFileContent("{{FILENAMECURRENT}}"),
+		).rejects.toThrow("Unable to get current file name");
+	});
+});
+
+describe("CompleteFormatter - title handling", () => {
+	it("replaces {{title}} in file content with the set title", async () => {
+		const f = defaultFormatter();
+		f.setTitle("Document Title");
+		await expect(f.formatFileContent("# {{title}}")).resolves.toBe(
+			"# Document Title",
+		);
+	});
+
+	it("formatFileName rejects {{title}} to avoid circular dependency", async () => {
+		const f = defaultFormatter();
+		await expect(
+			f.formatFileName("{{title}}-suffix", "Value"),
+		).rejects.toThrow("circular dependency");
+	});
+
+	it("formatFolderPath rejects {{title}} to avoid circular dependency", async () => {
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("folder/{{title}}")).rejects.toThrow(
+			"circular dependency",
+		);
+	});
+
+	it("formatFileName appends current file name replacement", async () => {
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "Source" } },
+		);
+		await expect(
+			f.formatFileName("{{FILENAMECURRENT}}-note", "Value"),
+		).resolves.toBe("Source-note");
+	});
+});
+
+describe("CompleteFormatter - selection handling", () => {
+	it("uses the editor selection for {{SELECTED}}", async () => {
+		const f = defaultFormatter({}, { selection: "highlighted text" });
+		await expect(
+			f.formatFolderPath("Q: {{SELECTED}}"),
+		).resolves.toBe("Q: highlighted text");
+	});
+
+	it("replaces {{SELECTED}} with empty string when no active markdown view", async () => {
+		const f = defaultFormatter({}, { selection: null });
+		await expect(f.formatFolderPath("[{{SELECTED}}]")).resolves.toBe("[]");
+	});
+
+	it("uses selected text as the {{VALUE}} when a selection exists", async () => {
+		const f = defaultFormatter({}, { selection: "picked" });
+		await expect(f.formatFolderPath("v={{VALUE}}")).resolves.toBe(
+			"v=picked",
+		);
+		// Selection short-circuits the prompt.
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
+	});
+});
+
+describe("CompleteFormatter - clipboard handling", () => {
+	it("replaces {{CLIPBOARD}} with clipboard contents", async () => {
+		(globalThis as any).navigator = {
+			clipboard: { readText: vi.fn().mockResolvedValue("copied!") },
+		};
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{CLIPBOARD}}")).resolves.toBe(
+			"copied!",
+		);
+	});
+
+	it("falls back to empty string when clipboard read rejects", async () => {
+		(globalThis as any).navigator = {
+			clipboard: {
+				readText: vi.fn().mockRejectedValue(new Error("denied")),
+			},
+		};
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("[{{CLIPBOARD}}]")).resolves.toBe("[]");
+	});
+});
+
+describe("CompleteFormatter - {{VALUE}} prompting", () => {
+	it("prompts for value and reuses it across multiple tokens", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("typed");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{VALUE}}-{{VALUE}}"),
+		).resolves.toBe("typed-typed");
+		// Prompt happens once per run.
+		expect(mocks.inputPromptPrompt).toHaveBeenCalledTimes(1);
+	});
+
+	it("wraps a user-cancellation in MacroAbortError", async () => {
+		// isCancellationError only treats specific string messages as cancels.
+		mocks.inputPromptPrompt.mockRejectedValue("No input given.");
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{VALUE}}")).rejects.toBeInstanceOf(
+			MacroAbortError,
+		);
+	});
+
+	it("re-throws non-cancellation errors as-is", async () => {
+		const realError = new Error("network down");
+		mocks.inputPromptPrompt.mockRejectedValue(realError);
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{VALUE}}")).rejects.toBe(realError);
+	});
+});
+
+describe("CompleteFormatter - {{VALUE:variable}} prompting", () => {
+	it("prompts for a named variable via the input prompt", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("Alice");
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{VALUE:name}}")).resolves.toBe(
+			"Alice",
+		);
+	});
+
+	it("uses the suggester for comma-separated option lists", async () => {
+		mocks.genericSuggesterSuggest.mockResolvedValue("Green");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{VALUE:Red,Green,Blue}}"),
+		).resolves.toBe("Green");
+		expect(mocks.genericSuggesterSuggest).toHaveBeenCalled();
+	});
+
+	it("maps a suggester cancellation to MacroAbortError", async () => {
+		mocks.genericSuggesterSuggest.mockRejectedValue("No input given.");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{VALUE:A,B}}"),
+		).rejects.toBeInstanceOf(MacroAbortError);
+	});
+});
+
+describe("CompleteFormatter - VDATE variable prompting", () => {
+	it("prompts via VDateInputPrompt and formats the resolved date", async () => {
+		// Returning an @date: prefixed value stores it directly; window.moment
+		// (from the obsidian stub) formats it deterministically.
+		mocks.vdatePrompt.mockResolvedValue(
+			"@date:2025-06-21T00:00:00.000Z",
+		);
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{VDATE:due,YYYY-MM-DD}}"),
+		).resolves.toBe("2025-06-21");
+		expect(mocks.vdatePrompt).toHaveBeenCalled();
+	});
+});
+
+describe("CompleteFormatter - math value prompting", () => {
+	it("replaces {{MVALUE}} with the math modal result", async () => {
+		mocks.mathPrompt.mockResolvedValue("42");
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("= {{MVALUE}}")).resolves.toBe("= 42");
+	});
+
+	it("maps a math modal cancellation to MacroAbortError", async () => {
+		mocks.mathPrompt.mockRejectedValue("No input given.");
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{MVALUE}}")).rejects.toBeInstanceOf(
+			MacroAbortError,
+		);
+	});
+});
+
+describe("CompleteFormatter - field suggestion (suggestForField)", () => {
+	it("suggests from collected values when matches exist", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "status",
+			filters: {},
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["open", "closed"],
+			hasDefaultValue: false,
+		});
+		mocks.inputSuggesterSuggest.mockResolvedValue("open");
+
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{FIELD:status}}")).resolves.toBe(
+			"open",
+		);
+		expect(mocks.inputSuggesterSuggest).toHaveBeenCalled();
+	});
+
+	it("falls back to a free-form prompt when no values are found", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "status",
+			filters: {},
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: [],
+			hasDefaultValue: false,
+		});
+		mocks.genericInputPromptWithContext.mockResolvedValue("manual");
+
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{FIELD:status}}")).resolves.toBe(
+			"manual",
+		);
+		expect(mocks.genericInputPromptWithContext).toHaveBeenCalled();
+		expect(mocks.inputSuggesterSuggest).not.toHaveBeenCalled();
+	});
+
+	it("maps a field-suggester cancellation to MacroAbortError", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "status",
+			filters: {},
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["a"],
+			hasDefaultValue: false,
+		});
+		mocks.inputSuggesterSuggest.mockRejectedValue("no input given.");
+
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{FIELD:status}}"),
+		).rejects.toBeInstanceOf(MacroAbortError);
+	});
+});
+
+describe("CompleteFormatter - constructor / dateParser injection", () => {
+	it("uses an injected date parser for VDATE coercion", async () => {
+		const injectedParser = {
+			parseDate: vi.fn().mockReturnValue({
+				moment: {
+					format: () => "2030-01-01",
+					toISOString: () => "2030-01-01T00:00:00.000Z",
+					isValid: () => true,
+				},
+			}),
+		};
+		const app = makeApp({
+			activeFile: null,
+			selection: null,
+			generatedLink: "",
+		});
+		// Non-@date: response forces a parseDate() coercion through the parser.
+		mocks.vdatePrompt.mockResolvedValue("tomorrow");
+		const f = new CompleteFormatter(
+			app as any,
+			makePlugin() as any,
+			undefined,
+			injectedParser,
+		);
+		await f.formatFolderPath("{{VDATE:when,YYYY-MM-DD}}");
+		expect(injectedParser.parseDate).toHaveBeenCalled();
+	});
+
+	it("shares variables from a provided choiceExecutor", async () => {
+		const sharedVars = new Map<string, unknown>([["preset", "shared!"]]);
+		const choiceExecutor = { variables: sharedVars };
+		const app = makeApp({
+			activeFile: null,
+			selection: null,
+			generatedLink: "",
+		});
+		const f = new CompleteFormatter(
+			app as any,
+			makePlugin() as any,
+			choiceExecutor as any,
+		);
+		// preset already lives in the shared map, so no prompt should fire.
+		await expect(
+			f.formatFolderPath("{{VALUE:preset}}"),
+		).resolves.toBe("shared!");
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
+	});
+});
+
+describe("CompleteFormatter - pipeline ordering", () => {
+	it("formats a macro's output further down the pipeline (date etc.)", async () => {
+		// Macro emits a global-var token; because globals are expanded after
+		// macros, the injected token is itself resolved.
+		mocks.macroRunAndGetOutput.mockResolvedValue("{{GLOBAL_VAR:g}}");
+		const f = defaultFormatter({ globalVariables: { g: "resolved" } });
+		await expect(f.formatFolderPath("{{MACRO:m}}")).resolves.toBe(
+			"resolved",
+		);
+	});
+});

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -1,0 +1,1048 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type QuickAdd from "./main";
+
+// ---------------------------------------------------------------------------
+// Hoisted mock state / spies. These back the vi.mock factories below.
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+	// GUI prompts
+	genericInputPrompt: vi.fn(),
+	genericWideInputPrompt: vi.fn(),
+	genericYesNoPrompt: vi.fn(),
+	genericInfoDialog: vi.fn(),
+	genericCheckboxPrompt: vi.fn(),
+	genericSuggester: vi.fn(),
+	inputSuggester: vi.fn(),
+	vDateInputPrompt: vi.fn(),
+	onePageModalWaitForClose: vi.fn(),
+
+	// AI
+	prompt: vi.fn(),
+	chunkedPrompt: vi.fn(),
+	getTokenCount: vi.fn(),
+	getAIRequestLogEntries: vi.fn(),
+	getAIRequestLogEntryById: vi.fn(),
+	getLastAIRequestLogEntry: vi.fn(),
+	clearAIRequestLogEntries: vi.fn(),
+	getModelByName: vi.fn(),
+	getModelNames: vi.fn(),
+	getModelProvider: vi.fn(),
+	resolveProviderApiKey: vi.fn(),
+
+	// misc
+	reportError: vi.fn(),
+	getDate: vi.fn(),
+	formatFileContent: vi.fn(),
+
+	// settings store
+	storeState: {
+		disableOnlineFeatures: false,
+		ai: { defaultSystemPrompt: "DEFAULT SYS" },
+	} as { disableOnlineFeatures: boolean; ai: { defaultSystemPrompt: string } },
+}));
+
+// Capture constructor args passed to OnePageInputModal so tests can assert what
+// the API forwarded (app, missing requirements, the live variables map).
+const onePageModalCalls: Array<{ app: unknown; missing: unknown; variables: unknown }> = [];
+
+vi.mock("./gui/GenericInputPrompt/GenericInputPrompt", () => ({
+	default: { Prompt: mocks.genericInputPrompt },
+}));
+vi.mock("./gui/GenericWideInputPrompt/GenericWideInputPrompt", () => ({
+	default: { Prompt: mocks.genericWideInputPrompt },
+}));
+vi.mock("./gui/GenericYesNoPrompt/GenericYesNoPrompt", () => ({
+	default: { Prompt: mocks.genericYesNoPrompt },
+}));
+vi.mock("./gui/GenericInfoDialog/GenericInfoDialog", () => ({
+	default: { Show: mocks.genericInfoDialog },
+}));
+vi.mock("./gui/GenericCheckboxPrompt/genericCheckboxPrompt", () => ({
+	default: { Open: mocks.genericCheckboxPrompt },
+}));
+vi.mock("./gui/GenericSuggester/genericSuggester", () => ({
+	default: { Suggest: mocks.genericSuggester },
+}));
+vi.mock("./gui/InputSuggester/inputSuggester", () => ({
+	default: { Suggest: mocks.inputSuggester },
+}));
+vi.mock("./gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	default: { Prompt: mocks.vDateInputPrompt },
+}));
+vi.mock("./preflight/OnePageInputModal", () => ({
+	OnePageInputModal: class {
+		waitForClose: Promise<Record<string, string>>;
+		constructor(app: unknown, missing: unknown, variables: unknown) {
+			onePageModalCalls.push({ app, missing, variables });
+			this.waitForClose = mocks.onePageModalWaitForClose();
+		}
+	},
+}));
+
+vi.mock("./ai/AIAssistant", () => ({
+	Prompt: mocks.prompt,
+	ChunkedPrompt: mocks.chunkedPrompt,
+	getTokenCount: mocks.getTokenCount,
+	getAIRequestLogEntries: mocks.getAIRequestLogEntries,
+	getAIRequestLogEntryById: mocks.getAIRequestLogEntryById,
+	getLastAIRequestLogEntry: mocks.getLastAIRequestLogEntry,
+	clearAIRequestLogEntries: mocks.clearAIRequestLogEntries,
+}));
+vi.mock("./ai/aiHelpers", () => ({
+	getModelByName: mocks.getModelByName,
+	getModelNames: mocks.getModelNames,
+	getModelProvider: mocks.getModelProvider,
+}));
+vi.mock("./ai/providerSecrets", () => ({
+	resolveProviderApiKey: mocks.resolveProviderApiKey,
+}));
+
+vi.mock("./formatters/completeFormatter", () => ({
+	CompleteFormatter: class {
+		formatFileContent = mocks.formatFileContent;
+	},
+}));
+
+vi.mock("./settingsStore", () => ({
+	settingsStore: {
+		getState: () => mocks.storeState,
+	},
+}));
+
+vi.mock("./utilityObsidian", () => ({
+	getDate: mocks.getDate,
+}));
+
+vi.mock("./utils/errorUtils", async () => {
+	// Keep the real isCancellationError so cancellation detection is exercised
+	// for real, but spy on reportError so we don't hit the logging subsystem.
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const actual = await vi.importActual<typeof import("./utils/errorUtils")>(
+		"./utils/errorUtils",
+	);
+	return {
+		...actual,
+		reportError: mocks.reportError,
+	};
+});
+
+// formatISODate, normalizeDisplayItem, MacroAbortError, the FieldSuggestion*
+// helpers and InlineFieldParser are intentionally left REAL: they are pure and
+// deterministic, so testing the API through them validates real behavior.
+
+const { QuickAddApi } = await import("./quickAddApi");
+const { MacroAbortError } = await import("./errors/MacroAbortError");
+
+// ---------------------------------------------------------------------------
+// Test doubles for app / plugin / choiceExecutor
+// ---------------------------------------------------------------------------
+type FakeFile = { path: string; basename?: string };
+
+function makeApp(overrides: Record<string, unknown> = {}) {
+	return {
+		workspace: {
+			getActiveViewOfType: vi.fn(() => undefined),
+		},
+		vault: {
+			getMarkdownFiles: vi.fn(() => [] as FakeFile[]),
+			read: vi.fn(async () => ""),
+		},
+		metadataCache: {
+			getFileCache: vi.fn(() => undefined),
+		},
+		...overrides,
+	} as unknown as App;
+}
+
+function makeChoiceExecutor() {
+	return {
+		variables: new Map<string, unknown>(),
+		execute: vi.fn(async () => {}),
+		consumeAbortSignal: vi.fn(
+			(): InstanceType<typeof MacroAbortError> | null => null,
+		),
+	};
+}
+
+function makePlugin(overrides: Record<string, unknown> = {}) {
+	return {
+		getChoiceByName: vi.fn(() => ({ name: "choice", id: "1" })),
+		...overrides,
+	} as unknown as QuickAdd;
+}
+
+function getApi(
+	app = makeApp(),
+	plugin = makePlugin(),
+	executor = makeChoiceExecutor(),
+) {
+	return {
+		api: QuickAddApi.GetApi(app, plugin, executor as never),
+		app,
+		plugin,
+		executor,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	onePageModalCalls.length = 0;
+	mocks.storeState.disableOnlineFeatures = false;
+	mocks.storeState.ai = { defaultSystemPrompt: "DEFAULT SYS" };
+});
+
+// ===========================================================================
+// Static prompt wrappers + cancellation semantics
+// ===========================================================================
+describe("static prompt wrappers", () => {
+	const app = makeApp();
+
+	describe("inputPrompt", () => {
+		it("returns the resolved value on success", async () => {
+			mocks.genericInputPrompt.mockResolvedValue("hello");
+			const out = await QuickAddApi.inputPrompt(app, "Header", "ph", "val");
+			expect(out).toBe("hello");
+			expect(mocks.genericInputPrompt).toHaveBeenCalledWith(
+				app,
+				"Header",
+				"ph",
+				"val",
+			);
+		});
+
+		it("returns undefined for a generic (non-cancellation) error", async () => {
+			mocks.genericInputPrompt.mockRejectedValue(new Error("boom"));
+			const out = await QuickAddApi.inputPrompt(app, "Header");
+			expect(out).toBeUndefined();
+		});
+
+		it("converts a cancellation string into a MacroAbortError", async () => {
+			// isCancellationError matches the literal string "No input given."
+			mocks.genericInputPrompt.mockRejectedValue("No input given.");
+			await expect(QuickAddApi.inputPrompt(app, "Header")).rejects.toBeInstanceOf(
+				MacroAbortError,
+			);
+		});
+
+		it("re-throws an existing MacroAbortError unchanged", async () => {
+			const abort = new MacroAbortError("aborted");
+			mocks.genericInputPrompt.mockRejectedValue(abort);
+			await expect(QuickAddApi.inputPrompt(app, "Header")).rejects.toBe(abort);
+		});
+	});
+
+	describe("wideInputPrompt", () => {
+		it("passes args through and returns the value", async () => {
+			mocks.genericWideInputPrompt.mockResolvedValue("wide");
+			const out = await QuickAddApi.wideInputPrompt(app, "H", "p", "v");
+			expect(out).toBe("wide");
+			expect(mocks.genericWideInputPrompt).toHaveBeenCalledWith(app, "H", "p", "v");
+		});
+
+		it("swallows generic errors as undefined", async () => {
+			mocks.genericWideInputPrompt.mockRejectedValue(new Error("x"));
+			expect(await QuickAddApi.wideInputPrompt(app, "H")).toBeUndefined();
+		});
+	});
+
+	describe("yesNoPrompt", () => {
+		it("returns the boolean answer", async () => {
+			mocks.genericYesNoPrompt.mockResolvedValue(true);
+			expect(await QuickAddApi.yesNoPrompt(app, "H", "txt")).toBe(true);
+			expect(mocks.genericYesNoPrompt).toHaveBeenCalledWith(app, "H", "txt");
+		});
+
+		it("treats 'No answer given.' as a cancellation abort", async () => {
+			mocks.genericYesNoPrompt.mockRejectedValue("No answer given.");
+			await expect(QuickAddApi.yesNoPrompt(app, "H")).rejects.toBeInstanceOf(
+				MacroAbortError,
+			);
+		});
+	});
+
+	describe("infoDialog", () => {
+		it("forwards header and text and returns the result", async () => {
+			mocks.genericInfoDialog.mockResolvedValue(undefined);
+			await QuickAddApi.infoDialog(app, "H", ["a", "b"]);
+			expect(mocks.genericInfoDialog).toHaveBeenCalledWith(app, "H", ["a", "b"]);
+		});
+	});
+
+	describe("checkboxPrompt", () => {
+		it("forwards items and selected items", async () => {
+			mocks.genericCheckboxPrompt.mockResolvedValue(["a"]);
+			const out = await QuickAddApi.checkboxPrompt(app, ["a", "b"], ["a"]);
+			expect(out).toEqual(["a"]);
+			expect(mocks.genericCheckboxPrompt).toHaveBeenCalledWith(
+				app,
+				["a", "b"],
+				["a"],
+			);
+		});
+
+		it("returns undefined on a generic error", async () => {
+			mocks.genericCheckboxPrompt.mockRejectedValue(new Error("nope"));
+			expect(await QuickAddApi.checkboxPrompt(app, [])).toBeUndefined();
+		});
+	});
+});
+
+// ===========================================================================
+// datePrompt formatting logic
+// ===========================================================================
+describe("datePrompt", () => {
+	const app = makeApp();
+
+	it("returns the raw value when it has no @date: prefix", async () => {
+		mocks.vDateInputPrompt.mockResolvedValue("just text");
+		const out = await QuickAddApi.datePrompt(app, "Pick a date");
+		expect(out).toBe("just text");
+	});
+
+	it("formats an @date: ISO value using the supplied dateFormat", async () => {
+		mocks.vDateInputPrompt.mockResolvedValue("@date:2025-06-21T00:00:00.000Z");
+		const out = await QuickAddApi.datePrompt(app, "Pick", {
+			dateFormat: "YYYY-MM-DD",
+		});
+		// real formatISODate -> stub moment formats YYYY-MM-DD to "2025-06-21"
+		expect(out).toBe("2025-06-21");
+	});
+
+	it("falls back to the raw ISO when no dateFormat is provided", async () => {
+		mocks.vDateInputPrompt.mockResolvedValue("@date:2025-06-21T00:00:00.000Z");
+		const out = await QuickAddApi.datePrompt(app, "Pick");
+		expect(out).toBe("2025-06-21T00:00:00.000Z");
+	});
+
+	it("forwards placeholder, defaultValue and dateFormat to the prompt", async () => {
+		mocks.vDateInputPrompt.mockResolvedValue("x");
+		await QuickAddApi.datePrompt(app, "Header", {
+			placeholder: "ph",
+			defaultValue: "dv",
+			dateFormat: "YYYY",
+		});
+		expect(mocks.vDateInputPrompt).toHaveBeenCalledWith(
+			app,
+			"Header",
+			"ph",
+			"dv",
+			"YYYY",
+		);
+	});
+
+	it("returns undefined on a generic error", async () => {
+		mocks.vDateInputPrompt.mockRejectedValue(new Error("fail"));
+		expect(await QuickAddApi.datePrompt(app, "H")).toBeUndefined();
+	});
+
+	it("converts a cancellation into a MacroAbortError", async () => {
+		mocks.vDateInputPrompt.mockRejectedValue("No input given.");
+		await expect(QuickAddApi.datePrompt(app, "H")).rejects.toBeInstanceOf(
+			MacroAbortError,
+		);
+	});
+});
+
+// ===========================================================================
+// suggester display-item normalization + routing
+// ===========================================================================
+describe("suggester", () => {
+	const app = makeApp();
+
+	it("maps an array of display items through normalizeDisplayItem and uses GenericSuggester", async () => {
+		mocks.genericSuggester.mockResolvedValue("picked");
+		const out = await QuickAddApi.suggester(
+			app,
+			["a", "b"],
+			["valA", "valB"],
+			"placeholder",
+		);
+		expect(out).toBe("picked");
+		expect(mocks.genericSuggester).toHaveBeenCalledWith(
+			app,
+			["a", "b"],
+			["valA", "valB"],
+			"placeholder",
+			undefined,
+		);
+		expect(mocks.inputSuggester).not.toHaveBeenCalled();
+	});
+
+	it("derives display items from a mapping function over actualItems", async () => {
+		mocks.genericSuggester.mockResolvedValue("x");
+		await QuickAddApi.suggester(
+			app,
+			(value: string, index?: number) => `${value}-${index}`,
+			["one", "two"],
+		);
+		// display items computed from actualItems with index
+		expect(mocks.genericSuggester).toHaveBeenCalledWith(
+			app,
+			["one-0", "two-1"],
+			["one", "two"],
+			undefined,
+			undefined,
+		);
+	});
+
+	it("normalizes non-string display values to strings", async () => {
+		mocks.genericSuggester.mockResolvedValue("x");
+		await QuickAddApi.suggester(
+			app,
+			[1 as unknown as string, null as unknown as string, "c"],
+			["a", "b", "c"],
+		);
+		expect(mocks.genericSuggester).toHaveBeenCalledWith(
+			app,
+			["1", "", "c"],
+			["a", "b", "c"],
+			undefined,
+			undefined,
+		);
+	});
+
+	it("routes to InputSuggester when allowCustomInput is true", async () => {
+		mocks.inputSuggester.mockResolvedValue("custom");
+		const out = await QuickAddApi.suggester(
+			app,
+			["a"],
+			["a"],
+			"ph",
+			true,
+		);
+		expect(out).toBe("custom");
+		expect(mocks.inputSuggester).toHaveBeenCalledWith(app, ["a"], ["a"], {
+			placeholder: "ph",
+		});
+		expect(mocks.genericSuggester).not.toHaveBeenCalled();
+	});
+
+	it("omits placeholder key for InputSuggester when none is given but includes renderItem", async () => {
+		mocks.inputSuggester.mockResolvedValue("custom");
+		const renderItem = vi.fn();
+		await QuickAddApi.suggester(app, ["a"], ["a"], undefined, true, {
+			renderItem,
+		});
+		expect(mocks.inputSuggester).toHaveBeenCalledWith(app, ["a"], ["a"], {
+			renderItem,
+		});
+	});
+
+	it("returns undefined on a generic error", async () => {
+		mocks.genericSuggester.mockRejectedValue(new Error("boom"));
+		expect(await QuickAddApi.suggester(app, ["a"], ["a"])).toBeUndefined();
+	});
+});
+
+// ===========================================================================
+// GetApi() thin wrappers delegate to the static methods
+// ===========================================================================
+describe("GetApi prompt wrappers", () => {
+	it("inputPrompt delegates with app/header/placeholder/value", async () => {
+		mocks.genericInputPrompt.mockResolvedValue("v");
+		const { api, app } = getApi();
+		const out = await api.inputPrompt("H", "p", "val");
+		expect(out).toBe("v");
+		expect(mocks.genericInputPrompt).toHaveBeenCalledWith(app, "H", "p", "val");
+	});
+
+	it("suggester delegates options through", async () => {
+		mocks.genericSuggester.mockResolvedValue("v");
+		const { api, app } = getApi();
+		await api.suggester(["d"], ["a"], "ph");
+		expect(mocks.genericSuggester).toHaveBeenCalledWith(
+			app,
+			["d"],
+			["a"],
+			"ph",
+			undefined,
+		);
+	});
+});
+
+// ===========================================================================
+// date helpers delegate to getDate with the right offset
+// ===========================================================================
+describe("date helpers", () => {
+	it("now() forwards format and offset", () => {
+		mocks.getDate.mockReturnValue("NOW");
+		const { api } = getApi();
+		expect(api.date.now("YYYY", 3)).toBe("NOW");
+		expect(mocks.getDate).toHaveBeenCalledWith({ format: "YYYY", offset: 3 });
+	});
+
+	it("tomorrow() uses offset 1", () => {
+		mocks.getDate.mockReturnValue("T");
+		const { api } = getApi();
+		api.date.tomorrow("YYYY-MM-DD");
+		expect(mocks.getDate).toHaveBeenCalledWith({
+			format: "YYYY-MM-DD",
+			offset: 1,
+		});
+	});
+
+	it("yesterday() uses offset -1", () => {
+		mocks.getDate.mockReturnValue("Y");
+		const { api } = getApi();
+		api.date.yesterday();
+		expect(mocks.getDate).toHaveBeenCalledWith({
+			format: undefined,
+			offset: -1,
+		});
+	});
+});
+
+// ===========================================================================
+// utility.getSelection / getSelectedText
+// ===========================================================================
+describe("utility selection helpers", () => {
+	it("getSelection returns empty string when no active markdown view", () => {
+		const { api } = getApi();
+		expect(api.utility.getSelection()).toBe("");
+	});
+
+	it("getSelection returns the editor selection when a view is active", () => {
+		const app = makeApp({
+			workspace: {
+				getActiveViewOfType: () => ({
+					editor: { getSelection: () => "selected text" },
+				}),
+			},
+		});
+		const { api } = getApi(app);
+		expect(api.utility.getSelection()).toBe("selected text");
+	});
+
+	it("getSelection coerces a null editor selection to empty string", () => {
+		const app = makeApp({
+			workspace: {
+				getActiveViewOfType: () => ({
+					editor: { getSelection: () => null },
+				}),
+			},
+		});
+		const { api } = getApi(app);
+		expect(api.utility.getSelection()).toBe("");
+	});
+
+	it("getSelectedText reports an error and returns undefined with no view", () => {
+		const { api } = getApi();
+		expect(api.utility.getSelectedText()).toBeUndefined();
+		expect(mocks.reportError).toHaveBeenCalled();
+	});
+
+	it("getSelectedText reports an error when nothing is selected", () => {
+		const app = makeApp({
+			workspace: {
+				getActiveViewOfType: () => ({
+					editor: {
+						somethingSelected: () => false,
+						getSelection: () => "",
+					},
+				}),
+			},
+		});
+		const { api } = getApi(app);
+		expect(api.utility.getSelectedText()).toBeUndefined();
+		expect(mocks.reportError).toHaveBeenCalled();
+	});
+
+	it("getSelectedText returns the selection when something is selected", () => {
+		const app = makeApp({
+			workspace: {
+				getActiveViewOfType: () => ({
+					editor: {
+						somethingSelected: () => true,
+						getSelection: () => "the text",
+					},
+				}),
+			},
+		});
+		const { api } = getApi(app);
+		expect(api.utility.getSelectedText()).toBe("the text");
+		expect(mocks.reportError).not.toHaveBeenCalled();
+	});
+});
+
+// ===========================================================================
+// AI sync helpers (getModels / getMaxTokens / countTokens / logs)
+// ===========================================================================
+describe("ai sync helpers", () => {
+	it("getModels delegates to getModelNames", () => {
+		mocks.getModelNames.mockReturnValue(["a", "b"]);
+		const { api } = getApi();
+		expect(api.ai.getModels()).toEqual(["a", "b"]);
+	});
+
+	it("getMaxTokens returns the model maxTokens", () => {
+		mocks.getModelByName.mockReturnValue({ name: "m", maxTokens: 4096 });
+		const { api } = getApi();
+		expect(api.ai.getMaxTokens("m")).toBe(4096);
+	});
+
+	it("getMaxTokens throws when the model is unknown", () => {
+		mocks.getModelByName.mockReturnValue(undefined);
+		const { api } = getApi();
+		expect(() => api.ai.getMaxTokens("nope")).toThrow("Model nope not found.");
+	});
+
+	it("countTokens delegates to getTokenCount", () => {
+		mocks.getTokenCount.mockReturnValue(7);
+		const { api } = getApi();
+		const model = { name: "m", maxTokens: 1 } as never;
+		expect(api.ai.countTokens("hi", model)).toBe(7);
+		expect(mocks.getTokenCount).toHaveBeenCalledWith("hi", model);
+	});
+
+	it("getRequestLogs delegates with a default limit of 10", () => {
+		mocks.getAIRequestLogEntries.mockReturnValue([]);
+		const { api } = getApi();
+		api.ai.getRequestLogs();
+		expect(mocks.getAIRequestLogEntries).toHaveBeenCalledWith(10);
+	});
+
+	it("getRequestLogs forwards an explicit limit", () => {
+		mocks.getAIRequestLogEntries.mockReturnValue([]);
+		const { api } = getApi();
+		api.ai.getRequestLogs(3);
+		expect(mocks.getAIRequestLogEntries).toHaveBeenCalledWith(3);
+	});
+
+	it("getRequestLogById delegates", () => {
+		mocks.getAIRequestLogEntryById.mockReturnValue({ id: "x" });
+		const { api } = getApi();
+		expect(api.ai.getRequestLogById("x")).toEqual({ id: "x" });
+		expect(mocks.getAIRequestLogEntryById).toHaveBeenCalledWith("x");
+	});
+
+	it("getLastRequestLog delegates", () => {
+		mocks.getLastAIRequestLogEntry.mockReturnValue({ id: "last" });
+		const { api } = getApi();
+		expect(api.ai.getLastRequestLog()).toEqual({ id: "last" });
+	});
+
+	it("clearRequestLogs delegates", () => {
+		const { api } = getApi();
+		api.ai.clearRequestLogs();
+		expect(mocks.clearAIRequestLogEntries).toHaveBeenCalled();
+	});
+});
+
+// ===========================================================================
+// AI prompt: pre-flight validation branches (no network)
+// ===========================================================================
+describe("ai.prompt validation", () => {
+	it("rejects when online features are disabled", async () => {
+		mocks.storeState.disableOnlineFeatures = true;
+		const { api } = getApi();
+		await expect(api.ai.prompt("hi", "gpt-4")).rejects.toThrow(
+			"Online features are disabled",
+		);
+	});
+
+	it("throws for an empty model string", async () => {
+		const { api } = getApi();
+		await expect(api.ai.prompt("hi", "")).rejects.toThrow(
+			"Invalid model parameter",
+		);
+	});
+
+	it("throws for a model object without a name", async () => {
+		const { api } = getApi();
+		await expect(
+			api.ai.prompt("hi", {} as never),
+		).rejects.toThrow("Invalid model parameter");
+	});
+
+	it("throws when the model is not found in configured providers", async () => {
+		mocks.getModelByName.mockReturnValue(undefined);
+		const { api } = getApi();
+		await expect(api.ai.prompt("hi", "gpt-4")).rejects.toThrow(
+			"not found in configured providers",
+		);
+	});
+
+	it("throws when no provider is configured for the model", async () => {
+		mocks.getModelByName.mockReturnValue({ name: "gpt-4", maxTokens: 1 });
+		mocks.getModelProvider.mockReturnValue(undefined);
+		const { api } = getApi();
+		await expect(api.ai.prompt("hi", "gpt-4")).rejects.toThrow(
+			"No provider configured",
+		);
+	});
+
+	it("invokes Prompt with resolved key/model and assigns variables when requested", async () => {
+		mocks.getModelByName.mockReturnValue({ name: "gpt-4", maxTokens: 1 });
+		mocks.getModelProvider.mockReturnValue({ name: "OpenAI" });
+		mocks.resolveProviderApiKey.mockResolvedValue("KEY");
+		mocks.prompt.mockResolvedValue({ output: "result", "output-quoted": "> result" });
+
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+
+		const res = await api.ai.prompt("Question?", "gpt-4", {
+			shouldAssignVariables: true,
+			variableName: "answer",
+			systemPrompt: "SYS",
+		});
+
+		expect(res).toEqual({ output: "result", "output-quoted": "> result" });
+		expect(mocks.resolveProviderApiKey).toHaveBeenCalledWith(
+			expect.anything(),
+			{ name: "OpenAI" },
+		);
+		// The options object passed to Prompt reflects our overrides.
+		const passedOptions = mocks.prompt.mock.calls[0][1];
+		expect(passedOptions).toMatchObject({
+			prompt: "Question?",
+			apiKey: "KEY",
+			outputVariableName: "answer",
+			systemPrompt: "SYS",
+		});
+		// shouldAssignVariables copies results into the executor's variable map.
+		expect(executor.variables.get("output")).toBe("result");
+		expect(executor.variables.get("output-quoted")).toBe("> result");
+	});
+
+	it("uses default outputVariableName and system prompt when not provided", async () => {
+		mocks.getModelByName.mockReturnValue({ name: "gpt-4", maxTokens: 1 });
+		mocks.getModelProvider.mockReturnValue({ name: "OpenAI" });
+		mocks.resolveProviderApiKey.mockResolvedValue("KEY");
+		mocks.prompt.mockResolvedValue({ output: "r" });
+		const { api } = getApi();
+		await api.ai.prompt("q", "gpt-4");
+		const passedOptions = mocks.prompt.mock.calls[0][1];
+		expect(passedOptions).toMatchObject({
+			outputVariableName: "output",
+			systemPrompt: "DEFAULT SYS",
+			showAssistantMessages: true,
+		});
+	});
+
+	it("returns {} and reports error when Prompt resolves null", async () => {
+		mocks.getModelByName.mockReturnValue({ name: "gpt-4", maxTokens: 1 });
+		mocks.getModelProvider.mockReturnValue({ name: "OpenAI" });
+		mocks.resolveProviderApiKey.mockResolvedValue("KEY");
+		mocks.prompt.mockResolvedValue(null);
+		const { api } = getApi();
+		const res = await api.ai.prompt("q", "gpt-4");
+		expect(res).toEqual({});
+		expect(mocks.reportError).toHaveBeenCalled();
+	});
+});
+
+// ===========================================================================
+// AI chunkedPrompt: pre-flight validation branches (no network)
+// ===========================================================================
+describe("ai.chunkedPrompt validation", () => {
+	it("rejects when online features are disabled", async () => {
+		mocks.storeState.disableOnlineFeatures = true;
+		const { api } = getApi();
+		await expect(
+			api.ai.chunkedPrompt("text", "tmpl", "gpt-4"),
+		).rejects.toThrow("Online features are disabled");
+	});
+
+	it("throws for a missing model name", async () => {
+		const { api } = getApi();
+		await expect(
+			api.ai.chunkedPrompt("text", "tmpl", "" as never),
+		).rejects.toThrow("Invalid model parameter");
+	});
+
+	it("throws when the model is not found", async () => {
+		mocks.getModelByName.mockReturnValue(undefined);
+		const { api } = getApi();
+		await expect(
+			api.ai.chunkedPrompt("text", "tmpl", "gpt-4"),
+		).rejects.toThrow("not found in configured providers");
+	});
+
+	it("passes default chunkSeparator/joiner/shouldMerge to ChunkedPrompt", async () => {
+		mocks.getModelByName.mockReturnValue({ name: "gpt-4", maxTokens: 1 });
+		mocks.getModelProvider.mockReturnValue({ name: "OpenAI" });
+		mocks.resolveProviderApiKey.mockResolvedValue("KEY");
+		mocks.chunkedPrompt.mockResolvedValue({ output: "ok" });
+		const { api } = getApi();
+		await api.ai.chunkedPrompt("text", "tmpl", "gpt-4");
+		const opts = mocks.chunkedPrompt.mock.calls[0][1];
+		expect(opts).toMatchObject({
+			text: "text",
+			promptTemplate: "tmpl",
+			resultJoiner: "\n",
+			shouldMerge: true,
+		});
+		expect(opts.chunkSeparator).toBeInstanceOf(RegExp);
+	});
+
+	it("returns {} and reports error when ChunkedPrompt resolves null", async () => {
+		mocks.getModelByName.mockReturnValue({ name: "gpt-4", maxTokens: 1 });
+		mocks.getModelProvider.mockReturnValue({ name: "OpenAI" });
+		mocks.resolveProviderApiKey.mockResolvedValue("KEY");
+		mocks.chunkedPrompt.mockResolvedValue(null);
+		const { api } = getApi();
+		expect(await api.ai.chunkedPrompt("t", "tmpl", "gpt-4")).toEqual({});
+		expect(mocks.reportError).toHaveBeenCalled();
+	});
+});
+
+// ===========================================================================
+// executeChoice
+// ===========================================================================
+describe("executeChoice", () => {
+	it("looks up the choice, sets variables, and executes it", async () => {
+		const choice = { name: "MyChoice", id: "id1" };
+		const executor = makeChoiceExecutor();
+		const plugin = makePlugin({ getChoiceByName: vi.fn(() => choice) });
+		const { api } = getApi(makeApp(), plugin, executor);
+
+		await api.executeChoice("MyChoice", { foo: "bar" });
+
+		expect(plugin.getChoiceByName).toHaveBeenCalledWith("MyChoice");
+		expect(executor.execute).toHaveBeenCalledWith(choice);
+		// Variables are cleared after execution.
+		expect(executor.variables.size).toBe(0);
+	});
+
+	it("reports an error when the choice is not found", async () => {
+		const plugin = makePlugin({ getChoiceByName: vi.fn(() => undefined) });
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), plugin, executor);
+		await api.executeChoice("Missing");
+		expect(mocks.reportError).toHaveBeenCalled();
+	});
+
+	it("throws the abort signal when the executor reports one", async () => {
+		const abort = new MacroAbortError("stop");
+		const executor = makeChoiceExecutor();
+		executor.consumeAbortSignal = vi.fn(
+			(): InstanceType<typeof MacroAbortError> | null => abort,
+		);
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+		await expect(api.executeChoice("C")).rejects.toBe(abort);
+		// Variables are still cleared even when aborting.
+		expect(executor.variables.size).toBe(0);
+	});
+
+	it("works when no variables are provided", async () => {
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+		await api.executeChoice("C");
+		expect(executor.execute).toHaveBeenCalled();
+	});
+});
+
+// ===========================================================================
+// format() variable snapshot/restore
+// ===========================================================================
+describe("format", () => {
+	it("formats the input via CompleteFormatter and returns the result", async () => {
+		mocks.formatFileContent.mockResolvedValue("formatted");
+		const { api } = getApi();
+		expect(await api.format("input")).toBe("formatted");
+		expect(mocks.formatFileContent).toHaveBeenCalledWith("input");
+	});
+
+	it("restores the original variables after formatting by default", async () => {
+		mocks.formatFileContent.mockResolvedValue("out");
+		const executor = makeChoiceExecutor();
+		executor.variables.set("pre", "existing");
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+
+		await api.format("in", { temp: "value" });
+
+		// The temporary variable must NOT leak; the original snapshot is restored.
+		expect(executor.variables.get("pre")).toBe("existing");
+		expect(executor.variables.has("temp")).toBe(false);
+	});
+
+	it("keeps injected variables when shouldClearVariables is false", async () => {
+		mocks.formatFileContent.mockResolvedValue("out");
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+
+		await api.format("in", { keep: "me" }, false);
+
+		expect(executor.variables.get("keep")).toBe("me");
+	});
+});
+
+// ===========================================================================
+// requestInputs
+// ===========================================================================
+describe("requestInputs", () => {
+	it("returns existing values immediately without opening the modal", async () => {
+		const executor = makeChoiceExecutor();
+		executor.variables.set("project", "Inbox");
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+
+		const result = await api.requestInputs([
+			{ id: "project", type: "text" },
+		]);
+
+		expect(result).toEqual({ project: "Inbox" });
+		expect(onePageModalCalls.length).toBe(0);
+	});
+
+	it("treats an empty-string variable as intentional and does not re-ask", async () => {
+		const executor = makeChoiceExecutor();
+		executor.variables.set("note", "");
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+
+		const result = await api.requestInputs([{ id: "note", type: "text" }]);
+
+		expect(result).toEqual({ note: "" });
+		expect(onePageModalCalls.length).toBe(0);
+	});
+
+	it("opens the modal for missing inputs and merges collected values", async () => {
+		mocks.onePageModalWaitForClose.mockResolvedValue({ name: "Alice" });
+		const executor = makeChoiceExecutor();
+		executor.variables.set("known", "yes");
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+
+		const result = await api.requestInputs([
+			{ id: "known", type: "text" },
+			{ id: "name", label: "Name", type: "text" },
+		]);
+
+		expect(result).toEqual({ known: "yes", name: "Alice" });
+		// Only the missing field is forwarded to the modal.
+		expect(onePageModalCalls.length).toBe(1);
+		const missing = onePageModalCalls[0].missing as Array<{ id: string; label: string }>;
+		expect(missing).toHaveLength(1);
+		expect(missing[0]).toMatchObject({
+			id: "name",
+			label: "Name",
+			source: "script",
+		});
+		// Raw values are written back to the live variable map.
+		expect(executor.variables.get("name")).toBe("Alice");
+	});
+
+	it("defaults a missing label to the field id", async () => {
+		mocks.onePageModalWaitForClose.mockResolvedValue({ city: "Oslo" });
+		const { api } = getApi();
+		await api.requestInputs([{ id: "city", type: "text" }]);
+		const missing = onePageModalCalls[0].missing as Array<{ label: string }>;
+		expect(missing[0].label).toBe("city");
+	});
+
+	it("formats a date field that returns an @date: value using dateFormat", async () => {
+		mocks.onePageModalWaitForClose.mockResolvedValue({
+			due: "@date:2025-06-21T00:00:00.000Z",
+		});
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+
+		const result = await api.requestInputs([
+			{ id: "due", type: "date", dateFormat: "YYYY-MM-DD" },
+		]);
+
+		// User-friendly value is formatted...
+		expect(result.due).toBe("2025-06-21");
+		// ...but the raw @date: value is stored for downstream processors.
+		expect(executor.variables.get("due")).toBe("@date:2025-06-21T00:00:00.000Z");
+	});
+
+	it("propagates a MacroAbortError when the modal is cancelled", async () => {
+		mocks.onePageModalWaitForClose.mockRejectedValue("cancelled");
+		const { api } = getApi();
+		await expect(
+			api.requestInputs([{ id: "x", type: "text" }]),
+		).rejects.toBeInstanceOf(MacroAbortError);
+	});
+});
+
+// ===========================================================================
+// fieldSuggestions
+// ===========================================================================
+describe("fieldSuggestions.getFieldValues", () => {
+	function fileCacheApp(
+		frontmatterByPath: Record<string, Record<string, unknown>>,
+		contentByPath: Record<string, string> = {},
+	) {
+		const files = Object.keys(frontmatterByPath).map((path) => ({ path }));
+		return makeApp({
+			vault: {
+				getMarkdownFiles: () => files,
+				read: async (file: FakeFile) => contentByPath[file.path] ?? "",
+			},
+			metadataCache: {
+				getFileCache: (file: FakeFile) => ({
+					frontmatter: frontmatterByPath[file.path],
+				}),
+			},
+		});
+	}
+
+	it("collects, de-duplicates and sorts frontmatter scalar values", async () => {
+		const app = fileCacheApp({
+			"a.md": { status: "done" },
+			"b.md": { status: "todo" },
+			"c.md": { status: "done" },
+		});
+		const { api } = getApi(app);
+		const values = await api.fieldSuggestions.getFieldValues("status");
+		expect(values).toEqual(["done", "todo"]);
+	});
+
+	it("expands array frontmatter values and trims whitespace", async () => {
+		const app = fileCacheApp({
+			"a.md": { tags: ["  one ", "two", ""] },
+		});
+		const { api } = getApi(app);
+		const values = await api.fieldSuggestions.getFieldValues("tags");
+		expect(values).toEqual(["one", "two"]);
+	});
+
+	it("ignores object-valued frontmatter and missing fields", async () => {
+		const app = fileCacheApp({
+			"a.md": { meta: { nested: true } },
+			"b.md": { other: "x" },
+		});
+		const { api } = getApi(app);
+		const values = await api.fieldSuggestions.getFieldValues("meta");
+		expect(values).toEqual([]);
+	});
+
+	it("reads inline field values when includeInline is true", async () => {
+		const app = fileCacheApp(
+			{ "a.md": {} },
+			{ "a.md": "priority:: high\npriority:: low\n" },
+		);
+		const { api } = getApi(app);
+		const values = await api.fieldSuggestions.getFieldValues("priority", {
+			includeInline: true,
+		});
+		expect(values).toEqual(["high", "low"]);
+	});
+
+	it("does not read file contents when includeInline is false", async () => {
+		const readSpy = vi.fn(async () => "priority:: high\n");
+		const app = makeApp({
+			vault: {
+				getMarkdownFiles: () => [{ path: "a.md" }],
+				read: readSpy,
+			},
+			metadataCache: { getFileCache: () => ({ frontmatter: {} }) },
+		});
+		const { api } = getApi(app);
+		await api.fieldSuggestions.getFieldValues("priority");
+		expect(readSpy).not.toHaveBeenCalled();
+	});
+
+	it("returns an empty array when there are no files", async () => {
+		const { api } = getApi(makeApp());
+		expect(await api.fieldSuggestions.getFieldValues("anything")).toEqual([]);
+	});
+});
+
+describe("fieldSuggestions.clearCache", () => {
+	it("delegates to the FieldSuggestionCache singleton without throwing", () => {
+		const { api } = getApi();
+		expect(() => api.fieldSuggestions.clearCache()).not.toThrow();
+		expect(() => api.fieldSuggestions.clearCache("status")).not.toThrow();
+	});
+});

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -190,7 +190,7 @@ export class QuickAddApi {
 			suggester: (
 				displayItems:
 					| string[]
-					| ((value: string, index?: number, arr?: string[]) => string[]),
+					| ((value: string, index?: number, arr?: string[]) => string),
 				actualItems: string[],
 				placeholder?: string,
 				allowCustomInput = false,
@@ -691,7 +691,7 @@ export class QuickAddApi {
 		app: App,
 		displayItems:
 			| string[]
-			| ((value: string, index?: number, arr?: string[]) => string[]),
+			| ((value: string, index?: number, arr?: string[]) => string),
 		actualItems: string[],
 		placeholder?: string,
 		allowCustomInput = false,

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -1,0 +1,575 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type QuickAdd from "../main";
+import type IChoice from "../types/choices/IChoice";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+
+// --- Hoisted mock state -----------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+	templateBuilder: vi.fn(),
+	captureBuilder: vi.fn(),
+	macroBuilder: vi.fn(),
+	multiModal: vi.fn(),
+	yesNoPrompt: vi.fn(),
+	storeChoices: [] as IChoice[],
+}));
+
+// Mock the GUI builders so importing the module does not pull in the full
+// Obsidian/Svelte stack. Each constructor records its args and exposes a
+// resolvable `waitForClose`.
+vi.mock("../gui/ChoiceBuilder/templateChoiceBuilder", () => ({
+	TemplateChoiceBuilder: class {
+		app: unknown;
+		choice: unknown;
+		plugin: unknown;
+		waitForClose: Promise<IChoice | undefined>;
+		constructor(app: unknown, choice: unknown, plugin: unknown) {
+			this.app = app;
+			this.choice = choice;
+			this.plugin = plugin;
+			this.waitForClose = mocks.templateBuilder(app, choice, plugin);
+		}
+	},
+}));
+
+vi.mock("../gui/ChoiceBuilder/captureChoiceBuilder", () => ({
+	CaptureChoiceBuilder: class {
+		app: unknown;
+		choice: unknown;
+		plugin: unknown;
+		waitForClose: Promise<IChoice | undefined>;
+		constructor(app: unknown, choice: unknown, plugin: unknown) {
+			this.app = app;
+			this.choice = choice;
+			this.plugin = plugin;
+			this.waitForClose = mocks.captureBuilder(app, choice, plugin);
+		}
+	},
+}));
+
+vi.mock("../gui/MacroGUIs/MacroBuilder", () => ({
+	MacroBuilder: class {
+		app: unknown;
+		plugin: unknown;
+		choice: unknown;
+		choices: unknown;
+		waitForClose: Promise<IChoice | undefined>;
+		constructor(
+			app: unknown,
+			plugin: unknown,
+			choice: unknown,
+			choices: unknown,
+		) {
+			this.app = app;
+			this.plugin = plugin;
+			this.choice = choice;
+			this.choices = choices;
+			this.waitForClose = mocks.macroBuilder(app, plugin, choice, choices);
+		}
+	},
+}));
+
+vi.mock("../gui/MultiChoiceSettingsModal", () => ({
+	MultiChoiceSettingsModal: class {
+		app: unknown;
+		choice: unknown;
+		waitForClose: Promise<IChoice | undefined>;
+		constructor(app: unknown, choice: unknown) {
+			this.app = app;
+			this.choice = choice;
+			this.waitForClose = mocks.multiModal(app, choice);
+		}
+	},
+}));
+
+vi.mock("../gui/GenericYesNoPrompt/GenericYesNoPrompt", () => ({
+	default: {
+		Prompt: (...args: unknown[]) => mocks.yesNoPrompt(...args),
+	},
+}));
+
+vi.mock("../settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({ choices: mocks.storeChoices }),
+	},
+}));
+
+const {
+	createChoice,
+	duplicateChoice,
+	getChoiceBuilder,
+	deleteChoiceWithConfirmation,
+	configureChoice,
+	createToggleCommandChoice,
+	CommandRegistry,
+	moveChoice,
+} = await import("./choiceService");
+
+const { TemplateChoice } = await import("../types/choices/TemplateChoice");
+const { CaptureChoice } = await import("../types/choices/CaptureChoice");
+const { MacroChoice } = await import("../types/choices/MacroChoice");
+const { MultiChoice } = await import("../types/choices/MultiChoice");
+
+// Minimal fakes — App/QuickAdd are only used as opaque references here.
+const fakeApp = { name: "fake-app" } as unknown as App;
+
+describe("choiceService", () => {
+	beforeEach(() => {
+		mocks.templateBuilder.mockReset();
+		mocks.captureBuilder.mockReset();
+		mocks.macroBuilder.mockReset();
+		mocks.multiModal.mockReset();
+		mocks.yesNoPrompt.mockReset();
+		mocks.storeChoices = [];
+	});
+
+	describe("createChoice", () => {
+		it("creates a TemplateChoice", () => {
+			const choice = createChoice("Template", "My Template");
+			expect(choice).toBeInstanceOf(TemplateChoice);
+			expect(choice.type).toBe("Template");
+			expect(choice.name).toBe("My Template");
+			expect(choice.command).toBe(false);
+			expect(typeof choice.id).toBe("string");
+			expect(choice.id.length).toBeGreaterThan(0);
+		});
+
+		it("creates a CaptureChoice", () => {
+			const choice = createChoice("Capture", "Cap");
+			expect(choice).toBeInstanceOf(CaptureChoice);
+			expect(choice.type).toBe("Capture");
+		});
+
+		it("creates a MacroChoice with an attached macro", () => {
+			const choice = createChoice("Macro", "Mac") as IMacroChoice;
+			expect(choice).toBeInstanceOf(MacroChoice);
+			expect(choice.type).toBe("Macro");
+			expect(choice.macro).toBeDefined();
+			expect(choice.macro.commands).toEqual([]);
+		});
+
+		it("creates a MultiChoice with an empty child list", () => {
+			const choice = createChoice("Multi", "Multi") as IMultiChoice;
+			expect(choice).toBeInstanceOf(MultiChoice);
+			expect(choice.type).toBe("Multi");
+			expect(choice.choices).toEqual([]);
+		});
+
+		it("gives each created choice a unique id", () => {
+			const a = createChoice("Template", "A");
+			const b = createChoice("Template", "B");
+			expect(a.id).not.toBe(b.id);
+		});
+
+		it("throws for an unknown choice type", () => {
+			expect(() =>
+				createChoice("Bogus" as unknown as "Template", "x"),
+			).toThrow("Unknown choice type: Bogus");
+		});
+	});
+
+	describe("duplicateChoice", () => {
+		it("appends ' (copy)' to the name and assigns a new id", () => {
+			const original = createChoice("Template", "Source");
+			const copy = duplicateChoice(original);
+			expect(copy.name).toBe("Source (copy)");
+			expect(copy.id).not.toBe(original.id);
+			expect(copy.type).toBe("Template");
+		});
+
+		it("copies simple props except id and name", () => {
+			const original = createChoice("Capture", "Cap") as ITemplateChoice;
+			// Mutate a simple property to verify it is carried over.
+			(original as unknown as { command: boolean }).command = true;
+			const copy = duplicateChoice(original);
+			expect(copy.command).toBe(true);
+			expect(copy.name).toBe("Cap (copy)");
+			expect(copy.id).not.toBe(original.id);
+		});
+
+		it("deep clones a Macro's macro and regenerates ids", () => {
+			const original = createChoice("Macro", "Mac") as IMacroChoice;
+			original.macro.commands.push({
+				id: "cmd-1",
+				name: "Cmd",
+			} as unknown as IMacroChoice["macro"]["commands"][number]);
+			const originalMacroId = original.macro.id;
+			const originalCmdId = original.macro.commands[0].id;
+
+			const copy = duplicateChoice(original) as IMacroChoice;
+
+			// Deep clone: the macro objects must be distinct references.
+			expect(copy.macro).not.toBe(original.macro);
+			expect(copy.macro.commands).not.toBe(original.macro.commands);
+			expect(copy.macro.commands[0]).not.toBe(original.macro.commands[0]);
+			// Ids regenerated.
+			expect(copy.macro.id).not.toBe(originalMacroId);
+			expect(copy.macro.commands[0].id).not.toBe(originalCmdId);
+			// Command name preserved.
+			expect(copy.macro.commands[0].name).toBe("Cmd");
+			// Mutating the copy does not affect the original.
+			copy.macro.commands[0].name = "Changed";
+			expect(original.macro.commands[0].name).toBe("Cmd");
+		});
+
+		it("recursively duplicates nested Multi choices and preserves placeholder/collapsed", () => {
+			const inner = createChoice("Template", "Inner");
+			const nestedMulti = createChoice("Multi", "Nested") as IMultiChoice;
+			const innerChild = createChoice("Capture", "Child");
+			nestedMulti.choices = [innerChild];
+
+			const root = createChoice("Multi", "Root") as IMultiChoice;
+			root.choices = [inner, nestedMulti];
+			root.placeholder = "ph";
+			root.collapsed = true;
+
+			const copy = duplicateChoice(root) as IMultiChoice;
+
+			expect(copy.name).toBe("Root (copy)");
+			expect(copy.placeholder).toBe("ph");
+			expect(copy.collapsed).toBe(true);
+			expect(copy.choices).toHaveLength(2);
+			expect(copy.choices[0].name).toBe("Inner (copy)");
+			expect(copy.choices[1].name).toBe("Nested (copy)");
+
+			const copiedNested = copy.choices[1] as IMultiChoice;
+			expect(copiedNested.choices).toHaveLength(1);
+			expect(copiedNested.choices[0].name).toBe("Child (copy)");
+
+			// New ids throughout — distinct from the originals.
+			expect(copy.id).not.toBe(root.id);
+			expect(copy.choices[0].id).not.toBe(inner.id);
+			expect(copiedNested.choices[0].id).not.toBe(innerChild.id);
+		});
+	});
+
+	describe("getChoiceBuilder", () => {
+		it("returns a TemplateChoiceBuilder for Template choices", () => {
+			mocks.templateBuilder.mockReturnValue(Promise.resolve(undefined));
+			const choice = createChoice("Template", "T");
+			const plugin = {} as unknown as QuickAdd;
+			const builder = getChoiceBuilder(choice, fakeApp, plugin);
+			expect(builder).toBeDefined();
+			expect(mocks.templateBuilder).toHaveBeenCalledWith(
+				fakeApp,
+				choice,
+				plugin,
+			);
+		});
+
+		it("returns a CaptureChoiceBuilder for Capture choices", () => {
+			mocks.captureBuilder.mockReturnValue(Promise.resolve(undefined));
+			const choice = createChoice("Capture", "C");
+			const plugin = {} as unknown as QuickAdd;
+			const builder = getChoiceBuilder(choice, fakeApp, plugin);
+			expect(builder).toBeDefined();
+			expect(mocks.captureBuilder).toHaveBeenCalledWith(
+				fakeApp,
+				choice,
+				plugin,
+			);
+		});
+
+		it("returns a MacroBuilder for Macro choices and passes the store's choices", () => {
+			mocks.macroBuilder.mockReturnValue(Promise.resolve(undefined));
+			const storeChoice = createChoice("Template", "Stored");
+			mocks.storeChoices = [storeChoice];
+			const choice = createChoice("Macro", "M");
+			const plugin = {} as unknown as QuickAdd;
+			const builder = getChoiceBuilder(choice, fakeApp, plugin);
+			expect(builder).toBeDefined();
+			expect(mocks.macroBuilder).toHaveBeenCalledWith(
+				fakeApp,
+				plugin,
+				choice,
+				[storeChoice],
+			);
+		});
+
+		it("returns undefined for Multi choices", () => {
+			const choice = createChoice("Multi", "Mu");
+			const plugin = {} as unknown as QuickAdd;
+			const builder = getChoiceBuilder(choice, fakeApp, plugin);
+			expect(builder).toBeUndefined();
+		});
+	});
+
+	describe("deleteChoiceWithConfirmation", () => {
+		it("returns the user's confirmation result (true)", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const choice = createChoice("Template", "Del");
+			const result = await deleteChoiceWithConfirmation(choice, fakeApp);
+			expect(result).toBe(true);
+			expect(mocks.yesNoPrompt).toHaveBeenCalledTimes(1);
+		});
+
+		it("returns the user's confirmation result (false)", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(false);
+			const choice = createChoice("Template", "Del");
+			const result = await deleteChoiceWithConfirmation(choice, fakeApp);
+			expect(result).toBe(false);
+		});
+
+		it("mentions the number of nested choices for a Multi choice", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const multi = createChoice("Multi", "Group") as IMultiChoice;
+			multi.choices = [
+				createChoice("Template", "a"),
+				createChoice("Template", "b"),
+			];
+			await deleteChoiceWithConfirmation(multi, fakeApp);
+			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
+			expect(message).toContain("Group");
+			expect(message).toContain("(2)");
+			expect(message).toContain("choices inside it");
+		});
+
+		it("warns about macro commands for a Macro choice", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const macro = createChoice("Macro", "MyMacro");
+			await deleteChoiceWithConfirmation(macro, fakeApp);
+			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
+			expect(message).toContain("MyMacro");
+			expect(message).toContain("macro commands");
+		});
+
+		it("does not include Multi/Macro warnings for a plain Template choice", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const choice = createChoice("Template", "Plain");
+			await deleteChoiceWithConfirmation(choice, fakeApp);
+			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
+			expect(message).not.toContain("choices inside it");
+			expect(message).not.toContain("macro commands");
+		});
+	});
+
+	describe("configureChoice", () => {
+		it("opens MultiChoiceSettingsModal for Multi choices and returns its result", async () => {
+			const updated = createChoice("Multi", "Updated");
+			mocks.multiModal.mockReturnValue(Promise.resolve(updated));
+			const choice = createChoice("Multi", "Group");
+			const plugin = {} as unknown as QuickAdd;
+			const result = await configureChoice(choice, fakeApp, plugin);
+			expect(result).toBe(updated);
+			expect(mocks.multiModal).toHaveBeenCalledWith(fakeApp, choice);
+		});
+
+		it("returns undefined when the Multi modal rejects", async () => {
+			mocks.multiModal.mockReturnValue(Promise.reject(new Error("closed")));
+			const choice = createChoice("Multi", "Group");
+			const plugin = {} as unknown as QuickAdd;
+			const result = await configureChoice(choice, fakeApp, plugin);
+			expect(result).toBeUndefined();
+		});
+
+		it("delegates to the builder for non-Multi choices and returns its result", async () => {
+			const updated = createChoice("Template", "Edited");
+			mocks.templateBuilder.mockReturnValue(Promise.resolve(updated));
+			const choice = createChoice("Template", "T");
+			const plugin = {} as unknown as QuickAdd;
+			const result = await configureChoice(choice, fakeApp, plugin);
+			expect(result).toBe(updated);
+		});
+
+		it("propagates a rejected builder waitForClose for non-Multi choices", async () => {
+			mocks.captureBuilder.mockReturnValue(
+				Promise.reject(new Error("builder failed")),
+			);
+			const choice = createChoice("Capture", "C");
+			const plugin = {} as unknown as QuickAdd;
+			await expect(
+				configureChoice(choice, fakeApp, plugin),
+			).rejects.toThrow("builder failed");
+		});
+	});
+
+	describe("createToggleCommandChoice", () => {
+		it("flips command from false to true without mutating the original", () => {
+			const choice = createChoice("Template", "T");
+			expect(choice.command).toBe(false);
+			const toggled = createToggleCommandChoice(choice);
+			expect(toggled.command).toBe(true);
+			expect(choice.command).toBe(false);
+			expect(toggled).not.toBe(choice);
+		});
+
+		it("flips command from true to false", () => {
+			const choice = createChoice("Template", "T");
+			choice.command = true;
+			const toggled = createToggleCommandChoice(choice);
+			expect(toggled.command).toBe(false);
+		});
+
+		it("preserves all other properties", () => {
+			const choice = createChoice("Capture", "C");
+			const toggled = createToggleCommandChoice(choice);
+			expect(toggled.id).toBe(choice.id);
+			expect(toggled.name).toBe(choice.name);
+			expect(toggled.type).toBe(choice.type);
+		});
+	});
+
+	describe("CommandRegistry", () => {
+		it("enableCommand adds the command via the plugin", () => {
+			const addCommandForChoice = vi.fn();
+			const removeCommandForChoice = vi.fn();
+			const plugin = {
+				addCommandForChoice,
+				removeCommandForChoice,
+			} as unknown as QuickAdd;
+			const registry = new CommandRegistry(plugin);
+			const choice = createChoice("Template", "T");
+			registry.enableCommand(choice);
+			expect(addCommandForChoice).toHaveBeenCalledWith(choice);
+			expect(removeCommandForChoice).not.toHaveBeenCalled();
+		});
+
+		it("disableCommand removes the command via the plugin", () => {
+			const addCommandForChoice = vi.fn();
+			const removeCommandForChoice = vi.fn();
+			const plugin = {
+				addCommandForChoice,
+				removeCommandForChoice,
+			} as unknown as QuickAdd;
+			const registry = new CommandRegistry(plugin);
+			const choice = createChoice("Template", "T");
+			registry.disableCommand(choice);
+			expect(removeCommandForChoice).toHaveBeenCalledWith(choice);
+			expect(addCommandForChoice).not.toHaveBeenCalled();
+		});
+
+		it("updateCommand removes the old choice then adds the new one in order", () => {
+			const calls: string[] = [];
+			const addCommandForChoice = vi.fn(() => calls.push("add"));
+			const removeCommandForChoice = vi.fn(() => calls.push("remove"));
+			const plugin = {
+				addCommandForChoice,
+				removeCommandForChoice,
+			} as unknown as QuickAdd;
+			const registry = new CommandRegistry(plugin);
+			const oldChoice = createChoice("Template", "Old");
+			const newChoice = createChoice("Template", "New");
+			registry.updateCommand(oldChoice, newChoice);
+			expect(removeCommandForChoice).toHaveBeenCalledWith(oldChoice);
+			expect(addCommandForChoice).toHaveBeenCalledWith(newChoice);
+			expect(calls).toEqual(["remove", "add"]);
+		});
+	});
+
+	describe("moveChoice", () => {
+		const makeMulti = (name: string, children: IChoice[] = []) => {
+			const m = createChoice("Multi", name) as IMultiChoice;
+			m.choices = children;
+			return m;
+		};
+
+		it("returns the input unchanged when ids are empty", () => {
+			const root = [createChoice("Template", "A")];
+			expect(moveChoice(root, "", "x")).toBe(root);
+			expect(moveChoice(root, "x", "")).toBe(root);
+		});
+
+		it("returns the input unchanged when the moving choice does not exist", () => {
+			const target = makeMulti("Group");
+			const root = [target];
+			expect(moveChoice(root, "missing", target.id)).toBe(root);
+		});
+
+		it("returns the input unchanged when the target does not exist", () => {
+			const moving = createChoice("Template", "A");
+			const root = [moving];
+			expect(moveChoice(root, moving.id, "missing")).toBe(root);
+		});
+
+		it("returns the input unchanged when the target is not a Multi", () => {
+			const moving = createChoice("Template", "A");
+			const target = createChoice("Template", "B");
+			const root = [moving, target];
+			expect(moveChoice(root, moving.id, target.id)).toBe(root);
+		});
+
+		it("moves a top-level choice into a Multi at the end of its list", () => {
+			const moving = createChoice("Template", "A");
+			const target = makeMulti("Group", [createChoice("Template", "Existing")]);
+			const root = [moving, target];
+
+			const result = moveChoice(root, moving.id, target.id);
+
+			// Immutability: a new array is returned.
+			expect(result).not.toBe(root);
+			// Moving choice removed from the top level.
+			expect(result.find((c) => c.id === moving.id)).toBeUndefined();
+			// Now appended at the end of the target's children.
+			const newTarget = result.find(
+				(c) => c.id === target.id,
+			) as IMultiChoice;
+			expect(newTarget.choices).toHaveLength(2);
+			expect(newTarget.choices[1].id).toBe(moving.id);
+			expect(newTarget.choices[0].name).toBe("Existing");
+		});
+
+		it("does not mutate the original choices array", () => {
+			const moving = createChoice("Template", "A");
+			const target = makeMulti("Group");
+			const root = [moving, target];
+
+			moveChoice(root, moving.id, target.id);
+
+			expect(root).toHaveLength(2);
+			expect((target as IMultiChoice).choices).toHaveLength(0);
+		});
+
+		it("moves a choice out of one Multi into another", () => {
+			const moving = createChoice("Template", "A");
+			const sourceMulti = makeMulti("Source", [moving]);
+			const destMulti = makeMulti("Dest");
+			const root = [sourceMulti, destMulti];
+
+			const result = moveChoice(root, moving.id, destMulti.id);
+
+			const newSource = result.find(
+				(c) => c.id === sourceMulti.id,
+			) as IMultiChoice;
+			const newDest = result.find(
+				(c) => c.id === destMulti.id,
+			) as IMultiChoice;
+			expect(newSource.choices).toHaveLength(0);
+			expect(newDest.choices).toHaveLength(1);
+			expect(newDest.choices[0].id).toBe(moving.id);
+		});
+
+		it("prevents moving a Multi into itself", () => {
+			const multi = makeMulti("Group", [createChoice("Template", "A")]);
+			const root = [multi];
+			expect(moveChoice(root, multi.id, multi.id)).toBe(root);
+		});
+
+		it("prevents moving a Multi into one of its descendants (cycle)", () => {
+			const child = makeMulti("Child");
+			const parent = makeMulti("Parent", [child]);
+			const root = [parent];
+			// Trying to move parent into its descendant child must be a no-op.
+			expect(moveChoice(root, parent.id, child.id)).toBe(root);
+		});
+
+		it("allows moving a non-Multi into a nested Multi", () => {
+			const moving = createChoice("Template", "Leaf");
+			const inner = makeMulti("Inner");
+			const outer = makeMulti("Outer", [inner]);
+			const root = [moving, outer];
+
+			const result = moveChoice(root, moving.id, inner.id);
+
+			expect(result.find((c) => c.id === moving.id)).toBeUndefined();
+			const newOuter = result.find(
+				(c) => c.id === outer.id,
+			) as IMultiChoice;
+			const newInner = newOuter.choices[0] as IMultiChoice;
+			expect(newInner.choices).toHaveLength(1);
+			expect(newInner.choices[0].id).toBe(moving.id);
+		});
+	});
+});

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -1,0 +1,641 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	buildPackage,
+	generateDefaultPackagePath,
+	writePackageToVault,
+} from "./packageExportService";
+import type { BuildPackageOptions } from "./packageExportService";
+import { QUICKADD_PACKAGE_SCHEMA_VERSION } from "../types/packages/QuickAddPackage";
+import type { QuickAddPackage } from "../types/packages/QuickAddPackage";
+import { decodeFromBase64 } from "../utils/base64";
+import { CommandType } from "../types/macros/CommandType";
+import type IChoice from "../types/choices/IChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+
+// --- Choice factory helpers (minimal but type-shaped) -----------------------
+
+function makeTemplateChoice(
+	id: string,
+	name: string,
+	templatePath: string,
+): ITemplateChoice {
+	return {
+		id,
+		name,
+		type: "Template",
+		command: false,
+		templatePath,
+		folder: {
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		},
+		fileNameFormat: { enabled: false, format: "" },
+		appendLink: false,
+		openFile: false,
+		fileOpening: {
+			location: "tab" as never,
+			direction: "vertical",
+			mode: "default" as never,
+			focus: true,
+		},
+		fileExistsBehavior: "Nothing" as never,
+	} as ITemplateChoice;
+}
+
+function makeCaptureChoice(
+	id: string,
+	name: string,
+	template?: string,
+): ICaptureChoice {
+	return {
+		id,
+		name,
+		type: "Capture",
+		command: false,
+		captureTo: "",
+		captureToActiveFile: false,
+		createFileIfItDoesntExist: {
+			enabled: template !== undefined,
+			createWithTemplate: template !== undefined,
+			template: template ?? "",
+		},
+		format: { enabled: false, format: "" },
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: {
+			enabled: false,
+			after: "",
+			insertAtEnd: false,
+			considerSubsections: false,
+			createIfNotFound: false,
+			createIfNotFoundLocation: "",
+		},
+		newLineCapture: { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab" as never,
+			direction: "vertical",
+			mode: "default" as never,
+			focus: true,
+		},
+	} as ICaptureChoice;
+}
+
+function makeMacroChoice(
+	id: string,
+	name: string,
+	commands: IMacroChoice["macro"]["commands"],
+): IMacroChoice {
+	return {
+		id,
+		name,
+		type: "Macro",
+		command: false,
+		runOnStartup: false,
+		macro: {
+			id: `${id}-macro`,
+			name: `${name} macro`,
+			commands,
+		},
+	} as IMacroChoice;
+}
+
+function makeMultiChoice(
+	id: string,
+	name: string,
+	children: IChoice[],
+): IMultiChoice {
+	return {
+		id,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: children,
+	} as IMultiChoice;
+}
+
+// --- Fake vault / app -------------------------------------------------------
+
+interface FakeVaultControls {
+	app: { vault: { adapter: any; createFolder: (p: string) => Promise<void> } };
+	createdFolders: string[];
+	writes: Array<{ path: string; content: string }>;
+	files: Map<string, string>;
+}
+
+function makeFakeApp(
+	options: {
+		files?: Record<string, string>;
+		existsImpl?: (path: string) => Promise<boolean> | boolean;
+		readImpl?: (path: string) => Promise<string> | string;
+	} = {},
+): FakeVaultControls {
+	const files = new Map<string, string>(Object.entries(options.files ?? {}));
+	const createdFolders: string[] = [];
+	const writes: Array<{ path: string; content: string }> = [];
+
+	const adapter = {
+		exists: vi.fn(async (path: string) => {
+			if (options.existsImpl) return options.existsImpl(path);
+			return files.has(path);
+		}),
+		read: vi.fn(async (path: string) => {
+			if (options.readImpl) return options.readImpl(path);
+			const content = files.get(path);
+			if (content === undefined) {
+				throw new Error(`No such file: ${path}`);
+			}
+			return content;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			writes.push({ path, content });
+			files.set(path, content);
+		}),
+	};
+
+	const app = {
+		vault: {
+			adapter,
+			createFolder: vi.fn(async (p: string) => {
+				createdFolders.push(p);
+			}),
+		},
+	};
+
+	return { app, createdFolders, writes, files };
+}
+
+function buildOptions(
+	overrides: Partial<BuildPackageOptions> & Pick<BuildPackageOptions, "choices" | "rootChoiceIds">,
+): BuildPackageOptions {
+	return {
+		quickAddVersion: "1.2.3",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+// --- generateDefaultPackagePath --------------------------------------------
+
+describe("generateDefaultPackagePath", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("produces a path under 'QuickAdd Packages' with a sanitized ISO timestamp", () => {
+		vi.setSystemTime(new Date("2026-05-29T13:45:30.123Z"));
+
+		const path = generateDefaultPackagePath();
+
+		// ':' and '.' are replaced with '-'
+		expect(path).toBe(
+			"QuickAdd Packages/quickadd-package-2026-05-29T13-45-30-123Z.quickadd.json",
+		);
+	});
+
+	it("never includes ':' or '.' from the timestamp (only the file extension dots)", () => {
+		vi.setSystemTime(new Date("2026-12-31T23:59:59.999Z"));
+
+		const path = generateDefaultPackagePath();
+		const timestampPart = path
+			.replace("QuickAdd Packages/quickadd-package-", "")
+			.replace(".quickadd.json", "");
+
+		expect(timestampPart).not.toContain(":");
+		expect(timestampPart).not.toContain(".");
+		expect(path.endsWith(".quickadd.json")).toBe(true);
+	});
+});
+
+// --- buildPackage -----------------------------------------------------------
+
+describe("buildPackage", () => {
+	it("builds a package for a single template choice with its template asset", async () => {
+		const template = makeTemplateChoice("t1", "Daily", "Templates/daily.md");
+		const { app } = makeFakeApp({
+			files: { "Templates/daily.md": "# Daily {{date}}" },
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [template], rootChoiceIds: ["t1"] }),
+		);
+
+		expect(result.pkg.schemaVersion).toBe(QUICKADD_PACKAGE_SCHEMA_VERSION);
+		expect(result.pkg.quickAddVersion).toBe("1.2.3");
+		expect(result.pkg.createdAt).toBe("2026-01-01T00:00:00.000Z");
+		expect(result.pkg.rootChoiceIds).toEqual(["t1"]);
+
+		expect(result.pkg.choices).toHaveLength(1);
+		expect(result.pkg.choices[0].choice.id).toBe("t1");
+		expect(result.pkg.choices[0].parentChoiceId).toBeNull();
+		expect(result.pkg.choices[0].pathHint).toEqual(["Daily"]);
+
+		expect(result.missingChoiceIds).toEqual([]);
+		expect(result.missingAssets).toEqual([]);
+
+		expect(result.pkg.assets).toHaveLength(1);
+		const asset = result.pkg.assets[0];
+		expect(asset.kind).toBe("template");
+		expect(asset.originalPath).toBe("Templates/daily.md");
+		expect(asset.contentEncoding).toBe("base64");
+		expect(decodeFromBase64(asset.content)).toBe("# Daily {{date}}");
+	});
+
+	it("defaults createdAt to the current time when not provided", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-15T08:00:00.000Z"));
+		try {
+			const choice = makeTemplateChoice("t1", "T", "Templates/a.md");
+			const { app } = makeFakeApp({ files: { "Templates/a.md": "x" } });
+
+			const result = await buildPackage(
+				app as never,
+				{
+					choices: [choice],
+					rootChoiceIds: ["t1"],
+					quickAddVersion: "9.9.9",
+				},
+			);
+
+			expect(result.pkg.createdAt).toBe("2026-03-15T08:00:00.000Z");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("includes child choices reachable through a Multi choice and records pathHint/parent", async () => {
+		const child = makeTemplateChoice("c1", "Child", "Templates/child.md");
+		const multi = makeMultiChoice("m1", "Parent", [child]);
+		const { app } = makeFakeApp({
+			files: { "Templates/child.md": "child body" },
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [multi], rootChoiceIds: ["m1"] }),
+		);
+
+		const ids = result.pkg.choices.map((c) => c.choice.id);
+		expect(ids).toContain("m1");
+		expect(ids).toContain("c1");
+
+		const childEntry = result.pkg.choices.find((c) => c.choice.id === "c1");
+		expect(childEntry?.parentChoiceId).toBe("m1");
+		expect(childEntry?.pathHint).toEqual(["Parent", "Child"]);
+	});
+
+	it("prunes excluded children out of an included Multi choice's choices array", async () => {
+		const keep = makeTemplateChoice("keep", "Keep", "Templates/keep.md");
+		const drop = makeTemplateChoice("drop", "Drop", "Templates/drop.md");
+		const multi = makeMultiChoice("m1", "Parent", [keep, drop]);
+		const { app } = makeFakeApp({
+			files: {
+				"Templates/keep.md": "keep",
+				"Templates/drop.md": "drop",
+			},
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({
+				choices: [multi],
+				rootChoiceIds: ["m1"],
+				excludedChoiceIds: ["drop"],
+			}),
+		);
+
+		const ids = result.pkg.choices.map((c) => c.choice.id);
+		expect(ids).toContain("m1");
+		expect(ids).toContain("keep");
+		expect(ids).not.toContain("drop");
+
+		// The cloned Multi choice should only retain the kept child.
+		const multiEntry = result.pkg.choices.find((c) => c.choice.id === "m1");
+		const multiChoice = multiEntry?.choice as IMultiChoice;
+		expect(multiChoice.choices.map((c) => c.id)).toEqual(["keep"]);
+
+		// Only the kept template asset is encoded.
+		const assetPaths = result.pkg.assets.map((a) => a.originalPath);
+		expect(assetPaths).toContain("Templates/keep.md");
+		expect(assetPaths).not.toContain("Templates/drop.md");
+	});
+
+	it("does not mutate the original choices when pruning (works on a deep clone)", async () => {
+		const keep = makeTemplateChoice("keep", "Keep", "Templates/keep.md");
+		const drop = makeTemplateChoice("drop", "Drop", "Templates/drop.md");
+		const multi = makeMultiChoice("m1", "Parent", [keep, drop]);
+		const { app } = makeFakeApp({
+			files: {
+				"Templates/keep.md": "keep",
+				"Templates/drop.md": "drop",
+			},
+		});
+
+		await buildPackage(
+			app as never,
+			buildOptions({
+				choices: [multi],
+				rootChoiceIds: ["m1"],
+				excludedChoiceIds: ["drop"],
+			}),
+		);
+
+		// Source structure untouched.
+		expect(multi.choices.map((c) => c.id)).toEqual(["keep", "drop"]);
+	});
+
+	it("excludes a root choice entirely when its id is in excludedChoiceIds", async () => {
+		const a = makeTemplateChoice("a", "A", "Templates/a.md");
+		const b = makeTemplateChoice("b", "B", "Templates/b.md");
+		const { app } = makeFakeApp({
+			files: { "Templates/a.md": "a", "Templates/b.md": "b" },
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({
+				choices: [a, b],
+				rootChoiceIds: ["a", "b"],
+				excludedChoiceIds: ["a"],
+			}),
+		);
+
+		expect(result.pkg.choices.map((c) => c.choice.id)).toEqual(["b"]);
+		// rootChoiceIds is normalized to only included ids.
+		expect(result.pkg.rootChoiceIds).toEqual(["b"]);
+	});
+
+	it("reports root ids not present in any choice as missingChoiceIds and omits them from roots", async () => {
+		const real = makeTemplateChoice("real", "Real", "Templates/real.md");
+		const { app } = makeFakeApp({ files: { "Templates/real.md": "r" } });
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({
+				choices: [real],
+				rootChoiceIds: ["real", "ghost"],
+			}),
+		);
+
+		expect(result.missingChoiceIds).toContain("ghost");
+		expect(result.pkg.rootChoiceIds).toEqual(["real"]);
+		expect(result.pkg.choices.map((c) => c.choice.id)).toEqual(["real"]);
+	});
+
+	it("collects user-script and conditional-script assets from a macro choice", async () => {
+		const macro = makeMacroChoice("macro1", "Macro", [
+			{
+				id: "cmd-us",
+				name: "Run script",
+				type: CommandType.UserScript,
+				path: "Scripts/userScript.js",
+				settings: {},
+			} as never,
+			{
+				id: "cmd-cond",
+				name: "If",
+				type: CommandType.Conditional,
+				condition: {
+					mode: "script",
+					scriptPath: "Scripts/condition.js",
+				},
+				thenCommands: [],
+				elseCommands: [],
+			} as never,
+		]);
+		const { app } = makeFakeApp({
+			files: {
+				"Scripts/userScript.js": "module.exports = () => {};",
+				"Scripts/condition.js": "module.exports = () => true;",
+			},
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [macro], rootChoiceIds: ["macro1"] }),
+		);
+
+		const byPath = new Map(
+			result.pkg.assets.map((a) => [a.originalPath, a.kind]),
+		);
+		expect(byPath.get("Scripts/userScript.js")).toBe("user-script");
+		expect(byPath.get("Scripts/condition.js")).toBe("conditional-script");
+		expect(result.missingAssets).toEqual([]);
+	});
+
+	it("collects capture-template assets from a Capture choice", async () => {
+		const capture = makeCaptureChoice(
+			"cap1",
+			"Capture",
+			"Templates/capture.md",
+		);
+		const { app } = makeFakeApp({
+			files: { "Templates/capture.md": "capture body" },
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [capture], rootChoiceIds: ["cap1"] }),
+		);
+
+		expect(result.pkg.assets).toHaveLength(1);
+		expect(result.pkg.assets[0].kind).toBe("capture-template");
+		expect(result.pkg.assets[0].originalPath).toBe("Templates/capture.md");
+	});
+
+	it("records missing assets when the file does not exist and does not encode them", async () => {
+		const template = makeTemplateChoice(
+			"t1",
+			"Daily",
+			"Templates/missing.md",
+		);
+		// No files registered -> exists() returns false.
+		const { app } = makeFakeApp({ files: {} });
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [template], rootChoiceIds: ["t1"] }),
+		);
+
+		expect(result.pkg.assets).toEqual([]);
+		expect(result.missingAssets).toEqual([
+			{ path: "Templates/missing.md", kind: "template" },
+		]);
+	});
+
+	it("records a missing asset when reading throws, without rejecting", async () => {
+		const template = makeTemplateChoice("t1", "Daily", "Templates/x.md");
+		const { app } = makeFakeApp({
+			existsImpl: () => true,
+			readImpl: () => {
+				throw new Error("read boom");
+			},
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [template], rootChoiceIds: ["t1"] }),
+		);
+
+		expect(result.pkg.assets).toEqual([]);
+		expect(result.missingAssets).toEqual([
+			{ path: "Templates/x.md", kind: "template" },
+		]);
+	});
+
+	it("produces an empty package for an empty choice/root set", async () => {
+		const { app } = makeFakeApp();
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [], rootChoiceIds: [] }),
+		);
+
+		expect(result.pkg.choices).toEqual([]);
+		expect(result.pkg.rootChoiceIds).toEqual([]);
+		expect(result.pkg.assets).toEqual([]);
+		expect(result.missingChoiceIds).toEqual([]);
+		expect(result.missingAssets).toEqual([]);
+	});
+
+	it("deduplicates a shared asset path across two choices into a single asset", async () => {
+		const shared = "Templates/shared.md";
+		const a = makeTemplateChoice("a", "A", shared);
+		const b = makeTemplateChoice("b", "B", shared);
+		const { app, files } = makeFakeApp({ files: { [shared]: "shared body" } });
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [a, b], rootChoiceIds: ["a", "b"] }),
+		);
+
+		const sharedAssets = result.pkg.assets.filter(
+			(asset) => asset.originalPath === shared,
+		);
+		expect(sharedAssets).toHaveLength(1);
+		// adapter.read should only have been called once for the deduped path.
+		const reads = (app.vault.adapter.read as ReturnType<typeof vi.fn>).mock.calls.filter(
+			(call) => call[0] === shared,
+		);
+		expect(reads).toHaveLength(1);
+		expect(files.get(shared)).toBe("shared body");
+	});
+});
+
+// --- writePackageToVault ----------------------------------------------------
+
+describe("writePackageToVault", () => {
+	function makePackage(): QuickAddPackage {
+		return {
+			schemaVersion: QUICKADD_PACKAGE_SCHEMA_VERSION,
+			quickAddVersion: "1.0.0",
+			createdAt: "2026-01-01T00:00:00.000Z",
+			rootChoiceIds: ["a"],
+			choices: [],
+			assets: [],
+		};
+	}
+
+	it("writes pretty-printed JSON to the normalized output path", async () => {
+		const pkg = makePackage();
+		const { app, writes } = makeFakeApp({ existsImpl: () => true });
+
+		await writePackageToVault(
+			app as never,
+			pkg,
+			"QuickAdd Packages/out.quickadd.json",
+		);
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0].path).toBe("QuickAdd Packages/out.quickadd.json");
+		// 2-space indentation -> contains a newline + indentation.
+		expect(writes[0].content).toBe(JSON.stringify(pkg, null, 2));
+		expect(JSON.parse(writes[0].content)).toEqual(pkg);
+	});
+
+	it("normalizes backslashes to forward slashes and trims surrounding whitespace", async () => {
+		const pkg = makePackage();
+		const { app, writes } = makeFakeApp({ existsImpl: () => true });
+
+		await writePackageToVault(
+			app as never,
+			pkg,
+			"  QuickAdd Packages\\nested\\out.json  ",
+		);
+
+		expect(writes[0].path).toBe("QuickAdd Packages/nested/out.json");
+	});
+
+	it("creates missing parent folders in order before writing", async () => {
+		const pkg = makePackage();
+		const existing = new Set<string>();
+		const { app, createdFolders, writes } = makeFakeApp({
+			existsImpl: (p) => existing.has(p),
+		});
+		// Track folders as created so re-checks would pass (mirrors real adapter).
+		(app.vault.createFolder as ReturnType<typeof vi.fn>).mockImplementation(
+			async (p: string) => {
+				existing.add(p);
+				createdFolders.push(p);
+			},
+		);
+
+		await writePackageToVault(
+			app as never,
+			pkg,
+			"A/B/C/file.json",
+		);
+
+		expect(createdFolders).toEqual(["A", "A/B", "A/B/C"]);
+		expect(writes[0].path).toBe("A/B/C/file.json");
+	});
+
+	it("does not create folders that already exist", async () => {
+		const pkg = makePackage();
+		const { app, createdFolders } = makeFakeApp({
+			existsImpl: () => true,
+		});
+
+		await writePackageToVault(app as never, pkg, "Existing/file.json");
+
+		expect(createdFolders).toEqual([]);
+		expect(app.vault.createFolder).not.toHaveBeenCalled();
+	});
+
+	it("writes to a top-level path without creating any folders", async () => {
+		const pkg = makePackage();
+		const { app, createdFolders, writes } = makeFakeApp({
+			existsImpl: () => false,
+		});
+
+		await writePackageToVault(app as never, pkg, "root.json");
+
+		expect(createdFolders).toEqual([]);
+		expect(writes[0].path).toBe("root.json");
+	});
+
+	it("throws when the output path is empty or whitespace-only", async () => {
+		const pkg = makePackage();
+		const { app, writes } = makeFakeApp();
+
+		await expect(
+			writePackageToVault(app as never, pkg, "   "),
+		).rejects.toThrow("Output path cannot be empty.");
+
+		expect(writes).toEqual([]);
+		expect(app.vault.adapter.write).not.toHaveBeenCalled();
+	});
+});

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -1,0 +1,957 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type IChoice from "../types/choices/IChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import type {
+	QuickAddPackage,
+	QuickAddPackageAsset,
+	QuickAddPackageChoice,
+} from "../types/packages/QuickAddPackage";
+import { QUICKADD_PACKAGE_SCHEMA_VERSION } from "../types/packages/QuickAddPackage";
+import { CommandType } from "../types/macros/CommandType";
+import type { IChoiceCommand } from "../types/macros/IChoiceCommand";
+import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
+import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
+import type { IUserScript } from "../types/macros/IUserScript";
+import { encodeToBase64 } from "../utils/base64";
+
+// Make uuid deterministic so duplicated-id remapping is verifiable.
+const uuidMock = vi.hoisted(() => ({ counter: 0 }));
+vi.mock("uuid", () => ({
+	v4: () => `uuid-${++uuidMock.counter}`,
+}));
+
+import {
+	parseQuickAddPackage,
+	readQuickAddPackage,
+	analysePackage,
+	applyPackageImport,
+} from "./packageImportService";
+import type {
+	ChoiceImportDecision,
+	AssetImportDecision,
+} from "./packageImportService";
+
+// --- Fake app / vault -------------------------------------------------------
+
+interface FakeVaultState {
+	existingPaths: Set<string>;
+	writes: Map<string, string>;
+	createdFolders: string[];
+	existThrowsFor?: Set<string>;
+}
+
+function createFakeApp(initialExisting: string[] = []): {
+	app: App;
+	state: FakeVaultState;
+} {
+	const state: FakeVaultState = {
+		existingPaths: new Set(initialExisting),
+		writes: new Map(),
+		createdFolders: [],
+	};
+
+	const adapter = {
+		exists: vi.fn(async (path: string) => {
+			if (state.existThrowsFor?.has(path)) {
+				throw new Error(`boom: ${path}`);
+			}
+			return state.existingPaths.has(path);
+		}),
+		read: vi.fn(async (path: string) => {
+			const content = state.writes.get(path);
+			if (content === undefined) {
+				throw new Error(`no file at ${path}`);
+			}
+			return content;
+		}),
+		write: vi.fn(async (path: string, content: string) => {
+			state.writes.set(path, content);
+			state.existingPaths.add(path);
+		}),
+	};
+
+	const app = {
+		vault: {
+			adapter,
+			createFolder: vi.fn(async (path: string) => {
+				state.createdFolders.push(path);
+				state.existingPaths.add(path);
+			}),
+		},
+	} as unknown as App;
+
+	return { app, state };
+}
+
+// --- Fixture builders -------------------------------------------------------
+
+function makeChoice(
+	id: string,
+	name: string,
+	type: IChoice["type"],
+	overrides: Partial<IChoice> = {},
+): IChoice {
+	return {
+		id,
+		name,
+		type,
+		command: false,
+		...overrides,
+	} as IChoice;
+}
+
+function makeMulti(
+	id: string,
+	name: string,
+	children: IChoice[] = [],
+): IMultiChoice {
+	return {
+		id,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: children,
+	} as IMultiChoice;
+}
+
+function makePackageChoice(
+	choice: IChoice,
+	parentChoiceId: string | null = null,
+	pathHint: string[] = [],
+): QuickAddPackageChoice {
+	return { choice, parentChoiceId, pathHint };
+}
+
+function makePackage(
+	overrides: Partial<QuickAddPackage> = {},
+): QuickAddPackage {
+	return {
+		schemaVersion: QUICKADD_PACKAGE_SCHEMA_VERSION,
+		quickAddVersion: "1.0.0",
+		createdAt: "2025-01-01T00:00:00.000Z",
+		rootChoiceIds: [],
+		choices: [],
+		assets: [],
+		...overrides,
+	};
+}
+
+function decisions(
+	entries: Array<[string, ChoiceImportDecision["mode"]]>,
+): ChoiceImportDecision[] {
+	return entries.map(([choiceId, mode]) => ({ choiceId, mode }));
+}
+
+beforeEach(() => {
+	uuidMock.counter = 0;
+});
+
+// --- parseQuickAddPackage ---------------------------------------------------
+
+describe("parseQuickAddPackage", () => {
+	it("parses a valid package payload", () => {
+		const pkg = makePackage({
+			rootChoiceIds: ["a"],
+			choices: [makePackageChoice(makeChoice("a", "A", "Template"))],
+		});
+		const result = parseQuickAddPackage(JSON.stringify(pkg));
+		expect(result.schemaVersion).toBe(QUICKADD_PACKAGE_SCHEMA_VERSION);
+		expect(result.choices).toHaveLength(1);
+		expect(result.choices[0].choice.id).toBe("a");
+	});
+
+	it("throws on invalid JSON", () => {
+		expect(() => parseQuickAddPackage("{not json")).toThrow(
+			/not valid JSON/,
+		);
+	});
+
+	it("throws when the payload is not a QuickAdd package", () => {
+		expect(() => parseQuickAddPackage(JSON.stringify({ foo: "bar" }))).toThrow(
+			/not a valid QuickAdd package/,
+		);
+	});
+
+	it("throws when schema version is newer than supported", () => {
+		// isQuickAddPackage requires schemaVersion === current, so a too-new
+		// version is rejected by the validator before the explicit version check.
+		const future = {
+			...makePackage(),
+			schemaVersion: QUICKADD_PACKAGE_SCHEMA_VERSION + 1,
+		};
+		expect(() => parseQuickAddPackage(JSON.stringify(future))).toThrow();
+	});
+
+	it("rejects a package whose choices are missing required fields", () => {
+		const bad = makePackage({
+			choices: [{ choice: { id: "x" }, parentChoiceId: null, pathHint: [] }],
+		} as unknown as Partial<QuickAddPackage>);
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/not a valid QuickAdd package/,
+		);
+	});
+
+	it("rejects a package with an invalid asset kind", () => {
+		const bad = makePackage({
+			assets: [
+				{
+					kind: "not-a-kind",
+					originalPath: "scripts/x.js",
+					contentEncoding: "base64",
+					content: "",
+				},
+			],
+		} as unknown as Partial<QuickAddPackage>);
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/not a valid QuickAdd package/,
+		);
+	});
+});
+
+// --- readQuickAddPackage ----------------------------------------------------
+
+describe("readQuickAddPackage", () => {
+	it("throws on an empty path", async () => {
+		const { app } = createFakeApp();
+		await expect(readQuickAddPackage(app, "   ")).rejects.toThrow(
+			/cannot be empty/,
+		);
+	});
+
+	it("throws when the file does not exist", async () => {
+		const { app } = createFakeApp();
+		await expect(
+			readQuickAddPackage(app, "packages/missing.json"),
+		).rejects.toThrow(/Package file not found/);
+	});
+
+	it("normalizes the path, reads, and parses the package", async () => {
+		const { app, state } = createFakeApp();
+		const pkg = makePackage({
+			rootChoiceIds: ["a"],
+			choices: [makePackageChoice(makeChoice("a", "A", "Template"))],
+		});
+		// Windows-style separators get normalized to POSIX by normalizePath stub.
+		state.existingPaths.add("packages/p.json");
+		state.writes.set("packages/p.json", JSON.stringify(pkg));
+
+		const loaded = await readQuickAddPackage(app, "packages\\p.json");
+		expect(loaded.path).toBe("packages/p.json");
+		expect(loaded.pkg.choices[0].choice.id).toBe("a");
+	});
+});
+
+// --- analysePackage ---------------------------------------------------------
+
+describe("analysePackage", () => {
+	it("flags choice conflicts for ids that already exist (incl. nested)", async () => {
+		const { app } = createFakeApp();
+		const existing: IChoice[] = [
+			makeMulti("parent", "Parent", [makeChoice("nested", "Nested", "Template")]),
+		];
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(makeChoice("nested", "Nested", "Template"), null, [
+					"Parent",
+				]),
+				makePackageChoice(makeChoice("fresh", "Fresh", "Template")),
+			],
+		});
+
+		const analysis = await analysePackage(app, existing, pkg);
+		expect(analysis.choiceConflicts).toEqual([
+			{
+				choiceId: "nested",
+				name: "Nested",
+				parentChoiceId: null,
+				pathHint: ["Parent"],
+				exists: true,
+			},
+			{
+				choiceId: "fresh",
+				name: "Fresh",
+				parentChoiceId: null,
+				pathHint: [],
+				exists: false,
+			},
+		]);
+	});
+
+	it("defaults missing pathHint to an empty array", async () => {
+		const { app } = createFakeApp();
+		const entry = {
+			choice: makeChoice("a", "A", "Template"),
+			parentChoiceId: null,
+		} as unknown as QuickAddPackageChoice;
+		const pkg = makePackage({ choices: [entry] });
+
+		const analysis = await analysePackage(app, [], pkg);
+		expect(analysis.choiceConflicts[0].pathHint).toEqual([]);
+	});
+
+	it("reports asset conflicts based on vault existence", async () => {
+		const { app } = createFakeApp(["scripts/exists.js"]);
+		const pkg = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "scripts/exists.js",
+					contentEncoding: "base64",
+					content: "",
+				},
+				{
+					kind: "template",
+					originalPath: "templates/new.md",
+					contentEncoding: "base64",
+					content: "",
+				},
+			],
+		});
+
+		const analysis = await analysePackage(app, [], pkg);
+		expect(analysis.assetConflicts).toEqual([
+			{ originalPath: "scripts/exists.js", exists: true, kind: "user-script" },
+			{ originalPath: "templates/new.md", exists: false, kind: "template" },
+		]);
+	});
+});
+
+// --- applyPackageImport: basic insertion -----------------------------------
+
+describe("applyPackageImport - root insertion", () => {
+	it("appends a brand-new root choice", async () => {
+		const { app } = createFakeApp();
+		const pkg = makePackage({
+			choices: [makePackageChoice(makeChoice("new", "New", "Template"))],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([["new", "import"]]),
+			assetDecisions: [],
+		});
+
+		expect(result.addedChoiceIds).toEqual(["new"]);
+		expect(result.overwrittenChoiceIds).toEqual([]);
+		expect(result.updatedChoices.map((c) => c.id)).toEqual(["new"]);
+	});
+
+	it("overwrites an existing root choice in place", async () => {
+		const { app } = createFakeApp();
+		const existing: IChoice[] = [makeChoice("dup", "Old Name", "Template")];
+		const pkg = makePackage({
+			choices: [makePackageChoice(makeChoice("dup", "New Name", "Template"))],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: existing,
+			pkg,
+			choiceDecisions: decisions([["dup", "overwrite"]]),
+			assetDecisions: [],
+		});
+
+		expect(result.overwrittenChoiceIds).toEqual(["dup"]);
+		expect(result.addedChoiceIds).toEqual([]);
+		expect(result.updatedChoices).toHaveLength(1);
+		expect(result.updatedChoices[0].name).toBe("New Name");
+	});
+
+	it("does not mutate the passed-in existingChoices array", async () => {
+		const { app } = createFakeApp();
+		const existing: IChoice[] = [makeChoice("dup", "Old Name", "Template")];
+		const pkg = makePackage({
+			choices: [makePackageChoice(makeChoice("dup", "New Name", "Template"))],
+		});
+
+		await applyPackageImport({
+			app,
+			existingChoices: existing,
+			pkg,
+			choiceDecisions: decisions([["dup", "overwrite"]]),
+			assetDecisions: [],
+		});
+
+		// Original input untouched (deepClone is used internally).
+		expect(existing).toHaveLength(1);
+		expect(existing[0].name).toBe("Old Name");
+	});
+
+	it("skips a choice marked skip and reports it", async () => {
+		const { app } = createFakeApp();
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(makeChoice("keep", "Keep", "Template")),
+				makePackageChoice(makeChoice("drop", "Drop", "Template")),
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([
+				["keep", "import"],
+				["drop", "skip"],
+			]),
+			assetDecisions: [],
+		});
+
+		expect(result.skippedChoiceIds).toEqual(["drop"]);
+		expect(result.addedChoiceIds).toEqual(["keep"]);
+		expect(result.updatedChoices.map((c) => c.id)).toEqual(["keep"]);
+	});
+});
+
+// --- applyPackageImport: parent/child handling ------------------------------
+
+describe("applyPackageImport - parent/child trees", () => {
+	it("inserts the multi parent (with children) and skips re-inserting children", async () => {
+		const { app } = createFakeApp();
+		const child = makeChoice("child", "Child", "Template");
+		const parent = makeMulti("parent", "Parent", [child]);
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(parent),
+				makePackageChoice(child, "parent", ["Parent"]),
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([
+				["parent", "import"],
+				["child", "import"],
+			]),
+			assetDecisions: [],
+		});
+
+		// Parent added once at root; child handled inside the parent's tree.
+		expect(result.addedChoiceIds).toEqual(["parent"]);
+		expect(result.updatedChoices).toHaveLength(1);
+		const insertedParent = result.updatedChoices[0] as IMultiChoice;
+		expect(insertedParent.id).toBe("parent");
+		expect(insertedParent.choices.map((c) => c.id)).toEqual(["child"]);
+	});
+
+	it("inserts a new child under an already-existing parent multi", async () => {
+		const { app } = createFakeApp();
+		const existing: IChoice[] = [makeMulti("parent", "Parent", [])];
+		const child = makeChoice("child", "Child", "Template");
+		const pkg = makePackage({
+			choices: [makePackageChoice(child, "parent", ["Parent"])],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: existing,
+			pkg,
+			choiceDecisions: decisions([["child", "import"]]),
+			assetDecisions: [],
+		});
+
+		expect(result.addedChoiceIds).toEqual(["child"]);
+		const parent = result.updatedChoices[0] as IMultiChoice;
+		expect(parent.choices.map((c) => c.id)).toEqual(["child"]);
+	});
+
+	it("falls back to pathHint to locate a parent multi by name", async () => {
+		const { app } = createFakeApp();
+		// Existing parent has a DIFFERENT id than the package's parentChoiceId,
+		// so id-based lookup fails and the pathHint name lookup kicks in.
+		const existing: IChoice[] = [makeMulti("local-parent-id", "Parent", [])];
+		const child = makeChoice("child", "Child", "Template");
+		// pathHint is the full path INCLUDING the choice's own name; the parent
+		// path is everything before the last segment (slice(0, -1) === ["Parent"]).
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(child, "missing-parent-id", ["Parent", "Child"]),
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: existing,
+			pkg,
+			choiceDecisions: decisions([["child", "import"]]),
+			assetDecisions: [],
+		});
+
+		expect(result.addedChoiceIds).toEqual(["child"]);
+		const parent = result.updatedChoices[0] as IMultiChoice;
+		expect(parent.choices.map((c) => c.id)).toEqual(["child"]);
+	});
+
+	it("adds an orphan child to the root when its parent cannot be found", async () => {
+		const { app } = createFakeApp();
+		const child = makeChoice("child", "Child", "Template");
+		const pkg = makePackage({
+			// parentChoiceId references something that's not in the package and
+			// no matching pathHint exists in the (empty) destination tree.
+			choices: [
+				makePackageChoice(child, "ghost-parent", ["Nonexistent", "Child"]),
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([["child", "import"]]),
+			assetDecisions: [],
+		});
+
+		expect(result.addedChoiceIds).toEqual(["child"]);
+		expect(result.updatedChoices.map((c) => c.id)).toEqual(["child"]);
+	});
+
+	it("treats a child importable even when its in-package parent is skipped", async () => {
+		const { app } = createFakeApp();
+		const existing: IChoice[] = [makeMulti("parent", "Parent", [])];
+		const child = makeChoice("child", "Child", "Template");
+		const parent = makeMulti("parent", "Parent", [child]);
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(parent),
+				makePackageChoice(child, "parent", ["Parent"]),
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: existing,
+			pkg,
+			choiceDecisions: decisions([
+				["parent", "skip"],
+				["child", "import"],
+			]),
+			assetDecisions: [],
+		});
+
+		// Parent skipped, child should still be importable and land under the
+		// existing parent multi via id lookup.
+		expect(result.skippedChoiceIds).toEqual(["parent"]);
+		expect(result.addedChoiceIds).toEqual(["child"]);
+		const destParent = result.updatedChoices.find(
+			(c) => c.id === "parent",
+		) as IMultiChoice;
+		expect(destParent.choices.map((c) => c.id)).toEqual(["child"]);
+	});
+});
+
+// --- applyPackageImport: duplicate / id remapping ---------------------------
+
+describe("applyPackageImport - duplicate mode and id remapping", () => {
+	it("assigns a fresh id when a choice is duplicated", async () => {
+		const { app } = createFakeApp();
+		const pkg = makePackage({
+			choices: [makePackageChoice(makeChoice("orig", "Orig", "Template"))],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([["orig", "duplicate"]]),
+			assetDecisions: [],
+		});
+
+		expect(result.addedChoiceIds).toEqual(["uuid-1"]);
+		expect(result.updatedChoices[0].id).toBe("uuid-1");
+		expect(result.updatedChoices[0].name).toBe("Orig");
+	});
+
+	it("propagates duplication to descendants and regenerates macro/command ids", async () => {
+		const { app } = createFakeApp();
+		const macroChild = {
+			...makeChoice("macroChild", "MacroChild", "Macro"),
+			macro: {
+				id: "macro-orig",
+				name: "M",
+				commands: [
+					{
+						id: "cmd-orig",
+						name: "Run sibling",
+						type: CommandType.Choice,
+						choiceId: "macroChild",
+					} as IChoiceCommand,
+				],
+			},
+			runOnStartup: false,
+		} as IMacroChoice;
+		const parent = makeMulti("parent", "Parent", [macroChild]);
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(parent),
+				makePackageChoice(macroChild, "parent", ["Parent"]),
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			// Only the parent is marked duplicate; the child should inherit it.
+			choiceDecisions: decisions([
+				["parent", "duplicate"],
+				["macroChild", "import"],
+			]),
+			assetDecisions: [],
+		});
+
+		const insertedParent = result.updatedChoices[0] as IMultiChoice;
+		// Parent and child both get new ids.
+		expect(insertedParent.id).not.toBe("parent");
+		const insertedMacro = insertedParent.choices[0] as IMacroChoice;
+		expect(insertedMacro.id).not.toBe("macroChild");
+		// Macro + command ids regenerated.
+		expect(insertedMacro.macro.id).not.toBe("macro-orig");
+		const cmd = insertedMacro.macro.commands[0] as IChoiceCommand;
+		expect(cmd.id).not.toBe("cmd-orig");
+		// Choice command pointing at the duplicated child gets remapped to the new id.
+		expect(cmd.choiceId).toBe(insertedMacro.id);
+	});
+
+	it("remaps Choice-command references to non-duplicated imported ids", async () => {
+		const { app } = createFakeApp();
+		const macro = {
+			...makeChoice("macro", "Macro", "Macro"),
+			macro: {
+				id: "macro-id",
+				name: "M",
+				commands: [
+					{
+						id: "cmd",
+						name: "Run target",
+						type: CommandType.Choice,
+						choiceId: "target",
+					} as IChoiceCommand,
+				],
+			},
+			runOnStartup: false,
+		} as IMacroChoice;
+		const target = makeChoice("target", "Target", "Template");
+		const pkg = makePackage({
+			choices: [makePackageChoice(macro), makePackageChoice(target)],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([
+				["macro", "import"],
+				["target", "import"],
+			]),
+			assetDecisions: [],
+		});
+
+		const insertedMacro = result.updatedChoices.find(
+			(c) => c.id === "macro",
+		) as IMacroChoice;
+		const cmd = insertedMacro.macro.commands[0] as IChoiceCommand;
+		// Not duplicated, so id stays the same.
+		expect(cmd.choiceId).toBe("target");
+	});
+
+	it("filters out non-importable children from a Multi during remap", async () => {
+		const { app } = createFakeApp();
+		const keepChild = makeChoice("keep", "Keep", "Template");
+		const dropChild = makeChoice("drop", "Drop", "Template");
+		const parent = makeMulti("parent", "Parent", [keepChild, dropChild]);
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(parent),
+				makePackageChoice(keepChild, "parent", ["Parent"]),
+				makePackageChoice(dropChild, "parent", ["Parent"]),
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([
+				["parent", "import"],
+				["keep", "import"],
+				["drop", "skip"],
+			]),
+			assetDecisions: [],
+		});
+
+		const insertedParent = result.updatedChoices[0] as IMultiChoice;
+		// The skipped child must not appear inside the imported parent's tree.
+		expect(insertedParent.choices.map((c) => c.id)).toEqual(["keep"]);
+		expect(result.skippedChoiceIds).toContain("drop");
+	});
+});
+
+// --- applyPackageImport: assets ---------------------------------------------
+
+describe("applyPackageImport - assets", () => {
+	it("writes a new asset, ensures parent folders, and decodes base64 content", async () => {
+		const { app, state } = createFakeApp();
+		const content = "console.log('hi');";
+		const asset: QuickAddPackageAsset = {
+			kind: "user-script",
+			originalPath: "scripts/sub/run.js",
+			contentEncoding: "base64",
+			content: encodeToBase64(content),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions: [],
+		});
+
+		expect(result.writtenAssets).toEqual(["scripts/sub/run.js"]);
+		expect(state.writes.get("scripts/sub/run.js")).toBe(content);
+		// Parent folders created in order.
+		expect(state.createdFolders).toEqual(["scripts", "scripts/sub"]);
+	});
+
+	it("respects an explicit skip decision for an asset", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "templates/t.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+		const assetDecisions: AssetImportDecision[] = [
+			{
+				originalPath: "templates/t.md",
+				destinationPath: "templates/t.md",
+				mode: "skip",
+			},
+		];
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions,
+		});
+
+		expect(result.skippedAssets).toEqual(["templates/t.md"]);
+		expect(result.writtenAssets).toEqual([]);
+		expect(state.writes.has("templates/t.md")).toBe(false);
+	});
+
+	it("writes to a custom (normalized) destination path", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "templates/t.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+		const assetDecisions: AssetImportDecision[] = [
+			{
+				originalPath: "templates/t.md",
+				destinationPath: "renamed\\dest.md",
+				mode: "write",
+			},
+		];
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions,
+		});
+
+		expect(result.writtenAssets).toEqual(["renamed/dest.md"]);
+		expect(state.writes.get("renamed/dest.md")).toBe("body");
+	});
+
+	it("rewrites template/userscript/conditional paths to remapped destinations", async () => {
+		const { app } = createFakeApp();
+
+		const templateChoice = {
+			...makeChoice("tmpl", "Template choice", "Template"),
+			templatePath: "templates/orig.md",
+		} as ITemplateChoice;
+
+		const captureChoice = {
+			...makeChoice("cap", "Capture choice", "Capture"),
+			createFileIfItDoesntExist: {
+				enabled: true,
+				createWithTemplate: true,
+				template: "templates/orig.md",
+			},
+		} as ICaptureChoice;
+
+		const macroChoice = {
+			...makeChoice("macro", "Macro choice", "Macro"),
+			macro: {
+				id: "macro-id",
+				name: "M",
+				commands: [
+					{
+						id: "us",
+						name: "Script",
+						type: CommandType.UserScript,
+						path: "scripts/orig.js",
+						settings: {},
+					} as IUserScript,
+					{
+						id: "cond",
+						name: "Cond",
+						type: CommandType.Conditional,
+						condition: {
+							mode: "script",
+							scriptPath: "scripts/orig.js",
+						},
+						thenCommands: [
+							{
+								id: "nested",
+								name: "Nested",
+								type: CommandType.NestedChoice,
+								choice: {
+									...makeChoice("nestedTmpl", "Nested tmpl", "Template"),
+									templatePath: "templates/orig.md",
+								} as ITemplateChoice,
+							} as INestedChoiceCommand,
+						],
+						elseCommands: [],
+					} as IConditionalCommand,
+				],
+			},
+			runOnStartup: false,
+		} as IMacroChoice;
+
+		const pkg = makePackage({
+			choices: [
+				makePackageChoice(templateChoice),
+				makePackageChoice(captureChoice),
+				makePackageChoice(macroChoice),
+			],
+			assets: [
+				{
+					kind: "template",
+					originalPath: "templates/orig.md",
+					contentEncoding: "base64",
+					content: encodeToBase64("tmpl body"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "scripts/orig.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("script body"),
+				},
+			],
+		});
+
+		const assetDecisions: AssetImportDecision[] = [
+			{
+				originalPath: "templates/orig.md",
+				destinationPath: "templates/new.md",
+				mode: "write",
+			},
+			{
+				originalPath: "scripts/orig.js",
+				destinationPath: "scripts/new.js",
+				mode: "write",
+			},
+		];
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([
+				["tmpl", "import"],
+				["cap", "import"],
+				["macro", "import"],
+			]),
+			assetDecisions,
+		});
+
+		const insertedTemplate = result.updatedChoices.find(
+			(c) => c.id === "tmpl",
+		) as ITemplateChoice;
+		expect(insertedTemplate.templatePath).toBe("templates/new.md");
+
+		const insertedCapture = result.updatedChoices.find(
+			(c) => c.id === "cap",
+		) as ICaptureChoice;
+		expect(insertedCapture.createFileIfItDoesntExist.template).toBe(
+			"templates/new.md",
+		);
+
+		const insertedMacro = result.updatedChoices.find(
+			(c) => c.id === "macro",
+		) as IMacroChoice;
+		const userScript = insertedMacro.macro.commands[0] as IUserScript;
+		expect(userScript.path).toBe("scripts/new.js");
+		const conditional = insertedMacro.macro.commands[1] as IConditionalCommand;
+		expect(
+			(conditional.condition as { scriptPath: string }).scriptPath,
+		).toBe("scripts/new.js");
+		const nested = conditional.thenCommands[0] as INestedChoiceCommand;
+		expect((nested.choice as ITemplateChoice).templatePath).toBe(
+			"templates/new.md",
+		);
+	});
+
+	it("does not throw when adapter.exists rejects while checking an asset", async () => {
+		const { app, state } = createFakeApp();
+		state.existThrowsFor = new Set(["scripts/run.js"]);
+		const asset: QuickAddPackageAsset = {
+			kind: "user-script",
+			originalPath: "scripts/run.js",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		// exists() throws -> assetExists swallows -> treated as not existing -> write.
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions: [],
+		});
+
+		expect(result.writtenAssets).toEqual(["scripts/run.js"]);
+	});
+
+	it("returns empty result arrays for an empty package", async () => {
+		const { app } = createFakeApp();
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg: makePackage(),
+			choiceDecisions: [],
+			assetDecisions: [],
+		});
+
+		expect(result).toEqual({
+			updatedChoices: [],
+			addedChoiceIds: [],
+			overwrittenChoiceIds: [],
+			skippedChoiceIds: [],
+			writtenAssets: [],
+			skippedAssets: [],
+		});
+	});
+});

--- a/src/utils/packageTraversal.test.ts
+++ b/src/utils/packageTraversal.test.ts
@@ -1,0 +1,784 @@
+import { describe, it, expect } from "vitest";
+import {
+	collectChoiceClosure,
+	collectScriptDependencies,
+	collectFileDependencies,
+	type ChoiceCatalogEntry,
+} from "./packageTraversal";
+import type IChoice from "../types/choices/IChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import type { ICommand } from "../types/macros/ICommand";
+import type { IChoiceCommand } from "../types/macros/IChoiceCommand";
+import type { IUserScript } from "../types/macros/IUserScript";
+import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
+import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
+import { CommandType } from "../types/macros/CommandType";
+
+// --- Factory helpers (typed, minimal, no Obsidian deps) -----------------
+
+let idCounter = 0;
+function uid(prefix: string): string {
+	idCounter += 1;
+	return `${prefix}-${idCounter}`;
+}
+
+function makeMulti(
+	name: string,
+	children: IChoice[],
+	id = uid("multi"),
+): IMultiChoice {
+	return {
+		id,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: children,
+	} as IMultiChoice;
+}
+
+function makeTemplate(
+	name: string,
+	templatePath: string,
+	id = uid("template"),
+): ITemplateChoice {
+	return {
+		id,
+		name,
+		type: "Template",
+		command: false,
+		templatePath,
+	} as unknown as ITemplateChoice;
+}
+
+function makeCapture(
+	name: string,
+	createFileIfItDoesntExist?: ICaptureChoice["createFileIfItDoesntExist"],
+	id = uid("capture"),
+): ICaptureChoice {
+	return {
+		id,
+		name,
+		type: "Capture",
+		command: false,
+		createFileIfItDoesntExist,
+	} as unknown as ICaptureChoice;
+}
+
+function makeMacro(
+	name: string,
+	commands: ICommand[],
+	id = uid("macro"),
+): IMacroChoice {
+	return {
+		id,
+		name,
+		type: "Macro",
+		command: false,
+		runOnStartup: false,
+		macro: {
+			id: uid("macroDef"),
+			name: `${name}-macro`,
+			commands,
+		},
+	} as unknown as IMacroChoice;
+}
+
+function choiceCommand(choiceId: string, id = uid("cmd")): IChoiceCommand {
+	return {
+		id,
+		name: "choice-cmd",
+		type: CommandType.Choice,
+		choiceId,
+	};
+}
+
+function nestedChoiceCommand(
+	choice: IChoice,
+	id = uid("cmd"),
+): INestedChoiceCommand {
+	return {
+		id,
+		name: "nested-cmd",
+		type: CommandType.NestedChoice,
+		choice,
+	};
+}
+
+function userScriptCommand(path: string, id = uid("cmd")): IUserScript {
+	return {
+		id,
+		name: "user-script",
+		type: CommandType.UserScript,
+		path,
+		settings: {},
+	};
+}
+
+function conditionalCommand(
+	condition: IConditionalCommand["condition"],
+	thenCommands: ICommand[],
+	elseCommands: ICommand[],
+	id = uid("cmd"),
+): IConditionalCommand {
+	return {
+		id,
+		name: "conditional",
+		type: CommandType.Conditional,
+		condition,
+		thenCommands,
+		elseCommands,
+	};
+}
+
+const scriptCondition = (scriptPath: string): IConditionalCommand["condition"] =>
+	({ mode: "script", scriptPath } as IConditionalCommand["condition"]);
+
+const variableCondition = (): IConditionalCommand["condition"] =>
+	({
+		mode: "variable",
+		variableName: "x",
+		operator: "isTruthy",
+		valueType: "boolean",
+	} as IConditionalCommand["condition"]);
+
+// --- collectChoiceClosure -----------------------------------------------
+
+describe("collectChoiceClosure", () => {
+	it("returns empty results for empty inputs", () => {
+		const result = collectChoiceClosure([], []);
+		expect(result.choiceIds).toEqual([]);
+		expect(result.missingChoiceIds).toEqual([]);
+		expect(result.catalog.size).toBe(0);
+	});
+
+	it("builds a catalog with parentId and path for nested multi choices", () => {
+		const leaf = makeTemplate("Leaf", "T.md", "leaf");
+		const inner = makeMulti("Inner", [leaf], "inner");
+		const root = makeMulti("Root", [inner], "root");
+
+		const { catalog } = collectChoiceClosure([root], ["root"]);
+
+		expect(catalog.get("root")).toMatchObject({
+			parentId: null,
+			path: ["Root"],
+		});
+		expect(catalog.get("inner")).toMatchObject({
+			parentId: "root",
+			path: ["Root", "Inner"],
+		});
+		expect(catalog.get("leaf")).toMatchObject({
+			parentId: "inner",
+			path: ["Root", "Inner", "Leaf"],
+		});
+	});
+
+	it("includes the multi choice and all of its descendants from the root", () => {
+		const a = makeTemplate("A", "a.md", "a");
+		const b = makeTemplate("B", "b.md", "b");
+		const root = makeMulti("Root", [a, b], "root");
+
+		const { choiceIds, missingChoiceIds } = collectChoiceClosure(
+			[root],
+			["root"],
+		);
+
+		expect(new Set(choiceIds)).toEqual(new Set(["root", "a", "b"]));
+		expect(missingChoiceIds).toEqual([]);
+	});
+
+	it("records the root first in traversal order (BFS)", () => {
+		const a = makeTemplate("A", "a.md", "a");
+		const b = makeTemplate("B", "b.md", "b");
+		const root = makeMulti("Root", [a, b], "root");
+
+		const { choiceIds } = collectChoiceClosure([root], ["root"]);
+
+		expect(choiceIds[0]).toBe("root");
+	});
+
+	it("does not pull in children when only a leaf is requested as root", () => {
+		const a = makeTemplate("A", "a.md", "a");
+		const b = makeTemplate("B", "b.md", "b");
+		const root = makeMulti("Root", [a, b], "root");
+
+		// Catalog is built from the full tree, but only `a` is the root.
+		const { choiceIds } = collectChoiceClosure([root], ["a"]);
+
+		expect(choiceIds).toEqual(["a"]);
+	});
+
+	it("follows Macro Choice-command dependencies", () => {
+		const target = makeTemplate("Target", "t.md", "target");
+		const macro = makeMacro("M", [choiceCommand("target")], "macro");
+
+		const { choiceIds } = collectChoiceClosure(
+			[macro, target],
+			["macro"],
+		);
+
+		expect(new Set(choiceIds)).toEqual(new Set(["macro", "target"]));
+	});
+
+	it("follows Conditional then/else Choice-command dependencies in a macro", () => {
+		const thenTarget = makeTemplate("Then", "then.md", "thenT");
+		const elseTarget = makeTemplate("Else", "else.md", "elseT");
+		const macro = makeMacro(
+			"M",
+			[
+				conditionalCommand(
+					variableCondition(),
+					[choiceCommand("thenT")],
+					[choiceCommand("elseT")],
+				),
+			],
+			"macro",
+		);
+
+		const { choiceIds } = collectChoiceClosure(
+			[macro, thenTarget, elseTarget],
+			["macro"],
+		);
+
+		expect(new Set(choiceIds)).toEqual(
+			new Set(["macro", "thenT", "elseT"]),
+		);
+	});
+
+	it("collects dependencies of an inline NestedChoice (its children, not its own id)", () => {
+		// A nested-choice command embeds a multi-choice inline. The nested
+		// choice's own id is NOT a registered catalog choice, but its child id
+		// is registered separately and should be reachable.
+		const registeredChild = makeTemplate("Child", "c.md", "child");
+		const inlineMulti = makeMulti(
+			"InlineMulti",
+			[registeredChild],
+			"inline",
+		);
+		const macro = makeMacro(
+			"M",
+			[nestedChoiceCommand(inlineMulti)],
+			"macro",
+		);
+
+		const { choiceIds, missingChoiceIds } = collectChoiceClosure(
+			[macro, registeredChild],
+			["macro"],
+		);
+
+		expect(new Set(choiceIds)).toEqual(new Set(["macro", "child"]));
+		// The inline nested-choice id itself is not enqueued as a dependency.
+		expect(missingChoiceIds).toEqual([]);
+	});
+
+	it("reports dependency ids absent from the catalog as missing", () => {
+		const macro = makeMacro(
+			"M",
+			[choiceCommand("ghost")],
+			"macro",
+		);
+
+		const { choiceIds, missingChoiceIds } = collectChoiceClosure(
+			[macro],
+			["macro"],
+		);
+
+		expect(choiceIds).toEqual(["macro"]);
+		expect(missingChoiceIds).toEqual(["ghost"]);
+	});
+
+	it("reports a missing root id when it is not in the catalog", () => {
+		const a = makeTemplate("A", "a.md", "a");
+
+		const { choiceIds, missingChoiceIds } = collectChoiceClosure(
+			[a],
+			["a", "nope"],
+		);
+
+		expect(choiceIds).toEqual(["a"]);
+		expect(missingChoiceIds).toEqual(["nope"]);
+	});
+
+	it("deduplicates diamond dependencies (a shared target is visited once)", () => {
+		const shared = makeTemplate("Shared", "s.md", "shared");
+		const m1 = makeMacro("M1", [choiceCommand("shared")], "m1");
+		const m2 = makeMacro("M2", [choiceCommand("shared")], "m2");
+		const root = makeMulti("Root", [m1, m2], "root");
+
+		const { choiceIds } = collectChoiceClosure(
+			[root, shared],
+			["root"],
+		);
+
+		const sharedCount = choiceIds.filter((id) => id === "shared").length;
+		expect(sharedCount).toBe(1);
+		expect(new Set(choiceIds)).toEqual(
+			new Set(["root", "m1", "m2", "shared"]),
+		);
+	});
+
+	it("terminates on cyclic Choice-command references", () => {
+		const a = makeMacro("A", [choiceCommand("b")], "a");
+		const b = makeMacro("B", [choiceCommand("a")], "b");
+
+		const { choiceIds } = collectChoiceClosure([a, b], ["a"]);
+
+		expect(new Set(choiceIds)).toEqual(new Set(["a", "b"]));
+	});
+
+	it("deduplicates repeated root ids", () => {
+		const a = makeTemplate("A", "a.md", "a");
+
+		const { choiceIds } = collectChoiceClosure([a], ["a", "a"]);
+
+		expect(choiceIds).toEqual(["a"]);
+	});
+
+	it("excludes a root id when listed in excludedChoiceIds", () => {
+		const a = makeTemplate("A", "a.md", "a");
+		const b = makeTemplate("B", "b.md", "b");
+
+		const { choiceIds, missingChoiceIds } = collectChoiceClosure(
+			[a, b],
+			["a", "b"],
+			{ excludedChoiceIds: new Set(["b"]) },
+		);
+
+		expect(choiceIds).toEqual(["a"]);
+		// Excluded ids are silently skipped, not reported as missing.
+		expect(missingChoiceIds).toEqual([]);
+	});
+
+	it("excludes a dependency reachable only through a macro", () => {
+		const dep = makeTemplate("Dep", "dep.md", "dep");
+		const macro = makeMacro("M", [choiceCommand("dep")], "macro");
+
+		const { choiceIds } = collectChoiceClosure(
+			[macro, dep],
+			["macro"],
+			{ excludedChoiceIds: new Set(["dep"]) },
+		);
+
+		expect(choiceIds).toEqual(["macro"]);
+	});
+
+	it("still includes a multi parent even when one of its children is excluded", () => {
+		const kept = makeTemplate("Kept", "kept.md", "kept");
+		const dropped = makeTemplate("Dropped", "dropped.md", "dropped");
+		const root = makeMulti("Root", [kept, dropped], "root");
+
+		const { choiceIds } = collectChoiceClosure(
+			[root],
+			["root"],
+			{ excludedChoiceIds: new Set(["dropped"]) },
+		);
+
+		expect(new Set(choiceIds)).toEqual(new Set(["root", "kept"]));
+	});
+
+	it("handles a Multi choice with a non-array `choices` property gracefully", () => {
+		const broken = {
+			id: "broken",
+			name: "Broken",
+			type: "Multi",
+			command: false,
+			collapsed: false,
+			choices: undefined,
+		} as unknown as IChoice;
+
+		const { choiceIds, catalog } = collectChoiceClosure(
+			[broken],
+			["broken"],
+		);
+
+		expect(choiceIds).toEqual(["broken"]);
+		expect(catalog.has("broken")).toBe(true);
+	});
+
+	it("ignores macro commands of unrelated types without crashing", () => {
+		const waitCommand: ICommand = {
+			id: uid("cmd"),
+			name: "wait",
+			type: CommandType.Wait,
+		};
+		const macro = makeMacro("M", [waitCommand], "macro");
+
+		const { choiceIds, missingChoiceIds } = collectChoiceClosure(
+			[macro],
+			["macro"],
+		);
+
+		expect(choiceIds).toEqual(["macro"]);
+		expect(missingChoiceIds).toEqual([]);
+	});
+});
+
+// --- collectScriptDependencies ------------------------------------------
+
+describe("collectScriptDependencies", () => {
+	function closureFor(
+		allChoices: IChoice[],
+		roots: string[],
+	): {
+		catalog: Map<string, ChoiceCatalogEntry>;
+		choiceIds: string[];
+	} {
+		const { catalog, choiceIds } = collectChoiceClosure(allChoices, roots);
+		return { catalog, choiceIds };
+	}
+
+	it("returns empty sets for no choices", () => {
+		const { catalog, choiceIds } = closureFor([], []);
+		const result = collectScriptDependencies(catalog, choiceIds);
+		expect(result.userScriptPaths.size).toBe(0);
+		expect(result.conditionalScriptPaths.size).toBe(0);
+	});
+
+	it("collects UserScript paths from a macro", () => {
+		const macro = makeMacro(
+			"M",
+			[userScriptCommand("scripts/foo.js")],
+			"macro",
+		);
+		const { catalog, choiceIds } = closureFor([macro], ["macro"]);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect([...result.userScriptPaths]).toEqual(["scripts/foo.js"]);
+		expect(result.conditionalScriptPaths.size).toBe(0);
+	});
+
+	it("collects script-mode conditional script paths", () => {
+		const macro = makeMacro(
+			"M",
+			[
+				conditionalCommand(
+					scriptCondition("scripts/cond.js"),
+					[],
+					[],
+				),
+			],
+			"macro",
+		);
+		const { catalog, choiceIds } = closureFor([macro], ["macro"]);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect([...result.conditionalScriptPaths]).toEqual([
+			"scripts/cond.js",
+		]);
+		expect(result.userScriptPaths.size).toBe(0);
+	});
+
+	it("does not collect a script path from variable-mode conditionals", () => {
+		const macro = makeMacro(
+			"M",
+			[conditionalCommand(variableCondition(), [], [])],
+			"macro",
+		);
+		const { catalog, choiceIds } = closureFor([macro], ["macro"]);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect(result.conditionalScriptPaths.size).toBe(0);
+	});
+
+	it("recurses into conditional then/else branches for UserScripts", () => {
+		const macro = makeMacro(
+			"M",
+			[
+				conditionalCommand(
+					variableCondition(),
+					[userScriptCommand("scripts/then.js")],
+					[userScriptCommand("scripts/else.js")],
+				),
+			],
+			"macro",
+		);
+		const { catalog, choiceIds } = closureFor([macro], ["macro"]);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect(result.userScriptPaths).toEqual(
+			new Set(["scripts/then.js", "scripts/else.js"]),
+		);
+	});
+
+	it("deduplicates identical script paths", () => {
+		const macro = makeMacro(
+			"M",
+			[
+				userScriptCommand("scripts/dup.js"),
+				userScriptCommand("scripts/dup.js"),
+			],
+			"macro",
+		);
+		const { catalog, choiceIds } = closureFor([macro], ["macro"]);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect([...result.userScriptPaths]).toEqual(["scripts/dup.js"]);
+	});
+
+	it("ignores UserScript commands with an empty path", () => {
+		const macro = makeMacro(
+			"M",
+			[userScriptCommand("")],
+			"macro",
+		);
+		const { catalog, choiceIds } = closureFor([macro], ["macro"]);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect(result.userScriptPaths.size).toBe(0);
+	});
+
+	it("descends into multi-choice children to find scripts", () => {
+		const innerMacro = makeMacro(
+			"Inner",
+			[userScriptCommand("scripts/inner.js")],
+			"innerMacro",
+		);
+		const root = makeMulti("Root", [innerMacro], "root");
+		const { catalog, choiceIds } = closureFor([root], ["root"]);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect([...result.userScriptPaths]).toEqual(["scripts/inner.js"]);
+	});
+
+	it("collects scripts from an inline nested choice not present in the catalog", () => {
+		// The inline nested choice's id is not in the catalog, so
+		// shouldIncludeChoice returns true and it is always traversed.
+		const inlineMacro = makeMacro(
+			"Inline",
+			[userScriptCommand("scripts/nested.js")],
+			"inlineNotInCatalog",
+		);
+		const macro = makeMacro(
+			"M",
+			[nestedChoiceCommand(inlineMacro)],
+			"macro",
+		);
+		// Build catalog from `macro` only; the inline macro id is not registered.
+		const { catalog } = collectChoiceClosure([macro], ["macro"]);
+
+		const result = collectScriptDependencies(catalog, ["macro"]);
+
+		expect([...result.userScriptPaths]).toEqual(["scripts/nested.js"]);
+	});
+
+	it("does not follow a Choice command whose target is outside the included set", () => {
+		// `target` exists in the catalog but is NOT in the included choiceIds,
+		// so its scripts must not be collected.
+		const target = makeMacro(
+			"Target",
+			[userScriptCommand("scripts/target.js")],
+			"target",
+		);
+		const macro = makeMacro("M", [choiceCommand("target")], "macro");
+		const { catalog } = collectChoiceClosure([macro, target], ["macro"]);
+
+		// Intentionally pass only the macro id as included.
+		const result = collectScriptDependencies(catalog, ["macro"]);
+
+		expect(result.userScriptPaths.size).toBe(0);
+	});
+
+	it("follows a Choice command whose target IS in the included set", () => {
+		const target = makeMacro(
+			"Target",
+			[userScriptCommand("scripts/target.js")],
+			"target",
+		);
+		const macro = makeMacro("M", [choiceCommand("target")], "macro");
+		const { catalog, choiceIds } = collectChoiceClosure(
+			[macro, target],
+			["macro"],
+		);
+
+		const result = collectScriptDependencies(catalog, choiceIds);
+
+		expect([...result.userScriptPaths]).toEqual(["scripts/target.js"]);
+	});
+});
+
+// --- collectFileDependencies --------------------------------------------
+
+describe("collectFileDependencies", () => {
+	function closureFor(allChoices: IChoice[], roots: string[]) {
+		return collectChoiceClosure(allChoices, roots);
+	}
+
+	const captureWithTemplate = (
+		name: string,
+		template: string,
+		id?: string,
+	): ICaptureChoice =>
+		makeCapture(
+			name,
+			{ enabled: true, createWithTemplate: true, template },
+			id,
+		);
+
+	it("returns empty sets for no choices", () => {
+		const { catalog, choiceIds } = closureFor([], []);
+		const result = collectFileDependencies(catalog, choiceIds);
+		expect(result.templatePaths.size).toBe(0);
+		expect(result.captureTemplatePaths.size).toBe(0);
+	});
+
+	it("collects template paths from template choices", () => {
+		const tmpl = makeTemplate("T", "templates/note.md", "t");
+		const { catalog, choiceIds } = closureFor([tmpl], ["t"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect([...result.templatePaths]).toEqual(["templates/note.md"]);
+		expect(result.captureTemplatePaths.size).toBe(0);
+	});
+
+	it("ignores template choices with an empty templatePath", () => {
+		const tmpl = makeTemplate("T", "", "t");
+		const { catalog, choiceIds } = closureFor([tmpl], ["t"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect(result.templatePaths.size).toBe(0);
+	});
+
+	it("collects capture templates when createFileIfItDoesntExist is fully enabled", () => {
+		const cap = captureWithTemplate("C", "templates/cap.md", "c");
+		const { catalog, choiceIds } = closureFor([cap], ["c"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect([...result.captureTemplatePaths]).toEqual([
+			"templates/cap.md",
+		]);
+		expect(result.templatePaths.size).toBe(0);
+	});
+
+	it("does not collect a capture template when createFileIfItDoesntExist is disabled", () => {
+		const cap = makeCapture("C", {
+			enabled: false,
+			createWithTemplate: true,
+			template: "templates/cap.md",
+		});
+		const { catalog, choiceIds } = closureFor([cap], [cap.id]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect(result.captureTemplatePaths.size).toBe(0);
+	});
+
+	it("does not collect a capture template when createWithTemplate is false", () => {
+		const cap = makeCapture("C", {
+			enabled: true,
+			createWithTemplate: false,
+			template: "templates/cap.md",
+		});
+		const { catalog, choiceIds } = closureFor([cap], [cap.id]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect(result.captureTemplatePaths.size).toBe(0);
+	});
+
+	it("does not collect a capture template when the template path is empty", () => {
+		const cap = makeCapture("C", {
+			enabled: true,
+			createWithTemplate: true,
+			template: "",
+		});
+		const { catalog, choiceIds } = closureFor([cap], [cap.id]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect(result.captureTemplatePaths.size).toBe(0);
+	});
+
+	it("handles a capture choice without a createFileIfItDoesntExist object", () => {
+		const cap = makeCapture("C", undefined);
+		const { catalog, choiceIds } = closureFor([cap], [cap.id]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect(result.captureTemplatePaths.size).toBe(0);
+	});
+
+	it("descends into multi-choice children to collect file dependencies", () => {
+		const tmpl = makeTemplate("T", "templates/child.md", "t");
+		const cap = captureWithTemplate("C", "templates/cap.md", "c");
+		const root = makeMulti("Root", [tmpl, cap], "root");
+		const { catalog, choiceIds } = closureFor([root], ["root"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect([...result.templatePaths]).toEqual(["templates/child.md"]);
+		expect([...result.captureTemplatePaths]).toEqual([
+			"templates/cap.md",
+		]);
+	});
+
+	it("collects template dependencies reached through macro Choice commands", () => {
+		const tmpl = makeTemplate("T", "templates/target.md", "target");
+		const macro = makeMacro("M", [choiceCommand("target")], "macro");
+		const { catalog, choiceIds } = closureFor([macro, tmpl], ["macro"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect([...result.templatePaths]).toEqual(["templates/target.md"]);
+	});
+
+	it("recurses into conditional then/else branches via nested choices", () => {
+		const inlineTemplate = makeTemplate(
+			"Inline",
+			"templates/inline.md",
+			"inlineTmpl",
+		);
+		const macro = makeMacro(
+			"M",
+			[
+				conditionalCommand(
+					variableCondition(),
+					[nestedChoiceCommand(inlineTemplate)],
+					[],
+				),
+			],
+			"macro",
+		);
+		// Inline template id is not registered in the catalog, so it is always
+		// traversed inside the conditional branch.
+		const { catalog } = collectChoiceClosure([macro], ["macro"]);
+
+		const result = collectFileDependencies(catalog, ["macro"]);
+
+		expect([...result.templatePaths]).toEqual(["templates/inline.md"]);
+	});
+
+	it("does not follow a Choice command target outside the included set", () => {
+		const tmpl = makeTemplate("T", "templates/target.md", "target");
+		const macro = makeMacro("M", [choiceCommand("target")], "macro");
+		const { catalog } = collectChoiceClosure([macro, tmpl], ["macro"]);
+
+		const result = collectFileDependencies(catalog, ["macro"]);
+
+		expect(result.templatePaths.size).toBe(0);
+	});
+
+	it("deduplicates a shared template reached through multiple choices", () => {
+		const shared = makeTemplate("Shared", "templates/shared.md", "shared");
+		const m1 = makeMacro("M1", [choiceCommand("shared")], "m1");
+		const m2 = makeMacro("M2", [choiceCommand("shared")], "m2");
+		const root = makeMulti("Root", [m1, m2], "root");
+		const { catalog, choiceIds } = closureFor([root, shared], ["root"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect([...result.templatePaths]).toEqual(["templates/shared.md"]);
+	});
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,5 +20,12 @@ export default defineConfig({
 				},
 			},
 		},
+		coverage: {
+			provider: "v8",
+			all: true,
+			include: ["src/**/*.ts"],
+			exclude: ["src/**/*.test.ts", "src/**/*.d.ts"],
+			reporter: ["text-summary", "json-summary"],
+		},
 	},
 });


### PR DESCRIPTION
Builds out the runtime-behavior safety net for the core logic (we had 1126 tests but **zero coverage visibility**).

## Coverage tooling
`@vitest/coverage-v8` + a `test:coverage` script + config (`coverage/` gitignored). Baseline was **45.86%** statements.

## 273 new tests across the most under-covered core modules
| module | before | after |
|---|---|---|
| services/choiceService | 0% | **99%** |
| utils/packageTraversal | 0% | **98%** |
| services/packageExportService | 0% | **98%** |
| services/packageImportService | 0% | **95%** |
| formatters/completeFormatter | 43% | **88%** |
| ai/OpenAIRequest | 3% | **100%** |
| quickAddApi | 35% | **93%** |

Overall statement coverage **45.86% → 54.14%**. All tests self-contained (mock Obsidian via `vi.mock` / fakes; deterministic), and they assert **correct** behavior — where the code looked wrong, the behavior was *not* locked in.

## One type fix (surfaced by the tests)
The public `suggester` API declared its `displayItems` mapper as `(value, index?, arr?) => string[]`, but it's applied per-item via `actualItems.map(...)` and must return a single `string`. The old type would reject a correct `=> string` user-script callback. Fixed both signatures — **type-only, no runtime change**.

## Suspected bugs
The tests surfaced 6 suspected bugs (1 medium, 5 low) — filed as a follow-up issue, not encoded into the tests. The notable one: `quickAddApi.executeChoice` logs an error for an unknown choice but then still calls `execute(undefined)` instead of returning early.

## Verification
`bun run test` (1399 pass), `bun run build-with-lint` clean (tsc + eslint + esbuild), `bun run check` (svelte-check) clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated the `suggester` API to accept display items as a function returning a single string per item, in addition to arrays of strings.

* **Tests**
  * Added comprehensive test suite coverage for core functionality and services.

* **Chores**
  * Added test coverage reporting configuration and updated project ignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->