### PR TITLE
feat: option to insert template or capture links into the frontmatter of active note

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -59,6 +59,7 @@ If you have a tag called `#people`, and you type `#people` in the _Capture To_ f
     -   **After selection** - Preserves selected text and places the link after it
     -   **End of line** - Places the link at the end of the current line
     -   **New line** - Places the link on a new line below the cursor
+    -   **In frontmatter property** - Adds the link to a frontmatter property
 
 ## Canvas Capture Notes
 

--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -61,6 +61,11 @@ If you have a tag called `#people`, and you type `#people` in the _Capture To_ f
     -   **New line** - Places the link on a new line below the cursor
     -   **In frontmatter property** - Adds the link to a frontmatter property
 
+        When _In frontmatter property_ is selected you can choose what to do when encountering non-list properties:
+        - **Throw an error** -  Throws error if the property is not a list or does not exist. Empty properties are handled as an empty list.
+        - **Create property** - Adds the property to frontmatter if it does not exist. Throws an error if the property already exists and is not a list. Empty properties are handled as an empty list.
+        - **Always append** - Will convert non-list properties to a list and append the value.
+
 ## Canvas Capture Notes
 
 QuickAdd supports two Canvas capture workflows:

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -31,6 +31,10 @@ When either enabled mode is selected, you can choose where the link is placed:
 - **New line** - Places the link on a new line below the cursor
 - **In frontmatter property** - Adds the link to a frontmatter property
 
+    When _In frontmatter property_ is selected you can choose what to do when encountering non-list properties:
+   - **Throw an error** -  Throws error if the property is not a list or does not exist. Empty properties are handled as an empty list.
+   - **Create property** - Adds the property to frontmatter if it does not exist. Throws an error if the property already exists and is not a list. Empty properties are handled as an empty list.
+   - **Always append** - Will convert non-list properties to a list and append the value.
 
 **If the target file already exists**. Choose whether QuickAdd should ask what to do, update the existing file, create another file, or keep the existing file.
 

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -29,6 +29,7 @@ When either enabled mode is selected, you can choose where the link is placed:
 - **After selection** - Preserves selected text and places the link after it  
 - **End of line** - Places the link at the end of the current line
 - **New line** - Places the link on a new line below the cursor
+- **In frontmatter property** - Adds the link to a frontmatter property
 
 
 **If the target file already exists**. Choose whether QuickAdd should ask what to do, update the existing file, create another file, or keep the existing file.

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -149,11 +149,11 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		);
 	}
 
-	private insertCaptureLink(
+	private async insertCaptureLink(
 		file: TFile,
 		linkOptions: AppendLinkOptions,
 		{ isCanvasTriggered }: { isCanvasTriggered: boolean },
-	): void {
+	): Promise<void> {
 		if (!linkOptions.enabled) {
 			return;
 		}
@@ -170,7 +170,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			return;
 		}
 
-		insertFileLinkToActiveView(this.app, file, linkOptions);
+		await insertFileLinkToActiveView(this.app, file, linkOptions);
 	}
 
 	async run(): Promise<void> {
@@ -301,7 +301,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				});
 			}
 
-			this.insertCaptureLink(file, linkOptions, {
+			await this.insertCaptureLink(file, linkOptions, {
 				isCanvasTriggered: !!canvasTarget,
 			});
 
@@ -381,7 +381,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			});
 		}
 
-		this.insertCaptureLink(file, linkOptions, {
+		await this.insertCaptureLink(file, linkOptions, {
 			isCanvasTriggered: true,
 		});
 

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -138,7 +138,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			}
 
 			if (linkOptions.enabled && createdFile) {
-			insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+				await insertFileLinkToActiveView(this.app, createdFile, linkOptions);
 			}
 
 			if ((this.choice.openFile || shouldAutoOpen) && createdFile) {

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -15,6 +15,7 @@ import type { LinkPlacement, LinkType } from "../../types/linkPlacement";
 import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
+	placementSupportsFrontmatter,
 } from "../../types/linkPlacement";
 import { getAllFolderPathsInVault } from "../../utilityObsidian";
 import { sortFolderPathsByTree } from "../../utils/folder-sorting";
@@ -819,6 +820,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 					dropdown.addOption("afterSelection", "After selection");
 					dropdown.addOption("endOfLine", "End of line");
 					dropdown.addOption("newLine", "New line");
+					dropdown.addOption("inFrontmatter", "In frontmatter property");
 
 					dropdown.setValue(normalizedOptions.placement);
 					dropdown.onChange((value: LinkPlacement) => {
@@ -871,6 +873,35 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 								placement,
 								requireActiveFile,
 								linkType: value,
+							};
+						});
+					});
+			}
+
+			if (placementSupportsFrontmatter(normalizedOptions.placement)) {
+				const linkTypeSetting: Setting = new Setting(this.contentEl);
+				const current = typeof this.choice.appendLink !== "boolean" ? this.choice.appendLink.frontmatterProperty : '';
+				linkTypeSetting
+					.setName("Frontmatter property")
+					.setDesc("Choose the frontmatter property to insert the link into.")
+					.addText((text) => {
+						text.setValue(current ?? '')
+						text.onChange((value: string) => {
+							const currentValue = this.choice.appendLink;
+							const requireActiveFile =
+								typeof currentValue === "boolean"
+									? normalizedOptions.requireActiveFile
+									: currentValue.requireActiveFile;
+							const placement =
+								typeof currentValue === "boolean"
+									? normalizedOptions.placement
+									: currentValue.placement;
+
+							this.choice.appendLink = {
+								enabled: true,
+								placement,
+								requireActiveFile,
+								frontmatterProperty: value,
 							};
 						});
 					});

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -879,9 +879,9 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			}
 
 			if (placementSupportsFrontmatter(normalizedOptions.placement)) {
-				const linkTypeSetting: Setting = new Setting(this.contentEl);
+				const frontmatterPropertySetting: Setting = new Setting(this.contentEl);
 				const current = typeof this.choice.appendLink !== "boolean" ? this.choice.appendLink.frontmatterProperty : '';
-				linkTypeSetting
+				frontmatterPropertySetting
 					.setName("Frontmatter property")
 					.setDesc("Choose the frontmatter property to insert the link into.")
 					.addText((text) => {
@@ -902,6 +902,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 								placement,
 								requireActiveFile,
 								frontmatterProperty: value,
+								linkType: 'link'
 							};
 						});
 					});

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -792,6 +792,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 							this.choice.appendLink = {
 								enabled: true,
 								placement: normalizedOptions.placement,
+								frontmatterProperty: normalizedOptions.frontmatterProperty,
 								requireActiveFile: true,
 								linkType: normalizedLinkType,
 							};
