### PR TITLE
chore(settings): move nested search option

### DIFF
--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -221,8 +221,8 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 			items?: Array<{ name?: unknown; control?: { key?: string } }>;
 		}>;
 
-		// Non-dev build (vitest defines __IS_DEV_BUILD__ = false): 7 groups.
-		expect(groups).toHaveLength(7);
+		// Non-dev build (vitest defines __IS_DEV_BUILD__ = false): 8 groups.
+		expect(groups).toHaveLength(8);
 
 		const validKeys = new Set(Object.keys(DEFAULT_SETTINGS));
 		const controlKeys: string[] = [];
@@ -245,6 +245,7 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 
 		expect(controlKeys).toEqual(
 			expect.arrayContaining([
+				"searchNestedChoices",
 				"inputPrompt",
 				"persistInputPromptDrafts",
 				"useSelectionAsCaptureValue",
@@ -257,5 +258,22 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 				"enableRibbonIcon",
 			]),
 		);
+	});
+
+	it("keeps nested choice search in the choice picker section", () => {
+		const tab = makeTab();
+		const [choicesGroup, choicePickerGroup] = tab.getSettingDefinitions() as unknown as Array<{
+			heading?: string;
+			items?: Array<{ name?: unknown }>;
+		}>;
+
+		expect(choicesGroup.items?.map((item) => item.name)).toEqual([
+			"Choices",
+			"Packages",
+		]);
+		expect(choicePickerGroup.heading).toBe("Choice Picker");
+		expect(choicePickerGroup.items?.map((item) => item.name)).toEqual([
+			"Search nested choices",
+		]);
 	});
 });

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -89,6 +89,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	override getSettingDefinitions(): SettingDefinitionItem<SettingsKey>[] {
 		const groups: SettingDefinitionGroup<SettingsKey>[] = [
 			this.choicesAndPackagesGroup(),
+			this.choicePickerGroup(),
 			this.inputGroup(),
 			this.templatesGroup(),
 			this.notificationsGroup(),
@@ -130,11 +131,6 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			heading: "Choices & Packages",
 			items: [
 				{
-					name: "Search nested choices",
-					desc: "When searching in the choice picker, also match choices nested inside Multi choices and show their path. Note that nested matches can outrank same-level ones. Disable to search only the open level.",
-					control: { type: "toggle", key: "searchNestedChoices" },
-				},
-				{
 					name: "Choices",
 					render: (setting) => this.renderChoicesView(setting),
 				},
@@ -142,6 +138,20 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					name: "Packages",
 					desc: "Bundle or import QuickAdd automations as reusable packages.",
 					render: (setting) => this.renderPackages(setting),
+				},
+			],
+		};
+	}
+
+	private choicePickerGroup(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: "group",
+			heading: "Choice Picker",
+			items: [
+				{
+					name: "Search nested choices",
+					desc: "When searching in the choice picker, also match choices nested inside Multi choices and show their path. Note that nested matches can outrank same-level ones. Disable to search only the open level.",
+					control: { type: "toggle", key: "searchNestedChoices" },
 				},
 			],
 		};


### PR DESCRIPTION
Move the nested-choice search toggle out of the top of `Choices & Packages` and into a dedicated `Choice Picker` settings section.

The setting controls runtime picker behavior, so separating it from the choices editor keeps the main choices/package management section focused while still placing the toggle near related choice settings.

The settings tab regression test now asserts that `Choices & Packages` contains only the choices editor and package actions, and that `Search nested choices` lives under `Choice Picker`.

Verification:
- `bun run test -- src/quickAddSettingsTab.test.ts`
- `bun run build-with-lint`
- Installed the worktree bundle in the `dev` vault, reloaded QuickAdd, and verified the settings DOM order: `Choices & Packages` -> `Packages` -> `Choice Picker` -> `Search nested choices`
- Captured a dev-vault screenshot of the new placement
- Checked Obsidian dev errors; none captured

Release impact: settings layout only; no migration needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized settings by creating a new dedicated "Choice Picker" settings group. Moved the nested choice search toggle from the general choices area to this new group for clearer settings organization.

* **Tests**
  * Updated test expectations to reflect the restructured settings layout and validate the new "Choice Picker" section displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->