### PR TITLE
fix: build folder-capture path without a double slash

### DIFF
--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Notice, type App } from "obsidian";
+import InputSuggester from "src/gui/InputSuggester/inputSuggester";
 import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
-import { insertFileLinkToActiveView, isFolder, openFile } from "../utilityObsidian";
+import {
+	getMarkdownFilesInFolder,
+	insertFileLinkToActiveView,
+	isFolder,
+	openFile,
+} from "../utilityObsidian";
 import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "../constants";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { MacroAbortError } from "../errors/MacroAbortError";
@@ -269,7 +275,10 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 describe("CaptureChoiceEngine capture target resolution", () => {
 	beforeEach(() => {
 		vi.mocked(isFolder).mockReset();
+		vi.mocked(getMarkdownFilesInFolder).mockReset();
+		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([]);
 		vi.mocked(insertFileLinkToActiveView).mockReset();
+		delete (InputSuggester as any).Suggest;
 		setTitleMock.mockClear();
 		singleTemplateRunMock.mockReset();
 		singleTemplateRunMock.mockResolvedValue("");
@@ -383,6 +392,25 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		const result = await (engine as any).getFormattedPathToCaptureTo(false);
 
 		expect(result).toBe("Boards/Map.CANVAS");
+	});
+
+	it("builds a single-slash path for a typed custom filename in a folder capture", async () => {
+		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([
+			{ path: "Inbox/Existing.md" } as any,
+		]);
+		(InputSuggester as any).Suggest = vi.fn(async () => "note");
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "Inbox/" }),
+			createExecutor(),
+		);
+
+		const resolved = await (engine as any).selectFileInFolder("Inbox/", false);
+
+		expect(resolved).not.toContain("//");
+		expect(resolved).toBe("Inbox/note.md");
 	});
 
 	it("uses extensionless title for created .canvas capture files", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -604,7 +604,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		// their own file path, so we need to make sure it's in the target folder.
 		const filePath = targetFilePath.startsWith(`${folderPathSlash}`)
 			? targetFilePath
-			: `${folderPathSlash}/${targetFilePath}`;
+			: `${folderPathSlash}${targetFilePath}`;
 
 		return await this.formatFilePath(filePath);
 	}


### PR DESCRIPTION
Fix folder capture path construction when the capture target is a folder and the user types a custom filename in the suggester.

The fallback join now uses the already-normalized trailing slash from `folderPathSlash`, so `Inbox/` + `note` resolves to `Inbox/note.md` instead of `Inbox//note.md`. This keeps the path aligned with Obsidian's exact vault lookups and avoids malformed create/append targets.

Added a focused regression test for the typed custom filename branch in `CaptureChoiceEngine.selection.test.ts`.

Verification:
- `bun run test -- CaptureChoiceEngine.selection`
- `bun run test`
- `bunx tsc -noEmit -skipLibCheck`
- `bun run lint`
- `bun run check`
- `bun run build` for dev-vault proof only; no tracked generated-file diff remained
- Dev-vault proof: temporarily repointed `vault=dev` QuickAdd `main.js` to this worktree build, reloaded QuickAdd, ran a real temporary Capture choice through `plugin.api.executeChoice`, typed `typed-note` into the real InputSuggester, and verified `folder/typed-note.md` existed, `folder//typed-note.md` did not, and proof content matched. Restored `main.js` to `/Users/christian/Developer/quickadd/main.js`; `data.json` hash stayed unchanged; `obsidian vault=dev dev:errors` reported no errors.

Release impact: bug fix only; no settings migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where file paths could contain unintended double slashes when selecting files in a folder with a custom-typed filename, ensuring paths are correctly formatted (e.g., `Inbox/note.md` instead of `Inbox//note.md`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->