### PR TITLE
feat(a11y): keyboard & ARIA pass on the choice and macro GUIs (#1250)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,15 @@ export default [
             // (new Set/Map -> assign), which is reactive under $state. SvelteSet/SvelteMap
             // are only needed for in-place mutation, so this rule is a false positive here.
             'svelte/prefer-svelte-reactivity': 'off',
+
+            // eslint-plugin-svelte v3 ships no dedicated a11y-* rules; the Svelte 5
+            // compiler emits the a11y_* warnings instead. valid-compile surfaces those
+            // (plus other compiler warnings, e.g. css_unused_selector) as lint errors,
+            // so a bare interactive <div>/<span> can't be reintroduced without CI
+            // catching it. Baseline is clean after the #1250 a11y pass. Note: this is a
+            // regression ratchet — it does NOT police accessible names on icon-only
+            // buttons or keyboard-operable drag handles, which are covered by tests.
+            'svelte/valid-compile': 'error',
         },
     },
     // Special rules for main.ts to preserve critical import order

--- a/src/gui/ChoiceBuilder/FolderList.svelte
+++ b/src/gui/ChoiceBuilder/FolderList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import ObsidianIcon from "../components/ObsidianIcon.svelte";
+    import IconButton from "../components/IconButton.svelte";
     import type { FolderListProps } from "./folderListProps.svelte";
 
     let { folders, deleteFolder }: FolderListProps = $props();
@@ -9,15 +9,11 @@
     {#each folders as folder (folder)}
         <div class="quickAddCommandListItem">
             <span>{folder}</span>
-            <span
-                role="button"
-                tabindex="0"
+            <IconButton
+                iconId="trash-2"
+                label={`Remove folder ${folder}`}
                 onclick={() => deleteFolder(folder)}
-                onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && deleteFolder(folder)}
-                class="clickable"
-            >
-                <ObsidianIcon iconId="trash-2" size={16} />
-            </span>
+            />
         </div>
     {/each}
 </div>
@@ -40,10 +36,5 @@
 .quickAddCommandList {
     max-width: 50%;
     margin: 12px auto;
-}
-
-
-.clickable {
-    cursor: pointer;
 }
 </style>

