### PR TITLE
fix(capture): preserve content when file creation fails

### DIFF
--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -6,10 +6,16 @@ import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { insertFileLinkToActiveView, isFolder, openFile } from "../utilityObsidian";
 import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "../constants";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
+import { MacroAbortError } from "../errors/MacroAbortError";
 
-const { setUseSelectionAsCaptureValueMock, setTitleMock } = vi.hoisted(() => ({
+const {
+	setUseSelectionAsCaptureValueMock,
+	setTitleMock,
+	singleTemplateRunMock,
+} = vi.hoisted(() => ({
 	setUseSelectionAsCaptureValueMock: vi.fn(),
 	setTitleMock: vi.fn(),
+	singleTemplateRunMock: vi.fn(async () => ""),
 }));
 
 vi.mock("../formatters/captureChoiceFormatter", () => ({
@@ -66,6 +72,18 @@ vi.mock("three-way-merge", () => ({
 
 vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
 	default: class {},
+}));
+
+vi.mock("./SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		setLinkToCurrentFileBehavior() {}
+		async run() {
+			return await singleTemplateRunMock();
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+	},
 }));
 
 vi.mock("obsidian-dataview", () => ({
@@ -226,6 +244,8 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		vi.mocked(isFolder).mockReset();
 		vi.mocked(insertFileLinkToActiveView).mockReset();
 		setTitleMock.mockClear();
+		singleTemplateRunMock.mockReset();
+		singleTemplateRunMock.mockResolvedValue("");
 	});
 
 	it("treats folder path without trailing slash as folder when folder exists", () => {
@@ -407,6 +427,44 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		await engine.run();
 
 		expect(clipboardWriteText).toHaveBeenCalledWith("Capture body to preserve");
+	});
+
+	it("does not copy capture content to clipboard when template creation is cancelled", async () => {
+		const clipboardWriteText = vi.fn(async () => {});
+		Object.defineProperty(navigator, "clipboard", {
+			value: { writeText: clipboardWriteText },
+			configurable: true,
+		});
+		singleTemplateRunMock.mockRejectedValueOnce(
+			new MacroAbortError("Input cancelled by user"),
+		);
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{
+				settings: {
+					useSelectionAsCaptureValue: false,
+					showCaptureNotification: true,
+				},
+			} as any,
+			createChoice({
+				captureTo: "New.md",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: true,
+					template: "Templates/New.md",
+				},
+				format: {
+					enabled: true,
+					format: "Capture body should not overwrite clipboard",
+				},
+			}),
+			createExecutor(),
+		);
+
+		await engine.run();
+
+		expect(clipboardWriteText).not.toHaveBeenCalled();
 	});
 
 	it("routes active canvas file-card capture to linked markdown path", async () => {

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
@@ -367,6 +367,46 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		);
 
 		expect(setTitleMock).toHaveBeenCalledWith("Map");
+	});
+
+	it("copies formatted capture content to clipboard when creating the target file fails", async () => {
+		const clipboardWriteText = vi.fn(async () => {});
+		Object.defineProperty(navigator, "clipboard", {
+			value: { writeText: clipboardWriteText },
+			configurable: true,
+		});
+		(Notice as unknown as { instances: unknown[] }).instances.length = 0;
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{
+				settings: {
+					useSelectionAsCaptureValue: false,
+					showCaptureNotification: true,
+				},
+			} as any,
+			createChoice({
+				captureTo: "Bad:Title.md",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+				format: {
+					enabled: true,
+					format: "Capture body to preserve",
+				},
+			}),
+			createExecutor(),
+		);
+
+		(engine as any).createFileWithInput = vi.fn(async () => {
+			throw new Error("File name cannot contain ':'");
+		});
+
+		await engine.run();
+
+		expect(clipboardWriteText).toHaveBeenCalledWith("Capture body to preserve");
 	});
 
 	it("routes active canvas file-card capture to linked markdown path", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -173,6 +173,37 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		insertFileLinkToActiveView(this.app, file, linkOptions);
 	}
 
+	private async copyCaptureContentToClipboardAfterFailure(
+		captureContent: string,
+	): Promise<void> {
+		const clipboard =
+			typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+
+		if (!clipboard?.writeText) {
+			new Notice(
+				"Capture failed before it could be written, and clipboard access is unavailable.",
+				DEFAULT_NOTICE_DURATION,
+			);
+			return;
+		}
+
+		try {
+			await clipboard.writeText(captureContent);
+			new Notice(
+				"Capture failed before it could be written. The capture content was copied to your clipboard.",
+				DEFAULT_NOTICE_DURATION,
+			);
+		} catch (err) {
+			log.logError(
+				`Failed to copy failed capture content to clipboard: ${err instanceof Error ? err.message : String(err)}`,
+			);
+			new Notice(
+				"Capture failed before it could be written, and QuickAdd could not copy the capture content to your clipboard.",
+				DEFAULT_NOTICE_DURATION,
+			);
+		}
+	}
+
 	async run(): Promise<void> {
 		try {
 			// Reset any pending structured values before starting a new capture run
@@ -707,73 +738,80 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			);
 		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
 
-		let fileContent = "";
-		if (this.choice.createFileIfItDoesntExist.createWithTemplate) {
-			const singleTemplateEngine: SingleTemplateEngine =
-				new SingleTemplateEngine(
-					this.app,
-					this.plugin,
-					this.choice.createFileIfItDoesntExist.template,
-					this.choiceExecutor,
+		try {
+			let fileContent = "";
+			if (this.choice.createFileIfItDoesntExist.createWithTemplate) {
+				const singleTemplateEngine: SingleTemplateEngine =
+					new SingleTemplateEngine(
+						this.app,
+						this.plugin,
+						this.choice.createFileIfItDoesntExist.template,
+						this.choiceExecutor,
+					);
+
+				if (linkOptions?.enabled && !linkOptions.requireActiveFile) {
+					singleTemplateEngine.setLinkToCurrentFileBehavior("optional");
+				}
+
+				fileContent = await singleTemplateEngine.run();
+
+				// Get template variables from the template engine's formatter
+				const templateVars = singleTemplateEngine.getAndClearTemplatePropertyVars();
+
+				log.logMessage(`CaptureChoiceEngine: Collected ${templateVars.size} template property variables`);
+				if (templateVars.size > 0) {
+					log.logMessage(`Variables: ${Array.from(templateVars.keys()).join(', ')}`);
+				}
+
+				// Store for later use
+				this.templatePropertyVars = templateVars;
+			}
+
+			// Create the new file with the (optional) template content
+			const file: TFile = await this.createFileWithInput(filePath, fileContent, {
+				suppressTemplaterOnCreate:
+					this.choice.createFileIfItDoesntExist.createWithTemplate,
+			});
+
+			// Post-process front matter for template property types if we used a template
+			if (this.choice.createFileIfItDoesntExist.createWithTemplate &&
+				this.templatePropertyVars &&
+				this.shouldPostProcessFrontMatter(file, this.templatePropertyVars)) {
+				await this.postProcessFrontMatter(file, this.templatePropertyVars);
+			}
+
+			// Process Templater commands in the template if a template was used
+			if (
+				this.choice.createFileIfItDoesntExist.createWithTemplate &&
+				fileContent
+			) {
+				await overwriteTemplaterOnce(this.app, file);
+			} else if (isTemplaterTriggerOnCreateEnabled(this.app)) {
+				await waitForTemplaterTriggerOnCreateToComplete(this.app, file);
+			}
+
+			// Read the file fresh from disk to avoid any potential cached content
+			// after the initial Templater run on newly created files.
+			const updatedFileContent: string = await this.app.vault.read(file);
+			// Second formatting pass: embed the already-resolved capture content into the newly created file
+			const newFileContent: string =
+				await this.formatter.withTemplatePropertyCollection(() =>
+					this.formatter.formatContentWithFile(
+						formattedCaptureContent,
+						this.choice,
+						updatedFileContent,
+						file,
+					),
 				);
+			this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
 
-			if (linkOptions?.enabled && !linkOptions.requireActiveFile) {
-				singleTemplateEngine.setLinkToCurrentFileBehavior("optional");
-			}
-
-			fileContent = await singleTemplateEngine.run();
-
-			// Get template variables from the template engine's formatter
-			const templateVars = singleTemplateEngine.getAndClearTemplatePropertyVars();
-
-			log.logMessage(`CaptureChoiceEngine: Collected ${templateVars.size} template property variables`);
-			if (templateVars.size > 0) {
-				log.logMessage(`Variables: ${Array.from(templateVars.keys()).join(', ')}`);
-			}
-
-			// Store for later use
-			this.templatePropertyVars = templateVars;
-		}
-
-		// Create the new file with the (optional) template content
-		const file: TFile = await this.createFileWithInput(filePath, fileContent, {
-			suppressTemplaterOnCreate:
-				this.choice.createFileIfItDoesntExist.createWithTemplate,
-		});
-
-		// Post-process front matter for template property types if we used a template
-		if (this.choice.createFileIfItDoesntExist.createWithTemplate &&
-			this.templatePropertyVars &&
-			this.shouldPostProcessFrontMatter(file, this.templatePropertyVars)) {
-			await this.postProcessFrontMatter(file, this.templatePropertyVars);
-		}
-
-		// Process Templater commands in the template if a template was used
-		if (
-			this.choice.createFileIfItDoesntExist.createWithTemplate &&
-			fileContent
-		) {
-			await overwriteTemplaterOnce(this.app, file);
-		} else if (isTemplaterTriggerOnCreateEnabled(this.app)) {
-			await waitForTemplaterTriggerOnCreateToComplete(this.app, file);
-		}
-
-		// Read the file fresh from disk to avoid any potential cached content
-		// after the initial Templater run on newly created files.
-		const updatedFileContent: string = await this.app.vault.read(file);
-		// Second formatting pass: embed the already-resolved capture content into the newly created file
-		const newFileContent: string =
-			await this.formatter.withTemplatePropertyCollection(() =>
-				this.formatter.formatContentWithFile(
-					formattedCaptureContent,
-					this.choice,
-					updatedFileContent,
-					file,
-				),
+			return { file, newFileContent, captureContent: formattedCaptureContent };
+		} catch (err) {
+			await this.copyCaptureContentToClipboardAfterFailure(
+				formattedCaptureContent,
 			);
-		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
-
-		return { file, newFileContent, captureContent: formattedCaptureContent };
+			throw err;
+		}
 	}
 
 	private async formatFilePath(captureTo: string) {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -807,6 +807,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 			return { file, newFileContent, captureContent: formattedCaptureContent };
 		} catch (err) {
+			if (err instanceof MacroAbortError || isCancellationError(err)) {
+				throw err;
+			}
+
 			await this.copyCaptureContentToClipboardAfterFailure(
 				formattedCaptureContent,
 			);


### PR DESCRIPTION
Copy resolved capture content to the clipboard when QuickAdd has already formatted the capture body but the missing target-file creation path fails. This prevents losing the entered capture text for invalid filenames or filesystem creation errors while preserving the existing error reporting path.

The fallback runs only after capture content has been resolved for the create-missing-file flow. If clipboard access itself fails, QuickAdd reports that separately without masking the original creation error.

Repo-level reproduction before implementation: added a focused Vitest regression that forced `createFileWithInput` to throw for `Bad:Title.md` after formatting `Capture body to preserve`; on current behavior, `navigator.clipboard.writeText` was never called.

Validation:
- `bun run test src/engine/CaptureChoiceEngine.selection.test.ts` failed before the fix with zero clipboard writes, then passed after the fix.
- `bun run test`
- `bun run build-with-lint`

Obsidian dev vault was not used; repo-level reproduction and tests covered the failure path without requiring the shared vault slot.

Fixes #1157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When capture/file creation fails, formatted content is now copied to the clipboard as a fallback; notifications are shown for success, failure, or when clipboard access is unavailable. The original error is still surfaced. Template cancellations/aborts do not trigger clipboard fallback.

* **Tests**
  * Added tests for clipboard fallback on capture failure and for ensuring no clipboard write on template cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->