### PR TITLE
feat: migrate settings to Obsidian 1.13 declarative API (port to 1.13, minAppVersion 1.13.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "eslint-plugin-svelte": "^3.18.0",
         "globals": "17",
         "jsdom": "29",
-        "obsidian": "1.11.4",
+        "obsidian": "1.13.0",
         "obsidian-dataview": "^0.5.68",
         "obsidian-e2e": "0.6.0",
         "semantic-release": "^24.2.9",
@@ -1058,7 +1058,7 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
-    "obsidian": ["obsidian@1.11.4", "", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "6.5.0", "@codemirror/view": "6.38.6" } }, "sha512-n0KD3S+VndgaByrEtEe8NELy0ya6/s+KZ7OcxA6xOm5NN4thxKpQjo6eqEudHEvfGCeT/TYToAKJzitQ1I3XTg=="],
+    "obsidian": ["obsidian@1.13.0", "", { "dependencies": { "@types/codemirror": "5.60.8", "moment": "2.29.4" }, "peerDependencies": { "@codemirror/state": "6.5.0", "@codemirror/view": "6.38.6" } }, "sha512-PHw5+SAPlJ0S3leFvJ0wgFg63Z3DavxL6+d1ll+8toXR2ZlYKc1rMWqdUv9LgUbTwPQUyY6yfhOMMivampRRiQ=="],
 
     "obsidian-calendar-ui": ["obsidian-calendar-ui@0.3.12", "", { "dependencies": { "obsidian-daily-notes-interface": "0.8.4", "svelte": "3.35.0", "tslib": "2.1.0" } }, "sha512-hdoRqCPnukfRgCARgArXaqMQZ+Iai0eY7f0ZsFHHfywpv4gKg3Tx5p47UsLvRO5DD+4knlbrL7Gel57MkfcLTw=="],
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "quickadd",
 	"name": "QuickAdd",
 	"version": "2.12.3",
-	"minAppVersion": "1.11.4",
+	"minAppVersion": "1.13.0",
 	"description": "Quickly add new pages or content to your vault.",
 	"author": "Christian B. B. Houmann",
 	"authorUrl": "https://bagerbach.com",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-svelte": "^3.18.0",
     "globals": "17",
     "jsdom": "29",
-    "obsidian": "1.11.4",
+    "obsidian": "1.13.0",
     "obsidian-dataview": "^0.5.68",
     "obsidian-e2e": "0.6.0",
     "semantic-release": "^24.2.9",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,23 +1,6 @@
