### PR TITLE
feat: apply template to existing note

### DIFF
--- a/docs/docs/ApplyTemplateToNote.md
+++ b/docs/docs/ApplyTemplateToNote.md
@@ -1,0 +1,43 @@
+---
+title: Apply Template to Note
+---
+
+Created a note manually — with `Cmd/Ctrl+N`, the Quick Switcher, or by clicking a link to a file that didn't exist yet — and then realized you forgot to use your template? You no longer need to delete the note and recreate it.
+
+The **QuickAdd: Apply template to active note** command applies a template to the note you already have open.
+
+You can also right-click a markdown file (in the file explorer, tab header, etc.) and pick **Apply QuickAdd template** to target that file directly.
+
+## How it works
+
+1. Run the command while a markdown note is active.
+2. **Pick what to apply.** The picker lists your [Template choices](./Choices/TemplateChoice.md) first (including ones nested in Multi choices), followed by template files from your configured templates folder that aren't already covered by a choice.
+3. **Pick how to apply it** (skipped for empty notes — see below):
+   - **Insert at cursor**: inserts the template at the cursor position. Only offered when the note is open in the active editor.
+   - **Insert at top**: inserts the template below the note's frontmatter, or at the very top if there is none.
+   - **Append to bottom**: adds the template content to the end of the note.
+   - **Replace note content**: replaces the entire note content with the template.
+
+The template runs through the full QuickAdd [format syntax](./FormatSyntax.md) pipeline, and Templater syntax is processed as usual.
+
+## Smart behaviors
+
+**Empty-note fast path.** If the note is empty (or contains only whitespace), the "how to apply" prompt is skipped and the template is applied as the note's full content — the most common case is a freshly created blank note.
+
+**Title pre-fill.** The note already has a name, so `{{title}}` and the unnamed `{{VALUE}}`/`{{NAME}}` resolve to the note's basename instead of prompting. Named values like `{{VALUE:project}}` still prompt as usual.
+
+**Frontmatter merge.** For the **Insert at top**, **Append to bottom**, and **Insert at cursor** modes, the template's frontmatter is not inserted as a second `---` block. Instead, its properties are merged into the note's existing frontmatter — and existing values in your note always win. Properties that are missing or empty in the note are filled from the template. (**Replace note content** replaces the whole note, frontmatter included.)
+
+**Move/rename to match the choice.** If you picked a Template choice that has a folder and/or file name format configured, and the note's current location or name doesn't match what the choice would have produced, QuickAdd offers to move/rename the note to match. Links to the note are updated automatically. This is skipped when the choice's folder settings require a runtime folder picker, or when a file already exists at the target path.
+
+## From scripts and macros
+
+The [QuickAdd API](./QuickAddAPI.md) exposes the same functionality without any prompts:
+
+```js
+await quickAddApi.applyTemplateToActiveFile("templates/meeting.md", {
+  mode: "top", // "cursor" | "top" | "bottom" | "replace"
+});
+```
+
+When `mode` is omitted, empty notes get `replace` and non-empty notes get `bottom`.

