### PR TITLE
fix: guard template expansion against inclusion cycles

### DIFF
--- a/src/engine/SingleTemplateEngine.ts
+++ b/src/engine/SingleTemplateEngine.ts
@@ -3,15 +3,17 @@ import type { App } from "obsidian";
 import type QuickAdd from "../main";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
+import type { TemplateInclusionState } from "../formatters/formatter";
 
 export class SingleTemplateEngine extends TemplateEngine {
 	constructor(
 		app: App,
 		plugin: QuickAdd,
 		private templatePath: string,
-		choiceExecutor?: IChoiceExecutor
+		choiceExecutor?: IChoiceExecutor,
+		inclusion?: TemplateInclusionState,
 	) {
-		super(app, plugin, choiceExecutor);
+		super(app, plugin, choiceExecutor, inclusion);
 	}
 	public async run(): Promise<string> {
 		let templateContent: string = await this.getTemplateContent(

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -1,6 +1,9 @@
 import { QuickAddEngine } from "./QuickAddEngine";
 import { CompleteFormatter } from "../formatters/completeFormatter";
-import type { LinkToCurrentFileBehavior } from "../formatters/formatter";
+import type {
+	LinkToCurrentFileBehavior,
+	TemplateInclusionState,
+} from "../formatters/formatter";
 import type { App } from "obsidian";
 import { Notice, TFile, TFolder } from "obsidian";
 import type QuickAdd from "../main";
@@ -81,11 +84,15 @@ export abstract class TemplateEngine extends QuickAddEngine {
 	protected constructor(
 		app: App,
 		protected plugin: QuickAdd,
-		choiceFormatter?: IChoiceExecutor
+		choiceFormatter?: IChoiceExecutor,
+		inclusion?: TemplateInclusionState,
 	) {
 		super(app);
 		this.templater = getTemplater(app);
 		this.formatter = new CompleteFormatter(app, plugin, choiceFormatter);
+		if (inclusion) {
+			this.formatter.setTemplateInclusionState(inclusion);
+		}
 	}
 
 	public abstract run():

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TemplateInclusionState } from "./formatter";
 
 /**
  * Unit tests for the concrete CompleteFormatter.
@@ -50,7 +51,23 @@ vi.mock("../engine/SingleMacroEngine", () => ({
 
 vi.mock("../engine/SingleTemplateEngine", () => ({
 	SingleTemplateEngine: class {
-		run = mocks.templateRun;
+		templatePath: string;
+		inclusion?: TemplateInclusionState;
+
+		constructor(
+			_app: unknown,
+			_plugin: unknown,
+			templatePath: string,
+			_choiceExecutor?: unknown,
+			inclusion?: TemplateInclusionState,
+		) {
+			this.templatePath = templatePath;
+			this.inclusion = inclusion;
+		}
+
+		run() {
+			return mocks.templateRun.call(this);
+		}
 	},
 }));
 
@@ -182,6 +199,20 @@ function defaultFormatter(
 	return new CompleteFormatter(app as any, plugin as any);
 }
 
+function mockTemplateVault(templates: Record<string, string>) {
+	mocks.templateRun.mockImplementation(async function (this: {
+		templatePath: string;
+		inclusion?: TemplateInclusionState;
+	}) {
+		const child = defaultFormatter();
+		if (this.inclusion) {
+			child.setTemplateInclusionState(this.inclusion);
+		}
+
+		return await child.formatFileContent(templates[this.templatePath] ?? "");
+	});
+}
+
 beforeEach(() => {
 	for (const key of Object.keys(mocks.inlineParamsVariables)) {
 		delete mocks.inlineParamsVariables[key];
@@ -302,6 +333,51 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 		await expect(
 			f.formatFolderPath("{{TEMPLATE:notes/a.md}}"),
 		).resolves.toBe("TEMPLATE_BODY");
+	});
+
+	it("terminates self-including templates with a visible placeholder", async () => {
+		mockTemplateVault({
+			"A.md": "before {{TEMPLATE:A.md}} after",
+		});
+		const f = defaultFormatter();
+
+		const result = await f.formatFileContent("{{TEMPLATE:A.md}}");
+
+		expect(result).toContain(
+			'[QuickAdd: template inclusion cycle detected at "A.md"]',
+		);
+		expect(result).toContain("before");
+		expect(result).toContain("after");
+	});
+
+	it("terminates mutually-including templates with a visible placeholder", async () => {
+		mockTemplateVault({
+			"A.md": "{{TEMPLATE:B.md}}",
+			"B.md": "{{TEMPLATE:A.md}}",
+		});
+		const f = defaultFormatter();
+
+		const result = await f.formatFileContent("{{TEMPLATE:A.md}}");
+
+		expect(result).toContain(
+			'[QuickAdd: template inclusion cycle detected at "A.md"]',
+		);
+	});
+
+	it("terminates over-depth template chains with a visible placeholder", async () => {
+		const templates: Record<string, string> = {};
+		for (let i = 0; i < 12; i++) {
+			templates[`T${i}.md`] =
+				i === 11 ? "leaf" : `{{TEMPLATE:T${i + 1}.md}}`;
+		}
+		mockTemplateVault(templates);
+		const f = defaultFormatter();
+
+		const result = await f.formatFileContent("{{TEMPLATE:T0.md}}");
+
+		expect(result).toContain(
+			'[QuickAdd: max template inclusion depth (10) exceeded at "T10.md"]',
+		);
 	});
 
 	it("replaces inline JavaScript with its string output", async () => {

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -364,6 +364,20 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 		);
 	});
 
+	it("allows repeated non-cyclic template inclusions after the stack unwinds", async () => {
+		mockTemplateVault({
+			"footer.md": "footer",
+		});
+		const f = defaultFormatter();
+
+		const result = await f.formatFileContent(
+			"{{TEMPLATE:footer.md}} and {{TEMPLATE:footer.md}}",
+		);
+
+		expect(result).toBe("footer and footer");
+		expect(result).not.toContain("template inclusion cycle detected");
+	});
+
 	it("terminates over-depth template chains with a visible placeholder", async () => {
 		const templates: Record<string, string> = {};
 		for (let i = 0; i < 12; i++) {

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -385,7 +385,6 @@ export class CompleteFormatter extends Formatter {
 			"../engine/SingleTemplateEngine"
 		);
 		this.templateInclusion ??= { visited: new Set<string>(), depth: 0 };
-		this.templateInclusion.visited.add(templatePath);
 		const childInclusion = {
 			visited: this.templateInclusion.visited,
 			depth: this.templateInclusion.depth + 1,

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -384,11 +384,18 @@ export class CompleteFormatter extends Formatter {
 		const { SingleTemplateEngine } = await import(
 			"../engine/SingleTemplateEngine"
 		);
+		this.templateInclusion ??= { visited: new Set<string>(), depth: 0 };
+		this.templateInclusion.visited.add(templatePath);
+		const childInclusion = {
+			visited: this.templateInclusion.visited,
+			depth: this.templateInclusion.depth + 1,
+		};
 		return await new SingleTemplateEngine(
 			this.app,
 			this.plugin,
 			templatePath,
 			this.choiceExecutor,
+			childInclusion,
 		).run();
 	}
 

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -712,7 +712,13 @@ export abstract class Formatter {
 				continue;
 			}
 
-			const templateContent = await this.getTemplateContent(templatePath);
+			this.templateInclusion.visited.add(templatePath);
+			let templateContent: string;
+			try {
+				templateContent = await this.getTemplateContent(templatePath);
+			} finally {
+				this.templateInclusion.visited.delete(templatePath);
+			}
 
 			output = this.replacer(output, TEMPLATE_REGEX, templateContent);
 		}

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -53,12 +53,20 @@ export interface PromptContext {
 	optional?: boolean; // Token carries |optional: empty submissions are accepted as the answer.
 }
 
+export interface TemplateInclusionState {
+	visited: Set<string>;
+	depth: number;
+}
+
+const MAX_TEMPLATE_INCLUSION_DEPTH = 10;
+
 export abstract class Formatter {
 	protected value: string;
 	protected variables: Map<string, unknown> = new Map<string, unknown>();
 	protected dateParser: IDateParser | undefined;
 	private linkToCurrentFileBehavior: LinkToCurrentFileBehavior = "required";
 	protected valuePromptContext?: PromptContext;
+	protected templateInclusion?: TemplateInclusionState;
 
 	// Tracks variables collected for YAML property post-processing
 	private readonly propertyCollector: TemplatePropertyCollector;
@@ -69,6 +77,10 @@ export abstract class Formatter {
 	}
 
 	protected abstract format(input: string): Promise<string>;
+
+	public setTemplateInclusionState(state: TemplateInclusionState): void {
+		this.templateInclusion = state;
+	}
 
 	/** Returns true when a variable is present AND its value is not undefined.
 	 *  Null and empty string are considered intentional values. */
@@ -684,6 +696,22 @@ export abstract class Formatter {
 			if (!exec || !exec[1]) continue;
 
 			const templatePath = exec[1];
+			this.templateInclusion ??= { visited: new Set<string>(), depth: 0 };
+
+			if (this.templateInclusion.visited.has(templatePath)) {
+				const placeholder = `[QuickAdd: template inclusion cycle detected at "${templatePath}"]`;
+				log.logError(placeholder);
+				output = this.replacer(output, TEMPLATE_REGEX, placeholder);
+				continue;
+			}
+
+			if (this.templateInclusion.depth >= MAX_TEMPLATE_INCLUSION_DEPTH) {
+				const placeholder = `[QuickAdd: max template inclusion depth (${MAX_TEMPLATE_INCLUSION_DEPTH}) exceeded at "${templatePath}"]`;
+				log.logError(placeholder);
+				output = this.replacer(output, TEMPLATE_REGEX, placeholder);
+				continue;
+			}
+
 			const templateContent = await this.getTemplateContent(templatePath);
 
 			output = this.replacer(output, TEMPLATE_REGEX, templateContent);


### PR DESCRIPTION
Add a runtime guard for recursive `{{TEMPLATE:...}}` expansion so cyclic or over-deep template inclusion terminates instead of recursing indefinitely.

The formatter now carries a shared template-inclusion state through `CompleteFormatter -> SingleTemplateEngine -> TemplateEngine`. Repeated template paths produce a visible QuickAdd placeholder and log an error; chains deeper than 10 levels get a max-depth placeholder. The lazy `await import("../engine/SingleTemplateEngine")` path is preserved.

Regression coverage now exercises self-inclusion, mutual inclusion, and an over-depth acyclic chain by re-entering `CompleteFormatter` through the mocked `SingleTemplateEngine`.

Verification:
- `bun run test -- src/formatters/completeFormatter.test.ts`
- `bun run test`
- `bunx tsc -noEmit -skipLibCheck`
- `bun run lint`
- `bun run check`
- `grep -n "MAX_TEMPLATE_INCLUSION_DEPTH" src/formatters/formatter.ts`
- `grep -n "await import(" src/formatters/completeFormatter.ts`
- Dev vault proof with temporary `main.js` wiring to this worktree: `plugin.api.format("{{TEMPLATE:QuickAddPlan003Cycle-1781291293842.md}}")` returned `before [QuickAdd: template inclusion cycle detected at "QuickAddPlan003Cycle-1781291293842.md"] after`, `hasPlaceholder: true`, temp file removed, `dev:errors` clean after proof. Dev-vault `main.js` link restored to `/Users/christian/Developer/quickadd/main.js`; `data.json` hash unchanged.

Generated files:
- Ran `bun run build` only for the authorized dev-vault proof bundle; no generated artifacts are included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added protection against circular template references and excessive nesting depth for included templates.

* **Bug Fixes**
  * Problematic template inclusions now terminate gracefully with visible error indicators instead of causing infinite loops or system failures.

* **Tests**
  * New test cases for template inclusion edge cases and cycle detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->