### PR TITLE
fix: suppress yes/no prompt pointer press

### DIFF
--- a/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.test.ts
+++ b/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.test.ts
@@ -1,0 +1,133 @@
+import type { App } from "obsidian";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import GenericYesNoPrompt from "./GenericYesNoPrompt";
+
+vi.mock("obsidian", () => {
+	class Modal {
+		containerEl: HTMLElement;
+		contentEl: HTMLElement;
+		titleEl: HTMLElement;
+
+		constructor(_app: App) {
+			this.containerEl = document.createElement("div");
+			this.contentEl = document.createElement("div");
+			this.titleEl = document.createElement("h1");
+			this.containerEl.append(this.titleEl, this.contentEl);
+			document.body.appendChild(this.containerEl);
+		}
+
+		open() {}
+
+		close() {
+			this.onClose();
+		}
+
+		onClose() {}
+	}
+
+	class ButtonComponent {
+		buttonEl: HTMLButtonElement;
+
+		constructor(containerEl: HTMLElement) {
+			this.buttonEl = document.createElement("button");
+			containerEl.appendChild(this.buttonEl);
+		}
+
+		setButtonText(text: string): this {
+			this.buttonEl.textContent = text;
+			return this;
+		}
+
+		onClick(callback: () => void): this {
+			this.buttonEl.addEventListener("click", callback);
+			return this;
+		}
+
+		setWarning(): this {
+			return this;
+		}
+	}
+
+	return { ButtonComponent, Modal };
+});
+
+function installObsidianElementHelpers(): void {
+	const proto = HTMLElement.prototype as unknown as {
+		addClass?: (this: HTMLElement, ...classes: string[]) => HTMLElement;
+		createDiv?: (
+			this: HTMLElement,
+			options?: { cls?: string },
+		) => HTMLDivElement;
+		createEl?: (
+			this: HTMLElement,
+			tag: string,
+			options?: { text?: string },
+		) => HTMLElement;
+		empty?: (this: HTMLElement) => void;
+	};
+
+	proto.addClass ??= function (...classes: string[]) {
+		this.classList.add(...classes);
+		return this;
+	};
+
+	proto.createDiv ??= function (options?: { cls?: string }) {
+		const div = document.createElement("div");
+		if (options?.cls) div.className = options.cls;
+		this.appendChild(div);
+		return div;
+	};
+
+	proto.createEl ??= function (tag: string, options?: { text?: string }) {
+		const el = document.createElement(tag);
+		if (options?.text) el.textContent = options.text;
+		this.appendChild(el);
+		return el;
+	};
+
+	proto.empty ??= function () {
+		this.replaceChildren();
+	};
+}
+
+installObsidianElementHelpers();
+
+describe("GenericYesNoPrompt", () => {
+	afterEach(() => {
+		document.body.replaceChildren();
+	});
+
+	it.each([
+		["Yes", "mousedown", true],
+		["No", "mousedown", false],
+		["Yes", "pointerdown", true],
+		["No", "pointerdown", false],
+	])(
+		"prevents prompt button %s %s from reaching the editor before click submit",
+		async (buttonText, eventName, expectedAnswer) => {
+			const waitForClose = GenericYesNoPrompt.Prompt(
+				{} as App,
+				"Confirm",
+				"Continue?",
+			);
+			const button = Array.from(document.querySelectorAll("button")).find(
+				(buttonEl) => buttonEl.textContent === buttonText,
+			);
+			const editorPointerPress = vi.fn();
+			document.body.addEventListener(eventName, editorPointerPress);
+
+			const pointerPress = new Event(eventName, {
+				bubbles: true,
+				cancelable: true,
+			});
+			button?.dispatchEvent(pointerPress);
+
+			expect(pointerPress.defaultPrevented).toBe(true);
+			expect(editorPointerPress).not.toHaveBeenCalled();
+
+			button?.click();
+
+			await expect(waitForClose).resolves.toBe(expectedAnswer);
+		},
+	);
+});

--- a/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.ts
+++ b/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.ts
@@ -1,4 +1,4 @@
-import type { App} from "obsidian";
+import type { App } from "obsidian";
 import { ButtonComponent, Modal } from "obsidian";
 
 export default class GenericYesNoPrompt extends Modal {
@@ -46,11 +46,13 @@ export default class GenericYesNoPrompt extends Modal {
 		const noButton = new ButtonComponent(buttonsDiv)
 			.setButtonText("No")
 			.onClick(() => this.submit(false));
+		suppressPointerPress(noButton.buttonEl);
 
 		const yesButton = new ButtonComponent(buttonsDiv)
 			.setButtonText("Yes")
 			.onClick(() => this.submit(true))
 			.setWarning();
+		suppressPointerPress(yesButton.buttonEl);
 
 		yesButton.buttonEl.focus();
 
@@ -71,15 +73,29 @@ export default class GenericYesNoPrompt extends Modal {
 	}
 }
 
+function suppressPointerPress(button: HTMLButtonElement): void {
+	const suppress = (event: MouseEvent | PointerEvent) => {
+		event.preventDefault();
+		event.stopPropagation();
+	};
+
+	button.addEventListener("pointerdown", suppress);
+	button.addEventListener("mousedown", suppress);
+}
+
 function addArrowKeyNavigation(buttons: HTMLButtonElement[]): void {
-    buttons.forEach((button) => {
-        button.addEventListener("keydown", (event) => {
-            if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
-                const currentIndex = buttons.indexOf(button);
-                const nextIndex = (currentIndex + (event.key === "ArrowRight" ? 1 : -1) + buttons.length) % buttons.length;
-                buttons[nextIndex].focus();
-                event.preventDefault();
-            }
-        });
-    });
+	buttons.forEach((button) => {
+		button.addEventListener("keydown", (event) => {
+			if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+				const currentIndex = buttons.indexOf(button);
+				const nextIndex =
+					(currentIndex +
+						(event.key === "ArrowRight" ? 1 : -1) +
+						buttons.length) %
+					buttons.length;
+				buttons[nextIndex].focus();
+				event.preventDefault();
+			}
+		});
+	});
 }


### PR DESCRIPTION
Suppress pointer presses on the yes/no prompt buttons before the normal click submit path runs. This keeps mouse/pointer activation from bubbling out of the modal and moving the editor caret underneath, while preserving keyboard activation through the existing click handlers.

Before the fix, a focused jsdom regression reproduced the vulnerable path: dispatching a cancelable `mousedown` on the Yes button left `defaultPrevented === false`, so an editor/body listener could observe the press before the prompt resolved.

This adds regression coverage for both Yes and No across `mousedown` and `pointerdown`.

Validation:
- `bun run test src/gui/GenericYesNoPrompt/GenericYesNoPrompt.test.ts`
- `bun run test`
- `bun run build-with-lint`

Obsidian dev-vault verification was skipped: the issue is covered by a repo-level DOM regression, and this delegated worktree was not granted the shared dev-vault slot.

Fixes #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the yes/no prompt, verifying button event handling and user interactions.

* **Bug Fixes**
  * Improved event handling on prompt buttons to prevent pointer/mouse events from unintentionally affecting the editor.
  * Refactored arrow-key navigation behavior for consistent button focus switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->