@@ -800,6 +801,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 							this.choice.appendLink = {
 								enabled: true,
 								placement: normalizedOptions.placement,
+								frontmatterProperty: normalizedOptions.frontmatterProperty,
 								requireActiveFile: false,
 								linkType: normalizedLinkType,
 							};
@@ -833,6 +835,10 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 							typeof currentValue === "boolean"
 								? normalizedLinkType
 								: currentValue.linkType ?? normalizedLinkType;
+						const frontmatterProperty =
+							typeof currentValue === "boolean"
+								? normalizedOptions.frontmatterProperty
+								: currentValue.frontmatterProperty;
 				const nextLinkType = placementSupportsEmbed(value)
 					? previousLinkType
 					: "link";
@@ -841,6 +847,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 							enabled: true,
 							placement: value,
 							requireActiveFile,
+							frontmatterProperty,
 							linkType: nextLinkType,
 						};
 
@@ -867,11 +874,16 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 								typeof currentValue === "boolean"
 									? normalizedOptions.placement
 									: currentValue.placement;
+							const frontmatterProperty =
+								typeof currentValue === "boolean"
+									? normalizedOptions.frontmatterProperty
+									: currentValue.frontmatterProperty;
 
 							this.choice.appendLink = {
 								enabled: true,
 								placement,
 								requireActiveFile,
+								frontmatterProperty,
 								linkType: value,
 							};
 						});
@@ -896,7 +908,8 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 								typeof currentValue === "boolean"
 									? normalizedOptions.placement
 									: currentValue.placement;
-
+							// Update value such that appendLinkSetting uses the correct updated value when switching.
+							normalizedOptions.frontmatterProperty = value
 							this.choice.appendLink = {
 								enabled: true,
 								placement,

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -11,7 +11,7 @@ import { FileNameDisplayFormatter } from "../../formatters/fileNameDisplayFormat
 import { FormatDisplayFormatter } from "../../formatters/formatDisplayFormatter";
 import type QuickAdd from "../../main";
 import type ICaptureChoice from "../../types/choices/ICaptureChoice";
-import type { LinkPlacement, LinkType } from "../../types/linkPlacement";
+import type { AppendLinkOptions, FrontmatterHandling, LinkPlacement, LinkType } from "../../types/linkPlacement";
 import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
@@ -793,6 +793,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 								enabled: true,
 								placement: normalizedOptions.placement,
 								frontmatterProperty: normalizedOptions.frontmatterProperty,
+								frontmatterHandling: normalizedOptions.frontmatterHandling,
 								requireActiveFile: true,
 								linkType: normalizedLinkType,
 							};
@@ -802,6 +803,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 								enabled: true,
 								placement: normalizedOptions.placement,
 								frontmatterProperty: normalizedOptions.frontmatterProperty,
+								frontmatterHandling: normalizedOptions.frontmatterHandling,
 								requireActiveFile: false,
 								linkType: normalizedLinkType,
 							};
@@ -839,6 +841,10 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 							typeof currentValue === "boolean"
 								? normalizedOptions.frontmatterProperty
 								: currentValue.frontmatterProperty;
+						const frontmatterHandling =
+							typeof currentValue === "boolean"
+								? normalizedOptions.frontmatterHandling
+								: currentValue.frontmatterHandling;
 				const nextLinkType = placementSupportsEmbed(value)
 					? previousLinkType
 					: "link";
@@ -848,6 +854,7 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 							placement: value,
 							requireActiveFile,
 							frontmatterProperty,
+							frontmatterHandling,
 							linkType: nextLinkType,
 						};
 
@@ -878,12 +885,17 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 								typeof currentValue === "boolean"
 									? normalizedOptions.frontmatterProperty
 									: currentValue.frontmatterProperty;
+							const frontmatterHandling =
+								typeof currentValue === "boolean"
+									? normalizedOptions.frontmatterHandling
+									: currentValue.frontmatterHandling;
 
 							this.choice.appendLink = {
 								enabled: true,
 								placement,
 								requireActiveFile,
 								frontmatterProperty,
+								frontmatterHandling,
 								linkType: value,
 							};
 						});
@@ -891,36 +903,80 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			}
 
 			if (placementSupportsFrontmatter(normalizedOptions.placement)) {
-				const frontmatterPropertySetting: Setting = new Setting(this.contentEl);
-				const current = typeof this.choice.appendLink !== "boolean" ? this.choice.appendLink.frontmatterProperty : '';
-				frontmatterPropertySetting
-					.setName("Frontmatter property")
-					.setDesc("Choose the frontmatter property to insert the link into.")
-					.addText((text) => {
-						text.setValue(current ?? '')
-						text.onChange((value: string) => {
-							const currentValue = this.choice.appendLink;
-							const requireActiveFile =
-								typeof currentValue === "boolean"
-									? normalizedOptions.requireActiveFile
-									: currentValue.requireActiveFile;
-							const placement =
-								typeof currentValue === "boolean"
-									? normalizedOptions.placement
-									: currentValue.placement;
-							// Update value such that appendLinkSetting uses the correct updated value when switching.
-							normalizedOptions.frontmatterProperty = value
-							this.choice.appendLink = {
-								enabled: true,
-								placement,
-								requireActiveFile,
-								frontmatterProperty: value,
-								linkType: 'link'
-							};
-						});
-					});
+				this.addFrontmatterSettings(normalizedOptions);
 			}
 		}
