### PR TITLE
docs(install): update manual release asset instructions

### DIFF
--- a/docs/docs/ManualInstallation.md
+++ b/docs/docs/ManualInstallation.md
@@ -2,7 +2,18 @@
 title: Manual Installation
 ---
 
-1. Go to [Releases](https://github.com/chhoumann/quickadd/releases) and download the ZIP file from the latest release. The one that looks like `quickadd-x.x.x.zip`.
-2. This ZIP file should be extracted in your Obsidian plugins folder. If you don't know where that is, you can go to `Community Plugins` inside Obsidian. There is a folder icon on the right of `Installed Plugins`. Click that and it opens your plugins folder.
-3. Extract the contents of the ZIP file there.
-4. Now you should have a folder in plugins called 'quickadd' containing a `main.js` file, `manifest.json` file, and a `styles.css` file.
+1. Go to [Releases](https://github.com/chhoumann/quickadd/releases) and open the latest release.
+2. Download the release assets. If there is a ZIP file named like `quickadd-x.x.x.zip`, download that. If the release lists loose files instead, download `main.js`, `manifest.json`, and `styles.css`.
+3. Open your Obsidian plugins folder. If you don't know where that is, go to `Community Plugins` inside Obsidian. There is a folder icon on the right of `Installed Plugins`. Click that and it opens your plugins folder.
+4. Create a folder named `quickadd` inside the plugins folder.
+5. Extract the ZIP file into `.obsidian/plugins/quickadd/`, or copy the loose `main.js`, `manifest.json`, and `styles.css` files into `.obsidian/plugins/quickadd/`.
+
+Do not place `main.js`, `manifest.json`, or `styles.css` directly in `.obsidian/plugins/`. They must be inside the `quickadd` folder.
+
+When finished, your vault should contain these files:
+
+```text
+.obsidian/plugins/quickadd/main.js
+.obsidian/plugins/quickadd/manifest.json
+.obsidian/plugins/quickadd/styles.css
+```

--- a/docs/versioned_docs/version-2.12.3/ManualInstallation.md
+++ b/docs/versioned_docs/version-2.12.3/ManualInstallation.md
@@ -2,7 +2,18 @@
 title: Manual Installation
 ---
 
-1. Go to [Releases](https://github.com/chhoumann/quickadd/releases) and download the ZIP file from the latest release. The one that looks like `quickadd-x.x.x.zip`.
-2. This ZIP file should be extracted in your Obsidian plugins folder. If you don't know where that is, you can go to `Community Plugins` inside Obsidian. There is a folder icon on the right of `Installed Plugins`. Click that and it opens your plugins folder.
-3. Extract the contents of the ZIP file there.
-4. Now you should have a folder in plugins called 'quickadd' containing a `main.js` file, `manifest.json` file, and a `styles.css` file.
+1. Go to [Releases](https://github.com/chhoumann/quickadd/releases) and open the latest release.
+2. Download the release assets. If there is a ZIP file named like `quickadd-x.x.x.zip`, download that. If the release lists loose files instead, download `main.js`, `manifest.json`, and `styles.css`.
+3. Open your Obsidian plugins folder. If you don't know where that is, go to `Community Plugins` inside Obsidian. There is a folder icon on the right of `Installed Plugins`. Click that and it opens your plugins folder.
+4. Create a folder named `quickadd` inside the plugins folder.
+5. Extract the ZIP file into `.obsidian/plugins/quickadd/`, or copy the loose `main.js`, `manifest.json`, and `styles.css` files into `.obsidian/plugins/quickadd/`.
+
+Do not place `main.js`, `manifest.json`, or `styles.css` directly in `.obsidian/plugins/`. They must be inside the `quickadd` folder.
+
+When finished, your vault should contain these files:
+
+```text
+.obsidian/plugins/quickadd/main.js
+.obsidian/plugins/quickadd/manifest.json
+.obsidian/plugins/quickadd/styles.css
+```


### PR DESCRIPTION
Update manual installation docs to match current release assets.

The latest release publishes loose `main.js`, `manifest.json`, and `styles.css` assets rather than a zip-only flow. This updates the docs to handle either asset style and warns users not to place loose files directly in `.obsidian/plugins/`; they must live under `.obsidian/plugins/quickadd/`.

Updated both Next docs and the latest `2.12.3` versioned snapshot.

Refs #1163

Validation:
- `cd docs && bun install --frozen-lockfile`
- `cd docs && bun run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Manual Installation documentation with clearer step-by-step procedures for downloading and installing the plugin from GitHub releases (both ZIP packages and individual files).
  * Added explicit warnings about correct folder placement and a checklist of expected installed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->