### PR TITLE
fix: keep non-breaking-space-only captures instead of dropping them as empty

### DIFF
--- a/src/formatters/captureChoiceFormatter-write-position.test.ts
+++ b/src/formatters/captureChoiceFormatter-write-position.test.ts
@@ -439,6 +439,70 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		expect(result).toBe("---\ntitle: Test\n---\nCAPTURE\n## Missing\nBody");
 	});
 
+	it("captures a non-breaking-space-only payload instead of dropping it as empty (issue #760)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"\u00A0",
+			createChoice({ captureToActiveFile: false, prepend: true }),
+			"Line A\nLine B",
+			createFile(),
+		);
+
+		expect(result).toBe("Line A\nLine B\n\u00A0");
+	});
+
+	it("returns a non-breaking-space-only payload from formatContentOnly (issue #760)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentOnly("\u00A0");
+
+		expect(result).toBe("\u00A0");
+	});
+
+	it("still treats ASCII-whitespace-only payloads as empty captures", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			" \t\n",
+			createChoice({ captureToActiveFile: false, prepend: true }),
+			"Line A\nLine B",
+			createFile(),
+		);
+
+		expect(result).toBe("Line A\nLine B");
+	});
+
 	it("keeps task captures separated when creating a missing insert-before target at top", async () => {
 		const formatter = new CaptureChoiceFormatter(
 			createMockApp(),

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -15,6 +15,17 @@ import { CompleteFormatter } from "./completeFormatter";
 import getEndOfSection from "./helpers/getEndOfSection";
 import { findYamlFrontMatterRange } from "../utils/yamlContext";
 
+/**
+	* Only ASCII whitespace counts as "nothing to capture". Unicode spaces such as
+	* the non-breaking space (U+00A0) are intentional content and must not be
+	* dropped, even though String.prototype.trim() strips them (issue #760).
+	*/
+const ASCII_WHITESPACE_ONLY_REGEX = /^[ \t\r\n\f\v]*$/;
+
+function isCaptureContentEmpty(content: string): boolean {
+	return ASCII_WHITESPACE_ONLY_REGEX.test(content);
+}
+
 export class CaptureChoiceFormatter extends CompleteFormatter {
 	private choice: ICaptureChoice;
 	private file: TFile | null = null;
@@ -119,7 +130,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			this.templaterProcessed = true;
 		}
 
-		const formattedContentIsEmpty = formatted.trim() === "";
+		const formattedContentIsEmpty = isCaptureContentEmpty(formatted);
 		if (formattedContentIsEmpty) return this.fileContent;
 
 		// Historical note: `prepend` is a legacy flag name that means
@@ -179,7 +190,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		// 2. formatContentWithFile() for all other cases
 		// This avoids double processing of templater commands
 
-		const formattedContentIsEmpty = formatted.trim() === "";
+		const formattedContentIsEmpty = isCaptureContentEmpty(formatted);
 		if (formattedContentIsEmpty) return this.fileContent;
 
 		return formatted;


### PR DESCRIPTION
## Summary
- A capture whose format is a single non-breaking space (U+00A0) inserted nothing, because the emptiness guards in `CaptureChoiceFormatter` used `String.prototype.trim()`, which strips NBSP as Unicode whitespace.
- The guards now treat only ASCII whitespace (space, tab, CR, LF, FF, VT) as an empty capture payload, so intentional Unicode spaces like NBSP are captured.

Fixes #760

## Verification
- Regression tests added in `captureChoiceFormatter-write-position.test.ts`: NBSP-only payloads survive both `formatContentWithFile` and `formatContentOnly`, while ASCII-whitespace-only payloads are still treated as empty (no behavior change).
- Verified live in the Obsidian dev vault via the `obsidian` CLI: an NBSP-only capture to the active file at cursor appends U+00A0 to the current line, and an NBSP-only capture to a fixed file appends it at the bottom. No runtime errors captured.
- `bun run test` (1660 passed), `bun run lint`, and `bun run build` all pass.

## Release impact
- Bug fix only; no settings or migration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the formatter was incorrectly dropping non-breaking space characters from capture payloads. Non-breaking spaces and other Unicode whitespace are now preserved as intentional content, while ASCII whitespace (spaces, tabs, newlines) continues to be treated as empty captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->