### PR TITLE
docs(macros): clarify user script discovery

### DIFF
--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -74,14 +74,31 @@ In the Macro Builder, you can add different types of commands:
 Macros do not contain JavaScript code directly. Your code lives in a `.js` file
 inside your vault, and the macro simply runs that file.
 
-Create a new script file such as `scripts/my-macro.js` and make sure it is not
-inside `.obsidian` or any folder whose name starts with a dot. QuickAdd ignores
-scripts in those locations, so they will not show up in the script picker.
+Create a new script file such as `scripts/my-macro.js`. Make sure the file is
+really a JavaScript file whose name ends in `.js`. If you create it from inside
+Obsidian, check that Obsidian did not create a Markdown note named
+`my-macro.js.md`; QuickAdd only discovers files ending in `.js`.
 
-Open the Macro Builder, add a **User Script** command, and select your script
-file. If the script exports multiple functions, QuickAdd will ask which export
-to run. You can also set an output variable name so later commands can reuse the
-result.
+Keep the script inside your vault, but not inside `.obsidian` or any folder
+whose name starts with a dot. Obsidian may exclude hidden folders from its file
+index, and QuickAdd builds the picker from Obsidian's indexed vault files. Use a
+normal folder such as `scripts/` or a visible underscore-prefixed folder such as
+`_quickadd/scripts/`.
+
+Open the Macro Builder and add a **User Script** command. The **Browse** button
+opens QuickAdd's script picker, not a native file picker. It searches the `.js`
+files Obsidian has already discovered in the vault, so it cannot pick files
+outside the vault, files hidden from Obsidian's index, or files whose extension
+is really `.md`.
+
+You can also type the script into the text field and click **Add**. Type the
+script basename, not a vault-relative path: for `scripts/my-macro.js`, enter
+`my-macro`. To run a specific exported member, append it with `::`, such as
+`my-macro::start`. Do not enter `scripts/my-macro.js` in the manual field.
+
+If the script exports multiple functions and you do not specify a member,
+QuickAdd will ask which export to run. You can also set an output variable name
+so later commands can reuse the result.
 
 If your goal is to insert text into a note, use a **Template** or **Capture**
 choice and run it from the macro using a **Nested Choice** command. This is the

