### PR TITLE
feat(api): add cursor option for input prompts

### DIFF
--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -115,13 +115,14 @@ const values = await quickAddApi.requestInputs([
 const tagArray = values.tags.split(', ').filter(Boolean);
 ```
 
-### `inputPrompt(header: string, placeholder?: string, value?: string): Promise<string>`
+### `inputPrompt(header: string, placeholder?: string, value?: string, options?: { cursorAtEnd?: boolean }): Promise<string>`
 Opens a prompt that asks for text input.
 
 **Parameters:**
 - `header`: The prompt title/question
 - `placeholder`: (Optional) Placeholder text in the input field
 - `value`: (Optional) Default value
+- `options.cursorAtEnd`: (Optional) When `true`, places the caret after the default value instead of selecting it
 
 **Returns:** Promise resolving to the entered string.
 
@@ -145,7 +146,7 @@ try {
 }
 ```
 
-### `wideInputPrompt(header: string, placeholder?: string, value?: string): Promise<string>`
+### `wideInputPrompt(header: string, placeholder?: string, value?: string, options?: { cursorAtEnd?: boolean }): Promise<string>`
 Opens a wider prompt for longer text input (multi-line).
 
 **Parameters:** Same as `inputPrompt`

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -3,6 +3,8 @@ import { ButtonComponent, Modal, TextComponent } from "obsidian";
 import { FileSuggester } from "../suggesters/fileSuggester";
 import { TagSuggester } from "../suggesters/tagSuggester";
 import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
+import type { InputPromptOptions } from "../../types/inputPrompt";
+import { positionInputPromptCursor } from "../inputPromptCursor";
 
 export default class GenericInputPrompt extends Modal {
 	public waitForClose: Promise<string>;
@@ -24,6 +26,7 @@ export default class GenericInputPrompt extends Modal {
 		placeholder?: string,
 		value?: string,
 		description?: string,
+		options?: InputPromptOptions,
 	): Promise<string> {
 		const newPromptModal = new GenericInputPrompt(
 			app,
@@ -32,6 +35,7 @@ export default class GenericInputPrompt extends Modal {
 			value,
 			undefined,
 			description,
+			options,
 		);
 		return newPromptModal.waitForClose;
 	}
@@ -43,6 +47,7 @@ export default class GenericInputPrompt extends Modal {
 		value?: string,
 		linkSourcePath?: string,
 		description?: string,
+		options?: InputPromptOptions,
 	): Promise<string> {
 		const newPromptModal = new GenericInputPrompt(
 			app,
@@ -51,6 +56,7 @@ export default class GenericInputPrompt extends Modal {
 			value,
 			linkSourcePath,
 			description,
+			options,
 		);
 		return newPromptModal.waitForClose;
 	}
@@ -62,6 +68,7 @@ export default class GenericInputPrompt extends Modal {
 		value?: string,
 		private linkSourcePath?: string,
 		description?: string,
+		private readonly options?: InputPromptOptions,
 	) {
 		super(app);
 		this.placeholder = placeholder ?? "";
@@ -220,8 +227,7 @@ export default class GenericInputPrompt extends Modal {
 	onOpen() {
 		super.onOpen();
 
-		this.inputComponent.inputEl.focus();
-		this.inputComponent.inputEl.select();
+		positionInputPromptCursor(this.inputComponent.inputEl, this.options);
 	}
 
 	onClose() {

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -3,6 +3,8 @@ import { ButtonComponent, Modal, TextAreaComponent } from "obsidian";
 import { FileSuggester } from "../suggesters/fileSuggester";
 import { TagSuggester } from "../suggesters/tagSuggester";
 import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
+import type { InputPromptOptions } from "../../types/inputPrompt";
+import { positionInputPromptCursor } from "../inputPromptCursor";
 
 export default class GenericWideInputPrompt extends Modal {
 	public waitForClose: Promise<string>;
@@ -24,6 +26,7 @@ export default class GenericWideInputPrompt extends Modal {
 		placeholder?: string,
 		value?: string,
 		description?: string,
+		options?: InputPromptOptions,
 	): Promise<string> {
 		const newPromptModal = new GenericWideInputPrompt(
 			app,
@@ -32,6 +35,7 @@ export default class GenericWideInputPrompt extends Modal {
 			value,
 			undefined,
 			description,
+			options,
 		);
 		return newPromptModal.waitForClose;
 	}
@@ -43,6 +47,7 @@ export default class GenericWideInputPrompt extends Modal {
 		value?: string,
 		linkSourcePath?: string,
 		description?: string,
+		options?: InputPromptOptions,
 	): Promise<string> {
 		const newPromptModal = new GenericWideInputPrompt(
 			app,
@@ -51,6 +56,7 @@ export default class GenericWideInputPrompt extends Modal {
 			value,
 			linkSourcePath,
 			description,
+			options,
 		);
 		return newPromptModal.waitForClose;
 	}
@@ -62,6 +68,7 @@ export default class GenericWideInputPrompt extends Modal {
 		value?: string,
 		private linkSourcePath?: string,
 		description?: string,
+		private readonly options?: InputPromptOptions,
 	) {
 		super(app);
 		this.placeholder = placeholder ?? "";
@@ -219,8 +226,7 @@ export default class GenericWideInputPrompt extends Modal {
 	onOpen() {
 		super.onOpen();
 
-		this.inputComponent.inputEl.focus();
-		this.inputComponent.inputEl.select();
+		positionInputPromptCursor(this.inputComponent.inputEl, this.options);
 	}
 
 	onClose() {

--- a/src/gui/inputPromptCursor.test.ts
+++ b/src/gui/inputPromptCursor.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { positionInputPromptCursor } from "./inputPromptCursor";
+
+describe("positionInputPromptCursor", () => {
+	it("selects the default input value unless options request cursor placement", () => {
+		const inputEl = document.createElement("input");
+		inputEl.value = "#";
+		document.body.appendChild(inputEl);
+
+		positionInputPromptCursor(inputEl);
+
+		expect(inputEl.selectionStart).toBe(0);
+		expect(inputEl.selectionEnd).toBe(1);
+
+		inputEl.remove();
+	});
+
+	it("places the input cursor at the end when cursorAtEnd is true", () => {
+		const inputEl = document.createElement("input");
+		inputEl.value = "#tag";
+		document.body.appendChild(inputEl);
+
+		positionInputPromptCursor(inputEl, { cursorAtEnd: true });
+
+		expect(inputEl.selectionStart).toBe(4);
+		expect(inputEl.selectionEnd).toBe(4);
+
+		inputEl.remove();
+	});
+
+	it("places the textarea cursor at the end when cursorAtEnd is true", () => {
+		const inputEl = document.createElement("textarea");
+		inputEl.value = "line one\nline two";
+		document.body.appendChild(inputEl);
+
+		positionInputPromptCursor(inputEl, { cursorAtEnd: true });
+
+		expect(inputEl.selectionStart).toBe(inputEl.value.length);
+		expect(inputEl.selectionEnd).toBe(inputEl.value.length);
+
+		inputEl.remove();
+	});
+});

--- a/src/gui/inputPromptCursor.ts
+++ b/src/gui/inputPromptCursor.ts
@@ -1,0 +1,18 @@
+import type { InputPromptOptions } from "../types/inputPrompt";
+
+type PromptInputEl = HTMLInputElement | HTMLTextAreaElement;
+
+export function positionInputPromptCursor(
+	inputEl: PromptInputEl,
+	options?: InputPromptOptions,
+) {
+	inputEl.focus();
+
+	if (options?.cursorAtEnd) {
+		const cursorPosition = inputEl.value.length;
+		inputEl.setSelectionRange(cursorPosition, cursorPosition);
+		return;
+	}
+
+	inputEl.select();
+}

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -211,6 +211,22 @@ describe("static prompt wrappers", () => {
 			);
 		});
 
+		it("forwards cursor placement options", async () => {
+			mocks.genericInputPrompt.mockResolvedValue("hello");
+			await (QuickAddApi.inputPrompt as any)(app, "Header", "ph", "val", {
+				cursorAtEnd: true,
+			});
+
+			expect(mocks.genericInputPrompt).toHaveBeenCalledWith(
+				app,
+				"Header",
+				"ph",
+				"val",
+				undefined,
+				{ cursorAtEnd: true },
+			);
+		});
+
 		it("returns undefined for a generic (non-cancellation) error", async () => {
 			mocks.genericInputPrompt.mockRejectedValue(new Error("boom"));
 			const out = await QuickAddApi.inputPrompt(app, "Header");
@@ -238,6 +254,22 @@ describe("static prompt wrappers", () => {
 			const out = await QuickAddApi.wideInputPrompt(app, "H", "p", "v");
 			expect(out).toBe("wide");
 			expect(mocks.genericWideInputPrompt).toHaveBeenCalledWith(app, "H", "p", "v");
+		});
+
+		it("forwards cursor placement options", async () => {
+			mocks.genericWideInputPrompt.mockResolvedValue("wide");
+			await (QuickAddApi.wideInputPrompt as any)(app, "H", "p", "v", {
+				cursorAtEnd: true,
+			});
+
+			expect(mocks.genericWideInputPrompt).toHaveBeenCalledWith(
+				app,
+				"H",
+				"p",
+				"v",
+				undefined,
+				{ cursorAtEnd: true },
+			);
 		});
 
 		it("swallows generic errors as undefined", async () => {
@@ -445,6 +477,36 @@ describe("GetApi prompt wrappers", () => {
 		const out = await api.inputPrompt("H", "p", "val");
 		expect(out).toBe("v");
 		expect(mocks.genericInputPrompt).toHaveBeenCalledWith(app, "H", "p", "val");
+	});
+
+	it("inputPrompt delegates cursor placement options", async () => {
+		mocks.genericInputPrompt.mockResolvedValue("v");
+		const { api, app } = getApi();
+		await (api.inputPrompt as any)("H", "p", "val", { cursorAtEnd: true });
+		expect(mocks.genericInputPrompt).toHaveBeenCalledWith(
+			app,
+			"H",
+			"p",
+			"val",
+			undefined,
+			{ cursorAtEnd: true },
+		);
+	});
+
+	it("wideInputPrompt delegates cursor placement options", async () => {
+		mocks.genericWideInputPrompt.mockResolvedValue("v");
+		const { api, app } = getApi();
+		await (api.wideInputPrompt as any)("H", "p", "val", {
+			cursorAtEnd: true,
+		});
+		expect(mocks.genericWideInputPrompt).toHaveBeenCalledWith(
+			app,
+			"H",
+			"p",
+			"val",
+			undefined,
+			{ cursorAtEnd: true },
+		);
 	});
 
 	it("suggester delegates options through", async () => {

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -208,6 +208,8 @@ describe("static prompt wrappers", () => {
 				"Header",
 				"ph",
 				"val",
+				undefined,
+				undefined,
 			);
 		});
 
@@ -253,7 +255,14 @@ describe("static prompt wrappers", () => {
 			mocks.genericWideInputPrompt.mockResolvedValue("wide");
 			const out = await QuickAddApi.wideInputPrompt(app, "H", "p", "v");
 			expect(out).toBe("wide");
-			expect(mocks.genericWideInputPrompt).toHaveBeenCalledWith(app, "H", "p", "v");
+			expect(mocks.genericWideInputPrompt).toHaveBeenCalledWith(
+				app,
+				"H",
+				"p",
+				"v",
+				undefined,
+				undefined,
+			);
 		});
 
 		it("forwards cursor placement options", async () => {
@@ -476,7 +485,14 @@ describe("GetApi prompt wrappers", () => {
 		const { api, app } = getApi();
 		const out = await api.inputPrompt("H", "p", "val");
 		expect(out).toBe("v");
-		expect(mocks.genericInputPrompt).toHaveBeenCalledWith(app, "H", "p", "val");
+		expect(mocks.genericInputPrompt).toHaveBeenCalledWith(
+			app,
+			"H",
+			"p",
+			"val",
+			undefined,
+			undefined,
+		);
 	});
 
 	it("inputPrompt delegates cursor placement options", async () => {

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -215,7 +215,7 @@ describe("static prompt wrappers", () => {
 
 		it("forwards cursor placement options", async () => {
 			mocks.genericInputPrompt.mockResolvedValue("hello");
-			await (QuickAddApi.inputPrompt as any)(app, "Header", "ph", "val", {
+			await QuickAddApi.inputPrompt(app, "Header", "ph", "val", {
 				cursorAtEnd: true,
 			});
 
@@ -267,7 +267,7 @@ describe("static prompt wrappers", () => {
 
 		it("forwards cursor placement options", async () => {
 			mocks.genericWideInputPrompt.mockResolvedValue("wide");
-			await (QuickAddApi.wideInputPrompt as any)(app, "H", "p", "v", {
+			await QuickAddApi.wideInputPrompt(app, "H", "p", "v", {
 				cursorAtEnd: true,
 			});
 
@@ -498,7 +498,7 @@ describe("GetApi prompt wrappers", () => {
 	it("inputPrompt delegates cursor placement options", async () => {
 		mocks.genericInputPrompt.mockResolvedValue("v");
 		const { api, app } = getApi();
-		await (api.inputPrompt as any)("H", "p", "val", { cursorAtEnd: true });
+		await api.inputPrompt("H", "p", "val", { cursorAtEnd: true });
 		expect(mocks.genericInputPrompt).toHaveBeenCalledWith(
 			app,
 			"H",
@@ -512,7 +512,7 @@ describe("GetApi prompt wrappers", () => {
 	it("wideInputPrompt delegates cursor placement options", async () => {
 		mocks.genericWideInputPrompt.mockResolvedValue("v");
 		const { api, app } = getApi();
-		await (api.wideInputPrompt as any)("H", "p", "val", {
+		await api.wideInputPrompt("H", "p", "val", {
 			cursorAtEnd: true,
 		});
 		expect(mocks.genericWideInputPrompt).toHaveBeenCalledWith(

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -622,16 +622,14 @@ export class QuickAddApi {
 		options?: InputPromptOptions,
 	) {
 		try {
-			return options
-				? await GenericInputPrompt.Prompt(
-						app,
-						header,
-						placeholder,
-						value,
-						undefined,
-						options,
-					)
-				: await GenericInputPrompt.Prompt(app, header, placeholder, value);
+			return await GenericInputPrompt.Prompt(
+				app,
+				header,
+				placeholder,
+				value,
+				undefined,
+				options,
+			);
 		} catch (error) {
 			throwIfPromptCancelled(error);
 			return undefined;
@@ -677,21 +675,14 @@ export class QuickAddApi {
 		options?: InputPromptOptions,
 	) {
 		try {
-			return options
-				? await GenericWideInputPrompt.Prompt(
-						app,
-						header,
-						placeholder,
-						value,
-						undefined,
-						options,
-					)
-				: await GenericWideInputPrompt.Prompt(
-						app,
-						header,
-						placeholder,
-						value,
-					);
+			return await GenericWideInputPrompt.Prompt(
+				app,
+				header,
+				placeholder,
+				value,
+				undefined,
+				options,
+			);
 		} catch (error) {
 			throwIfPromptCancelled(error);
 			return undefined;

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -40,6 +40,7 @@ import { FieldSuggestionFileFilter } from "./utils/FieldSuggestionFileFilter";
 import { InlineFieldParser } from "./utils/InlineFieldParser";
 import { MacroAbortError } from "./errors/MacroAbortError";
 import { formatISODate } from "./utils/dateParser";
+import type { InputPromptOptions } from "./types/inputPrompt";
 
 function snapshotVariables(
 	vars: Map<string, unknown>,
@@ -161,8 +162,13 @@ export class QuickAddApi {
 
 				return formattedResult;
 			},
-			inputPrompt: (header: string, placeholder?: string, value?: string) => {
-				return QuickAddApi.inputPrompt(app, header, placeholder, value);
+			inputPrompt: (
+				header: string,
+				placeholder?: string,
+				value?: string,
+				options?: InputPromptOptions,
+			) => {
+				return QuickAddApi.inputPrompt(app, header, placeholder, value, options);
 			},
 			datePrompt: (
 				header: string,
@@ -178,8 +184,15 @@ export class QuickAddApi {
 				header: string,
 				placeholder?: string,
 				value?: string,
+				options?: InputPromptOptions,
 			) => {
-				return QuickAddApi.wideInputPrompt(app, header, placeholder, value);
+				return QuickAddApi.wideInputPrompt(
+					app,
+					header,
+					placeholder,
+					value,
+					options,
+				);
 			},
 			yesNoPrompt: (header: string, text?: string) => {
 				return QuickAddApi.yesNoPrompt(app, header, text);
@@ -606,9 +619,19 @@ export class QuickAddApi {
 		header: string,
 		placeholder?: string,
 		value?: string,
+		options?: InputPromptOptions,
 	) {
 		try {
-			return await GenericInputPrompt.Prompt(app, header, placeholder, value);
+			return options
+				? await GenericInputPrompt.Prompt(
+						app,
+						header,
+						placeholder,
+						value,
+						undefined,
+						options,
+					)
+				: await GenericInputPrompt.Prompt(app, header, placeholder, value);
 		} catch (error) {
 			throwIfPromptCancelled(error);
 			return undefined;
@@ -651,14 +674,24 @@ export class QuickAddApi {
 		header: string,
 		placeholder?: string,
 		value?: string,
+		options?: InputPromptOptions,
 	) {
 		try {
-			return await GenericWideInputPrompt.Prompt(
-				app,
-				header,
-				placeholder,
-				value,
-			);
+			return options
+				? await GenericWideInputPrompt.Prompt(
+						app,
+						header,
+						placeholder,
+						value,
+						undefined,
+						options,
+					)
+				: await GenericWideInputPrompt.Prompt(
+						app,
+						header,
+						placeholder,
+						value,
+					);
 		} catch (error) {
 			throwIfPromptCancelled(error);
 			return undefined;

--- a/src/types/inputPrompt.ts
+++ b/src/types/inputPrompt.ts
@@ -1,0 +1,3 @@
+export interface InputPromptOptions {
+	cursorAtEnd?: boolean;
+}


### PR DESCRIPTION
Add a backward-compatible `cursorAtEnd` option to `quickAddApi.inputPrompt` and `quickAddApi.wideInputPrompt`.

By default, prefilled values are still selected on open. Passing `{ cursorAtEnd: true }` keeps the default value and places the caret after it, which supports prefix-style workflows like opening the prompt with `#` and immediately typing the rest of a tag.

Before implementation, I reproduced the missing API behavior with a focused failing repo-level test: a fourth options argument was dropped before it reached the prompt modal. The new tests cover static API forwarding, `GetApi()` wrapper forwarding, default select-all behavior, and opt-in caret-at-end behavior for input and textarea elements.

Validation:
- `bun run test`
- `bun run build-with-lint`

Obsidian dev-vault validation was skipped because this was verified through repo-level API and jsdom cursor tests, and no dev-vault slot was requested or granted.

Docs updated in `docs/docs/QuickAddAPI.md`. No migration required.

Fixes #717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input prompts gain an optional cursor positioning option that, when enabled, places the caret at the end of default text instead of selecting it.

* **Documentation**
  * QuickAdd API docs updated to describe the new cursor positioning option for both input and wide-input prompts.

* **Tests**
  * Added unit tests verifying cursor placement for inputs/textareas and API forwarding of the option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->