-import type {
-	BaseComponent,
-	IconName,
-	Plugin as ObsidianPlugin,
-} from "obsidian";
+import type { Plugin as ObsidianPlugin } from "obsidian";
 
 declare module "obsidian" {
-	interface CliData {
-		[key: string]: string;
-	}
-
-	interface CliFlag {
-		value?: string;
-		description: string;
-		required?: boolean;
-	}
-
-	type CliFlags = Record<string, CliFlag>;
-	type CliHandler = (params: CliData) => string | Promise<string>;
-
 	interface App {
 		plugins: {
 			plugins: {
@@ -46,29 +29,5 @@ declare module "obsidian" {
 			},
 			findCommand: (commandId: string) => Command;
 		};
-	}
-
-	interface Setting {
-		addComponent<T extends BaseComponent>(cb: (el: HTMLElement) => T): this;
-	}
-
-	export class SettingGroup {
-		constructor(containerEl: HTMLElement);
-		setHeading(text: string | DocumentFragment): this;
-		addClass(cls: string): this;
-		addSetting(cb: (setting: Setting) => void): this;
-	}
-
-	interface SettingTab {
-		icon: IconName;
-	}
-
-	interface Plugin {
-		registerCliHandler?: (
-			command: string,
-			description: string,
-			flags: CliFlags | null,
-			handler: CliHandler,
-		) => void;
 	}
 }

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -39,6 +39,14 @@
 
 	let filterQuery = $state(""); // not persisted
 
+	// Reactive mirror of the AI/online gate so the "AI Assistant" button below
+	// reflects toggles of `disableOnlineFeatures` made in the (now declarative)
+	// settings tab live — the old imperative tab re-rendered on every change, the
+	// declarative tab does not re-mount this view.
+	let disableOnlineFeatures = $state(
+		settingsStore.getState().disableOnlineFeatures,
+	);
+
 	// Command registry for managing Obsidian commands (plugin is constant for the
 	// component's life; untrack avoids a spurious state_referenced_locally warning).
 	const commandRegistry = new CommandRegistry(untrack(() => plugin));
@@ -49,6 +57,7 @@
 	$effect(() => {
 		const unsubSettingsStore = settingsStore.subscribe((settings) => {
 			choices = settings.choices;
+			disableOnlineFeatures = settings.disableOnlineFeatures;
 		});
 		return () => unsubSettingsStore();
 	});
@@ -244,7 +253,7 @@
 		/>
 	{/if}
 	<div class="choiceViewBottomBar">
-		{#if !settingsStore.getState().disableOnlineFeatures}
+		{#if !disableOnlineFeatures}
 			<button class="mod-cta" onclick={openAISettings}
 				>AI Assistant</button
 			>

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { App, Component } from "obsidian";
 import { renderChoiceName } from "./gui/choiceList/renderChoiceName";
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 import { formatDateAliasLines } from "./utils/dateAliases";
+import { QuickAddSettingsTab } from "./quickAddSettingsTab";
+import { settingsStore } from "./settingsStore";
+import { DEFAULT_SETTINGS, type QuickAddSettings } from "./settings";
+import { deepClone } from "./utils/deepClone";
+import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
+import type QuickAdd from "./main";
+
+// Importing the settings tab transitively pulls in ChoiceView -> the Dataview
+// integration, whose compiled CJS does a bare `require('obsidian')` that the
+// vitest alias can't intercept. Mock it as the choice-list tests do.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
 
 function expectNoPayloadDom(el: HTMLElement): void {
 	expect(el.querySelector("img, script, svg")).toBeNull();
@@ -119,5 +130,117 @@ describe("settings user-authored DOM XSS safety", () => {
 		expect(packageImportSource).toContain("{conflict.name}");
 		expect(packageImportSource).toContain("{conflict.originalPath}");
 		expectNoPayloadDom(document.body);
+	});
+});
+
+describe("QuickAddSettingsTab declarative bridge", () => {
+	function makeTab(): QuickAddSettingsTab {
+		const app = new App();
+		const plugin = { app } as unknown as QuickAdd;
+		return new QuickAddSettingsTab(app, plugin);
+	}
+
+	beforeEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	it("setControlValue writes through the settingsStore, not plugin.settings", () => {
+		const tab = makeTab();
+		const pluginSettings = (
+			tab.plugin as unknown as { settings?: QuickAddSettings }
+		).settings;
+
+		tab.setControlValue("useSelectionAsCaptureValue", false);
+
+		expect(settingsStore.getState().useSelectionAsCaptureValue).toBe(false);
+		// The bridge must not touch plugin.settings directly — persisting
+		// plugin.settings is the main.ts store subscriber's job.
+		expect(pluginSettings).toBeUndefined();
+	});
+
+	it("getControlValue reads the current store value", () => {
+		const tab = makeTab();
+
+		settingsStore.setState({ showCaptureNotification: false });
+		expect(tab.getControlValue("showCaptureNotification")).toBe(false);
+
+		settingsStore.setState({ showCaptureNotification: true });
+		expect(tab.getControlValue("showCaptureNotification")).toBe(true);
+	});
+
+	it("maps the inputPrompt toggle to and from its enum value", () => {
+		const tab = makeTab();
+
+		tab.setControlValue("inputPrompt", true);
+		expect(settingsStore.getState().inputPrompt).toBe("multi-line");
+		expect(tab.getControlValue("inputPrompt")).toBe(true);
+
+		tab.setControlValue("inputPrompt", false);
+		expect(settingsStore.getState().inputPrompt).toBe("single-line");
+		expect(tab.getControlValue("inputPrompt")).toBe(false);
+	});
+
+	it("clears draft storage when persist drafts is disabled", () => {
+		const tab = makeTab();
+		const clearAll = vi.spyOn(
+			InputPromptDraftStore.getInstance(),
+			"clearAll",
+		);
+
+		tab.setControlValue("persistInputPromptDrafts", true);
+		expect(settingsStore.getState().persistInputPromptDrafts).toBe(true);
+		expect(clearAll).not.toHaveBeenCalled();
+
+		tab.setControlValue("persistInputPromptDrafts", false);
+		expect(settingsStore.getState().persistInputPromptDrafts).toBe(false);
+		expect(clearAll).toHaveBeenCalledTimes(1);
+
+		clearAll.mockRestore();
+	});
+
+	it("exposes each section as a group whose control keys are real settings keys", () => {
+		const tab = makeTab();
+		const groups = tab.getSettingDefinitions() as unknown as Array<{
+			type: string;
+			heading?: string;
+			items?: Array<{ name?: unknown; control?: { key?: string } }>;
+		}>;
+
+		// Non-dev build (vitest defines __IS_DEV_BUILD__ = false): 7 groups.
+		expect(groups).toHaveLength(7);
+
+		const validKeys = new Set(Object.keys(DEFAULT_SETTINGS));
+		const controlKeys: string[] = [];
+
+		for (const group of groups) {
+			expect(group.type).toBe("group");
+			expect(typeof group.heading).toBe("string");
+			expect(Array.isArray(group.items)).toBe(true);
+
+			for (const item of group.items ?? []) {
+				// Every declarative definition must carry a name (search indexing).
+				expect(typeof item.name).toBe("string");
+				const key = item.control?.key;
+				if (key) {
+					controlKeys.push(key);
+					expect(validKeys.has(key)).toBe(true);
+				}
+			}
+		}
+
+		expect(controlKeys).toEqual(
+			expect.arrayContaining([
+				"inputPrompt",
+				"persistInputPromptDrafts",
+				"useSelectionAsCaptureValue",
+				"onePageInputEnabled",
+				"enableTemplatePropertyTypes",
+				"announceUpdates",
+				"showCaptureNotification",
+				"showInputCancellationNotification",
+				"disableOnlineFeatures",
+				"enableRibbonIcon",
+			]),
+		);
 	});
 });

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -146,16 +146,22 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 
 	it("setControlValue writes through the settingsStore, not plugin.settings", () => {
 		const tab = makeTab();
-		const pluginSettings = (
-			tab.plugin as unknown as { settings?: QuickAddSettings }
-		).settings;
+		const setState = vi.spyOn(settingsStore, "setState");
 
 		tab.setControlValue("useSelectionAsCaptureValue", false);
 
+		// The write goes through the store path — the bridge's whole contract...
+		expect(setState).toHaveBeenCalledWith({
+			useSelectionAsCaptureValue: false,
+		});
 		expect(settingsStore.getState().useSelectionAsCaptureValue).toBe(false);
-		// The bridge must not touch plugin.settings directly — persisting
-		// plugin.settings is the main.ts store subscriber's job.
-		expect(pluginSettings).toBeUndefined();
+		// ...and the bridge must not touch plugin.settings directly — persisting
+		// plugin.settings is the main.ts store subscriber's job. Read it AFTER
+		// the call so a stray write would actually be caught.
+		expect(
+			(tab.plugin as unknown as { settings?: QuickAddSettings }).settings,
+		).toBeUndefined();
+		setState.mockRestore();
 	});
 
 	it("getControlValue reads the current store value", () => {

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -1,12 +1,12 @@
-import type { App, TAbstractFile } from "obsidian";
-import type { TextAreaComponent } from "obsidian";
-import {
-	BaseComponent,
-	PluginSettingTab,
+import type {
+	App,
 	Setting,
-	SettingGroup,
-	TFolder,
+	SettingDefinitionGroup,
+	SettingDefinitionItem,
+	TAbstractFile,
+	TextAreaComponent,
 } from "obsidian";
+import { PluginSettingTab, TFolder } from "obsidian";
 import type QuickAdd from "./main";
 import type IChoice from "./types/choices/IChoice";
 import ChoiceView from "./gui/choiceList/ChoiceView.svelte";
@@ -25,15 +25,9 @@ import {
 } from "./utils/dateAliases";
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 
-type SettingGroupLike = {
-	addSetting(cb: (setting: Setting) => void): void;
-};
-
-class SvelteSettingComponent extends BaseComponent {
-	constructor(public containerEl: HTMLElement) {
-		super();
-	}
-}
+/** String-named keys of {@link QuickAddSettings} — used to type the declarative
+ * `control` keys so a mistyped key is caught at compile time. */
+type SettingsKey = Extract<keyof QuickAddSettings, string>;
 
 export class QuickAddSettingsTab extends PluginSettingTab {
 	public plugin: QuickAdd;
@@ -46,45 +40,78 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.icon = "zap";
 	}
 
-	display(): void {
-		this.destroySettingViews();
+	// -----------------------------------------------------------------------
+	// Store bridge
+	//
+	// QuickAdd's single source of truth is the zustand `settingsStore`, and the
+	// only persistence path is the subscriber installed in main.ts (which sets
+	// `plugin.settings` and calls `saveSettings()` on every store change). The
+	// declarative `control` API would otherwise bind directly to
+	// `plugin.settings[key]` and call `saveData` itself, bypassing the store and
+	// leaving every live store consumer (formatter, dateParser, choiceExecutor,
+	// the AI command, the Svelte views, ...) stale. Overriding both accessors to
+	// read/write the store keeps it authoritative. We must NOT also touch
+	// `plugin.settings` or call `saveData` here — the subscriber owns that.
+	// -----------------------------------------------------------------------
 
-		const { containerEl } = this;
-		containerEl.empty();
+	override getControlValue(key: string): unknown {
+		const state = settingsStore.getState();
 
-		const choicesGroup = this.createSettingGroup("Choices & Packages");
-		this.addChoicesSetting(choicesGroup);
-		this.addPackagesSetting(choicesGroup);
+		// `inputPrompt` is stored as an enum but surfaced as a boolean toggle.
+		if (key === "inputPrompt") {
+			return state.inputPrompt === "multi-line";
+		}
 
-		const inputGroup = this.createSettingGroup("Input");
-		this.addUseMultiLineInputPromptSetting(inputGroup);
-		this.addPersistInputPromptDraftsSetting(inputGroup);
-		this.addUseSelectionAsValueSetting(inputGroup);
-		this.addOnePageInputSetting(inputGroup);
-		this.addDateAliasesSetting(inputGroup);
+		return state[key as keyof QuickAddSettings];
+	}
 
-		const templatesGroup = this.createSettingGroup("Templates & Properties");
-		this.addTemplateFolderPathSetting(templatesGroup);
-		this.addTemplatePropertyTypesSetting(templatesGroup);
+	override setControlValue(key: string, value: unknown): void {
+		if (key === "inputPrompt") {
+			settingsStore.setState({
+				inputPrompt: value ? "multi-line" : "single-line",
+			});
+			return;
+		}
 
-		const notificationsGroup = this.createSettingGroup("Notifications");
-		this.addAnnounceUpdatesSetting(notificationsGroup);
-		this.addShowCaptureNotificationSetting(notificationsGroup);
-		this.addShowInputCancellationNotificationSetting(notificationsGroup);
+		if (key === "persistInputPromptDrafts") {
+			const enabled = Boolean(value);
+			settingsStore.setState({ persistInputPromptDrafts: enabled });
+			if (!enabled) {
+				InputPromptDraftStore.getInstance().clearAll();
+			}
+			return;
+		}
 
-		const globalsGroup = this.createSettingGroup("Global Variables");
-		this.addGlobalVariablesSetting(globalsGroup);
+		settingsStore.setState({ [key]: value } as Partial<QuickAddSettings>);
+	}
 
-		const onlineGroup = this.createSettingGroup("AI & Online");
-		this.addDisableOnlineFeaturesSetting(onlineGroup);
-
-		const appearanceGroup = this.createSettingGroup("Appearance");
-		this.addEnableRibbonIconSetting(appearanceGroup);
+	override getSettingDefinitions(): SettingDefinitionItem<SettingsKey>[] {
+		const groups: SettingDefinitionGroup<SettingsKey>[] = [
+			this.choicesAndPackagesGroup(),
+			this.inputGroup(),
+			this.templatesGroup(),
+			this.notificationsGroup(),
+			this.globalVariablesGroup(),
+			this.aiAndOnlineGroup(),
+			this.appearanceGroup(),
+		];
 
 		if (__IS_DEV_BUILD__) {
-			const devGroup = this.createSettingGroup("Developer");
-			this.addDevelopmentInfoSetting(devGroup);
+			groups.push(this.developerGroup());
 		}
+
+		return groups;
+	}
+
+	override hide(): void {
+		// In declarative mode the framework owns row teardown — unloading the
+		// control Components and running each render def's cleanup closure —
+		// which the base hide() drives. We must call it (the old imperative tab
+		// emptied containerEl itself, so the missing super.hide() was harmless
+		// then; it is not now). destroySettingViews() is the idempotent safety
+		// net for the two Svelte mounts.
+		super.hide();
+		this.destroySettingViews();
 	}
 
 	private destroySettingViews(): void {
@@ -94,408 +121,313 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.globalVariablesViewHandle = null;
 	}
 
-	private createSettingGroup(
-		heading: string,
-		className?: string,
-	): SettingGroupLike {
-		if (typeof SettingGroup === "function") {
-			const group = new SettingGroup(this.containerEl).setHeading(heading);
-			if (className) group.addClass(className);
-			return group;
-		}
+	// ----- group builders -----
 
-		const headingSetting = new Setting(this.containerEl)
-			.setName(heading)
-			.setHeading();
-		if (className) headingSetting.settingEl.addClass(className);
-
+	private choicesAndPackagesGroup(): SettingDefinitionGroup<SettingsKey> {
 		return {
-			addSetting: (cb) => {
-				cb(new Setting(this.containerEl));
-			},
+			type: "group",
+			heading: "Choices & Packages",
+			items: [
+				{
+					name: "Choices",
+					render: (setting) => this.renderChoicesView(setting),
+				},
+				{
+					name: "Packages",
+					desc: "Bundle or import QuickAdd automations as reusable packages.",
+					render: (setting) => this.renderPackages(setting),
+				},
+			],
 		};
 	}
 
+	private inputGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "Input",
+			items: [
+				{
+					name: "Use Multi-line Input Prompt",
+					desc: "Use multi-line input prompt instead of single-line input prompt",
+					control: { type: "toggle", key: "inputPrompt" },
+				},
+				{
+					name: "Persist Input Prompt Drafts",
+					desc: "Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.",
+					control: { type: "toggle", key: "persistInputPromptDrafts" },
+				},
+				{
+					name: "Use editor selection as default Capture value",
+					desc: "When enabled, Capture uses the current editor selection as {{VALUE}} and may skip the prompt. When disabled, Capture always prompts for {{VALUE}}.",
+					control: { type: "toggle", key: "useSelectionAsCaptureValue" },
+				},
+				{
+					name: "One-page input for choices (Beta)",
+					desc: "Experimental. Resolve variables up front and show a single dynamic form before executing Template/Capture choices. See Advanced → One-page Inputs in docs.",
+					control: { type: "toggle", key: "onePageInputEnabled" },
+				},
+				{
+					name: "Date aliases",
+					desc:
+						"Shortcodes for natural language date parsing. " +
+						"One per line: alias = phrase. Example: tm = tomorrow.",
+					render: (setting) => this.renderDateAliases(setting),
+				},
+			],
+		};
+	}
+
+	private templatesGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "Templates & Properties",
+			items: [
+				{
+					name: "Template Folder Path",
+					desc: "Path to the folder where templates are stored. Used to suggest template files when configuring QuickAdd.",
+					render: (setting) => this.renderTemplateFolderPath(setting),
+				},
+				{
+					name: "Format template variables as proper property types (Beta)",
+					desc:
+						"When enabled, template variables in front matter will be formatted as proper Obsidian property types. " +
+						"Arrays become List properties, numbers become Number properties, booleans become Checkbox properties, etc. " +
+						"This is a beta feature that may have edge cases.",
+					control: { type: "toggle", key: "enableTemplatePropertyTypes" },
+				},
+			],
+		};
+	}
+
+	private notificationsGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "Notifications",
+			items: [
+				{
+					name: "Announce Updates",
+					desc: "Display release notes when a new version is installed. This includes new features, demo videos, and bug fixes.",
+					control: {
+						type: "dropdown",
+						key: "announceUpdates",
+						defaultValue: "major",
+						options: {
+							all: "Show updates on each new release",
+							major:
+								"Show updates only on major releases (new features, breaking changes)",
+							none: "Don't show",
+						},
+					},
+				},
+				{
+					name: "Show Capture Notifications",
+					desc: "Display a notification when content is captured successfully to confirm the operation completed.",
+					control: { type: "toggle", key: "showCaptureNotification" },
+				},
+				{
+					name: "Show Input Cancellation Notifications",
+					desc: "Display a notification when an input prompt is cancelled without submitting. Disable this to avoid extra notices when dismissing prompts.",
+					control: {
+						type: "toggle",
+						key: "showInputCancellationNotification",
+					},
+				},
+			],
+		};
+	}
+
+	private globalVariablesGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "Global Variables",
+			items: [
+				{
+					name: "Global Variables",
+					render: (setting) => this.renderGlobalVariablesView(setting),
+				},
+			],
+		};
+	}
+
+	private aiAndOnlineGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "AI & Online",
+			items: [
+				{
+					name: "Disable AI & Online features",
+					desc: "This prevents the plugin from making requests to external providers like OpenAI. You can still use User Scripts to execute arbitrary code, including contacting external providers. However, this setting disables plugin features like the AI Assistant from doing so. You need to disable this setting to use the AI Assistant.",
+					control: { type: "toggle", key: "disableOnlineFeatures" },
+				},
+			],
+		};
+	}
+
+	private appearanceGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "Appearance",
+			items: [
+				{
+					name: "Show icon in sidebar",
+					desc: "Add QuickAdd icon to the sidebar ribbon. Requires a reload.",
+					control: { type: "toggle", key: "enableRibbonIcon" },
+				},
+			],
+		};
+	}
+
+	private developerGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "Developer",
+			items: [
+				{
+					name: "Development Information",
+					desc: "Git information for developers.",
+					render: (setting) => this.renderDevInfo(setting),
+				},
+			],
+		};
+	}
+
+	// ----- render helpers -----
+
+	/** Strip the label/description column and let a row span the full width —
+	 * used to host the mounted Svelte views. The declarative API requires a
+	 * `name` on every definition (for search indexing); we set it on the def and
+	 * remove the rendered `infoEl` here so the view still spans full width. */
 	private prepareFullWidthSetting(setting: Setting): void {
 		setting.infoEl.remove();
 		setting.settingEl.addClass("qa-setting-full-width");
 		setting.controlEl.addClass("qa-setting-full-width-control");
 	}
 
