### PR TITLE
feat(choices): highlight folders as drop targets while dragging + empty-folder hint

### DIFF
--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import type { ICommand } from "../../types/macros/ICommand";
 import { Platform } from "obsidian";
-import { type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
-import { replaceById, stripShadow } from "../shared/dndReorder";
-import { transformDragPill } from "../shared/dragPill";
+import { alertToScreenReader, type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
+import { baseDndOptions, replaceById, stripShadow } from "../shared/dndReorder";
+import { createDragArming } from "../shared/dragArming.svelte";
+import { getCommandDisplayName } from "../../utils/macroHelpers";
 import { snapshot } from "../svelte/persist.svelte";
 import type { CommandListProps } from "./commandListProps.svelte";
 import StandardCommand from "./Components/StandardCommand.svelte";
@@ -43,10 +44,11 @@ let {
 }: CommandListProps = $props();
 
 const isMobile = Platform.isMobile;
-// Desktop: drag is armed by grabbing the handle. Mobile: no handle — the whole row
+// Desktop: drag is armed by grabbing the handle (shared with the choices list; see
+// createDragArming for the click-swallow failsafe). Mobile: no handle — the whole row
 // is draggable by long-press (delayTouchStart), so drag stays enabled.
-let dragArmed = $state(false);
-const dragDisabled = $derived(!isMobile && !dragArmed);
+const drag = createDragArming();
+const dragDisabled = $derived(!isMobile && !drag.armed);
 
 // Narrowing helpers: the {#each} discriminates on command.type, so each child
 // receives the matching subtype. Passed one-way — children report edits via the
@@ -64,6 +66,7 @@ function persist() {
 }
 
 function handleConsider(e: CustomEvent<DndEvent>) {
+	drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
 	// Strip svelte-dnd-action's shadow placeholder so a command can't linger in
 	// state and vanish on reorder (ghost gap) — see [[svelte-dnd-action-shadow-placeholder]].
 	commands = stripShadow(e.detail.items as ICommand[]);
@@ -73,9 +76,9 @@ function handleSort(e: CustomEvent<DndEvent>) {
 	commands = stripShadow(e.detail.items as ICommand[]);
 
 	// Desktop: disarm after a pointer drag so the handle must be grabbed again.
-	// Mobile: dragDisabled ignores dragArmed, so this is a no-op.
+	// Mobile: dragDisabled ignores `armed`, so this is a no-op.
 	if (e.detail.info.source === SOURCES.POINTER) {
-		dragArmed = false;
+		drag.reset();
 	}
 
 	persist();
@@ -85,7 +88,7 @@ function handleSort(e: CustomEvent<DndEvent>) {
 // see DragHandle: preventDefault on pointerdown would suppress the compat mousedown
 // the library starts the drag from.
 let startDrag = () => {
-	dragArmed = true;
+	drag.startDrag();
 };
 
 // Keyboard reorder (ArrowUp/ArrowDown on a row's drag handle): move the command one
@@ -101,6 +104,11 @@ function moveCommand(id: string, direction: -1 | 1) {
 	next.splice(target, 0, moved);
 	commands = next;
 	persist();
+	// autoAriaDisabled silences the library's own move alerts, so announce the
+	// keyboard reorder ourselves.
+	alertToScreenReader(
+		`Moved ${getCommandDisplayName(moved)} to position ${target + 1} of ${list.length}`,
+	);
 }
 
 function updateCommand(command: ICommand) {
@@ -189,27 +197,15 @@ async function configureOpenFile(command: IOpenFileCommand) {
 
 <ol
 	class="quickAddCommandList"
-	use:dndzone={{
+	use:dndzone={baseDndOptions({
 		items: commands,
 		dragDisabled,
-		// The floating clone becomes a compact pill under the cursor (transformDragPill
-		// + the #dnd-action-dragged-el rules in styles.css), so there's no full-row
-		// ghost to feel "yanked" onto the cursor. morphDisabled stops the lib
-		// re-inflating the clone to full width each tick; useCursorForDetection keeps
-		// the drop hit-test on the cursor = the visible pill.
-		morphDisabled: true,
-		useCursorForDetection: true,
-		transformDraggedElement: transformDragPill,
-		dropTargetStyle: {},
 		type: "command",
-		autoAriaDisabled: true,
-		// Keep the rows out of the tab order — only the action buttons / drag handle
-		// inside each row are focusable (the library defaults this to 0, adding a dead
-		// tab stop per row even with autoAriaDisabled).
-		zoneItemTabIndex: -1,
-		// Mobile: long-press (hold) initiates a row drag; a quick swipe still scrolls.
-		delayTouchStart: 200,
-	}}
+		// A command's `.name` differs from its rendered label for Choice/Conditional
+		// commands (getCommandDisplayName resolves the referenced choice's name / the
+		// "If …" summary), so the pill must resolve the label the same way the row does.
+		resolveLabel: getCommandDisplayName,
+	})}
 	onconsider={handleConsider}
 	onfinalize={handleSort}
 >

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -191,6 +191,10 @@ async function configureOpenFile(command: IOpenFileCommand) {
 	use:dndzone={{
 		items: commands,
 		dragDisabled,
+		// Hit-test follows the cursor, not the floating clone's centre — so you don't
+		// have to aim a precise spot to land a drop. (Flip animation for the macro
+		// builder is a small follow-up; see the choices view for the full treatment.)
+		useCursorForDetection: true,
 		dropTargetStyle: {},
 		type: "command",
 		autoAriaDisabled: true,

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -191,9 +191,11 @@ async function configureOpenFile(command: IOpenFileCommand) {
 	use:dndzone={{
 		items: commands,
 		dragDisabled,
-		// Hit-test follows the cursor, not the floating clone's centre — so you don't
-		// have to aim a precise spot to land a drop. (Flip animation for the macro
-		// builder is a small follow-up; see the choices view for the full treatment.)
+		// Centre the dragged clone on the cursor so the cursor is the focal point — the
+		// fix for dragging a wide row over a small target (you aim the clone, which is
+		// now centred on your cursor = the detection point). useCursorForDetection keeps
+		// detection on the cursor too. (Flip animation here is a small follow-up.)
+		centreDraggedOnCursor: true,
 		useCursorForDetection: true,
 		dropTargetStyle: {},
 		type: "command",

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -3,6 +3,7 @@ import type { ICommand } from "../../types/macros/ICommand";
 import { Platform } from "obsidian";
 import { type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
 import { replaceById, stripShadow } from "../shared/dndReorder";
+import { transformDragPill } from "../shared/dragPill";
 import { snapshot } from "../svelte/persist.svelte";
 import type { CommandListProps } from "./commandListProps.svelte";
 import StandardCommand from "./Components/StandardCommand.svelte";
@@ -191,12 +192,14 @@ async function configureOpenFile(command: IOpenFileCommand) {
 	use:dndzone={{
 		items: commands,
 		dragDisabled,
-		// Centre the dragged clone on the cursor so the cursor is the focal point — the
-		// fix for dragging a wide row over a small target (you aim the clone, which is
-		// now centred on your cursor = the detection point). useCursorForDetection keeps
-		// detection on the cursor too. (Flip animation here is a small follow-up.)
-		centreDraggedOnCursor: true,
+		// The floating clone becomes a compact pill under the cursor (transformDragPill
+		// + the #dnd-action-dragged-el rules in styles.css), so there's no full-row
+		// ghost to feel "yanked" onto the cursor. morphDisabled stops the lib
+		// re-inflating the clone to full width each tick; useCursorForDetection keeps
+		// the drop hit-test on the cursor = the visible pill.
+		morphDisabled: true,
 		useCursorForDetection: true,
+		transformDraggedElement: transformDragPill,
 		dropTargetStyle: {},
 		type: "command",
 		autoAriaDisabled: true,

--- a/src/gui/choiceList/ChoiceList.a11y.test.ts
+++ b/src/gui/choiceList/ChoiceList.a11y.test.ts
@@ -38,6 +38,7 @@ function actionsSpy(): ChoiceListActions {
 		onReorderChoices: vi.fn(),
 		onAddChoice: vi.fn(),
 		onToggleCollapsed: vi.fn(),
+		onCommitFolder: vi.fn(),
 	};
 }
 
@@ -107,17 +108,22 @@ describe("ChoiceList keyboard reorder", () => {
 
 		await fireEvent.keyDown(getByLabelText("Reorder c1"), { key: "ArrowDown" });
 
-		expect(actions.onReorderChoices).toHaveBeenCalledTimes(1);
-		const rootArg = (actions.onReorderChoices as ReturnType<typeof vi.fn>).mock
-			.calls[0][0] as IChoice[];
-		// Root tree intact: exactly [Outer] (not the root array assigned into Outer,
-		// not Outer containing itself).
-		expect(rootArg.map((c) => c.id)).toEqual(["Outer"]);
-		const outerArg = rootArg[0] as unknown as { choices: IChoice[] };
-		expect(outerArg.choices.map((c) => c.id)).toEqual(["Inner"]);
-		// Inner's children are the ones actually reordered.
-		const innerArg = outerArg.choices[0] as unknown as { choices: IChoice[] };
-		expect(innerArg.choices.map((c) => c.id)).toEqual(["c2", "c1"]);
+		// The nested reorder edits Inner's children IN PLACE then commits by id via
+		// onCommitFolder (NOT onReorderChoices, which an ancestor Multi overrides) —
+		// the same path a cross-zone drag takes; see the duplication fix.
+		expect(actions.onCommitFolder).toHaveBeenCalledTimes(1);
+		expect(
+			(actions.onCommitFolder as ReturnType<typeof vi.fn>).mock.calls[0],
+		).toEqual(["Inner", [c2, c1]]);
+		expect(actions.onReorderChoices).not.toHaveBeenCalled();
+		// Inner's children reordered; ancestors intact (no depth >= 2 corruption).
+		expect(
+			(inner as unknown as { choices: IChoice[] }).choices.map((c) => c.id),
+		).toEqual(["c2", "c1"]);
+		expect(
+			(outer as unknown as { choices: IChoice[] }).choices.map((c) => c.id),
+		).toEqual(["Inner"]);
+		expect(choices.map((c) => c.id)).toEqual(["Outer"]);
 	});
 });
 

--- a/src/gui/choiceList/ChoiceList.callbacks.test.ts
+++ b/src/gui/choiceList/ChoiceList.callbacks.test.ts
@@ -32,6 +32,7 @@ function actionsSpy(): ChoiceListActions {
 		onReorderChoices: vi.fn(),
 		onAddChoice: vi.fn(),
 		onToggleCollapsed: vi.fn(),
+		onCommitFolder: vi.fn(),
 	};
 }
 

--- a/src/gui/choiceList/ChoiceList.crosszone.test.ts
+++ b/src/gui/choiceList/ChoiceList.crosszone.test.ts
@@ -1,0 +1,129 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { TRIGGERS } from "svelte-dnd-action";
+
+// ChoiceListItem -> renderChoiceName/contextMenu reach src/main -> obsidian-dataview.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+// jsdom lacks the Web Animations API that svelte's animate:flip touches when a keyed
+// {#each} removes a row (the cross-zone strip below). Stub it so the reorder doesn't throw.
+beforeAll(() => {
+	const proto = Element.prototype as unknown as {
+		getAnimations?: () => unknown[];
+		animate?: () => unknown;
+	};
+	if (!proto.getAnimations) proto.getAnimations = () => [];
+	if (!proto.animate)
+		proto.animate = () => ({ cancel() {}, finished: Promise.resolve() });
+});
+
+import { App } from "obsidian";
+import ChoiceList from "./ChoiceList.svelte";
+import type IChoice from "../../types/choices/IChoice";
+import type { ChoiceListActions } from "./choiceListActions";
+
+const normal = (name: string): IChoice =>
+	({ id: name, name, type: "Template", command: false }) as unknown as IChoice;
+
+function actionsSpy(): ChoiceListActions {
+	return {
+		onDeleteChoice: vi.fn(),
+		onConfigureChoice: vi.fn(),
+		onToggleCommand: vi.fn(),
+		onDuplicateChoice: vi.fn(),
+		onRenameChoice: vi.fn(),
+		onMoveChoice: vi.fn(),
+		onReorderChoices: vi.fn(),
+		onAddChoice: vi.fn(),
+		onToggleCollapsed: vi.fn(),
+		onCommitFolder: vi.fn(),
+	};
+}
+
+const committedIds = (fn: unknown): string[] =>
+	((fn as { mock: { calls: unknown[][] } }).mock.calls[0][0] as IChoice[]).map(
+		(c) => c.id,
+	);
+
+/** Dispatch the dndzone `finalize` CustomEvent the library emits on drop. */
+function fireFinalize(
+	zone: Element,
+	items: IChoice[],
+	trigger: string,
+	id: string,
+): Promise<unknown> {
+	return fireEvent(
+		zone,
+		new CustomEvent("finalize", {
+			detail: { items, info: { trigger, id, source: "pointer" } },
+		}),
+	);
+}
+
+/**
+ * The root<->folder de-dup has TWO co-dependent halves: (1) the by-id commit
+ * (onCommitFolder -> setFolderChildrenById) — covered by the nested-reorder test in
+ * ChoiceList.a11y.test.ts — and (2) THIS: stripping the dragged item from the SOURCE
+ * list on DROPPED_INTO_ANOTHER, because svelte-dnd-action can still report the dragged
+ * item in the origin zone's items, which would otherwise persist a copy in both places.
+ * Real pointer drags can't run in jsdom, so we drive the finalize events directly.
+ */
+describe("ChoiceList cross-zone de-dup (handleSort)", () => {
+	it("strips the dragged item from the SOURCE list on DROPPED_INTO_ANOTHER", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("A"), normal("B"), normal("C")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		// B was dragged into ANOTHER zone, yet the library still reports it here.
+		await fireFinalize(
+			zone,
+			[normal("A"), normal("B"), normal("C")],
+			TRIGGERS.DROPPED_INTO_ANOTHER,
+			"B",
+		);
+
+		expect(actions.onReorderChoices).toHaveBeenCalledTimes(1);
+		expect(committedIds(actions.onReorderChoices)).toEqual(["A", "C"]); // B removed
+	});
+
+	it("keeps every item on a same-zone reorder (DROPPED_INTO_ZONE)", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("A"), normal("B"), normal("C")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		await fireFinalize(
+			zone,
+			[normal("B"), normal("A"), normal("C")],
+			TRIGGERS.DROPPED_INTO_ZONE,
+			"B",
+		);
+
+		// A reorder must NOT strip the dragged item — only DROPPED_INTO_ANOTHER does.
+		expect(committedIds(actions.onReorderChoices)).toEqual(["B", "A", "C"]);
+	});
+
+	it("is a no-op strip when the library already removed the item from the source", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("A"), normal("B"), normal("C")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		// Origin already excludes B; the strip must not drop anything else.
+		await fireFinalize(
+			zone,
+			[normal("A"), normal("C")],
+			TRIGGERS.DROPPED_INTO_ANOTHER,
+			"B",
+		);
+
+		expect(committedIds(actions.onReorderChoices)).toEqual(["A", "C"]);
+	});
+});

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -3,10 +3,10 @@
     import type IMultiChoice from "../../types/choices/IMultiChoice";
     import ChoiceListItem from "./ChoiceListItem.svelte";
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
-    import { type DndEvent, dndzone, TRIGGERS } from "svelte-dnd-action";
+    import { alertToScreenReader, type DndEvent, dndzone, TRIGGERS } from "svelte-dnd-action";
     import { flip } from "svelte/animate";
-    import { stripShadow } from "../shared/dndReorder";
-    import { transformDragPill } from "../shared/dragPill";
+    import { baseDndOptions, stripShadow } from "../shared/dndReorder";
+    import { createDragArming } from "../shared/dragArming.svelte";
     import { Platform, type App } from "obsidian";
     import type { ChoiceListActions } from "./choiceListActions";
 
@@ -18,6 +18,7 @@
         actions,
         rootReorder,
         isEmptyFolder = false,
+        nested = false,
     }: {
         choices?: IChoice[];
         roots?: IChoice[];
@@ -33,23 +34,22 @@
         // MultiChoiceListItem). Sizes the empty-drop band independently of the live
         // `choices` length: previewing a dragged item into the zone momentarily fills
         // `choices` (toggling qa-empty), but the band must NOT resize then — that
-        // show/hide was the violent jumping. False/absent at the root level.
+        // show/hide was the violent jumping. False/absent at the root level. Stays
+        // drag-STABLE because MultiChoiceListItem mounts this list ONE-WAY
+        // (`choices={choice.choices}`, not bind:), so the consider-time preview never
+        // writes back to choice.choices mid-drag.
         isEmptyFolder?: boolean;
+        // Whether this is a folder's inner list (explicit; previously inferred from
+        // `rootReorder !== undefined`). Marks ONLY nested zones as drop-into-folder
+        // targets and gets the qa-nested ring/band styling — the root list never lights
+        // up. False/absent at the root level.
+        nested?: boolean;
     } = $props();
 
     // Resolve once: at the top level there is no incoming rootReorder, so the list's
     // own handler IS the top-level handler; nested lists receive it explicitly.
     const persistRoots = $derived(rootReorder ?? actions.onReorderChoices);
 
-    // rootReorder is undefined ONLY at the top-level list (ChoiceView mounts it
-    // without one; nested folder lists always receive it — MultiChoiceListItem
-    // threads it down). So this reliably means "this is a folder's inner list",
-    // used below to mark ONLY nested zones as drop-into-folder targets — the root
-    // reorder list never lights up.
-    const isNested = $derived(rootReorder !== undefined);
-
-    // Smooth FLIP reorder — svelte-dnd-action's flipDurationMs defaults to 0 (items
-    // snap). Read prefers-reduced-motion once at mount (the settings modal opens fresh).
     // flipDurationMs MUST be 0 for a responsive reorder: the library ties its
     // position-observation interval to it — 0 => 20ms polling (continuous), any value
     // > 0 => max(flip,100)*1.07 ≈ 107ms+, which felt "batched" (move several rows, then
@@ -59,19 +59,16 @@
     const isMobile = Platform.isMobile;
 
     let collapseId = $state("");
-    // Desktop: drag is armed by grabbing the handle (dragDisabled until then), which
-    // prevents accidental drags when interacting with a row. Mobile: there is no
-    // handle — the whole row is draggable by LONG-PRESS (delayTouchStart below), the
-    // native mobile reorder gesture — so drag stays enabled unless filtering.
-    let dragArmed = $state(false);
-    // Did arming actually become a real drag (a `consider` fired)? The failsafe in
-    // startDrag uses this to know whether handleSort already owns the disarm.
-    let dragStarted = false;
-    const dragDisabled = $derived(forceDragDisabled || (!isMobile && !dragArmed));
+    // Desktop drag is armed by grabbing the handle (shared with the macro builder; see
+    // createDragArming for the click-swallow failsafe). Mobile has no handle — the whole
+    // row is draggable by LONG-PRESS (delayTouchStart) — so drag stays enabled unless
+    // filtering.
+    const drag = createDragArming();
+    const dragDisabled = $derived(forceDragDisabled || (!isMobile && !drag.armed));
 
     function handleConsider(e: CustomEvent<DndEvent>) {
         if (forceDragDisabled) return; // filtered view: never mutate a derived list
-        dragStarted = true; // a genuine drag is underway (see startDrag failsafe)
+        drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
         collapseId = e.detail.info.id;
         // Strip the dnd shadow placeholder so it can't linger and cause ghost gaps
         // (bugs #1244/#883) — see [[svelte-dnd-action-shadow-placeholder]].
@@ -86,35 +83,23 @@
         // DIFFERENT zone, yet svelte-dnd can still report it in THIS (source) list — so
         // committing this list verbatim would persist a copy in BOTH the source and the
         // target. Strip the dragged item here so it lives only where it was dropped.
+        // CO-DEPENDENT with setFolderChildrenById's by-id commit (choiceService) — the
+        // strip alone is insufficient at depth >= 2; both are load-bearing.
         if (e.detail.info.trigger === TRIGGERS.DROPPED_INTO_ANOTHER) {
             next = next.filter((c) => c.id !== e.detail.info.id);
         }
         choices = next;
         // Desktop: disarm so a subsequent row interaction doesn't drag (handle must be
-        // grabbed again). Mobile: dragDisabled ignores dragArmed, so this is a no-op.
-        dragArmed = false;
-        dragStarted = false;
+        // grabbed again). Mobile: dragDisabled ignores `armed`, so this is a no-op.
+        drag.reset();
         actions.onReorderChoices(choices);
     }
 
+    // Arm the desktop drag on the handle's pointerdown (no-op while filtering). The
+    // failsafe that disarms a press-that-never-becomes-a-drag lives in createDragArming.
     let startDrag = () => {
         if (forceDragDisabled) return; // do not enable drag while filtering
-        dragArmed = true;
-        dragStarted = false;
-        // Failsafe: arming flips the zone draggable on the handle's pointerdown, but a
-        // press that never becomes a drag (a stray click/tap on the handle) leaves
-        // svelte-dnd-action without a `finalize` to fire — so handleSort never disarms,
-        // the zone stays draggable, and the library SWALLOWS row button clicks (e.g.
-        // the Multi collapse toggle). Disarm on the next pointer release; a genuine drag
-        // sets dragStarted (handleConsider) so its handleSort keeps the reset. Capture
-        // phase so a stopPropagation in the library's handlers can't hide the release.
-        const disarm = () => {
-            window.removeEventListener("pointerup", disarm, true);
-            window.removeEventListener("pointercancel", disarm, true);
-            if (!dragStarted) dragArmed = false;
-        };
-        window.addEventListener("pointerup", disarm, true);
-        window.addEventListener("pointercancel", disarm, true);
+        drag.startDrag();
     };
 
     // Keyboard reorder (ArrowUp/ArrowDown on a row's drag handle). Moves the choice
@@ -134,15 +119,20 @@
         next.splice(target, 0, moved);
         choices = next;
         actions.onReorderChoices(choices);
+        // autoAriaDisabled silences the library's own move alerts, so announce the
+        // keyboard reorder ourselves (cross-zone moves stay mouse-only).
+        alertToScreenReader(
+            `Moved ${choice.name} to position ${target + 1} of ${list.length}`,
+        );
     }
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, flipDurationMs, morphDisabled: true, useCursorForDetection: true, transformDraggedElement: transformDragPill, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
+        use:dndzone={baseDndOptions({items: choices, dragDisabled, flipDurationMs, dropTargetClasses: nested ? ["qa-folder-droptarget"] : []})}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"
-        class:qa-nested={isNested}
+        class:qa-nested={nested}
         class:qa-folder-empty={isEmptyFolder}
         class:qa-empty={choices.length === 0}>
     {#each stripShadow(choices) as choice (choice.id)}
@@ -183,6 +173,12 @@
 <style>
 .choiceList {
     width: auto;
+}
+
+/* Root (non-nested) empty list keeps a little bottom breathing room. The only way to
+   render it empty is a zero-match filter — a truly empty tree shows the hero state. */
+.choiceList.qa-empty:not(.qa-nested) {
+    padding-bottom: 0.5rem;
 }
 
 .choiceList.qa-nested {

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -169,40 +169,44 @@
     width: auto;
 }
 
-/* The drop-into-folder ring lives on the ACTUAL dndzone (.choiceList) so the
-   highlighted area is EXACTLY the droppable area (what you see is where it drops).
-   Reserved at rest (transparent) so a drag only swaps its colour — zero reflow.
-   outline-offset is negative (inside the box) because the settings container is
-   overflow-x:hidden and a positive offset would clip the ring at the right edge.
-   :global() wraps the runtime drop-target class; .choiceList.qa-nested is markup. */
 .choiceList.qa-nested {
-    /* Own the 12px name->first-row gap so a row PREVIEWED into an empty folder
-       doesn't shift the band down: this margin collapses with the previewed row's
-       own 12px margin-top (so populated folders look identical), while giving the
-       empty band the same gap at rest — zero vertical jump on enter/leave. */
+    /* Own the 12px name->first-row gap so the empty drop band sits the same distance
+       below the folder name as a populated folder's first row (collapses with the
+       row's own margin-top, so populated folders look identical). */
     margin-top: 12px;
+    position: relative; /* anchor the ring (::before) */
     border-radius: var(--radius-m);
-    outline: 2px dashed transparent;
-    outline-offset: -2px;
-    transition: outline-color 120ms ease, background-color 120ms ease;
+    transition: background-color 120ms ease;
+}
+
+/* The drop ring is drawn a few px OUTSIDE the content as an absolutely-positioned
+   ::before (adds no layout) — "synthetically" bigger than the rows so it doesn't
+   clamp straight against the choice names. The right edge stays at the content edge:
+   the settings pane is overflow-x:hidden, so extending the ring right would clip it. */
+.choiceList.qa-nested::before {
+    content: "";
+    position: absolute;
+    inset: -4px 0 -4px -6px;
+    border-radius: var(--radius-m);
+    border: 2px dashed transparent;
+    pointer-events: none;
+    transition: border-color 120ms ease;
 }
 
 .choiceList.qa-nested:global(.qa-folder-droptarget) {
-    outline-color: var(--interactive-accent);
     background-color: var(--background-modifier-hover);
-    /* Hold the band at one row's height for the WHOLE drag so it can't shrink the
-       instant qa-empty toggles off (the previewed row renders in). 21px = a single
-       row's measured zone height, so populated folders never heave at drag start. */
-    min-height: 21px;
 }
 
-/* Empty folder: a STABLE one-row drop band. 21px = the height the previewed row
-   occupies (its 12px margin collapses out), so the row swaps in with ZERO reflow —
-   no grow/shrink/flicker as the cursor approaches. The hint is pseudo-content, so it
-   can never become a dnd item / shadow placeholder (keeps the stripShadow invariant).
-   qa-empty (not :empty) drives it — robust against any whitespace text node. */
+.choiceList.qa-nested:global(.qa-folder-droptarget)::before {
+    border-color: var(--interactive-accent);
+}
+
+/* Empty folder: a GENEROUS, stable drop target. No row ever previews in during a
+   drag — the dnd shadow placeholder is stripped (stripShadow) so choices stays [] until
+   release — so the band can be comfortably large with zero reflow, making it an easy
+   target to land in (a thin band made it feel like a moving/precision target). */
 .choiceList.qa-nested.qa-empty {
-    min-height: 21px;
+    min-height: 3rem;
     display: flex;
     align-items: center;
 }
@@ -219,7 +223,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .choiceList.qa-nested {
+    .choiceList.qa-nested,
+    .choiceList.qa-nested::before {
         transition: none;
     }
 }

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -32,6 +32,13 @@
     // own handler IS the top-level handler; nested lists receive it explicitly.
     const persistRoots = $derived(rootReorder ?? actions.onReorderChoices);
 
+    // rootReorder is undefined ONLY at the top-level list (ChoiceView mounts it
+    // without one; nested folder lists always receive it — MultiChoiceListItem
+    // threads it down). So this reliably means "this is a folder's inner list",
+    // used below to mark ONLY nested zones as drop-into-folder targets — the root
+    // reorder list never lights up.
+    const isNested = $derived(rootReorder !== undefined);
+
     const isMobile = Platform.isMobile;
 
     let collapseId = $state("");
@@ -106,7 +113,7 @@
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
+        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"
@@ -144,5 +151,19 @@
 <style>
 .choiceList {
     width: auto;
+}
+
+/* While a choice is being dragged, svelte-dnd-action adds this class to every
+   NESTED folder zone (the root list passes [] and never gets it), advertising
+   "drop here to move INTO this folder". :global() because the class is applied at
+   runtime, not in markup; the .choiceList anchor keeps it from being flagged unused. */
+.choiceList:global(.qa-folder-droptarget) {
+    border-radius: var(--radius-m);
+    outline: 2px dashed var(--interactive-accent);
+    outline-offset: 2px;
+    background-color: var(--background-modifier-hover);
+    /* An empty folder's zone is only ~8px; guarantee an aimable target mid-drag. */
+    min-height: 1.5rem;
+    transition: background-color 120ms ease;
 }
 </style>

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -158,12 +158,10 @@
    "drop here to move INTO this folder". :global() because the class is applied at
    runtime, not in markup; the .choiceList anchor keeps it from being flagged unused. */
 .choiceList:global(.qa-folder-droptarget) {
-    border-radius: var(--radius-m);
-    outline: 2px dashed var(--interactive-accent);
-    outline-offset: 2px;
-    background-color: var(--background-modifier-hover);
-    /* An empty folder's zone is only ~8px; guarantee an aimable target mid-drag. */
-    min-height: 1.5rem;
-    transition: background-color 120ms ease;
+    /* Just give an empty folder's ~8px items-zone an aimable height mid-drag; the
+       visible ring/tint is drawn on the whole .nestedChoiceList (in
+       MultiChoiceListItem) so it wraps the folder's content with breathing room
+       rather than hugging this thin zone. */
+    min-height: 1.25rem;
 }
 </style>

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -4,6 +4,7 @@
     import ChoiceListItem from "./ChoiceListItem.svelte";
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
     import { type DndEvent, dndzone } from "svelte-dnd-action";
+    import { flip } from "svelte/animate";
     import { stripShadow } from "../shared/dndReorder";
     import { Platform, type App } from "obsidian";
     import type { ChoiceListActions } from "./choiceListActions";
@@ -38,6 +39,13 @@
     // used below to mark ONLY nested zones as drop-into-folder targets — the root
     // reorder list never lights up.
     const isNested = $derived(rootReorder !== undefined);
+
+    // Smooth FLIP reorder — svelte-dnd-action's flipDurationMs defaults to 0 (items
+    // snap). Read prefers-reduced-motion once at mount (the settings modal opens fresh).
+    const reduceMotion =
+        typeof window !== "undefined" &&
+        !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    const flipDurationMs = reduceMotion ? 0 : 180;
 
     const isMobile = Platform.isMobile;
 
@@ -113,38 +121,44 @@
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
+        use:dndzone={{items: choices, dragDisabled, flipDurationMs, useCursorForDetection: true, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"
-        style="{choices.length === 0 ? 'padding-bottom: 0.5rem' : ''}">
+        class:qa-nested={isNested}
+        class:qa-empty={choices.length === 0}>
     {#each stripShadow(choices) as choice (choice.id)}
-        {#if choice.type !== "Multi"}
-            <ChoiceListItem
-                    {app}
-                    roots={roots ?? choices}
-                    {dragDisabled}
-                    {startDrag}
-                    {actions}
-                    {choice}
-                    onMoveUp={forceDragDisabled ? undefined : () => moveChoice(choice, -1)}
-                    onMoveDown={forceDragDisabled ? undefined : () => moveChoice(choice, 1)}
-            />
-        {:else}
-            <MultiChoiceListItem
-                    {app}
-                    roots={roots ?? choices}
-                    {dragDisabled}
-                    {startDrag}
-                    {actions}
-                    {collapseId}
-                    {forceDragDisabled}
-                    rootReorder={persistRoots}
-                    choice={choice as IMultiChoice}
-                    onMoveUp={forceDragDisabled ? undefined : () => moveChoice(choice, -1)}
-                    onMoveDown={forceDragDisabled ? undefined : () => moveChoice(choice, 1)}
-            />
-        {/if}
+        <!-- Flip wrapper: the dndzone's direct child = the animated/draggable item.
+             Must stay margin/padding/border-less (the 12px inter-row margin lives on
+             the inner row). data-choice-id stays on the inner row for tests/menus. -->
+        <div animate:flip={{ duration: flipDurationMs }}>
+            {#if choice.type !== "Multi"}
+                <ChoiceListItem
+                        {app}
+                        roots={roots ?? choices}
+                        {dragDisabled}
+                        {startDrag}
+                        {actions}
+                        {choice}
+                        onMoveUp={forceDragDisabled ? undefined : () => moveChoice(choice, -1)}
+                        onMoveDown={forceDragDisabled ? undefined : () => moveChoice(choice, 1)}
+                />
+            {:else}
+                <MultiChoiceListItem
+                        {app}
+                        roots={roots ?? choices}
+                        {dragDisabled}
+                        {startDrag}
+                        {actions}
+                        {collapseId}
+                        {forceDragDisabled}
+                        rootReorder={persistRoots}
+                        choice={choice as IMultiChoice}
+                        onMoveUp={forceDragDisabled ? undefined : () => moveChoice(choice, -1)}
+                        onMoveDown={forceDragDisabled ? undefined : () => moveChoice(choice, 1)}
+                />
+            {/if}
+        </div>
     {/each}
 </div>
 
@@ -153,15 +167,15 @@
     width: auto;
 }
 
-/* While a choice is being dragged, svelte-dnd-action adds this class to every
-   NESTED folder zone (the root list passes [] and never gets it), advertising
-   "drop here to move INTO this folder". :global() because the class is applied at
-   runtime, not in markup; the .choiceList anchor keeps it from being flagged unused. */
-.choiceList:global(.qa-folder-droptarget) {
-    /* Just give an empty folder's ~8px items-zone an aimable height mid-drag; the
-       visible ring/tint is drawn on the whole .nestedChoiceList (in
-       MultiChoiceListItem) so it wraps the folder's content with breathing room
-       rather than hugging this thin zone. */
-    min-height: 1.25rem;
+/* An empty nested folder gets a generous, ALWAYS-PRESENT drop target — not a thin
+   ~8px band that only appears mid-drag — so you can aim at it without hitting a
+   precise spot, and it never pops/reflows when a drag starts. The drag highlight
+   itself (the dashed ring) is drawn on .nestedChoiceList in MultiChoiceListItem.
+   Root empties show the hero instead, so this is scoped to nested zones. */
+.choiceList.qa-nested.qa-empty {
+    /* Aimable but not bulky: cursor-based hit-testing is the main forgiveness win,
+       so this only needs to be a real (not ~8px) target without re-adding the empty
+       folder "weird space". Tunable. */
+    min-height: 1.5rem;
 }
 </style>

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -45,7 +45,10 @@
     const reduceMotion =
         typeof window !== "undefined" &&
         !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    const flipDurationMs = reduceMotion ? 0 : 180;
+    // 100ms keeps the position-observation interval at the library floor
+    // (max(flip,100)*1.07 ≈ 107ms) so reorder reacts continuously, not in batches,
+    // while rows still glide rather than snap.
+    const flipDurationMs = reduceMotion ? 0 : 100;
 
     const isMobile = Platform.isMobile;
 
@@ -167,15 +170,33 @@
     width: auto;
 }
 
-/* An empty nested folder gets a generous, ALWAYS-PRESENT drop target — not a thin
-   ~8px band that only appears mid-drag — so you can aim at it without hitting a
-   precise spot, and it never pops/reflows when a drag starts. The drag highlight
-   itself (the dashed ring) is drawn on .nestedChoiceList in MultiChoiceListItem.
-   Root empties show the hero instead, so this is scoped to nested zones. */
+/* The drop-into-folder ring lives on the ACTUAL dndzone (.choiceList) so the
+   highlighted area is EXACTLY the droppable area (what you see is where it drops).
+   Reserved at rest (transparent) so a drag only swaps its colour — zero reflow.
+   outline-offset is negative (inside the box) because the settings container is
+   overflow-x:hidden and a positive offset would clip the ring at the right edge.
+   :global() wraps the runtime drop-target class; .choiceList.qa-nested is markup. */
+.choiceList.qa-nested {
+    border-radius: var(--radius-m);
+    outline: 2px dashed transparent;
+    outline-offset: -2px;
+    transition: outline-color 120ms ease, background-color 120ms ease;
+}
+
+.choiceList.qa-nested:global(.qa-folder-droptarget) {
+    outline-color: var(--interactive-accent);
+    background-color: var(--background-modifier-hover);
+}
+
+/* An empty nested folder's drop zone is generous + ALWAYS present (not a thin ~8px
+   band that pops in mid-drag), so the ring is an easy, correctly-placed target. */
 .choiceList.qa-nested.qa-empty {
-    /* Aimable but not bulky: cursor-based hit-testing is the main forgiveness win,
-       so this only needs to be a real (not ~8px) target without re-adding the empty
-       folder "weird space". Tunable. */
-    min-height: 1.5rem;
+    min-height: 2rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .choiceList.qa-nested {
+        transition: none;
+    }
 }
 </style>

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -6,6 +6,7 @@
     import { type DndEvent, dndzone } from "svelte-dnd-action";
     import { flip } from "svelte/animate";
     import { stripShadow } from "../shared/dndReorder";
+    import { transformDragPill } from "../shared/dragPill";
     import { Platform, type App } from "obsidian";
     import type { ChoiceListActions } from "./choiceListActions";
 
@@ -122,7 +123,7 @@
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, flipDurationMs, centreDraggedOnCursor: true, useCursorForDetection: true, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
+        use:dndzone={{items: choices, dragDisabled, flipDurationMs, morphDisabled: true, useCursorForDetection: true, transformDraggedElement: transformDragPill, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"
@@ -175,6 +176,11 @@
    overflow-x:hidden and a positive offset would clip the ring at the right edge.
    :global() wraps the runtime drop-target class; .choiceList.qa-nested is markup. */
 .choiceList.qa-nested {
+    /* Own the 12px name->first-row gap so a row PREVIEWED into an empty folder
+       doesn't shift the band down: this margin collapses with the previewed row's
+       own 12px margin-top (so populated folders look identical), while giving the
+       empty band the same gap at rest — zero vertical jump on enter/leave. */
+    margin-top: 12px;
     border-radius: var(--radius-m);
     outline: 2px dashed transparent;
     outline-offset: -2px;
@@ -184,12 +190,32 @@
 .choiceList.qa-nested:global(.qa-folder-droptarget) {
     outline-color: var(--interactive-accent);
     background-color: var(--background-modifier-hover);
+    /* Hold the band at one row's height for the WHOLE drag so it can't shrink the
+       instant qa-empty toggles off (the previewed row renders in). 21px = a single
+       row's measured zone height, so populated folders never heave at drag start. */
+    min-height: 21px;
 }
 
-/* An empty nested folder's drop zone is generous + ALWAYS present (not a thin ~8px
-   band that pops in mid-drag), so the ring is an easy, correctly-placed target. */
+/* Empty folder: a STABLE one-row drop band. 21px = the height the previewed row
+   occupies (its 12px margin collapses out), so the row swaps in with ZERO reflow —
+   no grow/shrink/flicker as the cursor approaches. The hint is pseudo-content, so it
+   can never become a dnd item / shadow placeholder (keeps the stripShadow invariant).
+   qa-empty (not :empty) drives it — robust against any whitespace text node. */
 .choiceList.qa-nested.qa-empty {
-    min-height: 2rem;
+    min-height: 21px;
+    display: flex;
+    align-items: center;
+}
+
+.choiceList.qa-nested.qa-empty::after {
+    content: "Empty — add a choice or drag one here.";
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller, 12px);
+    font-style: italic;
+    line-height: 1.3;
+    padding-left: 2px;
+    pointer-events: none;
+    user-select: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -42,13 +42,11 @@
 
     // Smooth FLIP reorder — svelte-dnd-action's flipDurationMs defaults to 0 (items
     // snap). Read prefers-reduced-motion once at mount (the settings modal opens fresh).
-    const reduceMotion =
-        typeof window !== "undefined" &&
-        !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    // 100ms keeps the position-observation interval at the library floor
-    // (max(flip,100)*1.07 ≈ 107ms) so reorder reacts continuously, not in batches,
-    // while rows still glide rather than snap.
-    const flipDurationMs = reduceMotion ? 0 : 100;
+    // flipDurationMs MUST be 0 for a responsive reorder: the library ties its
+    // position-observation interval to it — 0 => 20ms polling (continuous), any value
+    // > 0 => max(flip,100)*1.07 ≈ 107ms+, which felt "batched" (move several rows, then
+    // a jump). We trade the row-glide animation for continuous, predictable reordering.
+    const flipDurationMs = 0;
 
     const isMobile = Platform.isMobile;
 
@@ -124,7 +122,7 @@
 </script>
 
 <div
-        use:dndzone={{items: choices, dragDisabled, flipDurationMs, useCursorForDetection: true, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
+        use:dndzone={{items: choices, dragDisabled, flipDurationMs, centreDraggedOnCursor: true, useCursorForDetection: true, dropTargetStyle: {}, dropTargetClasses: isNested ? ["qa-folder-droptarget"] : [], autoAriaDisabled: true, zoneItemTabIndex: -1, delayTouchStart: 200}}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -3,7 +3,7 @@
     import type IMultiChoice from "../../types/choices/IMultiChoice";
     import ChoiceListItem from "./ChoiceListItem.svelte";
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
-    import { type DndEvent, dndzone } from "svelte-dnd-action";
+    import { type DndEvent, dndzone, TRIGGERS } from "svelte-dnd-action";
     import { flip } from "svelte/animate";
     import { stripShadow } from "../shared/dndReorder";
     import { transformDragPill } from "../shared/dragPill";
@@ -17,6 +17,7 @@
         forceDragDisabled = false,
         actions,
         rootReorder,
+        isEmptyFolder = false,
     }: {
         choices?: IChoice[];
         roots?: IChoice[];
@@ -28,6 +29,12 @@
         // instead of an ancestor Multi's override (which would reinterpret the root
         // array as its own children — data loss at depth >= 2). Undefined at the top.
         rootReorder?: (choices: IChoice[]) => void;
+        // PERSISTED emptiness of the folder this list belongs to (passed by the parent
+        // MultiChoiceListItem). Sizes the empty-drop band independently of the live
+        // `choices` length: previewing a dragged item into the zone momentarily fills
+        // `choices` (toggling qa-empty), but the band must NOT resize then — that
+        // show/hide was the violent jumping. False/absent at the root level.
+        isEmptyFolder?: boolean;
     } = $props();
 
     // Resolve once: at the top level there is no incoming rootReorder, so the list's
@@ -74,7 +81,15 @@
     function handleSort(e: CustomEvent<DndEvent>) {
         if (forceDragDisabled) return;
         collapseId = "";
-        choices = stripShadow(e.detail.items as IChoice[]);
+        let next = stripShadow(e.detail.items as IChoice[]);
+        // Cross-zone de-dupe: on DROPPED_INTO_ANOTHER the dragged item landed in a
+        // DIFFERENT zone, yet svelte-dnd can still report it in THIS (source) list — so
+        // committing this list verbatim would persist a copy in BOTH the source and the
+        // target. Strip the dragged item here so it lives only where it was dropped.
+        if (e.detail.info.trigger === TRIGGERS.DROPPED_INTO_ANOTHER) {
+            next = next.filter((c) => c.id !== e.detail.info.id);
+        }
+        choices = next;
         // Desktop: disarm so a subsequent row interaction doesn't drag (handle must be
         // grabbed again). Mobile: dragDisabled ignores dragArmed, so this is a no-op.
         dragArmed = false;
@@ -128,6 +143,7 @@
         onfinalize={handleSort}
         class="choiceList"
         class:qa-nested={isNested}
+        class:qa-folder-empty={isEmptyFolder}
         class:qa-empty={choices.length === 0}>
     {#each stripShadow(choices) as choice (choice.id)}
         <!-- Flip wrapper: the dndzone's direct child = the animated/draggable item.
@@ -201,17 +217,22 @@
     border-color: var(--interactive-accent);
 }
 
-/* Empty folder: a GENEROUS, stable drop target. No row ever previews in during a
-   drag — the dnd shadow placeholder is stripped (stripShadow) so choices stays [] until
-   release — so the band can be comfortably large with zero reflow, making it an easy
-   target to land in (a thin band made it feel like a moving/precision target). */
-.choiceList.qa-nested.qa-empty {
+/* Empty folder: a GENEROUS, STABLE drop target. The band is sized by the folder's
+   PERSISTED emptiness (qa-folder-empty), NOT the live `choices` length — so when a
+   dragged item is previewed into the zone (filling `choices`, toggling qa-empty off)
+   the band keeps its height instead of collapsing/expanding under the cursor (the
+   "jumps all over the place"). Only persisted-empty folders get it, so populated
+   folders never heave at drag start. */
+.choiceList.qa-nested.qa-folder-empty {
     min-height: 3rem;
     display: flex;
     align-items: center;
 }
 
-.choiceList.qa-nested.qa-empty::after {
+/* Hint shows only when the folder is persisted-empty AND nothing is previewed in it
+   (qa-empty = live `choices` empty), so it cleanly swaps out for the previewed row
+   without changing the band's size. */
+.choiceList.qa-nested.qa-folder-empty.qa-empty::after {
     content: "Empty — add a choice or drag one here.";
     color: var(--text-muted);
     font-size: var(--font-ui-smaller, 12px);

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -14,6 +14,7 @@
 		duplicateChoice,
 		addChoiceToTree,
 		moveChoice as moveChoiceService,
+		removeChoiceById,
 		setFolderChildrenById,
 		setMultiCollapsedById,
 	} from "../../services/choiceService";
@@ -168,17 +169,12 @@
 		const userConfirmed = await deleteChoiceWithConfirmation(choice, app);
 		if (!userConfirmed) return;
 
-		// Remove choice from array (including nested choices)
-		choices = choices.filter((value) => removeChoiceHelper(choice.id, value));
+		// Immutable removal at any depth — so the delete is reactive on the runes
+		// $state array without relying on the top-array reassignment to heal an
+		// in-place nested mutation (which would silently fail for a nested-only delete).
+		choices = removeChoiceById(choices, choice.id).updated;
 		commandRegistry.disableCommand(choice);
 		save();
-	}
-
-	function removeChoiceHelper(id: string, value: IChoice): boolean {
-		if (isMultiChoice(value)) {
-			value.choices = value.choices.filter((v) => removeChoiceHelper(id, v));
-		}
-		return value.id !== id;
 	}
 
 	async function handleConfigureChoice(oldChoice: IChoice) {

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -14,6 +14,7 @@
 		duplicateChoice,
 		addChoiceToTree,
 		moveChoice as moveChoiceService,
+		setFolderChildrenById,
 		setMultiCollapsedById,
 	} from "../../services/choiceService";
 	import type { ChoiceType } from "../../types/choices/choiceType";
@@ -243,6 +244,15 @@
 		save();
 	}
 
+	// Commit a folder's children by id into ChoiceView's authoritative tree. A nested
+	// drag/reorder calls this rather than relying on its (cross-zone-stale) `choice`
+	// reference — finding the folder by id keeps the edit on the real live node, which
+	// is what fixes the root<->folder drag duplication. See onCommitFolder.
+	function handleCommitFolder(folderId: string, children: IChoice[]) {
+		choices = setFolderChildrenById(choices, folderId, children);
+		save();
+	}
+
 	// Reassign the tree immutably (by id, any depth) so the collapse is REACTIVE —
 	// an in-place `choice.collapsed = …` isn't tracked until the array is proxied by
 	// a reassignment, which is why folders wouldn't toggle on first render. save()
@@ -266,6 +276,7 @@
 		onReorderChoices: handleReorderChoices,
 		onAddChoice: addChoiceToList,
 		onToggleCollapsed: handleToggleCollapsed,
+		onCommitFolder: handleCommitFolder,
 	};
 
 	async function openAISettings() {

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -153,6 +153,7 @@
                     {app}
                     roots={roots}
                     choices={choice.choices}
+                    nested={true}
                     isEmptyFolder={choice.choices.length === 0}
                     {forceDragDisabled}
                     rootReorder={rootReorder ?? actions.onReorderChoices}

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -235,8 +235,23 @@
         border-radius: var(--radius-s, 4px);
     }
 
+    /* The drop-into-folder ring is RESERVED at rest (transparent) so a drag only
+       swaps its COLOUR — zero layout reflow, so the tree never heaves when you grab
+       something. outline-offset is NEGATIVE (drawn inside the box) because the
+       settings container is overflow-x:hidden and a positive offset would clip the
+       ring at the zone's right edge. The colour swap lives in the :has() rule below. */
     .nestedChoiceList {
         padding-left: 25px;
+        border-radius: var(--radius-m);
+        outline: 2px dashed transparent;
+        outline-offset: -2px;
+        transition: outline-color 120ms ease, background-color 120ms ease;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .nestedChoiceList {
+            transition: none;
+        }
     }
 
     /* The per-folder add-row is the folder's own affordance: one spacing step
@@ -253,19 +268,13 @@
         margin-top: 0;
     }
 
-    /* While a choice is dragged, ring the WHOLE nested folder area (items + hint +
-       add links) — not the folder row, and not the thin items zone — with a little
-       padding so the dashed ring sits OFF the content instead of hugging it. Scoped
-       to the folder's OWN inner list (`> .choiceList`) so a grandchild zone can't
-       light up an ancestor. :global() wraps the runtime class (it's on the child
-       ChoiceList's element, outside this component's scope). */
+    /* Drag active: colour-only swap of the reserved ring + a tint over the whole
+       nested folder area (items + hint + add links). NO box-model change -> no
+       reflow. Scoped to the folder's OWN inner list (`> .choiceList`) so a grandchild
+       zone can't light up an ancestor. :global() wraps the runtime class (it's on the
+       child ChoiceList's element, outside this component's scope). */
     .nestedChoiceList:has(> :global(.choiceList.qa-folder-droptarget)) {
-        padding-top: 6px;
-        padding-right: 6px;
-        padding-bottom: 6px;
-        outline: 2px dashed var(--interactive-accent);
-        outline-offset: 2px;
-        border-radius: var(--radius-m);
+        outline-color: var(--interactive-accent);
         background-color: var(--background-modifier-hover);
     }
 

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -235,23 +235,12 @@
         border-radius: var(--radius-s, 4px);
     }
 
-    /* The drop-into-folder ring is RESERVED at rest (transparent) so a drag only
-       swaps its COLOUR — zero layout reflow, so the tree never heaves when you grab
-       something. outline-offset is NEGATIVE (drawn inside the box) because the
-       settings container is overflow-x:hidden and a positive offset would clip the
-       ring at the zone's right edge. The colour swap lives in the :has() rule below. */
+    /* Just the indent — the drop-into-folder ring is drawn on the ACTUAL dndzone
+       (.choiceList, in ChoiceList.svelte) so the highlighted area equals the
+       droppable area (WYSIWYG); it is NOT drawn on this wrapper, which extends past
+       the zone to the add-row/hint. */
     .nestedChoiceList {
         padding-left: 25px;
-        border-radius: var(--radius-m);
-        outline: 2px dashed transparent;
-        outline-offset: -2px;
-        transition: outline-color 120ms ease, background-color 120ms ease;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        .nestedChoiceList {
-            transition: none;
-        }
     }
 
     /* The per-folder add-row is the folder's own affordance: one spacing step
@@ -266,16 +255,6 @@
 
     .nestedAddRow.emptyFolder {
         margin-top: 0;
-    }
-
-    /* Drag active: colour-only swap of the reserved ring + a tint over the whole
-       nested folder area (items + hint + add links). NO box-model change -> no
-       reflow. Scoped to the folder's OWN inner list (`> .choiceList`) so a grandchild
-       zone can't light up an ancestor. :global() wraps the runtime class (it's on the
-       child ChoiceList's element, outside this component's scope). */
-    .nestedChoiceList:has(> :global(.choiceList.qa-folder-droptarget)) {
-        outline-color: var(--interactive-accent);
-        background-color: var(--background-modifier-hover);
     }
 
     /* Faint, non-interactive empty-folder hint — advertises the add links below it

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -153,6 +153,7 @@
                     {app}
                     roots={roots}
                     choices={choice.choices}
+                    isEmptyFolder={choice.choices.length === 0}
                     {forceDragDisabled}
                     rootReorder={rootReorder ?? actions.onReorderChoices}
                     actions={nestedActions}

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -160,6 +160,11 @@
                         class="nestedAddRow"
                         class:emptyFolder={choice.choices.length === 0}
                     >
+                        {#if choice.choices.length === 0}
+                            <p class="emptyFolderHint">
+                                Empty — add a choice or drag one here.
+                            </p>
+                        {/if}
                         <AddChoiceControls
                             compact
                             targetFolderId={choice.id}
@@ -239,5 +244,29 @@
 
     .nestedAddRow.emptyFolder {
         margin-top: 0;
+    }
+
+    /* Project the active drop-target onto the folder ROW so the whole folder (row +
+       its inner zone) reads as one "drop here" target — important for empty folders
+       whose inner zone is a thin sliver. Scoped to the folder's OWN inner list via
+       `+ .nestedChoiceList > .choiceList` so a grandchild zone can't light up an
+       ancestor row. A tint only (the nested zone owns the dashed ring), so the two
+       don't read as competing boxes. :global() wraps the runtime-applied class. */
+    .multiChoiceListItem:has(
+        + .nestedChoiceList > :global(.choiceList.qa-folder-droptarget)
+    ) {
+        background-color: var(--background-modifier-hover);
+        border-radius: var(--radius-m);
+    }
+
+    /* Faint, non-interactive empty-folder hint — advertises the add links below it
+       and the new drag-into-folder path. */
+    .emptyFolderHint {
+        margin: 0 0 6px 0;
+        color: var(--text-muted);
+        font-size: var(--font-ui-smaller, 12px);
+        font-style: italic;
+        line-height: 1.3;
+        user-select: none;
     }
 </style>

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -74,16 +74,23 @@
     }
 
     // Nested children reordered: write the new order back to this Multi choice (the
-    // choice object is shared with the root tree, so this mutates in place), then
-    // persist the whole root tree via the TOP-LEVEL handler. Routing through
-    // `rootReorder` — NOT `actions.onReorderChoices`, which inside a nested Multi is
-    // an ancestor's override that would overwrite ITS children with the root array —
-    // keeps reorder correct at any nesting depth (fixes depth >= 2 data loss).
+    // choice object is shared with the root tree, so this mutates it in place), then
+    // COMMIT the tree via the top-level onCommit, which re-persists ChoiceView's own
+    // authoritative `choices`. We must NOT reassign it from `[...roots]` here: in a
+    // cross-zone drag (root <-> folder) svelte-dnd fires two synchronous finalizes,
+    // and the `roots` prop lags the source of truth within that tick — reassigning
+    // from it overwrote the folder's emptying and duplicated the dragged item.
     const nestedActions: ChoiceListActions = {
         ...untrack(() => actions),
         onReorderChoices: (reordered: IChoice[]) => {
+            // In-place edit keeps cross-zone IN consistent: the root zone's finalize
+            // reassigns from svelte-dnd's items, which reference THIS same folder
+            // object, so it must already carry the new children.
             choice.choices = reordered;
-            (rootReorder ?? actions.onReorderChoices)([...roots]);
+            // AND commit by id against the authoritative tree: on cross-zone OUT the
+            // root finalize reassigns the tree FIRST, leaving `choice` stale — by-id
+            // lands the edit on the real live folder node (fixes duplication).
+            actions.onCommitFolder(choice.id, reordered);
         },
     };
 

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -163,15 +163,7 @@
                      Hidden while filtering (the filtered tree is a clone that
                      must not be persisted). -->
                 {#if !forceDragDisabled}
-                    <div
-                        class="nestedAddRow"
-                        class:emptyFolder={choice.choices.length === 0}
-                    >
-                        {#if choice.choices.length === 0}
-                            <p class="emptyFolderHint">
-                                Empty — add a choice or drag one here.
-                            </p>
-                        {/if}
+                    <div class="nestedAddRow">
                         <AddChoiceControls
                             compact
                             targetFolderId={choice.id}
@@ -244,27 +236,11 @@
     }
 
     /* The per-folder add-row is the folder's own affordance: one spacing step
-       (8px) tighter than the 12px inter-row rhythm so it reads as "belongs to
-       this folder", but with real breathing room (2px cramped it). An EMPTY folder
-       gets that same 8px from its drop-zone padding (ChoiceList), so the add-row
-       sits flush there (margin 0) — identical 8px gap whether empty or populated,
-       and the empty drop target stays a usable 8px instead of collapsing. */
+       (8px) tighter than the 12px inter-row rhythm so it reads as "belongs to this
+       folder". An empty folder's add-row sits below the drop band (ChoiceList's
+       .qa-empty, which now owns the "Empty — …" hint as pseudo-content), getting
+       the same 8px gap as a populated one. */
     .nestedAddRow {
         margin: 8px 0 0 0;
-    }
-
-    .nestedAddRow.emptyFolder {
-        margin-top: 0;
-    }
-
-    /* Faint, non-interactive empty-folder hint — advertises the add links below it
-       and the new drag-into-folder path. */
-    .emptyFolderHint {
-        margin: 0 0 6px 0;
-        color: var(--text-muted);
-        font-size: var(--font-ui-smaller, 12px);
-        font-style: italic;
-        line-height: 1.3;
-        user-select: none;
     }
 </style>

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import ObsidianIcon from "../components/ObsidianIcon.svelte";
+    import { stopDragInit } from "../shared/stopDragInit";
     import AddChoiceControls from "./AddChoiceControls.svelte";
     import ChoiceList from "./ChoiceList.svelte";
     import type IMultiChoice from "../../types/choices/IMultiChoice";
@@ -117,6 +118,7 @@
             class="multiChoiceListItemName"
             aria-expanded={!choice.collapsed}
             aria-label={`Toggle ${choice.name}`}
+            use:stopDragInit
             onclick={toggleCollapsed}
         >
             <span
@@ -221,6 +223,9 @@
         color: inherit;
         text-align: left;
         cursor: pointer;
+        /* Suppress double-tap-zoom + its click delay on touch — proper touch hygiene
+           for a tap target, and reduces the ghost-click the dedupe above also guards. */
+        touch-action: manipulation;
     }
 
     .multiChoiceListItemName:focus-visible {

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -246,17 +246,20 @@
         margin-top: 0;
     }
 
-    /* Project the active drop-target onto the folder ROW so the whole folder (row +
-       its inner zone) reads as one "drop here" target — important for empty folders
-       whose inner zone is a thin sliver. Scoped to the folder's OWN inner list via
-       `+ .nestedChoiceList > .choiceList` so a grandchild zone can't light up an
-       ancestor row. A tint only (the nested zone owns the dashed ring), so the two
-       don't read as competing boxes. :global() wraps the runtime-applied class. */
-    .multiChoiceListItem:has(
-        + .nestedChoiceList > :global(.choiceList.qa-folder-droptarget)
-    ) {
-        background-color: var(--background-modifier-hover);
+    /* While a choice is dragged, ring the WHOLE nested folder area (items + hint +
+       add links) — not the folder row, and not the thin items zone — with a little
+       padding so the dashed ring sits OFF the content instead of hugging it. Scoped
+       to the folder's OWN inner list (`> .choiceList`) so a grandchild zone can't
+       light up an ancestor. :global() wraps the runtime class (it's on the child
+       ChoiceList's element, outside this component's scope). */
+    .nestedChoiceList:has(> :global(.choiceList.qa-folder-droptarget)) {
+        padding-top: 6px;
+        padding-right: 6px;
+        padding-bottom: 6px;
+        outline: 2px dashed var(--interactive-accent);
+        outline-offset: 2px;
         border-radius: var(--radius-m);
+        background-color: var(--background-modifier-hover);
     }
 
     /* Faint, non-interactive empty-folder hint — advertises the add links below it

--- a/src/gui/choiceList/choiceListActions.ts
+++ b/src/gui/choiceList/choiceListActions.ts
@@ -28,6 +28,15 @@ export interface ChoiceListActions {
 	 */
 	onToggleCollapsed: (choice: IChoice) => void;
 	/**
+	 * Commit a folder's new children by id against ChoiceView's authoritative tree.
+	 * A nested reorder/drag uses this instead of mutating a `choice` prop reference:
+	 * within a synchronous cross-zone drag finalize the root zone reassigns the tree
+	 * first, so the folder zone's `choice` goes stale (points at a folder no longer
+	 * in the live tree) — by-id keeps the edit landing on the real node, fixing the
+	 * root<->folder drag duplication.
+	 */
+	onCommitFolder: (folderId: string, children: IChoice[]) => void;
+	/**
 	 * Add a new choice. `targetFolderId` inserts it into that folder (root when
 	 * omitted); `skipConfigure` suppresses the post-add builder. Threaded from the
 	 * top-level ChoiceView handler so it persists the whole root tree (the same

--- a/src/gui/choiceList/cmpLifecycle.test.ts
+++ b/src/gui/choiceList/cmpLifecycle.test.ts
@@ -21,6 +21,7 @@ const actions = (): ChoiceListActions => ({
 	onReorderChoices: vi.fn(),
 	onAddChoice: vi.fn(),
 	onToggleCollapsed: vi.fn(),
+	onCommitFolder: vi.fn(),
 });
 const noop = () => {};
 

--- a/src/gui/components/IconButton.svelte
+++ b/src/gui/components/IconButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import ObsidianIcon from "./ObsidianIcon.svelte";
+    import { stopDragInit } from "../shared/stopDragInit";
 
     // Shared accessible icon button. Renders a real <button> so it is keyboard
     // operable (Enter + Space) and focusable for free — replacing the old
@@ -43,6 +44,7 @@
     {title}
     {disabled}
     onclick={onclick}
+    use:stopDragInit
 >
     <ObsidianIcon {iconId} {size} />
 </button>

--- a/src/gui/shared/dndReorder.ts
+++ b/src/gui/shared/dndReorder.ts
@@ -1,9 +1,13 @@
 import { SHADOW_PLACEHOLDER_ITEM_ID } from "svelte-dnd-action";
+import { transformDragPill } from "./dragPill";
 
 /** Anything svelte-dnd-action can reorder in QuickAdd: it has a stable string id. */
 export interface Reorderable {
 	id: string;
 }
+
+/** A QuickAdd drag item: reorderable, with a display name and a type discriminator. */
+type DragItem = Reorderable & { name?: string; type?: string };
 
 /**
  * Remove svelte-dnd-action's internal shadow-placeholder item, returning a NEW
@@ -26,4 +30,49 @@ export function replaceById<T extends Reorderable>(
 	next: T,
 ): T[] {
 	return items.map((item) => (item.id === next.id ? next : item));
+}
+
+/**
+ * Shared svelte-dnd-action options for QuickAdd's two drag zones (choices view + macro
+ * builder). These options are COUPLED and must move together (see dragPill.ts):
+ *  - morphDisabled:true  <-> the custom pill (else the lib re-inflates the clone to
+ *    full-row width every consider tick and fights the pill),
+ *  - centreDraggedOnCursor:false (explicit) + useCursorForDetection:true — the pill is
+ *    small and cursor-anchored, so the hit-test follows the cursor and we must NOT yank
+ *    the full-row box onto it,
+ *  - dropTargetStyle:{} hands the active-drop highlight entirely to CSS,
+ *  - autoAriaDisabled:true removes the lib's SR roles/alerts — each zone OWES its own
+ *    (see the alertToScreenReader calls on keyboard reorder),
+ *  - zoneItemTabIndex:-1 keeps rows out of the tab order,
+ *  - delayTouchStart gates touch drags (desktop is gated by the dragArmed handle).
+ * Per-zone overrides: items, dragDisabled, type, dropTargetClasses, flipDurationMs (kept
+ * in sync with animate:flip), and resolveLabel (the pill text — defaults to item.name;
+ * the macro builder passes getCommandDisplayName, since a command's `.name` differs from
+ * its rendered label for Choice/Conditional commands).
+ */
+export function baseDndOptions<T extends DragItem>(opts: {
+	items: T[];
+	dragDisabled: boolean;
+	resolveLabel?: (item: T) => string;
+	type?: string;
+	dropTargetClasses?: string[];
+	flipDurationMs?: number;
+}) {
+	const resolveLabel = opts.resolveLabel ?? ((item: T) => item.name ?? "");
+	return {
+		items: opts.items,
+		dragDisabled: opts.dragDisabled,
+		flipDurationMs: opts.flipDurationMs ?? 0,
+		morphDisabled: true,
+		useCursorForDetection: true,
+		centreDraggedOnCursor: false,
+		transformDraggedElement: (el?: HTMLElement, data?: T) =>
+			transformDragPill(el, data ? resolveLabel(data) : "", data?.type === "Multi"),
+		dropTargetStyle: {},
+		dropTargetClasses: opts.dropTargetClasses ?? [],
+		autoAriaDisabled: true,
+		zoneItemTabIndex: -1,
+		delayTouchStart: 200,
+		...(opts.type ? { type: opts.type } : {}),
+	};
 }

--- a/src/gui/shared/dragArming.svelte.ts
+++ b/src/gui/shared/dragArming.svelte.ts
@@ -1,0 +1,56 @@
+/**
+ * The desktop "arm drag by grabbing the handle" state machine, shared by the choices
+ * list and the macro builder so they can't drift (and so both carry the click-swallow
+ * FAILSAFE). On desktop a row is only draggable once its handle is pressed (armed);
+ * mobile is gated separately by delayTouchStart, so callers fold `armed` into their own
+ * `dragDisabled` derived alongside isMobile / forceDragDisabled.
+ *
+ * The failsafe: arming flips the zone draggable on the handle's pointerdown, but a press
+ * that never becomes a drag (a stray click/tap on the handle) leaves svelte-dnd-action
+ * with no `finalize` to fire — so the zone would stay draggable and the library would
+ * SWALLOW the next row-button click. We disarm on the next pointer release UNLESS a real
+ * drag started (markStarted, called from the zone's consider handler, hands the disarm
+ * to the finalize/reset path). Capture phase so a stopPropagation in the library's own
+ * handlers can't hide the release.
+ *
+ * Usage: `const drag = createDragArming();`
+ *  - dragDisabled (component derived): `forceDragDisabled || (!isMobile && !drag.armed)`
+ *  - startDrag (handle pointerdown): `drag.startDrag()`
+ *  - consider handler: `drag.markStarted()`
+ *  - finalize handler: `drag.reset()`
+ */
+export function createDragArming() {
+	let armed = $state(false);
+	// Non-reactive: did arming become a real drag (a `consider` fired)? Tells the
+	// failsafe whether the finalize/reset path already owns the disarm.
+	let started = false;
+
+	function startDrag() {
+		armed = true;
+		started = false;
+		const disarm = () => {
+			window.removeEventListener("pointerup", disarm, true);
+			window.removeEventListener("pointercancel", disarm, true);
+			if (!started) armed = false;
+		};
+		window.addEventListener("pointerup", disarm, true);
+		window.addEventListener("pointercancel", disarm, true);
+	}
+
+	return {
+		/** Reactive: is a desktop drag currently armed (handle pressed)? */
+		get armed() {
+			return armed;
+		},
+		/** Call from the dndzone's consider handler — a genuine drag is underway. */
+		markStarted() {
+			started = true;
+		},
+		/** Call from the dndzone's finalize handler — disarm after a completed drag. */
+		reset() {
+			armed = false;
+			started = false;
+		},
+		startDrag,
+	};
+}

--- a/src/gui/shared/dragPill.ts
+++ b/src/gui/shared/dragPill.ts
@@ -12,19 +12,23 @@ const GRIP_SVG =
 	'<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="5" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="19" r="1"/></svg>';
 
 /**
- * dndzone `transformDraggedElement` handler: build/refresh the compact drag pill.
- * The library invokes this on every consider tick, so the pill node is created once
- * and reused (only its label text is updated). `data` is the dragged item; we read
- * its name (shown as text — no markdown render, auto-escaped) and whether it is a
- * folder (Multi) for the differentiated dashed-border styling.
+ * Build/refresh the compact drag pill. The library invokes the zone's
+ * `transformDraggedElement` on every consider tick, so the pill node is created once
+ * and reused (only its label text is updated). The caller passes a PRE-RESOLVED
+ * `label` — each zone owns its own label semantics (the choices zone uses the choice
+ * name; the macro builder must resolve via getCommandDisplayName, since a command's
+ * `.name` differs from its rendered label for Choice/Conditional commands). `label` is
+ * set as textContent (no markdown render, auto-escaped). `isMulti` draws the dashed
+ * folder variant — only meaningful for the choices zone (a command is never Multi).
  */
 export function transformDragPill(
 	el: HTMLElement | undefined,
-	data: { name?: string; type?: string } | undefined,
+	label: string,
+	isMulti = false,
 ): void {
-	if (!el || !data) return;
+	if (!el) return;
 	el.classList.add("qa-drag-clone");
-	el.dataset.qaMulti = data.type === "Multi" ? "true" : "false";
+	el.dataset.qaMulti = isMulti ? "true" : "false";
 
 	let pill = el.querySelector<HTMLDivElement>(":scope > .qa-drag-pill");
 	if (!pill) {
@@ -33,13 +37,12 @@ export function transformDragPill(
 		const grip = document.createElement("span");
 		grip.className = "qa-drag-pill-grip";
 		grip.innerHTML = GRIP_SVG; // static inline glyph — no Obsidian render pass
-		const label = document.createElement("span");
-		label.className = "qa-drag-pill-label";
-		pill.append(grip, label);
+		const labelEl = document.createElement("span");
+		labelEl.className = "qa-drag-pill-label";
+		pill.append(grip, labelEl);
 		el.appendChild(pill);
 	}
 
-	const label = pill.querySelector<HTMLSpanElement>(".qa-drag-pill-label");
-	const name = data.name ?? "";
-	if (label && label.textContent !== name) label.textContent = name;
+	const textEl = pill.querySelector<HTMLSpanElement>(".qa-drag-pill-label");
+	if (textEl && textEl.textContent !== label) textEl.textContent = label;
 }

--- a/src/gui/shared/dragPill.ts
+++ b/src/gui/shared/dragPill.ts
@@ -1,0 +1,45 @@
+// Turns svelte-dnd-action's full-row drag clone (#dnd-action-dragged-el) into a
+// compact pill that sits under the cursor — passed as a dndzone's
+// `transformDraggedElement`. Pairs with the #dnd-action-dragged-el / .qa-drag-pill
+// rules in styles.css (the clone is created by the library, so it can't be styled
+// from a Svelte-scoped <style>), and REQUIRES morphDisabled:true on the zone — else
+// the library re-inflates the clone to full-row width every consider tick (lib
+// index.js ~2094) and fights the pill. centreDraggedOnCursor MUST be off too: the
+// pill is the only visible thing, so there is no full-row ghost to "yank" onto the
+// cursor (the feedback that the grab "puts the cursor in the middle").
+
+const GRIP_SVG =
+	'<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="5" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="19" r="1"/></svg>';
+
+/**
+ * dndzone `transformDraggedElement` handler: build/refresh the compact drag pill.
+ * The library invokes this on every consider tick, so the pill node is created once
+ * and reused (only its label text is updated). `data` is the dragged item; we read
+ * its name (shown as text — no markdown render, auto-escaped) and whether it is a
+ * folder (Multi) for the differentiated dashed-border styling.
+ */
+export function transformDragPill(
+	el: HTMLElement | undefined,
+	data: { name?: string; type?: string } | undefined,
+): void {
+	if (!el || !data) return;
+	el.classList.add("qa-drag-clone");
+	el.dataset.qaMulti = data.type === "Multi" ? "true" : "false";
+
+	let pill = el.querySelector<HTMLDivElement>(":scope > .qa-drag-pill");
+	if (!pill) {
+		pill = document.createElement("div");
+		pill.className = "qa-drag-pill";
+		const grip = document.createElement("span");
+		grip.className = "qa-drag-pill-grip";
+		grip.innerHTML = GRIP_SVG; // static inline glyph — no Obsidian render pass
+		const label = document.createElement("span");
+		label.className = "qa-drag-pill-label";
+		pill.append(grip, label);
+		el.appendChild(pill);
+	}
+
+	const label = pill.querySelector<HTMLSpanElement>(".qa-drag-pill-label");
+	const name = data.name ?? "";
+	if (label && label.textContent !== name) label.textContent = name;
+}

--- a/src/gui/shared/stopDragInit.ts
+++ b/src/gui/shared/stopDragInit.ts
@@ -1,0 +1,29 @@
+/**
+ * Svelte action: stop this element's press from reaching svelte-dnd-action's per-item
+ * `mousedown`/`touchstart` listener (which lives directly on the draggable row).
+ *
+ * Why an action and not `onmousedown`/`ontouchstart` handlers: Svelte 5 DELEGATES those
+ * events to the document root, so a component handler runs only after the event has
+ * bubbled all the way up — i.e. AFTER it already passed through the draggable row and
+ * fired the library's listener there. A direct `addEventListener` on the control runs in
+ * the bubble phase AT the control, before the row's listener, so `stopPropagation` here
+ * actually prevents it.
+ *
+ * The point: an interactive control (icon button, folder toggle) is an ACTION, never a
+ * drag start. Without this, on touch the library treats the tap as a maybe-drag and, on
+ * touchend, REPLAYS a synthetic click (handleFalseAlarm, dist/index.js:1840) on top of
+ * the native click — firing the control TWICE (Duplicate makes two copies, a folder
+ * toggle opens-then-shuts). The drag handle is a SEPARATE button without this action, so
+ * dragging is unaffected. Inert outside a dndzone (no library listener to stop).
+ */
+export function stopDragInit(node: HTMLElement) {
+	const stop = (e: Event) => e.stopPropagation();
+	node.addEventListener("mousedown", stop);
+	node.addEventListener("touchstart", stop, { passive: true });
+	return {
+		destroy() {
+			node.removeEventListener("mousedown", stop);
+			node.removeEventListener("touchstart", stop);
+		},
+	};
+}

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -11,6 +11,7 @@ import type QuickAdd from "./main";
 import type IChoice from "./types/choices/IChoice";
 import ChoiceView from "./gui/choiceList/ChoiceView.svelte";
 import { mountComponent, type MountHandle } from "./gui/svelte/mountComponent";
+import type { Plain } from "./gui/svelte/persist.svelte";
 import { GenericTextSuggester } from "./gui/suggesters/genericTextSuggester";
 import GlobalVariablesView from "./gui/GlobalVariables/GlobalVariablesView.svelte";
 import { settingsStore } from "./settingsStore";
@@ -311,7 +312,11 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			app: this.app,
 			plugin: this.plugin,
 			choices: settingsStore.getState().choices,
-			saveChoices: (choices: IChoice[]) => {
+			// Typed Plain<IChoice[]> (not IChoice[]) so a forgotten $state.snapshot at
+			// the call site is a COMPILE error here — this is the real persistence sink
+			// that must never receive a live Svelte $state proxy. Plain<T> is assignable
+			// to T, so setState still accepts it.
+			saveChoices: (choices: Plain<IChoice[]>) => {
 				settingsStore.setState({ choices });
 			},
 		});

--- a/src/services/choiceService.insertIntoMulti.test.ts
+++ b/src/services/choiceService.insertIntoMulti.test.ts
@@ -7,6 +7,7 @@ vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
 import {
 	addChoiceToTree,
 	insertIntoMulti,
+	setFolderChildrenById,
 	setMultiCollapsedById,
 } from "./choiceService";
 import type IChoice from "../types/choices/IChoice";
@@ -131,5 +132,38 @@ describe("setMultiCollapsedById", () => {
 		const res = setMultiCollapsedById(roots, "missing", true);
 		expect(res.map((c) => c.id)).toEqual(["f1", "b"]);
 		expect((res[0] as IMultiChoice).collapsed).toBe(false);
+	});
+});
+
+describe("setFolderChildrenById", () => {
+	it("replaces a root folder's children immutably (siblings preserved by identity)", () => {
+		const sib = leaf("b", "B");
+		const roots: IChoice[] = [folder("f1", "F1", [leaf("a", "A")]), sib];
+
+		const res = setFolderChildrenById(roots, "f1", [leaf("x", "X")]);
+
+		expect((res[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["x"]);
+		expect(res[1]).toBe(sib);
+		// Original untouched.
+		expect((roots[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["a"]);
+	});
+
+	it("empties a folder by id at depth >= 2 (the cross-zone drag-OUT case)", () => {
+		const roots: IChoice[] = [
+			folder("f1", "F1", [folder("f2", "F2", [leaf("a", "A")])]),
+		];
+
+		const res = setFolderChildrenById(roots, "f2", []);
+
+		const f2 = (res[0] as IMultiChoice).choices[0] as IMultiChoice;
+		expect(f2.choices).toEqual([]);
+		// Ancestor intact.
+		expect((res[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["f2"]);
+	});
+
+	it("is a no-op when the folder id is absent", () => {
+		const roots: IChoice[] = [folder("f1", "F1", [leaf("a", "A")])];
+		const res = setFolderChildrenById(roots, "nope", []);
+		expect((res[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["a"]);
 	});
 });

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -233,7 +233,7 @@ function collectDescendantIds(multi: IMultiChoice): Set<string> {
 	return ids;
 }
 
-function removeChoiceById(
+export function removeChoiceById(
 	choices: IChoice[],
 	id: string,
 ): { updated: IChoice[]; removed?: IChoice } {
@@ -311,27 +311,34 @@ export function addChoiceToTree(
 }
 
 /**
- * Immutably set a Multi (folder)'s `collapsed` flag by id, anywhere in the tree —
- * only the touched branch is recreated, siblings keep their identity. Reassigning
- * the result into the choices `$state` is what makes a collapse toggle REACTIVE: an
- * in-place `choice.collapsed = …` mutation isn't tracked until the array has been
- * proxied by a reassignment, so on first render (the plain array mounted from the
- * store) the folder wouldn't visibly open/close until some later add/reorder/drag.
+ * Immutably update a Multi (folder) by id, anywhere in the tree: replace the folder
+ * whose id matches with `patch(folder)`, recreating only the touched branch (siblings
+ * keep their identity). Reassigning the result into the choices `$state` is what makes
+ * the edit REACTIVE — an in-place `folder.<field> = …` mutation isn't tracked until the
+ * array has been proxied by a reassignment, so on first render (the plain array mounted
+ * from the store) the change wouldn't show until some later reassignment. Shared walker
+ * behind setMultiCollapsedById / setFolderChildrenById.
  */
+export function updateMultiById(
+	choices: IChoice[],
+	id: string,
+	patch: (folder: IMultiChoice) => IMultiChoice,
+): IChoice[] {
+	return choices.map((c) => {
+		if (c.type !== "Multi") return c;
+		const mc = c as IMultiChoice;
+		if (mc.id === id) return patch(mc) as IChoice;
+		return { ...mc, choices: updateMultiById(mc.choices, id, patch) } as IChoice;
+	});
+}
+
+/** Immutably set a Multi (folder)'s `collapsed` flag by id (see updateMultiById). */
 export function setMultiCollapsedById(
 	choices: IChoice[],
 	id: string,
 	collapsed: boolean,
 ): IChoice[] {
-	return choices.map((c) => {
-		if (c.type !== "Multi") return c;
-		const mc = c as IMultiChoice;
-		if (mc.id === id) return { ...mc, collapsed } as IChoice;
-		return {
-			...mc,
-			choices: setMultiCollapsedById(mc.choices, id, collapsed),
-		} as IChoice;
-	});
+	return updateMultiById(choices, id, (mc) => ({ ...mc, collapsed }));
 }
 
 function expandMultiById(choices: IChoice[], id: string): IChoice[] {
@@ -344,19 +351,13 @@ function expandMultiById(choices: IChoice[], id: string): IChoice[] {
  * not by mutating a `choice` prop reference, which goes stale within a synchronous
  * cross-zone drag finalize (the root zone reassigns the tree first, so the folder
  * zone's `choice` no longer points at the folder in the live tree -> duplication).
+ * CO-DEPENDENT with the DROPPED_INTO_ANOTHER source-strip in ChoiceList.handleSort —
+ * the strip alone is insufficient at depth >= 2; both are load-bearing.
  */
 export function setFolderChildrenById(
 	choices: IChoice[],
 	folderId: string,
 	children: IChoice[],
 ): IChoice[] {
-	return choices.map((c) => {
-		if (c.type !== "Multi") return c;
-		const mc = c as IMultiChoice;
-		if (mc.id === folderId) return { ...mc, choices: children } as IChoice;
-		return {
-			...mc,
-			choices: setFolderChildrenById(mc.choices, folderId, children),
-		} as IChoice;
-	});
+	return updateMultiById(choices, folderId, (mc) => ({ ...mc, choices: children }));
 }

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -337,3 +337,26 @@ export function setMultiCollapsedById(
 function expandMultiById(choices: IChoice[], id: string): IChoice[] {
 	return setMultiCollapsedById(choices, id, false);
 }
+
+/**
+ * Immutably replace a Multi (folder)'s children by id, anywhere in the tree.
+ * Used to commit a nested drag/reorder against the AUTHORITATIVE root tree by id —
+ * not by mutating a `choice` prop reference, which goes stale within a synchronous
+ * cross-zone drag finalize (the root zone reassigns the tree first, so the folder
+ * zone's `choice` no longer points at the folder in the live tree -> duplication).
+ */
+export function setFolderChildrenById(
+	choices: IChoice[],
+	folderId: string,
+	children: IChoice[],
+): IChoice[] {
+	return choices.map((c) => {
+		if (c.type !== "Multi") return c;
+		const mc = c as IMultiChoice;
+		if (mc.id === folderId) return { ...mc, choices: children } as IChoice;
+		return {
+			...mc,
+			choices: setFolderChildrenById(mc.choices, folderId, children),
+		} as IChoice;
+	});
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1109,7 +1109,14 @@
    right edge = under the cursor. Built by transformDragPill (src/gui/shared/dragPill.ts);
    requires morphDisabled:true and centreDraggedOnCursor OFF on the zone. These live
    in styles.css (always global) because the clone is library-created — a Svelte
-   component-scoped selector would be flagged css_unused_selector. */
+   component-scoped selector would be flagged css_unused_selector.
+   KNOWN-FRAGILE: this couples to svelte-dnd-action internals (the #dnd-action-dragged-el
+   id, its translate3d cursor-tracking so the clone's RIGHT edge ~ the cursor, and the
+   morphDisabled/centreDraggedOnCursor:false config). It is NOT unit-testable (jsdom has
+   no layout) — re-verify the pill position MANUALLY in the dev vault on any
+   svelte-dnd-action upgrade or row-layout change (handle must stay the rightmost row
+   element). If the lib renames the id, these rules simply stop applying (the pill falls
+   back to the full-row clone — degraded, not broken). */
 #dnd-action-dragged-el.qa-drag-clone {
 	background: transparent !important;
 	border: none !important;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1098,6 +1098,78 @@
 	   drag-induced reflow over a full second — the main source of drag jitter. */
 }
 
+/* ---- Drag clone -> compact pill (replaces the full-row ghost) ----
+   svelte-dnd-action clones the dragged row into a position:fixed
+   #dnd-action-dragged-el and moves it via transform: translate3d(cursorDelta)
+   (lib index.js ~1648) while top/left stay at the ORIGINAL row rect — so the
+   clone's RIGHT edge tracks the cursor (the drag handle is the row's rightmost
+   element). We KEEP the clone's box width (collapsing it would snap the right edge
+   onto the LEFT edge, throwing the pill a full row-width off the cursor), make the
+   box invisible, hide the cloned row chrome, and draw a small pill anchored at the
+   right edge = under the cursor. Built by transformDragPill (src/gui/shared/dragPill.ts);
+   requires morphDisabled:true and centreDraggedOnCursor OFF on the zone. These live
+   in styles.css (always global) because the clone is library-created — a Svelte
+   component-scoped selector would be flagged css_unused_selector. */
+#dnd-action-dragged-el.qa-drag-clone {
+	background: transparent !important;
+	border: none !important;
+	box-shadow: none !important;
+	overflow: visible !important;
+	pointer-events: none;
+}
+
+/* Hide the cloned real row (name, buttons, handle, any nested list) — keep the pill. */
+#dnd-action-dragged-el.qa-drag-clone > *:not(.qa-drag-pill) {
+	display: none !important;
+}
+
+/* The pill: content-width, vertically centred on the grab Y (top:50%) and anchored
+   ~at the cursor (left:100% = clone's right edge ≈ handle; nudged 12px left so the
+   grip lands on the cursor). It extends right; the clone is position:fixed so it's
+   never clipped by the settings panel's overflow. */
+#dnd-action-dragged-el.qa-drag-clone .qa-drag-pill {
+	position: absolute;
+	left: 100%;
+	top: 50%;
+	transform: translate(-12px, -50%);
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	max-width: 260px;
+	padding: 4px 10px;
+	border-radius: var(--radius-m, 8px);
+	background: var(--background-secondary);
+	border: 1px solid var(--interactive-accent);
+	box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28);
+	color: var(--text-normal);
+	font-size: var(--font-ui-small, 13px);
+	line-height: 1.2;
+	white-space: nowrap;
+	cursor: grabbing;
+}
+
+#dnd-action-dragged-el.qa-drag-clone .qa-drag-pill-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#dnd-action-dragged-el.qa-drag-clone .qa-drag-pill-grip {
+	display: inline-flex;
+	color: var(--text-muted);
+	flex: 0 0 auto;
+}
+
+/* A folder (Multi) reads with a dashed border so dropping a folder is unambiguous. */
+#dnd-action-dragged-el.qa-drag-clone[data-qa-multi="true"] .qa-drag-pill {
+	border-style: dashed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	#dnd-action-dragged-el.qa-drag-clone {
+		transition: none !important;
+	}
+}
+
 
 .choiceListItemName {
 	flex: 1 0 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1094,7 +1094,8 @@
 	font-size: 16px;
 	align-items: center;
 	margin: 12px 0 0 0;
-	transition: 1000ms ease-in-out;
+	/* No `transition` here: an unnamed (all-property) 1s transition smeared every
+	   drag-induced reflow over a full second — the main source of drag jitter. */
 }
 
 


### PR DESCRIPTION
Two discoverability features for the choices view (follow-up to #1262; closes #1263).

### 1. Drag-into-folder highlight
Dragging a choice already moves it into a folder, but nothing signalled a folder was a valid drop target. Now, the moment a drag starts, every **nested folder zone** gets a dashed accent ring + tint and its **folder row** is tinted (via `:has()`), so the whole folder reads as one "drop here → moves inside" target. An empty folder's ~8px zone gets a `min-height` mid-drag so it's aimable.

- Mechanism: `svelte-dnd-action` `dropTargetClasses`, applied to all valid zones at drag-start. Confirmed against the library source (`styleActiveDropZones`).
- **Root never glows**: the class is gated on `isNested = rootReorder !== undefined` — the root list is mounted without `rootReorder`; nested lists always receive it (the same threaded prop the depth-≥2 reorder fix relies on).
- Not per-cursor (the library can't do that with this API); the existing **shadow placeholder** still shows the precise landing slot.
- `:global()` wraps the runtime-applied class (it never appears in markup); scoped anchors keep `svelte/valid-compile` happy.

### 2. Empty-folder hint
A faint `Empty — add a choice or drag one here.` line in empty folders — advertises both the add links and the new drag-in path.

### Decisions / scope
- **Collapsed folders**: render no nested zone, so dropping requires expanding first (accepted). Auto-expand-on-drag-hover is a noted follow-up (high risk: mid-drag DOM mutation + the drag-start-only class application).

### Verification
- svelte-check 0/0, eslint clean, build clean, 22 choiceList tests pass.
- Visual treatment verified **statically** by injecting the runtime class (screenshot in the design pass).
- ⚠️ **Real drag needs manual QA** — synthetic/CLI events can't drive a `svelte-dnd-action` drag.

Design pass run via a 4-agent workflow (3 lenses → synthesis); mechanism cross-checked against `node_modules/svelte-dnd-action`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual drop-target indicators for nested lists clarify where items can be dragged into folders
  * Helpful hint text shown in empty folders: "Empty — add a choice or drag one here."

* **Improvements**
  * Empty nested folders retain minimum height to stay usable as drag targets
  * Nested reorders persist correctly for inner folders without affecting others
  * Cursor-based drag detection and smoother flip animations for more accurate targeting
  * Removed long all-property transitions to reduce drag jitter and improve responsiveness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->