### PR TITLE
refactor(imports): untangle ChoiceView's circular deps so settings views are CI-testable

### DIFF
--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -12,7 +12,8 @@ import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
 import type { IMacro } from "../types/macros/IMacro";
 import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
 import type { IChoiceCommand } from "../types/macros/IChoiceCommand";
-import QuickAdd from "../main";
+import type QuickAdd from "../main";
+import { getQuickAddInstance } from "../quickAddInstance";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { getUserScript } from "../utilityObsidian";
 import type { IWaitCommand } from "../types/macros/QuickCommands/IWaitCommand";
@@ -582,7 +583,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 
 		const formatter = new CompleteFormatter(
 			this.app,
-			QuickAdd.instance,
+			getQuickAddInstance(),
 			this.choiceExecutor
 		);
 
@@ -727,7 +728,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		try {
 			const formatter = new CompleteFormatter(
 				this.app,
-				QuickAdd.instance,
+				getQuickAddInstance(),
 				this.choiceExecutor
 			);
 

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -5,9 +5,6 @@ import InputSuggester from "src/gui/InputSuggester/inputSuggester";
 import VDateInputPrompt from "src/gui/VDateInputPrompt/VDateInputPrompt";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { GLOBAL_VAR_REGEX, INLINE_JAVASCRIPT_REGEX } from "../constants";
-import { SingleInlineScriptEngine } from "../engine/SingleInlineScriptEngine";
-import { SingleMacroEngine } from "../engine/SingleMacroEngine";
-import { SingleTemplateEngine } from "../engine/SingleTemplateEngine";
 import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
 import InputPrompt from "../gui/InputPrompt";
 import { MathModal } from "../gui/MathModal";
@@ -347,7 +344,12 @@ export class CompleteFormatter extends Formatter {
 		macroName: string,
 		context?: { label?: string },
 	): Promise<string> {
-		const macroEngine: SingleMacroEngine = new SingleMacroEngine(
+		// Imported lazily: a static import would re-create the
+		// completeFormatter ⇄ engine circular dependency (#1249).
+		const { SingleMacroEngine } = await import(
+			"../engine/SingleMacroEngine"
+		);
+		const macroEngine = new SingleMacroEngine(
 			this.app,
 			this.plugin,
 			this.plugin.settings.choices,
@@ -367,6 +369,10 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async getTemplateContent(templatePath: string): Promise<string> {
+		// Imported lazily to avoid the completeFormatter ⇄ engine cycle (#1249).
+		const { SingleTemplateEngine } = await import(
+			"../engine/SingleTemplateEngine"
+		);
 		return await new SingleTemplateEngine(
 			this.app,
 			this.plugin,
@@ -403,6 +409,10 @@ export class CompleteFormatter extends Formatter {
 			const code = match?.at(1)?.trim();
 
 			if (code) {
+				// Imported lazily to avoid the completeFormatter ⇄ engine cycle (#1249).
+				const { SingleInlineScriptEngine } = await import(
+					"../engine/SingleInlineScriptEngine"
+				);
 				const executor = new SingleInlineScriptEngine(
 					this.app,
 					this.plugin,

--- a/src/gui/AIAssistantSettingsModal.ts
+++ b/src/gui/AIAssistantSettingsModal.ts
@@ -2,7 +2,7 @@ import type { App } from "obsidian";
 import { Modal, Setting, TextAreaComponent } from "obsidian";
 import type { QuickAddSettings } from "src/settings";
 import { FormatSyntaxSuggester } from "./suggesters/formatSyntaxSuggester";
-import QuickAdd from "src/main";
+import { getQuickAddInstance } from "src/quickAddInstance";
 import { FormatDisplayFormatter } from "src/formatters/formatDisplayFormatter";
 import { AIAssistantProvidersModal } from "./AIAssistantProvidersModal";
 import { getModelNames } from "src/ai/aiHelpers";
@@ -133,11 +133,11 @@ export class AIAssistantSettingsModal extends Modal {
 		new FormatSyntaxSuggester(
 			this.app,
 			textAreaComponent.inputEl,
-			QuickAdd.instance
+			getQuickAddInstance()
 		);
 		const displayFormatter = new FormatDisplayFormatter(
 			this.app,
-			QuickAdd.instance
+			getQuickAddInstance()
 		);
 
 		textAreaComponent.inputEl.addClass("qa-ai-prompt-textarea");

--- a/src/gui/InputPrompt.test.ts
+++ b/src/gui/InputPrompt.test.ts
@@ -1,22 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("../main", () => ({
-	__esModule: true,
-	default: class QuickAddMock {
-		static instance = { settings: { inputPrompt: "single-line" } };
-	},
-}));
-
+import { beforeEach, describe, expect, it } from "vitest";
+import type QuickAdd from "../main";
+import { setQuickAddInstance } from "../quickAddInstance";
 import InputPrompt from "./InputPrompt";
 import GenericInputPrompt from "./GenericInputPrompt/GenericInputPrompt";
 import GenericWideInputPrompt from "./GenericWideInputPrompt/GenericWideInputPrompt";
-import QuickAdd from "../main";
+
+const fakePlugin = (inputPrompt: "single-line" | "multi-line") =>
+	({ settings: { inputPrompt } }) as unknown as QuickAdd;
 
 describe("InputPrompt factory", () => {
 	beforeEach(() => {
-		QuickAdd.instance = {
-			settings: { inputPrompt: "single-line" },
-		} as any;
+		setQuickAddInstance(fakePlugin("single-line"));
 	});
 
 	it("prefers multiline override over global single-line", () => {
@@ -25,9 +19,7 @@ describe("InputPrompt factory", () => {
 	});
 
 	it("uses global multiline when no override provided", () => {
-		QuickAdd.instance = {
-			settings: { inputPrompt: "multi-line" },
-		} as any;
+		setQuickAddInstance(fakePlugin("multi-line"));
 		const prompt = new InputPrompt();
 		expect(prompt.factory()).toBe(GenericWideInputPrompt);
 	});

--- a/src/gui/InputPrompt.ts
+++ b/src/gui/InputPrompt.ts
@@ -1,6 +1,6 @@
 import GenericWideInputPrompt from "./GenericWideInputPrompt/GenericWideInputPrompt";
 import GenericInputPrompt from "./GenericInputPrompt/GenericInputPrompt";
-import QuickAdd from "../main";
+import { getQuickAddInstance } from "../quickAddInstance";
 import type { ValueInputType } from "../utils/valueSyntax";
 
 export default class InputPrompt {
@@ -8,7 +8,7 @@ export default class InputPrompt {
 		if (inputTypeOverride === "multiline") {
 			return GenericWideInputPrompt;
 		}
-		if (QuickAdd.instance.settings.inputPrompt === "multi-line") {
+		if (getQuickAddInstance().settings.inputPrompt === "multi-line") {
 			return GenericWideInputPrompt;
 		} else {
 			return GenericInputPrompt;

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -1,7 +1,7 @@
 import type { App } from "obsidian";
 import { Modal, Setting, TextAreaComponent, debounce } from "obsidian";
 import { FormatSyntaxSuggester } from "./../suggesters/formatSyntaxSuggester";
-import QuickAdd from "src/main";
+import { getQuickAddInstance } from "src/quickAddInstance";
 import { FormatDisplayFormatter } from "src/formatters/formatDisplayFormatter";
 import type { IAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
 import { GenericTextSuggester } from "../suggesters/genericTextSuggester";
@@ -206,11 +206,11 @@ export class AIAssistantCommandSettingsModal extends Modal {
 		new FormatSyntaxSuggester(
 			this.app,
 			textAreaComponent.inputEl,
-			QuickAdd.instance
+			getQuickAddInstance()
 		);
 		const displayFormatter = new FormatDisplayFormatter(
 			this.app,
-			QuickAdd.instance
+			getQuickAddInstance()
 		);
 
 		textAreaComponent.inputEl.addClass("qa-ai-prompt-textarea");

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -1,7 +1,7 @@
 import type { App } from "obsidian";
 import { Modal, Setting, TextAreaComponent, debounce } from "obsidian";
 import { FormatSyntaxSuggester } from "./../suggesters/formatSyntaxSuggester";
-import QuickAdd from "src/main";
+import { getQuickAddInstance } from "src/quickAddInstance";
 import { FormatDisplayFormatter } from "src/formatters/formatDisplayFormatter";
 import type { IInfiniteAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
 import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
@@ -170,11 +170,11 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 		new FormatSyntaxSuggester(
 			this.app,
 			textAreaComponent.inputEl,
-			QuickAdd.instance
+			getQuickAddInstance()
 		);
 		const displayFormatter = new FormatDisplayFormatter(
 			this.app,
-			QuickAdd.instance
+			getQuickAddInstance()
 		);
 
 		textAreaComponent.inputEl.addClass("qa-ai-prompt-textarea");

--- a/src/gui/MacroGUIs/UserScriptSettingsModal.ts
+++ b/src/gui/MacroGUIs/UserScriptSettingsModal.ts
@@ -1,7 +1,7 @@
 import type { App } from "obsidian";
 import { Modal, Setting, TextAreaComponent } from "obsidian";
 import type { IUserScript } from "../../types/macros/IUserScript";
-import QuickAdd from "../../main";
+import { getQuickAddInstance } from "../../quickAddInstance";
 import { FormatDisplayFormatter } from "../../formatters/formatDisplayFormatter";
 import { FormatSyntaxSuggester } from "../suggesters/formatSyntaxSuggester";
 import { setPasswordOnBlur } from "../../utils/setPasswordOnBlur";
@@ -203,10 +203,10 @@ export class UserScriptSettingsModal extends Modal {
 
 		const formatDisplay = this.contentEl.createEl("span");
 		const input = new TextAreaComponent(this.contentEl);
-		new FormatSyntaxSuggester(this.app, input.inputEl, QuickAdd.instance);
+		new FormatSyntaxSuggester(this.app, input.inputEl, getQuickAddInstance());
 		const displayFormatter = new FormatDisplayFormatter(
 			this.app,
-			QuickAdd.instance
+			getQuickAddInstance()
 		);
 
 		input

--- a/src/gui/MathModal.ts
+++ b/src/gui/MathModal.ts
@@ -7,7 +7,7 @@ import {
 	renderMath,
 	TextAreaComponent,
 } from "obsidian";
-import QuickAdd from "../main";
+import { getQuickAddInstance } from "../quickAddInstance";
 import { LATEX_CURSOR_MOVE_HERE } from "../LaTeXSymbols";
 import { LaTeXSuggester } from "./suggesters/LaTeXSuggester";
 
@@ -35,7 +35,7 @@ export class MathModal extends Modal {
 	}
 
 	constructor() {
-		super(QuickAdd.instance.app);
+		super(getQuickAddInstance().app);
 
 		this.open();
 		this.display();

--- a/src/gui/choiceList/ChoiceView.test.ts
+++ b/src/gui/choiceList/ChoiceView.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+// CommandList/ChoiceListItem transitively reach the formatter/engine graph, which
+// pulls obsidian-dataview's CJS `require('obsidian')`; mock it like the rest of
+// the component suite does.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App } from "obsidian";
+import { fireEvent, render } from "@testing-library/svelte";
+import ChoiceView from "./ChoiceView.svelte";
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import type { Plain } from "../svelte/persist.svelte";
+
+// A Macro choice whose macro holds a Conditional command with a populated Then
+// branch — mirrors the on-disk shape the local obsidian-e2e test seeds. Built as
+// a plain object (the persisted representation) cast to IChoice.
+const conditionalMacroChoice = (): IChoice =>
+	({
+		id: "cond-macro",
+		name: "QA Conditional Macro",
+		type: "Macro",
+		command: false,
+		runOnStartup: false,
+		macro: {
+			id: "cond-macro-macro",
+			name: "QA Conditional Macro",
+			commands: [
+				{
+					id: "cond-1",
+					name: "If condition",
+					type: "Conditional",
+					condition: {
+						mode: "variable",
+						variableName: "",
+						operator: "isTruthy",
+						valueType: "string",
+					},
+					thenCommands: [
+						{ id: "wait-1", name: "Wait", type: "Wait", time: 100 },
+					],
+					elseCommands: [],
+				},
+			],
+		},
+	}) as unknown as IChoice;
+
+const findConditional = (choices: Plain<IChoice[]>) => {
+	const macro = choices.find((c) => c.id === "cond-macro") as
+		| undefined
+		| { macro: { commands: Array<{ id: string; thenCommands?: unknown[] }> } };
+	return macro?.macro.commands.find((c) => c.id === "cond-1");
+};
+
+const renderChoiceView = (
+	choices: IChoice[],
+	saveChoices: (next: Plain<IChoice[]>) => void = vi.fn(),
+) =>
+	render(ChoiceView, {
+		props: {
+			app: new App() as never,
+			// CommandRegistry only touches the plugin lazily (on command toggle),
+			// which this test never triggers, so an empty stub is enough.
+			plugin: {} as unknown as QuickAdd,
+			choices,
+			saveChoices,
+		},
+	});
+
+describe("ChoiceView", () => {
+	// The headline goal of #1249: ChoiceView's import graph no longer has the
+	// circular dependency that threw `Class extends value undefined`, so it can be
+	// mounted in a CI vitest component test at all.
+	it("mounts in vitest without the circular-import crash", () => {
+		const { getByLabelText, getByText } = renderChoiceView([
+			conditionalMacroChoice(),
+		]);
+
+		// Renders the seeded macro choice row (aria-label = `Configure <name>`).
+		expect(
+			getByLabelText("Configure QA Conditional Macro"),
+		).toBeInTheDocument();
+		// And the view chrome that proves the full subtree rendered.
+		expect(getByText("Add Choice")).toBeInTheDocument();
+	});
+
+	// Complements the local obsidian-e2e conditional-branch-persistence test in CI:
+	// drives ChoiceView's real save path and asserts the conditional Then-branch
+	// data survives the snapshot persistence boundary intact and plain.
+	it("persists conditional Then-branch data through saveChoices as a plain snapshot", async () => {
+		const saveChoices =
+			vi.fn<(next: Plain<IChoice[]>) => void>();
+		const { getByPlaceholderText, getByText } = renderChoiceView(
+			[conditionalMacroChoice()],
+			saveChoices,
+		);
+
+		// Drive the actual UI: name a new choice and add it -> ChoiceView.save().
+		await fireEvent.input(getByPlaceholderText("Name"), {
+			target: { value: "Second choice" },
+		});
+		await fireEvent.click(getByText("Add Choice"));
+
+		await vi.waitFor(() => expect(saveChoices).toHaveBeenCalledTimes(1));
+
+		const saved = saveChoices.mock.calls[0][0];
+		// The new choice was appended...
+		expect(saved.map((c) => c.name)).toEqual([
+			"QA Conditional Macro",
+			"Second choice",
+		]);
+		// ...and the pre-existing conditional's Then branch survives with full nested
+		// fidelity (not just length) — the exact data-loss the e2e test guards against.
+		const cond = findConditional(saved);
+		expect(cond?.thenCommands).toEqual([
+			{ id: "wait-1", name: "Wait", type: "Wait", time: 100 },
+		]);
+		// Persisted payload is a plain, JSON-serializable snapshot (no $state Proxy).
+		expect(JSON.parse(JSON.stringify(saved))).toEqual(saved);
+	});
+});

--- a/src/gui/choiceList/persistenceBoundary.svelte.ts
+++ b/src/gui/choiceList/persistenceBoundary.svelte.ts
@@ -1,13 +1,15 @@
 import type IChoice from "../../types/choices/IChoice";
 
 /**
- * Isolated mirror of ChoiceView's persistence boundary: hold choices in `$state`,
- * update immutably, and hand out a `$state.snapshot()` on save. Exists as a
- * `.svelte.ts` module because the full ChoiceView component cannot be mounted in
- * vitest (its dependency graph has pre-existing circular imports the bundler
- * tolerates but vitest's ESM evaluation order does not). This lets us unit-test
- * the load-bearing guarantee — snapshots are plain and do NOT alias the reactive
- * source — which is what stops `$state` proxies leaking into zustand/data.json.
+ * Fast, component-free probe of ChoiceView's persistence boundary: hold choices
+ * in `$state`, update immutably, and hand out a `$state.snapshot()` on save.
+ *
+ * ChoiceView itself is now mountable in vitest (the #1249 circular-import fix), and
+ * `ChoiceView.test.ts` exercises this boundary through the real save path. This
+ * `.svelte.ts` mirror is kept as an isolated, runes-level guard on the load-bearing
+ * guarantee — snapshots are plain and do NOT alias the reactive source, including
+ * nested branches — which is what stops `$state` proxies leaking into
+ * zustand/data.json.
  */
 export function createChoicesBuffer(initial: IChoice[]) {
 	let choices = $state(initial);

--- a/src/gui/choiceList/persistenceBoundary.test.ts
+++ b/src/gui/choiceList/persistenceBoundary.test.ts
@@ -27,4 +27,52 @@ describe("choices persistence snapshot boundary", () => {
 		expect(snap[0].name).toBe("A");
 		expect(buf.value[0].name).toBe("Renamed");
 	});
+
+	it("snapshot deep-detaches NESTED branches (a later nested mutation doesn't leak in)", () => {
+		// The actual #1249 data-loss mechanism is at depth: a Conditional command's
+		// then/else branch lives several levels down a Macro choice. A shallow clone
+		// would alias these and silently drop in-component edits.
+		const macroWithConditional = (): IChoice =>
+			({
+				id: "macro",
+				name: "Macro",
+				type: "Macro",
+				command: false,
+				macro: {
+					id: "macro-macro",
+					name: "Macro",
+					commands: [
+						{
+							id: "cond",
+							name: "If",
+							type: "Conditional",
+							thenCommands: [] as unknown[],
+							elseCommands: [] as unknown[],
+						},
+					],
+				},
+			}) as unknown as IChoice;
+
+		const buf = createChoicesBuffer([macroWithConditional()]);
+		const snap = buf.snapshot();
+
+		// Mutate a deeply-nested Then branch through the live reactive proxy AFTER
+		// snapshotting.
+		const liveCond = (
+			buf.value[0] as unknown as {
+				macro: { commands: Array<{ thenCommands: unknown[] }> };
+			}
+		).macro.commands[0];
+		liveCond.thenCommands.push({ id: "wait", name: "Wait", type: "Wait" });
+
+		const snappedCond = (
+			snap[0] as unknown as {
+				macro: { commands: Array<{ thenCommands: unknown[] }> };
+			}
+		).macro.commands[0];
+		// The detached snapshot's nested branch is unaffected...
+		expect(snappedCond.thenCommands).toEqual([]);
+		// ...while the live source did change.
+		expect(liveCond.thenCommands).toHaveLength(1);
+	});
 });

--- a/src/gui/suggesters/LaTeXSuggester.ts
+++ b/src/gui/suggesters/LaTeXSuggester.ts
@@ -2,7 +2,7 @@ import { TextInputSuggest } from "./suggest";
 import Fuse from "fuse.js";
 import { renderMath } from "obsidian";
 import { LATEX_CURSOR_MOVE_HERE, LaTeXSymbols } from "../../LaTeXSymbols";
-import QuickAdd from "../../main";
+import { getQuickAddInstance } from "../../quickAddInstance";
 
 const LATEX_REGEX = new RegExp(/\\([a-z{}A-Z0-9]*)$/);
 
@@ -12,7 +12,7 @@ export class LaTeXSuggester extends TextInputSuggest<string> {
 	private elementsRendered: Record<string, HTMLElement>;
 
 	constructor(public inputEl: HTMLInputElement | HTMLTextAreaElement) {
-		super(QuickAdd.instance.app, inputEl);
+		super(getQuickAddInstance().app, inputEl);
 		this.symbols = Object.assign([], LaTeXSymbols);
 
 		this.elementsRendered = this.symbols.reduce<Record<string, HTMLElement>>((elements, symbol) => {

--- a/src/gui/suggesters/fileSuggester.test.ts
+++ b/src/gui/suggesters/fileSuggester.test.ts
@@ -189,12 +189,11 @@ vi.mock('./suggest', () => {
     return { TextInputSuggest };
 });
 
-vi.mock("../../main", () => ({
-    default: {
-        instance: {
-            registerEvent: vi.fn(),
-        },
-    },
+vi.mock("../../quickAddInstance", () => ({
+    getQuickAddInstance: () => ({
+        registerEvent: vi.fn(),
+    }),
+    setQuickAddInstance: vi.fn(),
 }));
 
 // Mock Plugin

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -6,7 +6,7 @@ import { TFile } from "obsidian";
 import { FILE_LINK_REGEX } from "../../constants";
 import { FileIndex, type SearchResult, type SearchContext, type IndexedFile } from "./FileIndex";
 import { normalizeForSearch } from "./utils";
-import QuickAdd from "../../main";
+import { getQuickAddInstance } from "../../quickAddInstance";
 import { createOwnedElement, getOwnerDocument, getOwnerWindow } from "../../utils/activeWindow";
 
 interface HTMLElementWithTooltipCleanup extends HTMLElement {
@@ -55,7 +55,7 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		super(app, inputEl);
 
 		this.sourcePathOverride = options?.sourcePath;
-		this.fileIndex = FileIndex.getInstance(app, QuickAdd.instance);
+		this.fileIndex = FileIndex.getInstance(app, getQuickAddInstance());
 
 		// Initialize index in background
 		this.fileIndex.ensureIndexed();

--- a/src/gui/suggesters/tagSuggester.ts
+++ b/src/gui/suggesters/tagSuggester.ts
@@ -3,7 +3,7 @@ import type { App } from "obsidian";
 import { TAG_REGEX } from "../../constants";
 import { TextInputSuggest } from "./suggest";
 import { replaceRange } from "./utils";
-import QuickAdd from "../../main";
+import { getQuickAddInstance } from "../../quickAddInstance";
 
 export class TagSuggester extends TextInputSuggest<string> {
 	private lastInput = "";
@@ -23,7 +23,7 @@ export class TagSuggester extends TextInputSuggest<string> {
 
 		// Listen to metadata cache changes to refresh tag index
 		// Using registerEvent for automatic cleanup when plugin unloads
-		QuickAdd.instance.registerEvent(
+		getQuickAddInstance().registerEvent(
 			this.app.metadataCache.on("resolved", () => this.refreshTagIndex())
 		);
 	}

--- a/src/importCycles.test.ts
+++ b/src/importCycles.test.ts
@@ -75,10 +75,37 @@ const extendsByFile = new Map<string, Set<string>>();
 for (const file of files) {
 	let text = readFileSync(file, "utf8");
 	if (file.endsWith(".svelte")) {
-		// Closing tag tolerates whitespace (`</script >`) to satisfy CodeQL
-		// js/bad-tag-filter; we only parse our own trusted Svelte sources here.
-		const m = text.match(/<script[^>]*>([\s\S]*?)<\/script\s*>/i);
-		text = m ? m[1] : "";
+		// Extract every <script> body (instance + `<script module>` /
+		// `<script context="module">`) WITHOUT an HTML-tag regex, so CodeQL's
+		// js/bad-tag-filter has nothing to match. We only parse our own trusted
+		// Svelte sources here; this is an import scan, not an HTML sanitizer.
+		const lower = text.toLowerCase();
+		const bodies: string[] = [];
+		let searchFrom = 0;
+		for (;;) {
+			const tagStart = lower.indexOf("<script", searchFrom);
+			if (tagStart === -1) break;
+			// Confirm it's the `<script` tag (next char is `>`, whitespace, or
+			// `/`), not a substring like `<scripting>`.
+			const after = lower.charCodeAt(tagStart + 7); // 7 === "<script".length
+			const isTag =
+				Number.isNaN(after) || // EOF right after `<script`
+				after === 0x3e /* > */ ||
+				after === 0x2f /* / */ ||
+				after <= 0x20; /* whitespace/control */
+			const openEnd = lower.indexOf(">", tagStart);
+			if (!isTag || openEnd === -1) {
+				searchFrom = tagStart + 7;
+				continue;
+			}
+			const bodyStart = openEnd + 1;
+			const closeStart = lower.indexOf("</script", bodyStart);
+			if (closeStart === -1) break;
+			bodies.push(text.slice(bodyStart, closeStart));
+			const closeEnd = lower.indexOf(">", closeStart);
+			searchFrom = closeEnd === -1 ? closeStart + 8 : closeEnd + 1;
+		}
+		text = bodies.join("\n");
 	}
 
 	const extendsNames = new Set<string>();

--- a/src/importCycles.test.ts
+++ b/src/importCycles.test.ts
@@ -75,7 +75,9 @@ const extendsByFile = new Map<string, Set<string>>();
 for (const file of files) {
 	let text = readFileSync(file, "utf8");
 	if (file.endsWith(".svelte")) {
-		const m = text.match(/<script[^>]*>([\s\S]*?)<\/script>/i);
+		// Closing tag tolerates whitespace (`</script >`) to satisfy CodeQL
+		// js/bad-tag-filter; we only parse our own trusted Svelte sources here.
+		const m = text.match(/<script[^>]*>([\s\S]*?)<\/script\s*>/i);
 		text = m ? m[1] : "";
 	}
 

--- a/src/importCycles.test.ts
+++ b/src/importCycles.test.ts
@@ -1,0 +1,196 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Structural regression guard for #1249.
+ *
+ * The bug was NOT a single bad import — it was a 43-module circular-dependency
+ * component (SCC) in which a class `extends` a base that, due to ESM evaluation
+ * order, was still `undefined` ("Class extends value undefined"). Crucially, such
+ * a cycle can be *benign today yet fatal tomorrow*: whether it throws depends on
+ * module entry order, so a behavioural test (mounting ChoiceView) only catches the
+ * specific manifestation it happens to trigger. Reverting one half of the fix can
+ * leave every behavioural test green while re-arming the landmine.
+ *
+ * This test encodes the actual invariant the fix established and must preserve:
+ *   No `class X extends Y` where Y is a *value* import from a module in the same
+ *   strongly-connected component as X.
+ *
+ * Benign cycles (mutually-recursive functions, recursive Svelte components) are
+ * fine and intentionally NOT failed — only cross-cycle class inheritance, the
+ * thing that throws at module-eval time, is forbidden.
+ */
+
+const ROOT = resolve(__dirname, "..");
+const SRC = join(ROOT, "src");
+const EXTS = [".ts", ".tsx", ".svelte", ".js", ".mjs"];
+
+function walk(dir: string, acc: string[] = []): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const p = join(dir, entry.name);
+		if (entry.isDirectory()) walk(p, acc);
+		else if (
+			EXTS.includes(extname(entry.name)) &&
+			!/\.(test|spec)\./.test(entry.name) &&
+			!entry.name.endsWith(".d.ts")
+		) {
+			acc.push(p);
+		}
+	}
+	return acc;
+}
+
+const files = walk(SRC);
+const fileSet = new Set(files);
+
+function resolveSpec(fromFile: string, spec: string): string | null {
+	if (!spec.startsWith(".") && !spec.startsWith("src/")) return null; // external pkg
+	const base = spec.startsWith("src/")
+		? join(ROOT, spec)
+		: resolve(dirname(fromFile), spec);
+	const candidates = [base];
+	for (const ext of EXTS) candidates.push(base + ext);
+	for (const ext of EXTS) candidates.push(join(base, `index${ext}`));
+	return candidates.find((c) => fileSet.has(c)) ?? null;
+}
+
+// Whole-file import scan. `import ... from "x"` (multi-line tolerant) — but NOT
+// `await import("x")`, which is lazy and breaks eval-time cycles by design.
+const IMPORT_RE = /import\s+(type\s+)?([^;'"]*?)\s+from\s+(['"])([^'"]+)\3/g;
+// `class X extends Y` / `export default abstract class X<T> extends Y`.
+const EXTENDS_RE =
+	/\bclass\s+[A-Za-z_$][\w$]*(?:<[^>]*>)?\s+extends\s+([A-Za-z_$][\w$]*)/g;
+
+interface Edge {
+	to: string;
+	typeOnly: boolean;
+	names: Set<string>;
+}
+
+const valueAdj = new Map<string, string[]>();
+const edgesByFile = new Map<string, Edge[]>();
+const extendsByFile = new Map<string, Set<string>>();
+
+for (const file of files) {
+	let text = readFileSync(file, "utf8");
+	if (file.endsWith(".svelte")) {
+		const m = text.match(/<script[^>]*>([\s\S]*?)<\/script>/i);
+		text = m ? m[1] : "";
+	}
+
+	const extendsNames = new Set<string>();
+	for (const m of text.matchAll(EXTENDS_RE)) extendsNames.add(m[1]);
+	extendsByFile.set(file, extendsNames);
+
+	const merged = new Map<string, Edge>();
+	for (const m of text.matchAll(IMPORT_RE)) {
+		const typeOnly = !!m[1];
+		const clause = m[2].trim();
+		const to = resolveSpec(file, m[4]);
+		if (!to || to === file) continue;
+
+		const names = new Set<string>();
+		// default import (leading identifier, when not a `{...}` / `* as` clause)
+		if (!clause.startsWith("{") && !clause.startsWith("*")) {
+			const def = clause.match(/^([A-Za-z_$][\w$]*)/);
+			if (def) names.add(def[1]);
+		}
+		const brace = clause.match(/\{([^}]*)\}/);
+		if (brace) {
+			for (const part of brace[1].split(",")) {
+				const name = part
+					.trim()
+					.replace(/^type\s+/, "")
+					.split(/\s+as\s+/)[0]
+					.trim();
+				if (name) names.add(name);
+			}
+		}
+
+		const existing = merged.get(to);
+		if (existing) {
+			existing.typeOnly = existing.typeOnly && typeOnly;
+			for (const n of names) existing.names.add(n);
+		} else {
+			merged.set(to, { to, typeOnly, names });
+		}
+	}
+
+	const edges = [...merged.values()];
+	edgesByFile.set(file, edges);
+	valueAdj.set(
+		file,
+		edges.filter((e) => !e.typeOnly).map((e) => e.to),
+	);
+}
+
+// Tarjan SCC over the value-import graph (type-only edges erased at build time).
+function stronglyConnectedComponents(): Map<string, number> {
+	let index = 0;
+	const stack: string[] = [];
+	const onStack = new Set<string>();
+	const idx = new Map<string, number>();
+	const low = new Map<string, number>();
+	const sccId = new Map<string, number>();
+	let nextScc = 0;
+
+	const strongconnect = (v: string) => {
+		idx.set(v, index);
+		low.set(v, index);
+		index++;
+		stack.push(v);
+		onStack.add(v);
+		for (const w of valueAdj.get(v) ?? []) {
+			if (!idx.has(w)) {
+				strongconnect(w);
+				low.set(v, Math.min(low.get(v)!, low.get(w)!));
+			} else if (onStack.has(w)) {
+				low.set(v, Math.min(low.get(v)!, idx.get(w)!));
+			}
+		}
+		if (low.get(v) === idx.get(v)) {
+			const id = nextScc++;
+			let w: string;
+			do {
+				w = stack.pop()!;
+				onStack.delete(w);
+				sccId.set(w, id);
+			} while (w !== v);
+		}
+	};
+
+	// Iterative-safe for this graph size (~260 nodes); recursion depth is bounded.
+	for (const v of valueAdj.keys()) if (!idx.has(v)) strongconnect(v);
+	return sccId;
+}
+
+describe("import cycles (#1249 regression guard)", () => {
+	it("no class extends a base value-imported from its own dependency cycle", () => {
+		const sccId = stronglyConnectedComponents();
+		const offenders: string[] = [];
+
+		for (const [file, extendsNames] of extendsByFile) {
+			if (extendsNames.size === 0) continue;
+			const myScc = sccId.get(file);
+			for (const edge of edgesByFile.get(file) ?? []) {
+				if (edge.typeOnly) continue;
+				if (sccId.get(edge.to) !== myScc) continue; // different SCC -> safe
+				for (const name of edge.names) {
+					if (extendsNames.has(name)) {
+						offenders.push(
+							`${relative(ROOT, file)} extends ${name} (value-imported from ${relative(ROOT, edge.to)} in the same import cycle)`,
+						);
+					}
+				}
+			}
+		}
+
+		expect(
+			offenders,
+			`Found class inheritance across an import cycle — this is exactly the "Class extends value undefined" hazard from #1249.\n` +
+				`Break the cycle (lazy \`await import()\`, a leaf holder module, or \`import type\`) so the base class's module never transitively value-imports its subclass.\n` +
+				offenders.map((o) => `  - ${o}`).join("\n"),
+		).toEqual([]);
+	});
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { isMajorUpdate } from "./utils/semver";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
+import { setQuickAddInstance } from "./quickAddInstance";
 
 // Parameters prefixed with `value-` get used as named values for the executed choice
 type CaptureValueParameters = { [key in `value-${string}`]?: string };
@@ -36,7 +37,6 @@ interface DefinedUriParameters {
 type UriParameters = DefinedUriParameters & CaptureValueParameters;
 
 export default class QuickAdd extends Plugin {
-	static instance: QuickAdd;
 	settings: QuickAddSettings;
 	private unsubscribeSettingsStore: () => void;
 
@@ -50,7 +50,7 @@ export default class QuickAdd extends Plugin {
 
 	async onload() {
 		log.logMessage("Loading QuickAdd");
-		QuickAdd.instance = this;
+		setQuickAddInstance(this);
 
 		await this.loadSettings();
 		settingsStore.replaceState(this.settings);

--- a/src/quickAddInstance.ts
+++ b/src/quickAddInstance.ts
@@ -1,0 +1,37 @@
+// Dependency-light holder for the active QuickAdd plugin instance.
+//
+// Leaf modules (suggesters, prompts, engines, ...) frequently need the running
+// plugin instance. Reading it from `main.ts` as a *value* (`QuickAdd.instance`)
+// forces a value import of `main.ts` — the plugin entry point that imports the
+// entire app — which pulled every one of those leaf modules into a single giant
+// circular-import component. That cycle is benign for the esbuild production
+// bundle but fatal for vitest's ESM evaluation order (`Class extends value
+// undefined`), which is why the settings views could not be component-tested.
+//
+// This module imports `main.ts` for its *type* only (fully erased at build
+// time), so it stays a graph leaf. main.ts publishes the instance here during
+// load; everyone else reads it from here instead of from main. See #1249.
+import type QuickAdd from "./main";
+
+let instance: QuickAdd | undefined;
+
+/** Publish the active plugin instance. Called once from `QuickAdd.onload`. */
+export function setQuickAddInstance(plugin: QuickAdd): void {
+	instance = plugin;
+}
+
+/**
+ * Get the active plugin instance.
+ *
+ * Throws if accessed before the plugin has loaded — every caller runs while the
+ * plugin is active (a GUI is open, a macro is running, ...), so an unset value
+ * is a programming error rather than an expected state.
+ */
+export function getQuickAddInstance(): QuickAdd {
+	if (!instance) {
+		throw new Error(
+			"QuickAdd plugin instance accessed before it was initialised.",
+		);
+	}
+	return instance;
+}

--- a/src/utils/macroHelpers.ts
+++ b/src/utils/macroHelpers.ts
@@ -1,4 +1,4 @@
-import QuickAdd from "src/main";
+import { getQuickAddInstance } from "src/quickAddInstance";
 import { CommandType } from "src/types/macros/CommandType";
 import type { IChoiceCommand } from "src/types/macros/IChoiceCommand";
 import type { ICommand } from "src/types/macros/ICommand";
@@ -8,7 +8,7 @@ import { getConditionSummary } from "./conditionalHelpers";
 export function getCommandDisplayName(cmd: ICommand): string {
 	if (cmd.type === CommandType.Choice) {
 		try {
-			return QuickAdd.instance.getChoiceById((cmd as IChoiceCommand).choiceId)
+			return getQuickAddInstance().getChoiceById((cmd as IChoiceCommand).choiceId)
 				.name;
 		} catch {
 			return "(missing choice)";


### PR DESCRIPTION
Closes #1249.

## Problem

`ChoiceView` (and the other settings views) could not be mounted in a vitest component test. Their import graph formed a **43-module strongly-connected component** that esbuild's production bundle tolerates but vitest's ESM evaluation order does not — it threw `Class extends value undefined` (the fatal edge was `VDateInputPrompt extends GenericInputPrompt`, reached via `quickAddApi`). As a result the ChoiceView save/persistence flow was only covered by a **local** `obsidian-e2e` test that CI can't run.

## Root causes & fix

Two structural causes, identified with an import-graph SCC analysis and broken here:

1. **The `main.ts` god-module singleton.** 11 leaf modules did `import QuickAdd from "./main"` purely to read the static singleton `QuickAdd.instance` — and `main.ts` imports the whole app, dragging everything into one cycle. New leaf module **`src/quickAddInstance.ts`** holds the instance (imports `main` as a **type** only, fully erased). `main.onload` publishes it via `setQuickAddInstance(this)`; the 11 leaf modules read it via `getQuickAddInstance()`. Nothing value-imports `main` anymore, so it drops out of every cycle.
2. **`completeFormatter ⇄ engines`.** `completeFormatter` statically imported `SingleMacroEngine`/`SingleTemplateEngine`/`SingleInlineScriptEngine`, which transitively import it back. They're now loaded lazily with `await import()` at their async call-sites (esbuild inlines these into the single-file bundle).

The 43-node cycle is gone — only benign recursive-component (`MultiChoiceListItem ⇄ ChoiceList`) and mutual-function (`choiceSuggester ⇄ choiceExecutor`) cycles remain, **none with cross-cycle class inheritance**.

## Tests

- **`src/gui/choiceList/ChoiceView.test.ts`** — `render(ChoiceView)` now mounts in vitest, plus the conditional Then/Else persistence flow through ChoiceView's real save path (full nested-fidelity + plain-snapshot assertions). Complements the local e2e test.
- **`src/importCycles.test.ts`** — structural regression guard: builds the value-import graph, runs Tarjan SCC, and fails if any `class X extends Y` where `Y` is value-imported from `X`'s own SCC. Proven to catch a regression of *either* fix (a behavioural test alone does not — the removed `completeFormatter ⇄ engine` cycle is benign-but-fragile today, so reverting that half leaves the whole suite green).
- Strengthened `persistenceBoundary.test.ts` with nested-branch detachment coverage and corrected its now-stale header comment.

## Verification

Behaviour-preserving. Full vitest suite **1457 passing** (was 1451; +6), `tsc --noEmit`, `svelte-check` (0 errors), ESLint, and a production esbuild build all pass.

Also verified live in the dev vault (real Obsidian):
- Plugin loads clean — no errors, no "instance accessed before initialised".
- Settings → QuickAdd tab renders the full `ChoiceView` (filter, all rows, AddChoiceBox).
- Conditional macro: Configure → Edit then branch → Add Wait → Save persists `thenCommands` (length 1, `elseCommands` empty) to `data.json` as **plain JSON with no `$state` Proxy artifacts**.
- The lazily-imported `SingleInlineScriptEngine` and `SingleTemplateEngine` execute correctly at runtime via `api.format`.

## Release impact

None — behaviour-preserving refactor + tests (no `feat`/`fix`/`perf`, so no release). `main.js` is gitignored and not part of the diff.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized how the plugin obtains its runtime instance and switched some engines to load dynamically to improve module isolation and stability.

* **Bug Fixes**
  * Resolved circular-import issues that could crash or prevent UI components, modals, and suggesters from initializing.

* **Tests**
  * Added component tests and a new import-cycle regression guard to detect problematic module cycles early.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->