--- a/docs/docs/ApplyTemplateToNote.md
+++ b/docs/docs/ApplyTemplateToNote.md
@@ -20,6 +20,8 @@ You can also right-click a markdown file (in the file explorer, tab header, etc.
 
 The template runs through the full QuickAdd [format syntax](./FormatSyntax.md) pipeline, and Templater syntax is processed as usual.
 
+Only markdown templates can be applied: canvas (`.canvas`) and base (`.base`) templates contain data for their own file types and are excluded from the picker (use a regular [Template choice](./Choices/TemplateChoice.md) to create those). Likewise, the target must be a markdown note.
+
 ## Smart behaviors
 
 **Empty-note fast path.** If the note is empty (or contains only whitespace), the "how to apply" prompt is skipped and the template is applied as the note's full content — the most common case is a freshly created blank note.

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -417,6 +417,27 @@ for (const contact of contacts) {
 }
 ```
 
+### `applyTemplateToActiveFile(templatePath: string, options?: { mode?: "cursor" | "top" | "bottom" | "replace" }): Promise<TFile | null>`
+Applies a template to the active note without creating a new file. The template runs through the full QuickAdd format pipeline (`{{title}}` and the unnamed `{{VALUE}}` resolve to the note's basename), and Templater syntax is processed. See [Apply Template to Note](./ApplyTemplateToNote.md) for the full behavior, including frontmatter merging.
+
+**Parameters:**
+- `templatePath`: Vault path to the template file
+- `options.mode`: (Optional) How to apply the template. Defaults to `"replace"` for empty notes and `"bottom"` otherwise.
+  - `"cursor"`: Insert at the cursor position (requires the note to be open in the active editor)
+  - `"top"`: Insert below the note's frontmatter
+  - `"bottom"`: Append to the end of the note
+  - `"replace"`: Replace the entire note content
+
+**Returns:** The target file, or `null` if nothing was applied (e.g., no active markdown note).
+
+**Example:**
+```javascript
+// Apply a meeting template to the currently open note
+await quickAddApi.applyTemplateToActiveFile("templates/meeting.md", {
+    mode: "top"
+});
+```
+
 ## Utility Module
 
 Access via `quickAddApi.utility`:

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -418,7 +418,7 @@ for (const contact of contacts) {
 ```
 
 ### `applyTemplateToActiveFile(templatePath: string, options?: { mode?: "cursor" | "top" | "bottom" | "replace" }): Promise<TFile | null>`
-Applies a template to the active note without creating a new file. The template runs through the full QuickAdd format pipeline (`{{title}}` and the unnamed `{{VALUE}}` resolve to the note's basename), and Templater syntax is processed. See [Apply Template to Note](./ApplyTemplateToNote.md) for the full behavior, including frontmatter merging.
+Applies a template to the active note without creating a new file. The template runs through the full QuickAdd format pipeline (`{{title}}` and the unnamed `{{VALUE}}`/`{{NAME}}` resolve to the note's basename), and Templater syntax is processed. See [Apply Template to Note](./ApplyTemplateToNote.md) for the full behavior, including frontmatter merging.
 
 **Parameters:**
 - `templatePath`: Vault path to the template file

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -77,6 +77,11 @@ const sidebars = {
 				},
 				{
 					type: "doc",
+					id: "ApplyTemplateToNote",
+					label: "Apply Template to Note",
+				},
+				{
+					type: "doc",
 					id: "GlobalVariables",
 					label: "Global Variables",
 				},

--- a/src/commandLabels.ts
+++ b/src/commandLabels.ts
@@ -1,5 +1,6 @@
 export const QUICK_ADD_COMMAND_LABELS = {
 	run: "Run",
+	applyTemplate: "Apply template to active note",
 	reloadDev: "Reload (dev)",
 	testDev: "Test (dev)",
 } as const;

--- a/src/engine/QuickAddEngine.ts
+++ b/src/engine/QuickAddEngine.ts
@@ -306,7 +306,7 @@ export abstract class QuickAddEngine {
 		}
 	}
 
-	private assignFrontmatterValue(frontmatter: Record<string, unknown>, path: string[], value: unknown): void {
+	protected assignFrontmatterValue(frontmatter: Record<string, unknown>, path: string[], value: unknown): void {
 		if (path.length === 0) return;
 		let target = frontmatter;
 		for (let i = 0; i < path.length - 1; i++) {

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -1,6 +1,5 @@
 import type { App, WorkspaceLeaf } from "obsidian";
 import { TFile } from "obsidian";
-import { TFolder } from "obsidian";
 import invariant from "src/utils/invariant";
 import { VALUE_SYNTAX } from "../constants";
 import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
@@ -92,6 +91,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				this.shouldTreatFormattedNameAsVaultRelativePath(
 					formattedName,
 					strippedPrefix,
+					this.choice.folder.enabled,
 				);
 
 			const targetFilePath = this.normalizeTemplateFilePath(
@@ -374,46 +374,6 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			allowedRoots: folders,
 			topItems,
 		});
-	}
-
-	private stripDuplicateFolderPrefix(
-		fileName: string,
-		folderPath: string,
-	): { fileName: string; strippedPrefix: boolean } {
-		const normalizedFolder = this.stripLeadingSlash(folderPath);
-		const normalizedFileName = this.stripLeadingSlash(fileName);
-
-		if (!normalizedFolder) {
-			return { fileName: normalizedFileName, strippedPrefix: false };
-		}
-		if (!normalizedFileName.startsWith(`${normalizedFolder}/`)) {
-			return { fileName: normalizedFileName, strippedPrefix: false };
-		}
-
-		return {
-			fileName: normalizedFileName.slice(normalizedFolder.length + 1),
-			strippedPrefix: true,
-		};
-	}
-
-	private shouldTreatFormattedNameAsVaultRelativePath(
-		formattedName: string,
-		strippedPrefix: boolean,
-	): boolean {
-		if (this.choice.folder.enabled) return false;
-		if (strippedPrefix) return false;
-
-		const normalizedFileName = formattedName.trim();
-		if (!normalizedFileName.includes("/")) return false;
-		if (normalizedFileName.startsWith("./")) return false;
-
-		if (normalizedFileName.startsWith("/")) return true;
-
-		const [firstSegment] = this.stripLeadingSlash(normalizedFileName).split("/");
-		if (!firstSegment) return false;
-
-		const rootEntry = this.app.vault.getAbstractFileByPath(firstSegment);
-		return rootEntry instanceof TFolder;
 	}
 
 	private getCurrentFolderSuggestion():

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -2,7 +2,7 @@ import { QuickAddEngine } from "./QuickAddEngine";
 import { CompleteFormatter } from "../formatters/completeFormatter";
 import type { LinkToCurrentFileBehavior } from "../formatters/formatter";
 import type { App } from "obsidian";
-import { Notice, TFile } from "obsidian";
+import { Notice, TFile, TFolder } from "obsidian";
 import type QuickAdd from "../main";
 import {
 	getTemplater,
@@ -439,6 +439,57 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			promptHeader
 		);
 		return this.normalizeMarkdownFilePath(folderPath, formattedName);
+	}
+
+	/**
+	 * Strips the target folder from the start of a formatted file name so
+	 * formats like `Meetings/{{VALUE}}` with a `Meetings` folder don't
+	 * produce `Meetings/Meetings/...`.
+	 */
+	protected stripDuplicateFolderPrefix(
+		fileName: string,
+		folderPath: string,
+	): { fileName: string; strippedPrefix: boolean } {
+		const normalizedFolder = this.stripLeadingSlash(folderPath);
+		const normalizedFileName = this.stripLeadingSlash(fileName);
+
+		if (!normalizedFolder) {
+			return { fileName: normalizedFileName, strippedPrefix: false };
+		}
+		if (!normalizedFileName.startsWith(`${normalizedFolder}/`)) {
+			return { fileName: normalizedFileName, strippedPrefix: false };
+		}
+
+		return {
+			fileName: normalizedFileName.slice(normalizedFolder.length + 1),
+			strippedPrefix: true,
+		};
+	}
+
+	/**
+	 * When no folder is configured, a formatted name containing a path is
+	 * treated as vault-relative if it is absolute or its first segment is an
+	 * existing root folder.
+	 */
+	protected shouldTreatFormattedNameAsVaultRelativePath(
+		formattedName: string,
+		strippedPrefix: boolean,
+		folderEnabled: boolean,
+	): boolean {
+		if (folderEnabled) return false;
+		if (strippedPrefix) return false;
+
+		const normalizedFileName = formattedName.trim();
+		if (!normalizedFileName.includes("/")) return false;
+		if (normalizedFileName.startsWith("./")) return false;
+
+		if (normalizedFileName.startsWith("/")) return true;
+
+		const [firstSegment] = this.stripLeadingSlash(normalizedFileName).split("/");
+		if (!firstSegment) return false;
+
+		const rootEntry = this.app.vault.getAbstractFileByPath(firstSegment);
+		return rootEntry instanceof TFolder;
 	}
 
 	protected getTemplateExtension(templatePath: string): string {

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Simulates structured values collected by the formatter's property
+// collector during formatting (Template Property Types).
+const { collectedPropertyVars } = vi.hoisted(() => ({
+	collectedPropertyVars: new Map<string, unknown>(),
+}));
+
 vi.mock("../formatters/completeFormatter", () => {
 	class CompleteFormatterMock {
 		setLinkToCurrentFileBehavior() {}
@@ -17,7 +23,9 @@ vi.mock("../formatters/completeFormatter", () => {
 			return await work();
 		}
 		getAndClearTemplatePropertyVars() {
-			return new Map<string, unknown>();
+			const drained = new Map(collectedPropertyVars);
+			collectedPropertyVars.clear();
+			return drained;
 		}
 	}
 
@@ -32,7 +40,7 @@ vi.mock("../utilityObsidian", () => ({
 	),
 }));
 
-import { TFile, type App } from "obsidian";
+import { TFile, TFolder, type App } from "obsidian";
 import type QuickAdd from "../main";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import {
@@ -96,6 +104,7 @@ function makeHarness(options: {
 	templateContent: string;
 	noteContent: string;
 	frontmatter?: Record<string, unknown>;
+	rootFolders?: string[];
 }): TestHarness {
 	const templateFile = makeFile({
 		path: TEMPLATE_PATH,
@@ -107,10 +116,20 @@ function makeHarness(options: {
 	const replaceSelection = vi.fn();
 	let activeViewFile: TFile | null = null;
 
+	const rootFolders = new Map(
+		(options.rootFolders ?? []).map((path) => {
+			const folder = new TFolder();
+			folder.path = path;
+			return [path, folder];
+		}),
+	);
+
 	const app = {
 		vault: {
 			getAbstractFileByPath: (path: string) =>
-				path === TEMPLATE_PATH ? templateFile : null,
+				path === TEMPLATE_PATH
+					? templateFile
+					: (rootFolders.get(path) ?? null),
 			cachedRead: async (file: TFile) =>
 				file.path === TEMPLATE_PATH
 					? options.templateContent
@@ -160,6 +179,7 @@ function makeEngine(
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	collectedPropertyVars.clear();
 });
 
 describe("isTemplateInsertMode", () => {
@@ -310,6 +330,53 @@ describe("TemplateInsertEngine.apply", () => {
 		expect(harness.modify).not.toHaveBeenCalled();
 	});
 
+	it("cursor: skips whitespace-only body from frontmatter-only templates", async () => {
+		const harness = makeHarness({
+			templateContent: "---\nstatus: draft\n---\n\n",
+			noteContent: "EXISTING",
+		});
+		const file = makeFile();
+		harness.setActiveViewFile(file);
+
+		await makeEngine(harness, file, "cursor").apply();
+
+		expect(harness.replaceSelection).not.toHaveBeenCalled();
+		expect(harness.frontmatter).toEqual({ status: "draft" });
+	});
+
+	it("top: preserves structured property values collected during formatting", async () => {
+		// The formatter leaves a YAML placeholder ([]) for structured values
+		// and reports them via the property collector.
+		const harness = makeHarness({
+			templateContent: "---\ntags: []\ncount: 0\n---\nTPL_BODY",
+			noteContent: "EXISTING",
+		});
+		collectedPropertyVars.set("tags", ["work", "meeting"]);
+		collectedPropertyVars.set("count", 42);
+		const file = makeFile();
+
+		await makeEngine(harness, file, "top").apply();
+
+		expect(harness.frontmatter).toEqual({
+			tags: ["work", "meeting"],
+			count: 42,
+		});
+	});
+
+	it("top: existing note values still win over structured template values", async () => {
+		const harness = makeHarness({
+			templateContent: "---\ntags: []\n---\nTPL_BODY",
+			noteContent: "---\ntags: [keep]\n---\nEXISTING",
+			frontmatter: { tags: ["keep"] },
+		});
+		collectedPropertyVars.set("tags", ["work"]);
+		const file = makeFile();
+
+		await makeEngine(harness, file, "top").apply();
+
+		expect(harness.frontmatter).toEqual({ tags: ["keep"] });
+	});
+
 	it("cursor: throws when the note is not open in the active editor", async () => {
 		const harness = makeHarness({
 			templateContent: "TEMPLATE_CONTENT",
@@ -415,6 +482,65 @@ describe("TemplateInsertEngine.computeChoiceTargetPath", () => {
 		).computeChoiceTargetPath(choice);
 
 		expect(target).toBeNull();
+	});
+
+	it("strips a duplicated folder prefix from the formatted name", async () => {
+		const harness = makePathHarness();
+		const file = makeFile({ parent: { path: "notes" } as TFile["parent"] });
+		const choice = makeTemplateChoice({
+			folder: {
+				enabled: true,
+				folders: ["Meetings"],
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			},
+			fileNameFormat: { enabled: true, format: "Meetings/Renamed" },
+		});
+
+		const target = await makeEngine(
+			harness,
+			file,
+			"replace",
+		).computeChoiceTargetPath(choice);
+
+		expect(target).toBe("Meetings/Renamed.md");
+	});
+
+	it("treats a formatted name starting with an existing root folder as vault-relative when no folder is configured", async () => {
+		const harness = makeHarness({
+			templateContent: "",
+			noteContent: "",
+			rootFolders: ["Projects"],
+		});
+		const file = makeFile({ parent: { path: "notes" } as TFile["parent"] });
+		const choice = makeTemplateChoice({
+			fileNameFormat: { enabled: true, format: "Projects/Renamed" },
+		});
+
+		const target = await makeEngine(
+			harness,
+			file,
+			"replace",
+		).computeChoiceTargetPath(choice);
+
+		expect(target).toBe("Projects/Renamed.md");
+	});
+
+	it("keeps a path-containing name relative to the note's folder when the first segment is not a root folder", async () => {
+		const harness = makePathHarness();
+		const file = makeFile({ parent: { path: "notes" } as TFile["parent"] });
+		const choice = makeTemplateChoice({
+			fileNameFormat: { enabled: true, format: "Sub/Renamed" },
+		});
+
+		const target = await makeEngine(
+			harness,
+			file,
+			"replace",
+		).computeChoiceTargetPath(choice);
+
+		expect(target).toBe("notes/Sub/Renamed.md");
 	});
 
 	it("keeps the current path when neither folder nor file name format are configured", async () => {

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -32,13 +32,21 @@ vi.mock("../formatters/completeFormatter", () => {
 	return { CompleteFormatter: CompleteFormatterMock };
 });
 
-vi.mock("../utilityObsidian", () => ({
-	getTemplater: vi.fn(() => ({})),
-	overwriteTemplaterOnce: vi.fn(),
-	templaterParseTemplate: vi.fn(
-		async (_app: unknown, content: string) => content,
-	),
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
 }));
+
+vi.mock("../utilityObsidian", async (importOriginal) => {
+	const actual = await importOriginal<object>();
+	return {
+		...actual,
+		getTemplater: vi.fn(() => ({})),
+		overwriteTemplaterOnce: vi.fn(),
+		templaterParseTemplate: vi.fn(
+			async (_app: unknown, content: string) => content,
+		),
+	};
+});
 
 import { TFile, TFolder, type App } from "obsidian";
 import type QuickAdd from "../main";
@@ -207,13 +215,13 @@ describe("splitTemplateFrontmatter", () => {
 		const result = splitTemplateFrontmatter(
 			"---\ntags: [a, b]\nstatus: draft\n---\n# Heading\nBody",
 		);
-		expect(result.frontmatterYaml).toBe("tags: [a, b]\nstatus: draft");
+		expect(result.frontmatterYaml).toBe("tags: [a, b]\nstatus: draft\n");
 		expect(result.body).toBe("# Heading\nBody");
 	});
 
 	it("handles frontmatter-only templates", () => {
 		const result = splitTemplateFrontmatter("---\nstatus: draft\n---\n");
-		expect(result.frontmatterYaml).toBe("status: draft");
+		expect(result.frontmatterYaml).toBe("status: draft\n");
 		expect(result.body.trim()).toBe("");
 	});
 });

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -1,0 +1,433 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../formatters/completeFormatter", () => {
+	class CompleteFormatterMock {
+		setLinkToCurrentFileBehavior() {}
+		setTitle() {}
+		async formatFileContent(input: string) {
+			return input;
+		}
+		async formatFileName(format: string) {
+			return format;
+		}
+		async formatFolderPath(folder: string) {
+			return folder;
+		}
+		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
+			return await work();
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map<string, unknown>();
+		}
+	}
+
+	return { CompleteFormatter: CompleteFormatterMock };
+});
+
+vi.mock("../utilityObsidian", () => ({
+	getTemplater: vi.fn(() => ({})),
+	overwriteTemplaterOnce: vi.fn(),
+	templaterParseTemplate: vi.fn(
+		async (_app: unknown, content: string) => content,
+	),
+}));
+
+import { TFile, type App } from "obsidian";
+import type QuickAdd from "../main";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import {
+	TemplateInsertEngine,
+	insertBodyIntoNoteContent,
+	isTemplateInsertMode,
+	splitTemplateFrontmatter,
+	type TemplateInsertModeId,
+} from "./TemplateInsertEngine";
+
+const TEMPLATE_PATH = "templates/tpl.md";
+
+function makeFile(overrides: Partial<TFile> = {}): TFile {
+	const file = new TFile();
+	file.path = "notes/My note.md";
+	file.basename = "My note";
+	file.extension = "md";
+	Object.assign(file, overrides);
+	return file;
+}
+
+function makeTemplateChoice(
+	overrides: Partial<ITemplateChoice> = {},
+): ITemplateChoice {
+	return {
+		name: "Meeting note",
+		id: "choice-id",
+		type: "Template",
+		command: false,
+		templatePath: TEMPLATE_PATH,
+		folder: {
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		},
+		fileNameFormat: { enabled: false, format: "" },
+		appendLink: false,
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "source",
+			focus: false,
+		},
+		fileExistsBehavior: { kind: "prompt" },
+		...overrides,
+	};
+}
+
+interface TestHarness {
+	app: App;
+	modify: ReturnType<typeof vi.fn>;
+	frontmatter: Record<string, unknown>;
+	replaceSelection: ReturnType<typeof vi.fn>;
+	setActiveViewFile: (file: TFile | null) => void;
+}
+
+function makeHarness(options: {
+	templateContent: string;
+	noteContent: string;
+	frontmatter?: Record<string, unknown>;
+}): TestHarness {
+	const templateFile = makeFile({
+		path: TEMPLATE_PATH,
+		basename: "tpl",
+	});
+
+	const modify = vi.fn();
+	const frontmatter = options.frontmatter ?? {};
+	const replaceSelection = vi.fn();
+	let activeViewFile: TFile | null = null;
+
+	const app = {
+		vault: {
+			getAbstractFileByPath: (path: string) =>
+				path === TEMPLATE_PATH ? templateFile : null,
+			cachedRead: async (file: TFile) =>
+				file.path === TEMPLATE_PATH
+					? options.templateContent
+					: options.noteContent,
+			modify,
+		},
+		fileManager: {
+			processFrontMatter: async (
+				_file: TFile,
+				fn: (fm: Record<string, unknown>) => void,
+			) => {
+				fn(frontmatter);
+			},
+		},
+		workspace: {
+			getActiveViewOfType: () =>
+				activeViewFile
+					? { file: activeViewFile, editor: { replaceSelection } }
+					: null,
+		},
+	} as unknown as App;
+
+	return {
+		app,
+		modify,
+		frontmatter,
+		replaceSelection,
+		setActiveViewFile: (file) => {
+			activeViewFile = file;
+		},
+	};
+}
+
+function makeEngine(
+	harness: TestHarness,
+	file: TFile,
+	mode: TemplateInsertModeId,
+): TemplateInsertEngine {
+	return new TemplateInsertEngine(
+		harness.app,
+		{} as QuickAdd,
+		file,
+		TEMPLATE_PATH,
+		mode,
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("isTemplateInsertMode", () => {
+	it("accepts all known modes", () => {
+		for (const mode of ["cursor", "top", "bottom", "replace"]) {
+			expect(isTemplateInsertMode(mode)).toBe(true);
+		}
+	});
+
+	it("rejects unknown values", () => {
+		expect(isTemplateInsertMode("prepend")).toBe(false);
+		expect(isTemplateInsertMode(undefined)).toBe(false);
+		expect(isTemplateInsertMode(1)).toBe(false);
+	});
+});
+
+describe("splitTemplateFrontmatter", () => {
+	it("returns full content as body when there is no frontmatter", () => {
+		const result = splitTemplateFrontmatter("# Heading\nBody");
+		expect(result.frontmatterYaml).toBeNull();
+		expect(result.body).toBe("# Heading\nBody");
+	});
+
+	it("splits frontmatter from body", () => {
+		const result = splitTemplateFrontmatter(
+			"---\ntags: [a, b]\nstatus: draft\n---\n# Heading\nBody",
+		);
+		expect(result.frontmatterYaml).toBe("tags: [a, b]\nstatus: draft");
+		expect(result.body).toBe("# Heading\nBody");
+	});
+
+	it("handles frontmatter-only templates", () => {
+		const result = splitTemplateFrontmatter("---\nstatus: draft\n---\n");
+		expect(result.frontmatterYaml).toBe("status: draft");
+		expect(result.body.trim()).toBe("");
+	});
+});
+
+describe("insertBodyIntoNoteContent", () => {
+	it("appends to the bottom", () => {
+		expect(insertBodyIntoNoteContent("existing", "new", "bottom")).toBe(
+			"existing\nnew",
+		);
+	});
+
+	it("inserts at the top when the note has no frontmatter", () => {
+		expect(insertBodyIntoNoteContent("existing", "new", "top")).toBe(
+			"new\nexisting",
+		);
+	});
+
+	it("inserts below the note's frontmatter for top", () => {
+		const note = "---\ntitle: Note\n---\nexisting";
+		expect(insertBodyIntoNoteContent(note, "new", "top")).toBe(
+			"---\ntitle: Note\n---\nnew\nexisting",
+		);
+	});
+});
+
+describe("TemplateInsertEngine.apply", () => {
+	it("replace: overwrites the note with the formatted template", async () => {
+		const harness = makeHarness({
+			templateContent: "TEMPLATE_CONTENT",
+			noteContent: "OLD",
+		});
+		const file = makeFile();
+
+		const result = await makeEngine(harness, file, "replace").apply();
+
+		expect(result).toBe(file);
+		expect(harness.modify).toHaveBeenCalledWith(file, "TEMPLATE_CONTENT");
+	});
+
+	it("bottom: appends the template body to the note", async () => {
+		const harness = makeHarness({
+			templateContent: "TEMPLATE_CONTENT",
+			noteContent: "EXISTING",
+		});
+		const file = makeFile();
+
+		await makeEngine(harness, file, "bottom").apply();
+
+		expect(harness.modify).toHaveBeenCalledWith(
+			file,
+			"EXISTING\nTEMPLATE_CONTENT",
+		);
+	});
+
+	it("top: inserts body below note frontmatter and merges template properties with existing-wins", async () => {
+		const harness = makeHarness({
+			templateContent: "---\nstatus: draft\npriority: high\n---\nTPL_BODY",
+			noteContent: "---\nstatus: done\n---\nEXISTING",
+			frontmatter: { status: "done" },
+		});
+		const file = makeFile();
+
+		await makeEngine(harness, file, "top").apply();
+
+		expect(harness.modify).toHaveBeenCalledWith(
+			file,
+			"---\nstatus: done\n---\nTPL_BODY\nEXISTING",
+		);
+		// Existing note value wins; missing property is filled from template.
+		expect(harness.frontmatter).toEqual({
+			status: "done",
+			priority: "high",
+		});
+	});
+
+	it("top: fills empty existing properties from the template", async () => {
+		const harness = makeHarness({
+			templateContent: "---\nstatus: draft\n---\nTPL_BODY",
+			noteContent: "EXISTING",
+			frontmatter: { status: null },
+		});
+		const file = makeFile();
+
+		await makeEngine(harness, file, "top").apply();
+
+		expect(harness.frontmatter).toEqual({ status: "draft" });
+	});
+
+	it("frontmatter-only template: merges properties without touching the body", async () => {
+		const harness = makeHarness({
+			templateContent: "---\nstatus: draft\n---\n",
+			noteContent: "EXISTING",
+		});
+		const file = makeFile();
+
+		await makeEngine(harness, file, "bottom").apply();
+
+		expect(harness.modify).not.toHaveBeenCalled();
+		expect(harness.frontmatter).toEqual({ status: "draft" });
+	});
+
+	it("cursor: inserts the template body via the active editor", async () => {
+		const harness = makeHarness({
+			templateContent: "TEMPLATE_CONTENT",
+			noteContent: "EXISTING",
+		});
+		const file = makeFile();
+		harness.setActiveViewFile(file);
+
+		const result = await makeEngine(harness, file, "cursor").apply();
+
+		expect(result).toBe(file);
+		expect(harness.replaceSelection).toHaveBeenCalledWith("TEMPLATE_CONTENT");
+		expect(harness.modify).not.toHaveBeenCalled();
+	});
+
+	it("cursor: throws when the note is not open in the active editor", async () => {
+		const harness = makeHarness({
+			templateContent: "TEMPLATE_CONTENT",
+			noteContent: "EXISTING",
+		});
+		const file = makeFile();
+
+		await expect(makeEngine(harness, file, "cursor").apply()).rejects.toThrow(
+			/not open in the active editor/,
+		);
+	});
+});
+
+describe("TemplateInsertEngine.computeChoiceTargetPath", () => {
+	function makePathHarness() {
+		return makeHarness({ templateContent: "", noteContent: "" });
+	}
+
+	it("returns renamed path in the note's folder when only file name format is set", async () => {
+		const harness = makePathHarness();
+		const file = makeFile({ parent: { path: "notes" } as TFile["parent"] });
+		const choice = makeTemplateChoice({
+			fileNameFormat: { enabled: true, format: "Renamed" },
+		});
+
+		const target = await makeEngine(
+			harness,
+			file,
+			"replace",
+		).computeChoiceTargetPath(choice);
+
+		expect(target).toBe("notes/Renamed.md");
+	});
+
+	it("uses the choice's single configured folder", async () => {
+		const harness = makePathHarness();
+		const file = makeFile({ parent: { path: "notes" } as TFile["parent"] });
+		const choice = makeTemplateChoice({
+			folder: {
+				enabled: true,
+				folders: ["Meetings"],
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			},
+		});
+
+		const target = await makeEngine(
+			harness,
+			file,
+			"replace",
+		).computeChoiceTargetPath(choice);
+
+		expect(target).toBe("Meetings/My note.md");
+	});
+
+	it("returns null when the folder requires a runtime picker", async () => {
+		const harness = makePathHarness();
+		const file = makeFile();
+
+		for (const folderOverride of [
+			{ chooseWhenCreatingNote: true },
+			{ chooseFromSubfolders: true },
+		]) {
+			const choice = makeTemplateChoice({
+				folder: {
+					enabled: true,
+					folders: ["A", "B"],
+					chooseWhenCreatingNote: false,
+					createInSameFolderAsActiveFile: false,
+					chooseFromSubfolders: false,
+					...folderOverride,
+				},
+			});
+
+			const target = await makeEngine(
+				harness,
+				file,
+				"replace",
+			).computeChoiceTargetPath(choice);
+
+			expect(target).toBeNull();
+		}
+	});
+
+	it("returns null with multiple configured folders", async () => {
+		const harness = makePathHarness();
+		const file = makeFile();
+		const choice = makeTemplateChoice({
+			folder: {
+				enabled: true,
+				folders: ["A", "B"],
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			},
+		});
+
+		const target = await makeEngine(
+			harness,
+			file,
+			"replace",
+		).computeChoiceTargetPath(choice);
+
+		expect(target).toBeNull();
+	});
+
+	it("keeps the current path when neither folder nor file name format are configured", async () => {
+		const harness = makePathHarness();
+		const file = makeFile({ parent: { path: "notes" } as TFile["parent"] });
+		const choice = makeTemplateChoice();
+
+		const target = await makeEngine(
+			harness,
+			file,
+			"replace",
+		).computeChoiceTargetPath(choice);
+
+		expect(target).toBe(file.path);
+	});
+});

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -6,7 +6,9 @@ import type QuickAdd from "../main";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { templaterParseTemplate } from "../utilityObsidian";
 import invariant from "../utils/invariant";
+import { TemplatePropertyCollector } from "../utils/TemplatePropertyCollector";
 import { findYamlFrontMatterRange } from "../utils/yamlContext";
+import { coerceYamlValue } from "../utils/yamlValues";
 import { TemplateEngine } from "./TemplateEngine";
 
 export const templateInsertModes = [
@@ -171,15 +173,30 @@ export class TemplateInsertEngine extends TemplateEngine {
 		if (folderPath === "/") folderPath = "";
 
 		let fileName = this.targetFile.basename;
+		let treatAsVaultRelativePath = false;
 		if (choice.fileNameFormat?.enabled && choice.fileNameFormat.format) {
-			fileName = await this.formatter.formatFileName(
+			const formattedName = await this.formatter.formatFileName(
 				choice.fileNameFormat.format,
 				choice.name,
 			);
+			// Mirror TemplateChoiceEngine's resolution of formatted names that
+			// contain folders, so the move offer matches what the choice
+			// would actually have produced.
+			const stripped = this.stripDuplicateFolderPrefix(
+				formattedName,
+				folderPath,
+			);
+			fileName = stripped.fileName;
+			treatAsVaultRelativePath =
+				this.shouldTreatFormattedNameAsVaultRelativePath(
+					formattedName,
+					stripped.strippedPrefix,
+					folderSettings?.enabled ?? false,
+				);
 		}
 
 		return this.normalizeTemplateFilePath(
-			folderPath,
+			treatAsVaultRelativePath ? "" : folderPath,
 			fileName,
 			this.templatePath,
 		);
@@ -188,7 +205,8 @@ export class TemplateInsertEngine extends TemplateEngine {
 	private async insertTemplateIntoFile(
 		position: "top" | "bottom",
 	): Promise<TFile> {
-		const formatted = await this.formatTemplateForTargetFile();
+		const { formatted, templatePropertyVars } =
+			await this.formatTemplateForTargetFile();
 		const { frontmatterYaml, body } = splitTemplateFrontmatter(formatted);
 
 		if (body.trim().length > 0) {
@@ -201,7 +219,10 @@ export class TemplateInsertEngine extends TemplateEngine {
 			await this.app.vault.modify(this.targetFile, newContent);
 		}
 
-		await this.mergeFrontmatterProperties(frontmatterYaml);
+		await this.mergeFrontmatterProperties(
+			frontmatterYaml,
+			templatePropertyVars,
+		);
 		return this.targetFile;
 	}
 
@@ -212,23 +233,35 @@ export class TemplateInsertEngine extends TemplateEngine {
 			"Cannot insert at cursor: the note is not open in the active editor.",
 		);
 
-		const formatted = await this.formatTemplateForTargetFile();
+		const { formatted, templatePropertyVars } =
+			await this.formatTemplateForTargetFile();
 		const { frontmatterYaml, body } = splitTemplateFrontmatter(formatted);
 
-		if (body.length > 0) {
+		if (body.trim().length > 0) {
 			view.editor.replaceSelection(body);
 		}
 
-		await this.mergeFrontmatterProperties(frontmatterYaml);
+		await this.mergeFrontmatterProperties(
+			frontmatterYaml,
+			templatePropertyVars,
+		);
 		return this.targetFile;
 	}
 
-	private async formatTemplateForTargetFile(): Promise<string> {
+	private async formatTemplateForTargetFile(): Promise<{
+		formatted: string;
+		templatePropertyVars: Map<string, unknown>;
+	}> {
 		const templateContent = await this.getTemplateContent(this.templatePath);
 
 		this.formatter.setTitle(this.targetFile.basename);
 
-		let formatted = await this.formatter.formatFileContent(templateContent);
+		let formatted = await this.formatter.withTemplatePropertyCollection(() =>
+			this.formatter.formatFileContent(templateContent),
+		);
+		const templatePropertyVars =
+			this.formatter.getAndClearTemplatePropertyVars();
+
 		if (this.targetFile.extension === "md") {
 			formatted = await templaterParseTemplate(
 				this.app,
@@ -237,16 +270,21 @@ export class TemplateInsertEngine extends TemplateEngine {
 			);
 		}
 
-		return formatted;
+		return { formatted, templatePropertyVars };
 	}
 
 	/**
 	 * Merges template frontmatter properties into the note's frontmatter via
 	 * Obsidian's YAML processor. Existing note values win: only missing or
 	 * empty (undefined/null/"") properties are filled from the template.
+	 *
+	 * Structured values (arrays/objects) collected during formatting replace
+	 * their YAML placeholders before merging, so Template Property Types are
+	 * preserved like in replace mode.
 	 */
 	private async mergeFrontmatterProperties(
 		frontmatterYaml: string | null,
+		templatePropertyVars?: Map<string, unknown>,
 	): Promise<void> {
 		if (!frontmatterYaml || this.targetFile.extension !== "md") return;
 
@@ -262,6 +300,21 @@ export class TemplateInsertEngine extends TemplateEngine {
 
 		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 			return;
+		}
+
+		if (templatePropertyVars && templatePropertyVars.size > 0) {
+			for (const [key, value] of templatePropertyVars) {
+				const pathSegments = key.includes(
+					TemplatePropertyCollector.PATH_SEPARATOR,
+				)
+					? key.split(TemplatePropertyCollector.PATH_SEPARATOR)
+					: [key];
+				this.assignFrontmatterValue(
+					parsed as Record<string, unknown>,
+					pathSegments,
+					coerceYamlValue(value),
+				);
+			}
 		}
 
 		await this.app.fileManager.processFrontMatter(

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -1,0 +1,283 @@
+import type { App, TFile } from "obsidian";
+import { MarkdownView, parseYaml } from "obsidian";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { log } from "../logger/logManager";
+import type QuickAdd from "../main";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import { templaterParseTemplate } from "../utilityObsidian";
+import invariant from "../utils/invariant";
+import { findYamlFrontMatterRange } from "../utils/yamlContext";
+import { TemplateEngine } from "./TemplateEngine";
+
+export const templateInsertModes = [
+	{
+		id: "cursor",
+		label: "Insert at cursor",
+		description: "Inserts the template at the cursor position in the editor.",
+	},
+	{
+		id: "top",
+		label: "Insert at top",
+		description:
+			"Inserts the template below the note's frontmatter, or at the very top.",
+	},
+	{
+		id: "bottom",
+		label: "Append to bottom",
+		description: "Adds the template content to the end of the note.",
+	},
+	{
+		id: "replace",
+		label: "Replace note content",
+		description: "Replaces the entire note content with the template.",
+	},
+] as const;
+
+export type TemplateInsertModeId = (typeof templateInsertModes)[number]["id"];
+
+export function isTemplateInsertMode(
+	value: unknown,
+): value is TemplateInsertModeId {
+	return templateInsertModes.some((mode) => mode.id === value);
+}
+
+/**
+ * Splits formatted template content into its YAML frontmatter (without
+ * delimiters) and the remaining body.
+ */
+export function splitTemplateFrontmatter(content: string): {
+	frontmatterYaml: string | null;
+	body: string;
+} {
+	const range = findYamlFrontMatterRange(content);
+	if (!range) return { frontmatterYaml: null, body: content };
+
+	const block = content.slice(0, range[1]);
+	const body = content.slice(range[1]);
+	const match =
+		/^(\s*---\r?\n)([\s\S]*?)(\r?\n(?:---|\.\.\.)\s*(?:\r?\n|$))$/.exec(block);
+
+	return { frontmatterYaml: match ? match[2] : null, body };
+}
+
+/**
+ * Inserts a template body into existing note content. "top" is
+ * frontmatter-aware: the body lands below the note's frontmatter block.
+ */
+export function insertBodyIntoNoteContent(
+	noteContent: string,
+	body: string,
+	position: "top" | "bottom",
+): string {
+	if (position === "bottom") {
+		return `${noteContent}\n${body}`;
+	}
+
+	const range = findYamlFrontMatterRange(noteContent);
+	if (!range) {
+		return `${body}\n${noteContent}`;
+	}
+
+	const head = noteContent.slice(0, range[1]);
+	const rest = noteContent.slice(range[1]);
+	return `${head}${body}\n${rest}`;
+}
+
+export function getMarkdownEditorViewForFile(
+	app: App,
+	file: TFile,
+): MarkdownView | null {
+	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	if (view?.file?.path === file.path) return view;
+	return null;
+}
+
+/**
+ * Applies a template to an existing note (issue #526). Unlike
+ * TemplateChoiceEngine, this never creates a file: it inserts, prepends,
+ * appends, or replaces content in the target note. Top/bottom/cursor modes
+ * merge the template's frontmatter properties into the note's existing
+ * frontmatter, with existing values winning.
+ */
+export class TemplateInsertEngine extends TemplateEngine {
+	constructor(
+		app: App,
+		plugin: QuickAdd,
+		private readonly targetFile: TFile,
+		private readonly templatePath: string,
+		private readonly mode: TemplateInsertModeId,
+		choiceExecutor?: IChoiceExecutor,
+	) {
+		super(app, plugin, choiceExecutor);
+	}
+
+	public async run(): Promise<void> {
+		await this.apply();
+	}
+
+	public async apply(): Promise<TFile | null> {
+		invariant(
+			this.templatePath,
+			"Cannot apply template: no template path given.",
+		);
+
+		switch (this.mode) {
+			case "replace":
+				return await this.overwriteFileWithTemplate(
+					this.targetFile,
+					this.templatePath,
+				);
+			case "top":
+			case "bottom":
+				return await this.insertTemplateIntoFile(this.mode);
+			case "cursor":
+				return await this.insertTemplateAtCursor();
+		}
+	}
+
+	/**
+	 * Computes the file path the given Template choice would have produced,
+	 * for offering to move/rename the note to match the choice's settings.
+	 * Returns null when the choice's folder configuration requires a runtime
+	 * picker (cannot be resolved non-interactively).
+	 */
+	public async computeChoiceTargetPath(
+		choice: ITemplateChoice,
+	): Promise<string | null> {
+		const folderSettings = choice.folder;
+		let folderPath: string;
+
+		if (folderSettings?.enabled) {
+			if (
+				folderSettings.chooseWhenCreatingNote ||
+				folderSettings.chooseFromSubfolders
+			) {
+				return null;
+			}
+
+			if (folderSettings.createInSameFolderAsActiveFile) {
+				folderPath = this.targetFile.parent?.path ?? "";
+			} else if (folderSettings.folders.length === 1) {
+				folderPath = await this.formatter.formatFolderPath(
+					folderSettings.folders[0],
+				);
+			} else {
+				return null;
+			}
+		} else {
+			folderPath = this.targetFile.parent?.path ?? "";
+		}
+
+		if (folderPath === "/") folderPath = "";
+
+		let fileName = this.targetFile.basename;
+		if (choice.fileNameFormat?.enabled && choice.fileNameFormat.format) {
+			fileName = await this.formatter.formatFileName(
+				choice.fileNameFormat.format,
+				choice.name,
+			);
+		}
+
+		return this.normalizeTemplateFilePath(
+			folderPath,
+			fileName,
+			this.templatePath,
+		);
+	}
+
+	private async insertTemplateIntoFile(
+		position: "top" | "bottom",
+	): Promise<TFile> {
+		const formatted = await this.formatTemplateForTargetFile();
+		const { frontmatterYaml, body } = splitTemplateFrontmatter(formatted);
+
+		if (body.trim().length > 0) {
+			const noteContent = await this.app.vault.cachedRead(this.targetFile);
+			const newContent = insertBodyIntoNoteContent(
+				noteContent,
+				body,
+				position,
+			);
+			await this.app.vault.modify(this.targetFile, newContent);
+		}
+
+		await this.mergeFrontmatterProperties(frontmatterYaml);
+		return this.targetFile;
+	}
+
+	private async insertTemplateAtCursor(): Promise<TFile> {
+		const view = getMarkdownEditorViewForFile(this.app, this.targetFile);
+		invariant(
+			view,
+			"Cannot insert at cursor: the note is not open in the active editor.",
+		);
+
+		const formatted = await this.formatTemplateForTargetFile();
+		const { frontmatterYaml, body } = splitTemplateFrontmatter(formatted);
+
+		if (body.length > 0) {
+			view.editor.replaceSelection(body);
+		}
+
+		await this.mergeFrontmatterProperties(frontmatterYaml);
+		return this.targetFile;
+	}
+
+	private async formatTemplateForTargetFile(): Promise<string> {
+		const templateContent = await this.getTemplateContent(this.templatePath);
+
+		this.formatter.setTitle(this.targetFile.basename);
+
+		let formatted = await this.formatter.formatFileContent(templateContent);
+		if (this.targetFile.extension === "md") {
+			formatted = await templaterParseTemplate(
+				this.app,
+				formatted,
+				this.targetFile,
+			);
+		}
+
+		return formatted;
+	}
+
+	/**
+	 * Merges template frontmatter properties into the note's frontmatter via
+	 * Obsidian's YAML processor. Existing note values win: only missing or
+	 * empty (undefined/null/"") properties are filled from the template.
+	 */
+	private async mergeFrontmatterProperties(
+		frontmatterYaml: string | null,
+	): Promise<void> {
+		if (!frontmatterYaml || this.targetFile.extension !== "md") return;
+
+		let parsed: unknown;
+		try {
+			parsed = parseYaml(frontmatterYaml);
+		} catch (err) {
+			log.logWarning(
+				`Could not parse template frontmatter for merging: ${err}`,
+			);
+			return;
+		}
+
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return;
+		}
+
+		await this.app.fileManager.processFrontMatter(
+			this.targetFile,
+			(frontmatter: Record<string, unknown>) => {
+				for (const [key, value] of Object.entries(parsed)) {
+					const existing = frontmatter[key];
+					if (
+						existing === undefined ||
+						existing === null ||
+						existing === ""
+					) {
+						frontmatter[key] = value;
+					}
+				}
+			},
+		);
+	}
+}

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -1,13 +1,15 @@
 import type { App, TFile } from "obsidian";
-import { MarkdownView, parseYaml } from "obsidian";
+import { getFrontMatterInfo, parseYaml } from "obsidian";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
 import type QuickAdd from "../main";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
-import { templaterParseTemplate } from "../utilityObsidian";
+import {
+	getMarkdownEditorViewForFile,
+	templaterParseTemplate,
+} from "../utilityObsidian";
 import invariant from "../utils/invariant";
 import { TemplatePropertyCollector } from "../utils/TemplatePropertyCollector";
-import { findYamlFrontMatterRange } from "../utils/yamlContext";
 import { coerceYamlValue } from "../utils/yamlValues";
 import { TemplateEngine } from "./TemplateEngine";
 
@@ -51,15 +53,13 @@ export function splitTemplateFrontmatter(content: string): {
 	frontmatterYaml: string | null;
 	body: string;
 } {
-	const range = findYamlFrontMatterRange(content);
-	if (!range) return { frontmatterYaml: null, body: content };
+	const info = getFrontMatterInfo(content);
+	if (!info.exists) return { frontmatterYaml: null, body: content };
 
-	const block = content.slice(0, range[1]);
-	const body = content.slice(range[1]);
-	const match =
-		/^(\s*---\r?\n)([\s\S]*?)(\r?\n(?:---|\.\.\.)\s*(?:\r?\n|$))$/.exec(block);
-
-	return { frontmatterYaml: match ? match[2] : null, body };
+	return {
+		frontmatterYaml: info.frontmatter,
+		body: content.slice(info.contentStart),
+	};
 }
 
 /**
@@ -75,23 +75,14 @@ export function insertBodyIntoNoteContent(
 		return `${noteContent}\n${body}`;
 	}
 
-	const range = findYamlFrontMatterRange(noteContent);
-	if (!range) {
+	const info = getFrontMatterInfo(noteContent);
+	if (!info.exists) {
 		return `${body}\n${noteContent}`;
 	}
 
-	const head = noteContent.slice(0, range[1]);
-	const rest = noteContent.slice(range[1]);
+	const head = noteContent.slice(0, info.contentStart);
+	const rest = noteContent.slice(info.contentStart);
 	return `${head}${body}\n${rest}`;
-}
-
-export function getMarkdownEditorViewForFile(
-	app: App,
-	file: TFile,
-): MarkdownView | null {
-	const view = app.workspace.getActiveViewOfType(MarkdownView);
-	if (view?.file?.path === file.path) return view;
-	return null;
 }
 
 /**

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -44,6 +44,7 @@ import type IMultiChoice from "../types/choices/IMultiChoice";
 import {
 	applyTemplateToNote,
 	buildTemplatePickerItems,
+	isMarkdownTemplatePath,
 	isNoteEffectivelyEmpty,
 	templatePickerItemLabel,
 } from "./applyTemplateToActiveNote";
@@ -101,6 +102,19 @@ describe("isNoteEffectivelyEmpty", () => {
 	});
 });
 
+describe("isMarkdownTemplatePath", () => {
+	it("accepts markdown and extensionless template paths", () => {
+		expect(isMarkdownTemplatePath("templates/tpl.md")).toBe(true);
+		expect(isMarkdownTemplatePath("templates/tpl")).toBe(true);
+	});
+
+	it("rejects canvas and base templates", () => {
+		expect(isMarkdownTemplatePath("templates/board.canvas")).toBe(false);
+		expect(isMarkdownTemplatePath("templates/db.base")).toBe(false);
+		expect(isMarkdownTemplatePath("templates/Board.CANVAS")).toBe(false);
+	});
+});
+
 describe("buildTemplatePickerItems", () => {
 	it("lists Template choices first, then uncovered template files", () => {
 		const choices: IChoice[] = [
@@ -136,6 +150,27 @@ describe("buildTemplatePickerItems", () => {
 
 		expect(items).toHaveLength(1);
 		expect(items[0].kind).toBe("choice");
+	});
+
+	it("excludes canvas and base templates from choices and files", () => {
+		const choices: IChoice[] = [
+			makeTemplateChoice("Canvas board", "templates/board.canvas"),
+			makeTemplateChoice("Base db", "templates/db.base"),
+			makeTemplateChoice("Note", "templates/note.md"),
+		];
+
+		const items = buildTemplatePickerItems(choices, [
+			"templates/other.canvas",
+			"templates/other.base",
+			"templates/other.md",
+		]);
+
+		expect(items).toHaveLength(2);
+		expect(items[0]).toMatchObject({
+			kind: "choice",
+			choice: { name: "Note" },
+		});
+		expect(items[1]).toEqual({ kind: "file", path: "templates/other.md" });
 	});
 
 	it("skips non-Template choices and Template choices without a template path", () => {
@@ -272,6 +307,24 @@ describe("applyTemplateToNote (non-interactive)", () => {
 		});
 
 		expect(result).toBeNull();
+		expect(engineConstructorMock).not.toHaveBeenCalled();
+	});
+
+	it("returns null for canvas and base templates", async () => {
+		const file = makeFile();
+
+		for (const templatePath of [
+			"templates/board.canvas",
+			"templates/db.base",
+		]) {
+			const result = await applyTemplateToNote(makeApp("", file), plugin, {
+				templatePath,
+				choiceExecutor: makeExecutor(),
+			});
+
+			expect(result).toBeNull();
+		}
+
 		expect(engineConstructorMock).not.toHaveBeenCalled();
 	});
 

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { engineApplyMock, engineConstructorMock } = vi.hoisted(() => ({
+	engineApplyMock: vi.fn(),
+	engineConstructorMock: vi.fn(),
+}));
+
+vi.mock("./TemplateInsertEngine", async (importOriginal) => {
+	const actual = await importOriginal<object>();
+
+	class TemplateInsertEngineMock {
+		constructor(...args: unknown[]) {
+			engineConstructorMock(...args);
+		}
+		async apply() {
+			return await engineApplyMock();
+		}
+		async computeChoiceTargetPath() {
+			return null;
+		}
+	}
+
+	return { ...actual, TemplateInsertEngine: TemplateInsertEngineMock };
+});
+
+vi.mock("../utilityObsidian", () => ({
+	jumpToNextTemplaterCursorIfPossible: vi.fn(),
+	getTemplater: vi.fn(() => ({})),
+	templaterParseTemplate: vi.fn(
+		async (_app: unknown, content: string) => content,
+	),
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+import { TFile, type App } from "obsidian";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import type QuickAdd from "../main";
+import type IChoice from "../types/choices/IChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import {
+	applyTemplateToNote,
+	buildTemplatePickerItems,
+	isNoteEffectivelyEmpty,
+	templatePickerItemLabel,
+} from "./applyTemplateToActiveNote";
+
+function makeTemplateChoice(
+	name: string,
+	templatePath: string,
+): ITemplateChoice {
+	return {
+		name,
+		id: `id-${name}`,
+		type: "Template",
+		command: false,
+		templatePath,
+		folder: {
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		},
+		fileNameFormat: { enabled: false, format: "" },
+		appendLink: false,
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "source",
+			focus: false,
+		},
+		fileExistsBehavior: { kind: "prompt" },
+	};
+}
+
+function makeMultiChoice(name: string, choices: IChoice[]): IMultiChoice {
+	return {
+		name,
+		id: `id-${name}`,
+		type: "Multi",
+		command: false,
+		choices,
+		collapsed: false,
+	};
+}
+
+describe("isNoteEffectivelyEmpty", () => {
+	it("treats empty and whitespace-only content as empty", () => {
+		expect(isNoteEffectivelyEmpty("")).toBe(true);
+		expect(isNoteEffectivelyEmpty("  \n\t\n")).toBe(true);
+	});
+
+	it("treats any non-whitespace content as non-empty", () => {
+		expect(isNoteEffectivelyEmpty("x")).toBe(false);
+		expect(isNoteEffectivelyEmpty("\n# Heading\n")).toBe(false);
+	});
+});
+
+describe("buildTemplatePickerItems", () => {
+	it("lists Template choices first, then uncovered template files", () => {
+		const choices: IChoice[] = [
+			makeTemplateChoice("Meeting", "templates/meeting.md"),
+		];
+		const items = buildTemplatePickerItems(choices, [
+			"templates/meeting.md",
+			"templates/other.md",
+		]);
+
+		expect(items).toHaveLength(2);
+		expect(items[0]).toMatchObject({ kind: "choice" });
+		expect(items[1]).toEqual({ kind: "file", path: "templates/other.md" });
+	});
+
+	it("flattens Template choices nested in Multi choices", () => {
+		const nested = makeTemplateChoice("Nested", "templates/nested.md");
+		const choices: IChoice[] = [makeMultiChoice("Folder", [nested])];
+
+		const items = buildTemplatePickerItems(choices, []);
+
+		expect(items).toEqual([{ kind: "choice", choice: nested }]);
+	});
+
+	it("dedupes template files against choice template paths without extension", () => {
+		const choices: IChoice[] = [
+			makeTemplateChoice("Meeting", "templates/meeting"),
+		];
+
+		const items = buildTemplatePickerItems(choices, [
+			"templates/meeting.md",
+		]);
+
+		expect(items).toHaveLength(1);
+		expect(items[0].kind).toBe("choice");
+	});
+
+	it("skips non-Template choices and Template choices without a template path", () => {
+		const choices: IChoice[] = [
+			makeTemplateChoice("Empty", ""),
+			{
+				name: "Capture",
+				id: "id-capture",
+				type: "Capture",
+				command: false,
+			} as IChoice,
+		];
+
+		expect(buildTemplatePickerItems(choices, [])).toEqual([]);
+	});
+});
+
+describe("templatePickerItemLabel", () => {
+	it("labels choices and files distinctly", () => {
+		const choice = makeTemplateChoice("Meeting", "templates/meeting.md");
+		expect(templatePickerItemLabel({ kind: "choice", choice })).toBe(
+			"Choice: Meeting",
+		);
+		expect(
+			templatePickerItemLabel({ kind: "file", path: "templates/x.md" }),
+		).toBe("Template: templates/x.md");
+	});
+});
+
+describe("applyTemplateToNote (non-interactive)", () => {
+	function makeFile(): TFile {
+		const file = new TFile();
+		file.path = "notes/My note.md";
+		file.basename = "My note";
+		file.extension = "md";
+		return file;
+	}
+
+	function makeApp(noteContent: string, activeFile: TFile | null): App {
+		return {
+			workspace: { getActiveFile: () => activeFile },
+			vault: { cachedRead: async () => noteContent },
+		} as unknown as App;
+	}
+
+	function makeExecutor(): IChoiceExecutor {
+		return {
+			execute: async () => {},
+			variables: new Map<string, unknown>(),
+		};
+	}
+
+	const plugin = {} as QuickAdd;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		engineApplyMock.mockImplementation(async () => makeFile());
+	});
+
+	it("uses the empty-note fast path (replace) for empty notes", async () => {
+		const file = makeFile();
+		const result = await applyTemplateToNote(makeApp("", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(result).toBe(file);
+		expect(engineConstructorMock).toHaveBeenCalledTimes(1);
+		expect(engineConstructorMock.mock.calls[0][4]).toBe("replace");
+	});
+
+	it("defaults to bottom for non-empty notes", async () => {
+		const file = makeFile();
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(engineConstructorMock.mock.calls[0][4]).toBe("bottom");
+	});
+
+	it("respects an explicit mode even for empty notes", async () => {
+		const file = makeFile();
+		await applyTemplateToNote(makeApp("", file), plugin, {
+			templatePath: "templates/tpl.md",
+			mode: "top",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(engineConstructorMock.mock.calls[0][4]).toBe("top");
+	});
+
+	it("pre-fills {{VALUE}} with the note's basename", async () => {
+		const file = makeFile();
+		const executor = makeExecutor();
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: executor,
+		});
+
+		expect(executor.variables.get("value")).toBe("My note");
+	});
+
+	it("keeps a pre-existing value variable", async () => {
+		const file = makeFile();
+		const executor = makeExecutor();
+		executor.variables.set("value", "Custom");
+
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: executor,
+		});
+
+		expect(executor.variables.get("value")).toBe("Custom");
+	});
+
+	it("returns null without an active markdown note", async () => {
+		const result = await applyTemplateToNote(makeApp("", null), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(result).toBeNull();
+		expect(engineConstructorMock).not.toHaveBeenCalled();
+	});
+
+	it("returns null for non-markdown files", async () => {
+		const file = makeFile();
+		file.extension = "canvas";
+
+		const result = await applyTemplateToNote(makeApp("", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(result).toBeNull();
+		expect(engineConstructorMock).not.toHaveBeenCalled();
+	});
+
+	it("returns null when the engine could not apply the template", async () => {
+		engineApplyMock.mockResolvedValue(null);
+		const file = makeFile();
+
+		const result = await applyTemplateToNote(makeApp("", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(result).toBeNull();
+	});
+});

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -1,0 +1,267 @@
+import type { App, TFile } from "obsidian";
+import { Notice } from "obsidian";
+import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
+import GenericYesNoPrompt from "../gui/GenericYesNoPrompt/GenericYesNoPrompt";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { log } from "../logger/logManager";
+import type QuickAdd from "../main";
+import type IChoice from "../types/choices/IChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import { jumpToNextTemplaterCursorIfPossible } from "../utilityObsidian";
+import { flattenChoices } from "../utils/choiceUtils";
+import { isCancellationError, reportError } from "../utils/errorUtils";
+import {
+	getMarkdownEditorViewForFile,
+	TemplateInsertEngine,
+	templateInsertModes,
+	type TemplateInsertModeId,
+} from "./TemplateInsertEngine";
+
+export type TemplatePickerItem =
+	| { kind: "choice"; choice: ITemplateChoice }
+	| { kind: "file"; path: string };
+
+export interface ApplyTemplateToNoteParams {
+	/** Target note; defaults to the active file. */
+	file?: TFile;
+	/** Non-interactive template source; skips the template picker. */
+	templatePath?: string;
+	/** Non-interactive insert mode; skips the mode picker. */
+	mode?: TemplateInsertModeId;
+	choiceExecutor: IChoiceExecutor;
+}
+
+/** A note that only contains whitespace is treated as empty (fast path). */
+export function isNoteEffectivelyEmpty(content: string): boolean {
+	return content.trim().length === 0;
+}
+
+export function templatePickerItemLabel(item: TemplatePickerItem): string {
+	return item.kind === "choice"
+		? `Choice: ${item.choice.name}`
+		: `Template: ${item.path}`;
+}
+
+function normalizeTemplatePathForComparison(path: string): string {
+	const stripped = path.replace(/^\/+/, "").toLowerCase();
+	return /\.(md|canvas|base)$/.test(stripped) ? stripped : `${stripped}.md`;
+}
+
+/**
+ * Builds the template picker list: Template choices first (flattened from
+ * Multis), then raw template files not already covered by a choice.
+ */
+export function buildTemplatePickerItems(
+	choices: IChoice[],
+	templateFilePaths: string[],
+): TemplatePickerItem[] {
+	const templateChoices = flattenChoices(choices).filter(
+		(choice): choice is ITemplateChoice =>
+			choice.type === "Template" &&
+			Boolean((choice as ITemplateChoice).templatePath),
+	);
+
+	const coveredPaths = new Set(
+		templateChoices.map((choice) =>
+			normalizeTemplatePathForComparison(choice.templatePath),
+		),
+	);
+
+	const items: TemplatePickerItem[] = templateChoices.map((choice) => ({
+		kind: "choice",
+		choice,
+	}));
+
+	for (const path of templateFilePaths) {
+		if (coveredPaths.has(normalizeTemplatePathForComparison(path))) continue;
+		items.push({ kind: "file", path });
+	}
+
+	return items;
+}
+
+/**
+ * Applies a template to an existing note (issue #526).
+ *
+ * Interactive flow (no templatePath given): pick a Template choice or
+ * template file, then — unless the note is empty, which applies the template
+ * directly — pick how to insert it. Choice-backed picks may end with an
+ * offer to move/rename the note to match the choice's folder and file name
+ * settings.
+ *
+ * Non-interactive flow (templatePath given, e.g. via the API): no pickers
+ * and no reconciliation prompt. Mode defaults to "replace" for empty notes
+ * and "bottom" otherwise.
+ */
+export async function applyTemplateToNote(
+	app: App,
+	plugin: QuickAdd,
+	params: ApplyTemplateToNoteParams,
+): Promise<TFile | null> {
+	try {
+		const file = params.file ?? app.workspace.getActiveFile();
+		if (!file || file.extension !== "md") {
+			new Notice("QuickAdd: No active markdown note to apply a template to.");
+			return null;
+		}
+
+		const interactive = !params.templatePath;
+		let source: TemplatePickerItem;
+		if (params.templatePath) {
+			source = { kind: "file", path: params.templatePath };
+		} else {
+			const picked = await pickTemplate(app, plugin);
+			if (!picked) return null;
+			source = picked;
+		}
+
+		const templatePath =
+			source.kind === "choice" ? source.choice.templatePath : source.path;
+
+		const noteContent = await app.vault.cachedRead(file);
+		const noteIsEmpty = isNoteEffectivelyEmpty(noteContent);
+
+		let mode: TemplateInsertModeId;
+		if (params.mode) {
+			mode = params.mode;
+		} else if (noteIsEmpty) {
+			// Empty-note fast path: the most common case is a freshly created
+			// blank note, so skip the mode picker and apply the template as-is.
+			mode = "replace";
+		} else if (!interactive) {
+			mode = "bottom";
+		} else {
+			const pickedMode = await pickInsertMode(app, file);
+			if (!pickedMode) return null;
+			mode = pickedMode;
+		}
+
+		// Pre-fill the unnamed {{VALUE}} with the note's basename: the note
+		// already has a name, so don't re-ask for it. setTitle() in the engine
+		// covers {{title}} the same way.
+		if (!params.choiceExecutor.variables.has("value")) {
+			params.choiceExecutor.variables.set("value", file.basename);
+		}
+
+		const engine = new TemplateInsertEngine(
+			app,
+			plugin,
+			file,
+			templatePath,
+			mode,
+			params.choiceExecutor,
+		);
+		const result = await engine.apply();
+		if (!result) return null;
+
+		if (interactive && source.kind === "choice") {
+			await maybeReconcileNoteLocation(app, engine, source.choice, file);
+		}
+
+		await jumpToNextTemplaterCursorIfPossible(app, file);
+		new Notice(`Applied template to '${file.basename}'.`);
+		return file;
+	} catch (err) {
+		if (isCancellationError(err) || isAbortError(err)) {
+			return null;
+		}
+		reportError(err, "Error applying template to note");
+		return null;
+	}
+}
+
+function isAbortError(error: unknown): boolean {
+	return (
+		Boolean(error) &&
+		typeof error === "object" &&
+		(error as { name?: string }).name === "MacroAbortError"
+	);
+}
+
+async function pickTemplate(
+	app: App,
+	plugin: QuickAdd,
+): Promise<TemplatePickerItem | null> {
+	const items = buildTemplatePickerItems(
+		plugin.settings.choices,
+		plugin.getTemplateFiles().map((file) => file.path),
+	);
+
+	if (items.length === 0) {
+		new Notice(
+			"QuickAdd: No Template choices or template files found. Create a Template choice or set the template folder path in settings.",
+		);
+		return null;
+	}
+
+	try {
+		return await GenericSuggester.Suggest(
+			app,
+			items.map(templatePickerItemLabel),
+			items,
+			"Apply template to note",
+		);
+	} catch (error) {
+		if (isCancellationError(error)) return null;
+		throw error;
+	}
+}
+
+async function pickInsertMode(
+	app: App,
+	file: TFile,
+): Promise<TemplateInsertModeId | null> {
+	const cursorAvailable = Boolean(getMarkdownEditorViewForFile(app, file));
+	const modes = templateInsertModes.filter(
+		(mode) => mode.id !== "cursor" || cursorAvailable,
+	);
+
+	try {
+		return await GenericSuggester.Suggest(
+			app,
+			modes.map((mode) => mode.label),
+			modes.map((mode) => mode.id),
+			"How should the template be applied?",
+		);
+	} catch (error) {
+		if (isCancellationError(error)) return null;
+		throw error;
+	}
+}
+
+/**
+ * If the picked Template choice would have created the note at a different
+ * path (folder settings + file name format), offer to move/rename the note
+ * to match. Skipped when the target can't be resolved non-interactively or
+ * already exists.
+ */
+async function maybeReconcileNoteLocation(
+	app: App,
+	engine: TemplateInsertEngine,
+	choice: ITemplateChoice,
+	file: TFile,
+): Promise<void> {
+	try {
+		const targetPath = await engine.computeChoiceTargetPath(choice);
+		if (!targetPath || targetPath === file.path) return;
+		if (await app.vault.adapter.exists(targetPath)) return;
+
+		const shouldMove = await GenericYesNoPrompt.Prompt(
+			app,
+			"Move note to match choice settings?",
+			`'${choice.name}' creates notes at '${targetPath}'. Move '${file.path}' there? Links to the note will be updated.`,
+		);
+		if (!shouldMove) return;
+
+		const lastSlash = targetPath.lastIndexOf("/");
+		const targetFolder = lastSlash === -1 ? "" : targetPath.slice(0, lastSlash);
+		if (targetFolder && !(await app.vault.adapter.exists(targetFolder))) {
+			await app.vault.createFolder(targetFolder);
+		}
+
+		await app.fileManager.renameFile(file, targetPath);
+	} catch (error) {
+		if (isCancellationError(error) || isAbortError(error)) return;
+		log.logWarning(`Could not move note to match choice settings: ${error}`);
+	}
+}

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -1,5 +1,9 @@
 import type { App, TFile } from "obsidian";
 import { Notice } from "obsidian";
+import {
+	BASE_FILE_EXTENSION_REGEX,
+	CANVAS_FILE_EXTENSION_REGEX,
+} from "../constants";
 import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
 import GenericYesNoPrompt from "../gui/GenericYesNoPrompt/GenericYesNoPrompt";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
@@ -36,6 +40,18 @@ export function isNoteEffectivelyEmpty(content: string): boolean {
 	return content.trim().length === 0;
 }
 
+/**
+ * Only markdown templates can be applied to a (markdown) note: canvas and
+ * base templates contain JSON/YAML for their own file types. Extensionless
+ * paths default to markdown, matching template content resolution.
+ */
+export function isMarkdownTemplatePath(path: string): boolean {
+	return (
+		!CANVAS_FILE_EXTENSION_REGEX.test(path) &&
+		!BASE_FILE_EXTENSION_REGEX.test(path)
+	);
+}
+
 export function templatePickerItemLabel(item: TemplatePickerItem): string {
 	return item.kind === "choice"
 		? `Choice: ${item.choice.name}`
@@ -58,7 +74,8 @@ export function buildTemplatePickerItems(
 	const templateChoices = flattenChoices(choices).filter(
 		(choice): choice is ITemplateChoice =>
 			choice.type === "Template" &&
-			Boolean((choice as ITemplateChoice).templatePath),
+			Boolean((choice as ITemplateChoice).templatePath) &&
+			isMarkdownTemplatePath((choice as ITemplateChoice).templatePath),
 	);
 
 	const coveredPaths = new Set(
@@ -73,6 +90,7 @@ export function buildTemplatePickerItems(
 	}));
 
 	for (const path of templateFilePaths) {
+		if (!isMarkdownTemplatePath(path)) continue;
 		if (coveredPaths.has(normalizeTemplatePathForComparison(path))) continue;
 		items.push({ kind: "file", path });
 	}
@@ -117,6 +135,13 @@ export async function applyTemplateToNote(
 
 		const templatePath =
 			source.kind === "choice" ? source.choice.templatePath : source.path;
+
+		if (!isMarkdownTemplatePath(templatePath)) {
+			new Notice(
+				"QuickAdd: Only markdown templates can be applied to a note. Canvas and base templates create their own file types.",
+			);
+			return null;
+		}
 
 		const noteContent = await app.vault.cachedRead(file);
 		const noteIsEmpty = isNoteEffectivelyEmpty(noteContent);

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -11,11 +11,13 @@ import { log } from "../logger/logManager";
 import type QuickAdd from "../main";
 import type IChoice from "../types/choices/IChoice";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
-import { jumpToNextTemplaterCursorIfPossible } from "../utilityObsidian";
+import {
+	getMarkdownEditorViewForFile,
+	jumpToNextTemplaterCursorIfPossible,
+} from "../utilityObsidian";
 import { flattenChoices } from "../utils/choiceUtils";
 import { isCancellationError, reportError } from "../utils/errorUtils";
 import {
-	getMarkdownEditorViewForFile,
 	TemplateInsertEngine,
 	templateInsertModes,
 	type TemplateInsertModeId,

--- a/src/main.commandLabels.test.ts
+++ b/src/main.commandLabels.test.ts
@@ -5,6 +5,7 @@ describe("QuickAdd command labels", () => {
 	it("keeps built-in command labels free of the plugin name", () => {
 		expect(QUICK_ADD_COMMAND_LABELS).toEqual({
 			run: "Run",
+			applyTemplate: "Apply template to active note",
 			reloadDev: "Reload (dev)",
 			testDev: "Test (dev)",
 		});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all assist/source/organizeImports: Import order is critical to prevent circular dependencies - ChoiceExecutor must load before dependent classes */
-import type { Debouncer, TFile } from "obsidian";
-import { Plugin, debounce } from "obsidian";
+import type { Debouncer } from "obsidian";
+import { Plugin, TFile, debounce } from "obsidian";
 import { QuickAddSettingsTab } from "./quickAddSettingsTab";
 import { DEFAULT_SETTINGS } from "./settings";
 import type { QuickAddSettings } from "./settings";
@@ -26,6 +26,7 @@ import { isMajorUpdate } from "./utils/semver";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
 import { setQuickAddInstance } from "./quickAddInstance";
+import { applyTemplateToNote } from "./engine/applyTemplateToActiveNote";
 
 // Parameters prefixed with `value-` get used as named values for the executed choice
 type CaptureValueParameters = { [key in `value-${string}`]?: string };
@@ -77,6 +78,41 @@ export default class QuickAdd extends Plugin {
 				ChoiceSuggester.Open(this, this.settings.choices);
 			},
 		});
+
+		this.addCommand({
+			id: "applyTemplateToActiveFile",
+			name: QUICK_ADD_COMMAND_LABELS.applyTemplate,
+			checkCallback: (checking) => {
+				const file = this.app.workspace.getActiveFile();
+				const available = file?.extension === "md";
+				if (checking) return available;
+				if (!available) return;
+
+				void applyTemplateToNote(this.app, this, {
+					file,
+					choiceExecutor: new ChoiceExecutor(this.app, this),
+				});
+			},
+		});
+
+		this.registerEvent(
+			this.app.workspace.on("file-menu", (menu, abstractFile) => {
+				if (!(abstractFile instanceof TFile)) return;
+				if (abstractFile.extension !== "md") return;
+
+				menu.addItem((item) =>
+					item
+						.setTitle("Apply QuickAdd template")
+						.setIcon("file-plus")
+						.onClick(() => {
+							void applyTemplateToNote(this.app, this, {
+								file: abstractFile,
+								choiceExecutor: new ChoiceExecutor(this.app, this),
+							});
+						}),
+				);
+			}),
+		);
 
 		this.addCommand({
 			id: "reloadQuickAdd",

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -41,7 +41,10 @@ import { InlineFieldParser } from "./utils/InlineFieldParser";
 import { MacroAbortError } from "./errors/MacroAbortError";
 import { formatISODate } from "./utils/dateParser";
 import type { InputPromptOptions } from "./types/inputPrompt";
-import { applyTemplateToNote } from "./engine/applyTemplateToActiveNote";
+import {
+	applyTemplateToNote,
+	isMarkdownTemplatePath,
+} from "./engine/applyTemplateToActiveNote";
 import {
 	isTemplateInsertMode,
 	templateInsertModes,
@@ -268,6 +271,12 @@ export class QuickAddApi {
 				if (!templatePath) {
 					throw new Error(
 						"applyTemplateToActiveFile requires a template path.",
+					);
+				}
+
+				if (!isMarkdownTemplatePath(templatePath)) {
+					throw new Error(
+						"applyTemplateToActiveFile only supports markdown templates. Canvas and base templates cannot be applied to a markdown note.",
 					);
 				}
 

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -41,6 +41,12 @@ import { InlineFieldParser } from "./utils/InlineFieldParser";
 import { MacroAbortError } from "./errors/MacroAbortError";
 import { formatISODate } from "./utils/dateParser";
 import type { InputPromptOptions } from "./types/inputPrompt";
+import { applyTemplateToNote } from "./engine/applyTemplateToActiveNote";
+import {
+	isTemplateInsertMode,
+	templateInsertModes,
+	type TemplateInsertModeId,
+} from "./engine/TemplateInsertEngine";
 
 function snapshotVariables(
 	vars: Map<string, unknown>,
@@ -243,6 +249,45 @@ export class QuickAddApi {
 				choiceExecutor.variables.clear();
 				if (abort) {
 					throw abort;
+				}
+			},
+			/**
+			 * Applies a template to the active note without creating a new file.
+			 * Runs the full QuickAdd format pipeline on the template content.
+			 *
+			 * @param templatePath Vault path to the template file.
+			 * @param options.mode How to apply: "cursor" | "top" | "bottom" |
+			 *   "replace". Defaults to "replace" for empty notes and "bottom"
+			 *   otherwise.
+			 * @returns The target file, or null if nothing was applied.
+			 */
+			applyTemplateToActiveFile: async (
+				templatePath: string,
+				options?: { mode?: TemplateInsertModeId },
+			) => {
+				if (!templatePath) {
+					throw new Error(
+						"applyTemplateToActiveFile requires a template path.",
+					);
+				}
+
+				if (options?.mode !== undefined && !isTemplateInsertMode(options.mode)) {
+					throw new Error(
+						`Invalid mode '${String(options.mode)}'. Valid modes: ${templateInsertModes
+							.map((mode) => mode.id)
+							.join(", ")}.`,
+					);
+				}
+
+				const snapshot = snapshotVariables(choiceExecutor.variables);
+				try {
+					return await applyTemplateToNote(app, plugin, {
+						templatePath,
+						mode: options?.mode,
+						choiceExecutor,
+					});
+				} finally {
+					restoreVariables(choiceExecutor.variables, snapshot);
 				}
 			},
 			format: async (

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -484,6 +484,19 @@ export function getDate(input?: { format?: string; offset?: number; }) {
 		: window.moment().add(duration).format("YYYY-MM-DD");
 }
 
+/**
+ * Returns the active markdown view if it is showing the given file,
+ * meaning its editor can be used to insert at the cursor.
+ */
+export function getMarkdownEditorViewForFile(
+	app: App,
+	file: TFile,
+): MarkdownView | null {
+	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	if (view?.file?.path === file.path) return view;
+	return null;
+}
+
 export function appendToCurrentLine(toAppend: string, app: App) {
 	try {
 		const activeView = app.workspace.getActiveViewOfType(MarkdownView);

--- a/tests/e2e/apply-template-to-active-note.test.ts
+++ b/tests/e2e/apply-template-to-active-note.test.ts
@@ -1,0 +1,278 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	acquireVaultRunLock,
+	captureFailureArtifacts,
+	clearVaultRunLockMarker,
+	createObsidianClient,
+	createSandboxApi,
+} from "obsidian-e2e";
+import type {
+	ObsidianClient,
+	PluginHandle,
+	SandboxApi,
+	VaultRunLock,
+} from "obsidian-e2e";
+
+// ---------------------------------------------------------------------------
+// Constants & types
+// ---------------------------------------------------------------------------
+
+const VAULT = "dev";
+const PLUGIN_ID = "quickadd";
+const TPL_CONTENT = "APPLIED_TEMPLATE_CONTENT";
+const TPL_FM = "---\nstatus: draft\npriority: high\n---\nTPL_BODY";
+const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
+
+let obsidian: ObsidianClient;
+let sandbox: SandboxApi;
+let qa: PluginHandle;
+let lock: VaultRunLock | undefined;
+
+type ApplyResult = { ok: boolean; path?: string | null; error?: string };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Write a file into the sandbox and wait for Obsidian to index it. */
+async function seedFile(name: string, content: string) {
+	await sandbox.write(name, content, {
+		waitForContent: true,
+		waitOptions: WAIT_OPTS,
+	});
+}
+
+/**
+ * Opens the note in the active leaf, then calls the public API seam
+ * `applyTemplateToActiveFile`. Results land in a window global which we poll
+ * for, since dev.eval does not reliably await long async bodies.
+ */
+async function applyTemplate(
+	notePath: string,
+	templatePath: string,
+	mode?: string,
+): Promise<ApplyResult> {
+	const options = mode ? `{ mode: ${JSON.stringify(mode)} }` : "undefined";
+
+	await obsidian.dev.evalRaw(`(async () => {
+		window.__qaApplyTplResult = null;
+		try {
+			// The vault index can lag behind sandbox writes; poll for the note.
+			let file = null;
+			for (let attempt = 0; attempt < 50 && !file; attempt++) {
+				file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
+				if (!file) await new Promise((resolve) => setTimeout(resolve, 100));
+			}
+			if (!file) throw new Error("note not found: " + ${JSON.stringify(notePath)});
+			const leaf = app.workspace.getLeaf(false);
+			await leaf.openFile(file);
+			app.workspace.setActiveLeaf(leaf, { focus: true });
+			const result = await app.plugins.plugins.${PLUGIN_ID}.api.applyTemplateToActiveFile(
+				${JSON.stringify(templatePath)},
+				${options},
+			);
+			window.__qaApplyTplResult = { ok: true, path: result ? result.path : null };
+		} catch (e) {
+			window.__qaApplyTplResult = { ok: false, error: String((e && e.message) || e) };
+		}
+	})()`);
+
+	const result = await obsidian.waitFor(async () => {
+		const value = await obsidian.dev.evalJson<ApplyResult | null>(
+			"window.__qaApplyTplResult ?? null",
+		);
+		return value ?? false;
+	}, WAIT_OPTS);
+
+	return result as ApplyResult;
+}
+
+function expectOrderedSubstrings(
+	content: string,
+	first: string,
+	second: string,
+) {
+	const firstIndex = content.indexOf(first);
+	const secondIndex = content.indexOf(second);
+
+	expect(firstIndex).toBeGreaterThanOrEqual(0);
+	expect(secondIndex).toBeGreaterThanOrEqual(0);
+	expect(firstIndex).toBeLessThan(secondIndex);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+	obsidian = createObsidianClient({ vault: VAULT });
+	await obsidian.verify();
+
+	lock = await acquireVaultRunLock({
+		vaultName: VAULT,
+		vaultPath: await obsidian.vaultPath(),
+	});
+	await lock.publishMarker(obsidian);
+
+	qa = obsidian.plugin(PLUGIN_ID);
+	sandbox = await createSandboxApi({
+		obsidian,
+		sandboxRoot: "__obsidian_e2e__",
+		testName: "apply-template",
+	});
+
+	await seedFile("tpl-plain.md", TPL_CONTENT);
+	await seedFile("tpl-fm.md", TPL_FM);
+}, 30_000);
+
+afterAll(async () => {
+	await sandbox.cleanup();
+	await clearVaultRunLockMarker(obsidian).catch(() => {});
+	await lock?.release();
+}, 15_000);
+
+beforeEach((ctx) => {
+	ctx.onTestFailed(async () => {
+		await captureFailureArtifacts(
+			{ id: ctx.task.id, name: ctx.task.name },
+			obsidian,
+			{ plugin: qa, captureOnFailure: true },
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("apply template to active note (API seam)", () => {
+	it("A01: empty note fast path - applies template as full content", async () => {
+		await seedFile("a01-empty.md", "");
+
+		const result = await applyTemplate(
+			sandbox.path("a01-empty.md"),
+			sandbox.path("tpl-plain.md"),
+		);
+
+		expect(result.ok).toBe(true);
+		const content = await sandbox.waitForContent(
+			"a01-empty.md",
+			(c) => c.includes(TPL_CONTENT),
+			WAIT_OPTS,
+		);
+		expect(content.trim()).toBe(TPL_CONTENT);
+	});
+
+	it("A02: bottom (default for non-empty notes) - appends after existing content", async () => {
+		await seedFile("a02-bottom.md", "EXISTING_CONTENT");
+
+		const result = await applyTemplate(
+			sandbox.path("a02-bottom.md"),
+			sandbox.path("tpl-plain.md"),
+		);
+
+		expect(result.ok).toBe(true);
+		const content = await sandbox.waitForContent(
+			"a02-bottom.md",
+			(c) => c.includes(TPL_CONTENT),
+			WAIT_OPTS,
+		);
+		expectOrderedSubstrings(content, "EXISTING_CONTENT", TPL_CONTENT);
+	});
+
+	it("A03: top - inserts before existing content", async () => {
+		await seedFile("a03-top.md", "EXISTING_CONTENT");
+
+		const result = await applyTemplate(
+			sandbox.path("a03-top.md"),
+			sandbox.path("tpl-plain.md"),
+			"top",
+		);
+
+		expect(result.ok).toBe(true);
+		const content = await sandbox.waitForContent(
+			"a03-top.md",
+			(c) => c.includes(TPL_CONTENT),
+			WAIT_OPTS,
+		);
+		expectOrderedSubstrings(content, TPL_CONTENT, "EXISTING_CONTENT");
+	});
+
+	it("A04: replace - replaces existing content", async () => {
+		await seedFile("a04-replace.md", "OLD_CONTENT_TO_REPLACE");
+
+		const result = await applyTemplate(
+			sandbox.path("a04-replace.md"),
+			sandbox.path("tpl-plain.md"),
+			"replace",
+		);
+
+		expect(result.ok).toBe(true);
+		const content = await sandbox.waitForContent(
+			"a04-replace.md",
+			(c) => c.includes(TPL_CONTENT),
+			WAIT_OPTS,
+		);
+		expect(content).not.toContain("OLD_CONTENT_TO_REPLACE");
+	});
+
+	it("A05: cursor - inserts via the active editor", async () => {
+		await seedFile("a05-cursor.md", "EXISTING_CONTENT");
+
+		const result = await applyTemplate(
+			sandbox.path("a05-cursor.md"),
+			sandbox.path("tpl-plain.md"),
+			"cursor",
+		);
+
+		expect(result.ok).toBe(true);
+		const content = await sandbox.waitForContent(
+			"a05-cursor.md",
+			(c) => c.includes(TPL_CONTENT),
+			WAIT_OPTS,
+		);
+		expect(content).toContain("EXISTING_CONTENT");
+	});
+
+	it("A06: top with frontmatter - merges template properties, existing values win", async () => {
+		await seedFile(
+			"a06-fm.md",
+			"---\nstatus: done\n---\nEXISTING_CONTENT",
+		);
+
+		const result = await applyTemplate(
+			sandbox.path("a06-fm.md"),
+			sandbox.path("tpl-fm.md"),
+			"top",
+		);
+
+		expect(result.ok).toBe(true);
+		const content = await sandbox.waitForContent(
+			"a06-fm.md",
+			(c) => c.includes("TPL_BODY"),
+			WAIT_OPTS,
+		);
+
+		// Body lands below the note frontmatter, above existing content.
+		expectOrderedSubstrings(content, "TPL_BODY", "EXISTING_CONTENT");
+		// Existing property wins; missing property is filled from template.
+		expect(content).toContain("status: done");
+		expect(content).not.toContain("status: draft");
+		expect(content).toContain("priority: high");
+		// No duplicate frontmatter blocks.
+		expect(content.match(/^---$/gm)?.length).toBe(2);
+	});
+
+	it("A07: invalid mode - rejects with a helpful error", async () => {
+		await seedFile("a07-invalid.md", "EXISTING_CONTENT");
+
+		const result = await applyTemplate(
+			sandbox.path("a07-invalid.md"),
+			sandbox.path("tpl-plain.md"),
+			"sideways",
+		);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/Invalid mode/);
+	});
+});

--- a/tests/e2e/apply-template-to-active-note.test.ts
+++ b/tests/e2e/apply-template-to-active-note.test.ts
@@ -263,11 +263,25 @@ describe("apply template to active note (API seam)", () => {
 		expect(content.match(/^---$/gm)?.length).toBe(2);
 	});
 
-	it("A07: invalid mode - rejects with a helpful error", async () => {
-		await seedFile("a07-invalid.md", "EXISTING_CONTENT");
+	it("A07: canvas template - rejects with a helpful error", async () => {
+		await seedFile("tpl-board.canvas", '{"nodes":[],"edges":[]}');
+		await seedFile("a07-canvas-tpl.md", "EXISTING_CONTENT");
 
 		const result = await applyTemplate(
-			sandbox.path("a07-invalid.md"),
+			sandbox.path("a07-canvas-tpl.md"),
+			sandbox.path("tpl-board.canvas"),
+		);
+
+		expect(result.ok).toBe(false);
+		expect(result.error).toMatch(/only supports markdown templates/);
+		expect(await sandbox.read("a07-canvas-tpl.md")).toBe("EXISTING_CONTENT");
+	});
+
+	it("A08: invalid mode - rejects with a helpful error", async () => {
+		await seedFile("a08-invalid.md", "EXISTING_CONTENT");
+
+		const result = await applyTemplate(
+			sandbox.path("a08-invalid.md"),
 			sandbox.path("tpl-plain.md"),
 			"sideways",
 		);

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -666,6 +666,47 @@ export function parseYaml(yaml: string): Record<string, unknown> {
   return result;
 }
 
+export interface FrontMatterInfo {
+  exists: boolean;
+  frontmatter: string;
+  from: number;
+  to: number;
+  contentStart: number;
+}
+
+// Mirrors Obsidian's real implementation: the opening --- must be at offset 0
+// and the block closes with a --- line. `frontmatter` is the contents between
+// the fences (including the trailing newline).
+export function getFrontMatterInfo(content: string): FrontMatterInfo {
+  const none: FrontMatterInfo = {
+    exists: false,
+    frontmatter: "",
+    from: 0,
+    to: 0,
+    contentStart: 0,
+  };
+
+  const open = /^---(\r?\n)/.exec(content);
+  if (!open) return none;
+  const from = open[0].length;
+
+  const close = /---(\r?\n|$)/g;
+  close.lastIndex = from;
+  let match = close.exec(content);
+  while (match && content.charAt(match.index - 1) !== "\n") {
+    match = close.exec(content);
+  }
+  if (!match) return none;
+
+  return {
+    exists: true,
+    frontmatter: content.slice(from, match.index),
+    from,
+    to: match.index,
+    contentStart: close.lastIndex,
+  };
+}
+
 // Minimal normalizePath for tests: convert Windows separators to POSIX
 export function normalizePath(p: string): string {
   if (typeof p !== 'string') return '' as unknown as string;
@@ -802,6 +843,7 @@ export default {
   Notice,
   moment,
   parseYaml,
+  getFrontMatterInfo,
   normalizePath,
   debounce,
   setIcon,

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -622,6 +622,50 @@ export class Notice {
 
 export { moment };
 
+// Minimal parseYaml for tests: supports flat `key: value` pairs with scalar
+// values, inline arrays ([a, b]) and simple block lists. NOT a full YAML
+// parser — assert real YAML semantics in e2e tests against live Obsidian.
+export function parseYaml(yaml: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const lines = yaml.split(/\r?\n/);
+  let currentKey: string | null = null;
+
+  const parseScalar = (raw: string): unknown => {
+    const value = raw.trim();
+    if (value === "") return null;
+    if (value === "true") return true;
+    if (value === "false") return false;
+    if (value === "null" || value === "~") return null;
+    if (/^-?\d+(\.\d+)?$/.test(value)) return Number(value);
+    if (/^\[.*\]$/.test(value)) {
+      const inner = value.slice(1, -1).trim();
+      return inner === "" ? [] : inner.split(",").map((item) => parseScalar(item));
+    }
+    if (/^(['"]).*\1$/.test(value)) return value.slice(1, -1);
+    return value;
+  };
+
+  for (const line of lines) {
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+
+    const listMatch = /^\s+-\s*(.*)$/.exec(line);
+    if (listMatch && currentKey) {
+      if (!Array.isArray(result[currentKey])) result[currentKey] = [];
+      (result[currentKey] as unknown[]).push(parseScalar(listMatch[1]));
+      continue;
+    }
+
+    const kvMatch = /^([^:\s][^:]*):\s*(.*)$/.exec(line);
+    if (kvMatch) {
+      const key = kvMatch[1].trim();
+      currentKey = key;
+      result[key] = kvMatch[2].trim() === "" ? null : parseScalar(kvMatch[2]);
+    }
+  }
+
+  return result;
+}
+
 // Minimal normalizePath for tests: convert Windows separators to POSIX
 export function normalizePath(p: string): string {
   if (typeof p !== 'string') return '' as unknown as string;
@@ -757,6 +801,7 @@ export default {
   requestUrl,
   Notice,
   moment,
+  parseYaml,
   normalizePath,
   debounce,
   setIcon,


### PR DESCRIPTION
Adds a way to apply a template to a note that already exists — the "I created this note manually and forgot the template" recovery flow.

## What's new

- **Command**: `QuickAdd: Apply template to active note` (always registered, gated on an active markdown note), plus an **Apply QuickAdd template** entry in the file context menu.
- **Picker**: lists Template choices first (flattened from Multi choices), then raw template files from the configured templates folder, deduplicated against paths already covered by a choice.
- **Modes**: insert at cursor (only offered when the note is open in the active editor), insert at top, append to bottom, replace note content.
- **API**: `quickAddApi.applyTemplateToActiveFile(templatePath, { mode })` — non-interactive seam for macros/scripts and CLI verification. Defaults to `replace` for empty notes, `bottom` otherwise.

## Smart behaviors

- **Empty-note fast path**: empty/whitespace-only notes skip the mode picker and get the template applied as full content.
- **Title pre-fill**: `{{title}}` and the unnamed `{{VALUE}}`/`{{NAME}}` resolve to the note's basename instead of prompting; named `{{VALUE:x}}` variables still prompt.
- **Frontmatter merge** (top/bottom/cursor): template frontmatter properties merge into the note's existing frontmatter via `processFrontMatter` — existing note values win, no duplicate `---` blocks.
- **Move/rename reconciliation**: when a picked Template choice has folder/file-name-format settings that would have produced a different path, QuickAdd offers to move/rename the note to match (backlinks update). Skipped for raw template files, runtime folder pickers, and existing target paths.

## Implementation notes

- New `TemplateInsertEngine` extends `TemplateEngine`, reusing `overwriteFileWithTemplate` (replace) and the existing format pipeline; top/bottom/cursor split template frontmatter from the body before insertion.
- Trade-offs: frontmatter merge is shallow per-property; one-page preflight is not wired in (inline prompts fire during formatting); recency ranking in the picker was deliberately deferred.
- `tests/obsidian-stub.ts` gained a minimal `parseYaml`; real YAML semantics are covered by e2e against live Obsidian.

## Verification

- 1610 unit tests pass (30 new: picker building, frontmatter split/insert/merge, engine mode dispatch, reconcile path computation, fast-path/prefill logic).
- New e2e suite `tests/e2e/apply-template-to-active-note.test.ts` (7 tests) passes against the live dev vault: all four modes via the API seam, frontmatter merge with existing-wins, empty-note fast path, invalid-mode rejection.
- Live CLI check in the dev vault confirmed command registration, title/value prefill without prompting, and frontmatter merge; `dev:errors` clean.
- `bun run build-with-lint` passes.

Fixes #526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply templates directly into existing markdown notes (modes: replace, top, bottom, cursor)
  * Command and right-click file menu entry to apply a template to the active note
  * QuickAdd API method to apply a template programmatically (mode option)

* **Behavior**
  * Frontmatter-aware merging (existing values win), smart empty-note fast path, basename pre-fill for VALUE
  * Non-markdown/canvas templates are rejected; mode defaults applied based on note emptiness

* **Documentation**
  * User guide, API docs, and sidebar entry for “Apply Template to Note”

* **Tests**
  * Unit and end-to-end tests covering modes, frontmatter, path resolution, and API behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->