-	private addDevelopmentInfoSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting.setName("Development Information");
-			setting.setDesc("Git information for developers.");
+	private renderChoicesView(setting: Setting): () => void {
+		this.prepareFullWidthSetting(setting);
 
-			const infoContainer = setting.settingEl.createDiv();
-			infoContainer.addClass("qa-dev-info");
-
-			renderDevelopmentInfo(infoContainer, {
-				branch: __DEV_GIT_BRANCH__,
-				commit: __DEV_GIT_COMMIT__,
-				dirty: __DEV_GIT_DIRTY__,
-			});
+		this.choiceViewHandle?.destroy();
+		const handle = mountComponent(setting.controlEl, ChoiceView, {
+			app: this.app,
+			plugin: this.plugin,
+			choices: settingsStore.getState().choices,
+			saveChoices: (choices: IChoice[]) => {
+				settingsStore.setState({ choices });
+			},
 		});
-	}
+		this.choiceViewHandle = handle;
 
-	private addGlobalVariablesSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			this.prepareFullWidthSetting(setting);
-
-			const mountView = (target: HTMLElement) => {
-				this.globalVariablesViewHandle = mountComponent(
-					target,
-					GlobalVariablesView,
-					{ app: this.app, plugin: this.plugin },
-				);
-			};
-
-			if (typeof setting.addComponent === "function") {
-				setting.addComponent((el) => {
-					mountView(el);
-					return new SvelteSettingComponent(el);
-				});
-				return;
+		// Capture the handle so a stale cleanup can only ever destroy its own
+		// mount (and only nulls the field while it still points at this mount).
+		return () => {
+			handle.destroy();
+			if (this.choiceViewHandle === handle) {
+				this.choiceViewHandle = null;
 			}
-
-			mountView(setting.settingEl);
-		});
+		};
 	}
 
