### PR TITLE
feat: search nested choices in the choice picker

### DIFF
--- a/docs/docs/Choices/MultiChoice.md
+++ b/docs/docs/Choices/MultiChoice.md
@@ -13,3 +13,18 @@ Make sure the multi is unfolded (as it is in the screenshot). Click the drag han
 ## Placeholder text
 
 You can optionally set a placeholder for each Multi choice. This text shows up in the choice picker search box when you open the multi, which is handy for complex menus or grouped workflows. Leave it empty to use the multi name as the placeholder.
+
+Keep in mind that [searching covers everything nested under the multi](#searching-nested-choices), so word the placeholder accordingly.
+
+## Searching nested choices
+
+Typing in the choice picker searches every choice nested inside the current level's multis — not just the level you are looking at. Nested matches show their folder path (for example `Work / Meetings`) beneath the choice name. This also applies to the root picker opened by the **QuickAdd: Run** command or the ribbon icon.
+
+A few details:
+
+- Browsing is unchanged: with an empty search box, you still see one level at a time.
+- Your search also matches against the folder path, so `work meeting` finds `New meeting` inside `Work / Meetings`.
+- Selecting a nested multi from search results opens it. Its **← Back** entry returns to the level you searched from, skipping intermediate levels.
+- Searching from inside a multi only covers that multi's sub-choices. Go back (or open the root picker) to search more broadly.
+
+If you prefer search to only cover the level you have open, disable **Settings → QuickAdd → Search nested choices**.

--- a/src/gui/PackageManager/ExportPackageModal.svelte
+++ b/src/gui/PackageManager/ExportPackageModal.svelte
@@ -10,6 +10,10 @@
 		collectFileDependencies,
 	} from "../../utils/packageTraversal";
 	import {
+		flattenChoicesWithPath,
+		type FlatChoicePathEntry,
+	} from "../../utils/choiceUtils";
+	import {
 		buildPackage,
 		generateDefaultPackagePath,
 		writePackageToVault,
@@ -29,13 +33,7 @@
 		close: () => void;
 	} = $props();
 
-	interface FlatChoice {
-		choice: IChoice;
-		id: string;
-		path: string[];
-		depth: number;
-		parentId: string | null;
-	}
+	type FlatChoice = FlatChoicePathEntry;
 
 	interface Summary {
 		rootCount: number;
@@ -76,36 +74,6 @@
 			flatChoices.map((entry) => [entry.id, entry.path.join(" / ")]),
 		),
 	);