--- a/docs/docs/UserScripts.md
+++ b/docs/docs/UserScripts.md
@@ -11,6 +11,20 @@ User scripts are JavaScript files that extend QuickAdd's functionality with cust
 
 > **Obsidian API Reference**: This guide references the [Obsidian API](https://docs.obsidian.md/Home). Familiarize yourself with the [App](https://docs.obsidian.md/Reference/TypeScript+API/App), [Vault](https://docs.obsidian.md/Reference/TypeScript+API/Vault), and [Workspace](https://docs.obsidian.md/Reference/TypeScript+API/Workspace) modules for advanced scripting.
 
+## Adding Scripts to Macros
+
+User scripts must be real `.js` files inside your vault. Avoid `.obsidian` and
+hidden dot-folders such as `.scripts`, because Obsidian may exclude them from
+the vault file index QuickAdd uses for script discovery. If you create a script
+from inside Obsidian, confirm the file did not become a Markdown note such as
+`script.js.md`.
+
+In the Macro Builder, **Browse** opens QuickAdd's picker of discovered `.js`
+files; it is not a native file picker. If you add a script manually, type the
+script basename, not the relative path. For `scripts/my-script.js`, enter
+`my-script`; for a specific export, enter a member expression such as
+`my-script::start`.
+
 ## Basic Structure
 
 Every user script must export a module with at least an entry point function:

--- a/docs/versioned_docs/version-2.12.3/Choices/MacroChoice.md
+++ b/docs/versioned_docs/version-2.12.3/Choices/MacroChoice.md
@@ -74,14 +74,31 @@ In the Macro Builder, you can add different types of commands:
 Macros do not contain JavaScript code directly. Your code lives in a `.js` file
 inside your vault, and the macro simply runs that file.
 
-Create a new script file such as `scripts/my-macro.js` and make sure it is not
-inside `.obsidian` or any folder whose name starts with a dot. QuickAdd ignores
-scripts in those locations, so they will not show up in the script picker.
+Create a new script file such as `scripts/my-macro.js`. Make sure the file is
+really a JavaScript file whose name ends in `.js`. If you create it from inside
+Obsidian, check that Obsidian did not create a Markdown note named
+`my-macro.js.md`; QuickAdd only discovers files ending in `.js`.
 
-Open the Macro Builder, add a **User Script** command, and select your script
-file. If the script exports multiple functions, QuickAdd will ask which export
-to run. You can also set an output variable name so later commands can reuse the
-result.
+Keep the script inside your vault, but not inside `.obsidian` or any folder
+whose name starts with a dot. Obsidian may exclude hidden folders from its file
+index, and QuickAdd builds the picker from Obsidian's indexed vault files. Use a
+normal folder such as `scripts/` or a visible underscore-prefixed folder such as
+`_quickadd/scripts/`.
+
+Open the Macro Builder and add a **User Script** command. The **Browse** button
+opens QuickAdd's script picker, not a native file picker. It searches the `.js`
+files Obsidian has already discovered in the vault, so it cannot pick files
+outside the vault, files hidden from Obsidian's index, or files whose extension
+is really `.md`.
+
+You can also type the script into the text field and click **Add**. Type the
+script basename, not a vault-relative path: for `scripts/my-macro.js`, enter
+`my-macro`. To run a specific exported member, append it with `::`, such as
+`my-macro::start`. Do not enter `scripts/my-macro.js` in the manual field.
+
+If the script exports multiple functions and you do not specify a member,
+QuickAdd will ask which export to run. You can also set an output variable name
+so later commands can reuse the result.
 
 If your goal is to insert text into a note, use a **Template** or **Capture**
 choice and run it from the macro using a **Nested Choice** command. This is the

--- a/docs/versioned_docs/version-2.12.3/UserScripts.md
+++ b/docs/versioned_docs/version-2.12.3/UserScripts.md
@@ -11,6 +11,20 @@ User scripts are JavaScript files that extend QuickAdd's functionality with cust
 
 > **Obsidian API Reference**: This guide references the [Obsidian API](https://docs.obsidian.md/Home). Familiarize yourself with the [App](https://docs.obsidian.md/Reference/TypeScript+API/App), [Vault](https://docs.obsidian.md/Reference/TypeScript+API/Vault), and [Workspace](https://docs.obsidian.md/Reference/TypeScript+API/Workspace) modules for advanced scripting.
 
+## Adding Scripts to Macros
+
+User scripts must be real `.js` files inside your vault. Avoid `.obsidian` and
+hidden dot-folders such as `.scripts`, because Obsidian may exclude them from
+the vault file index QuickAdd uses for script discovery. If you create a script
+from inside Obsidian, confirm the file did not become a Markdown note such as
+`script.js.md`.
+
+In the Macro Builder, **Browse** opens QuickAdd's picker of discovered `.js`
+files; it is not a native file picker. If you add a script manually, type the
+script basename, not the relative path. For `scripts/my-script.js`, enter
+`my-script`; for a specific export, enter a member expression such as
+`my-script::start`.
+
 ## Basic Structure
 
 Every user script must export a module with at least an entry point function:


### PR DESCRIPTION
Clarify Macro User Script discovery and manual entry behavior.

This documents that Browse searches Obsidian-indexed `.js` files rather than opening a native file picker, manual Add expects a script basename or `basename::member` expression rather than a relative path, hidden dot-folders may be excluded from discovery, and files created inside Obsidian may accidentally become Markdown files such as `script.js.md`.

Updated both Next docs and the latest `2.12.3` versioned snapshot.

Refs #895

Validation:
- `cd docs && bun install --frozen-lockfile`
- `cd docs && bun run build`
- `git diff --check`

Note: the UI tooltip still says "Browse and select a script file", which can imply a native picker. This PR keeps to docs only.
