### PR TITLE
fix: resolve three verified bugs from #1246

### DIFF
--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -526,9 +526,9 @@ describe("utility selection helpers", () => {
 		expect(api.utility.getSelection()).toBe("");
 	});
 
-	it("getSelectedText reports an error and returns undefined with no view", () => {
+	it("getSelectedText reports an error and returns '' with no view", () => {
 		const { api } = getApi();
-		expect(api.utility.getSelectedText()).toBeUndefined();
+		expect(api.utility.getSelectedText()).toBe("");
 		expect(mocks.reportError).toHaveBeenCalled();
 	});
 
@@ -544,7 +544,7 @@ describe("utility selection helpers", () => {
 			},
 		});
 		const { api } = getApi(app);
-		expect(api.utility.getSelectedText()).toBeUndefined();
+		expect(api.utility.getSelectedText()).toBe("");
 		expect(mocks.reportError).toHaveBeenCalled();
 	});
 

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -504,7 +504,7 @@ export class QuickAddApi {
 							new Error("No active view"),
 							"Could not get selected text",
 						);
-						return;
+						return "";
 					}
 
 					if (!activeView.editor.somethingSelected()) {
@@ -512,7 +512,7 @@ export class QuickAddApi {
 							new Error("No text selected"),
 							"Could not get selected text",
 						);
-						return;
+						return "";
 					}
 
 					return activeView.editor.getSelection();

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -190,6 +190,23 @@ describe("choiceService", () => {
 			expect(copy.id).not.toBe(original.id);
 		});
 
+		it("preserves command and onePageInput when duplicating a Multi", () => {
+			const original = createChoice("Multi", "M") as IMultiChoice;
+			(original as unknown as { command: boolean }).command = true;
+			(original as unknown as { onePageInput: string }).onePageInput =
+				"always";
+			original.choices = [createChoice("Capture", "Child")];
+
+			const copy = duplicateChoice(original) as IMultiChoice;
+
+			expect(copy.command).toBe(true);
+			expect(
+				(copy as unknown as { onePageInput?: string }).onePageInput,
+			).toBe("always");
+			// children still duplicated with fresh ids
+			expect(copy.choices[0].id).not.toBe(original.choices[0].id);
+		});
+
 		it("deep clones a Macro's macro and regenerates ids", () => {
 			const original = createChoice("Macro", "Mac") as IMacroChoice;
 			original.macro.commands.push({

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -42,9 +42,11 @@ export function duplicateChoice(choice: IChoice): IChoice {
 	if (choice.type === "Multi") {
 		const newMulti = newChoice as IMultiChoice;
 		const sourceMulti = choice as IMultiChoice;
+		// Preserve command/onePageInput/placeholder/collapsed etc. (symmetry with
+		// the other choice types). `choices` is excluded here and set via the
+		// recursive map below so children get fresh ids, not the source's.
+		Object.assign(newMulti, excludeKeys(sourceMulti, ["id", "name", "choices"]));
 		newMulti.choices = sourceMulti.choices.map(duplicateChoice);
-		newMulti.placeholder = sourceMulti.placeholder;
-		newMulti.collapsed = sourceMulti.collapsed;
 		return newMulti;
 	}
 

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -177,14 +177,14 @@ describe("parseQuickAddPackage", () => {
 		);
 	});
 
-	it("throws when schema version is newer than supported", () => {
-		// isQuickAddPackage requires schemaVersion === current, so a too-new
-		// version is rejected by the validator before the explicit version check.
+	it("throws a version-specific error when the schema version is newer than supported", () => {
 		const future = {
 			...makePackage(),
 			schemaVersion: QUICKADD_PACKAGE_SCHEMA_VERSION + 1,
 		};
-		expect(() => parseQuickAddPackage(JSON.stringify(future))).toThrow();
+		expect(() => parseQuickAddPackage(JSON.stringify(future))).toThrow(
+			/newer than this plugin supports/,
+		);
 	});
 
 	it("rejects a package whose choices are missing required fields", () => {

--- a/src/types/packages/QuickAddPackage.ts
+++ b/src/types/packages/QuickAddPackage.ts
@@ -22,7 +22,7 @@ export interface QuickAddPackageChoice {
 }
 
 export interface QuickAddPackage {
-	schemaVersion: typeof QUICKADD_PACKAGE_SCHEMA_VERSION;
+	schemaVersion: number;
 	quickAddVersion: string;
 	createdAt: string;
 	rootChoiceIds: string[];
@@ -85,8 +85,13 @@ export function isQuickAddPackage(value: unknown): value is QuickAddPackage {
 		assets,
 	} = value;
 
+	// Structural check only — parseQuickAddPackage owns the version-range check so
+	// a too-new package gets a specific "newer than supported" error instead of
+	// this generic one.
 	const schemaMatches =
-		schemaVersion === QUICKADD_PACKAGE_SCHEMA_VERSION;
+		typeof schemaVersion === "number" &&
+		Number.isInteger(schemaVersion) &&
+		schemaVersion >= 1;
 
 	return (
 		schemaMatches &&


### PR DESCRIPTION
Fixes the suspected bugs from #1246 that we **empirically verified** as real — each was reproduced AND survived an independent refutation pass. The other three were verified as *not* real and left unchanged.

## Fixed (3, low severity)
- **`choiceService.duplicateChoice` dropped fields for Multi choices** — the Multi branch skipped the `excludeKeys` copy the other types use, so duplicating a Multi lost `command`/`onePageInput` (a Multi with a registered Obsidian command lost it on copy). Now copies all non-`id`/`name`/`choices` fields, then recursively duplicates children with fresh ids.
- **Unreachable package version error** — `isQuickAddPackage` required `schemaVersion === current` exactly, so a too-new package failed with the generic "not a valid package" error and `parseQuickAddPackage`'s specific "newer than this plugin supports" message never fired. Relaxed the guard to a structural check (`integer >= 1`); `parseQuickAddPackage` now owns the version-range check. Widened `schemaVersion` to `number`.
- **`quickAddApi.utility.getSelectedText` returned `undefined`** on no-view/no-selection while the sibling `getSelection` returns `""` — so `getSelectedText().toUpperCase()` could throw in user scripts. Now returns `""`.

## Verified NOT bugs (left unchanged)
- **`executeChoice` "proceeds with undefined choice"** — the `if (!choice)` branch is **unreachable**: `plugin.getChoiceByName` throws on a miss and is typed `: IChoice`. (This was the one I'd flagged "medium" — the refutation pass caught that stage-1's reproduction assumed the wrong `getChoiceByName` contract.)
- **Import cycle-guard bookkeeping** — proven harmless via a 5000-trial differential test (zero observable difference).
- **Export asset-kind dedup precedence** — intended; the export/import round-trip is lossless either way.

## Verification
`bun run test` (1400 pass), `bun run build-with-lint` clean, `bun run check` (svelte-check) clean. Each fix has a test asserting the corrected behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in text selection to return consistent empty string values
  * Enhanced schema version validation with clearer error messaging for incompatible packages

* **Improvements**
  * Duplicating Multi choices now preserves additional properties (`command`, `onePageInput`)
  * Package validation now supports forward compatibility with future schema versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->