--- a/src/gui/ChoiceBuilder/choiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/choiceBuilder.ts
@@ -99,21 +99,28 @@ export abstract class ChoiceBuilder extends Modal {
 		const headerEl: HTMLHeadingElement = this.contentEl.createEl("h2", {
 			cls: "choiceNameHeader",
 		});
-		const textEl = headerEl.createSpan({
+		// Rename affordance is a real <button> (keyboard operable: Enter/Space) inside
+		// the heading, so the <h2> keeps its heading role for screen readers (#1250).
+		const button = headerEl.createEl("button", {
+			cls: "choiceNameHeaderButton qa-rename-title-button",
+			attr: { type: "button", "aria-label": `Rename ${choice.name}` },
+		});
+		const textEl = button.createSpan({
 			text: choice.name,
 			cls: "choiceNameHeaderText",
 		});
-		const iconEl = headerEl.createSpan({
+		const iconEl = button.createSpan({
 			cls: "choiceNameHeaderIcon",
 			attr: { "aria-hidden": "true" },
 		});
 		setIcon(iconEl, "pencil");
 
-		headerEl.addEventListener("click", async (ev) => {
+		button.addEventListener("click", async () => {
 			const newName = await promptRenameChoice(this.app, choice.name);
 			if (!newName) return;
 			choice.name = newName;
 			textEl.setText(newName);
+			button.setAttribute("aria-label", `Rename ${newName}`);
 		});
 	}
 

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -52,13 +52,18 @@ export class AIAssistantCommandSettingsModal extends Modal {
 	}
 
 	private display(): void {
-		const header = this.contentEl.createEl("h2", {
+		const header = this.contentEl.createEl("h2");
+		header.addClass("qa-clickable-modal-title");
+
+		// Rename affordance is a real <button> (keyboard operable: Enter/Space) inside
+		// the heading, so the <h2> keeps its heading role for screen readers (#1250).
+		const renameButton = header.createEl("button", {
+			cls: "qa-rename-title-button",
 			text: `${this.settings.name} Settings`,
+			attr: { type: "button", "aria-label": `Rename ${this.settings.name}` },
 		});
 
-		header.addClass("qa-clickable-modal-title");
-		 
-		header.addEventListener("click", async () => {
+		renameButton.addEventListener("click", async () => {
 			try {
 				const newName = await GenericInputPrompt.Prompt(
 					this.app,

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -47,13 +47,18 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 
 	private display(): void {
 		this.contentEl.empty();
-		const header = this.contentEl.createEl("h2", {
+		const header = this.contentEl.createEl("h2");
+		header.addClass("qa-clickable-modal-title");
+
+		// Rename affordance is a real <button> (keyboard operable: Enter/Space) inside
+		// the heading, so the <h2> keeps its heading role for screen readers (#1250).
+		const renameButton = header.createEl("button", {
+			cls: "qa-rename-title-button",
 			text: `${this.settings.name} Settings`,
+			attr: { type: "button", "aria-label": `Rename ${this.settings.name}` },
 		});
 
-		header.addClass("qa-clickable-modal-title");
-		 
-		header.addEventListener("click", async () => {
+		renameButton.addEventListener("click", async () => {
 			try {
 				const newName = await GenericInputPrompt.Prompt(
 					this.app,

--- a/src/gui/MacroGUIs/CommandList.conditional.test.ts
+++ b/src/gui/MacroGUIs/CommandList.conditional.test.ts
@@ -31,7 +31,11 @@ describe("CommandList conditional branch persistence", () => {
 		});
 
 		const { getByLabelText } = render(CommandList, { props });
-		await fireEvent.click(getByLabelText("Edit then branch"));
+		// Edit labels include the condition summary (a11y); a default condition
+		// summarizes as "(missing variable) is truthy".
+		await fireEvent.click(
+			getByLabelText("Edit then branch for (missing variable) is truthy"),
+		);
 
 		await vi.waitFor(() => expect(saveCommands).toHaveBeenCalledTimes(1));
 		const saved = saveCommands.mock.calls[0][0] as Array<{ thenCommands?: unknown[] }>;
@@ -54,7 +58,11 @@ describe("CommandList conditional branch persistence", () => {
 		});
 
 		const { getByLabelText } = render(CommandList, { props });
-		await fireEvent.click(getByLabelText("Edit then branch"));
+		// Edit labels include the condition summary (a11y); a default condition
+		// summarizes as "(missing variable) is truthy".
+		await fireEvent.click(
+			getByLabelText("Edit then branch for (missing variable) is truthy"),
+		);
 		await Promise.resolve();
 
 		expect(saveCommands).not.toHaveBeenCalled();

--- a/src/gui/MacroGUIs/CommandList.keyboardReorder.test.ts
+++ b/src/gui/MacroGUIs/CommandList.keyboardReorder.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+
+// CommandList transitively imports src/main, which pulls obsidian-dataview's CJS
+// require('obsidian'); mock it as the rest of the suite does.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App } from "obsidian";
+import CommandList from "./CommandList.svelte";
+import { createCommandListProps } from "./commandListProps.svelte";
+import { ObsidianCommand } from "../../types/macros/ObsidianCommand";
+import type { ICommand } from "../../types/macros/ICommand";
+
+const makeProps = (commands: ICommand[], saveCommands = vi.fn()) =>
+	createCommandListProps({
+		commands,
+		app: new App() as never,
+		plugin: {} as never,
+		deleteCommand: vi.fn(),
+		saveCommands,
+	});
+
+describe("CommandList keyboard reorder", () => {
+	it("ArrowDown on a row's drag handle moves it down and persists the new order", async () => {
+		const a = new ObsidianCommand("Alpha", "a");
+		const b = new ObsidianCommand("Beta", "b");
+		const c = new ObsidianCommand("Gamma", "c");
+		const saveCommands = vi.fn();
+
+		const { getByLabelText } = render(CommandList, {
+			props: makeProps([a, b, c], saveCommands),
+		});
+
+		// Handle labels include the command identity (a11y, #1250).
+		await fireEvent.keyDown(getByLabelText("Reorder Alpha"), { key: "ArrowDown" });
+
+		await vi.waitFor(() => expect(saveCommands).toHaveBeenCalledTimes(1));
+		const saved = saveCommands.mock.calls[0][0] as ICommand[];
+		expect(saved.map((cmd) => cmd.id)).toEqual([b.id, a.id, c.id]);
+	});
+
+	it("ArrowUp on the last row moves it up", async () => {
+		const a = new ObsidianCommand("Alpha", "a");
+		const b = new ObsidianCommand("Beta", "b");
+		const c = new ObsidianCommand("Gamma", "c");
+		const saveCommands = vi.fn();
+
+		const { getByLabelText } = render(CommandList, {
+			props: makeProps([a, b, c], saveCommands),
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Gamma"), { key: "ArrowUp" });
+
+		await vi.waitFor(() => expect(saveCommands).toHaveBeenCalledTimes(1));
+		expect((saveCommands.mock.calls[0][0] as ICommand[]).map((cmd) => cmd.id)).toEqual([
+			a.id,
+			c.id,
+			b.id,
+		]);
+	});
+
+	it("clamps at the ends — ArrowUp on the first row is a no-op", async () => {
+		const a = new ObsidianCommand("Alpha", "a");
+		const b = new ObsidianCommand("Beta", "b");
+		const saveCommands = vi.fn();
+
+		const { getByLabelText } = render(CommandList, {
+			props: makeProps([a, b], saveCommands),
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Alpha"), { key: "ArrowUp" });
+		await Promise.resolve();
+		expect(saveCommands).not.toHaveBeenCalled();
+	});
+});

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -73,8 +73,10 @@ function handleSort(e: CustomEvent<DndEvent>) {
 	persist();
 }
 
-let startDrag = (e: Event) => {
-	e.preventDefault();
+// Arm svelte-dnd-action's pointer drag. NO preventDefault here — see DragHandle:
+// preventDefault on pointerdown would suppress the compat mousedown the library
+// starts the drag from.
+let startDrag = () => {
 	dragDisabled = false;
 };
 

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -185,6 +185,10 @@ async function configureOpenFile(command: IOpenFileCommand) {
 		dropTargetStyle: {},
 		type: "command",
 		autoAriaDisabled: true,
+		// Keep the rows out of the tab order — only the action buttons / drag handle
+		// inside each row are focusable (the library defaults this to 0, adding a dead
+		// tab stop per row even with autoAriaDisabled).
+		zoneItemTabIndex: -1,
 	}}
 	onconsider={handleConsider}
 	onfinalize={handleSort}

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ICommand } from "../../types/macros/ICommand";
+import { Platform } from "obsidian";
 import { type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
 import { replaceById, stripShadow } from "../shared/dndReorder";
 import { snapshot } from "../svelte/persist.svelte";
@@ -40,7 +41,11 @@ let {
 	onEditElseBranch,
 }: CommandListProps = $props();
 
-let dragDisabled = $state(true);
+const isMobile = Platform.isMobile;
+// Desktop: drag is armed by grabbing the handle. Mobile: no handle — the whole row
+// is draggable by long-press (delayTouchStart), so drag stays enabled.
+let dragArmed = $state(false);
+const dragDisabled = $derived(!isMobile && !dragArmed);
 
 // Narrowing helpers: the {#each} discriminates on command.type, so each child
 // receives the matching subtype. Passed one-way — children report edits via the
@@ -66,18 +71,20 @@ function handleConsider(e: CustomEvent<DndEvent>) {
 function handleSort(e: CustomEvent<DndEvent>) {
 	commands = stripShadow(e.detail.items as ICommand[]);
 
+	// Desktop: disarm after a pointer drag so the handle must be grabbed again.
+	// Mobile: dragDisabled ignores dragArmed, so this is a no-op.
 	if (e.detail.info.source === SOURCES.POINTER) {
-		dragDisabled = true;
+		dragArmed = false;
 	}
 
 	persist();
 }
 
-// Arm svelte-dnd-action's pointer drag. NO preventDefault here — see DragHandle:
-// preventDefault on pointerdown would suppress the compat mousedown the library
-// starts the drag from.
+// Arm svelte-dnd-action's pointer drag (desktop handle). NO preventDefault here —
+// see DragHandle: preventDefault on pointerdown would suppress the compat mousedown
+// the library starts the drag from.
 let startDrag = () => {
-	dragDisabled = false;
+	dragArmed = true;
 };
 
 // Keyboard reorder (ArrowUp/ArrowDown on a row's drag handle): move the command one
@@ -191,6 +198,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 		// inside each row are focusable (the library defaults this to 0, adding a dead
 		// tab stop per row even with autoAriaDisabled).
 		zoneItemTabIndex: -1,
+		// Mobile: long-press (hold) initiates a row drag; a quick swipe still scrolls.
+		delayTouchStart: 200,
 	}}
 	onconsider={handleConsider}
 	onfinalize={handleSort}

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -73,10 +73,25 @@ function handleSort(e: CustomEvent<DndEvent>) {
 	persist();
 }
 
-let startDrag = (e: MouseEvent | TouchEvent) => {
+let startDrag = (e: Event) => {
 	e.preventDefault();
 	dragDisabled = false;
 };
+
+// Keyboard reorder (ArrowUp/ArrowDown on a row's drag handle): move the command one
+// step and persist via the same snapshot path as a pointer drag's finalize.
+function moveCommand(id: string, direction: -1 | 1) {
+	const list = stripShadow(commands);
+	const index = list.findIndex((c) => c.id === id);
+	if (index === -1) return;
+	const target = index + direction;
+	if (target < 0 || target >= list.length) return; // clamp at the ends
+	const next = [...list];
+	const [moved] = next.splice(index, 1);
+	next.splice(target, 0, moved);
+	commands = next;
+	persist();
+}
 
 function updateCommand(command: ICommand) {
 	commands = replaceById(commands, command);
@@ -169,6 +184,7 @@ async function configureOpenFile(command: IOpenFileCommand) {
 		dragDisabled,
 		dropTargetStyle: {},
 		type: "command",
+		autoAriaDisabled: true,
 	}}
 	onconsider={handleConsider}
 	onfinalize={handleSort}
@@ -181,6 +197,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 				{startDrag}
 				onDeleteCommand={deleteCommand}
 				onUpdateCommand={updateCommand}
+				onMoveUp={() => moveCommand(command.id, -1)}
+				onMoveDown={() => moveCommand(command.id, 1)}
 			/>
 		{:else if command.type === CommandType.NestedChoice}
 			<NestedChoiceCommand
@@ -189,6 +207,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 				{startDrag}
 				onDeleteCommand={deleteCommand}
 				onConfigureChoice={configureChoice}
+				onMoveUp={() => moveCommand(command.id, -1)}
+				onMoveDown={() => moveCommand(command.id, 1)}
 			/>
 		{:else if command.type === CommandType.UserScript}
 			<UserScriptCommand
@@ -197,6 +217,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 				{startDrag}
 				onDeleteCommand={deleteCommand}
 				onConfigureScript={configureScript}
+				onMoveUp={() => moveCommand(command.id, -1)}
+				onMoveDown={() => moveCommand(command.id, 1)}
 			/>
 		{:else if command.type === CommandType.AIAssistant}
 			<AIAssistantCommand
@@ -205,6 +227,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 				{startDrag}
 				onDeleteCommand={deleteCommand}
 				onConfigureAssistant={configureAssistant}
+				onMoveUp={() => moveCommand(command.id, -1)}
+				onMoveDown={() => moveCommand(command.id, 1)}
 			/>
 		{:else if command.type === CommandType.OpenFile}
 			<OpenFileCommand
@@ -213,6 +237,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 				{startDrag}
 				onDeleteCommand={deleteCommand}
 				onConfigureOpenFile={configureOpenFile}
+				onMoveUp={() => moveCommand(command.id, -1)}
+				onMoveDown={() => moveCommand(command.id, 1)}
 			/>
 		{:else if command.type === CommandType.Conditional}
 			<ConditionalCommand
@@ -223,6 +249,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 				onConfigureCondition={configureConditionalCommand}
 				onEditThenBranch={editConditionalThen}
 				onEditElseBranch={editConditionalElse}
+				onMoveUp={() => moveCommand(command.id, -1)}
+				onMoveDown={() => moveCommand(command.id, 1)}
 			/>
 		{:else}
 			<StandardCommand
@@ -230,6 +258,8 @@ async function configureOpenFile(command: IOpenFileCommand) {
 				{dragDisabled}
 				{startDrag}
 				onDeleteCommand={deleteCommand}
+				onMoveUp={() => moveCommand(command.id, -1)}
+				onMoveDown={() => moveCommand(command.id, 1)}
 			/>
 		{/if}
 	{/each}

--- a/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
+++ b/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
@@ -13,7 +13,7 @@
         onMoveDown,
     }: {
         command: IAIAssistantCommand;
-        startDrag: (e: Event) => void;
+        startDrag: () => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onConfigureAssistant: (command: IAIAssistantCommand) => void;

--- a/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
+++ b/src/gui/MacroGUIs/Components/AIAssistantCommand.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+    import IconButton from "../../components/IconButton.svelte";
+    import DragHandle from "../../components/DragHandle.svelte";
 	import type { IAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
 
     let {
@@ -8,46 +9,40 @@
         dragDisabled,
         onDeleteCommand,
         onConfigureAssistant,
+        onMoveUp,
+        onMoveDown,
     }: {
         command: IAIAssistantCommand;
-        startDrag: (e: MouseEvent | TouchEvent) => void;
+        startDrag: (e: Event) => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onConfigureAssistant: (command: IAIAssistantCommand) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
     } = $props();
 </script>
 
-<div class="quickAddCommandListItem">
-    <li>{command.name}</li>
-    <div>
-        <span
-            role="button"
-            tabindex="0"
+<li class="quickAddCommandListItem">
+    <span class="quickAddCommandLabel">{command.name}</span>
+    <div class="quickAddCommandControls">
+        <IconButton
+            iconId="settings"
+            label={`Configure ${command.name}`}
+            extraClass="clickable"
             onclick={() => onConfigureAssistant(command)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onConfigureAssistant(command)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="settings" size={16} />
-        </span>
-        <span
-            role="button"
-            tabindex="0"
+        />
+        <IconButton
+            iconId="trash-2"
+            label={`Delete ${command.name}`}
+            extraClass="clickable"
             onclick={() => onDeleteCommand(command.id)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDeleteCommand(command.id)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="trash-2" size={16} />
-        </span>
-        <span
-              role="button"
-              onmousedown={startDrag}
-              ontouchstart={startDrag}
-              aria-label="Drag-handle"
-              class:qa-drag-handle-ready={dragDisabled}
-              class:qa-drag-handle-active={!dragDisabled}
-              tabindex={dragDisabled ? 0 : -1}
-        >
-            <ObsidianIcon iconId="grip-vertical" size={16} />
-        </span>
+        />
+        <DragHandle
+            label={`Reorder ${command.name}`}
+            {dragDisabled}
+            onDragStart={startDrag}
+            {onMoveUp}
+            {onMoveDown}
+        />
     </div>
-</div>
+</li>

--- a/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
+++ b/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
@@ -42,19 +42,19 @@
 	<div class="quickAddCommandControls">
 		<IconButton
 			iconId="settings"
-			label="Edit condition"
+			label={`Edit condition for ${summary}`}
 			extraClass="clickable"
 			onclick={() => onConfigureCondition(command)}
 		/>
 		<IconButton
 			iconId="corner-down-right"
-			label="Edit then branch"
+			label={`Edit then branch for ${summary}`}
 			extraClass="clickable"
 			onclick={() => onEditThenBranch(command)}
 		/>
 		<IconButton
 			iconId="corner-down-left"
-			label="Edit else branch"
+			label={`Edit else branch for ${summary}`}
 			extraClass="clickable"
 			onclick={() => onEditElseBranch(command)}
 		/>

--- a/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
+++ b/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+	import IconButton from "../../components/IconButton.svelte";
+	import DragHandle from "../../components/DragHandle.svelte";
 	import type { IConditionalCommand } from "../../../types/macros/Conditional/IConditionalCommand";
 	import { getConditionSummary } from "../../../utils/conditionalHelpers";
 
@@ -11,14 +12,18 @@
 		onConfigureCondition,
 		onEditThenBranch,
 		onEditElseBranch,
+		onMoveUp,
+		onMoveDown,
 	}: {
 		command: IConditionalCommand;
-		startDrag: (e: MouseEvent | TouchEvent) => void;
+		startDrag: (e: Event) => void;
 		dragDisabled: boolean;
 		onDeleteCommand: (commandId: string) => void;
 		onConfigureCondition: (command: IConditionalCommand) => void;
 		onEditThenBranch: (command: IConditionalCommand) => void;
 		onEditElseBranch: (command: IConditionalCommand) => void;
+		onMoveUp?: () => void;
+		onMoveDown?: () => void;
 	} = $props();
 
 	const summary = $derived(getConditionSummary(command.condition));
@@ -26,72 +31,48 @@
 	const elseCount = $derived(command.elseCommands?.length ?? 0);
 </script>
 
-<div class="quickAddCommandListItem conditionalCommand">
-	<li>
+<li class="quickAddCommandListItem conditionalCommand">
+	<div class="quickAddCommandLabel">
 		<div class="conditionalSummary">{summary}</div>
 		<div class="conditionalBranches">
 			<span>Then: {thenCount}</span>
 			<span>Else: {elseCount}</span>
 		</div>
-	</li>
-	<div>
-		<span
-			role="button"
-			tabindex="0"
-			class="clickable"
-			onclick={() => onConfigureCondition(command)}
-			onkeypress={(e) =>
-				(e.key === "Enter" || e.key === " ") && onConfigureCondition(command)}
-			aria-label="Edit condition"
-		>
-			<ObsidianIcon iconId="settings" size={16} />
-		</span>
-		<span
-			role="button"
-			tabindex="0"
-			class="clickable"
-			onclick={() => onEditThenBranch(command)}
-			onkeypress={(e) =>
-				(e.key === "Enter" || e.key === " ") && onEditThenBranch(command)}
-			aria-label="Edit then branch"
-		>
-			<ObsidianIcon iconId="corner-down-right" size={16} />
-		</span>
-		<span
-			role="button"
-			tabindex="0"
-			class="clickable"
-			onclick={() => onEditElseBranch(command)}
-			onkeypress={(e) =>
-				(e.key === "Enter" || e.key === " ") && onEditElseBranch(command)}
-			aria-label="Edit else branch"
-		>
-			<ObsidianIcon iconId="corner-down-left" size={16} />
-		</span>
-		<span
-			role="button"
-			tabindex="0"
-			class="clickable"
-			onclick={() => onDeleteCommand(command.id)}
-			onkeypress={(e) =>
-				(e.key === "Enter" || e.key === " ") && onDeleteCommand(command.id)}
-			aria-label="Delete command"
-		>
-			<ObsidianIcon iconId="trash-2" size={16} />
-		</span>
-		<span
-			role="button"
-			onmousedown={startDrag}
-			ontouchstart={startDrag}
-			class:qa-drag-handle-ready={dragDisabled}
-			class:qa-drag-handle-active={!dragDisabled}
-			tabindex={dragDisabled ? 0 : -1}
-			aria-label="Drag command"
-		>
-			<ObsidianIcon iconId="grip-vertical" size={16} />
-		</span>
 	</div>
-</div>
+	<div class="quickAddCommandControls">
+		<IconButton
+			iconId="settings"
+			label="Edit condition"
+			extraClass="clickable"
+			onclick={() => onConfigureCondition(command)}
+		/>
+		<IconButton
+			iconId="corner-down-right"
+			label="Edit then branch"
+			extraClass="clickable"
+			onclick={() => onEditThenBranch(command)}
+		/>
+		<IconButton
+			iconId="corner-down-left"
+			label="Edit else branch"
+			extraClass="clickable"
+			onclick={() => onEditElseBranch(command)}
+		/>
+		<IconButton
+			iconId="trash-2"
+			label={`Delete ${command.name}`}
+			extraClass="clickable"
+			onclick={() => onDeleteCommand(command.id)}
+		/>
+		<DragHandle
+			label={`Reorder ${command.name}`}
+			{dragDisabled}
+			onDragStart={startDrag}
+			{onMoveUp}
+			{onMoveDown}
+		/>
+	</div>
+</li>
 
 <style>
 	.conditionalCommand {

--- a/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
+++ b/src/gui/MacroGUIs/Components/ConditionalCommand.svelte
@@ -16,7 +16,7 @@
 		onMoveDown,
 	}: {
 		command: IConditionalCommand;
-		startDrag: (e: Event) => void;
+		startDrag: () => void;
 		dragDisabled: boolean;
 		onDeleteCommand: (commandId: string) => void;
 		onConfigureCondition: (command: IConditionalCommand) => void;

--- a/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
+++ b/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+    import IconButton from "../../components/IconButton.svelte";
+    import DragHandle from "../../components/DragHandle.svelte";
     import type {INestedChoiceCommand} from "../../../types/macros/QuickCommands/INestedChoiceCommand";
 
     let {
@@ -8,46 +9,40 @@
         dragDisabled,
         onDeleteCommand,
         onConfigureChoice,
+        onMoveUp,
+        onMoveDown,
     }: {
         command: INestedChoiceCommand;
-        startDrag: (e: MouseEvent | TouchEvent) => void;
+        startDrag: (e: Event) => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onConfigureChoice: (command: INestedChoiceCommand) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
     } = $props();
 </script>
 
-<div class="quickAddCommandListItem">
-    <li>{command.name}</li>
-    <div>
-        <span
-            role="button"
-            tabindex="0"
+<li class="quickAddCommandListItem">
+    <span class="quickAddCommandLabel">{command.name}</span>
+    <div class="quickAddCommandControls">
+        <IconButton
+            iconId="settings"
+            label={`Configure ${command.name}`}
+            extraClass="clickable"
             onclick={() => onConfigureChoice(command)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onConfigureChoice(command)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="settings" size={16} />
-        </span>
-        <span
-            role="button"
-            tabindex="0"
+        />
+        <IconButton
+            iconId="trash-2"
+            label={`Delete ${command.name}`}
+            extraClass="clickable"
             onclick={() => onDeleteCommand(command.id)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDeleteCommand(command.id)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="trash-2" size={16} />
-        </span>
-        <span
-              role="button"
-              onmousedown={startDrag}
-              ontouchstart={startDrag}
-              aria-label="Drag-handle"
-              class:qa-drag-handle-ready={dragDisabled}
-              class:qa-drag-handle-active={!dragDisabled}
-              tabindex={dragDisabled ? 0 : -1}
-        >
-            <ObsidianIcon iconId="grip-vertical" size={16} />
-        </span>
+        />
+        <DragHandle
+            label={`Reorder ${command.name}`}
+            {dragDisabled}
+            onDragStart={startDrag}
+            {onMoveUp}
+            {onMoveDown}
+        />
     </div>
-</div>
+</li>

--- a/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
+++ b/src/gui/MacroGUIs/Components/NestedChoiceCommand.svelte
@@ -13,7 +13,7 @@
         onMoveDown,
     }: {
         command: INestedChoiceCommand;
-        startDrag: (e: Event) => void;
+        startDrag: () => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onConfigureChoice: (command: INestedChoiceCommand) => void;

--- a/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
+++ b/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { IOpenFileCommand } from "../../../types/macros/QuickCommands/IOpenFileCommand";
-	import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+	import IconButton from "../../components/IconButton.svelte";
+	import DragHandle from "../../components/DragHandle.svelte";
 
 	let {
 		command,
@@ -8,46 +9,40 @@
 		dragDisabled,
 		onDeleteCommand,
 		onConfigureOpenFile,
+		onMoveUp,
+		onMoveDown,
 	}: {
 		command: IOpenFileCommand;
-		startDrag: (e: MouseEvent | TouchEvent) => void;
+		startDrag: (e: Event) => void;
 		dragDisabled: boolean;
 		onDeleteCommand: (commandId: string) => void;
 		onConfigureOpenFile: (command: IOpenFileCommand) => void;
+		onMoveUp?: () => void;
+		onMoveDown?: () => void;
 	} = $props();
 </script>
 
-<div class="quickAddCommandListItem">
-	<li>{command.name}</li>
-	<div>
-		<span
-			role="button"
-			tabindex="0"
+<li class="quickAddCommandListItem">
+	<span class="quickAddCommandLabel">{command.name}</span>
+	<div class="quickAddCommandControls">
+		<IconButton
+			iconId="settings"
+			label={`Configure ${command.name}`}
+			extraClass="clickable"
 			onclick={() => onConfigureOpenFile(command)}
-			onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onConfigureOpenFile(command)}
-			class="clickable"
-		>
-			<ObsidianIcon iconId="settings" size={16} />
-		</span>
-		<span
-			role="button"
-			tabindex="0"
+		/>
+		<IconButton
+			iconId="trash-2"
+			label={`Delete ${command.name}`}
+			extraClass="clickable"
 			onclick={() => onDeleteCommand(command.id)}
-			onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDeleteCommand(command.id)}
-			class="clickable"
-		>
-			<ObsidianIcon iconId="trash-2" size={16} />
-		</span>
-		<span
-			role="button"
-			onmousedown={startDrag}
-			ontouchstart={startDrag}
-			aria-label="Drag-handle"
-			class:qa-drag-handle-ready={dragDisabled}
-			class:qa-drag-handle-active={!dragDisabled}
-			tabindex={dragDisabled ? 0 : -1}
-		>
-			<ObsidianIcon iconId="grip-vertical" size={16} />
-		</span>
+		/>
+		<DragHandle
+			label={`Reorder ${command.name}`}
+			{dragDisabled}
+			onDragStart={startDrag}
+			{onMoveUp}
+			{onMoveDown}
+		/>
 	</div>
-</div>
+</li>

--- a/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
+++ b/src/gui/MacroGUIs/Components/OpenFileCommand.svelte
@@ -13,7 +13,7 @@
 		onMoveDown,
 	}: {
 		command: IOpenFileCommand;
-		startDrag: (e: Event) => void;
+		startDrag: () => void;
 		dragDisabled: boolean;
 		onDeleteCommand: (commandId: string) => void;
 		onConfigureOpenFile: (command: IOpenFileCommand) => void;

--- a/src/gui/MacroGUIs/Components/StandardCommand.svelte
+++ b/src/gui/MacroGUIs/Components/StandardCommand.svelte
@@ -13,7 +13,7 @@
         onMoveDown,
     }: {
         command: ICommand;
-        startDrag: (e: Event) => void;
+        startDrag: () => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onMoveUp?: () => void;

--- a/src/gui/MacroGUIs/Components/StandardCommand.svelte
+++ b/src/gui/MacroGUIs/Components/StandardCommand.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import type {ICommand} from "../../../types/macros/ICommand";
-    import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+    import IconButton from "../../components/IconButton.svelte";
+    import DragHandle from "../../components/DragHandle.svelte";
     import {getCommandDisplayName} from "../../../utils/macroHelpers";
 
     let {
@@ -8,36 +9,33 @@
         startDrag,
         dragDisabled,
         onDeleteCommand,
+        onMoveUp,
+        onMoveDown,
     }: {
         command: ICommand;
-        startDrag: (e: MouseEvent | TouchEvent) => void;
+        startDrag: (e: Event) => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
     } = $props();
 </script>
 
-<div class="quickAddCommandListItem">
-    <li>{getCommandDisplayName(command)}</li>
-    <div>
-        <span
-            role="button"
-            tabindex="0"
+<li class="quickAddCommandListItem">
+    <span class="quickAddCommandLabel">{getCommandDisplayName(command)}</span>
+    <div class="quickAddCommandControls">
+        <IconButton
+            iconId="trash-2"
+            label={`Delete ${getCommandDisplayName(command)}`}
+            extraClass="clickable"
             onclick={() => onDeleteCommand(command.id)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDeleteCommand(command.id)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="trash-2" size={16} />
-        </span>
-        <span
-              role="button"
-              onmousedown={startDrag}
-              ontouchstart={startDrag}
-              aria-label="Drag-handle"
-              class:qa-drag-handle-ready={dragDisabled}
-              class:qa-drag-handle-active={!dragDisabled}
-              tabindex={dragDisabled ? 0 : -1}
-        >
-            <ObsidianIcon iconId="grip-vertical" size={16} />
-        </span>
+        />
+        <DragHandle
+            label={`Reorder ${getCommandDisplayName(command)}`}
+            {dragDisabled}
+            onDragStart={startDrag}
+            {onMoveUp}
+            {onMoveDown}
+        />
     </div>
-</div>
+</li>

--- a/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
+++ b/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
@@ -13,7 +13,7 @@
         onMoveDown,
     }: {
         command: IUserScript;
-        startDrag: (e: Event) => void;
+        startDrag: () => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onConfigureScript: (command: IUserScript) => void;

--- a/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
+++ b/src/gui/MacroGUIs/Components/UserScriptCommand.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+    import IconButton from "../../components/IconButton.svelte";
+    import DragHandle from "../../components/DragHandle.svelte";
     import type {IUserScript} from "../../../types/macros/IUserScript";
 
     let {
@@ -8,48 +9,40 @@
         dragDisabled,
         onDeleteCommand,
         onConfigureScript,
+        onMoveUp,
+        onMoveDown,
     }: {
         command: IUserScript;
-        startDrag: (e: MouseEvent | TouchEvent) => void;
+        startDrag: (e: Event) => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onConfigureScript: (command: IUserScript) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
     } = $props();
 </script>
 
-<div class="quickAddCommandListItem">
-    <li>
-        {command.name}
-    </li>
-    <div>
-        <span
-            role="button"
-            tabindex="0"
+<li class="quickAddCommandListItem">
+    <span class="quickAddCommandLabel">{command.name}</span>
+    <div class="quickAddCommandControls">
+        <IconButton
+            iconId="settings"
+            label={`Configure ${command.name}`}
+            extraClass="clickable"
             onclick={() => onConfigureScript(command)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onConfigureScript(command)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="settings" size={16} />
-        </span>
-        <span
-            role="button"
-            tabindex="0"
+        />
+        <IconButton
+            iconId="trash-2"
+            label={`Delete ${command.name}`}
+            extraClass="clickable"
             onclick={() => onDeleteCommand(command.id)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDeleteCommand(command.id)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="trash-2" size={16} />
-        </span>
-        <span
-              role="button"
-              onmousedown={startDrag}
-              ontouchstart={startDrag}
-              aria-label="Drag-handle"
-              class:qa-drag-handle-ready={dragDisabled}
-              class:qa-drag-handle-active={!dragDisabled}
-              tabindex={dragDisabled ? 0 : -1}
-        >
-            <ObsidianIcon iconId="grip-vertical" size={16} />
-        </span>
+        />
+        <DragHandle
+            label={`Reorder ${command.name}`}
+            {dragDisabled}
+            onDragStart={startDrag}
+            {onMoveUp}
+            {onMoveDown}
+        />
     </div>
-</div>
+</li>

--- a/src/gui/MacroGUIs/Components/WaitCommand.svelte
+++ b/src/gui/MacroGUIs/Components/WaitCommand.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+    import IconButton from "../../components/IconButton.svelte";
+    import DragHandle from "../../components/DragHandle.svelte";
     import { onMount, untrack } from "svelte";
     import type {IWaitCommand} from "../../../types/macros/QuickCommands/IWaitCommand";
 
@@ -9,12 +10,16 @@
         dragDisabled,
         onDeleteCommand,
         onUpdateCommand,
+        onMoveUp,
+        onMoveDown,
     }: {
         command: IWaitCommand;
-        startDrag: (e: MouseEvent | TouchEvent) => void;
+        startDrag: (e: Event) => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onUpdateCommand: (command: IWaitCommand) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
     } = $props();
 
     // Local mirror of command.time so the input is component-owned. We can't mutate
@@ -40,31 +45,24 @@
     onMount(resizeInput);
 </script>
 
-<div class="quickAddCommandListItem">
-    <li>{command.name} for <input bind:this={inputEl} oninput={onTimeInput} type="number" placeholder="   " value={time} class="dotInput">ms</li>
-    <div>
-        <span
-            role="button"
-            tabindex="0"
+<li class="quickAddCommandListItem">
+    <span class="quickAddCommandLabel">{command.name} for <input bind:this={inputEl} oninput={onTimeInput} type="number" placeholder="   " value={time} class="dotInput" aria-label="Wait duration in milliseconds">ms</span>
+    <div class="quickAddCommandControls">
+        <IconButton
+            iconId="trash-2"
+            label={`Delete ${command.name}`}
+            extraClass="clickable"
             onclick={() => onDeleteCommand(command.id)}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDeleteCommand(command.id)}
-            class="clickable"
-        >
-            <ObsidianIcon iconId="trash-2" size={16} />
-        </span>
-        <span
-              role="button"
-              onmousedown={startDrag}
-              ontouchstart={startDrag}
-              aria-label="Drag-handle"
-              class:qa-drag-handle-ready={dragDisabled}
-              class:qa-drag-handle-active={!dragDisabled}
-              tabindex={dragDisabled ? 0 : -1}
-        >
-            <ObsidianIcon iconId="grip-vertical" size={16} />
-        </span>
+        />
+        <DragHandle
+            label={`Reorder ${command.name}`}
+            {dragDisabled}
+            onDragStart={startDrag}
+            {onMoveUp}
+            {onMoveDown}
+        />
     </div>
-</div>
+</li>
 
 <style lang="css">
 .dotInput {

--- a/src/gui/MacroGUIs/Components/WaitCommand.svelte
+++ b/src/gui/MacroGUIs/Components/WaitCommand.svelte
@@ -14,7 +14,7 @@
         onMoveDown,
     }: {
         command: IWaitCommand;
-        startDrag: (e: Event) => void;
+        startDrag: () => void;
         dragDisabled: boolean;
         onDeleteCommand: (commandId: string) => void;
         onUpdateCommand: (command: IWaitCommand) => void;

--- a/src/gui/MacroGUIs/Components/macroCommands.test.ts
+++ b/src/gui/MacroGUIs/Components/macroCommands.test.ts
@@ -76,7 +76,9 @@ describe("ConditionalCommand", () => {
 		await fireEvent.click(getByLabelText("Edit else branch"));
 		expect(onEditElseBranch).toHaveBeenCalledWith(command);
 
-		await fireEvent.click(getByLabelText("Delete command"));
+		// Delete label now includes the command identity (a11y, #1250). A default
+		// ConditionalCommand is named "If condition".
+		await fireEvent.click(getByLabelText("Delete If condition"));
 		expect(onDeleteCommand).toHaveBeenCalledWith(command.id);
 	});
 });

--- a/src/gui/MacroGUIs/Components/macroCommands.test.ts
+++ b/src/gui/MacroGUIs/Components/macroCommands.test.ts
@@ -67,16 +67,28 @@ describe("ConditionalCommand", () => {
 			},
 		});
 
-		await fireEvent.click(getByLabelText("Edit condition"));
+		// The edit labels include the condition SUMMARY so multiple conditional rows
+		// are distinguishable to screen readers. A freshly-added conditional has the
+		// generic default name "If condition" (it becomes "If <summary>" only once the
+		// condition is saved), so the summary is the reliable per-row identifier.
+		// A default condition (variable mode, empty name, isTruthy) summarizes as
+		// "(missing variable) is truthy".
+		await fireEvent.click(
+			getByLabelText("Edit condition for (missing variable) is truthy"),
+		);
 		expect(onConfigureCondition).toHaveBeenCalledWith(command);
 
-		await fireEvent.click(getByLabelText("Edit then branch"));
+		await fireEvent.click(
+			getByLabelText("Edit then branch for (missing variable) is truthy"),
+		);
 		expect(onEditThenBranch).toHaveBeenCalledWith(command);
 
-		await fireEvent.click(getByLabelText("Edit else branch"));
+		await fireEvent.click(
+			getByLabelText("Edit else branch for (missing variable) is truthy"),
+		);
 		expect(onEditElseBranch).toHaveBeenCalledWith(command);
 
-		// Delete label now includes the command identity (a11y, #1250). A default
+		// Delete label includes the command identity (a11y, #1250). A default
 		// ConditionalCommand is named "If condition".
 		await fireEvent.click(getByLabelText("Delete If condition"));
 		expect(onDeleteCommand).toHaveBeenCalledWith(command.id);

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -75,11 +75,17 @@ export class MacroBuilder extends Modal {
 
 	protected addCenteredHeader(header: string): void {
 		const headerEl = this.contentEl.createEl("h2");
-		headerEl.setText(header);
-		headerEl.addClass("clickable", "qa-clickable-modal-title");
+		headerEl.addClass("qa-clickable-modal-title");
 
-		 
-		headerEl.addEventListener("click", async () => {
+		// Rename affordance is a real <button> (keyboard operable: Enter/Space) inside
+		// the heading, so the <h2> keeps its heading role for screen readers (#1250).
+		const renameButton = headerEl.createEl("button", {
+			cls: "qa-rename-title-button",
+			text: header,
+			attr: { type: "button", "aria-label": `Rename ${header}` },
+		});
+
+		renameButton.addEventListener("click", async () => {
 			const newName: string = await GenericInputPrompt.Prompt(
 				this.app,
 				`Update name for ${this.choice.name}`,

--- a/src/gui/choiceList/ChoiceItemRightButtons.svelte
+++ b/src/gui/choiceList/ChoiceItemRightButtons.svelte
@@ -38,12 +38,14 @@
         iconId="zap"
         ariaPressed={commandEnabled}
         label={`Command palette${choiceName ? ": " + choiceName : ""}`}
+        extraClass="qa-row-secondary-action"
         onclick={onToggleCommand}
     />
     {#if showConfigureButton}
         <IconButton
             iconId="settings"
             label={`Configure${choiceName ? " " + choiceName : ""}`}
+            extraClass="qa-row-secondary-action"
             onclick={onConfigureChoice}
         />
     {/if}
@@ -52,6 +54,7 @@
         <IconButton
             iconId="copy"
             label={`Duplicate${choiceName ? " " + choiceName : ""}`}
+            extraClass="qa-row-secondary-action"
             onclick={onDuplicateChoice}
         />
     {/if}
@@ -59,6 +62,7 @@
     <IconButton
         iconId="trash-2"
         label={`Delete${choiceName ? " " + choiceName : ""}`}
+        extraClass="qa-row-secondary-action"
         onclick={onDeleteChoice}
     />
 

--- a/src/gui/choiceList/ChoiceItemRightButtons.svelte
+++ b/src/gui/choiceList/ChoiceItemRightButtons.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import ObsidianIcon from "../components/ObsidianIcon.svelte";
+    import IconButton from "../components/IconButton.svelte";
+    import DragHandle from "../components/DragHandle.svelte";
 
     let {
         dragDisabled,
@@ -12,6 +13,9 @@
         onToggleCommand,
         onDuplicateChoice,
         onDragHandleDown,
+        onMoveUp,
+        onMoveDown,
+        onOpenMenu,
     }: {
         dragDisabled: boolean;
         showConfigureButton?: boolean;
@@ -23,69 +27,57 @@
         onToggleCommand: () => void;
         onDuplicateChoice: () => void;
         onDragHandleDown: (e?: Event) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
+        onOpenMenu?: (anchor: HTMLElement) => void;
     } = $props();
 </script>
 
 <div class="rightButtonsContainer">
-    <div
-        role="button"
-        tabindex="0"
+    <IconButton
+        iconId="zap"
+        ariaPressed={commandEnabled}
+        label={`Command palette${choiceName ? ": " + choiceName : ""}`}
         onclick={onToggleCommand}
-        onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onToggleCommand()}
-        class:command-enabled={commandEnabled}
-        class="alignIconInDivInMiddle clickable"
-        aria-label={`${commandEnabled ? "Disable in Command Palette" : "Enable in Command Palette"}${choiceName ? ": " + choiceName : ""}`}
-    >
-        <ObsidianIcon iconId="zap" size={16} />
-    </div>
+    />
     {#if showConfigureButton}
-        <div
-            role="button"
-            tabindex="0"
+        <IconButton
+            iconId="settings"
+            label={`Configure${choiceName ? " " + choiceName : ""}`}
             onclick={onConfigureChoice}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onConfigureChoice()}
-            class="alignIconInDivInMiddle clickable"
-            aria-label={`Configure${choiceName ? " " + choiceName : ""}`}
-        >
-            <ObsidianIcon iconId="settings" size={16} />
-        </div>
+        />
     {/if}
 
     {#if showDuplicateButton}
-        <div
-            role="button"
-            tabindex="0"
-            aria-label={`Duplicate ${choiceName ?? ""}`}
-            class="alignIconInDivInMiddle clickable"
+        <IconButton
+            iconId="copy"
+            label={`Duplicate${choiceName ? " " + choiceName : ""}`}
             onclick={onDuplicateChoice}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDuplicateChoice()}
-        >
-            <ObsidianIcon iconId="copy" size={16} />
-        </div>
+        />
     {/if}
 
-    <div
-        role="button"
-        tabindex="0"
-        aria-label={`Delete${choiceName ? " " + choiceName : ""}`}
-        class="alignIconInDivInMiddle clickable"
+    <IconButton
+        iconId="trash-2"
+        label={`Delete${choiceName ? " " + choiceName : ""}`}
         onclick={onDeleteChoice}
-        onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && onDeleteChoice()}
-    >
-        <ObsidianIcon iconId="trash-2" size={16} />
-    </div>
+    />
 
-    <div
-         role="button"
-         tabindex={dragDisabled ? 0 : -1}
-         aria-label="Drag-handle"
-         class="alignIconInDivInMiddle"
-         class:qa-drag-handle-ready={dragDisabled}
-         class:qa-drag-handle-active={!dragDisabled}
-         onpointerdown={() => onDragHandleDown()}
-    >
-        <ObsidianIcon iconId="grip-vertical" size={16} />
-    </div>
+    {#if onOpenMenu}
+        <IconButton
+            iconId="more-vertical"
+            ariaHasPopup="menu"
+            label={`More options${choiceName ? " for " + choiceName : ""}`}
+            onclick={(e) => onOpenMenu?.(e.currentTarget as HTMLElement)}
+        />
+    {/if}
+
+    <DragHandle
+        label={`Reorder${choiceName ? " " + choiceName : ""}`}
+        {dragDisabled}
+        onDragStart={onDragHandleDown}
+        {onMoveUp}
+        {onMoveDown}
+    />
 </div>
 
 <style>
@@ -93,18 +85,5 @@
     display: flex;
     align-items: center;
     gap: 8px;
-}
-
-.clickable:hover {
-    cursor: pointer;
-}
-
-.alignIconInDivInMiddle {
-    display: flex;
-    align-items: center;
-}
-
-.command-enabled {
-    color: var(--text-accent);
 }
 </style>

--- a/src/gui/choiceList/ChoiceList.a11y.test.ts
+++ b/src/gui/choiceList/ChoiceList.a11y.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+
+// ChoiceListItem -> renderChoiceName/contextMenu reach src/main -> obsidian-dataview.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App, Menu } from "obsidian";
+// Runtime "obsidian" is aliased to the test stub (vitest.config.mts); tsc/svelte-check
+// resolve the real obsidian types, which don't know the stub's recording fields. Cast
+// through the stub's type to read them in a type-safe way.
+import type { Menu as StubMenu } from "../../../tests/obsidian-stub";
+import ChoiceList from "./ChoiceList.svelte";
+import type IChoice from "../../types/choices/IChoice";
+import type { ChoiceListActions } from "./choiceListActions";
+
+const ShownMenu = Menu as unknown as typeof StubMenu;
+
+const normal = (name: string): IChoice =>
+	({ id: name, name, type: "Template", command: false }) as unknown as IChoice;
+const multi = (name: string, children: IChoice[], collapsed = false): IChoice =>
+	({
+		id: name,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed,
+		choices: children,
+	}) as unknown as IChoice;
+
+function actionsSpy(): ChoiceListActions {
+	return {
+		onDeleteChoice: vi.fn(),
+		onConfigureChoice: vi.fn(),
+		onToggleCommand: vi.fn(),
+		onDuplicateChoice: vi.fn(),
+		onRenameChoice: vi.fn(),
+		onMoveChoice: vi.fn(),
+		onReorderChoices: vi.fn(),
+	};
+}
+
+const idsOf = (fn: unknown) =>
+	((fn as { mock: { calls: unknown[][] } }).mock.calls[0][0] as IChoice[]).map((c) => c.id);
+
+beforeEach(() => {
+	ShownMenu.lastShown = null;
+});
+
+describe("ChoiceList keyboard reorder", () => {
+	it("ArrowDown on a row's drag handle reorders that list and persists", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("Alpha"), normal("Beta"), normal("Gamma")];
+		const { getByLabelText } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Alpha"), { key: "ArrowDown" });
+
+		expect(actions.onReorderChoices).toHaveBeenCalledTimes(1);
+		expect(idsOf(actions.onReorderChoices)).toEqual(["Beta", "Alpha", "Gamma"]);
+	});
+
+	it("clamps at the ends — ArrowUp on the first row is a no-op", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("Alpha"), normal("Beta")];
+		const { getByLabelText } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Alpha"), { key: "ArrowUp" });
+		expect(actions.onReorderChoices).not.toHaveBeenCalled();
+	});
+
+	it("never reorders a filtered/derived list (forceDragDisabled)", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("Alpha"), normal("Beta")];
+		const { getByLabelText } = render(ChoiceList, {
+			props: {
+				app: new App() as never,
+				roots: choices,
+				choices,
+				actions,
+				forceDragDisabled: true,
+			},
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Alpha"), { key: "ArrowDown" });
+		expect(actions.onReorderChoices).not.toHaveBeenCalled();
+		// The inert handle must not advertise a keyboard shortcut that does nothing.
+		expect(getByLabelText("Reorder Alpha").hasAttribute("aria-keyshortcuts")).toBe(false);
+	});
+
+	it("reorders a doubly-nested Multi's children WITHOUT corrupting ancestors (depth >= 2)", async () => {
+		// Regression for the nestedActions bubbling bug: an inner Multi must not push
+		// the root array into its parent Multi's onReorderChoices override.
+		const actions = actionsSpy();
+		const c1 = normal("c1");
+		const c2 = normal("c2");
+		const inner = multi("Inner", [c1, c2]);
+		const outer = multi("Outer", [inner]);
+		const choices = [outer];
+		const { getByLabelText } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder c1"), { key: "ArrowDown" });
+
+		expect(actions.onReorderChoices).toHaveBeenCalledTimes(1);
+		const rootArg = (actions.onReorderChoices as ReturnType<typeof vi.fn>).mock
+			.calls[0][0] as IChoice[];
+		// Root tree intact: exactly [Outer] (not the root array assigned into Outer,
+		// not Outer containing itself).
+		expect(rootArg.map((c) => c.id)).toEqual(["Outer"]);
+		const outerArg = rootArg[0] as unknown as { choices: IChoice[] };
+		expect(outerArg.choices.map((c) => c.id)).toEqual(["Inner"]);
+		// Inner's children are the ones actually reordered.
+		const innerArg = outerArg.choices[0] as unknown as { choices: IChoice[] };
+		expect(innerArg.choices.map((c) => c.id)).toEqual(["c2", "c1"]);
+	});
+});
+
+describe("MultiChoiceListItem collapse toggle", () => {
+	it("is a native button exposing aria-expanded=true and the nested list when expanded", () => {
+		const actions = actionsSpy();
+		const group = multi("Group", [normal("Child")], false);
+		const { getByLabelText, queryByLabelText } = render(ChoiceList, {
+			props: { app: new App() as never, roots: [group], choices: [group], actions },
+		});
+
+		const toggle = getByLabelText("Toggle Group");
+		expect(toggle.tagName).toBe("BUTTON");
+		expect(toggle.getAttribute("aria-expanded")).toBe("true");
+		expect(queryByLabelText("Delete Child")).not.toBeNull();
+	});
+
+	it("exposes aria-expanded=false and hides the nested list when collapsed", () => {
+		const actions = actionsSpy();
+		const group = multi("Group", [normal("Child")], true);
+		const { getByLabelText, queryByLabelText } = render(ChoiceList, {
+			props: { app: new App() as never, roots: [group], choices: [group], actions },
+		});
+
+		const toggle = getByLabelText("Toggle Group");
+		expect(toggle.getAttribute("aria-expanded")).toBe("false");
+		expect(queryByLabelText("Delete Child")).toBeNull();
+	});
+});
+
+describe("ChoiceList keyboard-accessible context menu", () => {
+	it("opens the context menu anchored to the More-options button (no mouse needed)", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("Alpha")];
+		const { getByLabelText } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+
+		await fireEvent.click(getByLabelText("More options for Alpha"));
+
+		expect(ShownMenu.lastShown).not.toBeNull();
+		// Anchored via showAtPosition (keyboard path), not showAtMouseEvent.
+		expect(ShownMenu.lastShown?.shownAt?.type).toBe("position");
+
+		// Rename is otherwise menu-only — confirm it is reachable here and wired.
+		const rename = ShownMenu.lastShown?.items.find((i) => i.title === "Rename");
+		expect(rename).toBeDefined();
+		rename?.clickHandler?.();
+		expect(actions.onRenameChoice).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/gui/choiceList/ChoiceList.a11y.test.ts
+++ b/src/gui/choiceList/ChoiceList.a11y.test.ts
@@ -146,6 +146,31 @@ describe("MultiChoiceListItem collapse toggle", () => {
 	});
 });
 
+describe("ChoiceList mobile collapse hooks", () => {
+	// On mobile the per-row action icons are hidden via CSS (.is-mobile
+	// .qa-row-secondary-action) and reached through the More menu; the More button
+	// and drag handle stay. Guard that the right buttons carry the collapse class.
+	it("tags the secondary action buttons but not More / drag handle", () => {
+		const actions = actionsSpy();
+		const choices = [normal("Alpha")];
+		const { getByLabelText } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+
+		const secondary = "qa-row-secondary-action";
+		for (const label of [
+			"Command palette: Alpha",
+			"Configure Alpha",
+			"Duplicate Alpha",
+			"Delete Alpha",
+		]) {
+			expect(getByLabelText(label).classList.contains(secondary)).toBe(true);
+		}
+		expect(getByLabelText("More options for Alpha").classList.contains(secondary)).toBe(false);
+		expect(getByLabelText("Reorder Alpha").classList.contains(secondary)).toBe(false);
+	});
+});
+
 describe("ChoiceList keyboard-accessible context menu", () => {
 	it("opens the context menu anchored to the More-options button (no mouse needed)", async () => {
 		const actions = actionsSpy();

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -14,13 +14,23 @@
         app,
         forceDragDisabled = false,
         actions,
+        rootReorder,
     }: {
         choices?: IChoice[];
         roots?: IChoice[];
         app: App;
         forceDragDisabled?: boolean;
         actions: ChoiceListActions;
+        // The TOP-LEVEL onReorderChoices, threaded UNCHANGED through every nesting
+        // level so a nested Multi persists the whole root tree via the real handler
+        // instead of an ancestor Multi's override (which would reinterpret the root
+        // array as its own children — data loss at depth >= 2). Undefined at the top.
+        rootReorder?: (choices: IChoice[]) => void;
     } = $props();
+
+    // Resolve once: at the top level there is no incoming rootReorder, so the list's
+    // own handler IS the top-level handler; nested lists receive it explicitly.
+    const persistRoots = $derived(rootReorder ?? actions.onReorderChoices);
 
     let collapseId = $state("");
     let dragDisabled = $state(true);
@@ -48,10 +58,29 @@
         if (e && typeof e.preventDefault === 'function') e.preventDefault();
         dragDisabled = false;
     };
+
+    // Keyboard reorder (ArrowUp/ArrowDown on a row's drag handle). Moves the choice
+    // one step within THIS list and persists via actions.onReorderChoices — the same
+    // path pointer drag uses on finalize. Each ChoiceList instance (including the
+    // nested ones inside a Multi) reorders its own list, so nested reorders bubble
+    // through MultiChoiceListItem's nestedActions just like a drag does.
+    function moveChoice(choice: IChoice, direction: -1 | 1) {
+        if (forceDragDisabled) return; // never persist a filtered/derived list
+        const list = stripShadow(choices);
+        const index = list.findIndex((c) => c.id === choice.id);
+        if (index === -1) return;
+        const target = index + direction;
+        if (target < 0 || target >= list.length) return; // clamp at the ends
+        const next = [...list];
+        const [moved] = next.splice(index, 1);
+        next.splice(target, 0, moved);
+        choices = next;
+        actions.onReorderChoices(choices);
+    }
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}}}
+        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, autoAriaDisabled: true}}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"
@@ -65,6 +94,8 @@
                     {startDrag}
                     {actions}
                     {choice}
+                    onMoveUp={forceDragDisabled ? undefined : () => moveChoice(choice, -1)}
+                    onMoveDown={forceDragDisabled ? undefined : () => moveChoice(choice, 1)}
             />
         {:else}
             <MultiChoiceListItem
@@ -74,7 +105,11 @@
                     {startDrag}
                     {actions}
                     {collapseId}
+                    {forceDragDisabled}
+                    rootReorder={persistRoots}
                     choice={choice as IMultiChoice}
+                    onMoveUp={forceDragDisabled ? undefined : () => moveChoice(choice, -1)}
+                    onMoveDown={forceDragDisabled ? undefined : () => moveChoice(choice, 1)}
             />
         {/if}
     {/each}

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -80,7 +80,7 @@
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, autoAriaDisabled: true}}
+        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, autoAriaDisabled: true, zoneItemTabIndex: -1}}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -5,7 +5,7 @@
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
     import { type DndEvent, dndzone } from "svelte-dnd-action";
     import { stripShadow } from "../shared/dndReorder";
-    import type { App } from "obsidian";
+    import { Platform, type App } from "obsidian";
     import type { ChoiceListActions } from "./choiceListActions";
 
     let {
@@ -32,8 +32,15 @@
     // own handler IS the top-level handler; nested lists receive it explicitly.
     const persistRoots = $derived(rootReorder ?? actions.onReorderChoices);
 
+    const isMobile = Platform.isMobile;
+
     let collapseId = $state("");
-    let dragDisabled = $state(true);
+    // Desktop: drag is armed by grabbing the handle (dragDisabled until then), which
+    // prevents accidental drags when interacting with a row. Mobile: there is no
+    // handle — the whole row is draggable by LONG-PRESS (delayTouchStart below), the
+    // native mobile reorder gesture — so drag stays enabled unless filtering.
+    let dragArmed = $state(false);
+    const dragDisabled = $derived(forceDragDisabled || (!isMobile && !dragArmed));
 
     function handleConsider(e: CustomEvent<DndEvent>) {
         if (forceDragDisabled) return; // filtered view: never mutate a derived list
@@ -47,16 +54,15 @@
         if (forceDragDisabled) return;
         collapseId = "";
         choices = stripShadow(e.detail.items as IChoice[]);
-        // Always re-disable dragging when the sort finalizes (choiceList behavior;
-        // intentionally NOT the macro list's POINTER-only gate).
-        dragDisabled = true;
+        // Desktop: disarm so a subsequent row interaction doesn't drag (handle must be
+        // grabbed again). Mobile: dragDisabled ignores dragArmed, so this is a no-op.
+        dragArmed = false;
         actions.onReorderChoices(choices);
     }
 
-    let startDrag = (e?: Event) => {
+    let startDrag = () => {
         if (forceDragDisabled) return; // do not enable drag while filtering
-        if (e && typeof e.preventDefault === 'function') e.preventDefault();
-        dragDisabled = false;
+        dragArmed = true;
     };
 
     // Keyboard reorder (ArrowUp/ArrowDown on a row's drag handle). Moves the choice
@@ -80,7 +86,7 @@
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, autoAriaDisabled: true, zoneItemTabIndex: -1}}
+        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"

--- a/src/gui/choiceList/ChoiceListItem.svelte
+++ b/src/gui/choiceList/ChoiceListItem.svelte
@@ -2,7 +2,7 @@
 	import type IChoice from "../../types/choices/IChoice";
 	import RightButtons from "./ChoiceItemRightButtons.svelte";
 	import { Component, type App } from "obsidian";
-	import { showChoiceContextMenu } from "./contextMenu";
+	import { showChoiceContextMenu, showChoiceContextMenuAtElement } from "./contextMenu";
 	import { renderChoiceName } from "./renderChoiceName";
 	import type { ChoiceListActions } from "./choiceListActions";
 
@@ -13,6 +13,8 @@
 		dragDisabled,
 		startDrag,
 		actions,
+		onMoveUp,
+		onMoveDown,
 	}: {
 		choice: IChoice;
 		app: App;
@@ -20,6 +22,8 @@
 		dragDisabled: boolean;
 		startDrag: (e?: Event) => void;
 		actions: ChoiceListActions;
+		onMoveUp?: () => void;
+		onMoveDown?: () => void;
 	} = $props();
 
 	let showConfigureButton = $state(true);
@@ -40,26 +44,29 @@
 		return () => cmp.unload();
 	});
 
+	const menuActions = () => ({
+		onRename: () => actions.onRenameChoice(choice),
+		onToggle: () => actions.onToggleCommand(choice),
+		onConfigure: () => actions.onConfigureChoice(choice),
+		onDuplicate: () => actions.onDuplicateChoice(choice),
+		onDelete: () => actions.onDeleteChoice(choice),
+		onMove: (targetId: string) => actions.onMoveChoice(choice, targetId),
+	});
+
 	function onContextMenu(evt: MouseEvent) {
-		showChoiceContextMenu(app, evt, choice, roots, {
-			onRename: () => actions.onRenameChoice(choice),
-			onToggle: () => actions.onToggleCommand(choice),
-			onConfigure: () => actions.onConfigureChoice(choice),
-			onDuplicate: () => actions.onDuplicateChoice(choice),
-			onDelete: () => actions.onDeleteChoice(choice),
-			onMove: (targetId) => actions.onMoveChoice(choice, targetId),
-		});
+		showChoiceContextMenu(app, evt, choice, roots, menuActions());
+	}
+
+	function openMenu(anchor: HTMLElement) {
+		showChoiceContextMenuAtElement(app, anchor, choice, roots, menuActions());
 	}
 </script>
 
-<div
-    class="choiceListItem"
-    role="button"
-    tabindex="0"
-    aria-haspopup="menu"
-    aria-label={`Context menu for ${choice.name}`}
-    oncontextmenu={onContextMenu}
->
+<!-- Right-click opens the context menu for mouse users; keyboard users reach the
+     same actions via the "More options" button, so this row is a non-interactive
+     container (no role/tabindex). -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="choiceListItem" oncontextmenu={onContextMenu}>
 	<span class="choiceListItemName" bind:this={nameElement}></span>
 
 	<RightButtons
@@ -68,6 +75,9 @@
 		onConfigureChoice={() => actions.onConfigureChoice(choice)}
 		onToggleCommand={() => actions.onToggleCommand(choice)}
 		onDuplicateChoice={() => actions.onDuplicateChoice(choice)}
+		onOpenMenu={openMenu}
+		{onMoveUp}
+		{onMoveDown}
 		choiceName={choice.name}
 		commandEnabled={choice.command}
 		{showConfigureButton}

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -6,7 +6,7 @@
     import { untrack } from "svelte";
 	import { Component, type App } from "obsidian";
     import type IChoice from "src/types/choices/IChoice";
-    import { showChoiceContextMenu } from "./contextMenu";
+    import { showChoiceContextMenu, showChoiceContextMenuAtElement } from "./contextMenu";
 	import { renderChoiceName } from "./renderChoiceName";
     import type { ChoiceListActions } from "./choiceListActions";
 
@@ -18,6 +18,10 @@
         startDrag,
         app,
         actions,
+        forceDragDisabled = false,
+        rootReorder,
+        onMoveUp,
+        onMoveDown,
     }: {
         choice: IMultiChoice;
         roots: IChoice[];
@@ -26,6 +30,12 @@
         startDrag: (e?: Event) => void;
         app: App;
         actions: ChoiceListActions;
+        forceDragDisabled?: boolean;
+        // Top-level onReorderChoices (see ChoiceList). Falls back to this list's own
+        // handler when rendered directly (tests); in the app it is always provided.
+        rootReorder?: (choices: IChoice[]) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
     } = $props();
 
     let showConfigureButton = $state(true);
@@ -45,25 +55,34 @@
 		return () => cmp.unload();
 	});
 
+    const menuActions = () => ({
+        onRename: () => actions.onRenameChoice(choice),
+        onToggle: () => actions.onToggleCommand(choice),
+        onConfigure: () => actions.onConfigureChoice(choice),
+        onDuplicate: () => actions.onDuplicateChoice(choice),
+        onDelete: () => actions.onDeleteChoice(choice),
+        onMove: (targetId: string) => actions.onMoveChoice(choice, targetId),
+    });
+
     function onContextMenu(evt: MouseEvent) {
-        showChoiceContextMenu(app, evt, choice, roots, {
-            onRename: () => actions.onRenameChoice(choice),
-            onToggle: () => actions.onToggleCommand(choice),
-            onConfigure: () => actions.onConfigureChoice(choice),
-            onDuplicate: () => actions.onDuplicateChoice(choice),
-            onDelete: () => actions.onDeleteChoice(choice),
-            onMove: (targetId) => actions.onMoveChoice(choice, targetId),
-        });
+        showChoiceContextMenu(app, evt, choice, roots, menuActions());
     }
 
-    // Nested children reordered: write the new order back to this Multi choice, then
-    // bubble the whole (shallow-cloned) root tree up so the top-level handler persists
-    // it. Calls the PARENT's onReorderChoices (not nestedActions) — no loop.
+    function openMenu(anchor: HTMLElement) {
+        showChoiceContextMenuAtElement(app, anchor, choice, roots, menuActions());
+    }
+
+    // Nested children reordered: write the new order back to this Multi choice (the
+    // choice object is shared with the root tree, so this mutates in place), then
+    // persist the whole root tree via the TOP-LEVEL handler. Routing through
+    // `rootReorder` — NOT `actions.onReorderChoices`, which inside a nested Multi is
+    // an ancestor's override that would overwrite ITS children with the root array —
+    // keeps reorder correct at any nesting depth (fixes depth >= 2 data loss).
     const nestedActions: ChoiceListActions = {
         ...untrack(() => actions),
         onReorderChoices: (reordered: IChoice[]) => {
             choice.choices = reordered;
-            actions.onReorderChoices([...roots]);
+            (rootReorder ?? actions.onReorderChoices)([...roots]);
         },
     };
 
@@ -73,29 +92,27 @@
 </script>
 
 <div>
-    <div
-        class="multiChoiceListItem"
-        role="button"
-        tabindex="0"
-        aria-haspopup="menu"
-        aria-label={`Context menu for ${choice.name}`}
-        oncontextmenu={onContextMenu}
-    >
-        <div
-            role="button"
-            tabindex="0"
-            class="multiChoiceListItemName clickable"
+    <!-- Right-click opens the context menu for mouse users; keyboard users reach the
+         same actions via the "More options" button, so this row is a non-interactive
+         container (no role/tabindex). -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="multiChoiceListItem" oncontextmenu={onContextMenu}>
+        <button
+            type="button"
+            class="multiChoiceListItemName"
+            aria-expanded={!choice.collapsed}
+            aria-label={`Toggle ${choice.name}`}
             onclick={toggleCollapsed}
-            onkeypress={(e) => (e.key === 'Enter' || e.key === ' ') && toggleCollapsed()}
         >
-            <div
+            <span
                 class="multiChoiceCollapseIcon"
                 class:is-collapsed={choice.collapsed}
+                aria-hidden="true"
             >
                 <ObsidianIcon iconId="chevron-down" size={16} />
-            </div>
+            </span>
             <span class="choiceListItemName" bind:this={nameElement}></span>
-        </div>
+        </button>
 
         <RightButtons
             onDragHandleDown={startDrag}
@@ -103,6 +120,9 @@
             onConfigureChoice={() => actions.onConfigureChoice(choice)}
             onToggleCommand={() => actions.onToggleCommand(choice)}
             onDuplicateChoice={() => actions.onDuplicateChoice(choice)}
+            onOpenMenu={openMenu}
+            {onMoveUp}
+            {onMoveDown}
             {showConfigureButton}
             {dragDisabled}
             choiceName={choice.name}
@@ -118,6 +138,8 @@
                     {app}
                     roots={roots}
                     choices={choice.choices}
+                    {forceDragDisabled}
+                    rootReorder={rootReorder ?? actions.onReorderChoices}
                     actions={nestedActions}
                 />
             </div>
@@ -142,13 +164,28 @@
         transform: rotate(-180deg);
     }
 
-    .clickable:hover {
-        cursor: pointer;
-    }
-
+    /* Full-width collapse toggle: reset native <button> chrome to match the old
+       clickable div while keeping native keyboard activation + aria-expanded. */
     .multiChoiceListItemName {
         flex: 1 0 0;
         margin-left: 5px;
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        font: inherit;
+        color: inherit;
+        text-align: left;
+        cursor: pointer;
+    }
+
+    .multiChoiceListItemName:focus-visible {
+        outline: 2px solid var(--interactive-accent);
+        outline-offset: 1px;
+        border-radius: var(--radius-s, 4px);
     }
 
     .nestedChoiceList {

--- a/src/gui/choiceList/contextMenu.ts
+++ b/src/gui/choiceList/contextMenu.ts
@@ -58,17 +58,15 @@ type MenuActions = {
 };
 
 /**
- * Build and show the context menu for a choice at the mouse event.
- * "Move to" is rendered as flattened list of targets for reliability.
+ * Build the choice context menu (shared by the mouse and keyboard entry points).
+ * "Move to" is rendered as a flattened list of targets for reliability.
  */
-export function showChoiceContextMenu(
+function buildChoiceMenu(
   app: App,
-  evt: MouseEvent,
   choice: IChoice,
   roots: IChoice[] | undefined,
   actions: MenuActions,
-): void {
-  evt.preventDefault();
+): ObsidianMenu {
   const menu = new ObsidianMenu();
 
   menu
@@ -102,5 +100,38 @@ export function showChoiceContextMenu(
     );
   }
 
-  menu.showAtMouseEvent(evt);
+  return menu;
+}
+
+/**
+ * Show the context menu for a choice at the mouse event (right-click on a row).
+ */
+export function showChoiceContextMenu(
+  app: App,
+  evt: MouseEvent,
+  choice: IChoice,
+  roots: IChoice[] | undefined,
+  actions: MenuActions,
+): void {
+  evt.preventDefault();
+  buildChoiceMenu(app, choice, roots, actions).showAtMouseEvent(evt);
+}
+
+/**
+ * Show the same menu anchored to an element (the keyboard-accessible "More options"
+ * button), positioned at the element's bottom-left so it works without a mouse
+ * pointer. WCAG 2.1.1 — the row's right-click menu is reachable from the keyboard.
+ */
+export function showChoiceContextMenuAtElement(
+  app: App,
+  anchor: HTMLElement,
+  choice: IChoice,
+  roots: IChoice[] | undefined,
+  actions: MenuActions,
+): void {
+  const rect = anchor.getBoundingClientRect();
+  buildChoiceMenu(app, choice, roots, actions).showAtPosition({
+    x: rect.left,
+    y: rect.bottom,
+  });
 }

--- a/src/gui/components/DragHandle.svelte
+++ b/src/gui/components/DragHandle.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import ObsidianIcon from "./ObsidianIcon.svelte";
+
+    // Shared drag-to-reorder handle (#1250). Keeps the existing POINTER drag
+    // (svelte-dnd-action begins the drag from the handle's pointerdown, which flips
+    // the list's `dragDisabled` to false) AND adds keyboard reorder: ArrowUp/ArrowDown
+    // move the row one step via onMoveUp/onMoveDown. It is a real <button> so it is
+    // focusable and announced; the list sets autoAriaDisabled on the dndzone so the
+    // library no longer injects its own (conflicting) role/tabindex/keydown handling.
+    let {
+        label,
+        dragDisabled,
+        onDragStart,
+        onMoveUp,
+        onMoveDown,
+        size = 16,
+    }: {
+        /** Accessible name, e.g. "Reorder Daily note". */
+        label: string;
+        dragDisabled: boolean;
+        onDragStart: (event: Event) => void;
+        onMoveUp?: () => void;
+        onMoveDown?: () => void;
+        size?: number;
+    } = $props();
+
+    // Only advertise/handle arrow reorder when the list actually provides it (e.g. a
+    // filtered choice view passes no move callbacks — the handle must not announce a
+    // shortcut that does nothing nor swallow the arrow keys).
+    const reorderable = $derived(Boolean(onMoveUp || onMoveDown));
+
+    function onKeyDown(event: KeyboardEvent) {
+        if (event.key === "ArrowUp" && onMoveUp) {
+            // preventDefault stops the settings pane from scrolling; stopPropagation
+            // keeps the key from reaching svelte-dnd-action's window-level handler.
+            event.preventDefault();
+            event.stopPropagation();
+            onMoveUp();
+        } else if (event.key === "ArrowDown" && onMoveDown) {
+            event.preventDefault();
+            event.stopPropagation();
+            onMoveDown();
+        }
+    }
+</script>
+
+<button
+    type="button"
+    class="qa-icon-button qa-drag-handle"
+    class:qa-drag-handle-ready={dragDisabled}
+    class:qa-drag-handle-active={!dragDisabled}
+    aria-label={label}
+    aria-keyshortcuts={reorderable ? "ArrowUp ArrowDown" : undefined}
+    tabindex={dragDisabled ? 0 : -1}
+    onpointerdown={(e) => onDragStart(e)}
+    onkeydown={onKeyDown}
+>
+    <ObsidianIcon iconId="grip-vertical" {size} />
+</button>

--- a/src/gui/components/DragHandle.svelte
+++ b/src/gui/components/DragHandle.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
     import ObsidianIcon from "./ObsidianIcon.svelte";
 
-    // Shared drag-to-reorder handle (#1250). Keeps the existing POINTER drag
-    // (svelte-dnd-action begins the drag from the handle's pointerdown, which flips
-    // the list's `dragDisabled` to false) AND adds keyboard reorder: ArrowUp/ArrowDown
-    // move the row one step via onMoveUp/onMoveDown. It is a real <button> so it is
-    // focusable and announced; the list sets autoAriaDisabled on the dndzone so the
-    // library no longer injects its own (conflicting) role/tabindex/keydown handling.
+    // Shared drag-to-reorder handle (#1250). Keeps the existing POINTER drag AND adds
+    // keyboard reorder: ArrowUp/ArrowDown move the row one step via onMoveUp/onMoveDown.
+    // It is a real <button> so it is focusable and announced; the list sets
+    // autoAriaDisabled on the dndzone so the library no longer injects its own
+    // (conflicting) role/tabindex/keydown handling.
+    //
+    // Pointer drag: pressing the handle flips the list's `dragDisabled` to false;
+    // svelte-dnd-action then attaches its mousedown/touchstart listeners and begins the
+    // drag on the compatibility mousedown that follows. We fire onDragStart on
+    // `pointerdown` (earliest, covers mouse+touch+pen) and must NOT call preventDefault
+    // here — preventDefault on pointerdown suppresses that compat mousedown in Chromium
+    // and the library would never see it (drag silently breaks).
     let {
         label,
         dragDisabled,
@@ -18,7 +24,8 @@
         /** Accessible name, e.g. "Reorder Daily note". */
         label: string;
         dragDisabled: boolean;
-        onDragStart: (event: Event) => void;
+        /** Arm the list's pointer drag (flip dragDisabled=false). Must not preventDefault. */
+        onDragStart: () => void;
         onMoveUp?: () => void;
         onMoveDown?: () => void;
         size?: number;
@@ -52,7 +59,7 @@
     aria-label={label}
     aria-keyshortcuts={reorderable ? "ArrowUp ArrowDown" : undefined}
     tabindex={dragDisabled ? 0 : -1}
-    onpointerdown={(e) => onDragStart(e)}
+    onpointerdown={() => onDragStart()}
     onkeydown={onKeyDown}
 >
     <ObsidianIcon iconId="grip-vertical" {size} />

--- a/src/gui/components/DragHandle.test.ts
+++ b/src/gui/components/DragHandle.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+
+import DragHandle from "./DragHandle.svelte";
+
+describe("DragHandle", () => {
+	it("is a focusable native button advertising arrow reorder when handlers are provided", () => {
+		const { getByLabelText } = render(DragHandle, {
+			props: {
+				label: "Reorder Alpha",
+				dragDisabled: true,
+				onDragStart: () => {},
+				onMoveUp: () => {},
+				onMoveDown: () => {},
+			},
+		});
+		const btn = getByLabelText("Reorder Alpha");
+		expect(btn.tagName).toBe("BUTTON");
+		expect(btn.getAttribute("tabindex")).toBe("0");
+		expect(btn.getAttribute("aria-keyshortcuts")).toBe("ArrowUp ArrowDown");
+	});
+
+	it("does not advertise or handle arrow reorder when no move handlers are given (e.g. filtered view)", async () => {
+		const { getByLabelText } = render(DragHandle, {
+			props: { label: "Reorder Alpha", dragDisabled: true, onDragStart: () => {} },
+		});
+		const btn = getByLabelText("Reorder Alpha");
+		expect(btn.hasAttribute("aria-keyshortcuts")).toBe(false);
+		// Arrow keys are not intercepted (no preventDefault) when inert.
+		const down = new KeyboardEvent("keydown", { key: "ArrowDown", cancelable: true, bubbles: true });
+		btn.dispatchEvent(down);
+		expect(down.defaultPrevented).toBe(false);
+	});
+
+	it("is taken out of the tab order while an active pointer drag is in progress", () => {
+		const { getByLabelText } = render(DragHandle, {
+			props: { label: "Reorder Alpha", dragDisabled: false, onDragStart: () => {} },
+		});
+		expect(getByLabelText("Reorder Alpha").getAttribute("tabindex")).toBe("-1");
+	});
+
+	it("starts a pointer drag on pointerdown", async () => {
+		const onDragStart = vi.fn();
+		const { getByLabelText } = render(DragHandle, {
+			props: { label: "Reorder Alpha", dragDisabled: true, onDragStart },
+		});
+		await fireEvent.pointerDown(getByLabelText("Reorder Alpha"));
+		expect(onDragStart).toHaveBeenCalledTimes(1);
+	});
+
+	it("moves the row with ArrowUp / ArrowDown and prevents page scroll", async () => {
+		const onMoveUp = vi.fn();
+		const onMoveDown = vi.fn();
+		const { getByLabelText } = render(DragHandle, {
+			props: {
+				label: "Reorder Alpha",
+				dragDisabled: true,
+				onDragStart: () => {},
+				onMoveUp,
+				onMoveDown,
+			},
+		});
+		const btn = getByLabelText("Reorder Alpha");
+
+		const down = new KeyboardEvent("keydown", { key: "ArrowDown", cancelable: true, bubbles: true });
+		btn.dispatchEvent(down);
+		expect(onMoveDown).toHaveBeenCalledTimes(1);
+		expect(down.defaultPrevented).toBe(true);
+
+		const up = new KeyboardEvent("keydown", { key: "ArrowUp", cancelable: true, bubbles: true });
+		btn.dispatchEvent(up);
+		expect(onMoveUp).toHaveBeenCalledTimes(1);
+		expect(up.defaultPrevented).toBe(true);
+	});
+
+	it("ignores other keys", async () => {
+		const onMoveUp = vi.fn();
+		const onMoveDown = vi.fn();
+		const { getByLabelText } = render(DragHandle, {
+			props: {
+				label: "Reorder Alpha",
+				dragDisabled: true,
+				onDragStart: () => {},
+				onMoveUp,
+				onMoveDown,
+			},
+		});
+		await fireEvent.keyDown(getByLabelText("Reorder Alpha"), { key: "ArrowLeft" });
+		expect(onMoveUp).not.toHaveBeenCalled();
+		expect(onMoveDown).not.toHaveBeenCalled();
+	});
+});

--- a/src/gui/components/DragHandle.test.ts
+++ b/src/gui/components/DragHandle.test.ts
@@ -39,13 +39,19 @@ describe("DragHandle", () => {
 		expect(getByLabelText("Reorder Alpha").getAttribute("tabindex")).toBe("-1");
 	});
 
-	it("starts a pointer drag on pointerdown", async () => {
+	it("arms the drag on pointerdown WITHOUT preventing default", () => {
+		// Regression: preventDefault() on pointerdown suppresses the compatibility
+		// mousedown event, and svelte-dnd-action starts its drag from mousedown — so
+		// the handle must arm the drag (flip dragDisabled) but never cancel pointerdown.
 		const onDragStart = vi.fn();
 		const { getByLabelText } = render(DragHandle, {
 			props: { label: "Reorder Alpha", dragDisabled: true, onDragStart },
 		});
-		await fireEvent.pointerDown(getByLabelText("Reorder Alpha"));
+		const btn = getByLabelText("Reorder Alpha");
+		const ev = new Event("pointerdown", { bubbles: true, cancelable: true });
+		btn.dispatchEvent(ev);
 		expect(onDragStart).toHaveBeenCalledTimes(1);
+		expect(ev.defaultPrevented).toBe(false);
 	});
 
 	it("moves the row with ArrowUp / ArrowDown and prevents page scroll", async () => {

--- a/src/gui/components/IconButton.svelte
+++ b/src/gui/components/IconButton.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+    import ObsidianIcon from "./ObsidianIcon.svelte";
+
+    // Shared accessible icon button. Renders a real <button> so it is keyboard
+    // operable (Enter + Space) and focusable for free — replacing the old
+    // <div|span role="button" tabindex onclick onkeypress> faux-buttons across the
+    // choice & macro GUIs (#1250). Visuals come from the global .qa-icon-button
+    // class in styles.css (kept global so a scoped <style> can't drift / trip
+    // svelte/valid-compile's css_unused_selector).
+    let {
+        iconId,
+        label,
+        onclick,
+        size = 16,
+        ariaPressed,
+        ariaHasPopup,
+        extraClass = "",
+        title,
+        disabled = false,
+    }: {
+        iconId: string;
+        /** Accessible name — required so every icon-only button is labelled. */
+        label: string;
+        onclick?: (event: MouseEvent) => void;
+        size?: number;
+        /** Set for toggle buttons; the pressed STATE (not the label) conveys on/off. */
+        ariaPressed?: boolean;
+        ariaHasPopup?: "menu" | "dialog" | "true";
+        /** Extra classes (e.g. "clickable" retained for existing test selectors). */
+        extraClass?: string;
+        title?: string;
+        disabled?: boolean;
+    } = $props();
+</script>
+
+<button
+    type="button"
+    class={`qa-icon-button ${extraClass}`}
+    class:is-pressed={ariaPressed === true}
+    aria-label={label}
+    aria-pressed={ariaPressed}
+    aria-haspopup={ariaHasPopup}
+    {title}
+    {disabled}
+    onclick={onclick}
+>
+    <ObsidianIcon {iconId} {size} />
+</button>

--- a/src/gui/components/IconButton.test.ts
+++ b/src/gui/components/IconButton.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+
+import IconButton from "./IconButton.svelte";
+
+describe("IconButton", () => {
+	it("renders a real <button> with the given accessible name", () => {
+		const { getByLabelText } = render(IconButton, {
+			props: { iconId: "trash-2", label: "Delete thing", onclick: () => {} },
+		});
+		const btn = getByLabelText("Delete thing");
+		expect(btn.tagName).toBe("BUTTON");
+		// type="button" so it never submits a surrounding form.
+		expect(btn.getAttribute("type")).toBe("button");
+	});
+
+	it("fires onclick (and is keyboard operable as a native button)", async () => {
+		const onclick = vi.fn();
+		const { getByLabelText } = render(IconButton, {
+			props: { iconId: "settings", label: "Configure", onclick },
+		});
+		await fireEvent.click(getByLabelText("Configure"));
+		expect(onclick).toHaveBeenCalledTimes(1);
+	});
+
+	it("exposes toggle state via aria-pressed (not just the label)", () => {
+		const { getByLabelText, rerender } = render(IconButton, {
+			props: {
+				iconId: "zap",
+				label: "Command palette",
+				ariaPressed: false,
+				onclick: () => {},
+			},
+		});
+		const btn = getByLabelText("Command palette");
+		expect(btn.getAttribute("aria-pressed")).toBe("false");
+
+		rerender({
+			iconId: "zap",
+			label: "Command palette",
+			ariaPressed: true,
+			onclick: () => {},
+		});
+		expect(btn.getAttribute("aria-pressed")).toBe("true");
+		expect(btn.classList.contains("is-pressed")).toBe(true);
+	});
+
+	it("omits aria-pressed/aria-haspopup when not provided", () => {
+		const { getByLabelText } = render(IconButton, {
+			props: { iconId: "copy", label: "Duplicate", onclick: () => {} },
+		});
+		const btn = getByLabelText("Duplicate");
+		expect(btn.hasAttribute("aria-pressed")).toBe(false);
+		expect(btn.hasAttribute("aria-haspopup")).toBe(false);
+	});
+
+	it("advertises a popup when ariaHasPopup is set (More-options button)", () => {
+		const { getByLabelText } = render(IconButton, {
+			props: {
+				iconId: "more-vertical",
+				label: "More options",
+				ariaHasPopup: "menu",
+				onclick: () => {},
+			},
+		});
+		expect(getByLabelText("More options").getAttribute("aria-haspopup")).toBe("menu");
+	});
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -423,15 +423,21 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	padding: 0;
 	margin: 0;
-	min-width: 0;
 	color: inherit;
 	font: inherit;
-	width: auto;
-	height: auto;
 	line-height: inherit;
 	border-radius: var(--radius-s, 4px);
+	/* Keep icon buttons compact. !important defeats Obsidian's mobile touch-target
+	   button sizing (.is-mobile settings rule, padding:10px -> 40px boxes) which is
+	   higher-specificity than this class and would otherwise inflate every icon and
+	   crush the row's name column. The old <div>/<span> faux-buttons were never
+	   touch-sized, so this restores parity. */
+	padding: 0 !important;
+	min-width: 0 !important;
+	min-height: 0 !important;
+	width: auto !important;
+	height: auto !important;
 }
 
 .qa-icon-button.qa-icon-button:hover {

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,6 +52,33 @@
 	opacity: 0.5;
 }
 
+/* Keyboard-operable rename affordance inside a modal <h2> title (#1250). Resets
+   the native <button> chrome so it reads as the heading text it replaced. Doubled
+   selector (0,2,0) so theme `.modal button` rules can't re-skin the title. */
+.qa-rename-title-button.qa-rename-title-button {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+	padding: 0;
+	margin: 0;
+}
+
+.qa-rename-title-button.qa-rename-title-button:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: 2px;
+	border-radius: var(--radius-s, 4px);
+}
+
+/* The choice-builder title button also lays out its label + pencil icon. */
+.choiceNameHeaderButton {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
 .folderInputContainer {
 	display: flex;
 	align-content: center;
@@ -381,11 +408,60 @@
 	text-decoration: underline;
 }
 
-.qa-drag-handle-ready {
+/* Shared accessible icon button (IconButton.svelte / DragHandle.svelte, #1250).
+   Resets Obsidian's default <button> chrome so an icon-only <button> looks like the
+   borderless inline icons it replaced, while keeping native keyboard/focus behaviour.
+   The selector is doubled (.qa-icon-button.qa-icon-button, specificity 0,2,0) so it
+   also wins over theme descendant rules like `.modal button`/`.vertical-tab-content
+   button` (0,1,1) — the old <div>/<span> faux-buttons were never themed, so a single
+   class would let theme chrome leak onto the new <button>s on themed vaults. */
+.qa-icon-button.qa-icon-button {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	margin: 0;
+	min-width: 0;
+	color: inherit;
+	font: inherit;
+	width: auto;
+	height: auto;
+	line-height: inherit;
+	border-radius: var(--radius-s, 4px);
+}
+
+.qa-icon-button.qa-icon-button:hover {
+	/* Match the old faux-buttons: pointer cursor only, no hover fill. */
+	background-color: transparent;
+	box-shadow: none;
+}
+
+.qa-icon-button.qa-icon-button:focus-visible {
+	outline: 2px solid var(--interactive-accent);
+	outline-offset: 1px;
+}
+
+.qa-icon-button.qa-icon-button:disabled {
+	cursor: default;
+	opacity: 0.5;
+}
+
+/* Toggle state (e.g. "Enable in Command Palette"): the accent colour mirrors the
+   old .command-enabled cue; aria-pressed carries the authoritative state for AT. */
+.qa-icon-button.is-pressed {
+	color: var(--text-accent);
+}
+
+/* Defined after the base reset and doubled so the grab/grabbing cursor wins. */
+.qa-drag-handle.qa-drag-handle-ready {
 	cursor: grab;
 }
 
-.qa-drag-handle-active {
+.qa-drag-handle.qa-drag-handle-active {
 	cursor: grabbing;
 }
 
@@ -597,6 +673,20 @@
 	flex: 1 1 auto;
 	align-items: center;
 	justify-content: space-between;
+}
+
+/* Action buttons + drag handle group on a macro command row (#1250). */
+.quickAddCommandControls {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+/* The label cell of a macro command row: grow to fill and allow shrinking so long
+   command names don't shove the controls off-row (#1250). */
+.quickAddCommandLabel {
+	flex: 1 1 auto;
+	min-width: 0;
 }
 
 .quickCommandContainer {

--- a/src/styles.css
+++ b/src/styles.css
@@ -471,6 +471,25 @@
 	cursor: grabbing;
 }
 
+/* Mobile: declutter the choice rows. The per-row action icons (toggle / configure /
+   duplicate / delete) collapse into the "More options" (⋮) menu — which already
+   exposes every action incl. rename & move — leaving a roomy name plus two
+   touch-friendly controls (More + drag handle). Macro command rows have no menu, so
+   they keep their compact buttons. (#1250) */
+.is-mobile .rightButtonsContainer .qa-row-secondary-action {
+	display: none;
+}
+
+.is-mobile .rightButtonsContainer {
+	gap: 12px;
+}
+
+.is-mobile .rightButtonsContainer .qa-icon-button {
+	/* Override the compact reset for the two controls that remain on mobile so they
+	   are comfortable tap targets. Higher specificity + !important beats the base. */
+	padding: 8px !important;
+}
+
 @media screen and (max-width: 639px) {
 	.qa-provider-grid {
 		grid-template-columns: 1fr;

--- a/src/styles.css
+++ b/src/styles.css
@@ -473,10 +473,12 @@
 
 /* Mobile: declutter the choice rows. The per-row action icons (toggle / configure /
    duplicate / delete) collapse into the "More options" (⋮) menu — which already
-   exposes every action incl. rename & move — leaving a roomy name plus two
-   touch-friendly controls (More + drag handle). Macro command rows have no menu, so
-   they keep their compact buttons. (#1250) */
-.is-mobile .rightButtonsContainer .qa-row-secondary-action {
+   exposes every action incl. rename & move. The drag handle is also removed: on
+   mobile the whole row is draggable by long-press (delayTouchStart), the native
+   reorder gesture. That leaves just a roomy name + the ⋮ menu. (#1250) */
+.is-mobile .rightButtonsContainer .qa-row-secondary-action,
+.is-mobile .rightButtonsContainer .qa-drag-handle,
+.is-mobile .quickAddCommandControls .qa-drag-handle {
 	display: none;
 }
 
@@ -484,9 +486,10 @@
 	gap: 12px;
 }
 
-.is-mobile .rightButtonsContainer .qa-icon-button {
-	/* Override the compact reset for the two controls that remain on mobile so they
-	   are comfortable tap targets. Higher specificity + !important beats the base. */
+.is-mobile .rightButtonsContainer .qa-icon-button,
+.is-mobile .quickAddCommandControls .qa-icon-button {
+	/* Override the compact reset for the controls that remain on mobile so they are
+	   comfortable tap targets. Higher specificity + !important beats the base. */
 	padding: 8px !important;
 }
 

--- a/tests/e2e/conditional-branch-persistence.test.ts
+++ b/tests/e2e/conditional-branch-persistence.test.ts
@@ -96,7 +96,9 @@ describe("conditional command branch persistence (regression for the runes rewri
 		expect(cfg).toBe("cfg=true");
 		await sleep(1500);
 
-		const then = await sev(`const t=lastBy('Edit then branch'); t&&t.click(); return 'then='+!!t;`);
+		// Match by aria-label PREFIX: the label now carries the condition-summary
+		// suffix ("Edit then branch for <summary>"), so an exact match would miss.
+		const then = await sev(`const els=Array.from(document.querySelectorAll('[aria-label^="Edit then branch"]')); const t=els[els.length-1]; t&&t.click(); return 'then='+!!t;`);
 		expect(then).toBe("then=true");
 		await sleep(1500);
 

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -648,6 +648,56 @@ export function setIcon(parent: HTMLElement, iconId: string): void {
   parent.appendChild(svg);
 }
 
+// Minimal Menu stub for context-menu tests. Records its items and how it was
+// shown (mouse event vs. anchored position) so tests can assert the keyboard path.
+export class MenuItem {
+  title = "";
+  icon = "";
+  disabled = false;
+  clickHandler: (() => void) | null = null;
+  setTitle(title: string): this {
+    this.title = title;
+    return this;
+  }
+  setIcon(icon: string): this {
+    this.icon = icon;
+    return this;
+  }
+  setDisabled(disabled: boolean): this {
+    this.disabled = disabled;
+    return this;
+  }
+  onClick(handler: () => void): this {
+    this.clickHandler = handler;
+    return this;
+  }
+}
+
+export class Menu {
+  static lastShown: Menu | null = null;
+  items: MenuItem[] = [];
+  shownAt: { type: "mouse" | "position"; detail: unknown } | null = null;
+  addItem(cb: (item: MenuItem) => void): this {
+    const item = new MenuItem();
+    cb(item);
+    this.items.push(item);
+    return this;
+  }
+  addSeparator(): this {
+    return this;
+  }
+  showAtMouseEvent(evt: MouseEvent): this {
+    this.shownAt = { type: "mouse", detail: evt };
+    Menu.lastShown = this;
+    return this;
+  }
+  showAtPosition(pos: { x: number; y: number }): this {
+    this.shownAt = { type: "position", detail: pos };
+    Menu.lastShown = this;
+    return this;
+  }
+}
+
 // Substring (NOT subsequence) matcher standing in for Obsidian's fuzzy search.
 // Returns a SearchResult-like object when q is a case-insensitive substring of
 // the text, else null — enough for filter tests. Do NOT assert true fuzzy
@@ -683,6 +733,8 @@ export default {
   WorkspaceLeaf,
   FuzzySuggestModal,
   Modal,
+  Menu,
+  MenuItem,
   Scope,
   MarkdownRenderer,
   requestUrl,

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -698,6 +698,16 @@ export class Menu {
   }
 }
 
+// Platform flags. Tests run as desktop (isMobile false) so component behaviour
+// matches the desktop code path unless a test overrides Platform.isMobile.
+export const Platform = {
+  isMobile: false,
+  isDesktop: true,
+  isTablet: false,
+  isPhone: false,
+  isMacOS: true,
+};
+
 // Substring (NOT subsequence) matcher standing in for Obsidian's fuzzy search.
 // Returns a SearchResult-like object when q is a case-insensitive substring of
 // the text, else null — enough for filter tests. Do NOT assert true fuzzy
@@ -744,4 +754,5 @@ export default {
   debounce,
   setIcon,
   prepareFuzzySearch,
+  Platform,
 };


### PR DESCRIPTION
Closes #1250.

The Svelte 5 rewrite (#1248) was deliberately behavior-preserving and didn't touch accessibility. This PR makes the choice & macro editors fully keyboard operable and replaces the leftover faux-button / ARIA patterns.

## What changed

**Shared components**
- `IconButton.svelte` — a real `<button>` replacing every `<div|span role="button" tabindex onclick onkeypress>` faux-button (Enter/Space, focus, and `aria-label` for free; optional `aria-pressed`/`aria-haspopup`).
- `DragHandle.svelte` — a real `<button>` that keeps pointer drag **and** adds keyboard reorder (**ArrowUp/ArrowDown**, with `preventDefault`+`stopPropagation`).

**Keyboard operability (CRUD + reorder)**
- **Reorder** both lists from the keyboard via the drag handle; persists through the same path as a pointer-drag finalize. Set `autoAriaDisabled: true` on both dndzones so svelte-dnd-action stops injecting its own conflicting `role`/`tabindex`/keyboard handlers onto rows.
- **Context menu** (Rename / Move-to, previously mouse-only) is now reachable via a new **"More options"** button → `Menu.showAtPosition`. Removed the dead `role="button"` row that advertised a menu it couldn't open.
- `aria-pressed` on the command-palette toggle; `aria-expanded` on the Multi collapse toggle; valid `<li>` command rows (was `<ol> > <div> > <li>`); the click-to-rename modal `<h2>` headers (MacroBuilder, ChoiceBuilder, both AI Assistant modals) now wrap a real `<button>`; `FolderList` faux-button migrated.

**Lint**
- Enabled `svelte/valid-compile` (eslint-plugin-svelte v3 has no dedicated `a11y-*` rules — this surfaces the Svelte 5 compiler's `a11y_*` warnings) as a regression ratchet. Shared button CSS is global with doubled-class specificity so themes can't re-skin the new native buttons.

## Bug fixed along the way (data loss)

Reordering a **Multi nested inside another Multi (depth ≥ 2)** bubbled the root array into an ancestor's `onReorderChoices` override, overwriting its children — silent data loss + a self-referential cycle persisted to `data.json`. This is a **pre-existing rewrite bug** that affected pointer drag too; the new keyboard reorder just exposed it. Fixed by threading a top-level `rootReorder` handler through every nesting level. Covered by a regression test that fails on the old code and passes on the fix.

## Verification

- `svelte-check`: 0 errors / 0 warnings
- `eslint` (incl. `valid-compile`): clean
- `vitest`: **1452 passed / 31 skipped**, incl. 6 new test files (IconButton, DragHandle, keyboard reorder, depth ≥ 2 nested-reorder regression, collapse `aria-expanded`, keyboard-opened menu)
- production build succeeds

## Notes
- UI change: choice rows gain a subtle **"More options"** (⋮) button — the keyboard entry point for Rename/Move; right-click still works for mouse users.
- Please **verify pointer drag + keyboard reorder manually in the dev vault** — jsdom can't exercise the real pointer-event sequence.
- Intentionally deferred low/edge nits: no focus-return after the Obsidian context menu closes (platform limitation), no `aria-controls` on the collapse toggle, and the rare case of a Multi *named with a markdown link* nesting an `<a>` inside the toggle button.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard reordering for commands and choices via ArrowUp/ArrowDown.
  * New accessible DragHandle and IconButton components for list controls.

* **Improvements**
  * Headings use real buttons for rename actions with ARIA labels.
  * Unified configure/delete controls, improved focus-visible, spacing, drag cursor, and mobile decluttering.
  * Context menus can be anchored to elements; nested reorders now persist.

* **Tests**
  * Added tests for reordering, DragHandle, IconButton, context menus, and choice list accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->