### PR TITLE
docs(template): clarify folder formatting and filename prompts

### DIFF
--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -12,12 +12,14 @@ If you want a new markdown note to include a live embedded Base dashboard, see
 [Template: Create an MOC Note with a Link Dashboard](/Examples/Template_CreateMOCNoteWithLinkDashboard.md).
 
 ## Optional
-**File Name Format**. You can specify a format for the file name, which is based on the format syntax - which you can see further down this page.
+**File Name Format**. You can specify a format for the file name, which is based on the [format syntax](/FormatSyntax.md).
 Basically, this allows you to have dynamic file names. If you wrote `£ {{DATE}} {{NAME}}`, it would translate to a file name like `£ 2021-06-12 Manually-Written-File-Name`, where `Manually-Written-File-Name` is a value you enter when invoking the template.
+If you disable **File Name Format**, QuickAdd uses `{{VALUE}}` as the file name format. This keeps the default behavior of prompting for a file name when you run the choice, with the same `{{VALUE}}` / `{{NAME}}` behavior described in the format syntax docs.
 
 **Create in folder**. In which folder should the file be created in.
 You can specify as many folders as you want. If you don't, it'll just create the file in the root directory. If you specify one folder, it'll automatically create the file in there.
 If you specify multiple folders, you'll get a suggester asking which of the folders you wish to create the file in.
+Folder paths also support QuickAdd [format syntax](/FormatSyntax.md), including `{{VALUE}}`, named values such as `{{VALUE:client}}`, dates, and global variables. For example, `Projects/{{VALUE:client}}/{{DATE:YYYY}}` prompts for a client and creates the file under that client's folder for the current year.
 
 **Append link**. The file you're currently in will get a link to a newly created file. Pick one of three modes:
 - **Enabled (requires active file)** – throw an error if no note is focused (legacy behavior)

--- a/docs/versioned_docs/version-2.12.3/Choices/TemplateChoice.md
+++ b/docs/versioned_docs/version-2.12.3/Choices/TemplateChoice.md
@@ -12,12 +12,14 @@ If you want a new markdown note to include a live embedded Base dashboard, see
 [Template: Create an MOC Note with a Link Dashboard](/Examples/Template_CreateMOCNoteWithLinkDashboard.md).
 
 ## Optional
-**File Name Format**. You can specify a format for the file name, which is based on the format syntax - which you can see further down this page.
+**File Name Format**. You can specify a format for the file name, which is based on the [format syntax](/FormatSyntax.md).
 Basically, this allows you to have dynamic file names. If you wrote `£ {{DATE}} {{NAME}}`, it would translate to a file name like `£ 2021-06-12 Manually-Written-File-Name`, where `Manually-Written-File-Name` is a value you enter when invoking the template.
+If you disable **File Name Format**, QuickAdd uses `{{VALUE}}` as the file name format. This keeps the default behavior of prompting for a file name when you run the choice, with the same `{{VALUE}}` / `{{NAME}}` behavior described in the format syntax docs.
 
 **Create in folder**. In which folder should the file be created in.
 You can specify as many folders as you want. If you don't, it'll just create the file in the root directory. If you specify one folder, it'll automatically create the file in there.
 If you specify multiple folders, you'll get a suggester asking which of the folders you wish to create the file in.
+Folder paths also support QuickAdd [format syntax](/FormatSyntax.md), including `{{VALUE}}`, named values such as `{{VALUE:client}}`, dates, and global variables. For example, `Projects/{{VALUE:client}}/{{DATE:YYYY}}` prompts for a client and creates the file under that client's folder for the current year.
 
 **Append link**. The file you're currently in will get a link to a newly created file. Pick one of three modes:
 - **Enabled (requires active file)** – throw an error if no note is focused (legacy behavior)


### PR DESCRIPTION
Clarify two Template Choice behaviors that came up during issue cleanup.

This documents that Template Choice folder paths use QuickAdd format syntax, including `{{VALUE}}` and named values, and that disabling File Name Format keeps the default filename prompt via `{{VALUE}}`.

Updated both Next docs and the latest `2.12.3` versioned snapshot.

Refs #117
Refs #1115

Validation:
- `cd docs && bun install --frozen-lockfile`
- `cd docs && bun run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified File Name Format behavior in Template Choice optional settings.
  * Expanded Create in folder documentation to include support for QuickAdd format syntax, including dynamic values (e.g., `{{VALUE:client}}`), date tokens, and global variables.
  * Added illustrative example showing folder path customization with dynamic naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->