+	}
+
+	private addFrontmatterSettings(normalizedOptions: AppendLinkOptions & { linkType: LinkType }) {
+		const frontmatterPropertySetting: Setting = new Setting(this.contentEl);
+		frontmatterPropertySetting
+			.setName("Frontmatter property")
+			.setDesc("Choose the frontmatter property to insert the link into.")
+			.addText((text) => {
+				text.setValue(normalizedOptions.frontmatterProperty ?? '')
+				text.onChange((value: string) => {
+					const currentValue = this.choice.appendLink;
+					const requireActiveFile =
+						typeof currentValue === "boolean"
+							? normalizedOptions.requireActiveFile
+							: currentValue.requireActiveFile;
+					const placement =
+						typeof currentValue === "boolean"
+							? normalizedOptions.placement
+							: currentValue.placement;
+					const frontmatterHandling =
+						typeof currentValue === "boolean"
+							? normalizedOptions.frontmatterHandling
+							: currentValue.frontmatterHandling;
+					// Update value such that appendLinkSetting uses the correct updated value when switching.
+					normalizedOptions.frontmatterProperty = value
+					this.choice.appendLink = {
+						enabled: true,
+						placement,
+						requireActiveFile,
+						frontmatterProperty: value,
+						frontmatterHandling,
+						linkType: 'link'
+					};
+				});
+			});
+
+		const frontmatterHandlingSetting: Setting = new Setting(this.contentEl);
+		frontmatterHandlingSetting
+			.setName("Frontmatter appending behaviour")
+			.setDesc("Choose what QuickAdd should do when encountering a non-list property.")
+			.addDropdown((dropdown) => {
+				dropdown.addOption("error", "Throw an error");
+				dropdown.addOption("createProperty", "Create property.");
+				dropdown.addOption("alwaysAppend", "Always append value.");
+				dropdown.setValue(normalizedOptions.frontmatterHandling ?? 'error')
+				dropdown.onChange((value: FrontmatterHandling) => {
+					const currentValue = this.choice.appendLink;
+					const requireActiveFile =
+						typeof currentValue === "boolean"
+							? normalizedOptions.requireActiveFile
+							: currentValue.requireActiveFile;
+					const placement =
+						typeof currentValue === "boolean"
+							? normalizedOptions.placement
+							: currentValue.placement;
+					const frontmatterProperty =
+						typeof currentValue === "boolean"
+							? normalizedOptions.frontmatterProperty
+							: currentValue.frontmatterProperty;
+					// Update value such that appendLinkSetting uses the correct updated value when switching.
+					normalizedOptions.frontmatterHandling = value
+					this.choice.appendLink = {
+						enabled: true,
+						placement,
+						requireActiveFile,
+						frontmatterProperty,
+						frontmatterHandling: value,
+						linkType: 'link'
+					};
+				});
+			});
 	}
 
 	private addWritePositionSetting() {

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -18,7 +18,7 @@ import {
 	type FileExistsModeId,
 } from "../../template/fileExistsPolicy";
 import type ITemplateChoice from "../../types/choices/ITemplateChoice";
-import type { LinkPlacement, LinkType } from "../../types/linkPlacement";
+import type { AppendLinkOptions, FrontmatterHandling, LinkPlacement, LinkType } from "../../types/linkPlacement";
 import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
@@ -338,6 +338,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 								enabled: true,
 								placement: normalizedOptions.placement,
 								frontmatterProperty: normalizedOptions.frontmatterProperty,
+								frontmatterHandling: normalizedOptions.frontmatterHandling,
 								requireActiveFile: true,
 								linkType: normalizedLinkType,
 							};
@@ -347,6 +348,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 								enabled: true,
 								placement: normalizedOptions.placement,
 								frontmatterProperty: normalizedOptions.frontmatterProperty,
+								frontmatterHandling: normalizedOptions.frontmatterHandling,
 								requireActiveFile: false,
 								linkType: normalizedLinkType,
 							};
@@ -387,12 +389,17 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 							typeof currentValue === "boolean"
 								? normalizedOptions.frontmatterProperty
 								: currentValue.frontmatterProperty;
+						const frontmatterHandling =
+							typeof currentValue === "boolean"
+								? normalizedOptions.frontmatterHandling
+								: currentValue.frontmatterHandling;
 
 						this.choice.appendLink = {
 							enabled: true,
 							placement: value,
 							requireActiveFile,
 							frontmatterProperty,
+							frontmatterHandling,
 							linkType: nextLinkType,
 						};
 						this.reload();
@@ -422,12 +429,17 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 								typeof currentValue === "boolean"
 									? normalizedOptions.frontmatterProperty
 									: currentValue.frontmatterProperty;
+							const frontmatterHandling =
+								typeof currentValue === "boolean"
+									? normalizedOptions.frontmatterHandling
+									: currentValue.frontmatterHandling;
 
 							this.choice.appendLink = {
 								enabled: true,
 								placement,
 								requireActiveFile,
 								frontmatterProperty,
+								frontmatterHandling,
 								linkType: value,
 							};
 						});
@@ -435,36 +447,80 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 			}
 
 			if (placementSupportsFrontmatter(normalizedOptions.placement)) {
-				const frontmatterPropertySetting: Setting = new Setting(this.contentEl);
-				const current = typeof this.choice.appendLink !== "boolean" ? this.choice.appendLink.frontmatterProperty : '';
-				frontmatterPropertySetting
-					.setName("Frontmatter property")
-					.setDesc("Choose the frontmatter property to insert the link into.")
-					.addText((text) => {
-						text.setValue(current ?? '')
-						text.onChange((value: string) => {
-							const currentValue = this.choice.appendLink;
-							const requireActiveFile =
-								typeof currentValue === "boolean"
-									? normalizedOptions.requireActiveFile
-									: currentValue.requireActiveFile;
-							const placement =
-								typeof currentValue === "boolean"
-									? normalizedOptions.placement
-									: currentValue.placement;
-							// Update value such that appendLinkSetting uses the correct updated value when switching.
-							normalizedOptions.frontmatterProperty = value
-							this.choice.appendLink = {
-								enabled: true,
-								placement,
-								requireActiveFile,
-								frontmatterProperty: value,
-								linkType: 'link'
-							};
-						});
-					});
+				this.addFrontmatterSettings(normalizedOptions);
 			}
 		}
