### PR TITLE
fix: ignore unresolved field tokens in suggestions

### DIFF
--- a/src/formatters/formatter-field-title-regression.test.ts
+++ b/src/formatters/formatter-field-title-regression.test.ts
@@ -157,4 +157,13 @@ describe("Formatter FIELD and TITLE namespace handling", () => {
 
 		expect(result).toBe("Preview Title");
 	});
+
+	it("does not loop when a selected FIELD value is another FIELD token", async () => {
+		formatter.setMockFieldResponse("type", "{{FIELD:type}}");
+
+		const result = await formatter.runFormat("{{FIELD:type}}");
+
+		expect(result).toBe("{{FIELD:type}}");
+		expect(formatter.fieldCalls).toEqual(["type"]);
+	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -432,12 +432,13 @@ export abstract class Formatter {
 	}
 
 	protected async replaceFieldVarInString(input: string) {
-		let output: string = input;
+		const regex = new RegExp(FIELD_VAR_REGEX_WITH_FILTERS.source, "gi");
+		let output = "";
+		let lastIndex = 0;
+		let match: RegExpExecArray | null;
 
-		// Use the enhanced regex that supports filters
-		while (FIELD_VAR_REGEX_WITH_FILTERS.test(output)) {
-			const match = FIELD_VAR_REGEX_WITH_FILTERS.exec(output);
-			if (!match) throw new Error(`Unable to parse field variable. Invalid syntax in: "${output.substring(Math.max(0, output.search(FIELD_VAR_REGEX_WITH_FILTERS) - 10), Math.min(output.length, output.search(FIELD_VAR_REGEX_WITH_FILTERS) + 30))}..."`);
+		while ((match = regex.exec(input)) !== null) {
+			output += input.slice(lastIndex, match.index);
 
 			// match[1] contains the field name (and potentially the old filter syntax if no pipe is used)
 			// match[2] contains the filter part starting with |, if present
@@ -457,17 +458,15 @@ export abstract class Formatter {
 					? String(this.variables.get(fieldVariableKey))
 					: this.getVariableValue(fullMatch);
 
-				output = this.replacer(
-					output,
-					FIELD_VAR_REGEX_WITH_FILTERS,
-					replacement,
-				);
+				output += replacement;
 			} else {
-				break;
+				output += match[0];
 			}
+
+			lastIndex = regex.lastIndex;
 		}
 
-		return output;
+		return output + input.slice(lastIndex);
 	}
 
 	private getFieldVariableKey(fieldSpecifier: string): string {

--- a/src/utils/FieldValueCollector.issue644.test.ts
+++ b/src/utils/FieldValueCollector.issue644.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { FieldSuggestionCache } from "./FieldSuggestionCache";
+import { collectFieldValuesProcessed } from "./FieldValueCollector";
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: () => null,
+}));
+
+describe("Issue #644 - quoted FIELD values in frontmatter", () => {
+	beforeEach(() => {
+		FieldSuggestionCache.getInstance().clear();
+	});
+
+	it("excludes unresolved FIELD tokens from collected frontmatter suggestions", async () => {
+		const app = new App();
+		const files = [
+			{ path: "templates/quoted-field.md" },
+			{ path: "notes/task.md" },
+		] as any[];
+
+		app.vault.getMarkdownFiles = () => files;
+		app.metadataCache.getFileCache = (file: any) => {
+			if (file.path === "templates/quoted-field.md") {
+				return { frontmatter: { type: "{{FIELD:type}}" } } as any;
+			}
+
+			return { frontmatter: { type: "Task" } } as any;
+		};
+
+		const values = await collectFieldValuesProcessed(app, "type", {});
+
+		expect(values).toEqual(["Task"]);
+	});
+});

--- a/src/utils/FieldValueProcessor.ts
+++ b/src/utils/FieldValueProcessor.ts
@@ -1,3 +1,4 @@
+import { FIELD_VAR_REGEX_WITH_FILTERS } from "../constants";
 import { FieldValueDeduplicator, type DeduplicationOptions } from "./FieldValueDeduplicator";
 import type { FieldFilter } from "./FieldSuggestionParser";
 
@@ -9,6 +10,11 @@ export interface ProcessedValues {
 }
 
 export class FieldValueProcessor {
+	private static readonly unresolvedFieldTokenRegex = new RegExp(
+		`^${FIELD_VAR_REGEX_WITH_FILTERS.source}$`,
+		"i",
+	);
+
 	/**
 	 * Process field values with deduplication, defaults, and sorting
 	 */
@@ -44,7 +50,7 @@ export class FieldValueProcessor {
 	}
 
 	private static isUnresolvedFieldToken(value: string): boolean {
-		return /^{{FIELD:[^\n\r}]*\|?[^\n\r}]*}}$/i.test(value.trim());
+		return this.unresolvedFieldTokenRegex.test(value.trim());
 	}
 
 	/**

--- a/src/utils/FieldValueProcessor.ts
+++ b/src/utils/FieldValueProcessor.ts
@@ -16,8 +16,10 @@ export class FieldValueProcessor {
 		rawValues: Set<string>,
 		filters: FieldFilter
 	): ProcessedValues {
-		let values = Array.from(rawValues);
-		const totalProcessed = values.length;
+		const totalProcessed = rawValues.size;
+		let values = Array.from(rawValues).filter(
+			(value) => !this.isUnresolvedFieldToken(value),
+		);
 
 		// Apply deduplication
 		const deduplicationOptions: DeduplicationOptions = {
@@ -39,6 +41,10 @@ export class FieldValueProcessor {
 			duplicatesRemoved: deduplicationResult.duplicatesRemoved,
 			totalProcessed
 		};
+	}
+
+	private static isUnresolvedFieldToken(value: string): boolean {
+		return /^{{FIELD:[^\n\r}]*\|?[^\n\r}]*}}$/i.test(value.trim());
 	}
 
 	/**


### PR DESCRIPTION
Filter unresolved `{{FIELD:...}}` template tokens out of FIELD suggestion values so quoted template frontmatter does not pollute the dropdown.

This also changes FIELD replacement to scan the original input once, matching the existing MVALUE no-loop pattern. If a token-like value is somehow selected, formatting returns that literal value instead of repeatedly reprocessing the replacement.

Reproduction before fix:
- Added `src/utils/FieldValueCollector.issue644.test.ts` with frontmatter `type: \"{{FIELD:type}}\"` plus a real `type: Task` note.
- Before the fix, `bun run test src/utils/FieldValueCollector.issue644.test.ts` failed with received values `[\"{{FIELD:type}}\", \"Task\"]`.

Validation:
- `bun run test src/utils/FieldValueCollector.issue644.test.ts`
- `bun run test src/formatters/formatter-field-title-regression.test.ts`
- `bun run test`
- `bun run build-with-lint`

Obsidian dev-vault validation was skipped because the repo-level regression reproduces and verifies the issue, and the shared dev vault requires an orchestrator-granted slot.

No release migration needed.

Fixes #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented FIELD token substitution from recursing/looping when fields reference FIELD tokens
  * Excluded unresolved/quoted FIELD tokens from collected field suggestions and processing

* **Tests**
  * Added regression test for FIELD token recursion handling
  * Added test suite for quoted FIELD values in frontmatter
<!-- end of auto-generated comment: release notes by coderabbit.ai -->