-	private addChoicesSetting(group: SettingGroupLike): void {
-		group.addSetting((setting) => {
-			this.prepareFullWidthSetting(setting);
+	private renderGlobalVariablesView(setting: Setting): () => void {
+		this.prepareFullWidthSetting(setting);
 
-			const mountView = (target: HTMLElement) => {
-				this.choiceViewHandle = mountComponent(target, ChoiceView, {
-					app: this.app,
-					plugin: this.plugin,
-					choices: settingsStore.getState().choices,
-					saveChoices: (choices: IChoice[]) => {
-						settingsStore.setState({ choices });
-					},
-				});
-			};
+		this.globalVariablesViewHandle?.destroy();
+		const handle = mountComponent(
+			setting.controlEl,
+			GlobalVariablesView,
+			{ app: this.app, plugin: this.plugin },
+		);
+		this.globalVariablesViewHandle = handle;
 
-			if (typeof setting.addComponent === "function") {
-				setting.addComponent((el) => {
-					mountView(el);
-					return new SvelteSettingComponent(el);
-				});
-				return;
+		return () => {
+			handle.destroy();
+			if (this.globalVariablesViewHandle === handle) {
+				this.globalVariablesViewHandle = null;
 			}
-
-			mountView(setting.settingEl);
-		});
+		};
 	}
 
-	private addPackagesSetting(group: SettingGroupLike): void {
-		group.addSetting((setting) => {
-			setting.setName("Packages");
-			setting.setDesc(
-				"Bundle or import QuickAdd automations as reusable packages.",
-			);
-
-			setting.addButton((button) =>
-				button
-					.setButtonText("Export package…")
-					.setCta()
-					.onClick(() => {
-						const choicesSnapshot = settingsStore.getState().choices;
-						const modal = new ExportPackageModal(
-							this.app,
-							this.plugin,
-							choicesSnapshot,
-						);
-						modal.open();
-					}),
-			);
-
-			setting.addButton((button) =>
-				button.setButtonText("Import package…").onClick(() => {
-					const modal = new ImportPackageModal(this.app);
-					modal.open();
+	private renderPackages(setting: Setting): void {
+		setting.addButton((button) =>
+			button
+				.setButtonText("Export package…")
+				.setCta()
+				.onClick(() => {
+					const choicesSnapshot = settingsStore.getState().choices;
+					new ExportPackageModal(
+						this.app,
+						this.plugin,
+						choicesSnapshot,
+					).open();
 				}),
-			);
-		});
+		);
+
+		setting.addButton((button) =>
+			button.setButtonText("Import package…").onClick(() => {
+				new ImportPackageModal(this.app).open();
+			}),
+		);
 	}
 
-	private addAnnounceUpdatesSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting.setName("Announce Updates");
-			setting.setDesc(
-				"Display release notes when a new version is installed. This includes new features, demo videos, and bug fixes.",
-			);
-			setting.addDropdown((dropdown) => {
-				const currentValue = settingsStore.getState().announceUpdates;
-				dropdown
-					.addOption("all", "Show updates on each new release")
-					.addOption(
-						"major",
-						"Show updates only on major releases (new features, breaking changes)",
-					)
-					.addOption("none", "Don't show")
-					.setValue(currentValue)
-					.onChange((value) => {
-						settingsStore.setState({
-							announceUpdates: value as QuickAddSettings["announceUpdates"],
-						});
-					});
-			});
-		});
-	}
+	private renderDateAliases(setting: Setting): void {
+		setting.settingEl.addClass("qa-date-alias-setting");
+		setting.controlEl.addClass("qa-date-alias-control");
 
-	private addShowCaptureNotificationSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting.setName("Show Capture Notifications");
-			setting.setDesc(
-				"Display a notification when content is captured successfully to confirm the operation completed.",
-			);
-			setting.addToggle((toggle) => {
-				toggle.setValue(settingsStore.getState().showCaptureNotification);
-				toggle.onChange((value) => {
-					settingsStore.setState({ showCaptureNotification: value });
-				});
-			});
-		});
-	}
+		let textAreaRef: TextAreaComponent | null = null;
 
-	private addShowInputCancellationNotificationSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting.setName("Show Input Cancellation Notifications");
-			setting.setDesc(
-				"Display a notification when an input prompt is cancelled without submitting. Disable this to avoid extra notices when dismissing prompts.",
-			);
-			setting.addToggle((toggle) => {
-				toggle.setValue(
-					settingsStore.getState().showInputCancellationNotification,
-				);
-				toggle.onChange((value) => {
+		setting.addTextArea((textArea) => {
+			textAreaRef = textArea;
+			textArea
+				.setPlaceholder("t = today\ntm = tomorrow\nyd = yesterday")
+				.setValue(
+					formatDateAliasLines(settingsStore.getState().dateAliases),
+				)
+				.onChange((value) => {
 					settingsStore.setState({
-						showInputCancellationNotification: value,
+						dateAliases: parseDateAliasLines(value),
 					});
 				});
+			textArea.inputEl.addClass("qa-date-alias-input");
+		});
+
+		setting.addButton((button) => {
+			button.setButtonText("Reset to defaults").onClick(() => {
+				settingsStore.setState({ dateAliases: DEFAULT_DATE_ALIASES });
+				textAreaRef?.setValue(formatDateAliasLines(DEFAULT_DATE_ALIASES));
 			});
+			button.buttonEl.addClass("qa-date-alias-reset");
 		});
 	}
 
-	private addTemplatePropertyTypesSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting.setName(
-				"Format template variables as proper property types (Beta)",
-			);
-			setting.setDesc(
-				"When enabled, template variables in front matter will be formatted as proper Obsidian property types. " +
-					"Arrays become List properties, numbers become Number properties, booleans become Checkbox properties, etc. " +
-					"This is a beta feature that may have edge cases.",
-			);
-			setting.addToggle((toggle) => {
-				toggle.setValue(settingsStore.getState().enableTemplatePropertyTypes);
-				toggle.onChange((value) => {
-					settingsStore.setState({ enableTemplatePropertyTypes: value });
+	private renderTemplateFolderPath(setting: Setting): void {
+		setting.addText((text) => {
+			text
+				.setPlaceholder("templates/")
+				.setValue(settingsStore.getState().templateFolderPath)
+				.onChange((value) => {
+					settingsStore.setState({ templateFolderPath: value });
 				});
-			});
-		});
-	}
 
-	hide(): void {
-		this.destroySettingViews();
-	}
-
-	private addUseMultiLineInputPromptSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting
-				.setName("Use Multi-line Input Prompt")
-				.setDesc(
-					"Use multi-line input prompt instead of single-line input prompt",
-				)
-				.addToggle((toggle) =>
-					toggle
-						.setValue(this.plugin.settings.inputPrompt === "multi-line")
-						.setTooltip("Use multi-line input prompt")
-						.onChange((value) => {
-							if (value) {
-								settingsStore.setState({
-									inputPrompt: "multi-line",
-								});
-							} else {
-								settingsStore.setState({
-									inputPrompt: "single-line",
-								});
-							}
-						}),
-				);
-		});
-	}
-
-	private addPersistInputPromptDraftsSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting
-				.setName("Persist Input Prompt Drafts")
-				.setDesc(
-					"Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.",
-				)
-				.addToggle((toggle) =>
-					toggle
-						.setValue(settingsStore.getState().persistInputPromptDrafts)
-						.onChange((value) => {
-							settingsStore.setState({ persistInputPromptDrafts: value });
-							if (!value) {
-								InputPromptDraftStore.getInstance().clearAll();
-							}
-						}),
-				);
-		});
-	}
-
-	private addUseSelectionAsValueSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting
-				.setName("Use editor selection as default Capture value")
-				.setDesc(
-					"When enabled, Capture uses the current editor selection as {{VALUE}} and may skip the prompt. When disabled, Capture always prompts for {{VALUE}}.",
-				)
-				.addToggle((toggle) =>
-					toggle
-						.setValue(settingsStore.getState().useSelectionAsCaptureValue)
-						.onChange((value) => {
-							settingsStore.setState({ useSelectionAsCaptureValue: value });
-						}),
-				);
-		});
-	}
-
-	private addTemplateFolderPathSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting.setName("Template Folder Path");
-			setting.setDesc(
-				"Path to the folder where templates are stored. Used to suggest template files when configuring QuickAdd.",
-			);
-
-			setting.addText((text) => {
-				text
-					.setPlaceholder("templates/")
-					.setValue(settingsStore.getState().templateFolderPath)
-					.onChange((value) => {
-						settingsStore.setState({ templateFolderPath: value });
-					});
-
-				new GenericTextSuggester(
-					this.app,
-					text.inputEl,
-					this.app.vault
-						.getAllLoadedFiles()
-						.filter(
-							(f: TAbstractFile) =>
-								f instanceof TFolder && f.path !== "/",
-						)
-						.map((f: TAbstractFile) => f.path),
-				);
-			});
-		});
-	}
-
-	private addOnePageInputSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting
-				.setName("One-page input for choices (Beta)")
-				.setDesc(
-					"Experimental. Resolve variables up front and show a single dynamic form before executing Template/Capture choices. See Advanced → One-page Inputs in docs.",
-				)
-				.addToggle((toggle) =>
-					toggle
-						.setValue(settingsStore.getState().onePageInputEnabled)
-						.onChange((value) => {
-							settingsStore.setState({ onePageInputEnabled: value });
-						}),
-				);
-		});
-	}
-
-	private addDateAliasesSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting.setName("Date aliases");
-			setting.setDesc(
-				"Shortcodes for natural language date parsing. " +
-					"One per line: alias = phrase. Example: tm = tomorrow.",
-			);
-			setting.settingEl.addClass("qa-date-alias-setting");
-			setting.controlEl.addClass("qa-date-alias-control");
-
-			let textAreaRef: TextAreaComponent | null = null;
-
-			setting.addTextArea((textArea) => {
-				textAreaRef = textArea;
-				textArea
-					.setPlaceholder("t = today\ntm = tomorrow\nyd = yesterday")
-					.setValue(
-						formatDateAliasLines(settingsStore.getState().dateAliases),
+			new GenericTextSuggester(
+				this.app,
+				text.inputEl,
+				this.app.vault
+					.getAllLoadedFiles()
+					.filter(
+						(f: TAbstractFile) => f instanceof TFolder && f.path !== "/",
 					)
-					.onChange((value) => {
-						settingsStore.setState({
-							dateAliases: parseDateAliasLines(value),
-						});
-					});
-				textArea.inputEl.addClass("qa-date-alias-input");
-			});
-
-			setting.addButton((button) => {
-				button
-					.setButtonText("Reset to defaults")
-					.onClick(() => {
-						settingsStore.setState({
-							dateAliases: DEFAULT_DATE_ALIASES,
-						});
-						if (textAreaRef) {
-							textAreaRef.setValue(
-								formatDateAliasLines(DEFAULT_DATE_ALIASES),
-							);
-						}
-					});
-				button.buttonEl.addClass("qa-date-alias-reset");
-			});
+					.map((f: TAbstractFile) => f.path),
+			);
 		});
 	}
 
-	private addDisableOnlineFeaturesSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting
-				.setName("Disable AI & Online features")
-				.setDesc(
-					"This prevents the plugin from making requests to external providers like OpenAI. You can still use User Scripts to execute arbitrary code, including contacting external providers. However, this setting disables plugin features like the AI Assistant from doing so. You need to disable this setting to use the AI Assistant.",
-				)
-				.addToggle((toggle) =>
-					toggle
-						.setValue(settingsStore.getState().disableOnlineFeatures)
-						.onChange((value) => {
-							settingsStore.setState({
-								disableOnlineFeatures: value,
-							});
+	private renderDevInfo(setting: Setting): void {
+		const infoContainer = setting.settingEl.createDiv();
+		infoContainer.addClass("qa-dev-info");
 
-							this.display();
-						}),
-				);
-		});
-	}
-
-	private addEnableRibbonIconSetting(group: SettingGroupLike) {
-		group.addSetting((setting) => {
-			setting
-				.setName("Show icon in sidebar")
-				.setDesc(
-					"Add QuickAdd icon to the sidebar ribbon. Requires a reload.",
-				)
-				.addToggle((toggle) => {
-					toggle
-						.setValue(settingsStore.getState().enableRibbonIcon)
-						.onChange((value: boolean) => {
-							settingsStore.setState({
-								enableRibbonIcon: value,
-							});
-
-							this.display();
-						});
-				});
+		renderDevelopmentInfo(infoContainer, {
+			branch: __DEV_GIT_BRANCH__,
+			commit: __DEV_GIT_COMMIT__,
+			dirty: __DEV_GIT_DIRTY__,
 		});
 	}
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,6 +5,15 @@ import { svelteTesting } from "@testing-library/svelte/vite";
 
 export default defineConfig({
 	plugins: [svelte(), svelteTesting()],
+	// Mirror the esbuild build-time defines so code that reads these constants
+	// (e.g. the settings tab's dev-only group) runs under vitest without a
+	// ReferenceError. Tests run as a non-dev build.
+	define: {
+		__IS_DEV_BUILD__: "false",
+		__DEV_GIT_BRANCH__: "null",
+		__DEV_GIT_COMMIT__: "null",
+		__DEV_GIT_DIRTY__: "false",
+	},
 	resolve: {
 		alias: {
 			src: path.resolve("./src"),


### PR DESCRIPTION
Closes #1238.

Ports QuickAdd to the Obsidian **1.13** API and migrates the settings tab from the imperative `display()` to the new **declarative `getSettingDefinitions()`** API — full Path A, **no legacy/dual-path**.

## What changed
- **obsidian devDep `1.11.4` → `1.13.0`**, `manifest.json` `minAppVersion` → `1.13.0`. obsidian is esbuild-externalized, so this is type-only/build-time (zero runtime-byte change). `version-bump.mjs` stamps `minAppVersion` into `versions.json` at release, so users below 1.13 keep their last-compatible release via the normal fallback.
- **`quickAddSettingsTab.ts` rewritten** to `getSettingDefinitions()`. Every existing row is preserved, in order. Because QuickAdd's source of truth is the zustand `settingsStore` (not `plugin.settings`), the tab **overrides `getControlValue`/`setControlValue`** to route through the store — otherwise the declarative framework would bind to `plugin.settings` + `saveData` and bypass every live store consumer. The `inputPrompt` boolean↔enum mapping and the `persistInputPromptDrafts` clear-drafts side effect live in the bridge. The two Svelte mounts (ChoiceView, GlobalVariables), date-aliases textarea+reset, template-folder suggester, packages buttons, and dev-info are `render` defs.
- `hide()` now calls **`super.hide()`** so the 1.13 framework runs its declarative teardown; `destroySettingViews()` stays as the idempotent safety net for the mounts.
- **ChoiceView** gates the "AI Assistant" button on a reactive `$state` mirror of `disableOnlineFeatures` (the old tab re-rendered via `display()`; the declarative tab doesn't re-mount), so it updates live again.
- **`global.d.ts`**: dropped the obsidian augmentations now shipped natively in 1.13.0 (`CliData`/`CliFlags`/`CliHandler`, `Setting.addComponent`, `SettingGroup`, `SettingTab.icon`, `Plugin.registerCliHandler`); kept only the private `App.plugins`/`commands`.
- **Tests**: added settings-tab bridge unit tests; mirrored the esbuild build-time defines into `vitest.config.mts` so the dev-only group resolves under jsdom.

## Verification (real Obsidian 1.13.0 dev vault)
Drove the running app and asserted on `data.json`:
- Declarative tab renders — **22 rows across 7 groups**.
- **Control persists**: toggling a setting flips `data.json`, valid JSON, **no** `$state`/Proxy leakage, no double-write.
- `inputPrompt` bridge persists `"multi-line"` (enum), not `true`.
- Both Svelte mounts render full-width.
- **AI button toggles live** with `disableOnlineFeatures` (no reopen).
- **Lifecycle**: 3× open/close → mounts `1→0` with **no accumulation** and **zero runtime errors**.
- date-aliases edit + reset and the announce-updates dropdown persist.

Plus CI-equivalent gates locally: `build` (tsc), `check` (svelte-check, 0 errors), `lint`, **1462 tests** (+5 new).

## Release / migration impact
- **Releasing change** (`feat:`) — this must cut a release so `version-bump.mjs` writes the `<version> → 1.13.0` mapping into `versions.json`. Do not squash to a non-releasing type.
- Users on Obsidian < 1.13 will simply stay on their last compatible QuickAdd release (no breakage); the declarative settings API requires 1.13.0+.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum supported app version to 1.13.0; extension requires the newer host app version.

* **Refactor**
  * Redesigned Settings tab to a declarative UI and improved settings persistence and teardown for more reliable behavior.

* **Bug Fixes / UI**
  * “AI Assistant” button visibility now respects the “Disable Online Features” setting.
  * Disabling input-prompt persistence clears saved drafts as expected.

* **Tests**
  * Added tests covering settings behavior and store interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chhoumann/quickadd/pull/1255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->