### PR TITLE
fix(formatter): consume empty tokens without looping

### DIFF
--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -332,6 +332,34 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 	});
 });
 
+describe("CompleteFormatter - empty-token loop termination (regression)", () => {
+	it(
+		"consumes an empty {{MACRO:}} token and does not hang",
+		async () => {
+			const f = defaultFormatter();
+			await expect(f.formatFolderPath("a {{MACRO:}} b")).resolves.toBe(
+				"a  b",
+			);
+			// The empty token is consumed without ever invoking the macro engine.
+			expect(mocks.macroRunAndGetOutput).not.toHaveBeenCalled();
+		},
+		2000,
+	);
+
+	it(
+		"consumes an empty ```js quickadd``` fence and does not hang",
+		async () => {
+			const f = defaultFormatter();
+			await expect(
+				f.formatFolderPath("x```js quickadd\n```y"),
+			).resolves.toBe("xy");
+			// The empty fence is consumed without ever invoking the inline-script engine.
+			expect(mocks.inlineRunAndGetOutput).not.toHaveBeenCalled();
+		},
+		2000,
+	);
+});
+
 describe("CompleteFormatter - getCurrentFileLink / getCurrentFileName", () => {
 	it("replaces {{LINKCURRENT}} with the generated markdown link", async () => {
 		const f = defaultFormatter(

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -441,6 +441,10 @@ export class CompleteFormatter extends Formatter {
 					typeof outVal === "string"
 						? this.replacer(output, INLINE_JAVASCRIPT_REGEX, outVal)
 						: this.replacer(output, INLINE_JAVASCRIPT_REGEX, "");
+			} else {
+				// Empty/whitespace-only fence (e.g. ```js quickadd\n```): consume the
+				// matched block so the loop terminates instead of spinning forever.
+				output = this.replacer(output, INLINE_JAVASCRIPT_REGEX, "");
 			}
 		}
 

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -508,7 +508,13 @@ export abstract class Formatter {
 
 		while (MACRO_REGEX.test(output)) {
 			const exec = MACRO_REGEX.exec(output);
-			if (!exec || !exec[1]) continue;
+			if (!exec) continue;
+			if (!exec[1]) {
+				// Empty macro name (e.g. {{MACRO:}}): consume the token so the
+				// loop terminates instead of re-testing the unchanged string forever.
+				output = this.replacer(output, MACRO_REGEX, "");
+				continue;
+			}
 
 			const parsed = parseMacroToken(exec[1]);
 			if (!parsed) {


### PR DESCRIPTION
Consume empty formatter tokens so QuickAdd does not spin forever on synchronous formatter loops.

Empty `{{MACRO:}}` tokens now get stripped before `replaceMacrosInString` retries the non-global macro regex, matching the existing invalid-token consume path. Empty or whitespace-only inline `js quickadd` fences now get stripped before `replaceInlineJavascriptInString` retries its non-global regex.

This fixes the live-preview and choice-execution freeze cases from Plan 002 without touching the shared regexes, display formatters, GUI code, or the Plan 003 template recursion path.

Verification:
- `bun run test -- completeFormatter` (44 passed)
- `bun run test` (157 files passed, 1726 tests passed, 31 skipped)
- `bunx tsc -noEmit -skipLibCheck`
- `bun run lint`
- `bun run check`

Dev-vault proof:
- Temporarily built this worktree for proof with `bun run build`; `main.js` / `styles.css` had no tracked diff afterward.
- Temporarily pointed dev-vault QuickAdd `main.js` at this worktree bundle, reloaded with `obsidian vault=dev plugin:reload id=quickadd`, and verified `plugin.api.format("a {{MACRO:}} b") === "a  b"` and `plugin.api.format("x```js quickadd\\n```y") === "xy"`.
- `obsidian vault=dev dev:errors` reported `No errors captured.`
- Restored dev-vault `main.js` to `/Users/christian/Developer/quickadd/main.js` and reloaded QuickAdd before releasing the lock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential infinite loop issues when processing empty macro tokens and empty inline JavaScript fences, preventing document formatting from hanging.

* **Tests**
  * Added regression test suite to verify proper handling of empty tokens without invoking macro or script engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->