### PR TITLE
fix(capture): preserve literal backslash sequences in captured content

### DIFF
--- a/src/formatters/captureChoiceFormatter-linebreak.test.ts
+++ b/src/formatters/captureChoiceFormatter-linebreak.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory() {
+			return {
+				Prompt: vi.fn().mockResolvedValue(""),
+				PromptWithContext: vi.fn().mockResolvedValue(""),
+			} as any;
+		}
+	},
+}));
+
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: class {
+		constructor() {}
+	},
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: {
+		Suggest: vi.fn().mockResolvedValue(""),
+	},
+}));
+
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: {
+		Prompt: vi.fn().mockResolvedValue(""),
+	},
+}));
+
+vi.mock("../utils/errorUtils", () => ({
+	__esModule: true,
+	reportError: vi.fn(),
+	isCancellationError: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: {
+		Prompt: vi.fn().mockResolvedValue(""),
+	},
+}));
+
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		constructor() {}
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		constructor() {}
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		constructor() {}
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+	},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../main", () => ({
+	__esModule: true,
+	default: class QuickAdd {
+		static instance = {
+			settings: { inputPrompt: "single-line" },
+			app: {
+				workspace: { getActiveViewOfType: vi.fn().mockReturnValue(null) },
+			},
+		};
+		settings = QuickAdd.instance.settings;
+		app = QuickAdd.instance.app;
+	},
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+const createChoice = (
+	overrides: Partial<ICaptureChoice> = {},
+): ICaptureChoice =>
+	({
+		id: "test",
+		name: "Test Choice",
+		type: "Capture",
+		command: false,
+		captureTo: "Target.md",
+		captureToActiveFile: false,
+		captureToCanvasNodeId: "",
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: false,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: false, format: "" },
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: {
+			enabled: false,
+			after: "",
+			insertAtEnd: false,
+			considerSubsections: false,
+			createIfNotFound: false,
+			createIfNotFoundLocation: "",
+			inline: false,
+			replaceExisting: false,
+			blankLineAfterMatchMode: "auto",
+		},
+		newLineCapture: { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: true,
+		},
+		...overrides,
+	}) as ICaptureChoice;
+
+const createMockApp = (selection: string | null): App =>
+	({
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(
+				selection === null
+					? null
+					: { editor: { getSelection: () => selection } },
+			),
+		},
+		metadataCache: {
+			getFileCache: vi.fn().mockReturnValue(null),
+		},
+		fileManager: {
+			generateMarkdownLink: vi.fn().mockReturnValue(""),
+			processFrontMatter: vi.fn(),
+		},
+		vault: {
+			adapter: { exists: vi.fn() },
+			cachedRead: vi.fn(),
+		},
+	}) as unknown as App;
+
+const createFile = (path = "Target.md"): TFile => {
+	const name = path.split("/").pop() ?? path;
+	return {
+		path,
+		name,
+		basename: name.replace(/\.(md|canvas)$/i, ""),
+		extension: "md",
+	} as unknown as TFile;
+};
+
+const createFormatter = (selection: string | null) =>
+	new CaptureChoiceFormatter(createMockApp(selection), {
+		settings: {
+			inputPrompt: "single-line",
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any);
+
+describe("capture linebreak escapes only apply to the format string (issue #527)", () => {
+	beforeEach(() => {
+		(global as any).navigator = {
+			clipboard: {
+				readText: vi.fn().mockResolvedValue(""),
+			},
+		};
+	});
+
+	it("preserves literal \\n in selected text through the two-pass capture flow", async () => {
+		const formatter = createFormatter("\\nabla");
+
+		// Pass 1: resolve {{VALUE}} (selection) — mirrors CaptureChoiceEngine.onFileExists
+		const firstPass = await formatter.formatContentOnly("{{VALUE}}");
+		expect(firstPass).toBe("\\nabla");
+
+		// Pass 2: embed into the target file content
+		const result = await formatter.formatContentWithFile(
+			firstPass,
+			createChoice(),
+			"",
+			createFile(),
+		);
+		expect(result).toBe("\\nabla");
+	});
+
+	it("preserves literal \\n in selected text on single-pass formatContentWithFile (canvas flow)", async () => {
+		const formatter = createFormatter("\\nabla");
+
+		const result = await formatter.formatContentWithFile(
+			"{{VALUE}}",
+			createChoice(),
+			"existing",
+			createFile(),
+		);
+
+		// Top insertion without frontmatter concatenates capture + body directly;
+		// the point here is that the literal backslash-n survives untouched.
+		expect(result).toBe("\\nablaexisting");
+	});
+
+	it("preserves backslash sequences in path-like selected text", async () => {
+		const formatter = createFormatter("C:\\Users\\nadia");
+
+		const firstPass = await formatter.formatContentOnly("{{VALUE}}");
+
+		expect(firstPass).toBe("C:\\Users\\nadia");
+	});
+
+	it("still expands \\n typed in the capture format string", async () => {
+		const formatter = createFormatter("hello");
+
+		const firstPass = await formatter.formatContentOnly("- {{VALUE}}\\n");
+		expect(firstPass).toBe("- hello\n");
+
+		const result = await formatter.formatContentWithFile(
+			firstPass,
+			createChoice({ prepend: true }),
+			"Line A",
+			createFile(),
+		);
+		expect(result).toBe("Line A\n- hello\n");
+	});
+
+	it("keeps escaped \\\\n in the format string as literal \\n", async () => {
+		const formatter = createFormatter("hello");
+
+		const firstPass = await formatter.formatContentOnly("{{VALUE}} \\\\n");
+
+		expect(firstPass).toBe("hello \\n");
+	});
+});

--- a/src/formatters/captureChoiceFormatter-linebreak.test.ts
+++ b/src/formatters/captureChoiceFormatter-linebreak.test.ts
@@ -313,6 +313,34 @@ describe("capture linebreak escapes only apply to the format string (issue #527)
 		expect(result).toBe("existing\n## \\nabla\n\\nabla");
 	});
 
+	it("expands \\n from global variable snippets in created insert-after targets", async () => {
+		const formatter = createFormatter("hello", { Heading: "## Inbox\\n" });
+		const choice = createChoice({
+			insertAfter: {
+				enabled: true,
+				after: "{{GLOBAL_VAR:Heading}}",
+				insertAtEnd: false,
+				considerSubsections: false,
+				createIfNotFound: true,
+				createIfNotFoundLocation: "bottom",
+				inline: false,
+				replaceExisting: false,
+				blankLineAfterMatchMode: "auto",
+			},
+		});
+
+		const result = await formatter.formatContentWithFile(
+			"{{VALUE}}",
+			choice,
+			"existing",
+			createFile(),
+		);
+
+		// The snippet's \n must become a real newline in the created target line,
+		// matching pre-#527 behavior for global-variable targets.
+		expect(result).toBe("existing\n## Inbox\n\nhello");
+	});
+
 	describe("expandLinebreakEscapesOutsideTokens", () => {
 		it("expands escapes outside {{...}} tokens but never inside them", () => {
 			const formatter = createFormatter(null);

--- a/src/formatters/captureChoiceFormatter-linebreak.test.ts
+++ b/src/formatters/captureChoiceFormatter-linebreak.test.ts
@@ -184,12 +184,21 @@ const createFile = (path = "Target.md"): TFile => {
 	} as unknown as TFile;
 };
 
-const createFormatter = (selection: string | null) =>
-	new CaptureChoiceFormatter(createMockApp(selection), {
+class TestableCaptureFormatter extends CaptureChoiceFormatter {
+	public expandOutsideTokens(input: string): string {
+		return this.expandLinebreakEscapesOutsideTokens(input);
+	}
+}
+
+const createFormatter = (
+	selection: string | null,
+	globalVariables: Record<string, string> = {},
+) =>
+	new TestableCaptureFormatter(createMockApp(selection), {
 		settings: {
 			inputPrompt: "single-line",
 			enableTemplatePropertyTypes: false,
-			globalVariables: {},
+			globalVariables,
 			useSelectionAsCaptureValue: true,
 		},
 	} as any);
@@ -264,5 +273,73 @@ describe("capture linebreak escapes only apply to the format string (issue #527)
 		const firstPass = await formatter.formatContentOnly("{{VALUE}} \\\\n");
 
 		expect(firstPass).toBe("hello \\n");
+	});
+
+	it("expands \\n inside global variable snippets used as capture format", async () => {
+		const formatter = createFormatter("hello", {
+			JournalLine: "- {{VALUE}}\\n",
+		});
+
+		const firstPass = await formatter.formatContentOnly(
+			"{{GLOBAL_VAR:JournalLine}}",
+		);
+
+		expect(firstPass).toBe("- hello\n");
+	});
+
+	it("preserves backslash sequences in substituted insert-after targets created via createIfNotFound", async () => {
+		const formatter = createFormatter("\\nabla");
+		const choice = createChoice({
+			insertAfter: {
+				enabled: true,
+				after: "## {{VALUE}}",
+				insertAtEnd: false,
+				considerSubsections: false,
+				createIfNotFound: true,
+				createIfNotFoundLocation: "bottom",
+				inline: false,
+				replaceExisting: false,
+				blankLineAfterMatchMode: "auto",
+			},
+		});
+
+		const result = await formatter.formatContentWithFile(
+			"{{VALUE}}",
+			choice,
+			"existing",
+			createFile(),
+		);
+
+		expect(result).toBe("existing\n## \\nabla\n\\nabla");
+	});
+
+	describe("expandLinebreakEscapesOutsideTokens", () => {
+		it("expands escapes outside {{...}} tokens but never inside them", () => {
+			const formatter = createFormatter(null);
+
+			const result = formatter.expandOutsideTokens(
+				"a\\n{{VALUE:x|default:1\\n2}}b\\n",
+			);
+
+			expect(result).toBe("a\n{{VALUE:x|default:1\\n2}}b\n");
+		});
+
+		it("treats an unclosed {{ as plain text", () => {
+			const formatter = createFormatter(null);
+
+			const result = formatter.expandOutsideTokens("{{oops \\n");
+
+			expect(result).toBe("{{oops \n");
+		});
+
+		it("handles \\\\ escapes and adjacent tokens", () => {
+			const formatter = createFormatter(null);
+
+			const result = formatter.expandOutsideTokens(
+				"\\\\n{{DATE}}{{TIME}}\\n",
+			);
+
+			expect(result).toBe("\\n{{DATE}}{{TIME}}\n");
+		});
 	});
 });

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -125,7 +125,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 	async formatFileContent(input: string, runTemplater = true): Promise<string> {
 		let formatted = await super.formatFileContent(
-			this.expandTemplateLinebreaksOnce(input),
+			await this.expandTemplateLinebreaksOnce(input),
 		);
 
 		// Run templater only once per capture payload to prevent #533 double execution
@@ -194,7 +194,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		// Process the input with templater (if needed) at this stage
 		// This is the first pass where we want to run any templater code
 		const formatted = await super.formatFileContent(
-			this.expandTemplateLinebreaksOnce(input),
+			await this.expandTemplateLinebreaksOnce(input),
 		);
 
 		// DON'T run templater parsing here - it will be handled either by:
@@ -208,10 +208,15 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		return formatted;
 	}
 
-	private expandTemplateLinebreaksOnce(template: string): string {
+	private async expandTemplateLinebreaksOnce(template: string): Promise<string> {
 		if (this.linebreaksProcessed) return template;
 		this.linebreaksProcessed = true;
-		return this.replaceLinebreakInString(template);
+		// Global variable snippets are format-template material — the docs promise
+		// they are "processed by the usual formatter passes" — so they must be
+		// injected before linebreak expansion. The second expansion inside
+		// format() is a no-op since no {{GLOBAL_VAR}} tokens remain.
+		const withGlobals = await this.replaceGlobalVarInString(template);
+		return this.expandLinebreakEscapesOutsideTokens(withGlobals);
 	}
 
 	private normalizeTarget(target: string): string {
@@ -497,9 +502,11 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	private async createInsertAfterIfNotFound(formatted: string) {
-		// Build the line to insert using centralized location formatting
-		const insertAfterLine: string = this.replaceLinebreakInString(
-			await this.formatLocationString(this.choice.insertAfter.after),
+		// Build the line to insert using centralized location formatting.
+		// Linebreak escapes are expanded on the raw setting, before substitution,
+		// so backslash sequences in substituted values stay verbatim (issue #527).
+		const insertAfterLine: string = await this.formatLocationString(
+			this.expandLinebreakEscapesOutsideTokens(this.choice.insertAfter.after),
 		);
 		const insertAfterLineAndFormatted = `${insertAfterLine}\n${formatted}`;
 
@@ -584,8 +591,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			throw new ChoiceAbortError("Insert-before settings are missing.");
 		}
 
-		const insertBeforeLine: string = this.replaceLinebreakInString(
-			await this.formatLocationString(insertBefore.before),
+		const insertBeforeLine: string = await this.formatLocationString(
+			this.expandLinebreakEscapesOutsideTokens(insertBefore.before),
 		);
 		const formattedAndInsertBeforeLine =
 			formatted.endsWith("\n") || formatted.length === 0

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -39,6 +39,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		* tp.system.prompt).
 		*/
 	private templaterProcessed = false;
+	/**
+		* Tracks whether `\n` escapes in the capture format string have been expanded.
+		* Expansion must happen on the raw format template BEFORE token substitution,
+		* and only once per capture run: multi-stage flows pass already-substituted
+		* content back into formatFileContent, and backslash sequences inside captured
+		* content (selection, clipboard, prompt input) must survive verbatim — e.g.
+		* capturing the LaTeX selection `\nabla` must not turn into a linebreak + "abla"
+		* (issue #527).
+		*/
+	private linebreaksProcessed = false;
 
 	public setDestinationFile(file: TFile): void {
 		this.file = file;
@@ -114,8 +124,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	async formatFileContent(input: string, runTemplater = true): Promise<string> {
-		let formatted = await super.formatFileContent(input);
-		formatted = this.replaceLinebreakInString(formatted);
+		let formatted = await super.formatFileContent(
+			this.expandTemplateLinebreaksOnce(input),
+		);
 
 		// Run templater only once per capture payload to prevent #533 double execution
 		if (runTemplater && this.file && !this.templaterProcessed) {
@@ -182,8 +193,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	async formatContentOnly(input: string): Promise<string> {
 		// Process the input with templater (if needed) at this stage
 		// This is the first pass where we want to run any templater code
-		let formatted = await super.formatFileContent(input);
-		formatted = this.replaceLinebreakInString(formatted);
+		const formatted = await super.formatFileContent(
+			this.expandTemplateLinebreaksOnce(input),
+		);
 
 		// DON'T run templater parsing here - it will be handled either by:
 		// 1. CaptureChoiceEngine.run() for the active file + no insert after + no prepend case
@@ -194,6 +206,12 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		if (formattedContentIsEmpty) return this.fileContent;
 
 		return formatted;
+	}
+
+	private expandTemplateLinebreaksOnce(template: string): string {
+		if (this.linebreaksProcessed) return template;
+		this.linebreaksProcessed = true;
+		return this.replaceLinebreakInString(template);
 	}
 
 	private normalizeTarget(target: string): string {

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -211,10 +211,17 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	private async expandTemplateLinebreaksOnce(template: string): Promise<string> {
 		if (this.linebreaksProcessed) return template;
 		this.linebreaksProcessed = true;
-		// Global variable snippets are format-template material — the docs promise
-		// they are "processed by the usual formatter passes" — so they must be
-		// injected before linebreak expansion. The second expansion inside
-		// format() is a no-op since no {{GLOBAL_VAR}} tokens remain.
+		return this.expandFormatTemplateEscapes(template);
+	}
+
+	/**
+		* Expands linebreak escapes on format-template text. Global variable
+		* snippets are format-template material — the docs promise they are
+		* "processed by the usual formatter passes" — so they must be injected
+		* before linebreak expansion. The second global-var expansion inside
+		* format() is a no-op since no {{GLOBAL_VAR}} tokens remain.
+		*/
+	private async expandFormatTemplateEscapes(template: string): Promise<string> {
 		const withGlobals = await this.replaceGlobalVarInString(template);
 		return this.expandLinebreakEscapesOutsideTokens(withGlobals);
 	}
@@ -503,10 +510,11 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 	private async createInsertAfterIfNotFound(formatted: string) {
 		// Build the line to insert using centralized location formatting.
-		// Linebreak escapes are expanded on the raw setting, before substitution,
-		// so backslash sequences in substituted values stay verbatim (issue #527).
+		// Linebreak escapes are expanded on the raw setting (with globals injected
+		// first), before substitution, so backslash sequences in substituted
+		// values stay verbatim (issue #527).
 		const insertAfterLine: string = await this.formatLocationString(
-			this.expandLinebreakEscapesOutsideTokens(this.choice.insertAfter.after),
+			await this.expandFormatTemplateEscapes(this.choice.insertAfter.after),
 		);
 		const insertAfterLineAndFormatted = `${insertAfterLine}\n${formatted}`;
 
@@ -592,7 +600,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		}
 
 		const insertBeforeLine: string = await this.formatLocationString(
-			this.expandLinebreakEscapesOutsideTokens(insertBefore.before),
+			await this.expandFormatTemplateEscapes(insertBefore.before),
 		);
 		const formattedAndInsertBeforeLine =
 			formatted.endsWith("\n") || formatted.length === 0

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -31,7 +31,11 @@ export class FormatDisplayFormatter extends Formatter {
 		let output: string = input;
 
 		try {
-			// Expand global variables first so previews include their content
+			// Expand linebreak escapes on the raw format string first, mirroring
+			// CaptureChoiceFormatter: `\n` is a format-template escape and must not
+			// apply to substituted content (issue #527).
+			output = this.replaceLinebreakInString(output);
+			// Expand global variables so previews include their content
 			output = await this.replaceGlobalVarInString(output);
 			output = this.replaceDateInString(output);
 			output = this.replaceTimeInString(output);
@@ -46,7 +50,6 @@ export class FormatDisplayFormatter extends Formatter {
 			output = await this.replaceTemplateInString(output);
 			output = await this.replaceFieldVarInString(output);
 			output = this.replaceRandomInString(output);
-			output = this.replaceLinebreakInString(output);
 		} catch {
 			// Return the input as-is if formatting fails during preview
 			// This prevents crashes when typing incomplete syntax

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -31,12 +31,12 @@ export class FormatDisplayFormatter extends Formatter {
 		let output: string = input;
 
 		try {
-			// Expand linebreak escapes on the raw format string first, mirroring
-			// CaptureChoiceFormatter: `\n` is a format-template escape and must not
-			// apply to substituted content (issue #527).
-			output = this.replaceLinebreakInString(output);
-			// Expand global variables so previews include their content
+			// Expand global variables first so previews include their content
 			output = await this.replaceGlobalVarInString(output);
+			// Mirror CaptureChoiceFormatter: linebreak escapes are format-template
+			// material (including global snippets) and expand before token
+			// substitution, never on substituted content (issue #527).
+			output = this.expandLinebreakEscapesOutsideTokens(output);
 			output = this.replaceDateInString(output);
 			output = this.replaceTimeInString(output);
 			output = await this.replaceValueInString(output);

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -718,6 +718,50 @@ export abstract class Formatter {
 		return output;
 	}
 
+	/**
+		* Like replaceLinebreakInString, but leaves `{{...}}` token spans untouched.
+		* Format-token regexes cannot match across real linebreaks (see constants.ts),
+		* so expanding `\n` inside token options (e.g. `{{VALUE:x|default:a\nb}}`)
+		* would render the token unparseable and dump it literally into the output.
+		*/
+	protected expandLinebreakEscapesOutsideTokens(input: string): string {
+		let output = "";
+		let i = 0;
+
+		while (i < input.length) {
+			if (input[i] === "{" && input[i + 1] === "{") {
+				const close = input.indexOf("}}", i + 2);
+				if (close !== -1) {
+					output += input.slice(i, close + 2);
+					i = close + 2;
+					continue;
+				}
+			}
+
+			const curr = input[i];
+			const next = input[i + 1];
+
+			if (curr === "\\") {
+				if (next === "n") {
+					output += "\n";
+					i += 2;
+				} else if (next === "\\") {
+					output += "\\";
+					i += 2;
+				} else {
+					// Invalid use of escape character, but we keep it anyway.
+					output += "\\";
+					i += 1;
+				}
+			} else {
+				output += curr;
+				i += 1;
+			}
+		}
+
+		return output;
+	}
+
 
 	protected abstract getMacroValue(
 		macroName: string,


### PR DESCRIPTION
Capturing content that contains a literal `\n` sequence (e.g. selecting the LaTeX command `\nabla`) converted it into a real linebreak, so `\nabla` came out as `abla` on a new line. `\\` sequences in captured content (e.g. Windows paths like `C:\Users\nadia`) were mangled the same way.

**Root cause:** the `\n` linebreak escape supported in capture format strings (e.g. `- {{DATE:HH:mm}} {{VALUE}}\n`) was expanded by `replaceLinebreakInString` on the *fully formatted output* — after `{{VALUE}}`/selection/clipboard substitution — so backslash sequences originating in user content were treated as format escapes. The two-pass capture flow (`formatContentOnly` → `formatContentWithFile`) even ran the expansion twice.

**Fix:** expand linebreak escapes on the format template only, before token substitution, exactly once per capture run (`expandTemplateLinebreaksOnce`, mirroring the existing `templaterProcessed` once-per-run pattern). Three refinements from adversarial review (2 Codex reviewers, Skeptic + Architect lenses):

- **Global variables stay format material.** Docs promise snippets are "processed by the usual formatter passes", so `{{GLOBAL_VAR:...}}` is injected *before* the linebreak pass — `\n` inside a snippet still becomes a newline. The second global-var expansion inside `format()` is a no-op.
- **Token-aware expansion.** `\n` inside `{{...}}` spans is left untouched (`expandLinebreakEscapesOutsideTokens`): token regexes cannot match across real linebreaks, so expanding there would have dumped the raw token text into the note.
- **Insert-target creation fixed too.** The `createIfNotFound` insert-after/before paths expanded escapes on the *substituted* location string — the same bug class on a different path. They now expand on the raw setting, pre-substitution.

The settings live-preview formatter (`FormatDisplayFormatter`) applies the same order so previews match runtime behavior.

**Behavior notes for review:**
- `\n` in the capture format string and in global-variable snippets still expands to a newline (both verified end-to-end in the dev vault).
- `\\n` in the format string still escapes to a literal `\n`.
- Intentional behavior change: backslash sequences inside *substituted* content (selection, clipboard, prompt input, macro/template/inline-JS output) are now taken verbatim instead of being expanded. This matches the documented semantics (escapes are a format-string feature) but would affect anyone who relied on typing `\n` into a value prompt to inject linebreaks.

Reproduced before the fix and validated after via the Obsidian CLI in the dev vault (select `\nabla` → run capture): captured text was `<newline>abla` before, `\nabla` after. Regression tests cover the two-pass flow, the canvas single-pass flow, path-like selections, global-variable snippets, token protection, insert-target creation, and the format-string escape feature.

Fixes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of linebreak escape sequences in capture formats so typed `\n` expands to real newlines where intended, while literal backslash sequences in selected or path-like content remain unchanged. Insert-after/insert-before targets created during capture now respect these expansions.

* **Tests**
  * Added comprehensive tests covering escape expansion behavior across capture flows and format sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->