### PR TITLE
perf(ai): lazy-load js-tiktoken rank data

### DIFF
--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -585,17 +585,20 @@ const selectedModel = await quickAddApi.suggester(models, models);
 Gets the maximum token limit for a model.
 
 ### `countTokens(text: string, model: string): number`
-Counts tokens in text according to model's tokenization.
+Returns a fast synchronous token estimate (`~4` characters per token). This does
+not load tokenizer rank data and should be used for UI hints or rough preflight
+warnings, not as an exact model-limit gate. QuickAdd's built-in AI requests still
+use exact token counts internally before sending requests.
 
 **Example:**
 ```javascript
 const text = await quickAddApi.utility.getClipboard();
-const tokenCount = quickAddApi.ai.countTokens(text, "gpt-4");
+const estimatedTokens = quickAddApi.ai.countTokens(text, "gpt-4");
 
-if (tokenCount > 4000) {
+if (estimatedTokens > 4000) {
     await quickAddApi.infoDialog(
-        "Text Too Long",
-        `The text contains ${tokenCount} tokens, which exceeds the model limit.`
+        "Text May Be Too Long",
+        `The text is roughly ${estimatedTokens} tokens. Consider shortening it before sending.`
     );
 }
 ```

--- a/src/ai/AIAssistant.tokenCount.test.ts
+++ b/src/ai/AIAssistant.tokenCount.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { Model } from "./Provider";
+import {
+	estimateTokenCount,
+	getTokenCount,
+	getTokenCountAsync,
+} from "./AIAssistant";
+
+const model = { name: "gpt-4", maxTokens: 8192 } as unknown as Model;
+
+describe("AI Assistant token counting", () => {
+	it("estimates tokens from character length synchronously", () => {
+		expect(estimateTokenCount("")).toBe(0);
+		expect(estimateTokenCount("abcd")).toBe(1);
+		expect(estimateTokenCount("abcde")).toBe(2);
+	});
+
+	it("keeps getTokenCount as the synchronous estimate wrapper", () => {
+		const text = "count this prompt quickly";
+
+		expect(getTokenCount(text, model)).toBe(estimateTokenCount(text));
+	});
+
+	it("counts tokens exactly through the lazy async encoder", async () => {
+		const first = await getTokenCountAsync("hello world", model);
+		const second = await getTokenCountAsync("hello world", model);
+
+		expect(Number.isInteger(first)).toBe(true);
+		expect(first).toBeGreaterThan(0);
+		expect(first).toBeLessThanOrEqual("hello world".length);
+		expect(second).toBe(first);
+	});
+});

--- a/src/ai/AIAssistant.tokenCountCache.test.ts
+++ b/src/ai/AIAssistant.tokenCountCache.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Model } from "./Provider";
+
+describe("AI Assistant token encoding cache", () => {
+	it("shares one tokenizer construction between concurrent first callers", async () => {
+		vi.resetModules();
+		const constructorMock = vi.fn();
+
+		vi.doMock("js-tiktoken/lite", () => ({
+			Tiktoken: class {
+				constructor(rank: unknown) {
+					constructorMock(rank);
+				}
+
+				encode(text: string) {
+					return Array.from(text);
+				}
+			},
+			getEncodingNameForModel: () => "cl100k_base",
+		}));
+		vi.doMock("js-tiktoken/ranks/cl100k_base", () => ({
+			default: { name: "cl100k_base" },
+		}));
+		vi.doMock("js-tiktoken/ranks/o200k_base", () => ({
+			default: { name: "o200k_base" },
+		}));
+
+		const { getTokenCountAsync } = await import("./AIAssistant");
+		const model = { name: "gpt-4", maxTokens: 8192 } as unknown as Model;
+
+		const [first, second] = await Promise.all([
+			getTokenCountAsync("abc", model),
+			getTokenCountAsync("def", model),
+		]);
+
+		expect(first).toBe(3);
+		expect(second).toBe(3);
+		expect(constructorMock).toHaveBeenCalledTimes(1);
+		expect(constructorMock).toHaveBeenCalledWith({ name: "cl100k_base" });
+	});
+});

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -16,7 +16,7 @@ import { makeNoticeHandler } from "./makeNoticeHandler";
 
 type Encoding = ConstructorParameters<typeof Tiktoken>[0];
 
