### PR TITLE
fix(update-modal): render release videos as an inline player

### DIFF
--- a/src/gui/UpdateModal/UpdateModal.test.ts
+++ b/src/gui/UpdateModal/UpdateModal.test.ts
@@ -72,6 +72,44 @@ describe("renderVideoAttachments", () => {
 		expect(result).not.toMatch(new RegExp(`^${VIDEO_URL}$`, "m"));
 	});
 
+	it("uses an adjacent poster comment and removes it from the output", () => {
+		const body = [
+			"🎬 **A 60-second tour of the highlights:**",
+			"",
+			VIDEO_URL,
+			`<!-- poster: ${THUMB_URL} -->`,
+			"",
+			"## Next section",
+		].join("\n");
+
+		const result = renderVideoAttachments(body);
+
+		expect(result).toContain(`poster="${THUMB_URL}"`);
+		expect(result).not.toContain("<!-- poster:");
+		expect(result).toContain("## Next section");
+	});
+
+	it("prefers the poster comment over a thumbnail-derived poster", () => {
+		const otherPoster = "https://example.com/other.png";
+		const body = [
+			`[![Watch](${THUMB_URL})](${VIDEO_URL})`,
+			"",
+			VIDEO_URL,
+			"",
+			`<!-- poster: ${otherPoster} -->`,
+		].join("\n");
+
+		const result = renderVideoAttachments(body);
+
+		expect(result).toContain(`poster="${otherPoster}"`);
+		expect((result.match(/<video /g) ?? []).length).toBe(1);
+	});
+
+	it("leaves poster comments without an adjacent video URL untouched", () => {
+		const body = `Some text.\n<!-- poster: ${THUMB_URL} -->\nMore text.`;
+		expect(renderVideoAttachments(body)).toBe(body);
+	});
+
 	it("handles empty bodies", () => {
 		expect(renderVideoAttachments("")).toBe("");
 	});

--- a/src/gui/UpdateModal/UpdateModal.test.ts
+++ b/src/gui/UpdateModal/UpdateModal.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { renderVideoAttachments } from "./UpdateModal";
+
+const VIDEO_URL =
+	"https://github.com/user-attachments/assets/27712a0b-a26d-4a69-ac21-a7b4af6c5616";
+const THUMB_URL = "https://example.com/video-thumb.png";
+
+describe("renderVideoAttachments", () => {
+	it("replaces a bare video URL with an inline <video> player", () => {
+		const body = ["Intro text.", "", VIDEO_URL, "", "More text."].join("\n");
+
+		const result = renderVideoAttachments(body);
+
+		expect(result).toContain(`<video controls`);
+		expect(result).toContain(`src="${VIDEO_URL}"`);
+		expect(result).not.toMatch(new RegExp(`^${VIDEO_URL}$`, "m"));
+	});
+
+	it("folds a thumbnail linking to the same video into the player's poster", () => {
+		const body = [
+			"🎬 **A 60-second tour of the highlights:**",
+			"",
+			`[![Watch the release video](${THUMB_URL})](${VIDEO_URL})`,
+			"",
+			VIDEO_URL,
+			"",
+			"## Next section",
+		].join("\n");
+
+		const result = renderVideoAttachments(body);
+
+		const players = result.match(/<video /g) ?? [];
+		expect(players).toHaveLength(1);
+		expect(result).toContain(`poster="${THUMB_URL}"`);
+		expect(result).not.toContain("[![");
+		expect(result).toContain("## Next section");
+	});
+
+	it("keeps a linked thumbnail that has no matching bare URL", () => {
+		const body = `[![Watch](${THUMB_URL})](${VIDEO_URL.replace("27712a0b", "deadbeef")})`;
+
+		const result = renderVideoAttachments(body);
+
+		expect(result).toBe(body);
+	});
+
+	it("handles indented bare URLs and ignores non-attachment URLs", () => {
+		const body = [
+			`  ${VIDEO_URL}`,
+			"https://github.com/chhoumann/quickadd/releases/download/2.13.0/video.mp4",
+			"https://example.com/page",
+		].join("\n");
+
+		const result = renderVideoAttachments(body);
+
+		expect(result).toContain(`src="${VIDEO_URL}"`);
+		expect(result).toContain(
+			"https://github.com/chhoumann/quickadd/releases/download/2.13.0/video.mp4"
+		);
+		expect(result).toContain("https://example.com/page");
+	});
+
+	it("leaves bodies without video attachments untouched", () => {
+		const body = "## Features\n\n- something new\n";
+		expect(renderVideoAttachments(body)).toBe(body);
+	});
+});