+	}
+
+	private addFrontmatterSettings(normalizedOptions: AppendLinkOptions & { linkType: LinkType }) {
+		const frontmatterPropertySetting: Setting = new Setting(this.contentEl);
+		frontmatterPropertySetting
+			.setName("Frontmatter property")
+			.setDesc("Choose the frontmatter property to insert the link into.")
+			.addText((text) => {
+				text.setValue(normalizedOptions.frontmatterProperty ?? '')
+				text.onChange((value: string) => {
+					const currentValue = this.choice.appendLink;
+					const requireActiveFile =
+						typeof currentValue === "boolean"
+							? normalizedOptions.requireActiveFile
+							: currentValue.requireActiveFile;
+					const placement =
+						typeof currentValue === "boolean"
+							? normalizedOptions.placement
+							: currentValue.placement;
+					const frontmatterHandling =
+						typeof currentValue === "boolean"
+							? normalizedOptions.frontmatterHandling
+							: currentValue.frontmatterHandling;
+					// Update value such that appendLinkSetting uses the correct updated value when switching.
+					normalizedOptions.frontmatterProperty = value
+					this.choice.appendLink = {
+						enabled: true,
+						placement,
+						requireActiveFile,
+						frontmatterProperty: value,
+						frontmatterHandling,
+						linkType: 'link'
+					};
+				});
+			});
+
+		const frontmatterHandlingSetting: Setting = new Setting(this.contentEl);
+		frontmatterHandlingSetting
+			.setName("Frontmatter appending behaviour")
+			.setDesc("Choose what QuickAdd should do when encountering a non-list property.")
+			.addDropdown((dropdown) => {
+				dropdown.addOption("error", "Throw an error");
+				dropdown.addOption("createProperty", "Create property.");
+				dropdown.addOption("alwaysAppend", "Always append value.");
+				dropdown.setValue(normalizedOptions.frontmatterHandling ?? 'error')
+				dropdown.onChange((value: FrontmatterHandling) => {
+					const currentValue = this.choice.appendLink;
+					const requireActiveFile =
+						typeof currentValue === "boolean"
+							? normalizedOptions.requireActiveFile
+							: currentValue.requireActiveFile;
+					const placement =
+						typeof currentValue === "boolean"
+							? normalizedOptions.placement
+							: currentValue.placement;
+					const frontmatterProperty =
+						typeof currentValue === "boolean"
+							? normalizedOptions.frontmatterProperty
+							: currentValue.frontmatterProperty;
+					// Update value such that appendLinkSetting uses the correct updated value when switching.
+					normalizedOptions.frontmatterHandling = value
+					this.choice.appendLink = {
+						enabled: true,
+						placement,
+						requireActiveFile,
+						frontmatterProperty,
+						frontmatterHandling: value,
+						linkType: 'link'
+					};
+				});
+			});
 	}
 
 	private addFileAlreadyExistsSetting(): void {

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -22,6 +22,7 @@ import type { LinkPlacement, LinkType } from "../../types/linkPlacement";
 import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
+	placementSupportsFrontmatter,
 } from "../../types/linkPlacement";
 import { getAllFolderPathsInVault } from "../../utilityObsidian";
 import { sortFolderPathsByTree } from "../../utils/folder-sorting";
@@ -364,6 +365,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 					dropdown.addOption("afterSelection", "After selection");
 					dropdown.addOption("endOfLine", "End of line");
 					dropdown.addOption("newLine", "New line");
+					dropdown.addOption("inFrontmatter", "In frontmatter property");
 
 					dropdown.setValue(normalizedOptions.placement);
 					dropdown.onChange((value: LinkPlacement) => {
@@ -415,6 +417,35 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 								placement,
 								requireActiveFile,
 								linkType: value,
+							};
+						});
+					});
+			}
+
+			if (placementSupportsFrontmatter(normalizedOptions.placement)) {
+				const linkTypeSetting: Setting = new Setting(this.contentEl);
+				const current = typeof this.choice.appendLink !== "boolean" ? this.choice.appendLink.frontmatterProperty : '';
+				linkTypeSetting
+					.setName("Frontmatter property")
+					.setDesc("Choose the frontmatter property to insert the link into.")
+					.addText((text) => {
+						text.setValue(current ?? '')
+						text.onChange((value: string) => {
+							const currentValue = this.choice.appendLink;
+							const requireActiveFile =
+								typeof currentValue === "boolean"
+									? normalizedOptions.requireActiveFile
+									: currentValue.requireActiveFile;
+							const placement =
+								typeof currentValue === "boolean"
+									? normalizedOptions.placement
+									: currentValue.placement;
+
+							this.choice.appendLink = {
+								enabled: true,
+								placement,
+								requireActiveFile,
+								frontmatterProperty: value,
 							};
 						});
 					});

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -337,6 +337,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 							this.choice.appendLink = {
 								enabled: true,
 								placement: normalizedOptions.placement,
+								frontmatterProperty: normalizedOptions.frontmatterProperty,
 								requireActiveFile: true,
 								linkType: normalizedLinkType,
 							};
@@ -345,6 +346,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 							this.choice.appendLink = {
 								enabled: true,
 								placement: normalizedOptions.placement,
+								frontmatterProperty: normalizedOptions.frontmatterProperty,
 								requireActiveFile: false,
 								linkType: normalizedLinkType,
 							};
@@ -381,11 +383,16 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 						const nextLinkType = placementSupportsEmbed(value)
 							? previousLinkType
 							: "link";
+						const frontmatterProperty =
+							typeof currentValue === "boolean"
+								? normalizedOptions.frontmatterProperty
+								: currentValue.frontmatterProperty;
 
 						this.choice.appendLink = {
 							enabled: true,
 							placement: value,
 							requireActiveFile,
+							frontmatterProperty,
 							linkType: nextLinkType,
 						};
 						this.reload();
@@ -411,11 +418,16 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 								typeof currentValue === "boolean"
 									? normalizedOptions.placement
 									: currentValue.placement;
+							const frontmatterProperty =
+								typeof currentValue === "boolean"
+									? normalizedOptions.frontmatterProperty
+									: currentValue.frontmatterProperty;
 
 							this.choice.appendLink = {
 								enabled: true,
 								placement,
 								requireActiveFile,
+								frontmatterProperty,
 								linkType: value,
 							};
 						});