-const encodingCache = new Map<string, Tiktoken>();
+const encodingCache = new Map<string, Promise<Tiktoken>>();
 
 async function loadRank(name: string): Promise<Encoding> {
 	switch (name) {
@@ -28,7 +28,7 @@ async function loadRank(name: string): Promise<Encoding> {
 	}
 }
 
-async function getEncodingAsync(name: string): Promise<Tiktoken> {
+function getEncodingAsync(name: string): Promise<Tiktoken> {
 	const encodingName =
 		name === "o200k_base" || name === "cl100k_base"
 			? name
@@ -36,10 +36,14 @@ async function getEncodingAsync(name: string): Promise<Tiktoken> {
 	const cached = encodingCache.get(encodingName);
 	if (cached) return cached;
 
-	const rank = await loadRank(encodingName);
-	const encoding = new Tiktoken(rank);
-	encodingCache.set(encodingName, encoding);
-	return encoding;
+	const encodingPromise = loadRank(encodingName)
+		.then((rank) => new Tiktoken(rank))
+		.catch((error) => {
+			encodingCache.delete(encodingName);
+			throw error;
+		});
+	encodingCache.set(encodingName, encodingPromise);
+	return encodingPromise;
 }
 
 function resolveEncodingName(model: Model): string {

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -1,7 +1,5 @@
 import type { TiktokenModel } from "js-tiktoken";
 import { Tiktoken, getEncodingNameForModel } from "js-tiktoken/lite";
-import cl100k_base from "js-tiktoken/ranks/cl100k_base";
-import o200k_base from "js-tiktoken/ranks/o200k_base";
 import type { App } from "obsidian";
 import { TFile } from "obsidian";
 import { MacroAbortError } from "src/errors/MacroAbortError";
@@ -18,23 +16,33 @@ import { makeNoticeHandler } from "./makeNoticeHandler";
 
 type Encoding = ConstructorParameters<typeof Tiktoken>[0];
 
-const encodings: Record<string, Encoding> = {
-	cl100k_base,
-	o200k_base,
-};
 const encodingCache = new Map<string, Tiktoken>();
 
-function getEncoding(name: string) {
-	const encodingName = name in encodings ? name : "cl100k_base";
+async function loadRank(name: string): Promise<Encoding> {
+	switch (name) {
+		case "o200k_base":
+			return (await import("js-tiktoken/ranks/o200k_base")).default;
+		case "cl100k_base":
+		default:
+			return (await import("js-tiktoken/ranks/cl100k_base")).default;
+	}
+}
+
+async function getEncodingAsync(name: string): Promise<Tiktoken> {
+	const encodingName =
+		name === "o200k_base" || name === "cl100k_base"
+			? name
+			: "cl100k_base";
 	const cached = encodingCache.get(encodingName);
 	if (cached) return cached;
 
-	const encoding = new Tiktoken(encodings[encodingName]);
+	const rank = await loadRank(encodingName);
+	const encoding = new Tiktoken(rank);
 	encodingCache.set(encodingName, encoding);
 	return encoding;
 }
 
-export const getTokenCount = (text: string, model: Model) => {
+function resolveEncodingName(model: Model): string {
 	// Use best-effort for non-OpenAI/unknown models by falling back to cl100k.
 	let encodingName = "cl100k_base";
 	try {
@@ -49,8 +57,29 @@ export const getTokenCount = (text: string, model: Model) => {
 		encodingName = "cl100k_base";
 	}
 
-	return getEncoding(encodingName).encode(text).length;
-};
+	return encodingName;
+}
+
+// Exact count. Lazily loads the rank table on first use; only call this on
+// async request-gating paths that need a precise token count.
+export async function getTokenCountAsync(
+	text: string,
+	model: Model
+): Promise<number> {
+	const encodingName = resolveEncodingName(model);
+	const encoding = await getEncodingAsync(encodingName);
+	return encoding.encode(text).length;
+}
+
+// Cheap synchronous estimate (~4 chars per token) for UI/preview labels.
+export function estimateTokenCount(text: string): number {
+	return Math.ceil(text.length / 4);
+}
+
+// Backwards-compatible synchronous helper for the public user-script API.
+// Best-effort estimate; does not load tokenizer rank data.
+export const getTokenCount = (text: string, _model: Model): number =>
+	estimateTokenCount(text);
 
 export interface AIRequestLogEntry {
 	id: string;
@@ -545,12 +574,12 @@ export async function ChunkedPrompt(
 		const chunkSeparator = settings.chunkSeparator || /\n/g;
 		const chunks = text.split(chunkSeparator);
 
-		const systemPromptLength = getTokenCount(systemPrompt, model);
+		const systemPromptLength = await getTokenCountAsync(systemPrompt, model);
 		// We need the prompt template to be rendered to get the token count of it, except the chunk variable.
 		const renderedPromptTemplate = await formatter(promptTemplate, {
 			chunk: " ", // empty would make QA ask for a value, which we don't want
 		});
-		const promptTemplateTokenCount = getTokenCount(
+		const promptTemplateTokenCount = await getTokenCountAsync(
 			renderedPromptTemplate,
 			model
 		);
@@ -571,7 +600,7 @@ export async function ChunkedPrompt(
 			let combinedChunkSize = 0;
 
 			for (const chunk of chunks) {
-				const strSize = getTokenCount(chunk, model) + 1; // +1 for the newline
+				const strSize = (await getTokenCountAsync(chunk, model)) + 1; // +1 for the newline
 
 				if (strSize > maxCombinedChunkSize) {
 					throw new Error(
@@ -606,7 +635,7 @@ export async function ChunkedPrompt(
 			}
 		} else {
 			for (const chunk of chunks) {
-				const tokenCount = getTokenCount(chunk, model);
+				const tokenCount = await getTokenCountAsync(chunk, model);
 
 				if (tokenCount > maxChunkTokenSize) {
 					throw new Error(

--- a/src/ai/OpenAIRequest.test.ts
+++ b/src/ai/OpenAIRequest.test.ts
@@ -27,7 +27,7 @@ vi.mock("src/settingsStore", () => ({
 }));
 
 vi.mock("./AIAssistant", () => ({
-	getTokenCount: mocks.getTokenCountMock,
+	getTokenCountAsync: mocks.getTokenCountMock,
 	beginAIRequestLogEntry: mocks.beginAIRequestLogEntryMock,
 	finishAIRequestLogEntry: mocks.finishAIRequestLogEntryMock,
 }));
@@ -131,7 +131,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	storeState.disableOnlineFeatures = false;
 	// Default token count keeps every prompt well under any maxTokens limit.
-	getTokenCountMock.mockReturnValue(1);
+	getTokenCountMock.mockResolvedValue(1);
 	beginAIRequestLogEntryMock.mockReturnValue("log-id-1");
 });
 
@@ -155,7 +155,7 @@ describe("OpenAIRequest", () => {
 
 		it("throws when the combined token count exceeds the model limit", async () => {
 			// prompt + system both contribute; sum (60000+60000) > 100000.
-			getTokenCountMock.mockReturnValue(60000);
+			getTokenCountMock.mockResolvedValue(60000);
 			const model: Model = { name: "gpt-4o", maxTokens: 100000 };
 			const makeRequest = OpenAIRequest(makeApp(), "key", model, "system");
 
@@ -167,7 +167,7 @@ describe("OpenAIRequest", () => {
 
 		it("allows requests exactly at the token limit (boundary)", async () => {
 			// 2 * 50000 = 100000, not strictly greater than the limit.
-			getTokenCountMock.mockReturnValue(50000);
+			getTokenCountMock.mockResolvedValue(50000);
 			const model: Model = { name: "gpt-4o", maxTokens: 100000 };
 			getModelProviderMock.mockReturnValue(openAIProvider);
 			requestUrlMock.mockResolvedValue({ json: openAIResponse() });

--- a/src/ai/OpenAIRequest.ts
+++ b/src/ai/OpenAIRequest.ts
@@ -5,7 +5,7 @@ import { settingsStore } from "src/settingsStore";
 import {
 	beginAIRequestLogEntry,
 	finishAIRequestLogEntry,
-	getTokenCount,
+	getTokenCountAsync,
 } from "./AIAssistant";
 import { preventCursorChange } from "./preventCursorChange";
 import type { AIProvider, Model } from "./Provider";
@@ -266,7 +266,8 @@ export function OpenAIRequest(
 		}
 
 		const tokenCount =
-			getTokenCount(prompt, model) + getTokenCount(systemPrompt, model);
+			(await getTokenCountAsync(prompt, model)) +
+			(await getTokenCountAsync(systemPrompt, model));
 		const { maxTokens } = model;
 
 		if (tokenCount > maxTokens) {

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -14,7 +14,7 @@ import {
 	DEFAULT_TEMPERATURE,
 	DEFAULT_TOP_P,
 } from "src/ai/OpenAIModelParameters";
-import { getTokenCount } from "src/ai/AIAssistant";
+import { estimateTokenCount } from "src/ai/AIAssistant";
 import { getModelByName, getModelNames } from "src/ai/aiHelpers";
 
 export class AIAssistantCommandSettingsModal extends Modal {
@@ -32,7 +32,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 		const model = getModelByName(this.settings.model);
 		if (!model) return Number.POSITIVE_INFINITY;
 
-		return getTokenCount(this.settings.systemPrompt, model);
+		return estimateTokenCount(this.settings.systemPrompt);
 	}
 
 	constructor(app: App, settings: IAIAssistantCommand) {

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -11,7 +11,7 @@ import {
 	DEFAULT_TEMPERATURE,
 	DEFAULT_TOP_P,
 } from "src/ai/OpenAIModelParameters";
-import { getTokenCount } from "src/ai/AIAssistant";
+import { estimateTokenCount } from "src/ai/AIAssistant";
 import { getModelByName, getModelNames } from "src/ai/aiHelpers";
 
 export class InfiniteAIAssistantCommandSettingsModal extends Modal {
@@ -26,7 +26,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 	private get systemPromptTokenLength(): number {
 		const model = getModelByName(this.settings.model);
 		if (!model) return Number.POSITIVE_INFINITY;
-		return getTokenCount(this.settings.systemPrompt, model);
+		return estimateTokenCount(this.settings.systemPrompt);
 	}
 
 	constructor(app: App, settings: IInfiniteAIAssistantCommand) {

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -541,6 +541,7 @@ export class QuickAddApi {
 
 					return model.maxTokens;
 				},
+				// Synchronous best-effort estimate (~4 chars/token); does not load tokenizer ranks.
 				countTokens(text: string, model: Model) {
 					return getTokenCount(text, model);
 				},


### PR DESCRIPTION
## Summary

Lazy-load `js-tiktoken` rank data so QuickAdd no longer initializes the multi-MB `cl100k_base` / `o200k_base` tables on plugin startup.

Exact token counts remain on async request-gating paths. Synchronous UI/API surfaces now use a cheap `chars / 4` estimate so rendering token labels or calling `quickAddApi.ai.countTokens` does not force rank loading.

## Changes

- Replace eager tokenizer rank imports with dynamic rank loading and cached `Tiktoken` instances.
- Add `getTokenCountAsync` for exact counts and `estimateTokenCount` for synchronous preview paths.
- Keep OpenAI request budget checks and chunk sizing on exact async counts.
- Switch AI Assistant settings modals and public sync `countTokens` to the estimate path.
- Add focused token-count regression coverage and update the OpenAI request mock for the async count symbol.
- Update the current QuickAdd API docs so `countTokens` is documented as a fast estimate rather than an exact budget gate.
- Cache in-flight tokenizer construction promises so concurrent first callers share one lazy `Tiktoken` instance per encoding.

## Testing / validation

- `bun run test -- src/ai/OpenAIRequest`
- `bun run test -- src/ai/AIAssistant.tokenCount`
- `bunx tsc -noEmit -skipLibCheck`
- `bun run lint`
- `bun run check`
- `bun run test`
- Structural checks:
  - no static `import ... from "js-tiktoken/ranks/*"` remains
  - two dynamic rank imports remain in `src/ai/AIAssistant.ts`
  - production bare `getTokenCount` usage is limited to `src/ai/AIAssistant.ts` and `src/quickAddApi.ts`
- Temporary production proof bundle built to `/private/tmp/quickadd-plan007-proof` without writing root `main.js` / `styles.css`; proof `main.js` was 4,423,058 bytes and contains lazy `Promise.resolve().then(...init...)` rank wrappers.
- Dev-vault proof with `vault=dev`:
  - before: `main.js -> /Users/christian/Developer/quickadd/main.js`
  - temporarily repointed `main.js` to `/private/tmp/quickadd-plan007-proof/main.js`
  - reloaded QuickAdd successfully
  - `plugin.api.ai.countTokens("abcde", { name: "gpt-4", maxTokens: 8192 })` returned `2`, matching the sync estimate
  - `quickadd:testQuickAdd` rendered the AI Assistant modal with `Token count: 1` and range max `8191`
  - `dev:errors` reported `No errors captured.`
  - after: restored `main.js -> /Users/christian/Developer/quickadd/main.js` and reloaded QuickAdd again
  - `data.json` SHA-256 stayed `3ffb1b1a9f25ddfdfa398d7b9c4a9d14e028069f8308b1d5806aa4845e7a3f86`

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
      — it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s). Plan 007 orchestration task; no GitHub issue.
- [x] Noted release/migration impact, if any. Perf-only runtime change; no migration. `quickAddApi.ai.countTokens` remains synchronous but is now a best-effort estimate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added async token counting API for precise token count calculations

* **Documentation**
  * Clarified that UI token estimates are rough approximations (~4 characters per token)
  * Updated guidance to display preflight warnings advising users to shorten text if estimates exceed limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->