### PR TITLE
fix: preserve prompt drafts until choice execution commits

### DIFF
--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -15,6 +15,7 @@ import { runOnePagePreflight } from "./preflight/runOnePagePreflight";
 import { MacroAbortError } from "./errors/MacroAbortError";
 import { isCancellationError } from "./utils/errorUtils";
 import { getOpenFileOriginLeaf } from "./utilityObsidian";
+import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
@@ -34,57 +35,71 @@ export class ChoiceExecutor implements IChoiceExecutor {
 
 	async execute(choice: IChoice): Promise<void> {
 		this.pendingAbort = null;
+		const promptDraftStore = InputPromptDraftStore.getInstance();
+		promptDraftStore.beginExecutionScope();
 		const originLeaf = getOpenFileOriginLeaf(this.app);
-		// One-page preflight honoring per-choice override.
-		const globalEnabled = settingsStore.getState().onePageInputEnabled;
-		const override = choice.onePageInput;
-		const shouldUseOnePager =
-			override === "always" || (override !== "never" && globalEnabled);
-		if (
-			shouldUseOnePager &&
-			(choice.type === "Template" ||
-				choice.type === "Capture" ||
-				choice.type === "Macro")
-		) {
-			try {
-				await runOnePagePreflight(
-					this.app,
-					this.plugin as unknown as QuickAdd,
-					this,
-					choice,
-				);
-			} catch (error) {
-				if (isCancellationError(error)) {
-					throw new MacroAbortError("One-page input cancelled by user");
+		try {
+			// One-page preflight honoring per-choice override.
+			const globalEnabled = settingsStore.getState().onePageInputEnabled;
+			const override = choice.onePageInput;
+			const shouldUseOnePager =
+				override === "always" || (override !== "never" && globalEnabled);
+			if (
+				shouldUseOnePager &&
+				(choice.type === "Template" ||
+					choice.type === "Capture" ||
+					choice.type === "Macro")
+			) {
+				try {
+					await runOnePagePreflight(
+						this.app,
+						this.plugin as unknown as QuickAdd,
+						this,
+						choice,
+					);
+				} catch (error) {
+					if (isCancellationError(error)) {
+						throw new MacroAbortError("One-page input cancelled by user");
+					}
+					throw error;
 				}
-				throw error;
 			}
-		}
 
-		switch (choice.type) {
-			case "Template": {
-				const templateChoice: ITemplateChoice =
-					choice as ITemplateChoice;
-				await this.onChooseTemplateType(templateChoice, originLeaf);
-				break;
+			switch (choice.type) {
+				case "Template": {
+					const templateChoice: ITemplateChoice =
+						choice as ITemplateChoice;
+					await this.onChooseTemplateType(templateChoice, originLeaf);
+					break;
+				}
+				case "Capture": {
+					const captureChoice: ICaptureChoice = choice as ICaptureChoice;
+					await this.onChooseCaptureType(captureChoice, originLeaf);
+					break;
+				}
+				case "Macro": {
+					const macroChoice: IMacroChoice = choice as IMacroChoice;
+					await this.onChooseMacroType(macroChoice, originLeaf);
+					break;
+				}
+				case "Multi": {
+					const multiChoice: IMultiChoice = choice as IMultiChoice;
+					this.onChooseMultiType(multiChoice);
+					break;
+				}
+				default:
+					break;
 			}
-			case "Capture": {
-				const captureChoice: ICaptureChoice = choice as ICaptureChoice;
-				await this.onChooseCaptureType(captureChoice, originLeaf);
-				break;
+
+			if (this.pendingAbort) {
+				promptDraftStore.rollbackExecutionScope();
+				return;
 			}
-			case "Macro": {
-				const macroChoice: IMacroChoice = choice as IMacroChoice;
-				await this.onChooseMacroType(macroChoice, originLeaf);
-				break;
-			}
-			case "Multi": {
-				const multiChoice: IMultiChoice = choice as IMultiChoice;
-				this.onChooseMultiType(multiChoice);
-				break;
-			}
-			default:
-				break;
+
+			promptDraftStore.commitExecutionScope();
+		} catch (error) {
+			promptDraftStore.rollbackExecutionScope();
+			throw error;
 		}
 	}
 

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -35,9 +35,9 @@ export class ChoiceExecutor implements IChoiceExecutor {
 
 	async execute(choice: IChoice): Promise<void> {
 		this.pendingAbort = null;
+		const originLeaf = getOpenFileOriginLeaf(this.app);
 		const promptDraftStore = InputPromptDraftStore.getInstance();
 		promptDraftStore.beginExecutionScope();
-		const originLeaf = getOpenFileOriginLeaf(this.app);
 		try {
 			// One-page preflight honoring per-choice override.
 			const globalEnabled = settingsStore.getState().onePageInputEnabled;

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -7,15 +7,21 @@ import { insertFileLinkToActiveView, isFolder, openFile } from "../utilityObsidi
 import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "../constants";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { InputPromptDraftHandler } from "../utils/InputPromptDraftHandler";
+import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 
 const {
 	setUseSelectionAsCaptureValueMock,
 	setTitleMock,
 	singleTemplateRunMock,
+	promptResponses,
+	promptHydratedValues,
 } = vi.hoisted(() => ({
 	setUseSelectionAsCaptureValueMock: vi.fn(),
 	setTitleMock: vi.fn(),
 	singleTemplateRunMock: vi.fn(async () => ""),
+	promptResponses: [] as string[],
+	promptHydratedValues: [] as string[],
 }));
 
 vi.mock("../formatters/captureChoiceFormatter", () => ({
@@ -33,10 +39,26 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 			return await work();
 		}
 		async formatContentOnly(content: string) {
-			return content;
+			if (!/\{\{value\}\}/i.test(content)) return content;
+
+			const draftHandler = new InputPromptDraftHandler(
+				{
+					kind: "single",
+					header: "Capture Choice",
+					placeholder: "",
+				},
+				() => true,
+			);
+			const hydrated = draftHandler.hydrate("");
+			promptHydratedValues.push(hydrated);
+			const submitted = promptResponses.shift() ?? hydrated;
+			draftHandler.markChanged();
+			draftHandler.persist(submitted, true);
+
+			return content.replace(/\{\{value\}\}/gi, submitted);
 		}
-		async formatContentWithFile() {
-			return "";
+		async formatContentWithFile(content: string) {
+			return content;
 		}
 		async formatFileName(name: string) {
 			return name;
@@ -101,6 +123,8 @@ const createApp = () =>
 				exists: vi.fn(async () => false),
 			},
 			getAbstractFileByPath: vi.fn(() => null),
+			modify: vi.fn(async () => {}),
+			read: vi.fn(async () => ""),
 		},
 		workspace: {
 			getActiveFile: vi.fn(() => null),
@@ -158,6 +182,9 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 	beforeEach(() => {
 		setUseSelectionAsCaptureValueMock.mockClear();
 		setTitleMock.mockClear();
+		promptResponses.length = 0;
+		promptHydratedValues.length = 0;
+		InputPromptDraftStore.getInstance().clearAll();
 		vi.mocked(openFile).mockClear();
 	});
 
@@ -389,7 +416,7 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(setTitleMock).toHaveBeenCalledWith("Map");
 	});
 
-	it("copies formatted capture content to clipboard when creating the target file fails", async () => {
+	it("does not copy formatted capture content to clipboard when creating the target file fails", async () => {
 		const clipboardWriteText = vi.fn(async () => {});
 		Object.defineProperty(navigator, "clipboard", {
 			value: { writeText: clipboardWriteText },
@@ -426,7 +453,105 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 
 		await engine.run();
 
-		expect(clipboardWriteText).toHaveBeenCalledWith("Capture body to preserve");
+		expect(clipboardWriteText).not.toHaveBeenCalled();
+	});
+
+	it("keeps submitted VALUE prompt draft after failed target creation and clears it after success", async () => {
+		promptResponses.push("Capture body to preserve");
+		const store = InputPromptDraftStore.getInstance();
+		const draftKey = store.makeKey({
+			kind: "single",
+			header: "Capture Choice",
+			placeholder: "",
+		});
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{
+				settings: {
+					useSelectionAsCaptureValue: false,
+					showCaptureNotification: true,
+				},
+			} as any,
+			createChoice({
+				captureTo: "Bad:Title.md",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+				format: {
+					enabled: true,
+					format: "{{VALUE}}",
+				},
+			}),
+			createExecutor(),
+		);
+
+		(engine as any).createFileWithInput = vi.fn(async () => {
+			throw new Error("File name cannot contain ':'");
+		});
+
+		const clipboardWriteText = vi.fn(async () => {});
+		Object.defineProperty(navigator, "clipboard", {
+			value: { writeText: clipboardWriteText },
+			configurable: true,
+		});
+
+		store.beginExecutionScope();
+		await engine.run();
+		store.commitExecutionScope();
+
+		expect(store.get(draftKey)).toBe("Capture body to preserve");
+		expect(clipboardWriteText).not.toHaveBeenCalled();
+
+		const nextDraftHandler = new InputPromptDraftHandler(
+			{
+				kind: "single",
+				header: "Capture Choice",
+				placeholder: "",
+			},
+			() => true,
+		);
+
+		expect(nextDraftHandler.hydrate("")).toBe("Capture body to preserve");
+
+		const successfulEngine = new CaptureChoiceEngine(
+			createApp(),
+			{
+				settings: {
+					useSelectionAsCaptureValue: false,
+					showCaptureNotification: true,
+				},
+			} as any,
+			createChoice({
+				captureTo: "Recovered.md",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+				format: {
+					enabled: true,
+					format: "{{VALUE}}",
+				},
+			}),
+			createExecutor(),
+		);
+		(successfulEngine as any).createFileWithInput = vi.fn(
+			async (path: string) => ({
+				path,
+				basename: "Recovered",
+				extension: "md",
+			}),
+		);
+
+		store.beginExecutionScope();
+		await successfulEngine.run();
+		store.commitExecutionScope();
+
+		expect(promptHydratedValues).toContain("Capture body to preserve");
+		expect(store.get(draftKey)).toBeUndefined();
 	});
 
 	it("does not copy capture content to clipboard when template creation is cancelled", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -39,6 +39,7 @@ import {
 } from "../utilityObsidian";
 import { isCancellationError, reportError } from "../utils/errorUtils";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
+import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { basenameWithoutMdOrCanvas } from "../utils/pathUtils";
 import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
@@ -178,37 +179,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		}
 
 		insertFileLinkToActiveView(this.app, file, linkOptions);
-	}
-
-	private async copyCaptureContentToClipboardAfterFailure(
-		captureContent: string,
-	): Promise<void> {
-		const clipboard =
-			typeof navigator !== "undefined" ? navigator.clipboard : undefined;
-
-		if (!clipboard?.writeText) {
-			new Notice(
-				"Capture failed before it could be written, and clipboard access is unavailable.",
-				DEFAULT_NOTICE_DURATION,
-			);
-			return;
-		}
-
-		try {
-			await clipboard.writeText(captureContent);
-			new Notice(
-				"Capture failed before it could be written. The capture content was copied to your clipboard.",
-				DEFAULT_NOTICE_DURATION,
-			);
-		} catch (err) {
-			log.logError(
-				`Failed to copy failed capture content to clipboard: ${err instanceof Error ? err.message : String(err)}`,
-			);
-			new Notice(
-				"Capture failed before it could be written, and QuickAdd could not copy the capture content to your clipboard.",
-				DEFAULT_NOTICE_DURATION,
-			);
-		}
 	}
 
 	async run(): Promise<void> {
@@ -371,6 +341,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				this.choiceExecutor.signalAbort?.(err);
 				return;
 			}
+			InputPromptDraftStore.getInstance().markExecutionScopeFailed();
 			reportError(err, `Error running capture choice "${this.choice.name}"`);
 		}
 	}
@@ -824,9 +795,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				throw err;
 			}
 
-			await this.copyCaptureContentToClipboardAfterFailure(
-				formattedCaptureContent,
-			);
 			throw err;
 		}
 	}

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -722,81 +722,73 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			);
 		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
 
-		try {
-			let fileContent = "";
-			if (this.choice.createFileIfItDoesntExist.createWithTemplate) {
-				const singleTemplateEngine: SingleTemplateEngine =
-					new SingleTemplateEngine(
-						this.app,
-						this.plugin,
-						this.choice.createFileIfItDoesntExist.template,
-						this.choiceExecutor,
-					);
-
-				if (linkOptions?.enabled && !linkOptions.requireActiveFile) {
-					singleTemplateEngine.setLinkToCurrentFileBehavior("optional");
-				}
-
-				fileContent = await singleTemplateEngine.run();
-
-				// Get template variables from the template engine's formatter
-				const templateVars = singleTemplateEngine.getAndClearTemplatePropertyVars();
-
-				log.logMessage(`CaptureChoiceEngine: Collected ${templateVars.size} template property variables`);
-				if (templateVars.size > 0) {
-					log.logMessage(`Variables: ${Array.from(templateVars.keys()).join(', ')}`);
-				}
-
-				// Store for later use
-				this.templatePropertyVars = templateVars;
-			}
-
-			// Create the new file with the (optional) template content
-			const file: TFile = await this.createFileWithInput(filePath, fileContent, {
-				suppressTemplaterOnCreate:
-					this.choice.createFileIfItDoesntExist.createWithTemplate,
-			});
-
-			// Post-process front matter for template property types if we used a template
-			if (this.choice.createFileIfItDoesntExist.createWithTemplate &&
-				this.templatePropertyVars &&
-				this.shouldPostProcessFrontMatter(file, this.templatePropertyVars)) {
-				await this.postProcessFrontMatter(file, this.templatePropertyVars);
-			}
-
-			// Process Templater commands in the template if a template was used
-			if (
-				this.choice.createFileIfItDoesntExist.createWithTemplate &&
-				fileContent
-			) {
-				await overwriteTemplaterOnce(this.app, file);
-			} else if (isTemplaterTriggerOnCreateEnabled(this.app)) {
-				await waitForTemplaterTriggerOnCreateToComplete(this.app, file);
-			}
-
-			// Read the file fresh from disk to avoid any potential cached content
-			// after the initial Templater run on newly created files.
-			const updatedFileContent: string = await this.app.vault.read(file);
-			// Second formatting pass: embed the already-resolved capture content into the newly created file
-			const newFileContent: string =
-				await this.formatter.withTemplatePropertyCollection(() =>
-					this.formatter.formatContentWithFile(
-						formattedCaptureContent,
-						this.choice,
-						updatedFileContent,
-						file,
-					),
+		let fileContent = "";
+		if (this.choice.createFileIfItDoesntExist.createWithTemplate) {
+			const singleTemplateEngine: SingleTemplateEngine =
+				new SingleTemplateEngine(
+					this.app,
+					this.plugin,
+					this.choice.createFileIfItDoesntExist.template,
+					this.choiceExecutor,
 				);
-			this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
 
-			return { file, newFileContent, captureContent: formattedCaptureContent };
-		} catch (err) {
-			if (err instanceof MacroAbortError || isCancellationError(err)) {
-				throw err;
+			if (linkOptions?.enabled && !linkOptions.requireActiveFile) {
+				singleTemplateEngine.setLinkToCurrentFileBehavior("optional");
 			}
 
-			throw err;
+			fileContent = await singleTemplateEngine.run();
+
+			// Get template variables from the template engine's formatter
+			const templateVars = singleTemplateEngine.getAndClearTemplatePropertyVars();
+
+			log.logMessage(`CaptureChoiceEngine: Collected ${templateVars.size} template property variables`);
+			if (templateVars.size > 0) {
+				log.logMessage(`Variables: ${Array.from(templateVars.keys()).join(', ')}`);
+			}
+
+			// Store for later use
+			this.templatePropertyVars = templateVars;
 		}
+
+		// Create the new file with the (optional) template content
+		const file: TFile = await this.createFileWithInput(filePath, fileContent, {
+			suppressTemplaterOnCreate:
+				this.choice.createFileIfItDoesntExist.createWithTemplate,
+		});
+
+		// Post-process front matter for template property types if we used a template
+		if (this.choice.createFileIfItDoesntExist.createWithTemplate &&
+			this.templatePropertyVars &&
+			this.shouldPostProcessFrontMatter(file, this.templatePropertyVars)) {
+			await this.postProcessFrontMatter(file, this.templatePropertyVars);
+		}
+
+		// Process Templater commands in the template if a template was used
+		if (
+			this.choice.createFileIfItDoesntExist.createWithTemplate &&
+			fileContent
+		) {
+			await overwriteTemplaterOnce(this.app, file);
+		} else if (isTemplaterTriggerOnCreateEnabled(this.app)) {
+			await waitForTemplaterTriggerOnCreateToComplete(this.app, file);
+		}
+
+		// Read the file fresh from disk to avoid any potential cached content
+		// after the initial Templater run on newly created files.
+		const updatedFileContent: string = await this.app.vault.read(file);
+		// Second formatting pass: embed the already-resolved capture content into the newly created file
+		const newFileContent: string =
+			await this.formatter.withTemplatePropertyCollection(() =>
+				this.formatter.formatContentWithFile(
+					formattedCaptureContent,
+					this.choice,
+					updatedFileContent,
+					file,
+				),
+			);
+		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
+
+		return { file, newFileContent, captureContent: formattedCaptureContent };
 	}
 
 	private async formatFilePath(captureTo: string) {

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -300,6 +300,56 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 
 		expect(store.get(draftKey)).toBe("Submitted template name");
 	});
+
+	it("preserves submitted prompt drafts when an existing target cannot be resolved", async () => {
+		const store = InputPromptDraftStore.getInstance();
+		const draftKey = store.makeKey({
+			kind: "single",
+			header: "Test Template Choice",
+			placeholder: "",
+		});
+		const { engine, app } = createEngine("ignored", {
+			throwDuringFileName: false,
+		});
+
+		engine.choice.fileExistsBehavior = { kind: "apply", mode: "overwrite" };
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(
+			true,
+		);
+
+		store.beginExecutionScope();
+		store.handleSubmittedDraft(draftKey, "Submitted template name");
+
+		await engine.run();
+		store.commitExecutionScope();
+
+		expect(store.get(draftKey)).toBe("Submitted template name");
+	});
+
+	it("preserves submitted prompt drafts when template file creation returns null", async () => {
+		const store = InputPromptDraftStore.getInstance();
+		const draftKey = store.makeKey({
+			kind: "single",
+			header: "Test Template Choice",
+			placeholder: "",
+		});
+		const { engine } = createEngine("ignored", {
+			throwDuringFileName: false,
+		});
+		(
+			engine as unknown as {
+				createFileWithTemplate: () => Promise<TFile | null>;
+			}
+		).createFileWithTemplate = vi.fn().mockResolvedValue(null);
+
+		store.beginExecutionScope();
+		store.handleSubmittedDraft(draftKey, "Submitted template name");
+
+		await engine.run();
+		store.commitExecutionScope();
+
+		expect(store.get(draftKey)).toBe("Submitted template name");
+	});
 });
 
 describe("TemplateChoiceEngine file casing resolution", () => {

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -111,6 +111,7 @@ import type { IChoiceExecutor } from "../IChoiceExecutor";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { settingsStore } from "../settingsStore";
+import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 
 const defaultSettingsState = structuredClone(settingsStore.getState());
 
@@ -207,6 +208,7 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 	beforeEach(() => {
 		settingsStore.setState(structuredClone(defaultSettingsState));
 		noticeClass.instances.length = 0;
+		InputPromptDraftStore.getInstance().clearAll();
 		formatFileNameMock.mockReset();
 		formatFileContentMock.mockReset();
 		formatFileContentMock.mockResolvedValue("");
@@ -278,6 +280,25 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 		await engine.run();
 
 		expect(choiceExecutor.signalAbort).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves submitted prompt drafts when a non-abort template failure is reported", async () => {
+		const store = InputPromptDraftStore.getInstance();
+		const draftKey = store.makeKey({
+			kind: "single",
+			header: "Test Template Choice",
+			placeholder: "",
+		});
+		const { engine } = createEngine("ignored");
+		formatFileNameMock.mockRejectedValueOnce(new Error("Disk full"));
+
+		store.beginExecutionScope();
+		store.handleSubmittedDraft(draftKey, "Submitted template name");
+
+		await engine.run();
+		store.commitExecutionScope();
+
+		expect(store.get(draftKey)).toBe("Submitted template name");
 	});
 });
 

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -326,6 +326,48 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 		expect(store.get(draftKey)).toBe("Submitted template name");
 	});
 
+	it("preserves submitted prompt drafts when file-exists handling returns no file", async () => {
+		const store = InputPromptDraftStore.getInstance();
+		const draftKey = store.makeKey({
+			kind: "single",
+			header: "Test Template Choice",
+			placeholder: "",
+		});
+		const { engine, app } = createEngine("ignored", {
+			throwDuringFileName: false,
+		});
+		const existingFile = new TFile();
+		existingFile.path = "Test Template.md";
+		existingFile.name = "Test Template.md";
+		existingFile.extension = "md";
+		existingFile.basename = "Test Template";
+
+		engine.choice.fileExistsBehavior = { kind: "apply", mode: "overwrite" };
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(
+			true,
+		);
+		(app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(
+			existingFile,
+		);
+		vi.spyOn(
+			engine as unknown as {
+				overwriteFileWithTemplate: (
+					file: TFile,
+					templatePath: string,
+				) => Promise<TFile | null>;
+			},
+			"overwriteFileWithTemplate",
+		).mockResolvedValue(null);
+
+		store.beginExecutionScope();
+		store.handleSubmittedDraft(draftKey, "Submitted template name");
+
+		await engine.run();
+		store.commitExecutionScope();
+
+		expect(store.get(draftKey)).toBe("Submitted template name");
+	});
+
 	it("preserves submitted prompt drafts when template file creation returns null", async () => {
 		const store = InputPromptDraftStore.getInstance();
 		const draftKey = store.makeKey({

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -128,6 +128,11 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					targetFilePath,
 					existingFile,
 				));
+				if (!createdFile) {
+					InputPromptDraftStore.getInstance().markExecutionScopeFailed();
+					log.logWarning(`Could not resolve file exists behavior for '${targetFilePath}'.`);
+					return;
+				}
 			} else {
 				createdFile = await this.createFileWithTemplate(
 					targetFilePath,

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -116,6 +116,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 							existingFile.extension !== "canvas" &&
 							existingFile.extension !== "base"))
 				) {
+					InputPromptDraftStore.getInstance().markExecutionScopeFailed();
 					log.logError(
 						`'${targetFilePath}' already exists but could not be resolved as a markdown, canvas, or base file.`,
 					);
@@ -133,6 +134,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					this.choice.templatePath,
 				);
 				if (!createdFile) {
+					InputPromptDraftStore.getInstance().markExecutionScopeFailed();
 					log.logWarning(`Could not create file '${targetFilePath}'.`);
 					return;
 				}

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -28,6 +28,7 @@ import {
 	sortFolderPathsByTree,
 } from "../utils/folder-sorting";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
+import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { TemplateEngine } from "./TemplateEngine";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
@@ -170,6 +171,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				this.choiceExecutor.signalAbort?.(err);
 				return;
 			}
+			InputPromptDraftStore.getInstance().markExecutionScopeFailed();
 			reportError(err, `Error running template choice "${this.choice.name}"`);
 		}
 	}

--- a/src/utils/InputPromptDraftHandler.ts
+++ b/src/utils/InputPromptDraftHandler.ts
@@ -33,7 +33,7 @@ export class InputPromptDraftHandler {
 		if (!this.shouldPersist()) return;
 
 		if (didSubmit) {
-			this.store.clear(this.draftKey);
+			this.store.handleSubmittedDraft(this.draftKey, value);
 			return;
 		}
 

--- a/src/utils/InputPromptDraftStore.test.ts
+++ b/src/utils/InputPromptDraftStore.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { InputPromptDraftHandler } from "./InputPromptDraftHandler";
+import { InputPromptDraftStore } from "./InputPromptDraftStore";
+
+describe("InputPromptDraftStore execution scopes", () => {
+	const store = InputPromptDraftStore.getInstance();
+	const key = {
+		kind: "single" as const,
+		header: "Enter value",
+		placeholder: "",
+	};
+	const draftKey = store.makeKey(key);
+	const shouldPersist = () => true;
+
+	beforeEach(() => {
+		store.clearAll();
+	});
+
+	it("keeps existing submit behavior outside an execution scope", () => {
+		store.set(draftKey, "old draft");
+		const handler = new InputPromptDraftHandler(key, shouldPersist);
+
+		handler.persist("submitted", true);
+
+		expect(store.get(draftKey)).toBeUndefined();
+	});
+
+	it("keeps submitted drafts pending until the execution scope commits", () => {
+		const handler = new InputPromptDraftHandler(key, shouldPersist);
+
+		store.beginExecutionScope();
+		handler.persist("submitted", true);
+
+		expect(store.get(draftKey)).toBe("submitted");
+
+		store.commitExecutionScope();
+
+		expect(store.get(draftKey)).toBeUndefined();
+	});
+
+	it("preserves submitted drafts when the execution scope rolls back", () => {
+		const handler = new InputPromptDraftHandler(key, shouldPersist);
+
+		store.beginExecutionScope();
+		handler.persist("submitted", true);
+		store.rollbackExecutionScope();
+
+		expect(store.get(draftKey)).toBe("submitted");
+	});
+
+	it("preserves submitted drafts when a swallowed failure marks the scope failed", () => {
+		const handler = new InputPromptDraftHandler(key, shouldPersist);
+
+		store.beginExecutionScope();
+		handler.persist("submitted", true);
+		store.markExecutionScopeFailed();
+		store.commitExecutionScope();
+
+		expect(store.get(draftKey)).toBe("submitted");
+	});
+
+	it("does not resurrect unchanged defaults after cancellation before submit", () => {
+		const handler = new InputPromptDraftHandler(key, shouldPersist);
+
+		expect(handler.hydrate("default")).toBe("default");
+		handler.persist("default", false);
+
+		expect(store.get(draftKey)).toBeUndefined();
+	});
+
+	it("keeps changed non-empty drafts after cancellation before submit", () => {
+		const handler = new InputPromptDraftHandler(key, shouldPersist);
+
+		expect(handler.hydrate("default")).toBe("default");
+		handler.markChanged();
+		handler.persist("changed", false);
+
+		expect(store.get(draftKey)).toBe("changed");
+	});
+});

--- a/src/utils/InputPromptDraftStore.ts
+++ b/src/utils/InputPromptDraftStore.ts
@@ -15,6 +15,9 @@ interface DraftEntry {
 export class InputPromptDraftStore {
 	private static instance: InputPromptDraftStore;
 	private drafts: Map<string, DraftEntry> = new Map();
+	private pendingSubmittedDraftKeys: Set<string> = new Set();
+	private executionScopeDepth = 0;
+	private executionScopeFailed = false;
 	private readonly MAX_ENTRIES = 100;
 
 	static getInstance(): InputPromptDraftStore {
@@ -56,12 +59,63 @@ export class InputPromptDraftStore {
 		});
 	}
 
+	handleSubmittedDraft(key: string, value: string): void {
+		if (!this.hasActiveExecutionScope()) {
+			this.clear(key);
+			return;
+		}
+
+		this.set(key, value);
+		this.pendingSubmittedDraftKeys.add(key);
+	}
+
+	beginExecutionScope(): void {
+		this.executionScopeDepth += 1;
+	}
+
+	commitExecutionScope(): void {
+		if (!this.hasActiveExecutionScope()) return;
+
+		this.executionScopeDepth -= 1;
+		if (this.executionScopeDepth > 0) return;
+
+		if (!this.executionScopeFailed) {
+			for (const key of this.pendingSubmittedDraftKeys) {
+				this.clear(key);
+			}
+		}
+
+		this.resetExecutionScope();
+	}
+
+	rollbackExecutionScope(): void {
+		if (!this.hasActiveExecutionScope()) return;
+
+		this.executionScopeFailed = true;
+		this.executionScopeDepth -= 1;
+		if (this.executionScopeDepth === 0) {
+			this.resetExecutionScope();
+		}
+	}
+
+	markExecutionScopeFailed(): void {
+		if (!this.hasActiveExecutionScope()) return;
+
+		this.executionScopeFailed = true;
+	}
+
+	hasActiveExecutionScope(): boolean {
+		return this.executionScopeDepth > 0;
+	}
+
 	clear(key: string): void {
 		this.drafts.delete(key);
+		this.pendingSubmittedDraftKeys.delete(key);
 	}
 
 	clearAll(): void {
 		this.drafts.clear();
+		this.resetExecutionScope();
 	}
 
 	private evictOldest(count: number): void {
@@ -71,6 +125,13 @@ export class InputPromptDraftStore {
 
 		for (const [key] of entries) {
 			this.drafts.delete(key);
+			this.pendingSubmittedDraftKeys.delete(key);
 		}
+	}
+
+	private resetExecutionScope(): void {
+		this.pendingSubmittedDraftKeys.clear();
+		this.executionScopeDepth = 0;
+		this.executionScopeFailed = false;
 	}
 }


### PR DESCRIPTION
Preserve submitted input prompt drafts until the surrounding choice execution has either committed or failed. This replaces the clipboard-primary recovery added in #1270 with the existing session-only `InputPromptDraftStore` path, and removes the eager clipboard overwrite on capture target creation failures.

The change adds execution scopes to `InputPromptDraftStore`, routes submitted prompt persistence through those scopes, and wraps `ChoiceExecutor.execute()` so successful choices clear submitted drafts while failed or aborted executions leave them available for retry. Capture and Template errors that are reported without throwing now mark the active draft scope failed so the executor does not commit those submitted prompt values.

Reproduction evidence before the fix: the new capture regression failed on `origin/master` with `store.get(...)` returning `undefined` after a submitted `{{VALUE}}` prompt and failed target-file creation.

Validation:
- `bun run test src/engine/CaptureChoiceEngine.selection.test.ts` failed before implementation with the submitted draft cleared.
- `bun run test src/engine/CaptureChoiceEngine.template-property-types.test.ts`
- `bun run test src/utils/InputPromptDraftStore.test.ts src/engine/CaptureChoiceEngine.selection.test.ts`
- `bun run test src/engine/TemplateChoiceEngine.notice.test.ts src/utils/InputPromptDraftStore.test.ts src/engine/CaptureChoiceEngine.selection.test.ts`
- `bun run test`
- `bun run build-with-lint`
- `bun run test:e2e tests/e2e/scorecard-composed-flows.test.ts` was attempted; it failed in e2e setup before assertions while waiting for the sandbox template file content to be observed by Obsidian, and the generated `__obsidian_e2e__/` artifact was removed.

Obsidian dev-vault validation:
- Built the PR bundle with `bun run build`.
- Temporarily pointed the dev-vault QuickAdd plugin symlinks at the PR worktree bundle, reloaded with `obsidian vault=dev plugin:reload id=quickadd`, then restored the symlinks to `/Users/christian/Developer/quickadd/...`.
- Used `obsidian vault=dev dev:debug on`, `dev:console clear`, `dev:errors clear`, and detached with `obsidian vault=dev dev:debug off`.
- Created and removed temp choice `__qa-pr1275-draft-capture` via `data.json` backup restore.
- Verified failed capture target creation preserves the submitted VALUE draft and does not overwrite the clipboard.
- Verified retry hydrates the submitted draft, a same-key retry can succeed after a one-time `app.vault.create` failure, and the next prompt opens empty after success, confirming the submitted draft clears on commit.
- `obsidian vault=dev dev:errors` reported no captured runtime errors after validation.
- Cleaned temp file `__qa-pr1275-success.md`; no PR1275 temp leftovers found in the dev vault. Dev-vault slot is released.

Refs #1157
Refs #1270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added execution-scope tests to verify prompt-draft persistence, rollback, commit, failure and reuse behaviors across runs.

* **Bug Fixes**
  * Stop silently falling back to copying capture content to the clipboard after failures.
  * Preserve submitted prompt drafts across non-abort failures, reuse them on retry, and clear them only on successful commit or explicit clear.

* **Refactor**
  * Improved execution-scope management so in-progress and submitted prompt drafts behave consistently during multi-step flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->