### PR TITLE
fix(capture): allow clean concurrent-edit merges

### DIFF
--- a/src/engine/CaptureChoiceEngine.merge.test.ts
+++ b/src/engine/CaptureChoiceEngine.merge.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { formatContentWithFileMock } = vi.hoisted(() => ({
+	formatContentWithFileMock: vi.fn(),
+}));
+
+vi.mock("../quickAddSettingsTab", () => {
+	const defaultSettings = {
+		choices: [],
+		inputPrompt: "single-line",
+		devMode: false,
+		templateFolderPath: "",
+		useSelectionAsCaptureValue: true,
+		announceUpdates: "major",
+		version: "0.0.0",
+		globalVariables: {},
+		onePageInputEnabled: false,
+		disableOnlineFeatures: true,
+		enableRibbonIcon: false,
+		showCaptureNotification: true,
+		showInputCancellationNotification: true,
+		enableTemplatePropertyTypes: false,
+		ai: {
+			defaultModel: "Ask me",
+			defaultSystemPrompt: "",
+			promptTemplatesFolderPath: "",
+			showAssistant: true,
+			providers: [],
+		},
+		migrations: {
+			migrateToMacroIDFromEmbeddedMacro: true,
+			useQuickAddTemplateFolder: false,
+			incrementFileNameSettingMoveToDefaultBehavior: false,
+			consolidateFileExistsBehavior: false,
+			mutualExclusionInsertAfterAndWriteToBottomOfFile: false,
+			setVersionAfterUpdateModalRelease: false,
+			addDefaultAIProviders: false,
+			removeMacroIndirection: false,
+			migrateFileOpeningSettings: false,
+			backfillFileOpeningDefaults: false,
+		},
+	};
+
+	return {
+		DEFAULT_SETTINGS: defaultSettings,
+		QuickAddSettingsTab: class {},
+	};
+});
+
+vi.mock("../formatters/captureChoiceFormatter", () => ({
+	CaptureChoiceFormatter: class {
+		setLinkToCurrentFileBehavior() {}
+		setTitle() {}
+		setDestinationFile() {}
+		setDestinationSourcePath() {}
+		setUseSelectionAsCaptureValue() {}
+		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
+			return await work();
+		}
+		async formatContentOnly(content: string) {
+			return content;
+		}
+		async formatContentWithFile(
+			content: string,
+			...args: unknown[]
+		): Promise<string> {
+			return await formatContentWithFileMock(content, ...args);
+		}
+		async formatFileName(name: string) {
+			return name;
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+	},
+}));
+
+vi.mock("../utilityObsidian", () => ({
+	appendToCurrentLine: vi.fn(),
+	getMarkdownFilesInFolder: vi.fn(async () => []),
+	getMarkdownFilesWithTag: vi.fn(async () => []),
+	insertFileLinkToActiveView: vi.fn(),
+	insertOnNewLineAbove: vi.fn(),
+	insertOnNewLineBelow: vi.fn(),
+	isFolder: vi.fn(() => false),
+	isTemplaterTriggerOnCreateEnabled: vi.fn(() => false),
+	jumpToNextTemplaterCursorIfPossible: vi.fn(),
+	openExistingFileTab: vi.fn(() => null),
+	openFile: vi.fn(),
+	overwriteTemplaterOnce: vi.fn(),
+	templaterParseTemplate: vi.fn(async (_app, content) => content),
+	waitForTemplaterTriggerOnCreateToComplete: vi.fn(),
+}));
+
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
+	default: class InputSuggesterMock {},
+}));
+
+vi.mock("../main", () => ({
+	default: class QuickAddMock {},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+import type { App } from "obsidian";
+import { TFile } from "obsidian";
+import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+
+const createCaptureChoice = (): ICaptureChoice => ({
+	name: "Test Capture Choice",
+	id: "capture-choice-id",
+	type: "Capture",
+	command: false,
+	captureTo: "Daily/Test.md",
+	captureToActiveFile: false,
+	createFileIfItDoesntExist: {
+		enabled: false,
+		createWithTemplate: false,
+		template: "",
+	},
+	format: { enabled: false, format: "{{VALUE}}" },
+	prepend: false,
+	appendLink: false,
+	task: false,
+	insertAfter: {
+		enabled: false,
+		after: "",
+		insertAtEnd: false,
+		considerSubsections: false,
+		createIfNotFound: false,
+		createIfNotFoundLocation: "",
+	},
+	newLineCapture: {
+		enabled: false,
+		direction: "below",
+	},
+	openFile: false,
+	fileOpening: {
+		location: "tab",
+		direction: "vertical",
+		mode: "source",
+		focus: false,
+	},
+});
+
+const createFile = (path: string) => {
+	const file = new TFile();
+	file.path = path;
+	file.name = "Test.md";
+	file.basename = "Test";
+	file.extension = "md";
+	return file;
+};
+
+const createEngine = ({
+	firstRead,
+	secondRead,
+	formattedFileContent,
+}: {
+	firstRead: string;
+	secondRead: string;
+	formattedFileContent: string;
+}) => {
+	const filePath = "Daily/Test.md";
+	const file = createFile(filePath);
+	const app = {
+		vault: {
+			adapter: {
+				exists: vi.fn(async () => true),
+			},
+			getAbstractFileByPath: vi.fn(() => file),
+			read: vi
+				.fn()
+				.mockResolvedValueOnce(firstRead)
+				.mockResolvedValueOnce(secondRead),
+			modify: vi.fn(),
+			create: vi.fn(),
+		},
+		workspace: {
+			getActiveFile: vi.fn(() => null),
+			getActiveViewOfType: vi.fn(() => null),
+		},
+		fileManager: {
+			getNewFileParent: vi.fn(() => ({ path: "" })),
+		},
+	} as unknown as App;
+
+	const plugin = { settings: { showCaptureNotification: true } } as any;
+	const choiceExecutor: IChoiceExecutor = {
+		execute: vi.fn(),
+		variables: new Map<string, unknown>(),
+	};
+	const engine = new CaptureChoiceEngine(
+		app,
+		plugin,
+		createCaptureChoice(),
+		choiceExecutor,
+	);
+
+	formatContentWithFileMock.mockResolvedValue(formattedFileContent);
+
+	return { engine, filePath };
+};
+
+describe("CaptureChoiceEngine concurrent-edit merge", () => {
+	beforeEach(() => {
+		formatContentWithFileMock.mockReset();
+	});
+
+	it("proceeds when concurrent edits can be merged cleanly", async () => {
+		const firstRead = "alpha\nbeta\ngamma\n";
+		const secondRead = "alpha changed by sync\nbeta\ngamma\n";
+		const formattedFileContent = "alpha\nbeta\ngamma\ncaptured ours\n";
+		const { engine, filePath } = createEngine({
+			firstRead,
+			secondRead,
+			formattedFileContent,
+		});
+
+		const result = await (engine as any).onFileExists(filePath, "captured ours");
+
+		expect(result.newFileContent).toBe(
+			"alpha changed by sync\nbeta\ngamma\ncaptured ours\n",
+		);
+		expect(result.captureContent).toBe("captured ours");
+	});
+
+	it("aborts when concurrent edits conflict", async () => {
+		const firstRead = "alpha\nbeta\ngamma\n";
+		const secondRead = "alpha from sync\nbeta\ngamma\n";
+		const formattedFileContent = "alpha from capture\nbeta\ngamma\n";
+		const { engine, filePath } = createEngine({
+			firstRead,
+			secondRead,
+			formattedFileContent,
+		});
+
+		await expect(
+			(engine as any).onFileExists(filePath, "alpha from capture"),
+		).rejects.toThrow("has been modified since the last read");
+	});
+
+	it("uses formatted content directly when the file did not change between reads", async () => {
+		const firstRead = "alpha\nbeta\ngamma\n";
+		const formattedFileContent = "alpha\nbeta\ngamma\ncaptured ours\n";
+		const { engine, filePath } = createEngine({
+			firstRead,
+			secondRead: firstRead,
+			formattedFileContent,
+		});
+
+		const result = await (engine as any).onFileExists(filePath, "captured ours");
+
+		expect(result.newFileContent).toBe(formattedFileContent);
+	});
+});

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -685,7 +685,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				formattedFileContent,
 			);
 			invariant(
-				!res.isSuccess,
+				res.isSuccess(),
 				() =>
 					`The file ${filePath} has been modified since the last read.\nQuickAdd could not merge the versions two without conflicts, and will not modify the file.\nThis is in order to prevent data loss.`,
 			);


### PR DESCRIPTION
Fix the capture concurrent-edit merge guard so clean three-way merges can proceed.

QuickAdd already tries to protect Capture writes when the target file changes between the first and second read, but the guard was checking the `isSuccess` method reference instead of calling it. That made the merge path throw even when `three-way-merge` produced a clean result. This calls `res.isSuccess()` and adds regression coverage against the real merge library.

Verification:
- `git diff --stat 71d6ed71..HEAD -- src/engine/CaptureChoiceEngine.ts src/engine/CaptureChoiceEngine.notice.test.ts` printed no drift before implementation.
- `node -e 'const m=require("three-way-merge").default||require("three-way-merge"); const r=m("a-EDIT\nb\nc\n","a\nb\nc\n","a\nb\nc-OURS\n"); console.log(r.isSuccess(), typeof r.joinedResults(), JSON.stringify(r.joinedResults()));'` returned `true string "a-EDIT\nb\nc-OURS\n"`.
- `bun run test -- CaptureChoiceEngine`
- `bun run test -- src/engine/CaptureChoiceEngine.merge.test.ts --reporter=verbose`
- `bunx tsc -noEmit -skipLibCheck`
- `bun run lint`
- `bun run check`
- `bun run test`

Dev-vault proof:
- Built this worktree with `bun run build` for proof only.
- Temporarily repointed the dev-vault QuickAdd `main.js` symlink to this worktree bundle, reloaded with `obsidian vault=dev plugin:reload id=quickadd`, and restored the original symlink afterward.
- Executed a temporary Capture choice through `plugin.api.executeChoice` while patching the first read of only the temp target note to simulate a concurrent disk edit before the second read.
- Proof result was `ok: true`, with final content containing both the concurrent edit and the captured content: `alpha changed by sync\nbeta\ngamma\n\ncaptured ours`.
- Temporary proof files were deleted, the in-memory choice list was restored, the dev-vault symlink was restored to `/Users/christian/Developer/quickadd/main.js`, and final `obsidian vault=dev dev:errors` reported no captured errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating concurrent file edit merge scenarios, including successful merges, conflict detection, and handling of unchanged content.

* **Bug Fixes**
  * Updated merge validation logic to accurately detect conflicts when concurrent file modifications cannot be safely combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->