### PR TITLE
fix(security): reject unsafe package asset destinations

### DIFF
--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -863,6 +863,35 @@ describe("applyPackageImport - assets", () => {
 		expect(state.writes.size).toBe(0);
 	});
 
+	it("rejects a Windows-style absolute asset destination override", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "templates/t.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [
+					{
+						originalPath: "templates/t.md",
+						destinationPath: "C:\\evil\\path.md",
+						mode: "write",
+					},
+				],
+			}),
+		).rejects.toThrow(/absolute path/);
+
+		expect(state.writes.size).toBe(0);
+	});
+
 	it("rejects assets targeting dotfile config directories", async () => {
 		const { app, state } = createFakeApp();
 		const asset: QuickAddPackageAsset = {
@@ -884,6 +913,36 @@ describe("applyPackageImport - assets", () => {
 		).rejects.toThrow(/config directory/);
 
 		expect(state.writes.size).toBe(0);
+	});
+
+	it("rejects unsafe asset destinations before writing any asset", async () => {
+		const { app, state } = createFakeApp();
+		const safeAsset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "Templates/safe.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("safe"),
+		};
+		const unsafeAsset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: ".obsidian/plugins/x/main.js",
+			contentEncoding: "base64",
+			content: encodeToBase64("unsafe"),
+		};
+		const pkg = makePackage({ assets: [safeAsset, unsafeAsset] });
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [],
+			}),
+		).rejects.toThrow(/config directory/);
+
+		expect(state.writes.size).toBe(0);
+		expect(state.createdFolders).toEqual([]);
 	});
 
 	it("allows url-encoded traversal text as a literal filename", async () => {

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -782,6 +782,154 @@ describe("applyPackageImport - assets", () => {
 		expect(state.writes.get("renamed/dest.md")).toBe("body");
 	});
 
+	it("rejects traversal in an asset's original path", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "../escape.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [],
+			}),
+		).rejects.toThrow(/traversal|\.\./);
+
+		expect(state.writes.size).toBe(0);
+	});
+
+	it("rejects traversal in an asset destination override", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "templates/t.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [
+					{
+						originalPath: "templates/t.md",
+						destinationPath: "../../evil.md",
+						mode: "write",
+					},
+				],
+			}),
+		).rejects.toThrow(/traversal|\.\./);
+
+		expect(state.writes.size).toBe(0);
+	});
+
+	it("rejects an absolute asset destination override", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "templates/t.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [
+					{
+						originalPath: "templates/t.md",
+						destinationPath: "/abs/path.md",
+						mode: "write",
+					},
+				],
+			}),
+		).rejects.toThrow(/absolute path/);
+
+		expect(state.writes.size).toBe(0);
+	});
+
+	it("rejects assets targeting dotfile config directories", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: ".obsidian/plugins/x/main.js",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [],
+			}),
+		).rejects.toThrow(/config directory/);
+
+		expect(state.writes.size).toBe(0);
+	});
+
+	it("allows url-encoded traversal text as a literal filename", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "..%2fevil.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions: [],
+		});
+
+		expect(result.writtenAssets).toEqual(["..%2fevil.md"]);
+		expect(state.writes.get("..%2fevil.md")).toBe("body");
+	});
+
+	it("allows a legitimate asset path", async () => {
+		const { app, state } = createFakeApp();
+		const asset: QuickAddPackageAsset = {
+			kind: "template",
+			originalPath: "Templates/foo.md",
+			contentEncoding: "base64",
+			content: encodeToBase64("body"),
+		};
+		const pkg = makePackage({ assets: [asset] });
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions: [],
+		});
+
+		expect(result.writtenAssets).toEqual(["Templates/foo.md"]);
+		expect(state.writes.get("Templates/foo.md")).toBe("body");
+	});
+
 	it("rewrites template/userscript/conditional paths to remapped destinations", async () => {
 		const { app } = createFakeApp();
 

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -196,6 +196,40 @@ export async function analysePackagePreview(
 	return preview;
 }
 
+/**
+ * Validate that an imported asset's destination stays inside the vault and does
+ * not target a dotfile config directory (.obsidian, .git, ...). Throws on any
+ * out-of-bounds destination so the whole import aborts (surfaced as a Notice by
+ * ImportPackageModal). Defensive: imported packages are untrusted shared data.
+ */
+function validateAssetDestination(rawPath: string): string {
+	const normalized = normalizePath(rawPath);
+	if (!normalized || normalized.trim() === "") {
+		throw new Error("Package asset has an empty destination path.");
+	}
+
+	if (normalized.startsWith("/") || /^[a-zA-Z]:/.test(normalized)) {
+		throw new Error(
+			`Refusing to import asset to an absolute path outside the vault: "${normalized}".`,
+		);
+	}
+
+	const segments = normalized.split("/").filter((segment) => segment.length > 0);
+	if (segments.some((segment) => segment === "..")) {
+		throw new Error(
+			`Refusing to import asset with a path-traversal segment ("..") in: "${normalized}".`,
+		);
+	}
+
+	if (segments[0]?.startsWith(".") && !segments[0].startsWith("..%")) {
+		throw new Error(
+			`Refusing to import asset into a config directory: "${normalized}".`,
+		);
+	}
+
+	return normalized;
+}
+
 export async function applyPackageImport(
 	options: ApplyImportOptions,
 ): Promise<ApplyImportResult> {
@@ -416,9 +450,9 @@ export async function applyPackageImport(
 	for (const asset of pkg.assets) {
 		const decision = assetDecisionMap.get(asset.originalPath);
 		const destinationPathInput = decision?.destinationPath?.trim();
-		const destinationPath = destinationPathInput
-			? normalizePath(destinationPathInput)
-			: asset.originalPath;
+		const destinationPath = validateAssetDestination(
+			destinationPathInput || asset.originalPath,
+		);
 		const exists = await assetExists(app, destinationPath);
 		const mode =
 			decision?.mode ?? (exists ? "overwrite" : "write");

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -203,15 +203,25 @@ export async function analysePackagePreview(
  * ImportPackageModal). Defensive: imported packages are untrusted shared data.
  */
 function validateAssetDestination(rawPath: string): string {
-	const normalized = normalizePath(rawPath);
-	if (!normalized || normalized.trim() === "") {
+	const rawDestination = rawPath ?? "";
+	const trimmedDestination = rawDestination.trim();
+	if (!trimmedDestination) {
 		throw new Error("Package asset has an empty destination path.");
 	}
 
-	if (normalized.startsWith("/") || /^[a-zA-Z]:/.test(normalized)) {
+	const slashNormalizedRawDestination = trimmedDestination.replace(/\\/g, "/");
+	if (
+		slashNormalizedRawDestination.startsWith("/") ||
+		/^[a-zA-Z]:/.test(slashNormalizedRawDestination)
+	) {
 		throw new Error(
-			`Refusing to import asset to an absolute path outside the vault: "${normalized}".`,
+			`Refusing to import asset to an absolute path outside the vault: "${slashNormalizedRawDestination}".`,
 		);
+	}
+
+	const normalized = normalizePath(trimmedDestination);
+	if (!normalized || normalized.trim() === "") {
+		throw new Error("Package asset has an empty destination path.");
 	}
 
 	const segments = normalized.split("/").filter((segment) => segment.length > 0);
@@ -446,13 +456,17 @@ export async function applyPackageImport(
 	const assetPathOverrides = new Map<string, string>();
 	const writtenAssets: string[] = [];
 	const skippedAssets: string[] = [];
-
-	for (const asset of pkg.assets) {
+	const resolvedAssetDestinations = pkg.assets.map((asset) => {
 		const decision = assetDecisionMap.get(asset.originalPath);
 		const destinationPathInput = decision?.destinationPath?.trim();
 		const destinationPath = validateAssetDestination(
 			destinationPathInput || asset.originalPath,
 		);
+		return { asset, destinationPath };
+	});
+
+	for (const { asset, destinationPath } of resolvedAssetDestinations) {
+		const decision = assetDecisionMap.get(asset.originalPath);
 		const exists = await assetExists(app, destinationPath);
 		const mode =
 			decision?.mode ?? (exists ? "overwrite" : "write");


### PR DESCRIPTION
Reject unsafe asset destinations during package import before QuickAdd writes bundled files into the vault. Asset destinations now normalize through a single guard that rejects absolute paths, raw `..` traversal, and top-level dot-config directories such as `.obsidian/`, while preserving contained filenames like `..%2fevil.md` as literals.

This closes Plan 005 at the write boundary: both default asset paths and user-selected destination overrides now fail before `ensureParentFolders` or `adapter.write` can run.

Verification:
- `bunx tsc -noEmit -skipLibCheck`
- `bun run test -- packageImportService`
- `bun run test`
- `bun run lint`
- `bun run check`
- Dev vault proof: temporarily pointed `vault=dev` QuickAdd `main.js` at this worktree build, reloaded QuickAdd, imported a package asset targeting `.obsidian/plugins/x/main.js`, and observed `Refusing to import asset into a config directory: ".obsidian/plugins/x/main.js".` with no target file written. Restored the original dev-vault symlink to `/Users/christian/Developer/quickadd/main.js` and reloaded QuickAdd afterward.

Notes:
- `bun run build` was run only for the locked dev-vault proof and generated ignored local `main.js` / `styles.css` artifacts in the worktree.
- No generated bundle artifacts are included in this PR.
- Plan 006 is the sibling package-import disclosure fix and is intentionally not included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of asset destination paths during package imports to block traversal segments, absolute paths, empty destinations, and writes into dotfile-config directories; invalid destinations now abort the import.
* **Tests**
  * Added unit tests covering rejected unsafe paths (including mixed safe/unsafe packages) and allowed cases like URL-encoded traversal text and legitimate capitalized paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->