--- a/src/gui/UpdateModal/UpdateModal.test.ts
+++ b/src/gui/UpdateModal/UpdateModal.test.ts
@@ -60,6 +60,22 @@ describe("renderVideoAttachments", () => {
 		expect(result).toContain("https://example.com/page");
 	});
 
+	it("renders a player for every occurrence of a repeated bare URL", () => {
+		const body = ["Intro.", "", VIDEO_URL, "", "Recap:", "", VIDEO_URL].join(
+			"\n"
+		);
+
+		const result = renderVideoAttachments(body);
+
+		const players = result.match(/<video /g) ?? [];
+		expect(players).toHaveLength(2);
+		expect(result).not.toMatch(new RegExp(`^${VIDEO_URL}$`, "m"));
+	});
+
+	it("handles empty bodies", () => {
+		expect(renderVideoAttachments("")).toBe("");
+	});
+
 	it("leaves bodies without video attachments untouched", () => {
 		const body = "## Features\n\n- something new\n";
 		expect(renderVideoAttachments(body)).toBe(body);

--- a/src/gui/UpdateModal/UpdateModal.ts
+++ b/src/gui/UpdateModal/UpdateModal.ts
@@ -4,7 +4,8 @@ import { log } from "src/logger/logManager";
 
 type Release = {
 	tag_name: string;
-	body: string;
+	// The GitHub API allows a null release body.
+	body: string | null;
 	draft: boolean;
 	prerelease: boolean;
 };
@@ -178,7 +179,7 @@ export class UpdateModal extends Modal {
 
 		const contentDiv = contentEl.createDiv("quickadd-update-modal");
 		const releaseNotes = this.releases
-			.map((release) => renderVideoAttachments(release.body))
+			.map((release) => renderVideoAttachments(release.body ?? ""))
 			.join("\n---\n");
 
 		const andNow = `And now, here is everything new in QuickAdd since your last update (v${this.previousVersion}):`;

--- a/src/gui/UpdateModal/UpdateModal.ts
+++ b/src/gui/UpdateModal/UpdateModal.ts
@@ -57,6 +57,11 @@ const USER_ATTACHMENT_VIDEO_URL =
 // A linked thumbnail: [![alt](poster.png)](https://github.com/user-attachments/assets/...)
 const LINKED_VIDEO_THUMBNAIL =
 	/^\[!\[[^\]]*\]\(([^)\s"]+)\)\]\((https:\/\/github\.com\/user-attachments\/assets\/[A-Za-z0-9-]+)\)$/;
+// A poster hint next to a bare video URL: <!-- poster: https://... -->
+// GitHub strips HTML comments, so release notes can carry a poster for the
+// modal's player without rendering a duplicate video on the GitHub page
+// (GitHub also turns links to video attachments into players).
+const VIDEO_POSTER_COMMENT = /^<!--\s*poster:\s*(https:\/\/[^\s"'>]+)\s*-->$/;
 
 function videoPlayerHtml(url: string, poster?: string): string {
 	const posterAttr = poster ? ` poster="${poster}"` : "";
@@ -88,9 +93,34 @@ export function renderVideoAttachments(markdownText: string): string {
 		}
 	}
 
+	// A poster comment adjacent to a bare URL (above or below, across blank
+	// lines) wins over a thumbnail-derived poster.
+	const consumedPosterLines = new Set<number>();
+	for (let i = 0; i < lines.length; i++) {
+		if (!USER_ATTACHMENT_VIDEO_URL.test(lines[i].trim())) continue;
+		for (const direction of [1, -1]) {
+			let j = i + direction;
+			while (j >= 0 && j < lines.length && lines[j].trim() === "") {
+				j += direction;
+			}
+			const comment =
+				j >= 0 && j < lines.length
+					? lines[j].trim().match(VIDEO_POSTER_COMMENT)
+					: null;
+			if (comment) {
+				posters.set(lines[i].trim(), comment[1]);
+				consumedPosterLines.add(j);
+				break;
+			}
+		}
+	}
+
 	const result: string[] = [];
-	for (const line of lines) {
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
 		const trimmed = line.trim();
+
+		if (consumedPosterLines.has(i)) continue;
 
 		const thumbnail = trimmed.match(LINKED_VIDEO_THUMBNAIL);
 		if (thumbnail && bareUrls.has(thumbnail[2])) continue;

--- a/src/gui/UpdateModal/UpdateModal.ts
+++ b/src/gui/UpdateModal/UpdateModal.ts
@@ -51,6 +51,60 @@ export async function getReleaseNotesAfter(
 		.filter((release) => !release.draft && !release.prerelease);
 }
 
+const USER_ATTACHMENT_VIDEO_URL =
+	/^https:\/\/github\.com\/user-attachments\/assets\/[A-Za-z0-9-]+$/;
+// A linked thumbnail: [![alt](poster.png)](https://github.com/user-attachments/assets/...)
+const LINKED_VIDEO_THUMBNAIL =
+	/^\[!\[[^\]]*\]\(([^)\s"]+)\)\]\((https:\/\/github\.com\/user-attachments\/assets\/[A-Za-z0-9-]+)\)$/;
+
+function videoPlayerHtml(url: string, poster?: string): string {
+	const posterAttr = poster ? ` poster="${poster}"` : "";
+	return `<video controls preload="metadata" playsinline style="width: 100%; border-radius: 8px;" src="${url}"${posterAttr}></video>`;
+}
+
+/**
+ * GitHub renders a bare user-attachments URL on its own line as an inline
+ * video player, but Obsidian's markdown renderer would show it as a raw
+ * link. Obsidian can play these URLs natively, so replace the bare line
+ * with a real <video> player. A thumbnail image linking to the same video
+ * (the GitHub-page fallback) becomes the player's poster instead of a
+ * duplicate visual.
+ */
+export function renderVideoAttachments(markdownText: string): string {
+	const lines = markdownText.split("\n");
+
+	const bareUrls = new Set<string>();
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (USER_ATTACHMENT_VIDEO_URL.test(trimmed)) bareUrls.add(trimmed);
+	}
+
+	const posters = new Map<string, string>();
+	for (const line of lines) {
+		const thumbnail = line.trim().match(LINKED_VIDEO_THUMBNAIL);
+		if (thumbnail && bareUrls.has(thumbnail[2])) {
+			posters.set(thumbnail[2], thumbnail[1]);
+		}
+	}
+
+	const result: string[] = [];
+	for (const line of lines) {
+		const trimmed = line.trim();
+
+		const thumbnail = trimmed.match(LINKED_VIDEO_THUMBNAIL);
+		if (thumbnail && bareUrls.has(thumbnail[2])) continue;
+
+		if (USER_ATTACHMENT_VIDEO_URL.test(trimmed)) {
+			result.push(videoPlayerHtml(trimmed, posters.get(trimmed)));
+			continue;
+		}
+
+		result.push(line);
+	}
+
+	return result.join("\n");
+}
+
 function addExtraHashToHeadings(
 	markdownText: string,
 	numHashes = 1
@@ -124,7 +178,7 @@ export class UpdateModal extends Modal {
 
 		const contentDiv = contentEl.createDiv("quickadd-update-modal");
 		const releaseNotes = this.releases
-			.map((release) => release.body)
+			.map((release) => renderVideoAttachments(release.body))
 			.join("\n---\n");
 
 		const andNow = `And now, here is everything new in QuickAdd since your last update (v${this.previousVersion}):`;


### PR DESCRIPTION
## Summary

Release notes embed videos the GitHub-native way: a bare `github.com/user-attachments/...` URL on its own line (renders as an inline player on GitHub) plus a clickable play-button thumbnail as fallback. Obsidian's markdown renderer showed that bare URL as an ugly raw link in the update modal.

Obsidian's renderer can play these URLs natively, so the modal now renders an **actual inline video player**:

- a bare user-attachments URL line becomes `<video controls preload="metadata">` with the URL as `src`;
- a markdown thumbnail (`[![alt](thumb)](video-url)`) linking to the same video is folded into the player's **poster** instead of rendering as a duplicate visual;
- lone thumbnails (no matching bare URL) and non-attachment URLs are untouched.

## Verification

- 5 unit tests for the transform (`src/gui/UpdateModal/UpdateModal.test.ts`)
- Verified live in the dev vault against the real 2.13.0 release body: the modal shows a working player (poster + native controls, metadata loaded, 1920×1080 / 0:56) where the raw URL used to be — confirmed `user-attachments` URLs stream fine in Obsidian's `<video>` (302 → signed CDN URL, range requests OK)
- `bun run build` (tsc) and `bun lint` clean

## Release impact

Cosmetic/UX fix, rides the next release; no migration or settings impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notes now render bare video URLs as embedded playable video players; matching thumbnail links are used as poster images. Adjacent "poster" comments can override the poster. Non-matching links and unrelated content remain unchanged; repeated URLs render multiple players.

* **Tests**
  * Added comprehensive tests covering rendering, poster selection, comment handling, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->