### PR TITLE
feat(capture): add insert-before write position

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -87,8 +87,8 @@ helps you choose a node id directly from that board.
 
 ### Write position support in Canvas
 
-- Text cards support: **Top of file**, **Bottom of file**, **After line...**
-- File cards (markdown targets) support: **Top of file**, **Bottom of file**, **After line...**
+- Text cards support: **Top of file**, **Bottom of file**, **After line...**, **Before line...**
+- File cards (markdown targets) support: **Top of file**, **Bottom of file**, **After line...**, **Before line...**
 - Canvas does not support cursor-based modes: **At cursor**, **New line above cursor**, **New line below cursor**
 
 If **Capture to active file** is enabled and you leave the default write
@@ -123,7 +123,7 @@ Yes. Set capture path to a `.canvas` file and choose a **Target canvas node**.
 
 **Does "At cursor" work in Canvas cards?**
 
-No. Use top, bottom, or insert-after placement.
+No. Use top, bottom, insert-after, or insert-before placement.
 
 **Can I capture to a file card that points to a Canvas file?**
 
@@ -208,6 +208,17 @@ Content
 
 Content
 ```
+
+## Insert before
+
+Insert Before inserts the capture before the first line that matches the specified text.
+The target accepts QuickAdd format syntax, so values such as `{{title}}` and
+`{{linkcurrent}}` can be used in the match text.
+
+It's also possible to use `Create line if not found`, which will create the
+line if it doesn't exist. For Insert Before, QuickAdd writes the captured
+content first, then creates the missing line below it. This setting can place
+the line at the start or end of the file, or at your current cursor position.
 
 ## Capture Format
 

--- a/docs/docs/Examples/Capture_CanvasCapture.md
+++ b/docs/docs/Examples/Capture_CanvasCapture.md
@@ -23,7 +23,7 @@ Good fits:
 3. Open a Canvas file.
 4. Select exactly one supported card.
 5. Set **Write position** to **Top of file**, **Bottom of file**, or
-   **After line...**.
+   **After line...** / **Before line...**.
 6. Run the Capture choice.
 
 Supported selected-card targets:
@@ -53,6 +53,7 @@ Canvas capture supports these write positions:
 - **Top of file**
 - **Bottom of file**
 - **After line...**
+- **Before line...**
 
 Canvas capture does not support cursor-based write positions:
 
@@ -75,7 +76,7 @@ from.
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | Capture aborts before writing | No card or multiple cards are selected | Select exactly one supported card |
-| Capture aborts with cursor-position wording | The write mode is cursor-based | Use top, bottom, or after-line placement |
+| Capture aborts with cursor-position wording | The write mode is cursor-based | Use top, bottom, after-line, or before-line placement |
 | Nothing is written to a file card | The file card points to a non-Markdown file | Use a Markdown file card or a text card |
 | The target picker is not shown | Capture target is not a `.canvas` file | Set **Capture To** to the Canvas file path |
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -123,6 +123,13 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					: `Captured to ${fileName}`;
 				break;
 			}
+			case "insertBefore": {
+				const heading = this.choice.insertBefore?.before;
+				msg = heading
+					? `Captured to ${fileName} before '${heading}'`
+					: `Captured to ${fileName}`;
+				break;
+			}
 			default:
 				msg = `Captured to ${fileName}`;
 				break;
@@ -207,12 +214,15 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 			if (
 				canvasTarget?.kind === "file" &&
-				action === "insertAfter" &&
-				this.choice.insertAfter?.createIfNotFound &&
-				this.choice.insertAfter?.createIfNotFoundLocation === "cursor"
+				((action === "insertAfter" &&
+					this.choice.insertAfter?.createIfNotFound &&
+					this.choice.insertAfter?.createIfNotFoundLocation === "cursor") ||
+					(action === "insertBefore" &&
+						this.choice.insertBefore?.createIfNotFound &&
+						this.choice.insertBefore?.createIfNotFoundLocation === "cursor"))
 			) {
 				throw new ChoiceAbortError(
-					"Canvas file cards do not support creating missing insert-after targets at cursor. Use top or bottom.",
+					"Canvas file cards do not support creating missing line targets at cursor. Use top or bottom.",
 				);
 			}
 
@@ -345,17 +355,20 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			action === "newLineBelow"
 		) {
 			throw new ChoiceAbortError(
-				"Canvas text cards support top, bottom, and insert-after positions only.",
+				"Canvas text cards support top, bottom, insert-after, and insert-before positions only.",
 			);
 		}
 
 		if (
-			action === "insertAfter" &&
-			this.choice.insertAfter?.createIfNotFound &&
-			this.choice.insertAfter?.createIfNotFoundLocation === "cursor"
+			(action === "insertAfter" &&
+				this.choice.insertAfter?.createIfNotFound &&
+				this.choice.insertAfter?.createIfNotFoundLocation === "cursor") ||
+			(action === "insertBefore" &&
+				this.choice.insertBefore?.createIfNotFound &&
+				this.choice.insertBefore?.createIfNotFoundLocation === "cursor")
 		) {
 			throw new ChoiceAbortError(
-				"Canvas text cards do not support creating missing insert-after targets at cursor. Use top or bottom.",
+				"Canvas text cards do not support creating missing line targets at cursor. Use top or bottom.",
 			);
 		}
 

--- a/src/engine/canvasCapture.test.ts
+++ b/src/engine/canvasCapture.test.ts
@@ -367,6 +367,9 @@ describe("canvasCapture", () => {
 			getCanvasActionUnsupportedReason("text", "insertAfter" as CaptureAction),
 		).toBeNull();
 		expect(
+			getCanvasActionUnsupportedReason("text", "insertBefore" as CaptureAction),
+		).toBeNull();
+		expect(
 			getCanvasActionUnsupportedReason("file", "newLineBelow" as CaptureAction),
 		).toContain("cursor-based");
 		expect(

--- a/src/engine/canvasCapture.ts
+++ b/src/engine/canvasCapture.ts
@@ -124,11 +124,11 @@ export function getCanvasActionUnsupportedReason(
 ): string | null {
 	if (nodeKind === "text") {
 		if (action === "currentLine") {
-			return "Canvas capture does not support 'At cursor' for text cards. Use top, bottom, or insert-after placement.";
+			return "Canvas capture does not support 'At cursor' for text cards. Use top, bottom, insert-after, or insert-before placement.";
 		}
 
 		if (action === "newLineAbove" || action === "newLineBelow") {
-			return "Canvas capture does not support 'New line above/below cursor' for text cards. Use top, bottom, or insert-after placement.";
+			return "Canvas capture does not support 'New line above/below cursor' for text cards. Use top, bottom, insert-after, or insert-before placement.";
 		}
 	}
 
@@ -138,7 +138,7 @@ export function getCanvasActionUnsupportedReason(
 			action === "newLineAbove" ||
 			action === "newLineBelow"
 		) {
-			return "Canvas file cards do not support cursor-based capture modes. Use top, bottom, or insert-after modes.";
+			return "Canvas file cards do not support cursor-based capture modes. Use top, bottom, insert-after, or insert-before modes.";
 		}
 	}
 

--- a/src/engine/captureAction.test.ts
+++ b/src/engine/captureAction.test.ts
@@ -33,6 +33,18 @@ describe("getCaptureAction", () => {
 		expect(getCaptureAction(choice)).toBe("insertAfter");
 	});
 
+	it("returns 'insertBefore' when insertBefore is enabled", () => {
+		const choice = createChoice({
+			insertBefore: {
+				enabled: true,
+				before: "heading",
+				createIfNotFound: false,
+				createIfNotFoundLocation: "",
+			},
+		});
+		expect(getCaptureAction(choice)).toBe("insertBefore");
+	});
+
 	it("returns 'prepend' when prepend is true", () => {
 		const choice = createChoice({ prepend: true });
 		expect(getCaptureAction(choice)).toBe("prepend");
@@ -54,6 +66,19 @@ describe("getCaptureAction", () => {
 			insertAfter: { enabled: true, after: "heading", insertAtEnd: false, considerSubsections: false, createIfNotFound: false, createIfNotFoundLocation: "" }
 		});
 		expect(getCaptureAction(choice)).toBe("insertAfter");
+	});
+
+	it("prioritizes insertBefore over prepend when both are set", () => {
+		const choice = createChoice({
+			prepend: true,
+			insertBefore: {
+				enabled: true,
+				before: "heading",
+				createIfNotFound: false,
+				createIfNotFoundLocation: "",
+			},
+		});
+		expect(getCaptureAction(choice)).toBe("insertBefore");
 	});
 
 	it("returns 'newLineAbove' when newLineCapture is enabled with above direction", () => {

--- a/src/engine/captureAction.ts
+++ b/src/engine/captureAction.ts
@@ -1,17 +1,20 @@
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 
-export type CaptureAction = "append" | "prepend" | "insertAfter" | "currentLine" | "newLineAbove" | "newLineBelow" | "activeFileTop";
+export type CaptureAction = "append" | "prepend" | "insertAfter" | "insertBefore" | "currentLine" | "newLineAbove" | "newLineBelow" | "activeFileTop";
 
 /**
  * Gets the capture action based on choice configuration.
  * Uses explicit if/else logic instead of nested ternary for clarity.
  */
 export function getCaptureAction(choice: ICaptureChoice): CaptureAction {
-	if (choice.captureToActiveFile && !choice.insertAfter.enabled && choice.newLineCapture?.enabled) {
+	const lineTargetCaptureEnabled =
+		choice.insertAfter.enabled || !!choice.insertBefore?.enabled;
+
+	if (choice.captureToActiveFile && !lineTargetCaptureEnabled && choice.newLineCapture?.enabled) {
 		return choice.newLineCapture.direction === "above" ? "newLineAbove" : "newLineBelow";
 	}
 
-	if (choice.captureToActiveFile && !choice.insertAfter.enabled) {
+	if (choice.captureToActiveFile && !lineTargetCaptureEnabled) {
 		if (choice.activeFileWritePosition === "top") {
 			return "activeFileTop";
 		}
@@ -29,6 +32,10 @@ export function getCaptureAction(choice: ICaptureChoice): CaptureAction {
 
 	if (choice.insertAfter.enabled) {
 		return "insertAfter";
+	}
+
+	if (choice.insertBefore?.enabled) {
+		return "insertBefore";
 	}
 
 	if (choice.prepend) {

--- a/src/formatters/captureChoiceFormatter-write-position.test.ts
+++ b/src/formatters/captureChoiceFormatter-write-position.test.ts
@@ -257,4 +257,125 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 
 		expect(result).toBe("Line A\nLine B\nCAPTURE");
 	});
+
+	it("inserts before a matched target line", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE\n",
+			createChoice({
+				insertBefore: {
+					enabled: true,
+					before: "## Later",
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+				},
+			}),
+			"# Inbox\nBody\n## Later\nNext",
+			createFile(),
+		);
+
+		expect(result).toBe("# Inbox\nBody\nCAPTURE\n## Later\nNext");
+	});
+
+	it("separates capture content from the matched line when inserting before", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE",
+			createChoice({
+				insertBefore: {
+					enabled: true,
+					before: "Line B",
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+				},
+			}),
+			"Line A\nLine B",
+			createFile(),
+		);
+
+		expect(result).toBe("Line A\nCAPTURE\nLine B");
+	});
+
+	it("resolves format syntax in insert-before target lines", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+		formatter.setTitle("Project Alpha");
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE\n",
+			createChoice({
+				insertBefore: {
+					enabled: true,
+					before: "{{title}}",
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+				},
+			}),
+			"# Inbox\nProject Alpha\nBody",
+			createFile("Project Alpha.md"),
+		);
+
+		expect(result).toBe("# Inbox\nCAPTURE\nProject Alpha\nBody");
+	});
+
+	it("creates a missing insert-before target below the capture", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE",
+			createChoice({
+				insertBefore: {
+					enabled: true,
+					before: "## Missing",
+					createIfNotFound: true,
+					createIfNotFoundLocation: "bottom",
+				},
+			}),
+			"# Inbox",
+			createFile(),
+		);
+
+		expect(result).toBe("# Inbox\nCAPTURE\n## Missing");
+	});
 });

--- a/src/formatters/captureChoiceFormatter-write-position.test.ts
+++ b/src/formatters/captureChoiceFormatter-write-position.test.ts
@@ -378,4 +378,95 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 
 		expect(result).toBe("# Inbox\nCAPTURE\n## Missing");
 	});
+
+	it("keeps existing body content separated when creating a missing insert-before target at top", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE",
+			createChoice({
+				insertBefore: {
+					enabled: true,
+					before: "## Missing",
+					createIfNotFound: true,
+					createIfNotFoundLocation: "top",
+				},
+			}),
+			"Body",
+			createFile(),
+		);
+
+		expect(result).toBe("CAPTURE\n## Missing\nBody");
+	});
+
+	it("keeps frontmatter body content separated when creating a missing insert-before target at top", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE",
+			createChoice({
+				insertBefore: {
+					enabled: true,
+					before: "## Missing",
+					createIfNotFound: true,
+					createIfNotFoundLocation: "top",
+				},
+			}),
+			"---\ntitle: Test\n---\nBody",
+			createFile(),
+		);
+
+		expect(result).toBe("---\ntitle: Test\n---\nCAPTURE\n## Missing\nBody");
+	});
+
+	it("keeps task captures separated when creating a missing insert-before target at top", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"- [ ] CAPTURE",
+			createChoice({
+				task: true,
+				insertBefore: {
+					enabled: true,
+					before: "## Missing",
+					createIfNotFound: true,
+					createIfNotFoundLocation: "top",
+				},
+			}),
+			"Body",
+			createFile(),
+		);
+
+		expect(result).toBe("- [ ] CAPTURE\n## Missing\nBody");
+	});
 });

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -83,6 +83,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		// This is needed because in these cases, the content won't be processed by templaterParseTemplate in CaptureChoiceEngine
 		const shouldRunTemplater =
 			choice.insertAfter.enabled ||
+			!!choice.insertBefore?.enabled ||
 			choice.prepend ||
 			!choice.captureToActiveFile ||
 			choice.activeFileWritePosition === "top" ||
@@ -143,6 +144,10 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 		if (this.choice.insertAfter.enabled) {
 			return await this.insertAfterHandler(formatted);
+		}
+
+		if (this.choice.insertBefore?.enabled) {
+			return await this.insertBeforeHandler(formatted);
 		}
 
 		const frontmatterEndPosition = this.file
@@ -227,6 +232,10 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		}
 
 		return partialIndex; // -1 if no match at all
+	}
+
+	private findInsertBeforeIndex(lines: string[], rawTarget: string): number {
+		return this.findInsertAfterIndex(lines, rawTarget);
 	}
 
 	private shouldSkipBlankLinesAfterMatch(
@@ -363,6 +372,39 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		}
 
 		return this.insertTextAfterPositionInBody(
+			formatted,
+			this.fileContent,
+			targetPosition,
+		);
+	}
+
+	private async insertBeforeHandler(formatted: string) {
+		const insertBefore = this.choice.insertBefore;
+		if (!insertBefore) {
+			throw new ChoiceAbortError("Insert-before settings are missing.");
+		}
+
+		const targetString: string = await this.formatLocationString(
+			insertBefore.before,
+		);
+
+		const fileContentLines: string[] = getLinesInString(this.fileContent);
+		const targetPosition = this.findInsertBeforeIndex(
+			fileContentLines,
+			targetString,
+		);
+		const targetNotFound = targetPosition === -1;
+		if (targetNotFound) {
+			if (insertBefore.createIfNotFound) {
+				return await this.createInsertBeforeIfNotFound(formatted);
+			}
+
+			throw new ChoiceAbortError(
+				`Insert-before target not found: '${targetString}'.`,
+			);
+		}
+
+		return this.insertTextBeforePositionInBody(
 			formatted,
 			this.fileContent,
 			targetPosition,
@@ -507,6 +549,72 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		);
 	}
 
+	private async createInsertBeforeIfNotFound(formatted: string) {
+		const insertBefore = this.choice.insertBefore;
+		if (!insertBefore) {
+			throw new ChoiceAbortError("Insert-before settings are missing.");
+		}
+
+		const insertBeforeLine: string = this.replaceLinebreakInString(
+			await this.formatLocationString(insertBefore.before),
+		);
+		const formattedAndInsertBeforeLine =
+			formatted.endsWith("\n") || formatted.length === 0
+				? `${formatted}${insertBeforeLine}`
+				: `${formatted}\n${insertBeforeLine}`;
+
+		if (
+			insertBefore.createIfNotFoundLocation ===
+			CREATE_IF_NOT_FOUND_TOP
+		) {
+			const frontmatterEndPosition = this.file
+				? this.getFrontmatterEndPosition(this.file, this.fileContent)
+				: -1;
+			return this.insertTextAfterPositionInBody(
+				formattedAndInsertBeforeLine,
+				this.fileContent,
+
+				frontmatterEndPosition,
+			);
+		}
+
+		if (
+			insertBefore.createIfNotFoundLocation ===
+			CREATE_IF_NOT_FOUND_BOTTOM
+		) {
+			return `${this.fileContent}\n${formattedAndInsertBeforeLine}`;
+		}
+
+		if (
+			insertBefore.createIfNotFoundLocation ===
+			CREATE_IF_NOT_FOUND_CURSOR
+		) {
+			try {
+				const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+
+				if (!activeView) {
+					throw new Error("No active view.");
+				}
+
+				const cursor = activeView.editor.getCursor();
+
+				return this.insertTextBeforePositionInBody(
+					formattedAndInsertBeforeLine,
+					this.fileContent,
+					cursor.line,
+				);
+			} catch {
+				throw new ChoiceAbortError(
+					`Unable to insert line '${insertBefore.before}' at cursor position.`,
+				);
+			}
+		}
+
+		throw new ChoiceAbortError(
+			`Unknown createIfNotFoundLocation: ${insertBefore.createIfNotFoundLocation}`,
+		);
+	}
+
 	private async createInlineInsertAfterIfNotFound(
 		formatted: string,
 		targetString: string,
@@ -615,5 +723,23 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		const post = splitContent.slice(pos + 1).join("\n");
 
 		return `${pre}\n${text}${post}`;
+	}
+
+	private insertTextBeforePositionInBody(
+		text: string,
+		body: string,
+		pos: number,
+	): string {
+		const separator = body.length > 0 && !text.endsWith("\n") ? "\n" : "";
+
+		if (pos <= 0) {
+			return `${text}${separator}${body}`;
+		}
+
+		const splitContent = body.split("\n");
+		const pre = splitContent.slice(0, pos).join("\n");
+		const post = splitContent.slice(pos).join("\n");
+
+		return `${pre}\n${text}${separator}${post}`;
 	}
 }

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -570,8 +570,14 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			const frontmatterEndPosition = this.file
 				? this.getFrontmatterEndPosition(this.file, this.fileContent)
 				: -1;
+			const needsTrailingSeparator =
+				frontmatterEndPosition >= 0 || this.choice.task;
+			const textAtTop =
+				needsTrailingSeparator && !formattedAndInsertBeforeLine.endsWith("\n")
+					? `${formattedAndInsertBeforeLine}\n`
+					: formattedAndInsertBeforeLine;
 			return this.insertTextAfterPositionInBody(
-				formattedAndInsertBeforeLine,
+				textAtTop,
 				this.fileContent,
 
 				frontmatterEndPosition,

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -118,7 +118,7 @@ export class CompleteFormatter extends Formatter {
 
 	/**
 	 * Formats small inline target strings used for location matching, e.g.,
-	 * the "Insert after" selector. This intentionally does not run Templater,
+	 * the line-target capture selectors. This intentionally does not run Templater,
 	 * but applies the core QuickAdd format pipeline plus link/title expansion
 	 * so selectors can reference {{linkcurrent}} and {{title}} consistently.
 	 */

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -881,6 +881,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 	private addWritePositionSetting() {
 		const positionSetting: Setting = new Setting(this.contentEl);
 		const isActiveFile = !!this.choice?.captureToActiveFile;
+		this.ensureInsertBeforeSettings();
 
 		if (!this.choice.activeFileWritePosition) {
 			this.choice.activeFileWritePosition = "cursor";
@@ -896,6 +897,8 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			.addDropdown((dropdown) => {
 				const current = this.choice.insertAfter?.enabled
 					? "after"
+					: this.choice.insertBefore?.enabled
+						? "before"
 					: this.choice.newLineCapture?.enabled
 						? this.choice.newLineCapture.direction === "above"
 							? "newLineAbove"
@@ -920,12 +923,14 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 				}
 				
 				dropdown.addOption("after", "After line…");
+				dropdown.addOption("before", "Before line…");
 				dropdown.addOption("bottom", "Bottom of file");
 				dropdown.setValue(current);
 				dropdown.onChange((value: string) => {
 					const v = value as
 						| "top"
 						| "after"
+						| "before"
 						| "bottom"
 						| "newLineAbove"
 						| "newLineBelow"
@@ -933,6 +938,8 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 					
 					this.choice.prepend = false;
 					this.choice.insertAfter.enabled = false;
+					this.ensureInsertBeforeSettings();
+					this.choice.insertBefore!.enabled = false;
 					if (!this.choice.newLineCapture) {
 						this.choice.newLineCapture = { enabled: false, direction: "below" };
 					}
@@ -979,6 +986,12 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 						return;
 					}
 
+					if (v === "before") {
+						this.choice.insertBefore!.enabled = true;
+						this.reload();
+						return;
+					}
+
 					// after line
 					this.choice.insertAfter.enabled = true;
 					this.reload();
@@ -989,7 +1002,21 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			this.addInsertAfterFields();
 		}
 
+		if (this.choice.insertBefore?.enabled) {
+			this.addInsertBeforeFields();
+		}
+
 		this.addCanvasModeCompatibilityNotice(isActiveFile);
+	}
+
+	private ensureInsertBeforeSettings() {
+		if (this.choice.insertBefore) return;
+		this.choice.insertBefore = {
+			enabled: false,
+			before: "",
+			createIfNotFound: false,
+			createIfNotFoundLocation: CREATE_IF_NOT_FOUND_TOP,
+		};
 	}
 
 	private addCanvasModeCompatibilityNotice(isActiveFile: boolean) {
@@ -1001,6 +1028,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 		const usesCursorMode =
 			isActiveFile &&
 			!this.choice.insertAfter.enabled &&
+			!this.choice.insertBefore?.enabled &&
 			!this.choice.newLineCapture?.enabled &&
 			(this.choice.activeFileWritePosition ?? "cursor") === "cursor" &&
 			!this.choice.prepend;
@@ -1012,7 +1040,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 
 		const warning = this.contentEl.createDiv({ cls: "setting-item-description" });
 		warning.setText(
-			"Canvas note: 'At cursor' and 'New line above/below cursor' are not supported for Canvas card capture. Use top, bottom, or insert-after placement.",
+			"Canvas note: 'At cursor' and 'New line above/below cursor' are not supported for Canvas card capture. Use top, bottom, insert-after, or insert-before placement.",
 		);
 	}
 
@@ -1210,6 +1238,89 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 					.onChange(
 						(value) =>
 							(this.choice.insertAfter.createIfNotFoundLocation = value),
+					);
+			});
+	}
+
+	private addInsertBeforeFields() {
+		this.ensureInsertBeforeSettings();
+		const insertBefore = this.choice.insertBefore!;
+
+		const descText =
+			"Insert capture before specified text. Accepts format syntax.";
+
+		new Setting(this.contentEl)
+			.setName("Insert before")
+			.setDesc(descText);
+
+		const displayFormatter: FormatDisplayFormatter = new FormatDisplayFormatter(
+			this.app,
+			this.plugin,
+		);
+
+		const previewRow = this.contentEl.createDiv({ cls: "qa-preview-row" });
+		previewRow.createEl("span", { text: "Preview: ", cls: "qa-preview-label" });
+		const previewValue = previewRow.createEl("span");
+		previewValue.setAttribute("aria-live", "polite");
+		previewValue.innerText = "Loading preview…";
+
+		createValidatedInput({
+			app: this.app,
+			parent: this.contentEl,
+			initialValue: insertBefore.before,
+			placeholder: "Insert before",
+			required: true,
+			requiredMessage: "Insert before text is required",
+			attachSuggesters: [
+				(el) => new FormatSyntaxSuggester(this.app, el, this.plugin),
+			],
+			onChange: async (value) => {
+				insertBefore.before = value;
+				try {
+					previewValue.innerText = await displayFormatter.format(value);
+				} catch {
+					previewValue.innerText = "Preview unavailable";
+				}
+			},
+		});
+
+		void (async () => {
+			try {
+				previewValue.innerText = await displayFormatter.format(
+					insertBefore.before,
+				);
+			} catch {
+				previewValue.innerText = "Preview unavailable";
+			}
+		})();
+
+		const createLineIfNotFound: Setting = new Setting(this.contentEl);
+		createLineIfNotFound
+			.setName("Create line if not found")
+			.setDesc("Creates the 'insert before' line if it is not found.")
+			.addToggle((toggle) => {
+				if (!insertBefore.createIfNotFound)
+					insertBefore.createIfNotFound = false;
+
+				toggle
+					.setValue(insertBefore.createIfNotFound)
+					.onChange(
+						(value) => (insertBefore.createIfNotFound = value),
+					).toggleEl.style.marginRight = "1em";
+			})
+			.addDropdown((dropdown) => {
+				if (!insertBefore.createIfNotFoundLocation)
+					insertBefore.createIfNotFoundLocation =
+						CREATE_IF_NOT_FOUND_TOP;
+
+				dropdown
+					.addOption(CREATE_IF_NOT_FOUND_TOP, "Top")
+					.addOption(CREATE_IF_NOT_FOUND_BOTTOM, "Bottom")
+					.addOption(CREATE_IF_NOT_FOUND_CURSOR, "Cursor")
+					.setValue(insertBefore.createIfNotFoundLocation)
+					.onChange(
+						(value) =>
+							(insertBefore.createIfNotFoundLocation = value),
 					);
 			});
 	}

--- a/src/types/choices/CaptureChoice.test.ts
+++ b/src/types/choices/CaptureChoice.test.ts
@@ -50,4 +50,18 @@ describe("CaptureChoice.Load", () => {
 
 		expect(loaded.activeFileWritePosition).toBe("cursor");
 	});
+
+	it("adds default insert-before settings to legacy choices", () => {
+		const choice = new CaptureChoice("Legacy") as any;
+		delete choice.insertBefore;
+
+		const loaded = CaptureChoice.Load(choice);
+
+		expect(loaded.insertBefore).toEqual({
+			enabled: false,
+			before: "",
+			createIfNotFound: false,
+			createIfNotFoundLocation: "top",
+		});
+	});
 });

--- a/src/types/choices/CaptureChoice.ts
+++ b/src/types/choices/CaptureChoice.ts
@@ -29,6 +29,12 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 		replaceExisting?: boolean;
 		blankLineAfterMatchMode?: BlankLineAfterMatchMode;
 	};
+	insertBefore: {
+		enabled: boolean;
+		before: string;
+		createIfNotFound: boolean;
+		createIfNotFoundLocation: string;
+	};
 	newLineCapture: {
 		enabled: boolean;
 		direction: "above" | "below";
@@ -71,6 +77,12 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 			replaceExisting: false,
 			blankLineAfterMatchMode: "auto",
 		};
+		this.insertBefore = {
+			enabled: false,
+			before: "",
+			createIfNotFound: false,
+			createIfNotFoundLocation: "top",
+		};
 		this.newLineCapture = {
 			enabled: false,
 			direction: "below",
@@ -97,10 +109,19 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 		if (typeof loaded.captureToCanvasNodeId !== "string") {
 			loaded.captureToCanvasNodeId = "";
 		}
+		if (!loaded.insertBefore) {
+			loaded.insertBefore = {
+				enabled: false,
+				before: "",
+				createIfNotFound: false,
+				createIfNotFoundLocation: "top",
+			};
+		}
 		if (
 			loaded.captureToActiveFile &&
 			loaded.prepend &&
 			!loaded.insertAfter?.enabled &&
+			!loaded.insertBefore.enabled &&
 			!loaded.newLineCapture?.enabled
 		) {
 			if (loaded.activeFileWritePosition !== "top") {

--- a/src/types/choices/ICaptureChoice.ts
+++ b/src/types/choices/ICaptureChoice.ts
@@ -40,6 +40,12 @@ export default interface ICaptureChoice extends IChoice {
 		replaceExisting?: boolean;
 		blankLineAfterMatchMode?: BlankLineAfterMatchMode;
 	};
+	insertBefore?: {
+		enabled: boolean;
+		before: string;
+		createIfNotFound: boolean;
+		createIfNotFoundLocation: string;
+	};
 	newLineCapture: {
 		enabled: boolean;
 		direction: "above" | "below";


### PR DESCRIPTION
Add a capture write-position option for inserting content before a matched line, alongside the existing after-line option.

This adds persisted `insertBefore` settings, action routing, formatter insertion and create-if-not-found behavior, the Choice Builder dropdown/fields, Canvas compatibility wording, and current docs for the new placement.

Before implementation, I reproduced the missing behavior with a focused repo-level action test: `insertBefore.enabled` fell through to `append`. Obsidian dev-vault validation was skipped because this worktree was not granted the shared dev-vault slot and the behavior is covered by repo-level formatter/action tests.

Validation:
- `bun run test src/engine/captureAction.test.ts src/formatters/captureChoiceFormatter-write-position.test.ts src/types/choices/CaptureChoice.test.ts src/engine/canvasCapture.test.ts`
- `bun run build-with-lint`
- `bun run test`

Fixes #1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Insert Before" write-position option for captures, including UI support and configurable "create if not found" placement.

* **Documentation**
  * Updated Canvas capture docs and FAQ to document Top/Bottom/After/Before support and clarify cursor-placement limitations.

* **Bug Fixes / UX**
  * Improved notices and abort messages to explicitly cover insert-before behavior and unsupported cursor-based missing-line cases.

* **Tests**
  * Added/expanded tests covering insert-before selection and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->