@@ -440,7 +452,8 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 								typeof currentValue === "boolean"
 									? normalizedOptions.placement
 									: currentValue.placement;
-
+							// Update value such that appendLinkSetting uses the correct updated value when switching.
+							normalizedOptions.frontmatterProperty = value
 							this.choice.appendLink = {
 								enabled: true,
 								placement,

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -423,9 +423,9 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 			}
 
 			if (placementSupportsFrontmatter(normalizedOptions.placement)) {
-				const linkTypeSetting: Setting = new Setting(this.contentEl);
+				const frontmatterPropertySetting: Setting = new Setting(this.contentEl);
 				const current = typeof this.choice.appendLink !== "boolean" ? this.choice.appendLink.frontmatterProperty : '';
-				linkTypeSetting
+				frontmatterPropertySetting
 					.setName("Frontmatter property")
 					.setDesc("Choose the frontmatter property to insert the link into.")
 					.addText((text) => {
@@ -446,6 +446,7 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 								placement,
 								requireActiveFile,
 								frontmatterProperty: value,
+								linkType: 'link'
 							};
 						});
 					});

--- a/src/types/linkPlacement.test.ts
+++ b/src/types/linkPlacement.test.ts
@@ -6,6 +6,7 @@ import {
 	normalizeAppendLinkOptions,
 	isAppendLinkEnabled,
 	placementSupportsEmbed,
+	placementSupportsFrontmatter,
 } from "./linkPlacement";
 
 describe("LinkPlacement", () => {
@@ -126,6 +127,7 @@ describe("LinkPlacement", () => {
 				"afterSelection",
 				"endOfLine",
 				"newLine",
+				"inFrontmatter"
 			];
 
 			for (const placement of placements) {
@@ -145,6 +147,17 @@ describe("LinkPlacement", () => {
 			expect(placementSupportsEmbed("afterSelection")).toBe(false);
 			expect(placementSupportsEmbed("endOfLine")).toBe(false);
 			expect(placementSupportsEmbed("newLine")).toBe(false);
+			expect(placementSupportsEmbed("inFrontmatter")).toBe(false);
+		});
+	});
+
+	describe("placementSupportsFrontmatter", () => {
+		it("should return true only for inFrontmatter placement", () => {
+			expect(placementSupportsFrontmatter("replaceSelection")).toBe(false);
+			expect(placementSupportsFrontmatter("afterSelection")).toBe(false);
+			expect(placementSupportsFrontmatter("endOfLine")).toBe(false);
+			expect(placementSupportsFrontmatter("newLine")).toBe(false);
+			expect(placementSupportsFrontmatter("inFrontmatter")).toBe(true);
 		});
 	});
 });

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -5,12 +5,17 @@ export type LinkPlacement =
 	| "replaceSelection"  // Replace the current selection with the link
 	| "afterSelection"    // Insert the link after the current selection
 	| "endOfLine"         // Insert the link at the end of the current line