-
-	function flattenChoicesWithPath(
-		choices: IChoice[],
-		parentPath: string[] = [],
-		depth = 0,
-		parentId: string | null = null,
-	): FlatChoice[] {
-		const result: FlatChoice[] = [];
-		for (const choice of choices) {
-			const path = [...parentPath, choice.name];
-			result.push({
-				choice,
-				id: choice.id,
-				path,
-				depth,
-				parentId,
-			});
-			if (isMultiChoice(choice)) {
-				result.push(
-					...flattenChoicesWithPath(
-						(choice as IMultiChoice).choices ?? [],
-						path,
-						depth + 1,
-						choice.id,
-					),
-				);
-			}
-		}
-		return result;
-	}
 
 	function isMultiChoice(choice: IChoice): choice is IMultiChoice {
 		return choice.type === "Multi";

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -1,0 +1,421 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import type IMultiChoice from "../../types/choices/IMultiChoice";
+import type { IChoiceExecutor } from "../../IChoiceExecutor";
+import { MultiChoice } from "../../types/choices/MultiChoice";
+import { settingsStore } from "../../settingsStore";
+import ChoiceSuggester, {
+	BACK_CHOICE_ID,
+	stripInlineMarkdown,
+} from "./choiceSuggester";
+
+let idCounter = 0;
+function choice(name: string): IChoice {
+	return {
+		name,
+		id: `choice-${idCounter++}`,
+		type: "Template",
+		command: false,
+	};
+}
+
+function multi(name: string, children: IChoice[]): IMultiChoice {
+	return {
+		name,
+		id: `multi-${idCounter++}`,
+		type: "Multi",
+		command: false,
+		choices: children,
+		collapsed: false,
+	};
+}
+
+function makeBack(wrapping: IChoice[]): IMultiChoice {
+	const back = new MultiChoice("← Back").addChoices(wrapping);
+	back.id = BACK_CHOICE_ID;
+	return back;
+}
+
+describe("ChoiceSuggester", () => {
+	let app: App;
+	let plugin: QuickAdd;
+	let executor: IChoiceExecutor;
+	let executed: IChoice[];
+
+	// Fixture tree:
+	//   Top note
+	//   Work (Multi)
+	//     Meetings (Multi)
+	//       New meeting
+	//     Work log
+	//   Footnotes
+	let topNote: IChoice;
+	let newMeeting: IChoice;
+	let workLog: IChoice;
+	let meetings: IMultiChoice;
+	let work: IMultiChoice;
+	let footnotes: IChoice;
+	let rootChoices: IChoice[];
+
+	beforeAll(() => {
+		// Obsidian's DOM extensions, used by renderSuggestion, are absent in jsdom.
+		const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+		proto.empty ??= function (this: HTMLElement) {
+			this.replaceChildren();
+		};
+		proto.createDiv ??= function (
+			this: HTMLElement,
+			opts?: string | { cls?: string; text?: string }
+		) {
+			const div = document.createElement("div");
+			if (typeof opts === "string") div.className = opts;
+			else if (opts?.cls) div.className = opts.cls;
+			if (typeof opts === "object" && opts?.text) div.textContent = opts.text;
+			this.appendChild(div);
+			return div;
+		};
+	});
+
+	beforeEach(() => {
+		app = new App();
+		plugin = { app } as unknown as QuickAdd;
+		executed = [];
+		executor = {
+			execute: (c: IChoice) => {
+				executed.push(c);
+				return Promise.resolve();
+			},
+			variables: new Map(),
+		} as unknown as IChoiceExecutor;
+
+		topNote = choice("Top note");
+		newMeeting = choice("New meeting");
+		workLog = choice("Work log");
+		meetings = multi("Meetings", [newMeeting]);
+		work = multi("Work", [meetings, workLog]);
+		footnotes = choice("Footnotes");
+		rootChoices = [topNote, work, footnotes];
+
+		settingsStore.setState({ searchNestedChoices: true });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function makeSuggester(choices: IChoice[]): ChoiceSuggester {
+		return new ChoiceSuggester(plugin, choices, { choiceExecutor: executor });
+	}
+
+	describe("getSuggestions", () => {
+		it("shows only the current level for an empty query", () => {
+			const suggester = makeSuggester(rootChoices);
+
+			const items = suggester.getSuggestions("").map((s) => s.item);
+
+			expect(items).toEqual(rootChoices);
+		});
+
+		it("treats a whitespace-only query as empty", () => {
+			const suggester = makeSuggester(rootChoices);
+
+			const items = suggester.getSuggestions("   ").map((s) => s.item);
+
+			expect(items).toEqual(rootChoices);
+		});
+
+		it("searches only the current level when the setting is disabled", () => {
+			settingsStore.setState({ searchNestedChoices: false });
+			const suggester = makeSuggester(rootChoices);
+
+			const items = suggester.getSuggestions("meeting").map((s) => s.item);
+
+			expect(items).not.toContain(newMeeting);
+			expect(items).not.toContain(meetings);
+			// Positive control: the level-scoped fallback still matches.
+			expect(suggester.getSuggestions("work").map((s) => s.item)).toEqual([
+				work,
+			]);
+		});
+
+		it("surfaces nested choices by identity when the setting is enabled", () => {
+			const suggester = makeSuggester(rootChoices);
+
+			const items = suggester.getSuggestions("meeting").map((s) => s.item);
+
+			expect(items).toContain(newMeeting);
+			expect(items).toContain(meetings);
+		});
+
+		it("matches against the full breadcrumb path text", () => {
+			const suggester = makeSuggester(rootChoices);
+
+			const items = suggester
+				.getSuggestions("work / mee")
+				.map((s) => s.item);
+
+			expect(items).toContain(meetings);
+			expect(items).toContain(newMeeting);
+			expect(items).not.toContain(workLog);
+		});
+
+		it("penalizes matches confined to the breadcrumb prefix", () => {
+			const suggester = makeSuggester(rootChoices);
+
+			const results = suggester.getSuggestions("work");
+			const scoreOf = (c: IChoice) =>
+				results.find((s) => s.item === c)?.match.score;
+
+			// The stub scores every match 0, so any delta is the penalty.
+			expect(scoreOf(work)).toBe(0);
+			expect(scoreOf(meetings)).toBeLessThan(0);
+			expect(scoreOf(newMeeting)).toBeLessThan(0);
+		});
+
+		it("does not penalize matches that touch the choice's own name", () => {
+			const suggester = makeSuggester(rootChoices);
+
+			const results = suggester.getSuggestions("meetings");
+			const scoreOf = (c: IChoice) =>
+				results.find((s) => s.item === c)?.match.score;
+
+			// "Meetings" matches its own name segment of "Work / Meetings".
+			expect(scoreOf(meetings)).toBe(0);
+			// "...New meeting"'s match falls entirely within "Work / Meetings /".
+			expect(scoreOf(newMeeting)).toBeLessThan(0);
+		});
+
+		it("ranks name matches above breadcrumb-only descendant matches", () => {
+			// "Networking" flattens AFTER Work's subtree; without the penalty,
+			// stable sorting by flatten order would bury it below them.
+			const networking = choice("Networking");
+			const suggester = makeSuggester([...rootChoices, networking]);
+
+			const items = suggester.getSuggestions("work").map((s) => s.item);
+
+			expect(items[0]).toBe(work);
+			expect(items.indexOf(networking)).toBeLessThan(
+				items.indexOf(meetings)
+			);
+			expect(items).toEqual(
+				expect.arrayContaining([meetings, newMeeting, workLog])
+			);
+		});
+
+		it("never traverses into the back item or returns it for typed queries", () => {
+			const drilledLevel = [...work.choices, makeBack(rootChoices)];
+			const suggester = makeSuggester(drilledLevel);
+
+			expect(
+				suggester.getSuggestions("top").map((s) => s.item)
+			).not.toContain(topNote);
+			expect(
+				suggester.getSuggestions("back").map((s) => s.item.id)
+			).not.toContain(BACK_CHOICE_ID);
+		});
+
+		it("keeps the back item in the empty-query view", () => {
+			const drilledLevel = [...work.choices, makeBack(rootChoices)];
+			const suggester = makeSuggester(drilledLevel);
+
+			const ids = suggester.getSuggestions("").map((s) => s.item.id);
+
+			expect(ids).toContain(BACK_CHOICE_ID);
+		});
+
+		it("excludes ancestor back items after navigating back from depth 2", () => {
+			// Drill root -> Work -> Meetings, then press Back: the restored level
+			// is back_meetings.choices, which still contains back_work. The
+			// sentinel id must catch that ancestor back item statelessly.
+			const workLevel = [...work.choices, makeBack(rootChoices)];
+			const meetingsLevel = [...meetings.choices, makeBack(workLevel)];
+			const backToWork = meetingsLevel[meetingsLevel.length - 1] as IMultiChoice;
+
+			const restored = makeSuggester([...backToWork.choices]);
+			const items = restored.getSuggestions("o").map((s) => s.item);
+
+			expect(items).toContain(workLog);
+			expect(items).not.toContain(topNote);
+			expect(items).not.toContain(footnotes);
+			expect(items.map((i) => i.id)).not.toContain(BACK_CHOICE_ID);
+		});
+	});
+
+	describe("onChooseItem", () => {
+		it("executes nested leaves through the injected executor", () => {
+			const suggester = makeSuggester(rootChoices);
+
+			suggester.onChooseItem(newMeeting, new MouseEvent("click"));
+
+			expect(executed).toEqual([newMeeting]);
+		});
+
+		it("appends a sentinel back item when drilling into a Multi", () => {
+			const openSpy = vi
+				.spyOn(ChoiceSuggester, "Open")
+				.mockImplementation(() => {});
+			const suggester = makeSuggester(rootChoices);
+
+			suggester.onChooseItem(work, new MouseEvent("click"));
+
+			const [, passedChoices, options] = openSpy.mock.calls[0] as unknown as [
+				QuickAdd,
+				IChoice[],
+				{
+					choiceExecutor?: IChoiceExecutor;
+					placeholder?: string;
+					placeholderStack?: Array<string | undefined>;
+				},
+			];
+			const back = passedChoices.find((c) => c.id === BACK_CHOICE_ID);
+			expect(back).toBeDefined();
+			expect((back as IMultiChoice).choices).toEqual(rootChoices);
+			expect(passedChoices.slice(0, -1)).toEqual(work.choices);
+			// The same executor is threaded through, so variables survive
+			// drill-down, and the placeholder stack records the origin level.
+			expect(options.choiceExecutor).toBe(executor);
+			expect(options.placeholder).toBe("Work");
+			expect(options.placeholderStack).toEqual([undefined]);
+		});
+
+		it("navigates back without appending another back item", () => {
+			const openSpy = vi
+				.spyOn(ChoiceSuggester, "Open")
+				.mockImplementation(() => {});
+			const drilledLevel = [...work.choices, makeBack(rootChoices)];
+			const suggester = makeSuggester(drilledLevel);
+
+			suggester.onChooseItem(
+				drilledLevel[drilledLevel.length - 1],
+				new MouseEvent("click")
+			);
+
+			const [, passedChoices] = openSpy.mock.calls[0] as unknown as [
+				QuickAdd,
+				IChoice[],
+			];
+			expect(passedChoices).toEqual(rootChoices);
+		});
+
+		it("treats a user Multi literally named '← Back' as a normal Multi", () => {
+			const openSpy = vi
+				.spyOn(ChoiceSuggester, "Open")
+				.mockImplementation(() => {});
+			const impostor = multi("← Back", [choice("Inside impostor")]);
+			const suggester = makeSuggester([impostor]);
+
+			suggester.onChooseItem(impostor, new MouseEvent("click"));
+
+			const [, passedChoices] = openSpy.mock.calls[0] as unknown as [
+				QuickAdd,
+				IChoice[],
+			];
+			// A real back item is appended, so the user is not stranded.
+			expect(passedChoices.some((c) => c.id === BACK_CHOICE_ID)).toBe(true);
+		});
+	});
+
+	describe("renderSuggestion", () => {
+		async function render(
+			suggester: ChoiceSuggester,
+			item: IChoice
+		): Promise<HTMLElement> {
+			const el = document.createElement("div");
+			suggester.renderSuggestion(
+				{ item, match: { score: 0, matches: [] } },
+				el
+			);
+			await Promise.resolve();
+			return el;
+		}
+
+		it("renders breadcrumbs that disambiguate duplicate names", async () => {
+			const taskA = choice("New task");
+			const taskB = choice("New task");
+			const clientA = multi("Client A", [taskA]);
+			const clientB = multi("Client B", [taskB]);
+			const suggester = makeSuggester([clientA, clientB]);
+			suggester.getSuggestions("new task");
+
+			const elA = await render(suggester, taskA);
+			const elB = await render(suggester, taskB);
+
+			expect(elA.querySelector(".suggestion-note")?.textContent).toBe(
+				"Client A"
+			);
+			expect(elB.querySelector(".suggestion-note")?.textContent).toBe(
+				"Client B"
+			);
+			expect(elA.querySelector(".suggestion-title")?.textContent).toBe(
+				"New task"
+			);
+			expect(elA.classList.contains("mod-complex")).toBe(true);
+		});
+
+		it("strips inline markdown from breadcrumb segments", async () => {
+			const inner = choice("Inner");
+			const styled = multi("**Bold** folder", [inner]);
+			const suggester = makeSuggester([styled]);
+			suggester.getSuggestions("inner");
+
+			const el = await render(suggester, inner);
+
+			expect(el.querySelector(".suggestion-note")?.textContent).toBe(
+				"Bold folder"
+			);
+		});
+
+		it("renders current-level items without breadcrumbs", async () => {
+			const suggester = makeSuggester(rootChoices);
+			suggester.getSuggestions("top");
+
+			const el = await render(suggester, topNote);
+
+			expect(el.querySelector(".suggestion-note")).toBeNull();
+			expect(el.textContent).toBe("Top note");
+		});
+
+		it("styles the sentinel back item but not a Multi named '← Back'", async () => {
+			const impostor = multi("← Back", []);
+			const back = makeBack(rootChoices);
+			const suggester = makeSuggester([impostor, back]);
+			suggester.getSuggestions("anything");
+
+			const backEl = await render(suggester, back);
+			const impostorEl = await render(suggester, impostor);
+
+			expect(
+				backEl.classList.contains("quickadd-choice-suggestion-back")
+			).toBe(true);
+			expect(backEl.querySelector(".suggestion-note")).toBeNull();
+			expect(
+				impostorEl.classList.contains("quickadd-choice-suggestion-back")
+			).toBe(false);
+		});
+	});
+});
+
+describe("stripInlineMarkdown", () => {
+	it.each([
+		["**bold**", "bold"],
+		["__bold__", "bold"],
+		["*italic*", "italic"],
+		["my_file_name", "my_file_name"],
+		["`code`", "code"],
+		["~~gone~~", "gone"],
+		["[label](https://example.com)", "label"],
+		["[[Note]]", "Note"],
+		["[[Note|alias]]", "alias"],
+		["plain name", "plain name"],
+		["**Work** / not nested", "Work / not nested"],
+	])("reduces %s to %s", (input, expected) => {
+		expect(stripInlineMarkdown(input)).toBe(expected);
+	});
+});

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -1,5 +1,9 @@
 import type { FuzzyMatch } from "obsidian";
-import { FuzzySuggestModal, MarkdownRenderer } from "obsidian";
+import {
+	FuzzySuggestModal,
+	MarkdownRenderer,
+	prepareFuzzySearch,
+} from "obsidian";
 import type IChoice from "../../types/choices/IChoice";
 import { ChoiceExecutor } from "../../choiceExecutor";
 import { MultiChoice } from "../../types/choices/MultiChoice";
@@ -7,8 +11,54 @@ import type IMultiChoice from "../../types/choices/IMultiChoice";
 import type QuickAdd from "../../main";
 import type { IChoiceExecutor } from "../../IChoiceExecutor";
 import { log } from "../../logger/logManager";
+import { settingsStore } from "../../settingsStore";
+import { flattenChoicesWithPath } from "../../utils/choiceUtils";
 
 const backLabel = "← Back";
+
+/**
+ * Sentinel id for the synthetic back item. Back items are created fresh per
+ * level and never persisted, so a constant non-uuid id cannot collide with a
+ * real choice — and unlike name matching, it cannot be spoofed by a user
+ * choice literally named "← Back". Detection must be stateless: pressing Back
+ * restores a level that contains an ancestor's back item, whose identity no
+ * other modal could have threaded along.
+ */
+export const BACK_CHOICE_ID = "quickadd:back";
+
+/**
+ * Applied to matches that fall entirely within the breadcrumb prefix, so a
+ * query hitting a folder's name ranks the folder itself and genuine name
+ * matches above the folder's entire subtree. Sized to outweigh same-name
+ * fuzzy penalties (worst ~0.3) while staying above fragmented-match scores
+ * (at most -1).
+ */
+const BREADCRUMB_ONLY_PENALTY = 0.5;
+
+/**
+ * Reduces basic inline markdown (emphasis, code, links) to its display text,
+ * so breadcrumbs show ancestor names the way their own rows render them.
+ */
+export function stripInlineMarkdown(text: string): string {
+	return text
+		.replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, "$2")
+		.replace(/\[\[([^\]]+)\]\]/g, "$1")
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+		.replace(/(\*\*|__)(.+?)\1/g, "$2")
+		// Single underscores are left alone: intraword `_` is not emphasis in
+		// CommonMark, and names like my_file_name must survive intact.
+		.replace(/\*(.+?)\*/g, "$1")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/~~(.+?)~~/g, "$1");
+}
+
+type NestedSearchCandidate = {
+	choice: IChoice;
+	/** Raw text the fuzzy search runs against: "Parent / Sub / Choice name". */
+	text: string;
+	/** Offset where the choice's own name starts within `text`. */
+	nameOffset: number;
+};
 
 type ChoiceSuggesterOptions = {
 	choiceExecutor?: IChoiceExecutor;
@@ -19,6 +69,11 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 	private choiceExecutor: IChoiceExecutor;
 	private placeholderStack: Array<string | undefined> = [];
 	private currentPlaceholder?: string;
+	private nestedSearchCandidates?: NestedSearchCandidate[];
+	// Populated by getNestedSearchCandidates(); nested items can only reach
+	// renderSuggestion through the nested-search branch of getSuggestions,
+	// which builds the candidate cache (and thus this map) first.
+	private breadcrumbById = new Map<string, string>();
 
 	public static Open(
 		plugin: QuickAdd,
@@ -36,22 +91,84 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		super(plugin.app);
 		// Initialize here (not as a field initializer) so the `plugin` parameter
 		// property is already assigned; a field initializer runs before it.
-		this.choiceExecutor = new ChoiceExecutor(this.app, this.plugin);
-		if (options?.choiceExecutor) this.choiceExecutor = options.choiceExecutor;
+		this.choiceExecutor =
+			options?.choiceExecutor ?? new ChoiceExecutor(this.app, this.plugin);
 		this.placeholderStack = options?.placeholderStack ?? [];
 		this.currentPlaceholder = options?.placeholder?.trim() || undefined;
 		if (this.currentPlaceholder) this.setPlaceholder(this.currentPlaceholder);
 	}
 
+	getSuggestions(query: string): FuzzyMatch<IChoice>[] {
+		const trimmed = query.trim();
+		if (!trimmed || !settingsStore.getState().searchNestedChoices) {
+			return super.getSuggestions(trimmed);
+		}
+
+		const fuzzy = prepareFuzzySearch(trimmed);
+		const results: FuzzyMatch<IChoice>[] = [];
+		for (const candidate of this.getNestedSearchCandidates()) {
+			const match = fuzzy(candidate.text);
+			if (!match) continue;
+			if (
+				candidate.nameOffset > 0 &&
+				match.matches.length > 0 &&
+				match.matches.every(([, end]) => end <= candidate.nameOffset)
+			) {
+				match.score -= BREADCRUMB_ONLY_PENALTY;
+			}
+			results.push({ item: candidate.choice, match });
+		}
+		results.sort((a, b) => b.match.score - a.match.score);
+		return results;
+	}
+
+	private getNestedSearchCandidates(): NestedSearchCandidate[] {
+		if (!this.nestedSearchCandidates) {
+			// The back item wraps the entire previous level; flattening through
+			// it would leak every ancestor into the results. It is dropped as a
+			// candidate altogether — it is navigation, not content.
+			const searchable = this.choices.filter(
+				(choice) => choice.id !== BACK_CHOICE_ID
+			);
+			this.nestedSearchCandidates = flattenChoicesWithPath(searchable).map(
+				({ choice, path }) => {
+					const breadcrumb = path.slice(0, -1);
+					if (breadcrumb.length > 0) {
+						this.breadcrumbById.set(
+							choice.id,
+							breadcrumb.map(stripInlineMarkdown).join(" / ")
+						);
+					}
+					const text = path.join(" / ");
+					return {
+						choice,
+						text,
+						nameOffset: text.length - choice.name.length,
+					};
+				}
+			);
+		}
+		return this.nestedSearchCandidates;
+	}
+
 	renderSuggestion(item: FuzzyMatch<IChoice>, el: HTMLElement): void {
 		el.empty();
-		void MarkdownRenderer.render(this.app, item.item.name, el, "", this.plugin)
+		el.classList.remove("mod-complex");
+		const breadcrumb = this.breadcrumbById.get(item.item.id);
+		let nameEl: HTMLElement = el;
+		if (breadcrumb) {
+			el.classList.add("mod-complex");
+			const content = el.createDiv({ cls: "suggestion-content" });
+			nameEl = content.createDiv({ cls: "suggestion-title" });
+			content.createDiv({ cls: "suggestion-note", text: breadcrumb });
+		}
+		void MarkdownRenderer.render(this.app, item.item.name, nameEl, "", this.plugin)
 			.catch((error) => {
-				el.textContent = item.item.name;
+				nameEl.textContent = item.item.name;
 				log.logError(`Failed to render choice suggestion: ${error}`);
 			});
 		el.classList.add("quickadd-choice-suggestion");
-		if (item.item.name === backLabel)
+		if (item.item.id === BACK_CHOICE_ID)
 			el.classList.add("quickadd-choice-suggestion-back");
 	}
 
@@ -78,10 +195,12 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 
 	private onChooseMultiType(multi: IMultiChoice) {
 		const choices = [...multi.choices];
-		const isBack = multi.name === backLabel;
+		const isBack = multi.id === BACK_CHOICE_ID;
 
 		if (!isBack) {
-			choices.push(new MultiChoice(backLabel).addChoices(this.choices));
+			const back = new MultiChoice(backLabel).addChoices(this.choices);
+			back.id = BACK_CHOICE_ID;
+			choices.push(back);
 		}
 
 		const nextPlaceholder = isBack

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -130,6 +130,11 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			heading: "Choices & Packages",
 			items: [
 				{
+					name: "Search nested choices",
+					desc: "When searching in the choice picker, also match choices nested inside Multi choices and show their path. Note that nested matches can outrank same-level ones. Disable to search only the open level.",
+					control: { type: "toggle", key: "searchNestedChoices" },
+				},
+				{
 					name: "Choices",
 					render: (setting) => this.renderChoicesView(setting),
 				},

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,11 @@ export interface QuickAddSettings {
 		* When enabled, Capture uses the current editor selection as the default {{VALUE}}.
 		*/
 	useSelectionAsCaptureValue: boolean;
+	/**
+		* When enabled, typing in the choice picker also searches choices nested
+		* inside Multi choices and shows matches with their folder path.
+		*/
+	searchNestedChoices: boolean;
 	devMode: boolean;
 	templateFolderPath: string;
 	announceUpdates: "all" | "major" | "none";
@@ -60,6 +65,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	inputPrompt: "single-line",
 	persistInputPromptDrafts: true,
 	useSelectionAsCaptureValue: true,
+	searchNestedChoices: true,
 	devMode: false,
 	templateFolderPath: "",
 	announceUpdates: "major",

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type IChoice from "src/types/choices/IChoice";
+import type IMultiChoice from "src/types/choices/IMultiChoice";
+import { flattenChoices, flattenChoicesWithPath } from "./choiceUtils";
+
+let idCounter = 0;
+function choice(name: string): IChoice {
+	return {
+		name,
+		id: `choice-${idCounter++}`,
+		type: "Template",
+		command: false,
+	};
+}
+
+function multi(name: string, children: IChoice[]): IMultiChoice {
+	return {
+		name,
+		id: `multi-${idCounter++}`,
+		type: "Multi",
+		command: false,
+		choices: children,
+		collapsed: false,
+	};
+}
+
+describe("flattenChoicesWithPath", () => {
+	const newMeeting = choice("New meeting");
+	const workLog = choice("Work log");
+	const meetings = multi("Meetings", [newMeeting]);
+	const work = multi("Work", [meetings, workLog]);
+	const topNote = choice("Top note");
+	const tree = [topNote, work];
+
+	it("walks the tree in pre-order", () => {
+		const flat = flattenChoicesWithPath(tree);
+
+		expect(flat.map((entry) => entry.choice)).toEqual([
+			topNote,
+			work,
+			meetings,
+			newMeeting,
+			workLog,
+		]);
+		expect(flat.map((entry) => entry.choice)).toEqual(flattenChoices(tree));
+	});
+
+	it("includes the choice's own name in its path", () => {
+		const flat = flattenChoicesWithPath(tree);
+		const byId = new Map(flat.map((entry) => [entry.id, entry]));
+
+		expect(byId.get(topNote.id)?.path).toEqual(["Top note"]);
+		expect(byId.get(meetings.id)?.path).toEqual(["Work", "Meetings"]);
+		expect(byId.get(newMeeting.id)?.path).toEqual([
+			"Work",
+			"Meetings",
+			"New meeting",
+		]);
+	});
+
+	it("tracks depth and parent id", () => {
+		const flat = flattenChoicesWithPath(tree);
+		const byId = new Map(flat.map((entry) => [entry.id, entry]));
+
+		expect(byId.get(topNote.id)).toMatchObject({ depth: 0, parentId: null });
+		expect(byId.get(newMeeting.id)).toMatchObject({
+			depth: 2,
+			parentId: meetings.id,
+		});
+		expect(byId.get(workLog.id)).toMatchObject({
+			depth: 1,
+			parentId: work.id,
+		});
+	});
+
+	it("handles a Multi with missing children array", () => {
+		const broken = multi("Broken", undefined as unknown as IChoice[]);
+
+		expect(flattenChoicesWithPath([broken])).toHaveLength(1);
+	});
+});

--- a/src/utils/choiceUtils.ts
+++ b/src/utils/choiceUtils.ts
@@ -21,3 +21,40 @@ export function flattenChoices(choices: IChoice[]): IChoice[] {
 	choices.forEach(walk);
 	return result;
 }
+
+export interface FlatChoicePathEntry {
+	choice: IChoice;
+	id: string;
+	/** Name path from the root to this choice, including the choice's own name. */
+	path: string[];
+	depth: number;
+	parentId: string | null;
+}
+
+/**
+ * Recursively flattens the choice hierarchy in pre-order, tracking each
+ * choice's name path through its ancestor Multi choices.
+ */
+export function flattenChoicesWithPath(
+	choices: IChoice[],
+	parentPath: string[] = [],
+	depth = 0,
+	parentId: string | null = null,
+): FlatChoicePathEntry[] {
+	const result: FlatChoicePathEntry[] = [];
+	for (const choice of choices) {
+		const path = [...parentPath, choice.name];
+		result.push({ choice, id: choice.id, path, depth, parentId });
+		if (isMultiChoice(choice)) {
+			result.push(
+				...flattenChoicesWithPath(
+					choice.choices ?? [],
+					path,
+					depth + 1,
+					choice.id,
+				),
+			);
+		}
+	}
+	return result;
+}

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -802,14 +802,16 @@ export const Platform = {
 
 // Substring (NOT subsequence) matcher standing in for Obsidian's fuzzy search.
 // Returns a SearchResult-like object when q is a case-insensitive substring of
-// the text, else null — enough for filter tests. Do NOT assert true fuzzy
-// (subsequence) semantics against this stub.
+// the text, else null — enough for filter tests. The single match range covers
+// the first substring hit; scores are always 0. Do NOT assert true fuzzy
+// (subsequence) semantics or graded scores against this stub.
 export function prepareFuzzySearch(query: string) {
   const q = query.toLowerCase();
   return (text: string) => {
     if (q.length === 0) return { score: 0, matches: [] as Array<[number, number]> };
-    return text.toLowerCase().includes(q)
-      ? { score: 0, matches: [] as Array<[number, number]> }
+    const idx = text.toLowerCase().indexOf(q);
+    return idx >= 0
+      ? { score: 0, matches: [[idx, idx + q.length]] as Array<[number, number]> }
       : null;
   };
 }


### PR DESCRIPTION
Closes #1185

## Summary

Typing in the choice picker now fuzzy-searches the **entire subtree under the current level**, not just the open level. Nested matches show a muted `Parent / Sub` breadcrumb and match against their full path text, so queries like `work meeting` find `Work / Meetings / New meeting` from the root. Browsing with an empty query is unchanged — you still see one level at a time.

| Behavior | Detail |
|---|---|
| Empty query | Unchanged: current level in settings order, `← Back` last |
| Typed query | Recursive over the current subtree; breadcrumbed results, score-ranked |
| Scope | Root picker searches everything; inside a Multi, only its subtree |
| Back after a deep jump | Returns to the level you searched from (history-back) |
| Setting | `searchNestedChoices`, default **on**, under Choices & Packages |

## Implementation notes

- `ChoiceSuggester.getSuggestions(query)` override: empty/disabled delegates to the native `FuzzySuggestModal` path; otherwise a once-per-modal flatten + `prepareFuzzySearch` over `"Parent / Sub / Name"` text, sorted by score (`limit` is applied by `SuggestModal` after return).
- Matches confined to the breadcrumb prefix get a fixed down-rank, so a folder-name query lists the folder and genuine name matches above the folder's entire subtree.
- The synthetic back item now carries a **sentinel id** (`quickadd:back`) instead of name-based detection. Name detection had a real bug (a user Multi literally named `← Back` was treated as navigation — no back item appended, placeholder stack popped) and a threaded id cannot survive the Back-reopen path, which restores a level containing an *ancestor's* back item. The flatten skips the sentinel, so the back wrapper can never leak ancestor choices into results.
- Breadcrumbs use Obsidian-native `mod-complex`/`suggestion-content`/`suggestion-note` (full-width wrapping second line, themed for free). Ancestor names are stripped of basic inline markdown for display; single underscores are left intact (intraword `_` is not emphasis in CommonMark).
- `flattenChoicesWithPath` is consolidated into `choiceUtils.ts`; `ExportPackageModal.svelte`'s identical local copy migrated onto it (field-for-field same shape).
- Test stub: `prepareFuzzySearch` now returns first-substring-hit offsets (scores stay 0), making the penalty guard unit-testable.

## Release & migration impact

- **Minor release** (new feature, `feat:`).
- New setting defaults **on** with no migration (`DEFAULT_SETTINGS` shallow merge). Verified live: a `data.json` without the key picks up `true` on load.
- Behavior note for release notes: with the default on, a typed query can rank a nested word-start match above a current-level mid-word match, changing what <kbd>Enter</kbd> executes for existing muscle memory. Breadcrumbs make nested results visually distinct, and the setting restores level-scoped search.

## Verification

- `bun run test` — 1654 passing (30 new: suggester behavior incl. depth-2 back-reopen regression, penalty guard both directions, breadcrumb rendering, impostor `← Back`; flatten util). Penalty tests are mutation-verified: removing the penalty or breaking its guard fails the suite.
- `bun run build-with-lint` — clean.
- Live in the dev vault via `obsidian` CLI (seeded a depth-2 `QA1185` tree): nested find with correct breadcrumbs from root, folder-first ranking, drill-in placeholder + scoping (no root leak through the back wrapper), Back restore, toggle-off level-only search, default-merge of the new setting, `dev:errors` clean.

Ranking-quality assertions can't run in CI (the obsidian stub scores every match 0 by design) — ranking was verified manually in the dev vault as above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nested choice search to find choices within Multi containers, with breadcrumb path display for nested results
  * New "Search nested choices" setting to control this behavior (enabled by default)

* **Documentation**
  * Added documentation on nested choice search behavior including path matching, navigation scope, and customization options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->