### PR TITLE
fix: store one-page FIELD inputs under the runtime FIELD: variable key

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -93,6 +93,9 @@ export const NAME_VALUE_REGEX = new RegExp(
 );
 export const VARIABLE_REGEX = new RegExp(/{{VALUE:([^\n\r}]*)}}/i);
 export const FIELD_VAR_REGEX = new RegExp(/{{FIELD:([^\n\r}]*)}}/i);
+// Prefix used to namespace FIELD variable values in the variables map,
+// keeping them separate from plain VALUE variables with the same name.
+export const FIELD_VARIABLE_PREFIX = "FIELD:";
 export const FIELD_VAR_REGEX_WITH_FILTERS = new RegExp(
 	/{{FIELD:([^\n\r}]*)(\|[^\n\r}]*)?}}/i,
 );

--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -300,13 +300,15 @@ describe("Format Syntax documentation examples", () => {
 			displayOptions: ["Low", "Normal", "High"],
 		});
 		expect(
-			collector.requirements.get("status|default:Draft|default-always:true"),
+			collector.requirements.get(
+				"FIELD:status|default:Draft|default-always:true",
+			),
 		).toMatchObject({
 			type: "field-suggest",
 		});
 		expect(
 			collector.requirements.get(
-				"Id|inline:true|inline-code-blocks:ad-note",
+				"FIELD:Id|inline:true|inline-code-blocks:ad-note",
 			),
 		).toMatchObject({
 			type: "field-suggest",

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -13,6 +13,7 @@ import {
 	VARIABLE_REGEX,
 
 	FIELD_VAR_REGEX_WITH_FILTERS,
+	FIELD_VARIABLE_PREFIX,
 	SELECTED_REGEX,
 	CLIPBOARD_REGEX,
 	TIME_REGEX,
@@ -55,7 +56,6 @@ export abstract class Formatter {
 	protected variables: Map<string, unknown> = new Map<string, unknown>();
 	protected dateParser: IDateParser | undefined;
 	private linkToCurrentFileBehavior: LinkToCurrentFileBehavior = "required";
-	private static readonly FIELD_VARIABLE_PREFIX = "FIELD:";
 	protected valuePromptContext?: PromptContext;
 
 	// Tracks variables collected for YAML property post-processing
@@ -470,7 +470,7 @@ export abstract class Formatter {
 	}
 
 	private getFieldVariableKey(fieldSpecifier: string): string {
-		return `${Formatter.FIELD_VARIABLE_PREFIX}${fieldSpecifier}`;
+		return `${FIELD_VARIABLE_PREFIX}${fieldSpecifier}`;
 	}
 
 	protected abstract promptForMathValue(): Promise<string>;

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -170,8 +170,16 @@ vi.mock("src/gui/date-picker/datePicker", () => ({
 	createDatePicker: () => ({ setSelectedIso: vi.fn() }),
 }));
 
+const { fieldSuggestConstructorArgs } = vi.hoisted(() => ({
+	fieldSuggestConstructorArgs: [] as unknown[][],
+}));
+
 vi.mock("src/gui/suggesters/FieldValueInputSuggest", () => ({
-	FieldValueInputSuggest: class {},
+	FieldValueInputSuggest: class {
+		constructor(...args: unknown[]) {
+			fieldSuggestConstructorArgs.push(args);
+		}
+	},
 }));
 
 vi.mock("src/gui/suggesters/SuggesterInputSuggest", () => ({
@@ -346,6 +354,45 @@ describe("OnePageInputModal", () => {
 			await expect(modal.waitForClose).resolves.toEqual({
 				[id]: "option-a",
 			});
+		});
+	});
+
+	// Regression: issue #1184 — field-suggest requirements are keyed with the
+	// runtime "FIELD:" prefix; the modal must submit under that key while the
+	// vault suggester receives the bare field specifier.
+	describe("field-suggest (issue #1184)", () => {
+		it("submits under the FIELD: id and passes the bare specifier to the suggester", async () => {
+			fieldSuggestConstructorArgs.length = 0;
+			const requirements: FieldRequirement[] = [
+				{
+					id: "FIELD:People",
+					label: "People",
+					type: "field-suggest",
+				},
+			];
+
+			const modal = new OnePageInputModal({} as App, requirements, new Map());
+			const contentEl = (modal as any).contentEl as HTMLElement;
+			const fieldInput = contentEl.querySelector(
+				"input",
+			) as HTMLInputElement;
+			fieldInput.value = "Alice";
+			fieldInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+			const submitButton = Array.from(
+				contentEl.querySelectorAll(
+					"button",
+				) as NodeListOf<HTMLButtonElement>,
+			).find(
+				(button) => button.textContent === "Submit",
+			) as HTMLButtonElement;
+			submitButton.click();
+
+			await expect(modal.waitForClose).resolves.toEqual({
+				"FIELD:People": "Alice",
+			});
+			expect(fieldSuggestConstructorArgs).toHaveLength(1);
+			expect(fieldSuggestConstructorArgs[0][2]).toBe("People");
 		});
 	});
 });

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -7,6 +7,7 @@ import {
 	debounce,
 	type App,
 } from "obsidian";
+import { FIELD_VARIABLE_PREFIX } from "src/constants";
 import { createDatePicker } from "src/gui/date-picker/datePicker";
 import { FieldValueInputSuggest } from "src/gui/suggesters/FieldValueInputSuggest";
 import { SuggesterInputSuggest } from "src/gui/suggesters/SuggesterInputSuggest";
@@ -331,9 +332,14 @@ export class OnePageInputModal extends Modal {
 					.setPlaceholder(req.placeholder ?? "")
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
-				// Attach inline suggester powered by vault data & filters encoded in req.id
+				// Attach inline suggester powered by vault data & filters encoded in
+				// req.id. Collected FIELD requirements are keyed "FIELD:<specifier>";
+				// strip the prefix so the suggester parses the bare field specifier.
+				const fieldSpecifier = req.id.startsWith(FIELD_VARIABLE_PREFIX)
+					? req.id.slice(FIELD_VARIABLE_PREFIX.length)
+					: req.id;
 				try {
-					new FieldValueInputSuggest(this.app, input.inputEl, req.id);
+					new FieldValueInputSuggest(this.app, input.inputEl, fieldSpecifier);
 				} catch {
 					// Non-fatal; leave as plain input if suggester fails
 				}

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -218,4 +218,36 @@ Body`);
     const requirement = rc.requirements.get("title");
     expect(requirement?.type).toBe("textarea");
   });
+
+  // Regression: issue #1184 — FIELD requirements were registered under the
+  // bare field name ("People") while the runtime formatter looks up the
+  // prefixed key ("FIELD:People"), so one-page values were lost and the
+  // user was prompted a second time.
+  describe("FIELD requirements (issue #1184)", () => {
+    it("registers FIELD requirements under the runtime FIELD: key", async () => {
+      const app = makeApp();
+      const plugin = makePlugin();
+      const rc = new RequirementCollector(app, plugin);
+      await rc.scanString("People: {{FIELD:People}}");
+
+      expect(rc.requirements.get("FIELD:People")).toMatchObject({
+        id: "FIELD:People",
+        label: "People",
+        type: "field-suggest",
+      });
+      expect(rc.requirements.has("People")).toBe(false);
+    });
+
+    it("keeps filters in the FIELD requirement id so runtime lookup matches", async () => {
+      const app = makeApp();
+      const plugin = makePlugin();
+      const rc = new RequirementCollector(app, plugin);
+      await rc.scanString("{{FIELD:People|folder:Contacts}}");
+
+      expect(rc.requirements.get("FIELD:People|folder:Contacts")).toMatchObject({
+        id: "FIELD:People|folder:Contacts",
+        type: "field-suggest",
+      });
+    });
+  });
 });

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -1,5 +1,10 @@
 import type { App } from "obsidian";
-import { GLOBAL_VAR_REGEX, TEMPLATE_REGEX, VARIABLE_REGEX } from "src/constants";
+import {
+	FIELD_VARIABLE_PREFIX,
+	GLOBAL_VAR_REGEX,
+	TEMPLATE_REGEX,
+	VARIABLE_REGEX,
+} from "src/constants";
 import { Formatter, type PromptContext } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import type QuickAdd from "src/main";
@@ -283,10 +288,13 @@ export class RequirementCollector extends Formatter {
 	}
 
 	protected async suggestForField(variableName: string): Promise<string> {
-		// Store as a field-suggest requirement; actual suggestions are provided by UI
-		if (!this.requirements.has(variableName)) {
-			this.requirements.set(variableName, {
-				id: variableName,
+		// Key the requirement with the runtime "FIELD:" prefix so values entered
+		// in the one-page form land where replaceFieldVarInString looks them up
+		// (issue #1184). Actual suggestions are provided by the UI.
+		const key = `${FIELD_VARIABLE_PREFIX}${variableName}`;
+		if (!this.requirements.has(key)) {
+			this.requirements.set(key, {
+				id: key,
 				label: variableName,
 				type: "field-suggest",
 				source: "collected",


### PR DESCRIPTION
One-page input double-prompted for `{{FIELD:...}}` variables: the preflight `RequirementCollector` registered FIELD requirements under the bare field name (`People`), while the runtime formatter looks values up under the prefixed key (`FIELD:People`). The value submitted in the one-page form was therefore never found, and QuickAdd fell through to a second individual prompt.

Changes:

- `RequirementCollector.suggestForField` now keys FIELD requirements with the runtime `FIELD:` prefix (shared `FIELD_VARIABLE_PREFIX` constant extracted to `src/constants.ts`), so one-page values land where `replaceFieldVarInString` looks them up.
- `OnePageInputModal` strips the prefix before handing the specifier to `FieldValueInputSuggest`, keeping vault suggestions and filter parsing intact. Script-declared `field-suggest` inputs (unprefixed ids) are unaffected.
- Regression tests for the collector key, the modal submit key, and the suggester specifier; updated the docs-examples test that codified the old key.

Verified end-to-end in the dev vault via the Obsidian CLI: on `master`, submitting the one-page form for a template with `{{FIELD:People}}` opened a second "Enter value for People" prompt and never created the note; on this branch, the same flow completes with no second prompt, the note is created with `People: "Alice"`, inline vault suggestions still appear, and no runtime errors are captured.

Fixes #1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field variable handling to properly use the `FIELD:` prefix format, ensuring field-suggest requirements are correctly identified and resolved at runtime.

* **Tests**
  * Added regression tests for field variable prefix behavior in requirement collection and modal input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->