-	| "newLine";          // Insert the link on a new line
+	| "newLine"           // Insert the link on a new line
+	| "inFrontmatter";	  // Insert the link into a frontmatter field
 
 export type LinkType = "link" | "embed";
 
 export function placementSupportsEmbed(placement: LinkPlacement): boolean {
 	return placement === "replaceSelection";
+}
+
+export function placementSupportsFrontmatter(placement : LinkPlacement) : boolean {
+	return placement === "inFrontmatter";
 }
 
 function sanitizeLinkType(
@@ -41,6 +46,10 @@ export interface AppendLinkOptions {
 	 * Defaults to "link" for legacy settings.
 	 */
 	linkType?: LinkType;
+	/**
+	 * Controls the frontmatter property the link is added to. Only used when placement is inFrontmatter.
+	 */
+	frontmatterProperty? : string
 }
 
 /**
@@ -73,6 +82,7 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 			placement,
 			requireActiveFile: appendLink.requireActiveFile ?? true,
 			linkType: sanitizeLinkType(appendLink.linkType, placement),
+			frontmatterProperty: appendLink.frontmatterProperty
 		};
 	}
 

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -10,6 +10,11 @@ export type LinkPlacement =
 
 export type LinkType = "link" | "embed";
 
+export type FrontmatterHandling =
+	| "error"			// Error if property is not an array.
+	| "createProperty"  // Create if property does not exist, error if object is not array
+	| "alwaysAppend" 	// Convert single values into array.
+
 export function placementSupportsEmbed(placement: LinkPlacement): boolean {
 	return placement === "replaceSelection";
 }
@@ -49,7 +54,11 @@ export interface AppendLinkOptions {
 	/**
 	 * Controls the frontmatter property the link is added to. Only used when placement is inFrontmatter.
 	 */
-	frontmatterProperty? : string
+	frontmatterProperty?: string
+	/**
+	 * How to handle (non)-existing property types.
+	 */
+	frontmatterHandling?: FrontmatterHandling
 }
 
 /**
@@ -82,7 +91,8 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 			placement,
 			requireActiveFile: appendLink.requireActiveFile ?? true,
 			linkType: sanitizeLinkType(appendLink.linkType, placement),
-			frontmatterProperty: appendLink.frontmatterProperty
+			frontmatterProperty: appendLink.frontmatterProperty,
+			frontmatterHandling : appendLink.frontmatterHandling
 		};
 	}
 

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -14,7 +14,7 @@ export function placementSupportsEmbed(placement: LinkPlacement): boolean {
 	return placement === "replaceSelection";
 }
 
-export function placementSupportsFrontmatter(placement : LinkPlacement) : boolean {
+export function placementSupportsFrontmatter(placement : LinkPlacement): boolean {
 	return placement === "inFrontmatter";
 }
 

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -14,6 +14,7 @@ import {
 	normalizeVaultFilePath,
 	getOpenFileOriginLeaf,
 	openFile,
+	insertIntoFrontmatterProperty,
 } from "./utilityObsidian";
 import type { IUserScript } from "./types/macros/IUserScript";
 import { CommandType } from "./types/macros/CommandType";
@@ -573,3 +574,153 @@ describe("areSameVaultFilePath", () => {
 		expect(areSameVaultFilePath("notes/Foo.md", "notes/foo.md")).toBe(false);
 	});
 });
+
+describe("insertIntoFrontmatterProperty ", () => {
+
+	describe("alwaysAppend", () => {
+		const frontmatterHandling = "alwaysAppend";
+
+		it("should create a property if it does not exist", () => {
+			let frontmatter = {};
+			let result = {foo: ["bar"]}
+			insertIntoFrontmatterProperty(frontmatter, "foo", "bar", frontmatterHandling)
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should create a property if it is null or undefined", () => {
+			let frontmatter = {fooNull: null, fooUndefined: undefined};
+			let result = {fooNull: ["bar"], fooUndefined: ["baz"]};
+			insertIntoFrontmatterProperty(frontmatter, "fooNull", "bar", frontmatterHandling)
+			insertIntoFrontmatterProperty(frontmatter, "fooUndefined", "baz", frontmatterHandling)
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should convert text scalars and other non object types into arrays", () => {
+			let frontmatter = {int: 10, text: "Hello World!"};
+			let result = {int: [10, "bar"], text: ["Hello World!", "baz"]}
+			insertIntoFrontmatterProperty(frontmatter, "int", "bar", frontmatterHandling)
+			insertIntoFrontmatterProperty(frontmatter, "text", "baz", frontmatterHandling)
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should append values to existing arrays", () => {
+			let frontmatter = {list: [1, "2"]}
+			let result = {list: [1, "2", "three"]}
+			insertIntoFrontmatterProperty(frontmatter, "list", "three", frontmatterHandling);
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error when trying to overwrite an object and keep the frontmatter unchanged", () => {
+			let frontmatter = {data: {list: [1, "2"], value: "Hello World!"}}
+			let result = {data: {list: [1, "2"], value: "Hello World!"}}
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "data", "bar", frontmatterHandling)).toThrowError()
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error on empty frontmatterProperty", () => {
+			let frontmatter = {list: [1, "2"]}
+			let result = {list: [1, "2"]}
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "", "bar", frontmatterHandling)).toThrowError()
+			expect(frontmatter).toEqual(result)
+		})
+
+	})
+
+
+	describe("createProperty", () => {
+		const frontmatterType = "createProperty"
+
+		it("should create a property if it does not exist", () => {
+			let frontmatter = {};
+			let result = {foo: ["bar"]}
+			insertIntoFrontmatterProperty(frontmatter, "foo", "bar", frontmatterType)
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should create a property if it is null or undefined", () => {
+			let frontmatter = {fooNull: null, fooUndefined: undefined};
+			let result = {fooNull: ["bar"], fooUndefined: ["baz"]};
+			insertIntoFrontmatterProperty(frontmatter, "fooNull", "bar", frontmatterType)
+			insertIntoFrontmatterProperty(frontmatter, "fooUndefined", "baz", frontmatterType)
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error on non array types", () => {
+			let frontmatter = {int: 10, text: "Hello World!"};
+			let result = {int: 10, text: "Hello World!"};
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "int", "bar", frontmatterType)).toThrow()
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "text", "baz", frontmatterType)).toThrow()
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should append values to existing arrays", () => {
+			let frontmatter = {list: [1, "2"]}
+			let result = {list: [1, "2", "three"]}
+			insertIntoFrontmatterProperty(frontmatter, "list", "three", frontmatterType);
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error when trying to overwrite an object and keep the frontmatter unchanged", () => {
+			let frontmatter = {data: {list: [1, "2"], value: "Hello World!"}}
+			let result = {data: {list: [1, "2"], value: "Hello World!"}}
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "data", "bar", frontmatterType)).toThrowError()
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error on empty frontmatterProperty", () => {
+			let frontmatter = {list: [1, "2"]}
+			let result = {list: [1, "2"]}
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "", "bar", frontmatterType)).toThrowError()
+			expect(frontmatter).toEqual(result)
+		})
+
+	})
+
+
+	describe("error", () => {
+		const frontmatterType = "error"
+		it("should error if a property does not exist", () => {
+			let frontmatter = {};
+			let result = {}
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "foo", "bar", frontmatterType)).toThrow()
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should create a property if it is null but throw error if undefined", () => {
+			let frontmatter = {fooNull: null, fooUndefined: undefined};
+			let result = {fooNull: ["bar"], fooUndefined: undefined};
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "fooNull", "bar", frontmatterType)).not.toThrow()
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "fooUndefined", "baz", frontmatterType)).toThrow()
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error on scalars and other non object types", () => {
+			let frontmatter = {int: 10, text: "Hello World!"};
+			let result = {int: 10, text: "Hello World!"};
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "int", "bar", frontmatterType)).toThrow()
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "text", "baz", frontmatterType)).toThrow()
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should append values to existing arrays", () => {
+			let frontmatter = {list: [1, "2"]}
+			let result = {list: [1, "2", "three"]}
+			insertIntoFrontmatterProperty(frontmatter, "list", "three", frontmatterType);
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error when trying to overwrite an object and keep the frontmatter unchanged", () => {
+			let frontmatter = {data: {list: [1, "2"], value: "Hello World!"}}
+			let result = {data: {list: [1, "2"], value: "Hello World!"}}
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "data", "bar", frontmatterType)).toThrowError()
+			expect(frontmatter).toEqual(result)
+		})
+
+		it("should error on empty frontmatterProperty", () => {
+			let frontmatter = {list: [1, "2"]}
+			let result = {list: [1, "2"]}
+			expect(() => insertIntoFrontmatterProperty(frontmatter, "", "bar", frontmatterType)).toThrowError()
+			expect(frontmatter).toEqual(result)
+		})
+	})
+})

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -18,11 +18,11 @@ import type {
 	OpenFileOptions as FileOpenOptions,
 	FileViewMode2 as FileViewModeNew
 } from "./types/fileOpening";
-import type { AppendLinkOptions, LinkPlacement } from "./types/linkPlacement";
-import { placementSupportsEmbed } from "./types/linkPlacement";
-import type { IUserScript } from "./types/macros/IUserScript";
-import { reportError } from "./utils/errorUtils";
-import { deepClone } from "./utils/deepClone";
+import type { AppendLinkOptions, FrontmatterHandling, LinkPlacement } from "./types/linkPlacement";
+import {placementSupportsEmbed} from "./types/linkPlacement";
+import type {IUserScript} from "./types/macros/IUserScript";
+import {reportError} from "./utils/errorUtils";
+import {deepClone} from "./utils/deepClone";
 
 export type TemplaterPluginLike = {
 	settings?: {
@@ -540,6 +540,37 @@ export function insertOnNewLineBelow(toInsert: string, app: App) {
 	insertOnNewLine(toInsert, "below", app);
 }
 
+
+export function insertIntoFrontmatterProperty(frontmatter: any, frontmatterProperty: string, value: string, frontmatterHandling: FrontmatterHandling) {
+	if (!frontmatterProperty) {
+		const message = `Invalid frontmatter property: '${frontmatterProperty}'`;
+		throw new Error(message);
+	}
+	if (frontmatter[frontmatterProperty] === null) {
+		// treat null as empty array
+		frontmatter[frontmatterProperty] = []
+	} else if (frontmatter[frontmatterProperty] === undefined) {
+		if (frontmatterHandling === "error") {
+			const message = `Inserting link into: ${frontmatterProperty} failed: Property does not exist and frontmatterType is set to 'error'`;
+			throw new Error(message)
+		}
+		// create missing property with empty array
+		frontmatter[frontmatterProperty] = []
+	} else if (typeof frontmatter[frontmatterProperty] === "object" && !Array.isArray(frontmatter[frontmatterProperty])) {
+		const message = `Inserting link into: ${frontmatterProperty} failed: Existing property is object, expected string, scalar or array`;
+		throw new Error(message)
+	} else if (!Array.isArray(frontmatter[frontmatterProperty])) {
+		if (frontmatterHandling !== "alwaysAppend") {
+			const message = `Inserting link into: ${frontmatterProperty} failed: Property is not an array and frontmatterType is set to '${frontmatterHandling}'`;
+			throw new Error(message)
+		}
+		// Convert existing value to array
+		frontmatter[frontmatterProperty] = [frontmatter[frontmatterProperty]]
+	}
+	// Append the value
+	frontmatter[frontmatterProperty].push(value)
+}
+
 /**
  * Core routine that inserts a link (or any text) in the active markdown
  * editor according to the chosen placement mode.
@@ -553,9 +584,9 @@ export async function insertLinkWithPlacement(
 	app: App,
 	text: string,
 	mode: LinkPlacement = "replaceSelection",
-	options: { requireActiveView?: boolean; frontmatterProperty?: string} = {},
+	options: { requireActiveView?: boolean; frontmatterProperty?: string, frontmatterHandling? : FrontmatterHandling } = {},
 ) {
-	const { requireActiveView = true, frontmatterProperty = '' } = options;
+	const { requireActiveView = true, frontmatterProperty = '', frontmatterHandling = 'error' } = options;
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
 	if (!view) {
 		const message = "Cannot append link because no active Markdown view is available.";
@@ -584,32 +615,19 @@ export async function insertLinkWithPlacement(
 		editor.replaceSelection(text);
 		return;
 	}
-	
+
 	//////////////////////////////////////////////////////////////////
 	//  FRONTMATTER-SELECTION
 	//////////////////////////////////////////////////////////////////
 
 	if (mode === "inFrontmatter") {
-		if(!frontmatterProperty) {
-			const message = "Invalid frontmatter property: " + frontmatterProperty;
-			throw new Error(message);
-		}
 		const file = view.file;
-		if(!file) {
+		if (!file) {
 			const message = "Could not find file of active view";
 			throw new Error(message);
 		}
-		await app.fileManager.processFrontMatter(file, (frontmatter) => {
-			if (frontmatter[frontmatterProperty] === undefined || frontmatter[frontmatterProperty] === null) {
-				frontmatter[frontmatterProperty] = []
-			}
-			if (!Array.isArray(frontmatter[frontmatterProperty])) {
-				const message = "Could not add into non array property: " + frontmatterProperty;
-				throw new Error(message)
-			}
-			frontmatter[frontmatterProperty].push(text)
-		})
-		return
+		return app.fileManager.processFrontMatter(file, (frontmatter) =>
+			insertIntoFrontmatterProperty(frontmatter, frontmatterProperty, text, frontmatterHandling))
 	}
 
 	//////////////////////////////////////////////////////////////////
@@ -762,7 +780,7 @@ export async function insertFileLinkToActiveView(
 		app,
 		linkText,
 		linkOptions.placement,
-		{ requireActiveView: false, frontmatterProperty : linkOptions.frontmatterProperty },
+		{requireActiveView: false, frontmatterProperty: linkOptions.frontmatterProperty, frontmatterHandling : linkOptions.frontmatterHandling},
 	);
 
 	return true;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -553,9 +553,9 @@ export function insertLinkWithPlacement(
 	app: App,
 	text: string,
 	mode: LinkPlacement = "replaceSelection",
-	options: { requireActiveView?: boolean; } = {},
+	options: { requireActiveView?: boolean; frontmatterProperty?: string} = {},
 ) {
-	const { requireActiveView = true } = options;
+	const { requireActiveView = true, frontmatterProperty = '' } = options;
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
 	if (!view) {
 		const message = "Cannot append link because no active Markdown view is available.";
@@ -583,6 +583,33 @@ export function insertLinkWithPlacement(
 	if (mode === "replaceSelection") {
 		editor.replaceSelection(text);
 		return;
+	}
+	
+	//////////////////////////////////////////////////////////////////
+	//  FRONTMATTER-SELECTION
+	//////////////////////////////////////////////////////////////////
+
+	if (mode === "inFrontmatter") {
+		if(!frontmatterProperty) {
+			const message = "Invalid frontmatter property: " + frontmatterProperty;
+			throw new Error(message);
+		}
+		const file = view.file;
+		if(!file) {
+			const message = "Could not find file of active view";
+			throw new Error(message);
+		}
+		app.fileManager.processFrontMatter(file, (frontmatter) => {
+			if (frontmatter[frontmatterProperty] === undefined) {
+				frontmatter[frontmatterProperty] = []
+			}
+			if (!Array.isArray(frontmatter[frontmatterProperty])) {
+				const message = "Could not add into non array property:" + frontmatterProperty;
+				throw new Error(message)
+			}
+			frontmatter[frontmatterProperty].push(text)
+		})
+		return
 	}
 
 	//////////////////////////////////////////////////////////////////
@@ -735,7 +762,7 @@ export function insertFileLinkToActiveView(
 		app,
 		linkText,
 		linkOptions.placement,
-		{ requireActiveView: false },
+		{ requireActiveView: false, frontmatterProperty : linkOptions.frontmatterProperty },
 	);
 
 	return true;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -600,7 +600,7 @@ export function insertLinkWithPlacement(
 			throw new Error(message);
 		}
 		app.fileManager.processFrontMatter(file, (frontmatter) => {
-			if (frontmatter[frontmatterProperty] === undefined) {
+			if (frontmatter[frontmatterProperty] === undefined || frontmatter[frontmatterProperty] === null) {
 				frontmatter[frontmatterProperty] = []
 			}
 			if (!Array.isArray(frontmatter[frontmatterProperty])) {

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -549,7 +549,7 @@ export function insertOnNewLineBelow(toInsert: string, app: App) {
  * – Keeps the editor's undo history clean by performing a single
  *   CodeMirror transaction.
  */
