### PR TITLE
feat(packages): capability-review preview for package import

### DIFF
--- a/docs/docs/Choices/Packages.md
+++ b/docs/docs/Choices/Packages.md
@@ -90,7 +90,7 @@ whatever file already exists at that path after import.
 For scripting or CI, the `quickadd:package-preview` CLI command returns the same
 review as JSON without opening the modal:
 
-```
+```bash
 obsidian quickadd:package-preview path=path/to/package.quickadd.json
 ```
 

--- a/docs/docs/Choices/Packages.md
+++ b/docs/docs/Choices/Packages.md
@@ -26,23 +26,75 @@ warning so you can locate or recreate the file before distributing the package.
 
 1. Open **Settings → QuickAdd** and click **Import package…**.
 2. Paste the full contents of a `.quickadd.json` file into the text box.
-3. QuickAdd analyses the JSON automatically and lists the choices and assets it
-   contains:
+3. QuickAdd analyses the JSON and shows a **review** of exactly what the package
+   will add and run before you commit (see [Review what a package can do](#review-what-a-package-can-do)).
+4. Under **Choices**, pick an action per choice:
    - **Import** adds a new choice only when its ID does not already exist.
    - **Overwrite** keeps the original ID and replaces the existing choice.
    - **Duplicate** copies the choice with new IDs so you can keep both versions.
    - **Skip** leaves the choice untouched.
-4. For each asset, choose **Write**, **Overwrite**, or **Skip**, and adjust the
-   destination path if you want it saved elsewhere (templates default to your
-   QuickAdd template folder when set). QuickAdd automatically updates the
-   imported choices to reference the new locations.
-5. Click **Import package**. The choices list updates immediately and a notice
-   summarises what changed.
+5. Under **Files**, each bundled file is grouped as **Added** or **Will
+   overwrite**. Choose **Write**, **Overwrite**, or **Skip** per file, and adjust
+   the destination path if you want it saved elsewhere (templates default to your
+   QuickAdd template folder when set). QuickAdd updates the imported choices to
+   reference the new locations.
+6. If the package runs code, tick the acknowledgement, then click **Import
+   package**. The choices list updates immediately and a notice summarises what
+   changed.
 
 QuickAdd preserves choice hierarchy using the stored parent IDs and path hints.
 If QuickAdd cannot locate the original parent (for example, the destination
 vault does not contain the same multi-choice folder), the imported choice is
 added to the root and a warning is logged.
+
+## Review what a package can do
+
+Importing a package can run scripts and macros that have full access to your
+vault and the network, so the import screen treats it as a trust decision and
+makes everything visible **before** anything is written.
+
+### Capability summary
+
+A **Review before importing** panel lists what the package can do, ranked by how
+much it can affect your vault:
+
+- **Runs custom JavaScript** — a user script or a script-mode condition that runs
+  arbitrary code.
+- **Runs on startup** — a macro set to run automatically every time Obsidian
+  launches, with no interaction.
+- **Adds commands** — choices that register a command in the palette / hotkeys.
+- **Overwrites existing choices or files**, **sends content to an AI provider**,
+  **triggers other Obsidian commands**, and similar.
+
+Each row names the choice it comes from. Hover any badge for a plain-language
+explanation of what it means.
+
+### Read the files before you trust them
+
+Every bundled file appears under **Files** with its destination and size. Click
+**View contents** to read a script or template exactly as it will be written.
+Files that are run as code are marked **Executable** (regardless of their
+declared type), and very long or minified scripts are flagged as not fully
+reviewable.
+
+### Acknowledgement gate
+
+When a package can run code, the **Import package** button stays disabled until
+you have opened **View contents** on each bundled executable script and ticked
+the acknowledgement. Reviewed scripts are marked so you can track what is left.
+If a referenced script is **not** bundled, QuickAdd warns that it will run from
+whatever file already exists at that path after import.
+
+### Preview from the command line
+
+For scripting or CI, the `quickadd:package-preview` CLI command returns the same
+review as JSON without opening the modal:
+
+```
+obsidian quickadd:package-preview path=path/to/package.quickadd.json
+```
+
+Add `decode=true` to inline the decoded contents of each bundled file.
 
 ## Version compatibility
 

--- a/src/cli/registerQuickAddCliHandlers.test.ts
+++ b/src/cli/registerQuickAddCliHandlers.test.ts
@@ -147,7 +147,7 @@ describe("registerQuickAddCliHandlers", () => {
 		getUnresolvedRequirementsMock.mockReturnValue([]);
 	});
 
-	it("registers run/list/check handlers when CLI API is available", () => {
+	it("registers run/list/check/preview handlers when CLI API is available", () => {
 		const { plugin, handlers } = createPlugin([
 			templateChoice,
 			macroChoice,
@@ -162,6 +162,7 @@ describe("registerQuickAddCliHandlers", () => {
 			"quickadd:run",
 			"quickadd:list",
 			"quickadd:check",
+			"quickadd:package-preview",
 		]);
 	});
 
@@ -254,6 +255,91 @@ describe("registerQuickAddCliHandlers", () => {
 			templateChoice.id,
 			macroChoice.id,
 		]);
+	});
+
+	it("previews a package and reports its dangerous capabilities", async () => {
+		const packageJson = JSON.stringify({
+			schemaVersion: 1,
+			quickAddVersion: "1.18.0",
+			createdAt: "2026-06-01T00:00:00.000Z",
+			rootChoiceIds: ["m1"],
+			choices: [
+				{
+					choice: {
+						id: "m1",
+						name: "Daily Sync",
+						type: "Macro",
+						command: false,
+						runOnStartup: true,
+						macro: {
+							id: "macro-m1",
+							name: "Daily Sync",
+							commands: [
+								{
+									id: "cmd1",
+									name: "fetch",
+									type: "UserScript",
+									path: "scripts/fetch.js",
+									settings: {},
+								},
+							],
+						},
+					},
+					pathHint: ["Daily Sync"],
+					parentChoiceId: null,
+				},
+			],
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "scripts/fetch.js",
+					contentEncoding: "base64",
+					// "console.log('hi')" base64
+					content: "Y29uc29sZS5sb2coJ2hpJyk=",
+				},
+			],
+		});
+
+		const adapter = {
+			exists: vi.fn(async (path: string) => path === "packages/p.quickadd.json"),
+			read: vi.fn(async (path: string) => {
+				if (path === "packages/p.quickadd.json") return packageJson;
+				throw new Error(`no file at ${path}`);
+			}),
+		};
+		const { plugin, handlers } = createPlugin([]);
+		(plugin as unknown as { app: unknown }).app = { vault: { adapter } };
+		registerQuickAddCliHandlers(plugin);
+		const preview = handlers.find(
+			(handler) => handler.command === "quickadd:package-preview",
+		);
+		expect(preview).toBeDefined();
+
+		const output = await Promise.resolve(
+			preview!.handler({ path: "packages/p.quickadd.json", decode: "true" }),
+		);
+		const payload = JSON.parse(String(output));
+
+		expect(payload.ok).toBe(true);
+		expect(payload.preview.summary.runsOnStartup).toBe(true);
+		expect(payload.preview.summary.criticalCount).toBeGreaterThan(0);
+		expect(payload.preview.criticalScriptPaths).toContain("scripts/fetch.js");
+		const decoded = payload.contents.find(
+			(entry: { path: string }) => entry.path === "scripts/fetch.js",
+		);
+		expect(decoded.text).toBe("console.log('hi')");
+	});
+
+	it("returns an error envelope when the package path is missing", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		registerQuickAddCliHandlers(plugin);
+		const preview = handlers.find(
+			(handler) => handler.command === "quickadd:package-preview",
+		);
+		const output = await Promise.resolve(preview!.handler({}));
+		const payload = JSON.parse(String(output));
+		expect(payload.ok).toBe(false);
+		expect(payload.command).toBe("quickadd:package-preview");
 	});
 
 	it("checks unresolved requirements without executing the choice", async () => {

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -9,6 +9,15 @@ import {
 } from "../preflight/collectChoiceRequirements";
 import type IChoice from "../types/choices/IChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
+import {
+	analysePackagePreview,
+	readQuickAddPackage,
+} from "../services/packageImportService";
+import { decodeAssetPreview } from "../services/packagePreview";
+import type {
+	AssetPreviewContent,
+	PackagePreview,
+} from "../services/packagePreview";
 
 type ChoiceType = IChoice["type"];
 
@@ -25,6 +34,11 @@ interface CliResponse {
 	ok: boolean;
 	command: string;
 	[key: string]: unknown;
+}
+
+interface PackagePreviewCliResponse extends CliResponse {
+	preview: PackagePreview;
+	contents?: Array<{ path: string } & AssetPreviewContent>;
 }
 
 interface RegisterCliHandlerTarget {
@@ -79,6 +93,16 @@ const CHECK_FLAGS: CliFlags = {
 	},
 };
 
+const PREVIEW_FLAGS: CliFlags = {
+	path: {
+		value: "<vault-path>",
+		description: "Path to a .quickadd.json package file in the vault",
+	},
+	decode: {
+		description: "Inline decoded contents for each bundled file",
+	},
+};
+
 const RESERVED_RUN_PARAMS = new Set<string>(["choice", "id", "vars", "ui"]);
 const RESERVED_CHECK_PARAMS = new Set<string>(["choice", "id", "vars"]);
 
@@ -87,6 +111,7 @@ const CLI_COMMANDS = {
 	run: "quickadd:run",
 	list: "quickadd:list",
 	check: "quickadd:check",
+	preview: "quickadd:package-preview",
 } as const;
 
 const SUPPORTED_LIST_TYPES = new Set(["template", "capture", "macro", "multi"]);
@@ -403,6 +428,51 @@ async function checkChoiceHandler(
 	}
 }
 
+async function previewPackageHandler(
+	plugin: QuickAdd,
+	params: CliData,
+): Promise<string> {
+	try {
+		const path =
+			typeof params.path === "string" ? params.path.trim() : "";
+		if (!path) {
+			return serialize({
+				ok: false,
+				command: CLI_COMMANDS.preview,
+				error: "Missing package path. Provide path=<vault-path>.",
+			});
+		}
+
+		const { pkg } = await readQuickAddPackage(plugin.app, path);
+		const preview = await analysePackagePreview(
+			plugin.app,
+			plugin.settings.choices,
+			pkg,
+		);
+
+		const response: PackagePreviewCliResponse = {
+			ok: true,
+			command: CLI_COMMANDS.preview,
+			preview,
+		};
+
+		if (isTruthy(params.decode)) {
+			response.contents = preview.files.map((file) => ({
+				path: file.originalPath,
+				...decodeAssetPreview(pkg, file.originalPath),
+			}));
+		}
+
+		return serialize(response);
+	} catch (error) {
+		return serialize({
+			ok: false,
+			command: CLI_COMMANDS.preview,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
 export function registerQuickAddCliHandlers(plugin: QuickAdd): boolean {
 	const cliTarget = plugin as unknown as RegisterCliHandlerTarget;
 	if (typeof cliTarget.registerCliHandler !== "function") {
@@ -438,6 +508,12 @@ export function registerQuickAddCliHandlers(plugin: QuickAdd): boolean {
 		"Check missing inputs for a QuickAdd choice",
 		CHECK_FLAGS,
 		(params: CliData) => checkChoiceHandler(plugin, params),
+	);
+	register(
+		CLI_COMMANDS.preview,
+		"Preview a QuickAdd package before importing (files + capabilities)",
+		PREVIEW_FLAGS,
+		(params: CliData) => previewPackageHandler(plugin, params),
 	);
 
 	log.logMessage("Registered QuickAdd CLI handlers.");

--- a/src/gui/PackageManager/CapabilityBanner.svelte
+++ b/src/gui/PackageManager/CapabilityBanner.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+	import ObsidianIcon from "../components/ObsidianIcon.svelte";
+	import CapabilityTag from "./CapabilityTag.svelte";
+	import type { PackagePreview } from "../../services/packagePreview";
+
+	let { preview }: { preview: PackagePreview } = $props();
+
+	const showReloadNote = $derived(
+		preview.summary.runsOnStartup ||
+			preview.summary.registersCommandCount > 0,
+	);
+</script>
+
+<section
+	class="qa-import-banner"
+	class:critical={preview.summary.hasCritical}
+	aria-label="What this package can do"
+>
+	<div class="qa-import-banner-head">
+		<span class="qa-import-banner-icon">
+			<ObsidianIcon iconId="alert-triangle" size={17} />
+		</span>
+		<h3>What this package can do</h3>
+	</div>
+
+	<ul class="qa-import-banner-rows">
+		{#each preview.capabilityRows as row (row.flag + row.detail)}
+			<li
+				class:sev-critical={row.severity === "critical"}
+				class:sev-warning={row.severity === "warning"}
+				class:sev-info={row.severity === "info"}
+			>
+				<span class="qa-import-banner-tag"
+					><CapabilityTag flag={row.flag} /></span
+				><span class="qa-import-banner-title">{row.title}</span>
+				{#if row.detail}
+					<span class="qa-import-banner-detail">{row.detail}</span>
+				{/if}
+			</li>
+		{/each}
+	</ul>
+
+	{#if showReloadNote}
+		<p class="qa-import-banner-note">
+			Takes effect after you reload the plugin or restart Obsidian.
+		</p>
+	{/if}
+</section>
+
+<style>
+	.qa-import-banner {
+		background: var(--background-secondary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m, 8px);
+		padding: 0.85rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	/* Critical packages get a red-tinted hairline + red icon, not a blanket-red
+	   fill: severity stays ranked and all text keeps its contrast on the neutral
+	   surface. (A solid colored side-stripe would be the banned pattern.) */
+	.qa-import-banner.critical {
+		border-color: var(--qa-sev-critical-border);
+	}
+
+	.qa-import-banner-head {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.qa-import-banner-icon {
+		display: inline-flex;
+		color: var(--text-warning, var(--text-muted));
+	}
+
+	.qa-import-banner.critical .qa-import-banner-icon {
+		color: var(--text-error);
+	}
+
+	.qa-import-banner-head h3 {
+		margin: 0;
+		font-size: 1rem;
+	}
+
+	.qa-import-banner-rows {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	/* The pill is an inline lead-in to the sentence (not a fixed left column),
+	   so long titles wrap full-width under it instead of leaving a dead column
+	   of whitespace beside a one-line pill. */
+	.qa-import-banner-rows li {
+		display: block;
+		padding: 0.4rem 0.5rem;
+		border-radius: var(--radius-s, 4px);
+	}
+
+	.qa-import-banner-tag {
+		display: inline-block;
+		vertical-align: middle;
+		margin: 0 0.4rem 0.15rem 0;
+	}
+
+	/* Faint per-row severity wash so critical rows read hottest while warnings
+	   recede, without saturating the whole banner. Composited over the banner
+	   surface (not transparent) so the tint is a solid, predictable colour. */
+	.qa-import-banner-rows li.sev-critical {
+		background: var(--qa-sev-critical-wash);
+	}
+
+	.qa-import-banner-rows li.sev-warning {
+		background: var(--qa-sev-warning-wash);
+	}
+
+	.qa-import-banner-rows li.sev-info {
+		background: var(--qa-sev-info-wash);
+	}
+
+	.qa-import-banner-title {
+		line-height: 1.4;
+	}
+
+	.qa-import-banner-detail {
+		display: block;
+		margin-top: 0.15rem;
+		font-size: var(--font-ui-smaller, 0.8rem);
+		color: var(--text-muted);
+		overflow-wrap: anywhere;
+	}
+
+	.qa-import-banner-note {
+		margin: 0;
+		font-size: var(--font-ui-smaller, 0.8rem);
+		color: var(--text-muted);
+	}
+</style>

--- a/src/gui/PackageManager/CapabilityBanner.test.ts
+++ b/src/gui/PackageManager/CapabilityBanner.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/svelte";
+import CapabilityBanner from "./CapabilityBanner.svelte";
+import { buildPackagePreview } from "../../services/packagePreview";
+import type { QuickAddPackage } from "../../types/packages/QuickAddPackage";
+import type IMacroChoice from "../../types/choices/IMacroChoice";
+import type { IUserScript } from "../../types/macros/IUserScript";
+import { CommandType } from "../../types/macros/CommandType";
+import { encodeToBase64 } from "../../utils/base64";
+
+function criticalPackage(): QuickAddPackage {
+	const script: IUserScript = {
+		id: "cmd1",
+		name: "fetch",
+		type: CommandType.UserScript,
+		path: "scripts/fetch.js",
+		settings: {},
+	};
+	const macro: IMacroChoice = {
+		id: "m1",
+		name: "Daily Sync",
+		type: "Macro",
+		command: false,
+		runOnStartup: true,
+		macro: { id: "macro-m1", name: "Daily Sync", commands: [script] },
+	};
+	return {
+		schemaVersion: 1,
+		quickAddVersion: "1.18.0",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		rootChoiceIds: ["m1"],
+		choices: [{ choice: macro, pathHint: ["Daily Sync"], parentChoiceId: null }],
+		assets: [
+			{
+				kind: "user-script",
+				originalPath: "scripts/fetch.js",
+				contentEncoding: "base64",
+				content: encodeToBase64("console.log(1)"),
+			},
+		],
+	};
+}
+
+const preview = buildPackagePreview([], criticalPackage(), new Set());
+
+describe("CapabilityBanner", () => {
+	it("renders capability rows describing the danger", () => {
+		const { getByText } = render(CapabilityBanner, { props: { preview } });
+		expect(getByText("What this package can do")).toBeTruthy();
+		expect(
+			getByText(/Runs automatically every time Obsidian starts/),
+		).toBeTruthy();
+	});
+
+	it("is a pure summary: the acknowledgement checkbox lives elsewhere", () => {
+		// The gate moved next to the Import button so its 'review each script
+		// above' copy is spatially honest; the banner no longer owns a checkbox.
+		const { queryByRole } = render(CapabilityBanner, { props: { preview } });
+		expect(queryByRole("checkbox")).toBeNull();
+	});
+});

--- a/src/gui/PackageManager/CapabilityTag.svelte
+++ b/src/gui/PackageManager/CapabilityTag.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import type { PreviewFlag } from "../../services/packagePreview";
+	import {
+		flagSeverity,
+		flagLabel,
+		flagDescription,
+	} from "../../services/packagePreview";
+	import { tooltip } from "../shared/tooltip";
+
+	let { flag }: { flag: PreviewFlag } = $props();
+
+	const severity = $derived(flagSeverity(flag));
+	const label = $derived(flagLabel(flag));
+	const description = $derived(flagDescription(flag));
+</script>
+
+<span
+	class="qa-import-tag"
+	use:tooltip={description}
+	class:critical={severity === "critical"}
+	class:warning={severity === "warning"}
+	class:info={severity === "info"}>{label}</span
+>
+
+<style>
+	.qa-import-tag {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.05rem 0.4rem;
+		border-radius: var(--radius-s, 4px);
+		font-size: 0.7rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
+		line-height: 1.45;
+		white-space: nowrap;
+		cursor: help;
+	}
+
+	/* Critical: darkened red so white text clears WCAG AA (~5:1) at this size,
+	   where Obsidian's stock --color-red (#e93147) lands at ~3.5:1. */
+	.qa-import-tag.critical {
+		background: var(--qa-sev-critical-pill);
+		color: #fff;
+	}
+
+	/* Warning: amber is medium-luminance in both themes, so near-black text
+	   (~8:1) beats white-on-amber (~2.9:1). Fallback #ff8c00 matches styles.css
+	   and clears AA (~5.9:1) with #1a1a1a. */
+	.qa-import-tag.warning {
+		background: var(--color-orange, #ff8c00);
+		color: #1a1a1a;
+	}
+
+	.qa-import-tag.info {
+		background: var(--background-modifier-border);
+		color: var(--text-normal);
+	}
+</style>

--- a/src/gui/PackageManager/ExportPackageModal.svelte
+++ b/src/gui/PackageManager/ExportPackageModal.svelte
@@ -621,11 +621,14 @@
 		font-size: 1.1rem;
 	}
 
+	/* Neutral surface with an amber-tinted border (these are warnings, not
+	   critical danger): ranked, not a blanket-red fill — matches the import
+	   modal's CapabilityBanner treatment. */
 	.warning {
-		border: 1px solid var(--background-modifier-error);
-		background: var(--background-modifier-error);
-		border-radius: 4px;
-		padding: 0.5rem;
+		border: 1px solid var(--qa-sev-warning-border);
+		background: var(--background-secondary);
+		border-radius: var(--radius-m, 8px);
+		padding: 0.6rem 0.75rem;
 		color: var(--text-normal);
 	}
 

--- a/src/gui/PackageManager/FilePreviewRow.svelte
+++ b/src/gui/PackageManager/FilePreviewRow.svelte
@@ -85,7 +85,7 @@
 				use:tooltip={"Runs as code when its choice runs. It can read, change, or delete files in your vault and access the network."}
 				>Executable</span
 			>
-			{#if reviewed}
+			{#if reviewed && mode !== "skip"}
 				<span class="qa-import-file-reviewed">
 					<ObsidianIcon iconId="check" size={12} /> Reviewed
 				</span>
@@ -123,6 +123,14 @@
 			</select>
 		</label>
 	</div>
+
+	{#if file.executable && mode === "skip"}
+		<p class="qa-import-file-skip-warn" role="note">
+			Won't be written. Any choice that uses this script will run whatever
+			file already exists at this path after import, not the contents you
+			reviewed.
+		</p>
+	{/if}
 
 	<button
 		type="button"
@@ -365,6 +373,16 @@
 		margin: 0;
 		color: var(--text-warning, var(--text-muted));
 		font-size: var(--font-ui-smaller, 0.85rem);
+	}
+
+	.qa-import-file-skip-warn {
+		margin: 0;
+		padding: 0.4rem 0.5rem;
+		border-radius: var(--radius-s, 4px);
+		background: var(--qa-sev-warning-wash);
+		color: var(--text-normal);
+		font-size: var(--font-ui-smaller, 0.85rem);
+		line-height: 1.4;
 	}
 
 	.qa-import-file-error {

--- a/src/gui/PackageManager/FilePreviewRow.svelte
+++ b/src/gui/PackageManager/FilePreviewRow.svelte
@@ -1,0 +1,425 @@
+<script lang="ts">
+	import ObsidianIcon from "../components/ObsidianIcon.svelte";
+	import type {
+		AssetPreviewContent,
+		PreviewFile,
+	} from "../../services/packagePreview";
+	import { decodeAssetPreview } from "../../services/packagePreview";
+	import type { AssetImportMode } from "../../services/packageImportService";
+	import type { QuickAddPackage } from "../../types/packages/QuickAddPackage";
+	import { tooltip } from "../shared/tooltip";
+
+	let {
+		file,
+		pkg,
+		mode,
+		destinationPath,
+		destinationExists,
+		reviewed = false,
+		onPathInput,
+		onModeChange,
+		onReviewed,
+	}: {
+		file: PreviewFile;
+		pkg: QuickAddPackage;
+		mode: AssetImportMode;
+		destinationPath: string;
+		destinationExists: boolean;
+		/** Whether this executable script has been opened toward the gate. */
+		reviewed?: boolean;
+		onPathInput: (value: string) => void;
+		onModeChange: (mode: AssetImportMode) => void;
+		onReviewed: (path: string) => void;
+	} = $props();
+
+	let expanded = $state(false);
+	// Derived (not cached $state) so a re-paste that reuses this row for a
+	// different package/file decodes the CURRENT content, never a stale blob.
+	const content = $derived<AssetPreviewContent | null>(
+		expanded ? decodeAssetPreview(pkg, file.originalPath) : null,
+	);
+	const previewId = $derived(
+		`qa-file-preview-${file.originalPath.replace(/[^a-zA-Z0-9_-]/g, "-")}`,
+	);
+
+	function formatBytes(bytes: number): string {
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	}
+
+	function toggle() {
+		expanded = !expanded;
+		// Only executable scripts count toward the disclosure gate.
+		if (expanded && file.executable) onReviewed(file.originalPath);
+	}
+
+	function onDestinationInput(event: Event) {
+		onPathInput((event.currentTarget as HTMLInputElement).value);
+	}
+
+	function onActionChange(event: Event) {
+		onModeChange(
+			(event.currentTarget as HTMLSelectElement).value as AssetImportMode,
+		);
+	}
+</script>
+
+<div class="qa-import-file" class:overwrite={destinationExists}>
+	<div class="qa-import-file-head">
+		<ObsidianIcon
+			iconId={destinationExists ? "file-warning" : "file-plus"}
+			size={16}
+		/>
+		<span class="qa-import-file-status" class:overwrite={destinationExists}>
+			{destinationExists ? "Will overwrite" : "New file"}
+		</span>
+		<span class="qa-import-file-arrow" aria-hidden="true">→</span>
+		<span class="qa-import-file-dest">{destinationPath}</span>
+	</div>
+
+	<div class="qa-import-file-badges">
+		{#if file.executable}
+			<span
+				class="qa-import-file-exec"
+				use:tooltip={"Runs as code when its choice runs. It can read, change, or delete files in your vault and access the network."}
+				>Executable</span
+			>
+			{#if reviewed}
+				<span class="qa-import-file-reviewed">
+					<ObsidianIcon iconId="check" size={12} /> Reviewed
+				</span>
+			{/if}
+		{/if}
+		{#if file.orphan}
+			<span
+				class="qa-import-file-orphan"
+				use:tooltip={"Bundled in this package but not referenced by any choice."}
+				>Unused</span
+			>
+		{/if}
+		<span class="qa-import-file-size">{formatBytes(file.sizeBytes)}</span>
+	</div>
+
+	<div class="qa-import-file-fields">
+		<label class="qa-import-file-field">
+			<span class="qa-import-file-field-name">Destination</span>
+			<input
+				type="text"
+				value={destinationPath}
+				oninput={onDestinationInput}
+				placeholder="vault/path/to/file"
+				disabled={mode === "skip"}
+			/>
+		</label>
+		<label class="qa-import-file-field">
+			<span class="qa-import-file-field-name">Action</span>
+			<select class="dropdown" value={mode} onchange={onActionChange}>
+				<option value="write">Write</option>
+				{#if destinationExists}
+					<option value="overwrite">Overwrite</option>
+				{/if}
+				<option value="skip">Skip</option>
+			</select>
+		</label>
+	</div>
+
+	<button
+		type="button"
+		class="qa-import-file-toggle"
+		aria-expanded={expanded}
+		aria-controls={previewId}
+		onclick={toggle}
+	>
+		<span class="qa-import-file-chevron" class:open={expanded}>
+			<ObsidianIcon iconId="chevron-right" size={14} />
+		</span>
+		<span>{expanded ? "Hide contents" : "View contents"}</span>
+	</button>
+
+	<div
+		class="qa-import-file-preview-wrap"
+		class:open={expanded}
+		id={previewId}
+	>
+		<div class="qa-import-file-preview-inner">
+			{#if content}
+				<div class="qa-import-file-preview">
+					{#if content.error}
+						<p class="qa-import-file-error">
+							Preview unavailable: {content.error}
+						</p>
+					{:else}
+						{#if content.looksMinified}
+							<p class="qa-import-file-warn">
+								Minified: cannot be visually reviewed. Import
+								only if you trust the source.
+							</p>
+						{/if}
+						<!-- Focusable so keyboard users can scroll long scripts. -->
+						<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+						<pre
+							class="qa-import-file-code"
+							tabindex="0"
+							role="region"
+							aria-label="Contents of {file.originalPath}">{content.text}</pre>
+						{#if content.truncated}
+							<p class="qa-import-file-warn">
+								Preview truncated. The full {file.executable
+									? "script will run"
+									: "file will be imported"}.
+							</p>
+						{/if}
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.qa-import-file {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m, 8px);
+		padding: 0.6rem 0.75rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		background: var(--background-secondary);
+	}
+
+	.qa-import-file.overwrite {
+		border-color: var(--qa-sev-critical-border);
+	}
+
+	.qa-import-file-head {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+	}
+
+	.qa-import-file-status {
+		font-size: 0.78rem;
+		font-weight: 700;
+		letter-spacing: 0.01em;
+		color: var(--text-muted);
+	}
+
+	.qa-import-file-status.overwrite {
+		color: var(--text-error);
+	}
+
+	.qa-import-file-arrow {
+		color: var(--text-muted);
+	}
+
+	.qa-import-file-dest {
+		font-family: var(--font-monospace);
+		font-size: 0.85rem;
+		overflow-wrap: anywhere;
+	}
+
+	.qa-import-file-badges {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		align-items: center;
+	}
+
+	.qa-import-file-orphan {
+		display: inline-flex;
+		padding: 0.05rem 0.4rem;
+		border-radius: var(--radius-s, 4px);
+		font-size: 0.7rem;
+		background: var(--background-modifier-hover);
+		/* --text-normal (not --text-muted) so the badge clears AA on the hover
+		   surface in dark themes too. */
+		color: var(--text-normal);
+		cursor: help;
+	}
+
+	.qa-import-file-exec {
+		display: inline-flex;
+		padding: 0.05rem 0.4rem;
+		border-radius: var(--radius-s, 4px);
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
+		background: var(--qa-sev-critical-pill);
+		color: #fff;
+		cursor: help;
+	}
+
+	.qa-import-file-reviewed {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.15rem;
+		font-size: 0.72rem;
+		color: var(--text-success, var(--color-green, #0aa344));
+	}
+
+	.qa-import-file-size {
+		font-size: 0.72rem;
+		color: var(--text-faint);
+		margin-left: auto;
+	}
+
+	/* Obsidian Setting-row geometry: field name on the left at --text-normal,
+	   control docked right at its native height — not a stacked label-above
+	   form field (which read as non-native). */
+	.qa-import-file-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.qa-import-file-field {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.qa-import-file-field-name {
+		flex: 1 1 auto;
+		min-width: 0;
+		color: var(--text-normal);
+	}
+
+	.qa-import-file-field input {
+		flex: 0 1 300px;
+		min-width: 0;
+	}
+
+	.qa-import-file-field select {
+		flex: 0 0 auto;
+	}
+
+	/* The native Obsidian input/dropdown focus box-shadow handles focus; no
+	   custom outline (which would read as non-native). */
+
+	.qa-import-file-field input:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.qa-import-file-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		align-self: flex-start;
+		background: transparent;
+		border: none;
+		box-shadow: none;
+		padding: 0.1rem 0.2rem;
+		margin-left: -0.2rem;
+		cursor: pointer;
+		color: var(--text-accent);
+		font-size: 0.85rem;
+		border-radius: var(--radius-s, 4px);
+	}
+
+	.qa-import-file-toggle:hover {
+		color: var(--interactive-accent-hover, var(--text-accent));
+		text-decoration: underline;
+	}
+
+	.qa-import-file-toggle:focus-visible {
+		outline: 2px solid var(--interactive-accent);
+		outline-offset: 1px;
+	}
+
+	.qa-import-file-chevron {
+		display: inline-flex;
+		transition: transform 180ms ease;
+	}
+
+	.qa-import-file-chevron.open {
+		transform: rotate(90deg);
+	}
+
+	.qa-import-file-preview-wrap {
+		display: grid;
+		grid-template-rows: 0fr;
+		transition: grid-template-rows 200ms ease;
+	}
+
+	.qa-import-file-preview-wrap.open {
+		grid-template-rows: 1fr;
+	}
+
+	.qa-import-file-preview-inner {
+		overflow: hidden;
+		min-height: 0;
+	}
+
+	.qa-import-file-preview {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		padding-top: 0.2rem;
+	}
+
+	.qa-import-file-warn {
+		margin: 0;
+		color: var(--text-warning, var(--text-muted));
+		font-size: var(--font-ui-smaller, 0.85rem);
+	}
+
+	.qa-import-file-error {
+		margin: 0;
+		color: var(--text-error);
+		font-size: var(--font-ui-smaller, 0.85rem);
+	}
+
+	.qa-import-file-code {
+		margin: 0;
+		max-height: 240px;
+		overflow: auto;
+		padding: 0.5rem 0.6rem;
+		border-radius: var(--radius-s, 4px);
+		background: var(--background-modifier-form-field);
+		border: 1px solid var(--background-modifier-border);
+		font-family: var(--font-monospace);
+		font-size: 0.8rem;
+		line-height: 1.5;
+		white-space: pre;
+		tab-size: 4;
+	}
+
+	.qa-import-file-code:focus-visible {
+		outline: 2px solid var(--interactive-accent);
+		outline-offset: 1px;
+	}
+
+	@media (max-width: 600px) {
+		/* Stack control under its name and let it use the full width on narrow
+		   screens, where a right-docked control would be cramped. */
+		.qa-import-file-field {
+			flex-wrap: wrap;
+			gap: 0.25rem;
+		}
+
+		.qa-import-file-field input,
+		.qa-import-file-field select {
+			flex: 1 1 100%;
+		}
+
+		.qa-import-file-size {
+			margin-left: 0;
+		}
+	}
+
+	:global(.is-mobile) .qa-import-file-toggle {
+		min-height: 36px;
+		padding: 0.4rem 0.3rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.qa-import-file-chevron,
+		.qa-import-file-preview-wrap {
+			transition: none;
+		}
+	}
+</style>

--- a/src/gui/PackageManager/FilePreviewRow.test.ts
+++ b/src/gui/PackageManager/FilePreviewRow.test.ts
@@ -129,6 +129,47 @@ describe("FilePreviewRow", () => {
 		expect(onReviewed).not.toHaveBeenCalled();
 	});
 
+	it("warns and drops the Reviewed badge when an executable script is skipped", () => {
+		// Skip points the dependent choice at whatever file is already on disk,
+		// so the reviewed bundled contents are NOT what runs: the badge must not
+		// imply otherwise, and a warning must explain the substitution.
+		const { getByText, queryByText } = render(FilePreviewRow, {
+			props: {
+				file: makeFile(),
+				pkg: makePackage("scripts/fetch.js", "x"),
+				mode: "skip",
+				destinationPath: "scripts/fetch.js",
+				destinationExists: true,
+				reviewed: true,
+				onPathInput: noop,
+				onModeChange: noop,
+				onReviewed: noop,
+			},
+		});
+
+		expect(queryByText("Reviewed")).toBeNull();
+		expect(getByText(/Won't be written/)).toBeTruthy();
+	});
+
+	it("keeps the Reviewed badge and no skip warning when the script will be written", () => {
+		const { getByText, queryByText } = render(FilePreviewRow, {
+			props: {
+				file: makeFile(),
+				pkg: makePackage("scripts/fetch.js", "x"),
+				mode: "write",
+				destinationPath: "scripts/fetch.js",
+				destinationExists: false,
+				reviewed: true,
+				onPathInput: noop,
+				onModeChange: noop,
+				onReviewed: noop,
+			},
+		});
+
+		expect(getByText("Reviewed")).toBeTruthy();
+		expect(queryByText(/Won't be written/)).toBeNull();
+	});
+
 	it("drives the destination/action callbacks via labelled controls", async () => {
 		const onPathInput = vi.fn();
 		const onModeChange = vi.fn();

--- a/src/gui/PackageManager/FilePreviewRow.test.ts
+++ b/src/gui/PackageManager/FilePreviewRow.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import FilePreviewRow from "./FilePreviewRow.svelte";
+import type { PreviewFile } from "../../services/packagePreview";
+import type {
+	QuickAddPackage,
+	QuickAddPackageAssetKind,
+} from "../../types/packages/QuickAddPackage";
+import { encodeToBase64 } from "../../utils/base64";
+
+function makeFile(overrides: Partial<PreviewFile> = {}): PreviewFile {
+	return {
+		originalPath: "scripts/fetch.js",
+		kind: "user-script",
+		bundled: true,
+		executable: true,
+		exists: false,
+		sizeBytes: 20,
+		orphan: false,
+		referencedBy: [],
+		...overrides,
+	};
+}
+
+function makePackage(
+	path: string,
+	content: string,
+	kind: QuickAddPackageAssetKind = "user-script",
+): QuickAddPackage {
+	return {
+		schemaVersion: 1,
+		quickAddVersion: "1.18.0",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		rootChoiceIds: [],
+		choices: [],
+		assets: [
+			{
+				kind,
+				originalPath: path,
+				contentEncoding: "base64",
+				content: encodeToBase64(content),
+			},
+		],
+	};
+}
+
+const noop = () => {};
+
+describe("FilePreviewRow", () => {
+	it("shows a NEW FILE status when the destination does not exist", () => {
+		const { getByText } = render(FilePreviewRow, {
+			props: {
+				file: makeFile(),
+				pkg: makePackage("scripts/fetch.js", "x"),
+				mode: "write",
+				destinationPath: "scripts/fetch.js",
+				destinationExists: false,
+				onPathInput: noop,
+				onModeChange: noop,
+				onReviewed: noop,
+			},
+		});
+		expect(getByText("New file")).toBeTruthy();
+	});
+
+	it("shows a WILL OVERWRITE status when the destination exists", () => {
+		const { getByText } = render(FilePreviewRow, {
+			props: {
+				file: makeFile({ exists: true }),
+				pkg: makePackage("scripts/fetch.js", "x"),
+				mode: "overwrite",
+				destinationPath: "scripts/fetch.js",
+				destinationExists: true,
+				onPathInput: noop,
+				onModeChange: noop,
+				onReviewed: noop,
+			},
+		});
+		expect(getByText("Will overwrite")).toBeTruthy();
+	});
+
+	it("labels executable scripts and reveals decoded contents on expand", async () => {
+		const onReviewed = vi.fn();
+		const source = "console.log('hello')";
+		const { getByText, queryByText } = render(FilePreviewRow, {
+			props: {
+				file: makeFile(),
+				pkg: makePackage("scripts/fetch.js", source),
+				mode: "write",
+				destinationPath: "scripts/fetch.js",
+				destinationExists: false,
+				onPathInput: noop,
+				onModeChange: noop,
+				onReviewed,
+			},
+		});
+
+		// Contents hidden until expanded.
+		expect(queryByText(source)).toBeNull();
+
+		await fireEvent.click(getByText("View contents"));
+
+		expect(getByText(source)).toBeTruthy();
+		expect(getByText("Executable")).toBeTruthy();
+		// Expanding a critical script reports it as reviewed for the gate.
+		expect(onReviewed).toHaveBeenCalledWith("scripts/fetch.js");
+	});
+
+	it("does not report non-executable files as reviewed", async () => {
+		const onReviewed = vi.fn();
+		const { getByText } = render(FilePreviewRow, {
+			props: {
+				file: makeFile({
+					originalPath: "templates/Note.md",
+					kind: "template",
+					executable: false,
+				}),
+				pkg: makePackage("templates/Note.md", "# Note", "template"),
+				mode: "write",
+				destinationPath: "templates/Note.md",
+				destinationExists: false,
+				onPathInput: noop,
+				onModeChange: noop,
+				onReviewed,
+			},
+		});
+
+		await fireEvent.click(getByText("View contents"));
+		expect(onReviewed).not.toHaveBeenCalled();
+	});
+
+	it("drives the destination/action callbacks via labelled controls", async () => {
+		const onPathInput = vi.fn();
+		const onModeChange = vi.fn();
+		const { getByLabelText } = render(FilePreviewRow, {
+			props: {
+				file: makeFile(),
+				pkg: makePackage("scripts/fetch.js", "x"),
+				mode: "write",
+				destinationPath: "scripts/fetch.js",
+				destinationExists: false,
+				onPathInput,
+				onModeChange,
+				onReviewed: noop,
+			},
+		});
+
+		// Controls are reachable by their field name (label association intact).
+		const input = getByLabelText("Destination") as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: "vault/new.js" } });
+		expect(onPathInput).toHaveBeenCalledWith("vault/new.js");
+
+		const select = getByLabelText("Action") as HTMLSelectElement;
+		await fireEvent.change(select, { target: { value: "skip" } });
+		expect(onModeChange).toHaveBeenCalledWith("skip");
+	});
+});

--- a/src/gui/PackageManager/ImportPackageModal.svelte
+++ b/src/gui/PackageManager/ImportPackageModal.svelte
@@ -99,6 +99,10 @@
 	);
 	const canImport = $derived(
 		Boolean(loadedPackage && analysis) &&
+			// A re-paste keeps the previous package live until its analysis
+			// resolves; block Import in that window so a stale package can't be
+			// written while new content is being analysed.
+			!isAnalyzing &&
 			(!requiresAck || (acknowledged && fullyReviewed)),
 	);
 

--- a/src/gui/PackageManager/ImportPackageModal.svelte
+++ b/src/gui/PackageManager/ImportPackageModal.svelte
@@ -1,174 +1,254 @@
 <script lang="ts">
 	import type { App } from "obsidian";
-	import { Notice, normalizePath } from "obsidian";
+	import { Notice } from "obsidian";
 	import { settingsStore } from "../../settingsStore";
 	import type {
 		LoadedQuickAddPackage,
 		PackageAnalysis,
-		ChoiceImportDecision,
-		AssetImportDecision,
 		ChoiceImportMode,
 		AssetImportMode,
 	} from "../../services/packageImportService";
 	import {
 		analysePackage,
+		analysePackagePreview,
 		applyPackageImport,
 		parseQuickAddPackage,
 	} from "../../services/packageImportService";
+	import type { PackagePreview } from "../../services/packagePreview";
+	import {
+		isFullyReviewed,
+		requiresAcknowledgement,
+	} from "../../services/packagePreview";
+	import CapabilityBanner from "./CapabilityBanner.svelte";
+	import FilePreviewRow from "./FilePreviewRow.svelte";
+	import MacroDisclosure from "./MacroDisclosure.svelte";
+	import ObsidianIcon from "../components/ObsidianIcon.svelte";
+	import {
+		ExistenceResolver,
+		applyExistsResult,
+		effectiveChoiceMode,
+		initAssetDecisions,
+		initChoiceDecisions,
+		resolveAssetDecision,
+		setAssetMode,
+		setAssetPath,
+		setChoiceMode,
+		snapshotAssetDecisions,
+		snapshotChoiceDecisions,
+	} from "./importDecisions";
+	import type {
+		AssetConflict,
+		AssetDecisions,
+		ChoiceDecisions,
+		ExistsProbe,
+	} from "./importDecisions";
 
-let { app, close }: { app: App; close: () => void } = $props();
+	let { app, close }: { app: App; close: () => void } = $props();
 
-let loadedPackage = $state<LoadedQuickAddPackage | null>(null);
-let analysis = $state<PackageAnalysis | null>(null);
-let loadError = $state<string | null>(null);
-let isImporting = $state(false);
-let importSummary = $state<{
-	added: number;
-	overwritten: number;
-	skipped: number;
-	assetsWritten: number;
-	assetsSkipped: number;
-} | null>(null);
-
-let choiceDecisions = $state(new Map<string, ChoiceImportMode>());
-
-type AssetDecisionState = {
-	mode: AssetImportMode;
-	destinationPath: string;
-	destinationExists: boolean;
-};
-
-type AssetConflict = PackageAnalysis["assetConflicts"][number];
-
-let assetDecisions = $state(new Map<string, AssetDecisionState>());
-let pastedContent = $state("");
-let isAnalyzing = $state(false);
-let analysisToken = $state(0);
-let hasImported = $state(false);
-
-function defaultAssetDestination(conflict: AssetConflict): string {
-	const templateFolder = settingsStore.getState().templateFolderPath?.trim();
-	const needsTemplateFolder =
-		conflict.kind === "template" || conflict.kind === "capture-template";
-
-	if (templateFolder && needsTemplateFolder) {
-		const baseName =
-			conflict.originalPath.split("/").pop() ?? conflict.originalPath;
-		const sanitizedFolder = templateFolder.replace(/\/+$/, "");
-		return sanitizedFolder ? `${sanitizedFolder}/${baseName}` : baseName;
+	// Lazily memoized so the `app` prop is read inside a closure (not captured at
+	// the top level) and so the monotonic token survives every re-paste.
+	let existenceResolver: ExistenceResolver | undefined;
+	function existence(): ExistenceResolver {
+		return (existenceResolver ??= new ExistenceResolver(app));
 	}
 
-	return conflict.originalPath;
-}
+	let loadedPackage = $state<LoadedQuickAddPackage | null>(null);
+	let analysis = $state<PackageAnalysis | null>(null);
+	let preview = $state<PackagePreview | null>(null);
+	let acknowledged = $state(false);
+	let reviewedScriptPaths = $state(new Set<string>());
+	let expandedMacros = $state(new Set<string>());
+	let loadError = $state<string | null>(null);
+	let isImporting = $state(false);
+	let importSummary = $state<{
+		added: number;
+		overwritten: number;
+		skipped: number;
+		assetsWritten: number;
+		assetsSkipped: number;
+	} | null>(null);
 
-function pathExists(path: string): boolean {
-	const trimmed = path.trim();
-	if (!trimmed) return false;
-	const normalized = normalizePath(trimmed);
-	return Boolean(app.vault.getAbstractFileByPath(normalized));
-}
+	let choiceDecisions = $state<ChoiceDecisions>(new Map());
+	let assetDecisions = $state<AssetDecisions>(new Map());
+	let pastedContent = $state("");
+	let isAnalyzing = $state(false);
+	let analysisToken = $state(0);
+	let hasImported = $state(false);
 
-function initialiseDecisions() {
-	choiceDecisions = new Map();
-	assetDecisions = new Map();
-	if (!analysis) return;
+	const requiresAck = $derived(
+		preview ? requiresAcknowledgement(preview) : false,
+	);
+	const fullyReviewed = $derived(
+		preview ? isFullyReviewed(preview, reviewedScriptPaths) : true,
+	);
+	const previewChoiceById = $derived(
+		new Map(
+			(preview?.choices ?? []).map((choice) => [choice.choiceId, choice]),
+		),
+	);
+	const previewFileByPath = $derived(
+		new Map(
+			(preview?.files ?? []).map((file) => [file.originalPath, file]),
+		),
+	);
+	const showBanner = $derived(
+		Boolean(
+			preview &&
+			(preview.summary.hasCritical || preview.summary.hasWarning),
+		),
+	);
+	const canImport = $derived(
+		Boolean(loadedPackage && analysis) &&
+			(!requiresAck || (acknowledged && fullyReviewed)),
+	);
 
-	for (const conflict of analysis.choiceConflicts) {
-		const defaultMode = conflict.exists ? "overwrite" : "import";
-		choiceDecisions.set(conflict.choiceId, defaultMode);
+	const criticalScriptCount = $derived(
+		preview?.criticalScriptPaths.length ?? 0,
+	);
+	const hasUnbundledScript = $derived(
+		preview?.missingReferences.some((ref) => ref.asScript) ?? false,
+	);
+	// The checkbox only claims a script review when there are bundled scripts to
+	// open; otherwise the copy stays honest about why no code is shown.
+	const importSummaryText = $derived.by(() => {
+		const s = importSummary;
+		if (!s) return "";
+		const parts: string[] = [];
+		if (s.added)
+			parts.push(`${s.added} choice${s.added === 1 ? "" : "s"} added`);
+		if (s.overwritten) parts.push(`${s.overwritten} overwritten`);
+		if (s.assetsWritten)
+			parts.push(
+				`${s.assetsWritten} file${s.assetsWritten === 1 ? "" : "s"} written`,
+			);
+		const skipped = s.skipped + s.assetsSkipped;
+		if (skipped) parts.push(`${skipped} skipped`);
+		return parts.length
+			? `Imported: ${parts.join(", ")}.`
+			: "Nothing was imported.";
+	});
+
+	const ackLabel = $derived(
+		criticalScriptCount > 0
+			? hasUnbundledScript
+				? "I have reviewed each bundled script above and trust the source, including scripts that are not included and cannot be shown."
+				: "I have reviewed each script above and trust the source."
+			: hasUnbundledScript
+				? "This package runs scripts that are not included and cannot be reviewed. I trust the source."
+				: "I understand this package can run code, and I trust the source.",
+	);
+
+	function markReviewed(path: string) {
+		if (reviewedScriptPaths.has(path)) return;
+		const next = new Set(reviewedScriptPaths);
+		next.add(path);
+		reviewedScriptPaths = next;
 	}
 
-	for (const conflict of analysis.assetConflicts) {
-		const defaultDestination = defaultAssetDestination(conflict);
-		const destinationExists =
-			conflict.exists || pathExists(defaultDestination);
-		const defaultMode = destinationExists ? "overwrite" : "write";
-		assetDecisions.set(conflict.originalPath, {
-			mode: defaultMode,
-			destinationPath: defaultDestination,
-			destinationExists,
+	function toggleMacro(choiceId: string) {
+		const next = new Set(expandedMacros);
+		if (next.has(choiceId)) next.delete(choiceId);
+		else next.add(choiceId);
+		expandedMacros = next;
+	}
+
+	const optimisticExists: ExistsProbe = (path) =>
+		existence().optimistic(path);
+
+	const fileRows = $derived(
+		(analysis?.assetConflicts ?? []).map((conflict) => ({
+			conflict,
+			state: resolveAssetDecision(
+				assetDecisions,
+				conflict,
+				defaultAssetDestination,
+				optimisticExists,
+			),
+			file: previewFileByPath.get(conflict.originalPath),
+		})),
+	);
+	const addedFileRows = $derived(
+		fileRows.filter((row) => !row.state.destinationExists),
+	);
+	const overwriteFileRows = $derived(
+		fileRows.filter((row) => row.state.destinationExists),
+	);
+
+	function defaultAssetDestination(conflict: AssetConflict): string {
+		const templateFolder = settingsStore
+			.getState()
+			.templateFolderPath?.trim();
+		const needsTemplateFolder =
+			conflict.kind === "template" ||
+			conflict.kind === "capture-template";
+
+		if (templateFolder && needsTemplateFolder) {
+			const baseName =
+				conflict.originalPath.split("/").pop() ?? conflict.originalPath;
+			const sanitizedFolder = templateFolder.replace(/\/+$/, "");
+			return sanitizedFolder
+				? `${sanitizedFolder}/${baseName}`
+				: baseName;
+		}
+
+		return conflict.originalPath;
+	}
+
+	// Reconcile a destination against the authoritative adapter.exists (which sees
+	// config/dot-folder files the vault index omits) and correct the stored
+	// decision when it differs.
+	function scheduleExists(originalPath: string, effectivePath: string) {
+		existence().schedule(originalPath, effectivePath, (exists) => {
+			assetDecisions = applyExistsResult(
+				assetDecisions,
+				originalPath,
+				exists,
+			);
 		});
 	}
-}
 
-function updateChoiceDecision(
-	choiceId: string,
-	mode: ChoiceImportMode,
-) {
-	const map = new Map(choiceDecisions);
-	map.set(choiceId, mode);
-	choiceDecisions = map;
-}
-
-function updateAssetMode(originalPath: string, mode: AssetImportMode) {
-	const previous =
-		assetDecisions.get(originalPath) ??
-		({
-			mode,
-			destinationPath: originalPath,
-			destinationExists: pathExists(originalPath),
-		} as AssetDecisionState);
-	const next: AssetDecisionState = { ...previous, mode };
-	const map = new Map(assetDecisions);
-	map.set(originalPath, next);
-	assetDecisions = map;
-}
-
-function updateAssetPath(conflict: AssetConflict, value: string) {
-	const previous =
-		assetDecisions.get(conflict.originalPath) ??
-		({
-			mode: "write",
-			destinationPath: conflict.originalPath,
-			destinationExists: pathExists(conflict.originalPath),
-		} as AssetDecisionState);
-	const trimmed = value.trim();
-	const effectivePath = trimmed || conflict.originalPath;
-	const destinationPath = trimmed ? trimmed : value;
-	const destinationExists = pathExists(effectivePath);
-	let nextMode = previous.mode;
-
-	if (previous.mode !== "skip") {
-		if (destinationExists && previous.mode === "write") {
-			nextMode = "overwrite";
-		} else if (!destinationExists && previous.mode === "overwrite") {
-			nextMode = "write";
+	function initialiseDecisions() {
+		if (!analysis) {
+			choiceDecisions = new Map();
+			assetDecisions = new Map();
+			return;
+		}
+		choiceDecisions = initChoiceDecisions(analysis.choiceConflicts);
+		assetDecisions = initAssetDecisions(
+			analysis.assetConflicts,
+			defaultAssetDestination,
+			optimisticExists,
+		);
+		for (const conflict of analysis.assetConflicts) {
+			const decision = assetDecisions.get(conflict.originalPath);
+			if (decision)
+				scheduleExists(conflict.originalPath, decision.destinationPath);
 		}
 	}
 
-	const next: AssetDecisionState = {
-		...previous,
-		mode: nextMode,
-		destinationPath,
-		destinationExists,
-	};
-	const map = new Map(assetDecisions);
-	map.set(conflict.originalPath, next);
-	assetDecisions = map;
-}
-
-function resolveAssetBadge(
-	conflict: AssetConflict,
-	state: AssetDecisionState,
-): { className: string; label: string } {
-	const destinationExists = state.destinationExists;
-
-	if (state.mode === "skip") {
-		return { className: "assetBadge--info", label: "Skipped" };
+	function updateChoiceDecision(choiceId: string, mode: ChoiceImportMode) {
+		choiceDecisions = setChoiceMode(choiceDecisions, choiceId, mode);
 	}
 
-	if (state.mode === "overwrite") {
-		return {
-			className: destinationExists ? "assetBadge--warning" : "assetBadge--info",
-			label: destinationExists ? "Will overwrite" : "Overwrite",
-		};
+	function updateAssetMode(originalPath: string, mode: AssetImportMode) {
+		assetDecisions = setAssetMode(
+			assetDecisions,
+			originalPath,
+			mode,
+			optimisticExists,
+		);
 	}
 
-	return {
-		className: destinationExists ? "assetBadge--warning" : "assetBadge--info",
-		label: destinationExists ? "Will overwrite" : "New file",
-	};
-}
+	function updateAssetPath(conflict: AssetConflict, value: string) {
+		const { decisions, effectivePath } = setAssetPath(
+			assetDecisions,
+			conflict.originalPath,
+			value,
+			optimisticExists,
+		);
+		assetDecisions = decisions;
+		scheduleExists(conflict.originalPath, effectivePath);
+	}
 
 	function onChoiceModeChange(choiceId: string, event: Event) {
 		const element = event.currentTarget as HTMLSelectElement;
@@ -176,16 +256,12 @@ function resolveAssetBadge(
 		updateChoiceDecision(choiceId, mode);
 	}
 
-function onAssetModeChange(path: string, event: Event) {
-	const element = event.currentTarget as HTMLSelectElement;
-	const mode = element.value as AssetImportMode;
-	updateAssetMode(path, mode);
-}
-
-function onAssetPathChange(conflict: AssetConflict, event: Event) {
-	const value = (event.currentTarget as HTMLInputElement).value;
-	updateAssetPath(conflict, value);
-}
+	function resetPreviewState() {
+		preview = null;
+		acknowledged = false;
+		reviewedScriptPaths = new Set();
+		expandedMacros = new Set();
+	}
 
 	async function analyzePastedContent(raw: string) {
 		const trimmed = raw.trim();
@@ -197,6 +273,7 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 			analysis = null;
 			choiceDecisions = new Map();
 			assetDecisions = new Map();
+			resetPreviewState();
 			loadError = null;
 			return;
 		}
@@ -204,9 +281,15 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 		isAnalyzing = true;
 		try {
 			const pkg = parseQuickAddPackage(trimmed);
+			const existingChoices = settingsStore.getState().choices;
 			const analysisResult = await analysePackage(
 				app,
-				settingsStore.getState().choices,
+				existingChoices,
+				pkg,
+			);
+			const previewResult = await analysePackagePreview(
+				app,
+				existingChoices,
 				pkg,
 			);
 
@@ -214,6 +297,8 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 
 			loadedPackage = { pkg, path: "[pasted]" };
 			analysis = analysisResult;
+			resetPreviewState();
+			preview = previewResult;
 			loadError = null;
 			initialiseDecisions();
 		} catch (error) {
@@ -223,6 +308,7 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 			analysis = null;
 			choiceDecisions = new Map();
 			assetDecisions = new Map();
+			resetPreviewState();
 		} finally {
 			if (token === analysisToken) {
 				isAnalyzing = false;
@@ -255,64 +341,42 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 		isImporting = true;
 		importSummary = null;
 		try {
-			const choiceDecisionsList: ChoiceImportDecision[] = analysis.choiceConflicts.map(
-				(conflict) => {
-					const rawMode = choiceDecisions.get(conflict.choiceId) ?? "import";
-					const mode =
-						conflict.exists || rawMode !== "overwrite" ? rawMode : "import";
-
-					return {
-						choiceId: conflict.choiceId,
-						mode,
-					};
-				},
-			);
-
-			const assetDecisionsList: AssetImportDecision[] =
-				analysis.assetConflicts.map((conflict) => {
-					const decisionState = assetDecisions.get(conflict.originalPath);
-					const destinationPath =
-						decisionState?.destinationPath?.trim() ||
-						conflict.originalPath;
-					const destinationExists =
-						decisionState?.destinationExists ??
-						(conflict.exists ? true : pathExists(destinationPath));
-					const mode =
-						decisionState?.mode ??
-						(destinationExists ? "overwrite" : "write");
-
-					return {
-						originalPath: conflict.originalPath,
-						destinationPath,
-						mode,
-					};
-				});
-
 			const result = await applyPackageImport({
 				app,
 				existingChoices: settingsStore.getState().choices,
 				pkg: loadedPackage.pkg,
-				choiceDecisions: choiceDecisionsList,
-				assetDecisions: assetDecisionsList,
+				choiceDecisions: snapshotChoiceDecisions(
+					analysis.choiceConflicts,
+					choiceDecisions,
+				),
+				assetDecisions: snapshotAssetDecisions(
+					analysis.assetConflicts,
+					assetDecisions,
+					optimisticExists,
+				),
 			});
 
-		settingsStore.setState((state) => ({
-			...state,
-			choices: result.updatedChoices,
-		}));
+			settingsStore.setState((state) => ({
+				...state,
+				choices: result.updatedChoices,
+			}));
 
-		importSummary = {
-			added: result.addedChoiceIds.length,
-			overwritten: result.overwrittenChoiceIds.length,
-			skipped: result.skippedChoiceIds.length,
-			assetsWritten: result.writtenAssets.length,
-			assetsSkipped: result.skippedAssets.length,
-		};
-		hasImported = true;
+			importSummary = {
+				added: result.addedChoiceIds.length,
+				overwritten: result.overwrittenChoiceIds.length,
+				skipped: result.skippedChoiceIds.length,
+				assetsWritten: result.writtenAssets.length,
+				assetsSkipped: result.skippedAssets.length,
+			};
+			hasImported = true;
 
 			new Notice(
 				`Imported ${result.addedChoiceIds.length + result.overwrittenChoiceIds.length} choice${
-					result.addedChoiceIds.length + result.overwrittenChoiceIds.length === 1 ? "" : "s"
+					result.addedChoiceIds.length +
+						result.overwrittenChoiceIds.length ===
+					1
+						? ""
+						: "s"
 				} successfully.`,
 			);
 		} catch (error) {
@@ -327,7 +391,7 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 <div class="importPackageModal">
 	<header>
 		<h2>Import QuickAdd Package</h2>
-		<p>Select a package file, review conflicts, and choose how to import each item.</p>
+		<p>Review what this package adds and runs before importing.</p>
 	</header>
 
 	<section class="pasteSection">
@@ -349,148 +413,301 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 
 	{#if loadedPackage && analysis}
 		<section class="packageMeta">
-			<div>
-				<strong>QuickAdd version:</strong> {loadedPackage.pkg.quickAddVersion}
-			</div>
-			<div>
-				<strong>Created:</strong> {new Date(loadedPackage.pkg.createdAt).toLocaleString()}
-			</div>
-			<div>
-				<strong>Choices:</strong> {analysis.choiceConflicts.length}
-			</div>
-			<div>
-				<strong>Assets:</strong> {loadedPackage.pkg.assets.length}
-			</div>
+			<span
+				><span class="metaLabel">Version</span>
+				{loadedPackage.pkg.quickAddVersion}</span
+			>
+			<span class="metaSep" aria-hidden="true">·</span>
+			<span
+				><span class="metaLabel">Created</span>
+				{new Date(
+					loadedPackage.pkg.createdAt,
+				).toLocaleDateString()}</span
+			>
+			<span class="metaSep" aria-hidden="true">·</span>
+			<span
+				>{analysis.choiceConflicts.length} choice{analysis
+					.choiceConflicts.length === 1
+					? ""
+					: "s"}</span
+			>
+			<span class="metaSep" aria-hidden="true">·</span>
+			<span
+				>{loadedPackage.pkg.assets.length} file{loadedPackage.pkg.assets
+					.length === 1
+					? ""
+					: "s"}</span
+			>
 		</section>
 
+		{#if showBanner && preview}
+			<CapabilityBanner {preview} />
+		{/if}
+
 		<section class="choicesSection">
-			<h3>Choice decisions</h3>
+			<h3>Choices</h3>
 			{#if analysis.choiceConflicts.length === 0}
 				<p>No choices found in this package.</p>
 			{:else}
 				<table>
+					<colgroup>
+						<col class="colName" />
+						<col class="colLocation" />
+						<col class="colAction" />
+					</colgroup>
 					<thead>
 						<tr>
 							<th>Name</th>
 							<th>Location</th>
-							<th>Existing</th>
 							<th>Action</th>
 						</tr>
 					</thead>
 					<tbody>
 						{#each analysis.choiceConflicts as conflict (conflict.choiceId)}
-							{@const storedMode =
-								choiceDecisions.get(conflict.choiceId) ?? "import"}
-							{@const effectiveMode =
-								!conflict.exists && storedMode === "overwrite"
-									? "import"
-									: storedMode}
+							{@const effectiveMode = effectiveChoiceMode(
+								choiceDecisions.get(conflict.choiceId) ??
+									"import",
+								conflict.exists,
+							)}
+							{@const pc = previewChoiceById.get(
+								conflict.choiceId,
+							)}
+							{@const hasMacro = (pc?.commands?.length ?? 0) > 0}
 							<tr>
-								<td>{conflict.name}</td>
-								<td>{formatPathHint(conflict.pathHint)}</td>
-								<td>{conflict.exists ? "Yes" : "No"}</td>
-								<td>
+								<td data-label="Name">
+									<div class="choiceName">
+										{conflict.name}
+									</div>
+									{#if conflict.exists}
+										<div class="choiceExists">
+											already in vault
+										</div>
+									{/if}
+									{#if hasMacro}
+										<button
+											type="button"
+											class="macroToggle"
+											aria-expanded={expandedMacros.has(
+												conflict.choiceId,
+											)}
+											onclick={() =>
+												toggleMacro(conflict.choiceId)}
+										>
+											{expandedMacros.has(
+												conflict.choiceId,
+											)
+												? "Hide macro"
+												: "Show macro"}
+										</button>
+									{/if}
+								</td>
+								<td data-label="Location"
+									>{formatPathHint(conflict.pathHint)}</td
+								>
+								<td data-label="Action">
 									<select
+										class="dropdown"
 										value={effectiveMode}
 										onchange={(event) =>
-											onChoiceModeChange(conflict.choiceId, event)}
+											onChoiceModeChange(
+												conflict.choiceId,
+												event,
+											)}
 									>
 										<option value="import">Import</option>
 										{#if conflict.exists}
-											<option value="overwrite">Overwrite</option>
+											<option value="overwrite"
+												>Overwrite</option
+											>
 										{/if}
-										<option value="duplicate">Duplicate</option>
+										<option value="duplicate"
+											>Duplicate</option
+										>
 										<option value="skip">Skip</option>
 									</select>
 								</td>
 							</tr>
+							{#if hasMacro && expandedMacros.has(conflict.choiceId)}
+								<tr class="macroRow">
+									<td colspan="3">
+										<MacroDisclosure
+											commands={pc?.commands ?? []}
+										/>
+									</td>
+								</tr>
+							{/if}
 						{/each}
 					</tbody>
 				</table>
 			{/if}
 		</section>
 
-	<section class="assetsSection">
-		<h3>Asset decisions</h3>
-		{#if loadedPackage.pkg.assets.length === 0}
-			<p>No additional assets bundled with this package.</p>
-		{:else}
-			<div class="assetCards">
-				{#each analysis.assetConflicts as conflict (conflict.originalPath)}
-					{@const defaultDestination = defaultAssetDestination(conflict)}
-					{@const assetState =
-						assetDecisions.get(conflict.originalPath) ??
-						{
-							mode: conflict.exists ? "overwrite" : "write",
-							destinationPath: defaultDestination,
-							destinationExists:
-								conflict.exists || pathExists(defaultDestination),
-						}}
-					{@const badgeDisplay = resolveAssetBadge(conflict, assetState)}
-					<div class="assetCard">
-						<div class="assetHeader">
-							<div class="assetTitle">{conflict.originalPath}</div>
-							<div class="assetBadges">
-								<span class="assetBadge">{conflict.kind}</span>
-								<span class={`assetBadge ${badgeDisplay.className}`}>
-									{badgeDisplay.label}
-								</span>
-							</div>
+		{#if loadedPackage}
+			<section class="filesSection">
+				<h3>Files</h3>
+				{#if fileRows.length === 0}
+					<p>No files bundled with this package.</p>
+				{:else}
+					{#if addedFileRows.length > 0}
+						<h4 class="filesGroupHeading">
+							Added ({addedFileRows.length})
+						</h4>
+						<div class="fileRows">
+							{#each addedFileRows as row (row.conflict.originalPath)}
+								{#if row.file}
+									<FilePreviewRow
+										file={row.file}
+										pkg={loadedPackage.pkg}
+										mode={row.state.mode}
+										destinationPath={row.state
+											.destinationPath}
+										destinationExists={row.state
+											.destinationExists}
+										onPathInput={(value) =>
+											updateAssetPath(
+												row.conflict,
+												value,
+											)}
+										onModeChange={(mode) =>
+											updateAssetMode(
+												row.conflict.originalPath,
+												mode,
+											)}
+										reviewed={reviewedScriptPaths.has(
+											row.file.originalPath,
+										)}
+										onReviewed={markReviewed}
+									/>
+								{/if}
+							{/each}
 						</div>
-						<div class="assetFields">
-							<label>
-								<span>Destination path</span>
-								<input
-									type="text"
-									value={assetState.destinationPath}
-									oninput={(event) => onAssetPathChange(conflict, event)}
-									placeholder="vault/path/to/file"
-									disabled={assetState.mode === "skip"}
-								/>
-							</label>
-							<label>
-								<span>Action</span>
-								<select
-									value={assetState.mode}
-									onchange={(event) => onAssetModeChange(conflict.originalPath, event)}
-								>
-									<option value="write">Write</option>
-									{#if conflict.exists || assetState.destinationExists}
-										<option value="overwrite">Overwrite</option>
-									{/if}
-									<option value="skip">Skip</option>
-								</select>
-							</label>
+					{/if}
+					{#if overwriteFileRows.length > 0}
+						<h4 class="filesGroupHeading overwrite">
+							Will overwrite ({overwriteFileRows.length})
+						</h4>
+						<div class="fileRows">
+							{#each overwriteFileRows as row (row.conflict.originalPath)}
+								{#if row.file}
+									<FilePreviewRow
+										file={row.file}
+										pkg={loadedPackage.pkg}
+										mode={row.state.mode}
+										destinationPath={row.state
+											.destinationPath}
+										destinationExists={row.state
+											.destinationExists}
+										onPathInput={(value) =>
+											updateAssetPath(
+												row.conflict,
+												value,
+											)}
+										onModeChange={(mode) =>
+											updateAssetMode(
+												row.conflict.originalPath,
+												mode,
+											)}
+										reviewed={reviewedScriptPaths.has(
+											row.file.originalPath,
+										)}
+										onReviewed={markReviewed}
+									/>
+								{/if}
+							{/each}
 						</div>
-					</div>
-				{/each}
-			</div>
+					{/if}
+				{/if}
+			</section>
+
+			{#if preview && (preview.missingReferences.length > 0 || preview.orphanAssets.length > 0)}
+				<section class="warningsBand">
+					{#if preview.missingReferences.length > 0}
+						<div class="warnItem">
+							<h4>Missing files</h4>
+							<ul>
+								{#each preview.missingReferences as ref (ref.path)}
+									<li class:script={ref.asScript}>
+										<code>{ref.path}</code>:
+										{ref.asScript
+											? "not bundled, so it runs from whatever file exists at that path after import"
+											: "not bundled and not in your vault"}
+										<span class="warnLoc"
+											>{ref.breadcrumb}</span
+										>
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+					{#if preview.orphanAssets.length > 0}
+						<div class="warnItem">
+							<h4>Unreferenced files</h4>
+							<ul>
+								{#each preview.orphanAssets as path (path)}
+									<li>
+										<code>{path}</code>: bundled but not
+										used by any choice
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+				</section>
+			{/if}
 		{/if}
-	</section>
 
 		{#if importSummary}
 			<section class="summary">
-				<h3>Last import</h3>
-				<ul>
-					<li>{importSummary.added} added</li>
-					<li>{importSummary.overwritten} overwritten</li>
-					<li>{importSummary.skipped} skipped</li>
-				<li>{importSummary.assetsWritten} assets written</li>
-				<li>{importSummary.assetsSkipped} assets skipped</li>
-			</ul>
-		</section>
+				<ObsidianIcon iconId="check-circle" size={16} />
+				<span>{importSummaryText}</span>
+			</section>
+		{/if}
 	{/if}
+
+	{#if loadedPackage && requiresAck && !hasImported}
+		<section class="ackGate" class:critical={preview?.summary.hasCritical}>
+			<label class="ackGate-label">
+				<input
+					id="qa-import-ack-checkbox"
+					type="checkbox"
+					checked={acknowledged}
+					disabled={!fullyReviewed}
+					aria-describedby={criticalScriptCount > 0 && !fullyReviewed
+						? "qa-import-ack-hint"
+						: undefined}
+					onchange={(event) =>
+						(acknowledged = (
+							event.currentTarget as HTMLInputElement
+						).checked)}
+				/>
+				<span>{ackLabel}</span>
+			</label>
+			{#if criticalScriptCount > 0 && !fullyReviewed}
+				<p id="qa-import-ack-hint" class="ackGate-hint">
+					Open “View contents” on each of the {criticalScriptCount} executable
+					script{criticalScriptCount === 1 ? "" : "s"} above to enable this.
+				</p>
+			{/if}
+		</section>
 	{/if}
 
 	<section class="footer">
-		<button type="button" onclick={close} class="secondary" disabled={isImporting}>
+		<button
+			type="button"
+			onclick={close}
+			class="secondary"
+			disabled={isImporting}
+		>
 			Cancel
 		</button>
 		<button
 			type="button"
 			onclick={hasImported ? close : handleImport}
 			class="primary"
-			disabled={isImporting || !loadedPackage || !analysis}
+			disabled={isImporting || (!hasImported && !canImport)}
+			title={!hasImported && requiresAck && fullyReviewed && !acknowledged
+				? "Confirm the acknowledgement above to continue"
+				: undefined}
 		>
 			{#if isImporting}
 				Importing…
@@ -511,7 +728,11 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 		width: min(720px, 100%);
 		max-height: 80vh;
 		overflow-y: auto;
+		/* overflow-x:hidden (paired with overflow-y:auto) clips child focus rings
+		   at the flush left/right edges; the inline padding gives the ring room. */
 		overflow-x: hidden;
+		box-sizing: border-box;
+		padding: 2px 4px;
 	}
 
 	.importPackageModal * {
@@ -528,115 +749,154 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 		gap: 0.5rem;
 	}
 
-.pasteSection textarea {
-	width: 100%;
-	font-family: var(--font-monospace);
-	resize: vertical;
-}
-
-.errorMessage {
-	color: var(--text-error);
-}
-
-.info {
-	color: var(--text-muted);
-}
-
-	.packageMeta {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-		gap: 0.5rem;
-		padding: 0.5rem;
-		border: 1px solid var(--background-modifier-border);
-		border-radius: 6px;
+	.pasteSection textarea {
 		width: 100%;
+		font-family: var(--font-monospace);
+		resize: vertical;
 	}
 
-	.packageMeta div {
-		overflow-wrap: anywhere;
+	.errorMessage {
+		color: var(--text-error);
 	}
 
-	.choicesSection,
-	.assetsSection {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.assetCards {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.assetCard {
-		border: 1px solid var(--background-modifier-border);
-		border-radius: 8px;
-		padding: 0.75rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		background: var(--background-secondary);
-	}
-
-	.assetHeader {
-		display: flex;
-		flex-direction: column;
-		gap: 0.4rem;
-	}
-
-	.assetTitle {
-		font-weight: 600;
-		word-break: break-word;
-	}
-
-	.assetBadges {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.4rem;
-	}
-
-	.assetBadge {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.1rem 0.5rem;
-		border-radius: 999px;
-		font-size: 0.75rem;
-		background: var(--background-tertiary);
+	.info {
 		color: var(--text-muted);
 	}
 
-	.assetBadge--warning {
-		background: var(--background-modifier-error);
-		color: var(--text-normal);
+	/* A single compact line that sizes to content and wraps naturally, instead
+	   of a 4-equal-column grid where the date wraps to 3 lines and the rest
+	   leave dead space. */
+	.packageMeta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.3rem 0.6rem;
+		padding: 0.55rem 0.75rem;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m, 8px);
+		width: 100%;
+		font-size: var(--font-ui-small, 0.9rem);
+		overflow-wrap: anywhere;
 	}
 
-	.assetBadge--info {
-		background: var(--background-modifier-border);
-		color: var(--text-normal);
+	.metaLabel {
+		color: var(--text-muted);
 	}
 
-	.assetFields {
+	.metaSep {
+		color: var(--text-faint);
+	}
+
+	.choicesSection,
+	.filesSection {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.filesGroupHeading {
+		margin: 0;
+		font-size: var(--font-ui-small, 0.9rem);
+		font-weight: 600;
+		color: var(--text-muted);
+	}
+
+	.filesGroupHeading.overwrite {
+		color: var(--text-error);
+	}
+
+	.fileRows {
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
 	}
 
-	.assetFields label {
-		display: flex;
-		flex-direction: column;
-		gap: 0.3rem;
+	.choiceName {
+		font-weight: 500;
 	}
 
-	.assetFields input,
-	.assetFields select {
-		width: 100%;
+	/* A plain inline text link, not a chrome button: neutralise Obsidian's
+	   default button background/shadow on every state (!important to win over
+	   the global button:hover / :focus rules that paint the grey box). */
+	.macroToggle {
+		display: inline-block;
+		margin-top: 0.35rem;
+		padding: 0;
+		background: transparent !important;
+		border: none;
+		box-shadow: none !important;
+		color: var(--text-accent);
+		cursor: pointer;
+		font-size: var(--font-ui-smaller, 0.8rem);
+		border-radius: var(--radius-s, 4px);
+	}
+
+	.macroToggle:hover {
+		color: var(--interactive-accent-hover, var(--text-accent));
+		text-decoration: underline;
+	}
+
+	.macroToggle:focus-visible {
+		outline: 2px solid var(--interactive-accent);
+		outline-offset: 2px;
+	}
+
+	.macroRow td {
+		background: var(--background-primary-alt, var(--background-secondary));
+	}
+
+	.warningsBand {
+		display: flex;
+		flex-direction: column;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m, 8px);
+		padding: 0.6rem 0.75rem;
+		gap: 0.5rem;
+	}
+
+	.warnItem h4 {
+		margin: 0;
+		font-size: var(--font-ui-small, 0.9rem);
+	}
+
+	.warnItem ul {
+		margin: 0.25rem 0 0;
+		padding-left: 1rem;
+	}
+
+	.warnItem li {
+		overflow-wrap: anywhere;
+	}
+
+	/* A missing SCRIPT reference is an execution-hijack risk, not a broken
+	   link: it runs from whatever exists at that path. Mark it as critical. */
+	.warnItem li.script {
+		padding: 0.25rem 0.4rem;
+		border-radius: var(--radius-s, 4px);
+		background: var(--qa-sev-critical-wash);
+	}
+
+	.warnLoc {
+		color: var(--text-muted);
+		font-size: var(--font-ui-smaller, 0.8rem);
 	}
 
 	.choicesSection table {
 		width: 100%;
 		border-collapse: collapse;
 		table-layout: fixed;
+	}
+
+	.choicesSection col.colName {
+		width: 52%;
+	}
+
+	.choicesSection col.colLocation {
+		width: 26%;
+	}
+
+	.choicesSection col.colAction {
+		width: 22%;
 	}
 
 	.choicesSection th,
@@ -647,16 +907,136 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 		word-break: break-word;
 		overflow-wrap: anywhere;
 		white-space: normal;
+		vertical-align: top;
 	}
 
-	.choicesSection select,
-	.assetsSection select {
+	.choicesSection th {
+		font-size: var(--font-ui-smaller, 0.8rem);
+		color: var(--text-muted);
+		font-weight: 600;
+	}
+
+	.choiceExists {
+		font-size: var(--font-ui-smaller, 0.8rem);
+		color: var(--text-muted);
+		margin-top: 0.1rem;
+	}
+
+	.choicesSection tbody tr:not(.macroRow):hover td {
+		background: var(--background-modifier-hover);
+	}
+
+	.choicesSection select {
 		max-width: 100%;
 	}
 
-	.summary ul {
+	/* Narrow viewports (mobile): a 3-column table can't breathe, so each row
+	   becomes a stacked card with the column name as an inline label. */
+	@media (max-width: 500px) {
+		.choicesSection thead {
+			display: none;
+		}
+
+		.choicesSection table,
+		.choicesSection tbody,
+		.choicesSection tr,
+		.choicesSection td {
+			display: block;
+			width: 100%;
+		}
+
+		.choicesSection tbody tr:not(.macroRow) {
+			border: 1px solid var(--background-modifier-border);
+			border-radius: var(--radius-m, 8px);
+			padding: 0.5rem 0.6rem;
+			margin-bottom: 0.5rem;
+		}
+
+		.choicesSection td {
+			border-bottom: none;
+			padding: 0.15rem 0;
+		}
+
+		.choicesSection td[data-label="Location"]::before,
+		.choicesSection td[data-label="Action"]::before {
+			content: attr(data-label) ": ";
+			font-weight: 600;
+			color: var(--text-muted);
+		}
+
+		.choicesSection td[data-label="Action"] {
+			display: flex;
+			align-items: center;
+			gap: 0.4rem;
+			margin-top: 0.25rem;
+		}
+
+		.choicesSection td[data-label="Action"] select {
+			flex: 1;
+		}
+
+		.macroRow td {
+			padding: 0.25rem 0;
+		}
+	}
+
+	.summary {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.55rem 0.7rem;
+		border-radius: var(--radius-m, 8px);
+		border: 1px solid var(--qa-sev-success-border);
+		background: var(--qa-sev-success-wash);
+		color: var(--text-normal);
+	}
+
+	.summary :global(.quickadd-icon) {
+		color: var(--text-success, var(--color-green, #0aa344));
+		flex-shrink: 0;
+	}
+
+	.ackGate {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		padding: 0.75rem;
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m, 8px);
+		background: var(--background-secondary);
+	}
+
+	.ackGate.critical {
+		border-color: var(--qa-sev-critical-border);
+	}
+
+	.ackGate-label {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.5rem;
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	.ackGate-label:has(input:disabled) {
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+
+	.ackGate-label input {
+		margin-top: 0.2rem;
+		flex-shrink: 0;
+	}
+
+	.ackGate-label input:focus-visible {
+		outline: 2px solid var(--interactive-accent);
+		outline-offset: 2px;
+	}
+
+	.ackGate-hint {
 		margin: 0;
-		padding-left: 1rem;
+		font-size: var(--font-ui-smaller, 0.8rem);
+		color: var(--text-muted);
 	}
 
 	.footer {
@@ -671,7 +1051,48 @@ function onAssetPathChange(conflict: AssetConflict, event: Event) {
 		color: var(--text-on-accent);
 	}
 
+	.footer .primary:hover:not(:disabled) {
+		background: var(--interactive-accent-hover);
+	}
+
+	.footer .primary:active:not(:disabled),
+	.footer .secondary:active:not(:disabled) {
+		transform: translateY(1px);
+	}
+
 	.footer .secondary {
 		background: transparent;
+	}
+
+	.footer .secondary:hover:not(:disabled) {
+		background: var(--background-modifier-hover);
+	}
+
+	.footer .secondary:focus-visible {
+		outline: 2px solid var(--interactive-accent);
+		outline-offset: 2px;
+	}
+
+	/* Accent background needs a light outline to stay visible. */
+	.footer .primary:focus-visible {
+		outline: 2px solid var(--text-on-accent);
+		outline-offset: -4px;
+	}
+
+	:global(.is-mobile) .macroToggle {
+		min-height: 36px;
+		padding: 0.4rem 0.3rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.footer .primary,
+		.footer .secondary {
+			transition: none;
+		}
+
+		.footer .primary:active:not(:disabled),
+		.footer .secondary:active:not(:disabled) {
+			transform: none;
+		}
 	}
 </style>

--- a/src/gui/PackageManager/ImportPackageModal.test.ts
+++ b/src/gui/PackageManager/ImportPackageModal.test.ts
@@ -4,6 +4,7 @@ import type { App } from "obsidian";
 import ImportPackageModal from "./ImportPackageModal.svelte";
 import { settingsStore } from "../../settingsStore";
 import { encodeToBase64 } from "../../utils/base64";
+import type * as PackageImportService from "../../services/packageImportService";
 
 // Lets a test hold `analysePackagePreview` mid-flight to observe the re-analysis
 // window. Disabled by default so other tests keep the real (immediate) preview.
@@ -13,10 +14,7 @@ const previewGate = vi.hoisted(() => ({
 }));
 
 vi.mock("../../services/packageImportService", async (importOriginal) => {
-	const actual =
-		await importOriginal<
-			typeof import("../../services/packageImportService")
-		>();
+	const actual = await importOriginal<typeof PackageImportService>();
 	return {
 		...actual,
 		analysePackagePreview: vi.fn(

--- a/src/gui/PackageManager/ImportPackageModal.test.ts
+++ b/src/gui/PackageManager/ImportPackageModal.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import type { App } from "obsidian";
+import ImportPackageModal from "./ImportPackageModal.svelte";
+import { settingsStore } from "../../settingsStore";
+import { encodeToBase64 } from "../../utils/base64";
+
+// A critical package: a run-on-startup macro that runs one bundled user script.
+const PACKAGE = JSON.stringify({
+	schemaVersion: 1,
+	quickAddVersion: "1.18.0",
+	createdAt: "2026-06-01T00:00:00.000Z",
+	rootChoiceIds: ["m1"],
+	choices: [
+		{
+			choice: {
+				id: "m1",
+				name: "Daily Sync",
+				type: "Macro",
+				command: false,
+				runOnStartup: true,
+				macro: {
+					id: "macro-m1",
+					name: "Daily Sync",
+					commands: [
+						{
+							id: "c1",
+							name: "fetch",
+							type: "UserScript",
+							path: "scripts/fetch.js",
+							settings: {},
+						},
+					],
+				},
+			},
+			pathHint: ["Daily Sync"],
+			parentChoiceId: null,
+		},
+	],
+	assets: [
+		{
+			kind: "user-script",
+			originalPath: "scripts/fetch.js",
+			contentEncoding: "base64",
+			content: encodeToBase64("console.log('hi')"),
+		},
+	],
+});
+
+function fakeApp(): App {
+	return {
+		vault: {
+			adapter: {
+				exists: vi.fn(async () => false),
+				read: vi.fn(async () => ""),
+			},
+			getAbstractFileByPath: vi.fn(() => null),
+		},
+	} as unknown as App;
+}
+
+afterEach(() => {
+	settingsStore.setState((s) => ({ ...s, choices: [] }));
+});
+
+describe("ImportPackageModal gate flow", () => {
+	it("keeps Import locked until the script is reviewed and acknowledged", async () => {
+		settingsStore.setState((s) => ({ ...s, choices: [] }));
+
+		const { container, getByText, getByRole } = render(ImportPackageModal, {
+			props: { app: fakeApp(), close: () => {} },
+		});
+
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+		await fireEvent.input(textarea, { target: { value: PACKAGE } });
+
+		// Banner appears once the (async) analysis resolves.
+		await waitFor(() =>
+			expect(getByText("What this package can do")).toBeTruthy(),
+		);
+
+		const importButton = getByText("Import package") as HTMLButtonElement;
+		const checkbox = getByRole("checkbox") as HTMLInputElement;
+
+		// Gate is locked: checkbox disabled (script unreviewed), Import disabled.
+		expect(checkbox.disabled).toBe(true);
+		expect(importButton.disabled).toBe(true);
+
+		// Reviewing the one bundled critical script enables the checkbox.
+		await fireEvent.click(getByText("View contents"));
+		await waitFor(() => expect(checkbox.disabled).toBe(false));
+		expect(importButton.disabled).toBe(true);
+
+		// Acknowledging then enables Import.
+		await fireEvent.click(checkbox);
+		await waitFor(() => expect(importButton.disabled).toBe(false));
+	});
+});

--- a/src/gui/PackageManager/ImportPackageModal.test.ts
+++ b/src/gui/PackageManager/ImportPackageModal.test.ts
@@ -5,6 +5,35 @@ import ImportPackageModal from "./ImportPackageModal.svelte";
 import { settingsStore } from "../../settingsStore";
 import { encodeToBase64 } from "../../utils/base64";
 
+// Lets a test hold `analysePackagePreview` mid-flight to observe the re-analysis
+// window. Disabled by default so other tests keep the real (immediate) preview.
+const previewGate = vi.hoisted(() => ({
+	enabled: false,
+	releases: [] as Array<() => void>,
+}));
+
+vi.mock("../../services/packageImportService", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("../../services/packageImportService")
+		>();
+	return {
+		...actual,
+		analysePackagePreview: vi.fn(
+			async (
+				...args: Parameters<typeof actual.analysePackagePreview>
+			) => {
+				if (previewGate.enabled) {
+					await new Promise<void>((resolve) =>
+						previewGate.releases.push(resolve),
+					);
+				}
+				return actual.analysePackagePreview(...args);
+			},
+		),
+	};
+});
+
 // A critical package: a run-on-startup macro that runs one bundled user script.
 const PACKAGE = JSON.stringify({
 	schemaVersion: 1,
@@ -61,6 +90,8 @@ function fakeApp(): App {
 
 afterEach(() => {
 	settingsStore.setState((s) => ({ ...s, choices: [] }));
+	previewGate.enabled = false;
+	previewGate.releases = [];
 });
 
 describe("ImportPackageModal gate flow", () => {
@@ -94,5 +125,44 @@ describe("ImportPackageModal gate flow", () => {
 		// Acknowledging then enables Import.
 		await fireEvent.click(checkbox);
 		await waitFor(() => expect(importButton.disabled).toBe(false));
+	});
+
+	it("blocks Import while a re-paste is being analysed", async () => {
+		settingsStore.setState((s) => ({ ...s, choices: [] }));
+		previewGate.enabled = true;
+
+		const { container, getByText, getByRole } = render(ImportPackageModal, {
+			props: { app: fakeApp(), close: () => {} },
+		});
+		const textarea = container.querySelector(
+			"textarea",
+		) as HTMLTextAreaElement;
+
+		// First paste: release its preview so the package fully loads, then
+		// satisfy the gate so Import is enabled.
+		await fireEvent.input(textarea, { target: { value: PACKAGE } });
+		await waitFor(() => expect(previewGate.releases.length).toBe(1));
+		previewGate.releases[0]();
+		await waitFor(() =>
+			expect(getByText("What this package can do")).toBeTruthy(),
+		);
+
+		const importButton = getByText("Import package") as HTMLButtonElement;
+		const checkbox = getByRole("checkbox") as HTMLInputElement;
+		await fireEvent.click(getByText("View contents"));
+		await waitFor(() => expect(checkbox.disabled).toBe(false));
+		await fireEvent.click(checkbox);
+		await waitFor(() => expect(importButton.disabled).toBe(false));
+
+		// Re-paste: the previous package stays acknowledged until the new
+		// analysis resolves, but Import must lock during that window so the
+		// stale package can't be written.
+		await fireEvent.input(textarea, { target: { value: PACKAGE } });
+		await waitFor(() => expect(previewGate.releases.length).toBe(2));
+		expect(importButton.disabled).toBe(true);
+
+		// Let the re-analysis settle (resets the gate, so it stays disabled).
+		previewGate.releases[1]();
+		await waitFor(() => expect(checkbox.disabled).toBe(true));
 	});
 });

--- a/src/gui/PackageManager/MacroDisclosure.svelte
+++ b/src/gui/PackageManager/MacroDisclosure.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import CapabilityTag from "./CapabilityTag.svelte";
+	import type { PreviewCommand } from "../../services/packagePreview";
+
+	let { commands }: { commands: PreviewCommand[] } = $props();
+
+	const HUMAN_COMMAND_TYPE: Record<string, string> = {
+		UserScript: "User script",
+		Conditional: "Conditional",
+		NestedChoice: "Nested choice",
+		Obsidian: "Obsidian command",
+		Choice: "Choice",
+		Wait: "Wait",
+		EditorCommand: "Editor command",
+		AIAssistant: "AI assistant",
+		InfiniteAIAssistant: "AI assistant",
+		OpenFile: "Open file",
+	};
+
+	function humanCommandType(type: string): string {
+		return HUMAN_COMMAND_TYPE[type] ?? type;
+	}
+</script>
+
+<ul class="macroCommands">
+	{#each commands as command, index (index)}
+		<li style={`padding-left:${command.depth * 1}rem`}>
+			<span class="macroCommandName">{command.name}</span>
+			{#if command.flag}
+				<CapabilityTag flag={command.flag} />
+			{:else}
+				<span class="macroCommandType"
+					>{humanCommandType(command.type)}</span
+				>
+			{/if}
+			{#if command.scriptPath}
+				<code>{command.scriptPath}</code>
+			{:else if command.summary}
+				<span class="macroCommandSummary">{command.summary}</span>
+			{/if}
+		</li>
+	{/each}
+</ul>
+
+<style>
+	.macroCommands {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.macroCommands li {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: var(--font-ui-smaller, 0.85rem);
+	}
+
+	.macroCommandName {
+		font-weight: 500;
+	}
+
+	.macroCommandType {
+		color: var(--text-muted);
+		font-size: 0.72rem;
+	}
+
+	.macroCommandSummary {
+		color: var(--text-muted);
+	}
+</style>

--- a/src/gui/PackageManager/importDecisions.test.ts
+++ b/src/gui/PackageManager/importDecisions.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import {
+	ExistenceResolver,
+	applyExistsResult,
+	defaultAssetDecision,
+	effectiveChoiceMode,
+	initAssetDecisions,
+	reconcileMode,
+	resolveAssetDecision,
+	setAssetMode,
+	setAssetPath,
+	snapshotAssetDecisions,
+	snapshotChoiceDecisions,
+	type AssetConflict,
+	type AssetDecisions,
+} from "./importDecisions";
+
+const conflict = (
+	originalPath: string,
+	exists = false,
+	kind: AssetConflict["kind"] = "user-script",
+): AssetConflict => ({ originalPath, exists, kind });
+
+const never = () => false;
+const always = () => true;
+
+describe("reconcileMode", () => {
+	it("keeps skip sticky regardless of existence", () => {
+		expect(reconcileMode("skip", true)).toBe("skip");
+		expect(reconcileMode("skip", false)).toBe("skip");
+	});
+
+	it("flips write -> overwrite when the destination exists", () => {
+		expect(reconcileMode("write", true)).toBe("overwrite");
+	});
+
+	it("flips overwrite -> write when the destination no longer exists", () => {
+		expect(reconcileMode("overwrite", false)).toBe("write");
+	});
+
+	it("leaves an already-consistent mode unchanged", () => {
+		expect(reconcileMode("write", false)).toBe("write");
+		expect(reconcileMode("overwrite", true)).toBe("overwrite");
+	});
+});
+
+describe("effectiveChoiceMode", () => {
+	it("downgrades overwrite to import when the choice does not exist", () => {
+		expect(effectiveChoiceMode("overwrite", false)).toBe("import");
+		expect(effectiveChoiceMode("overwrite", true)).toBe("overwrite");
+		expect(effectiveChoiceMode("duplicate", false)).toBe("duplicate");
+	});
+});
+
+describe("asset decision construction", () => {
+	it("defaults to overwrite when the destination exists, write otherwise", () => {
+		const id = (c: AssetConflict) => c.originalPath;
+		expect(defaultAssetDecision(conflict("a.js"), id, never)).toMatchObject({
+			mode: "write",
+			destinationExists: false,
+		});
+		expect(defaultAssetDecision(conflict("a.js"), id, always)).toMatchObject({
+			mode: "overwrite",
+			destinationExists: true,
+		});
+		// conflict.exists alone (analysis-time truth) forces overwrite.
+		expect(
+			defaultAssetDecision(conflict("a.js", true), id, never),
+		).toMatchObject({ mode: "overwrite", destinationExists: true });
+	});
+
+	it("resolveAssetDecision falls back to a default when none is stored", () => {
+		const id = (c: AssetConflict) => c.originalPath;
+		const decisions: AssetDecisions = new Map();
+		expect(
+			resolveAssetDecision(decisions, conflict("a.js"), id, never).mode,
+		).toBe("write");
+	});
+});
+
+describe("editing the destination", () => {
+	const id = (c: AssetConflict) => c.originalPath;
+
+	it("reconciles the mode when the typed path's existence changes", () => {
+		let decisions = initAssetDecisions([conflict("a.js")], id, never);
+		expect(decisions.get("a.js")?.mode).toBe("write");
+
+		// Type a path that exists -> write flips to overwrite.
+		const r1 = setAssetPath(decisions, "a.js", "exists.md", always);
+		expect(r1.decisions.get("a.js")).toMatchObject({
+			mode: "overwrite",
+			destinationPath: "exists.md",
+			destinationExists: true,
+		});
+		expect(r1.effectivePath).toBe("exists.md");
+
+		// Type a path that doesn't exist -> overwrite flips back to write.
+		const r2 = setAssetPath(r1.decisions, "a.js", "new.md", never);
+		expect(r2.decisions.get("a.js")?.mode).toBe("write");
+	});
+
+	it("never auto-changes a skip decision while editing", () => {
+		let decisions = setAssetMode(
+			initAssetDecisions([conflict("a.js")], id, never),
+			"a.js",
+			"skip",
+			never,
+		);
+		const r = setAssetPath(decisions, "a.js", "exists.md", always);
+		expect(r.decisions.get("a.js")?.mode).toBe("skip");
+	});
+});
+
+describe("applyExistsResult", () => {
+	const id = (c: AssetConflict) => c.originalPath;
+
+	it("corrects the stored mode when async existence differs", () => {
+		const decisions = initAssetDecisions([conflict("a.js")], id, never);
+		// Optimistic said new -> write; the authoritative check finds it exists.
+		const next = applyExistsResult(decisions, "a.js", true);
+		expect(next.get("a.js")).toMatchObject({
+			destinationExists: true,
+			mode: "overwrite",
+		});
+	});
+
+	it("is a no-op (same Map) when existence is unchanged", () => {
+		const decisions = initAssetDecisions([conflict("a.js")], id, never);
+		expect(applyExistsResult(decisions, "a.js", false)).toBe(decisions);
+	});
+
+	it("ignores a key that is not in the decisions", () => {
+		const decisions = initAssetDecisions([conflict("a.js")], id, never);
+		expect(applyExistsResult(decisions, "ghost.js", true)).toBe(decisions);
+	});
+});
+
+describe("snapshots for applyPackageImport", () => {
+	const id = (c: AssetConflict) => c.originalPath;
+
+	it("snapshots choice decisions with the effective mode", () => {
+		const conflicts = [
+			{ choiceId: "a", name: "A", parentChoiceId: null, pathHint: [], exists: false },
+			{ choiceId: "b", name: "B", parentChoiceId: null, pathHint: [], exists: true },
+		];
+		const decisions = new Map<string, "import" | "overwrite" | "duplicate" | "skip">([
+			["a", "overwrite"], // invalid (a does not exist) -> import
+			["b", "overwrite"],
+		]);
+		expect(snapshotChoiceDecisions(conflicts, decisions)).toEqual([
+			{ choiceId: "a", mode: "import" },
+			{ choiceId: "b", mode: "overwrite" },
+		]);
+	});
+
+	it("snapshots asset decisions with destination + mode", () => {
+		const conflicts = [conflict("a.js"), conflict("b.js")];
+		let decisions = initAssetDecisions(conflicts, id, never);
+		decisions = setAssetPath(decisions, "a.js", "moved/a.js", never).decisions;
+		const snap = snapshotAssetDecisions(conflicts, decisions, never);
+		expect(snap).toEqual([
+			{ originalPath: "a.js", destinationPath: "moved/a.js", mode: "write" },
+			{ originalPath: "b.js", destinationPath: "b.js", mode: "write" },
+		]);
+	});
+});
+
+describe("ExistenceResolver — monotonic token (regression: re-paste race)", () => {
+	function deferredApp() {
+		const pending: Array<(value: boolean) => void> = [];
+		const app = {
+			vault: {
+				getAbstractFileByPath: vi.fn(() => null),
+				adapter: {
+					exists: vi.fn(
+						() => new Promise<boolean>((resolve) => pending.push(resolve)),
+					),
+				},
+			},
+		} as unknown as App;
+		return { app, pending };
+	}
+
+	const flush = () => new Promise((r) => setTimeout(r, 0));
+
+	it("drops a stale in-flight result when the same key is rescheduled", async () => {
+		const { app, pending } = deferredApp();
+		const resolver = new ExistenceResolver(app);
+		const got: boolean[] = [];
+
+		// First schedule (token 1) — simulates package A, still in flight.
+		resolver.schedule("scripts/x.js", "destA", (e) => got.push(e));
+		// Re-schedule same key (token 2) — simulates re-paste / edit.
+		resolver.schedule("scripts/x.js", "destB", (e) => got.push(e));
+
+		// The newer (current) call resolves first.
+		pending[1](true);
+		await flush();
+		expect(got).toEqual([true]);
+
+		// The stale call resolves later — its callback MUST be ignored, even
+		// though the old buggy code reset tokens and would have let it through.
+		pending[0](false);
+		await flush();
+		expect(got).toEqual([true]);
+	});
+
+	it("delivers the authoritative result for the latest schedule", async () => {
+		const { app, pending } = deferredApp();
+		const resolver = new ExistenceResolver(app);
+		let result: boolean | undefined;
+		resolver.schedule("k", "p", (e) => (result = e));
+		pending[0](true);
+		await flush();
+		expect(result).toBe(true);
+	});
+});

--- a/src/gui/PackageManager/importDecisions.ts
+++ b/src/gui/PackageManager/importDecisions.ts
@@ -1,0 +1,278 @@
+import type { App } from "obsidian";
+import { normalizePath } from "obsidian";
+import type {
+	AssetImportMode,
+	AssetImportDecision,
+	ChoiceImportMode,
+	ChoiceImportDecision,
+	PackageAnalysis,
+} from "../../services/packageImportService";
+
+/**
+ * The per-file and per-choice import decision model, extracted from
+ * ImportPackageModal so the (fiddly) write/overwrite reconciliation and the
+ * optimistic-vs-authoritative existence checking are pure and unit-testable.
+ *
+ * Everything here operates on plain immutable Maps; the modal holds the
+ * `$state`-backed references and reassigns them, preserving Svelte reactivity.
+ */
+
+export type AssetConflict = PackageAnalysis["assetConflicts"][number];
+export type ChoiceConflict = PackageAnalysis["choiceConflicts"][number];
+
+export interface AssetDecisionState {
+	mode: AssetImportMode;
+	destinationPath: string;
+	destinationExists: boolean;
+}
+
+export type AssetDecisions = Map<string, AssetDecisionState>;
+export type ChoiceDecisions = Map<string, ChoiceImportMode>;
+
+/** Path-existence probe a decision uses; injected so this module stays App-free. */
+export type ExistsProbe = (path: string) => boolean;
+
+// --- The one rule for asset mode --------------------------------------------
+
+/**
+ * Skip is sticky; otherwise the write/overwrite mode tracks whether the
+ * destination currently exists. This is the single home for a rule that was
+ * previously inlined in three places.
+ */
+export function reconcileMode(
+	mode: AssetImportMode,
+	exists: boolean,
+): AssetImportMode {
+	if (mode === "skip") return mode;
+	if (exists && mode === "write") return "overwrite";
+	if (!exists && mode === "overwrite") return "write";
+	return mode;
+}
+
+/** A choice's `overwrite` is only meaningful when the choice already exists. */
+export function effectiveChoiceMode(
+	mode: ChoiceImportMode,
+	exists: boolean,
+): ChoiceImportMode {
+	return !exists && mode === "overwrite" ? "import" : mode;
+}
+
+// --- Decision construction --------------------------------------------------
+
+export function defaultAssetDecision(
+	conflict: AssetConflict,
+	destinationFor: (conflict: AssetConflict) => string,
+	exists: ExistsProbe,
+): AssetDecisionState {
+	const destinationPath = destinationFor(conflict);
+	const destinationExists = conflict.exists || exists(destinationPath);
+	return {
+		mode: destinationExists ? "overwrite" : "write",
+		destinationPath,
+		destinationExists,
+	};
+}
+
+function fallbackDecision(
+	originalPath: string,
+	exists: ExistsProbe,
+): AssetDecisionState {
+	const destinationExists = exists(originalPath);
+	return {
+		mode: destinationExists ? "overwrite" : "write",
+		destinationPath: originalPath,
+		destinationExists,
+	};
+}
+
+export function initAssetDecisions(
+	conflicts: readonly AssetConflict[],
+	destinationFor: (conflict: AssetConflict) => string,
+	exists: ExistsProbe,
+): AssetDecisions {
+	const decisions: AssetDecisions = new Map();
+	for (const conflict of conflicts) {
+		decisions.set(
+			conflict.originalPath,
+			defaultAssetDecision(conflict, destinationFor, exists),
+		);
+	}
+	return decisions;
+}
+
+export function resolveAssetDecision(
+	decisions: AssetDecisions,
+	conflict: AssetConflict,
+	destinationFor: (conflict: AssetConflict) => string,
+	exists: ExistsProbe,
+): AssetDecisionState {
+	return (
+		decisions.get(conflict.originalPath) ??
+		defaultAssetDecision(conflict, destinationFor, exists)
+	);
+}
+
+export function initChoiceDecisions(
+	conflicts: readonly ChoiceConflict[],
+): ChoiceDecisions {
+	const decisions: ChoiceDecisions = new Map();
+	for (const conflict of conflicts) {
+		decisions.set(conflict.choiceId, conflict.exists ? "overwrite" : "import");
+	}
+	return decisions;
+}
+
+// --- Decision updates (return new Maps) -------------------------------------
+
+export function setChoiceMode(
+	decisions: ChoiceDecisions,
+	choiceId: string,
+	mode: ChoiceImportMode,
+): ChoiceDecisions {
+	const next = new Map(decisions);
+	next.set(choiceId, mode);
+	return next;
+}
+
+export function setAssetMode(
+	decisions: AssetDecisions,
+	originalPath: string,
+	mode: AssetImportMode,
+	exists: ExistsProbe,
+): AssetDecisions {
+	const previous =
+		decisions.get(originalPath) ?? fallbackDecision(originalPath, exists);
+	const next = new Map(decisions);
+	next.set(originalPath, { ...previous, mode });
+	return next;
+}
+
+export interface SetAssetPathResult {
+	decisions: AssetDecisions;
+	/** The path whose existence should be reconciled asynchronously. */
+	effectivePath: string;
+}
+
+export function setAssetPath(
+	decisions: AssetDecisions,
+	originalPath: string,
+	value: string,
+	exists: ExistsProbe,
+): SetAssetPathResult {
+	const previous =
+		decisions.get(originalPath) ?? fallbackDecision(originalPath, exists);
+	const trimmed = value.trim();
+	const effectivePath = trimmed || originalPath;
+	// Preserve the raw (untrimmed) value while editing so the cursor doesn't jump.
+	const destinationPath = trimmed ? trimmed : value;
+	const destinationExists = exists(effectivePath);
+	const next = new Map(decisions);
+	next.set(originalPath, {
+		...previous,
+		mode: reconcileMode(previous.mode, destinationExists),
+		destinationPath,
+		destinationExists,
+	});
+	return { decisions: next, effectivePath };
+}
+
+/** Apply an authoritative async existence result, correcting the stored mode. */
+export function applyExistsResult(
+	decisions: AssetDecisions,
+	originalPath: string,
+	exists: boolean,
+): AssetDecisions {
+	const current = decisions.get(originalPath);
+	if (!current || current.destinationExists === exists) return decisions;
+	const next = new Map(decisions);
+	next.set(originalPath, {
+		...current,
+		destinationExists: exists,
+		mode: reconcileMode(current.mode, exists),
+	});
+	return next;
+}
+
+// --- Snapshots for applyPackageImport ---------------------------------------
+
+export function snapshotChoiceDecisions(
+	conflicts: readonly ChoiceConflict[],
+	decisions: ChoiceDecisions,
+): ChoiceImportDecision[] {
+	return conflicts.map((conflict) => ({
+		choiceId: conflict.choiceId,
+		mode: effectiveChoiceMode(
+			decisions.get(conflict.choiceId) ?? "import",
+			conflict.exists,
+		),
+	}));
+}
+
+export function snapshotAssetDecisions(
+	conflicts: readonly AssetConflict[],
+	decisions: AssetDecisions,
+	exists: ExistsProbe,
+): AssetImportDecision[] {
+	return conflicts.map((conflict) => {
+		const decision = decisions.get(conflict.originalPath);
+		const destinationPath =
+			decision?.destinationPath?.trim() || conflict.originalPath;
+		const destinationExists =
+			decision?.destinationExists ??
+			(conflict.exists || exists(destinationPath));
+		const mode = decision?.mode ?? (destinationExists ? "overwrite" : "write");
+		return { originalPath: conflict.originalPath, destinationPath, mode };
+	});
+}
+
+// --- Existence resolver -----------------------------------------------------
+
+/**
+ * Resolves whether a destination already exists.
+ *
+ * - `optimistic` is synchronous and a strict SUBSET of the truth:
+ *   getAbstractFileByPath only knows the vault index, so it never
+ *   false-positives but misses files under config / dot-folders.
+ * - `schedule` reconciles against adapter.exists (which sees everything on
+ *   disk) and calls back with the authoritative answer.
+ *
+ * The per-key token is MONOTONIC for the lifetime of the resolver and is never
+ * reset, so a stale in-flight result from a previously-pasted package can never
+ * pass the staleness guard and clobber the current package's decision.
+ */
+export class ExistenceResolver {
+	private readonly tokens = new Map<string, number>();
+
+	constructor(private readonly app: App) {}
+
+	optimistic(path: string): boolean {
+		const trimmed = path.trim();
+		if (!trimmed) return false;
+		return Boolean(
+			this.app.vault.getAbstractFileByPath(normalizePath(trimmed)),
+		);
+	}
+
+	private async resolve(path: string): Promise<boolean> {
+		const trimmed = path.trim();
+		if (!trimmed) return false;
+		try {
+			return await this.app.vault.adapter.exists(normalizePath(trimmed));
+		} catch {
+			return false;
+		}
+	}
+
+	schedule(
+		key: string,
+		path: string,
+		onResolved: (exists: boolean) => void,
+	): void {
+		const token = (this.tokens.get(key) ?? 0) + 1;
+		this.tokens.set(key, token);
+		void this.resolve(path).then((exists) => {
+			if (this.tokens.get(key) !== token) return;
+			onResolved(exists);
+		});
+	}
+}

--- a/src/gui/shared/tooltip.ts
+++ b/src/gui/shared/tooltip.ts
@@ -1,0 +1,17 @@
+import { setTooltip } from "obsidian";
+
+/**
+ * Svelte action attaching Obsidian's native (styled) tooltip to an element.
+ * The plain HTML `title` attribute does not render reliably inside Obsidian's
+ * Electron window, so use this instead for hover hints.
+ *
+ *   <span use:tooltip={"Explains the term"}>Executable</span>
+ */
+export function tooltip(node: HTMLElement, text: string) {
+	if (text) setTooltip(node, text);
+	return {
+		update(next: string) {
+			setTooltip(node, next ?? "");
+		},
+	};
+}

--- a/src/gui/shared/tooltip.ts
+++ b/src/gui/shared/tooltip.ts
@@ -13,5 +13,9 @@ export function tooltip(node: HTMLElement, text: string) {
 		update(next: string) {
 			setTooltip(node, next ?? "");
 		},
+		destroy() {
+			// Clear Obsidian's tooltip state when the element unmounts.
+			setTooltip(node, "");
+		},
 	};
 }

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -107,6 +107,9 @@ describe("settings user-authored DOM XSS safety", () => {
 			"gui/GlobalVariables/GlobalVariablesView.svelte",
 			"gui/PackageManager/ImportPackageModal.svelte",
 			"gui/PackageManager/ExportPackageModal.svelte",
+			"gui/PackageManager/FilePreviewRow.svelte",
+			"gui/PackageManager/CapabilityBanner.svelte",
+			"gui/PackageManager/CapabilityTag.svelte",
 			"gui/choiceList/ChoiceListItem.svelte",
 			"gui/choiceList/MultiChoiceListItem.svelte",
 		];
@@ -128,7 +131,13 @@ describe("settings user-authored DOM XSS safety", () => {
 			"utf8",
 		);
 		expect(packageImportSource).toContain("{conflict.name}");
-		expect(packageImportSource).toContain("{conflict.originalPath}");
+
+		// File paths render through escaped bindings in FilePreviewRow now.
+		const fileRowSource = readFileSync(
+			join(srcRoot, "gui/PackageManager/FilePreviewRow.svelte"),
+			"utf8",
+		);
+		expect(fileRowSource).toContain("{destinationPath}");
 		expectNoPayloadDom(document.body);
 	});
 });

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -172,11 +172,15 @@ export async function analysePackagePreview(
 		...collectReferencedAssetPaths(pkg),
 	]);
 
+	// Probe paths concurrently: latency is one disk round-trip, not N. Set.add
+	// from parallel microtasks is safe on JS's single thread.
 	const existsByPath = new Set<string>();
-	for (const path of candidatePaths) {
-		if (!path) continue;
-		if (await assetExists(app, path)) existsByPath.add(path);
-	}
+	await Promise.all(
+		Array.from(candidatePaths, async (path) => {
+			if (!path) return;
+			if (await assetExists(app, path)) existsByPath.add(path);
+		}),
+	);
 
 	const preview = buildPackagePreview(existingChoices, pkg, existsByPath);
 

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -22,6 +22,11 @@ import { log } from "../logger/logManager";
 import { decodeFromBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
 import { ensureParentFolders } from "../utils/ensureParentFolders";
+import {
+	buildPackagePreview,
+	collectReferencedAssetPaths,
+} from "./packagePreview";
+import type { PackagePreview } from "./packagePreview";
 
 export interface LoadedQuickAddPackage {
 	pkg: QuickAddPackage;
@@ -148,6 +153,43 @@ export async function analysePackage(
 	}
 
 	return { choiceConflicts, assetConflicts };
+}
+
+/**
+ * Build the rich import-preview model: every file added/overwritten, readable
+ * script contents (decoded lazily by the UI), and the package's dangerous
+ * capabilities. Additive over {@link analysePackage} — it owns the single vault
+ * touch needed to resolve which referenced paths already exist, then delegates
+ * to the pure {@link buildPackagePreview}.
+ */
+export async function analysePackagePreview(
+	app: App,
+	existingChoices: IChoice[],
+	pkg: QuickAddPackage,
+): Promise<PackagePreview> {
+	const candidatePaths = new Set<string>([
+		...pkg.assets.map((asset) => asset.originalPath),
+		...collectReferencedAssetPaths(pkg),
+	]);
+
+	const existsByPath = new Set<string>();
+	for (const path of candidatePaths) {
+		if (!path) continue;
+		if (await assetExists(app, path)) existsByPath.add(path);
+	}
+
+	const preview = buildPackagePreview(existingChoices, pkg, existsByPath);
+
+	const { summary } = preview;
+	log.logMessage(
+		`QuickAdd import preview: choices=${preview.choiceCount} files=${preview.fileCount} ` +
+			`scripts=${summary.scriptCount} runOnStartup=${summary.runsOnStartup} ` +
+			`registersCommands=${summary.registersCommandCount} ` +
+			`overwritesChoices=${summary.overwritesChoices} overwritesFiles=${summary.overwritesFiles} ` +
+			`missing=${summary.missingCount} critical=${summary.criticalCount} warning=${summary.warningCount}`,
+	);
+
+	return preview;
 }
 
 export async function applyPackageImport(

--- a/src/services/packagePreview.decode.test.ts
+++ b/src/services/packagePreview.decode.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import type { QuickAddPackage } from "../types/packages/QuickAddPackage";
+
+// In the real Electron runtime decodeFromBase64 uses window.atob, which THROWS
+// on malformed base64; jsdom's Buffer path silently decodes garbage, so the
+// error branch can only be exercised by mocking decode to throw.
+vi.mock("../utils/base64", () => ({
+	decodeFromBase64: () => {
+		throw new Error("Invalid base64");
+	},
+	encodeToBase64: (value: string) => value,
+}));
+
+import { decodeAssetPreview } from "./packagePreview";
+
+function pkgWith(content: string): QuickAddPackage {
+	return {
+		schemaVersion: 1,
+		quickAddVersion: "1.18.0",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		rootChoiceIds: [],
+		choices: [],
+		assets: [
+			{
+				kind: "user-script",
+				originalPath: "scripts/bad.js",
+				contentEncoding: "base64",
+				content,
+			},
+		],
+	};
+}
+
+describe("decodeAssetPreview malformed content", () => {
+	it("degrades to an error result instead of throwing", () => {
+		const result = decodeAssetPreview(pkgWith("!!!not-base64!!!"), "scripts/bad.js");
+		expect(result.found).toBe(true);
+		expect(result.error).toBeTruthy();
+		expect(result.text).toBe("");
+		expect(result.truncated).toBe(false);
+	});
+});

--- a/src/services/packagePreview.test.ts
+++ b/src/services/packagePreview.test.ts
@@ -1,0 +1,583 @@
+import { describe, expect, it } from "vitest";
+import type IChoice from "../types/choices/IChoice";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import type { ICommand } from "../types/macros/ICommand";
+import type { IUserScript } from "../types/macros/IUserScript";
+import type { IObsidianCommand } from "../types/macros/IObsidianCommand";
+import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
+import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
+import type { ConditionalCondition } from "../types/macros/Conditional/types";
+import { CommandType } from "../types/macros/CommandType";
+import type {
+	QuickAddPackage,
+	QuickAddPackageAsset,
+	QuickAddPackageAssetKind,
+	QuickAddPackageChoice,
+} from "../types/packages/QuickAddPackage";
+import { encodeToBase64 } from "../utils/base64";
+import {
+	buildPackagePreview,
+	collectReferencedAssetPaths,
+	decodeAssetPreview,
+	isFullyReviewed,
+	requiresAcknowledgement,
+	MAX_PREVIEW_CHARS,
+} from "./packagePreview";
+
+// --- Builders ---------------------------------------------------------------
+
+function asset(
+	kind: QuickAddPackageAssetKind,
+	path: string,
+	content = "// content",
+): QuickAddPackageAsset {
+	return {
+		kind,
+		originalPath: path,
+		contentEncoding: "base64",
+		content: encodeToBase64(content),
+	};
+}
+
+function pkgChoice(
+	choice: IChoice,
+	pathHint: string[],
+	parentChoiceId: string | null = null,
+): QuickAddPackageChoice {
+	return { choice, pathHint, parentChoiceId };
+}
+
+function makePackage(
+	choices: QuickAddPackageChoice[],
+	assets: QuickAddPackageAsset[] = [],
+): QuickAddPackage {
+	return {
+		schemaVersion: 1,
+		quickAddVersion: "1.18.0",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		rootChoiceIds: choices
+			.filter((entry) => entry.parentChoiceId === null)
+			.map((entry) => entry.choice.id),
+		choices,
+		assets,
+	};
+}
+
+function macro(
+	id: string,
+	name: string,
+	commands: ICommand[],
+	opts: { runOnStartup?: boolean; command?: boolean } = {},
+): IMacroChoice {
+	return {
+		id,
+		name,
+		type: "Macro",
+		command: opts.command ?? false,
+		runOnStartup: opts.runOnStartup ?? false,
+		macro: { id: `macro-${id}`, name, commands },
+	};
+}
+
+function multi(
+	id: string,
+	name: string,
+	choices: IChoice[],
+	opts: { command?: boolean } = {},
+): IMultiChoice {
+	return {
+		id,
+		name,
+		type: "Multi",
+		command: opts.command ?? false,
+		choices,
+		collapsed: false,
+	};
+}
+
+function userScript(id: string, name: string, path: string): IUserScript {
+	return { id, name, type: CommandType.UserScript, path, settings: {} };
+}
+
+function conditional(
+	id: string,
+	name: string,
+	condition: ConditionalCondition,
+	thenCommands: ICommand[] = [],
+	elseCommands: ICommand[] = [],
+): IConditionalCommand {
+	return {
+		id,
+		name,
+		type: CommandType.Conditional,
+		condition,
+		thenCommands,
+		elseCommands,
+	};
+}
+
+function nested(id: string, name: string, choice: IChoice): INestedChoiceCommand {
+	return { id, name, type: CommandType.NestedChoice, choice };
+}
+
+function obsidianCmd(id: string, name: string, commandId: string): IObsidianCommand {
+	return { id, name, type: CommandType.Obsidian, commandId };
+}
+
+const NO_EXISTING: IChoice[] = [];
+const NONE = new Set<string>();
+
+// --- Tests ------------------------------------------------------------------
+
+describe("buildPackagePreview - script detection & recursion", () => {
+	it("detects a user script in a macro and marks the file executable + critical", () => {
+		const m = macro("m1", "Daily Sync", [
+			userScript("c1", "fetch", "scripts/fetch.js"),
+		]);
+		const pkg = makePackage(
+			[pkgChoice(m, ["Daily Sync"])],
+			[asset("user-script", "scripts/fetch.js")],
+		);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+
+		const file = preview.files.find((f) => f.originalPath === "scripts/fetch.js");
+		expect(file?.executable).toBe(true);
+		expect(preview.criticalScriptPaths).toContain("scripts/fetch.js");
+		expect(preview.summary.hasCritical).toBe(true);
+		expect(preview.summary.scriptCount).toBe(1);
+		expect(
+			preview.capabilityRows.some(
+				(r) => r.flag === "user-script" && r.scriptPath === "scripts/fetch.js",
+			),
+		).toBe(true);
+		const choice = preview.choices.find((c) => c.choiceId === "m1");
+		expect(choice?.flags).toContain("user-script");
+	});
+
+	it("detects a user script inside a Conditional else-branch", () => {
+		const cond = conditional(
+			"c1",
+			"branch",
+			{ mode: "variable", variableName: "x", operator: "isTruthy", valueType: "boolean" },
+			[],
+			[userScript("c2", "cleanup", "scripts/cleanup.js")],
+		);
+		const m = macro("m1", "Brancher", [cond]);
+		const pkg = makePackage(
+			[pkgChoice(m, ["Brancher"])],
+			[asset("user-script", "scripts/cleanup.js")],
+		);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(preview.criticalScriptPaths).toContain("scripts/cleanup.js");
+		const file = preview.files.find((f) => f.originalPath === "scripts/cleanup.js");
+		expect(file?.executable).toBe(true);
+	});
+
+	it("detects a script-mode Conditional as critical", () => {
+		const cond = conditional("c1", "check", {
+			mode: "script",
+			scriptPath: "scripts/cond.js",
+		});
+		const m = macro("m1", "Conditional Macro", [cond]);
+		const pkg = makePackage(
+			[pkgChoice(m, ["Conditional Macro"])],
+			[asset("conditional-script", "scripts/cond.js")],
+		);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(preview.criticalScriptPaths).toContain("scripts/cond.js");
+		expect(
+			preview.capabilityRows.some((r) => r.flag === "conditional-script"),
+		).toBe(true);
+	});
+
+	it("detects a user script inside a NestedChoice-embedded macro (attributed to parent)", () => {
+		const innerMacro = macro("inner", "Inner", [
+			userScript("c2", "deep", "scripts/deep.js"),
+		]);
+		const outer = macro("m1", "Outer", [nested("n1", "Run inner", innerMacro)]);
+		const pkg = makePackage(
+			[pkgChoice(outer, ["Outer"])],
+			[asset("user-script", "scripts/deep.js")],
+		);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		// The embedded macro is not its own pkg.choices entry.
+		expect(preview.choices).toHaveLength(1);
+		expect(preview.criticalScriptPaths).toContain("scripts/deep.js");
+		const choice = preview.choices.find((c) => c.choiceId === "m1");
+		expect(choice?.flags).toContain("user-script");
+	});
+
+	it("detects runOnStartup at top level and inside a nested macro", () => {
+		const startupTop = macro("m1", "Startup", [], { runOnStartup: true });
+		const nestedStartup = macro("inner", "NestedStartup", [], {
+			runOnStartup: true,
+		});
+		const host = macro("m2", "Host", [nested("n1", "Run", nestedStartup)]);
+		const pkg = makePackage([
+			pkgChoice(startupTop, ["Startup"]),
+			pkgChoice(host, ["Host"]),
+		]);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(preview.summary.runsOnStartup).toBe(true);
+		expect(preview.choices.find((c) => c.choiceId === "m1")?.flags).toContain(
+			"run-on-startup",
+		);
+		expect(preview.choices.find((c) => c.choiceId === "m2")?.flags).toContain(
+			"run-on-startup",
+		);
+		const startupRows = preview.capabilityRows.filter(
+			(r) => r.flag === "run-on-startup",
+		);
+		expect(startupRows).toHaveLength(2);
+	});
+});
+
+describe("buildPackagePreview - choice flags & dedupe", () => {
+	it("flags command:true on a Multi child without double-counting it", () => {
+		const child = macro("child", "Child", [], { command: true });
+		const parent = multi("parent", "Folder", [child]);
+		// Both parent and child are their own pkg.choices entries (as export emits).
+		const pkg = makePackage([
+			pkgChoice(parent, ["Folder"]),
+			pkgChoice(child, ["Folder", "Child"], "parent"),
+		]);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(preview.choices).toHaveLength(2);
+		const childPreview = preview.choices.find((c) => c.choiceId === "child");
+		expect(childPreview?.registersCommand).toBe(true);
+		expect(childPreview?.flags).toContain("registers-command");
+		// The parent Multi entry must NOT re-collect the child's capability.
+		const parentPreview = preview.choices.find((c) => c.choiceId === "parent");
+		expect(parentPreview?.flags).not.toContain("registers-command");
+		expect(preview.summary.registersCommandCount).toBe(1);
+	});
+
+	it("attributes an inline-only Multi child's capabilities to its parent (no hiding)", () => {
+		// A crafted package puts a dangerous macro inline in a Multi.choices array
+		// WITHOUT listing it as its own pkg.choices entry.
+		const hidden = macro(
+			"hidden",
+			"Hidden",
+			[userScript("c1", "run", "scripts/hidden.js")],
+			{ runOnStartup: true },
+		);
+		const folder = multi("folder", "Folder", [hidden]);
+		const pkg = makePackage(
+			[pkgChoice(folder, ["Folder"])],
+			[asset("user-script", "scripts/hidden.js")],
+		);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		// Only the folder has a row; the inline child must not be silently dropped.
+		expect(preview.choices).toHaveLength(1);
+		const folderChoice = preview.choices.find((c) => c.choiceId === "folder");
+		expect(folderChoice?.flags).toContain("run-on-startup");
+		expect(folderChoice?.flags).toContain("user-script");
+		expect(preview.criticalScriptPaths).toContain("scripts/hidden.js");
+	});
+
+	it("does not double-count a Multi child that is also its own entry", () => {
+		const child = macro("child", "Child", [
+			userScript("c1", "run", "scripts/child.js"),
+		]);
+		const parent = multi("parent", "Folder", [child]);
+		const pkg = makePackage(
+			[
+				pkgChoice(parent, ["Folder"]),
+				pkgChoice(child, ["Folder", "Child"], "parent"),
+			],
+			[asset("user-script", "scripts/child.js")],
+		);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		// The script is attributed to the child row only, not also to the parent.
+		const parentChoice = preview.choices.find((c) => c.choiceId === "parent");
+		expect(parentChoice?.flags).not.toContain("user-script");
+		const userScriptRows = preview.capabilityRows.filter(
+			(r) => r.flag === "user-script",
+		);
+		expect(userScriptRows).toHaveLength(1);
+	});
+
+	it("flags AI commands as warning (not critical)", () => {
+		const m = macro("m1", "AI", [
+			{ id: "c1", name: "Assist", type: CommandType.AIAssistant } as ICommand,
+		]);
+		const pkg = makePackage([pkgChoice(m, ["AI"])]);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		const aiRow = preview.capabilityRows.find((r) => r.flag === "ai");
+		expect(aiRow?.severity).toBe("warning");
+		expect(preview.summary.hasCritical).toBe(false);
+	});
+
+	it("surfaces the literal Obsidian commandId", () => {
+		const m = macro("m1", "Runner", [
+			obsidianCmd("c1", "Toggle", "app:toggle-left-sidebar"),
+		]);
+		const pkg = makePackage([pkgChoice(m, ["Runner"])]);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		const row = preview.capabilityRows.find((r) => r.flag === "obsidian-command");
+		expect(row?.detail).toContain("app:toggle-left-sidebar");
+	});
+
+	it("flags an unknown CommandType instead of dropping it", () => {
+		const m = macro("m1", "Future", [
+			{ id: "c1", name: "Mystery", type: "FutureThing" as CommandType } as ICommand,
+		]);
+		const pkg = makePackage([pkgChoice(m, ["Future"])]);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(
+			preview.capabilityRows.some((r) => r.flag === "unknown-command"),
+		).toBe(true);
+	});
+});
+
+describe("buildPackagePreview - safety must-fixes", () => {
+	it("treats a script mislabeled as a template as executable + critical (command graph wins)", () => {
+		const m = macro("m1", "Sneaky", [
+			userScript("c1", "run", "scripts/looks-like-template.md"),
+		]);
+		// Bundled as kind 'template' but referenced as a script.
+		const pkg = makePackage(
+			[pkgChoice(m, ["Sneaky"])],
+			[asset("template", "scripts/looks-like-template.md")],
+		);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		const file = preview.files.find(
+			(f) => f.originalPath === "scripts/looks-like-template.md",
+		);
+		expect(file?.executable).toBe(true);
+		expect(
+			preview.capabilityRows.some((r) => r.flag === "mislabeled-executable"),
+		).toBe(true);
+		expect(preview.criticalScriptPaths).toContain(
+			"scripts/looks-like-template.md",
+		);
+	});
+
+	it("reports a referenced-but-unbundled script as a missing reference, not a file", () => {
+		const m = macro("m1", "Needs script", [
+			userScript("c1", "run", "scripts/absent.js"),
+		]);
+		const pkg = makePackage([pkgChoice(m, ["Needs script"])], []);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(preview.files).toHaveLength(0);
+		expect(preview.missingReferences).toHaveLength(1);
+		expect(preview.missingReferences[0]).toMatchObject({
+			path: "scripts/absent.js",
+			asScript: true,
+		});
+		expect(preview.summary.missingCount).toBe(1);
+	});
+
+	it("does not report a referenced unbundled path as missing when it exists in the vault", () => {
+		const m = macro("m1", "Uses local", [
+			userScript("c1", "run", "scripts/local.js"),
+		]);
+		const pkg = makePackage([pkgChoice(m, ["Uses local"])], []);
+		const preview = buildPackagePreview(
+			NO_EXISTING,
+			pkg,
+			new Set(["scripts/local.js"]),
+		);
+		expect(preview.missingReferences).toHaveLength(0);
+	});
+
+	it("keeps a brand-new user script critical and acknowledgement-required (nothing overwritten)", () => {
+		const m = macro("m1", "New", [userScript("c1", "run", "scripts/new.js")]);
+		const pkg = makePackage(
+			[pkgChoice(m, ["New"])],
+			[asset("user-script", "scripts/new.js")],
+		);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(preview.summary.overwritesChoices).toBe(0);
+		expect(preview.summary.overwritesFiles).toBe(0);
+		expect(requiresAcknowledgement(preview)).toBe(true);
+	});
+});
+
+describe("buildPackagePreview - files manifest, overwrites, orphans, captures", () => {
+	it("marks files added vs overwritten from existsByPath", () => {
+		const tmpl = {
+			id: "t1",
+			name: "Note",
+			type: "Template",
+			command: false,
+			templatePath: "templates/Note.md",
+			fileExistsBehavior: { kind: "apply", mode: "overwrite" },
+		} as unknown as ITemplateChoice;
+		const pkg = makePackage(
+			[pkgChoice(tmpl, ["Note"])],
+			[
+				asset("template", "templates/Note.md"),
+				asset("user-script", "scripts/new.js"),
+			],
+		);
+		const preview = buildPackagePreview(
+			NO_EXISTING,
+			pkg,
+			new Set(["templates/Note.md"]),
+		);
+		const note = preview.files.find((f) => f.originalPath === "templates/Note.md");
+		expect(note?.exists).toBe(true);
+		expect(preview.summary.overwritesFiles).toBe(1);
+		expect(preview.choices.find((c) => c.choiceId === "t1")?.flags).toContain(
+			"template-write",
+		);
+	});
+
+	it("detects an orphan bundled asset", () => {
+		const m = macro("m1", "Empty", []);
+		const pkg = makePackage(
+			[pkgChoice(m, ["Empty"])],
+			[asset("user-script", "scripts/unused.js")],
+		);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(preview.orphanAssets).toContain("scripts/unused.js");
+		const file = preview.files.find((f) => f.originalPath === "scripts/unused.js");
+		expect(file?.orphan).toBe(true);
+		// Unreferenced => not classified executable.
+		expect(file?.executable).toBe(false);
+	});
+
+	it("gates the capture-template by the triple-boolean", () => {
+		const base = {
+			id: "cap1",
+			name: "Cap",
+			type: "Capture",
+			command: false,
+			captureTo: "Inbox.md",
+			captureToActiveFile: false,
+		};
+		const withoutTemplate = {
+			...base,
+			createFileIfItDoesntExist: {
+				enabled: true,
+				createWithTemplate: false,
+				template: "templates/Cap.md",
+			},
+		} as unknown as ICaptureChoice;
+		const pkg = makePackage([pkgChoice(withoutTemplate, ["Cap"])], []);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		// createWithTemplate=false => the template is NOT referenced.
+		expect(preview.missingReferences).toHaveLength(0);
+		expect(preview.choices.find((c) => c.choiceId === "cap1")?.flags).toContain(
+			"capture-writes",
+		);
+	});
+
+	it("flags an existing choice id as an overwrite", () => {
+		const m = macro("m1", "Existing", []);
+		const pkg = makePackage([pkgChoice(m, ["Existing"])]);
+		const existing: IChoice[] = [
+			{ id: "m1", name: "Existing", type: "Macro", command: false } as IChoice,
+		];
+		const preview = buildPackagePreview(existing, pkg, NONE);
+		expect(preview.choices.find((c) => c.choiceId === "m1")?.exists).toBe(true);
+		expect(preview.summary.overwritesChoices).toBe(1);
+	});
+});
+
+describe("collectReferencedAssetPaths", () => {
+	it("collects every referenced script/template path once", () => {
+		const m = macro("m1", "Multi-ref", [
+			userScript("c1", "a", "scripts/a.js"),
+			userScript("c2", "b", "scripts/a.js"),
+			conditional("c3", "c", { mode: "script", scriptPath: "scripts/cond.js" }),
+		]);
+		const pkg = makePackage([pkgChoice(m, ["Multi-ref"])]);
+		const paths = collectReferencedAssetPaths(pkg).sort();
+		expect(paths).toEqual(["scripts/a.js", "scripts/cond.js"]);
+	});
+});
+
+describe("decodeAssetPreview", () => {
+	it("round-trips bundled base64 content", () => {
+		const source = "const x = 1;\nexport default x;";
+		const pkg = makePackage([], [asset("user-script", "s.js", source)]);
+		const result = decodeAssetPreview(pkg, "s.js");
+		expect(result.found).toBe(true);
+		expect(result.text).toBe(source);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("flags truncation past the cap", () => {
+		const source = "a".repeat(MAX_PREVIEW_CHARS + 50);
+		const pkg = makePackage([], [asset("user-script", "big.js", source)]);
+		const result = decodeAssetPreview(pkg, "big.js");
+		expect(result.truncated).toBe(true);
+		expect(result.text.length).toBe(MAX_PREVIEW_CHARS);
+	});
+
+	it("detects a minified single-line script", () => {
+		const source = `const f=()=>{${"x".repeat(2000)}};`;
+		const pkg = makePackage([], [asset("user-script", "min.js", source)]);
+		const result = decodeAssetPreview(pkg, "min.js");
+		expect(result.looksMinified).toBe(true);
+	});
+
+	it("returns not-found for an unbundled path", () => {
+		const pkg = makePackage([], []);
+		const result = decodeAssetPreview(pkg, "missing.js");
+		expect(result.found).toBe(false);
+		expect(result.error).toBeTruthy();
+	});
+});
+
+describe("gate predicates", () => {
+	it("isFullyReviewed requires every critical script path to be reviewed", () => {
+		const m = macro("m1", "Two scripts", [
+			userScript("c1", "a", "scripts/a.js"),
+			userScript("c2", "b", "scripts/b.js"),
+		]);
+		const pkg = makePackage(
+			[pkgChoice(m, ["Two scripts"])],
+			[asset("user-script", "scripts/a.js"), asset("user-script", "scripts/b.js")],
+		);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(isFullyReviewed(preview, new Set(["scripts/a.js"]))).toBe(false);
+		expect(
+			isFullyReviewed(preview, new Set(["scripts/a.js", "scripts/b.js"])),
+		).toBe(true);
+	});
+
+	it("requires acknowledgement but has no script gate set for a startup-only macro", () => {
+		// runOnStartup is critical on its own, but there is no bundled script to
+		// review — the gate set must be empty so the flow stays honest (the banner
+		// copy, not a vacuous 'reviewed each script' claim, carries the weight).
+		const m = macro("m1", "Startup", [], { runOnStartup: true });
+		const pkg = makePackage([pkgChoice(m, ["Startup"])]);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(requiresAcknowledgement(preview)).toBe(true);
+		expect(preview.criticalScriptPaths).toEqual([]);
+		// Nothing to expand -> trivially reviewed; acknowledgement still required.
+		expect(isFullyReviewed(preview, new Set())).toBe(true);
+	});
+
+	it("requiresAcknowledgement is false for a package with no critical capability", () => {
+		const tmpl = {
+			id: "t1",
+			name: "Note",
+			type: "Template",
+			command: false,
+			templatePath: "templates/Note.md",
+			fileExistsBehavior: { kind: "prompt" },
+		} as unknown as ITemplateChoice;
+		const pkg = makePackage(
+			[pkgChoice(tmpl, ["Note"])],
+			[asset("template", "templates/Note.md")],
+		);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(requiresAcknowledgement(preview)).toBe(false);
+	});
+});

--- a/src/services/packagePreview.ts
+++ b/src/services/packagePreview.ts
@@ -1,0 +1,919 @@
+import type IChoice from "../types/choices/IChoice";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import type { ICommand } from "../types/macros/ICommand";
+import type { IUserScript } from "../types/macros/IUserScript";
+import type { IObsidianCommand } from "../types/macros/IObsidianCommand";
+import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
+import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
+import type { ConditionalCondition } from "../types/macros/Conditional/types";
+import { CommandType } from "../types/macros/CommandType";
+import type {
+	QuickAddPackage,
+	QuickAddPackageAssetKind,
+} from "../types/packages/QuickAddPackage";
+import { flattenChoices } from "../utils/choiceUtils";
+import { decodeFromBase64 } from "../utils/base64";
+
+/**
+ * Pure, App-free analysis of a QuickAdd package for the import preview.
+ *
+ * Everything in this module is computed from the package payload + a set of
+ * already-existing vault paths (and the importer's existing choices). It never
+ * touches the Obsidian App, so it is unit-testable under jsdom and is the exact
+ * model the import modal renders and the `quickadd:package-preview` CLI handler
+ * returns.
+ *
+ * Key safety invariant: a file's "executable" status is decided from the
+ * COMMAND GRAPH (is it referenced by a UserScript / script-mode Conditional?),
+ * never from the package-declared `asset.kind`, which is an untrusted hint.
+ */
+
+export type PreviewSeverity = "critical" | "warning" | "info";
+
+export type PreviewFlag =
+	| "user-script"
+	| "conditional-script"
+	| "run-on-startup"
+	| "mislabeled-executable"
+	| "registers-command"
+	| "obsidian-command"
+	| "ai"
+	| "capture-writes"
+	| "template-write"
+	| "overwrites-existing-choice"
+	| "overwrites-existing-file"
+	| "missing-reference"
+	| "unknown-command"
+	| "editor-command"
+	| "open-file";
+
+interface FlagMeta {
+	severity: PreviewSeverity;
+	/** Short uppercase pill label. */
+	label: string;
+	/** Plain-language hover explanation. */
+	description: string;
+}
+
+// One row per flag — severity, pill label, and hover description in lockstep so
+// adding a capability can't half-define it across parallel tables.
+const FLAG_META: Record<PreviewFlag, FlagMeta> = {
+	"user-script": {
+		severity: "critical",
+		label: "SCRIPT",
+		description: "Runs custom JavaScript with full access to your vault and the network.",
+	},
+	"conditional-script": {
+		severity: "critical",
+		label: "CONDITIONAL",
+		description: "Runs custom JavaScript to decide which branch executes.",
+	},
+	"run-on-startup": {
+		severity: "critical",
+		label: "STARTUP",
+		description: "Runs automatically every time Obsidian starts.",
+	},
+	"mislabeled-executable": {
+		severity: "critical",
+		label: "EXECUTABLE",
+		description: "A bundled file is run as code even though it is labeled a template.",
+	},
+	"registers-command": {
+		severity: "warning",
+		label: "COMMAND",
+		description: "Adds a command to the command palette.",
+	},
+	"obsidian-command": {
+		severity: "warning",
+		label: "OBSIDIAN",
+		description: "Triggers another Obsidian command.",
+	},
+	ai: {
+		severity: "warning",
+		label: "AI",
+		description: "Sends note content to your AI provider over the network.",
+	},
+	"capture-writes": {
+		severity: "warning",
+		label: "WRITES",
+		description: "Writes captured text into your notes.",
+	},
+	"template-write": {
+		severity: "warning",
+		label: "TEMPLATE",
+		description: "Creates notes from a bundled template.",
+	},
+	"overwrites-existing-choice": {
+		severity: "warning",
+		label: "OVERWRITES",
+		description: "Replaces a choice that already exists in your vault.",
+	},
+	"overwrites-existing-file": {
+		severity: "warning",
+		label: "OVERWRITES",
+		description: "Overwrites a file that already exists in your vault.",
+	},
+	"missing-reference": {
+		severity: "warning",
+		label: "MISSING",
+		description: "References a file that is not bundled in this package.",
+	},
+	"unknown-command": {
+		severity: "warning",
+		label: "UNKNOWN",
+		description: "An unrecognised command type. Review it manually.",
+	},
+	"editor-command": {
+		severity: "info",
+		label: "EDITOR",
+		description: "Runs a built-in editor command.",
+	},
+	"open-file": {
+		severity: "info",
+		label: "OPEN FILE",
+		description: "Opens a file in your vault.",
+	},
+};
+
+export function flagSeverity(flag: PreviewFlag): PreviewSeverity {
+	return FLAG_META[flag].severity;
+}
+
+export function flagLabel(flag: PreviewFlag): string {
+	return FLAG_META[flag].label;
+}
+
+export function flagDescription(flag: PreviewFlag): string {
+	return FLAG_META[flag].description;
+}
+
+const SEVERITY_ORDER: Record<PreviewSeverity, number> = {
+	critical: 0,
+	warning: 1,
+	info: 2,
+};
+
+const KNOWN_COMMAND_TYPES = new Set<string>(Object.values(CommandType));
+
+/** A site where a script/template file path is referenced. */
+export interface PreviewUsageSite {
+	choiceId: string;
+	path: string;
+	/** Referenced as an executable script (UserScript / script-mode Conditional). */
+	asScript: boolean;
+	/** The asset kind this reference implies, regardless of the bundled kind. */
+	impliedKind: QuickAddPackageAssetKind;
+	/** Human-readable location, e.g. "Daily Sync › fetch (User Script)". */
+	breadcrumb: string;
+}
+
+/** A flattened command in a macro, for the read-only "Show macro" disclosure. */
+export interface PreviewCommand {
+	name: string;
+	type: string;
+	depth: number;
+	flag?: PreviewFlag;
+	scriptPath?: string;
+	summary?: string;
+}
+
+export interface PreviewChoice {
+	choiceId: string;
+	name: string;
+	type: string;
+	/** Folder location (does not include the choice's own name). */
+	location: string;
+	/** Id already present in the importer's vault -> will overwrite a choice. */
+	exists: boolean;
+	registersCommand: boolean;
+	flags: PreviewFlag[];
+	commands: PreviewCommand[];
+}
+
+export interface PreviewFile {
+	originalPath: string;
+	kind: QuickAddPackageAssetKind;
+	/** Present in pkg.assets (content available to preview). */
+	bundled: boolean;
+	/** Decided from the command graph, NOT from `kind`. */
+	executable: boolean;
+	/** Default destination already exists -> import will overwrite it. */
+	exists: boolean;
+	/** Cheap decoded-size estimate from base64 length (no decode). */
+	sizeBytes: number;
+	/** Bundled but referenced by no choice/command. */
+	orphan: boolean;
+	referencedBy: PreviewUsageSite[];
+}
+
+export interface CapabilityRow {
+	flag: PreviewFlag;
+	severity: PreviewSeverity;
+	/** Plain-language description of what the capability does. */
+	title: string;
+	/** Location / count detail. */
+	detail: string;
+	/** Set for critical script rows; ties the row to the disclosure gate. */
+	scriptPath?: string;
+}
+
+export interface MissingReference {
+	path: string;
+	asScript: boolean;
+	breadcrumb: string;
+}
+
+export interface PreviewSummary {
+	hasCritical: boolean;
+	hasWarning: boolean;
+	criticalCount: number;
+	warningCount: number;
+	runsOnStartup: boolean;
+	scriptCount: number;
+	registersCommandCount: number;
+	overwritesChoices: number;
+	overwritesFiles: number;
+	missingCount: number;
+}
+
+export interface PackagePreview {
+	quickAddVersion: string;
+	createdAt: string;
+	choiceCount: number;
+	fileCount: number;
+	choices: PreviewChoice[];
+	files: PreviewFile[];
+	capabilityRows: CapabilityRow[];
+	missingReferences: MissingReference[];
+	orphanAssets: string[];
+	/** Bundled executable scripts the user must review to satisfy the gate. */
+	criticalScriptPaths: string[];
+	summary: PreviewSummary;
+}
+
+// --- Walk -------------------------------------------------------------------
+
+interface ChoiceWalk {
+	choiceId: string;
+	name: string;
+	type: string;
+	location: string;
+	registersCommand: boolean;
+	flags: Set<PreviewFlag>;
+	commands: PreviewCommand[];
+	usages: PreviewUsageSite[];
+	/** Granular critical/warning rows attributable to this choice. */
+	rows: CapabilityRow[];
+}
+
+interface PackageWalk {
+	choiceWalks: ChoiceWalk[];
+}
+
+function joinCrumb(parts: Array<string | undefined>): string {
+	return parts.filter((part): part is string => Boolean(part)).join(" › ");
+}
+
+function commandLabel(command: ICommand): string {
+	const name = command.name?.trim();
+	return name && name.length > 0 ? name : String(command.type);
+}
+
+function conditionSummary(condition: ConditionalCondition): string {
+	if (condition.mode === "script") {
+		return `script: ${condition.scriptPath}${
+			condition.exportName ? ` (${condition.exportName})` : ""
+		}`;
+	}
+	const expected =
+		condition.expectedValue !== undefined ? ` ${condition.expectedValue}` : "";
+	return `${condition.variableName} ${condition.operator}${expected}`;
+}
+
+function isMacroChoice(choice: IChoice): choice is IMacroChoice {
+	return choice.type === "Macro";
+}
+
+function isMultiChoice(choice: IChoice): choice is IMultiChoice {
+	return choice.type === "Multi";
+}
+
+function isTemplateChoice(choice: IChoice): choice is ITemplateChoice {
+	return choice.type === "Template";
+}
+
+function isCaptureChoice(choice: IChoice): choice is ICaptureChoice {
+	return choice.type === "Capture";
+}
+
+/** True when a template's file-exists behavior can modify an existing note. */
+function templateModifiesExisting(choice: ITemplateChoice): boolean {
+	const behavior = choice.fileExistsBehavior;
+	if (!behavior || behavior.kind !== "apply") return false;
+	return (
+		behavior.mode === "overwrite" ||
+		behavior.mode === "appendTop" ||
+		behavior.mode === "appendBottom"
+	);
+}
+
+function walkPackage(pkg: QuickAddPackage): PackageWalk {
+	const choiceWalks: ChoiceWalk[] = [];
+	// Every choice that has its own top-level row. A Multi child that is also a
+	// separate entry is skipped during recursion (it gets its own walk), while an
+	// inline-only child (present in a Multi.choices array but NOT an entry) is
+	// recursed and attributed to its host — so a crafted package can't hide a
+	// capability by inlining a child without listing it as an entry.
+	const entryIds = new Set(pkg.choices.map((entry) => entry.choice.id));
+
+	for (const entry of pkg.choices) {
+		const choice = entry.choice;
+		const location = joinCrumb(entry.pathHint.slice(0, -1)) || "Root";
+		const walk: ChoiceWalk = {
+			choiceId: choice.id,
+			name: choice.name,
+			type: choice.type,
+			location,
+			registersCommand: false,
+			flags: new Set<PreviewFlag>(),
+			commands: [],
+			usages: [],
+			rows: [],
+		};
+
+		collectChoice(choice, walk, [choice.name], entryIds, 0);
+
+		choiceWalks.push(walk);
+	}
+
+	return { choiceWalks };
+}
+
+function collectChoice(
+	choice: IChoice,
+	walk: ChoiceWalk,
+	crumbs: string[],
+	entryIds: ReadonlySet<string>,
+	depthLevel: number,
+): void {
+	if (choice.command) {
+		walk.registersCommand = true;
+		walk.flags.add("registers-command");
+	}
+
+	if (isMacroChoice(choice)) {
+		if (choice.runOnStartup) {
+			walk.flags.add("run-on-startup");
+			walk.rows.push({
+				flag: "run-on-startup",
+				severity: "critical",
+				title: "Runs automatically every time Obsidian starts",
+				detail: joinCrumb(crumbs),
+			});
+		}
+		collectCommands(choice.macro?.commands ?? [], walk, crumbs, entryIds, depthLevel);
+	}
+
+	if (isTemplateChoice(choice)) {
+		if (choice.templatePath) {
+			walk.usages.push({
+				choiceId: walk.choiceId,
+				path: choice.templatePath,
+				asScript: false,
+				impliedKind: "template",
+				breadcrumb: joinCrumb([...crumbs, "template"]),
+			});
+		}
+		if (templateModifiesExisting(choice)) {
+			walk.flags.add("template-write");
+		}
+	}
+
+	if (isCaptureChoice(choice)) {
+		walk.flags.add("capture-writes");
+		const createCfg = choice.createFileIfItDoesntExist;
+		if (
+			createCfg?.enabled &&
+			createCfg.createWithTemplate &&
+			createCfg.template
+		) {
+			walk.usages.push({
+				choiceId: walk.choiceId,
+				path: createCfg.template,
+				asScript: false,
+				impliedKind: "capture-template",
+				breadcrumb: joinCrumb([...crumbs, "new-file template"]),
+			});
+		}
+	}
+
+	if (isMultiChoice(choice) && Array.isArray(choice.choices)) {
+		for (const child of choice.choices) {
+			// Skip children that have their own top-level row (avoids double
+			// counting); recurse inline-only children so they can't hide.
+			if (entryIds.has(child.id)) continue;
+			collectChoice(child, walk, [...crumbs, child.name], entryIds, depthLevel);
+		}
+	}
+}
+
+function collectCommands(
+	commands: ICommand[],
+	walk: ChoiceWalk,
+	crumbs: string[],
+	entryIds: ReadonlySet<string>,
+	depth: number,
+): void {
+	for (const command of commands) {
+		if (!command) continue;
+		const label = commandLabel(command);
+		const commandCrumbs = [...crumbs, label];
+
+		switch (command.type) {
+			case CommandType.UserScript: {
+				const script = command as IUserScript;
+				walk.flags.add("user-script");
+				walk.commands.push({
+					name: label,
+					type: command.type,
+					depth,
+					flag: "user-script",
+					scriptPath: script.path,
+				});
+				if (script.path) {
+					walk.usages.push({
+						choiceId: walk.choiceId,
+						path: script.path,
+						asScript: true,
+						impliedKind: "user-script",
+						breadcrumb: joinCrumb(commandCrumbs),
+					});
+					walk.rows.push({
+						flag: "user-script",
+						severity: "critical",
+						title: "Runs custom JavaScript with full access to your vault and the network",
+						detail: `${joinCrumb(commandCrumbs)} (${script.path})`,
+						scriptPath: script.path,
+					});
+				}
+				break;
+			}
+			case CommandType.Conditional: {
+				const conditional = command as IConditionalCommand;
+				const condition = conditional.condition;
+				const summary = condition ? conditionSummary(condition) : undefined;
+				const isScript =
+					condition?.mode === "script" && Boolean(condition.scriptPath);
+				walk.commands.push({
+					name: label,
+					type: command.type,
+					depth,
+					flag: isScript ? "conditional-script" : undefined,
+					scriptPath: isScript ? condition.scriptPath : undefined,
+					summary,
+				});
+				if (isScript) {
+					const scriptPath = (condition as { scriptPath: string }).scriptPath;
+					walk.flags.add("conditional-script");
+					walk.usages.push({
+						choiceId: walk.choiceId,
+						path: scriptPath,
+						asScript: true,
+						impliedKind: "conditional-script",
+						breadcrumb: joinCrumb(commandCrumbs),
+					});
+					walk.rows.push({
+						flag: "conditional-script",
+						severity: "critical",
+						title: "Runs custom JavaScript chosen by a condition",
+						detail: `${joinCrumb(commandCrumbs)} (${scriptPath})`,
+						scriptPath,
+					});
+				}
+				collectCommands(
+					conditional.thenCommands ?? [],
+					walk,
+					[...commandCrumbs, "then"],
+					entryIds,
+					depth + 1,
+				);
+				collectCommands(
+					conditional.elseCommands ?? [],
+					walk,
+					[...commandCrumbs, "else"],
+					entryIds,
+					depth + 1,
+				);
+				break;
+			}
+			case CommandType.NestedChoice: {
+				const nested = command as INestedChoiceCommand;
+				walk.commands.push({ name: label, type: command.type, depth });
+				if (nested.choice) {
+					// Embedded choice has no pkg.choices entry: recurse fully,
+					// attributing its capabilities to this top-level choice.
+					collectChoice(
+						nested.choice,
+						walk,
+						[...commandCrumbs, nested.choice.name],
+						entryIds,
+						depth + 1,
+					);
+				}
+				break;
+			}
+			case CommandType.Obsidian: {
+				const obsidian = command as IObsidianCommand;
+				walk.flags.add("obsidian-command");
+				walk.commands.push({ name: label, type: command.type, depth });
+				walk.rows.push({
+					flag: "obsidian-command",
+					severity: "warning",
+					title: "Triggers another Obsidian command",
+					detail: `${joinCrumb(commandCrumbs)}${
+						obsidian.commandId ? ` (${obsidian.commandId})` : ""
+					}`,
+				});
+				break;
+			}
+			case CommandType.AIAssistant:
+			case CommandType.InfiniteAIAssistant: {
+				walk.flags.add("ai");
+				walk.commands.push({ name: label, type: command.type, depth });
+				walk.rows.push({
+					flag: "ai",
+					severity: "warning",
+					title: "Sends note content to your AI provider over the network",
+					detail: joinCrumb(commandCrumbs),
+				});
+				break;
+			}
+			case CommandType.EditorCommand: {
+				walk.flags.add("editor-command");
+				walk.commands.push({ name: label, type: command.type, depth });
+				break;
+			}
+			case CommandType.OpenFile: {
+				walk.flags.add("open-file");
+				walk.commands.push({ name: label, type: command.type, depth });
+				break;
+			}
+			case CommandType.Choice:
+			case CommandType.Wait: {
+				walk.commands.push({ name: label, type: command.type, depth });
+				break;
+			}
+			default: {
+				if (!KNOWN_COMMAND_TYPES.has(String(command.type))) {
+					walk.flags.add("unknown-command");
+					walk.commands.push({
+						name: label,
+						type: String(command.type),
+						depth,
+						flag: "unknown-command",
+					});
+					walk.rows.push({
+						flag: "unknown-command",
+						severity: "warning",
+						title: "Unknown capability. Review it manually.",
+						detail: `${joinCrumb(commandCrumbs)} (${String(command.type)})`,
+					});
+				} else {
+					walk.commands.push({ name: label, type: String(command.type), depth });
+				}
+				break;
+			}
+		}
+	}
+}
+
+// --- Public analysis --------------------------------------------------------
+
+/**
+ * Every script/template path the package references (deduped). The orchestrator
+ * uses this to resolve existence for both bundled and unbundled references in a
+ * single vault pass.
+ */
+export function collectReferencedAssetPaths(pkg: QuickAddPackage): string[] {
+	const { choiceWalks } = walkPackage(pkg);
+	const paths = new Set<string>();
+	for (const walk of choiceWalks) {
+		for (const usage of walk.usages) {
+			if (usage.path) paths.add(usage.path);
+		}
+	}
+	return Array.from(paths);
+}
+
+// Cheap decoded-size estimate (no decode). Assumes RFC 4648 base64 as produced
+// by btoa/Buffer; the floor handles unpadded input correctly too.
+function estimateBytesFromBase64(content: string): number {
+	const len = content.length;
+	if (len === 0) return 0;
+	let padding = 0;
+	if (content.endsWith("==")) padding = 2;
+	else if (content.endsWith("=")) padding = 1;
+	return Math.max(0, Math.floor((len * 3) / 4) - padding);
+}
+
+function flagComparator(a: PreviewFlag, b: PreviewFlag): number {
+	return SEVERITY_ORDER[flagSeverity(a)] - SEVERITY_ORDER[flagSeverity(b)];
+}
+
+/**
+ * Build the full preview model.
+ *
+ * @param existingChoices the importer's current choices (for id-collision detection)
+ * @param pkg the parsed package
+ * @param existsByPath paths (bundled or referenced) that already exist in the vault
+ */
+export function buildPackagePreview(
+	existingChoices: IChoice[],
+	pkg: QuickAddPackage,
+	existsByPath: ReadonlySet<string>,
+): PackagePreview {
+	const { choiceWalks } = walkPackage(pkg);
+	const existingById = new Set(
+		flattenChoices(existingChoices).map((choice) => choice.id),
+	);
+
+	// Index usage sites by referenced path.
+	const usagesByPath = new Map<string, PreviewUsageSite[]>();
+	for (const walk of choiceWalks) {
+		for (const usage of walk.usages) {
+			const list = usagesByPath.get(usage.path) ?? [];
+			list.push(usage);
+			usagesByPath.set(usage.path, list);
+		}
+	}
+	const referencedAsScript = new Set<string>();
+	for (const [path, usages] of usagesByPath) {
+		if (usages.some((u) => u.asScript)) referencedAsScript.add(path);
+	}
+
+	const bundledPaths = new Set(pkg.assets.map((asset) => asset.originalPath));
+
+	// Files manifest (one per bundled asset).
+	const files: PreviewFile[] = pkg.assets.map((asset) => {
+		const usages = usagesByPath.get(asset.originalPath) ?? [];
+		const executable = referencedAsScript.has(asset.originalPath);
+		return {
+			originalPath: asset.originalPath,
+			kind: asset.kind,
+			bundled: true,
+			executable,
+			exists: existsByPath.has(asset.originalPath),
+			sizeBytes: estimateBytesFromBase64(asset.content),
+			orphan: usages.length === 0,
+			referencedBy: usages,
+		};
+	});
+
+	// Choices.
+	const choices: PreviewChoice[] = choiceWalks.map((walk) => {
+		const exists = existingById.has(walk.choiceId);
+		const flags = Array.from(walk.flags);
+		if (exists) flags.push("overwrites-existing-choice");
+		flags.sort(flagComparator);
+		return {
+			choiceId: walk.choiceId,
+			name: walk.name,
+			type: walk.type,
+			location: walk.location,
+			exists,
+			registersCommand: walk.registersCommand,
+			flags,
+			commands: walk.commands,
+		};
+	});
+
+	// Missing references: referenced but neither bundled nor present in vault.
+	const missingReferences: MissingReference[] = [];
+	for (const [path, usages] of usagesByPath) {
+		if (bundledPaths.has(path)) continue;
+		if (existsByPath.has(path)) continue; // will reuse an existing vault file
+		const asScript = usages.some((u) => u.asScript);
+		missingReferences.push({
+			path,
+			asScript,
+			breadcrumb: usages[0]?.breadcrumb ?? path,
+		});
+	}
+
+	const orphanAssets = files.filter((file) => file.orphan).map((f) => f.originalPath);
+
+	// Capability rows: granular critical/per-item rows from the walk, plus
+	// aggregated warning rows for counts.
+	const capabilityRows: CapabilityRow[] = [];
+	for (const walk of choiceWalks) {
+		for (const row of walk.rows) capabilityRows.push(row);
+	}
+
+	// Mislabeled executable: a bundled file run as a script whose declared kind
+	// is not a script kind.
+	for (const file of files) {
+		if (!file.executable) continue;
+		if (file.kind === "user-script" || file.kind === "conditional-script") continue;
+		capabilityRows.push({
+			flag: "mislabeled-executable",
+			severity: "critical",
+			title: "Runs a file as code even though it is labeled a template",
+			detail: file.originalPath,
+			scriptPath: file.originalPath,
+		});
+	}
+
+	const registersCommandCount = choices.filter((c) => c.registersCommand).length;
+	if (registersCommandCount > 0) {
+		capabilityRows.push({
+			flag: "registers-command",
+			severity: "warning",
+			title: "Adds commands to the command palette",
+			detail: `${registersCommandCount} choice${
+				registersCommandCount === 1 ? "" : "s"
+			}`,
+		});
+	}
+
+	const overwriteChoiceCount = choices.filter((c) => c.exists).length;
+	if (overwriteChoiceCount > 0) {
+		capabilityRows.push({
+			flag: "overwrites-existing-choice",
+			severity: "warning",
+			title: "Replaces choices that already exist in your vault",
+			detail: `${overwriteChoiceCount} choice${
+				overwriteChoiceCount === 1 ? "" : "s"
+			}`,
+		});
+	}
+
+	const overwriteFileCount = files.filter((f) => f.exists).length;
+	if (overwriteFileCount > 0) {
+		capabilityRows.push({
+			flag: "overwrites-existing-file",
+			severity: "warning",
+			title: "Overwrites existing files in your vault",
+			detail: `${overwriteFileCount} file${overwriteFileCount === 1 ? "" : "s"}`,
+		});
+	}
+
+	if (missingReferences.length > 0) {
+		const scriptMissing = missingReferences.filter((m) => m.asScript).length;
+		capabilityRows.push({
+			// A missing SCRIPT runs from whatever file exists at that path: an
+			// execution-hijack risk, so it ranks critical (and requires the gate).
+			flag: "missing-reference",
+			severity: scriptMissing > 0 ? "critical" : "warning",
+			title:
+				scriptMissing > 0
+					? "References scripts that are not bundled, so they run from whatever exists at those paths after import"
+					: "References files that are not bundled and not in your vault",
+			detail: `${missingReferences.length} reference${
+				missingReferences.length === 1 ? "" : "s"
+			}`,
+		});
+	}
+
+	capabilityRows.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+
+	const criticalScriptPaths = files
+		.filter((file) => file.executable && file.bundled)
+		.map((file) => file.originalPath);
+
+	const scriptCount = referencedAsScript.size;
+	const runsOnStartup = choiceWalks.some((w) => w.flags.has("run-on-startup"));
+	const criticalCount = capabilityRows.filter((r) => r.severity === "critical").length;
+	const warningCount = capabilityRows.filter((r) => r.severity === "warning").length;
+
+	const summary: PreviewSummary = {
+		hasCritical: criticalCount > 0,
+		hasWarning: warningCount > 0,
+		criticalCount,
+		warningCount,
+		runsOnStartup,
+		scriptCount,
+		registersCommandCount,
+		overwritesChoices: overwriteChoiceCount,
+		overwritesFiles: overwriteFileCount,
+		missingCount: missingReferences.length,
+	};
+
+	return {
+		quickAddVersion: pkg.quickAddVersion,
+		createdAt: pkg.createdAt,
+		choiceCount: pkg.choices.length,
+		fileCount: pkg.assets.length,
+		choices,
+		files,
+		capabilityRows,
+		missingReferences,
+		orphanAssets,
+		criticalScriptPaths,
+		summary,
+	};
+}
+
+// --- Lazy content preview + gate predicates ---------------------------------
+
+/** Cap on previewed characters; larger scripts are flagged truncated. */
+export const MAX_PREVIEW_CHARS = 100_000;
+
+export interface AssetPreviewContent {
+	found: boolean;
+	text: string;
+	truncated: boolean;
+	sizeBytes: number;
+	looksMinified: boolean;
+	error?: string;
+}
+
+function byteLength(text: string): number {
+	if (typeof TextEncoder !== "undefined") {
+		return new TextEncoder().encode(text).length;
+	}
+	return text.length;
+}
+
+function looksMinified(text: string): boolean {
+	if (text.length < 1000) return false;
+	let longestLine = 0;
+	let lineCount = 1;
+	let current = 0;
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] === "\n") {
+			if (current > longestLine) longestLine = current;
+			current = 0;
+			lineCount++;
+		} else {
+			current++;
+		}
+	}
+	if (current > longestLine) longestLine = current;
+	const avgPerLine = text.length / lineCount;
+	return longestLine > 1000 || avgPerLine > 250;
+}
+
+/**
+ * Decode a bundled asset's content for display. Lazy by design — call this only
+ * when the user expands a file, never during initial analysis.
+ */
+export function decodeAssetPreview(
+	pkg: QuickAddPackage,
+	originalPath: string,
+): AssetPreviewContent {
+	const asset = pkg.assets.find((a) => a.originalPath === originalPath);
+	if (!asset) {
+		return {
+			found: false,
+			text: "",
+			truncated: false,
+			sizeBytes: 0,
+			looksMinified: false,
+			error: "File is not bundled in this package.",
+		};
+	}
+
+	try {
+		const decoded = decodeFromBase64(asset.content);
+		const truncated = decoded.length > MAX_PREVIEW_CHARS;
+		const text = truncated ? decoded.slice(0, MAX_PREVIEW_CHARS) : decoded;
+		return {
+			found: true,
+			text,
+			truncated,
+			sizeBytes: byteLength(decoded),
+			// Scan only the previewed slice — enough to spot minification.
+			looksMinified: looksMinified(text),
+		};
+	} catch (error) {
+		return {
+			found: true,
+			text: "",
+			truncated: false,
+			sizeBytes: 0,
+			looksMinified: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+/** A package needs explicit acknowledgement when it has any critical capability. */
+export function requiresAcknowledgement(preview: PackagePreview): boolean {
+	return preview.summary.hasCritical;
+}
+
+/**
+ * True when every bundled critical script has been expanded/reviewed at least
+ * once. Used to gate the acknowledgement checkbox.
+ */
+export function isFullyReviewed(
+	preview: PackagePreview,
+	reviewedScriptPaths: ReadonlySet<string>,
+): boolean {
+	return preview.criticalScriptPaths.every((path) =>
+		reviewedScriptPaths.has(path),
+	);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1265,3 +1265,42 @@ textarea.is-invalid {
 .userScriptSettingsModal .setting-item-control {
 	min-width: 0;
 }
+
+/* Package import/export severity surfaces — one source for the ranked
+   "tint, don't blanket-fill" recipe shared by CapabilityBanner, CapabilityTag,
+   FilePreviewRow, and the import/export modals. */
+.quickAddModal {
+	--qa-sev-critical-wash: color-mix(
+		in srgb,
+		var(--color-red, #e93147) 9%,
+		var(--background-secondary)
+	);
+	--qa-sev-warning-wash: color-mix(
+		in srgb,
+		var(--color-orange, #ff8c00) 11%,
+		var(--background-secondary)
+	);
+	--qa-sev-info-wash: var(--background-modifier-hover);
+	--qa-sev-critical-border: color-mix(
+		in srgb,
+		var(--color-red, #e93147) 40%,
+		var(--background-modifier-border)
+	);
+	--qa-sev-warning-border: color-mix(
+		in srgb,
+		var(--color-orange, #ff8c00) 40%,
+		var(--background-modifier-border)
+	);
+	--qa-sev-success-border: color-mix(
+		in srgb,
+		var(--color-green, #0aa344) 40%,
+		var(--background-modifier-border)
+	);
+	--qa-sev-success-wash: color-mix(
+		in srgb,
+		var(--color-green, #0aa344) 7%,
+		var(--background-secondary)
+	);
+	/* Darkened red so white pill text clears WCAG AA at small sizes. */
+	--qa-sev-critical-pill: color-mix(in srgb, var(--color-red, #c0392b) 82%, #000);
+}

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -648,6 +648,13 @@ export function setIcon(parent: HTMLElement, iconId: string): void {
   parent.appendChild(svg);
 }
 
+// Standalone setTooltip — mirror Obsidian's behaviour enough for tests by
+// reflecting the text into aria-label so it stays assertable.
+export function setTooltip(el: HTMLElement, tooltip: string): void {
+  if (tooltip) el.setAttribute("aria-label", tooltip);
+  else el.removeAttribute("aria-label");
+}
+
 // Minimal Menu stub for context-menu tests. Records its items and how it was
 // shown (mouse event vs. anchored position) so tests can assert the keyboard path.
 export class MenuItem {


### PR DESCRIPTION
## Summary

Importing a QuickAdd package can run bundled scripts and macros with full access to your vault and the network, but the old import modal only surfaced id/path conflicts, never *what the package does*. This makes the import a transparent trust decision: before anything is written you see every file added or overwritten, can read each bundled script's contents, and get a ranked summary of the package's capabilities. When a package can run code, **Import is gated** behind reviewing each bundled script and acknowledging the source.

## What's new

- **Capability banner** — ranks what the package can do (runs code, runs on startup, registers commands, uses AI, overwrites existing files), each with a hover tooltip explaining the term. Neutral surface with per-row severity tints, not a blanket-red fear UI.
- **Files manifest** — split into *Added* / *Will overwrite*. Each row has a "View contents" disclosure that decodes the bundled script/template lazily; minified blobs are flagged as not visually reviewable; oversized previews are truncated with a note that the full file still imports.
- **Disclosure gate** — when the package can run code, the Import button stays disabled until every bundled **critical** script has been opened *and* the source is acknowledged. The gate set is bundled critical scripts only, so harmless capture/template packages aren't nagged.
- **`quickadd:package-preview` CLI command** — returns the same pure analysis model (optionally with decoded contents) for scripted/automated verification.
- **Export modal parity** — its warnings get the same restrained, ranked treatment.

## Security model

- **Executability comes from the macro command graph** (a UserScript / script-Conditional reference), never `asset.kind` — so a script mislabeled as a template is still flagged and gated, and a template mislabeled as a script isn't forced critical.
- The gate cannot be satisfied by collapsing rows you didn't read: only opening an *executable* row counts, and acknowledgement is required on top.

## Bug fix

- **Silent overwrite** — destination existence now resolves via `adapter.exists`, which sees config and dot-folder files (e.g. `.obsidian/...`) that the vault index (`getAbstractFileByPath`) misses, so "Will overwrite" is accurate for those paths.

## Internal / refactor

- Decision logic extracted to a pure, unit-tested `importDecisions.ts`: a single home for the skip/write/overwrite reconcile rule (was inlined 3×) and an `ExistenceResolver` with a **monotonic per-key token** that fixes a stale-probe race where a re-paste could let an old existence check win.
- Capability flag metadata collapsed from three parallel maps into one `FLAG_META` table.
- Severity tints lifted to shared `--qa-sev-*` CSS tokens; `MacroDisclosure.svelte` extracted. `ImportPackageModal.svelte` dropped from 1164 → ~990 lines.

## Testing

- `bun run test` — 1572 passed / 31 skipped; `bun run check` (svelte-check) 0 errors / 0 warnings; `bun run build-with-lint` clean.
- New coverage: `packagePreview` model + lazy decode (incl. malformed-base64 branch), `importDecisions` (reconcile, snapshots, the monotonic-token regression), `CapabilityBanner`, `FilePreviewRow`, full `ImportPackageModal` gate-flow integration, the CLI handler, and a no-`{@html}` security sweep over the new components.
- Manually verified in a dev vault (light + dark, desktop + emulated mobile): gate locks/releases correctly, config-dir overwrite detection works, native dropdowns/inputs render correctly, no runtime errors.

## Release / migration notes

- No package schema or version change; the `analysePackage` / `applyPackageImport` write path is unchanged — this is preview/UX + a correctness fix on conflict detection.
- `main.js` / `styles.css` are gitignored (generated), so no built artifacts in this diff.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit package review UI: per-choice actions, per-file write controls, destination-path editing, and expandable file previews with decoded contents.
  * Capability banner summarizing what a package can do and acknowledgement gating that requires viewing critical scripts before import.
  * CLI package-preview command (supports inline decoded preview).

* **Documentation**
  * Expanded docs covering the review flow, trust guidance for bundled executable scripts, and CLI preview usage.

* **Style**
  * New severity-themed styling for import/export surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->