-export function insertLinkWithPlacement(
+export async function insertLinkWithPlacement(
 	app: App,
 	text: string,
 	mode: LinkPlacement = "replaceSelection",
@@ -599,12 +599,12 @@ export function insertLinkWithPlacement(
 			const message = "Could not find file of active view";
 			throw new Error(message);
 		}
-		app.fileManager.processFrontMatter(file, (frontmatter) => {
+		await app.fileManager.processFrontMatter(file, (frontmatter) => {
 			if (frontmatter[frontmatterProperty] === undefined || frontmatter[frontmatterProperty] === null) {
 				frontmatter[frontmatterProperty] = []
 			}
 			if (!Array.isArray(frontmatter[frontmatterProperty])) {
-				const message = "Could not add into non array property:" + frontmatterProperty;
+				const message = "Could not add into non array property: " + frontmatterProperty;
 				throw new Error(message)
 			}
 			frontmatter[frontmatterProperty].push(text)
@@ -731,11 +731,11 @@ function convertLinkToEmbed(link: string): string {
  * @param linkOptions - Options controlling link insertion behavior
  * @returns True if the link was inserted, false otherwise
  */
-export function insertFileLinkToActiveView(
+export async function insertFileLinkToActiveView(
 	app: App,
 	file: TFile,
 	linkOptions: AppendLinkOptions,
-): boolean {
+): Promise<boolean> {
 	if (!linkOptions?.enabled) return false;
 
 	const activeFile = app.workspace.getActiveFile();
@@ -758,7 +758,7 @@ export function insertFileLinkToActiveView(
 		placementSupportsEmbed(linkOptions.placement);
 	const linkText = shouldEmbed ? convertLinkToEmbed(baseLink) : baseLink;
 
-	insertLinkWithPlacement(
+	await insertLinkWithPlacement(
 		app,
 		linkText,
 		linkOptions.placement,


### PR DESCRIPTION
## Summary

This adds an option to insert links for templates and captures into the frontmatter of the active note. For my TTRPG vault i make heavy use of quickadd and needed this feature to quickly add links to the frontmatter of a file. For example for quickly adding npcs or sub locations to the frontmatter of my towns.

## Changes

* option to insert template or capture links into the frontmatter of active note

## Testing / validation
Obsidian version 1.12.7
I updated the tests in `linkPlacement.test.ts` to account for the new LinkPlacement. 
Testing the feature was done manually, see the gif for results.

<img width="555" height="205" alt="Screenshot_2026-06-01_21-15-06" src="https://github.com/user-attachments/assets/547b46e6-1e99-4e94-8604-298e5e2b7f03" />

<img width="640" height="400" alt="output" src="https://github.com/user-attachments/assets/5cf4b14c-a235-4b3f-a90e-5870d2c6f22a" />


## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
      — it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s).
- [x] Noted release/migration impact, if any.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **“In frontmatter property”** as a link placement option for capture and template choices, including controls to choose the target property and appending behavior.
  * Supports inserting link text into frontmatter when the active file is available.

* **Documentation**
  * Updated choice docs to explain how behavior works when the targeted frontmatter property is not a list (including create/append/error handling).

* **Bug Fixes / Improvements**
  * Ensures capture and template link insertion completes before subsequent actions continue.

* **Tests**
  * Added coverage for frontmatter insertion behavior and placement support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->