### PR TITLE
fix(file-suggester): register one document scroll listener per instance

### DIFF
--- a/src/gui/suggesters/fileSuggester.test.ts
+++ b/src/gui/suggesters/fileSuggester.test.ts
@@ -680,6 +680,103 @@ describe('FileSuggester DOM XSS safety', () => {
         }
     });
 
+    it('registers exactly one document scroll listener regardless of row count', () => {
+        vi.useFakeTimers();
+        const frame = document.createElement('iframe');
+        document.body.appendChild(frame);
+        const popoutDocument = frame.contentDocument!;
+        const popoutWindow = frame.contentWindow!;
+        const inputEl = popoutDocument.createElement('input');
+        popoutDocument.body.appendChild(inputEl);
+
+        const runtimeFiles = new Map<string, TFile>();
+        const app = {
+            dom: { appContainerEl: document.body },
+            keymap: {
+                pushScope: vi.fn(),
+                popScope: vi.fn(),
+            },
+            workspace: {
+                getActiveFile: vi.fn(() => null),
+                on: vi.fn(() => ({})),
+            },
+            fileManager: {
+                getNewFileParent: vi.fn(() => ({ path: '' })),
+            },
+            vault: {
+                getAbstractFileByPath: vi.fn((path: string) => runtimeFiles.get(path) ?? null),
+                getFiles: vi.fn(() => []),
+                getMarkdownFiles: vi.fn(() => []),
+                on: vi.fn(),
+            },
+            metadataCache: {
+                on: vi.fn(),
+                getFileCache: vi.fn(),
+                unresolvedLinks: {},
+            },
+        };
+
+        const plugin = { registerEvent: vi.fn() };
+        (FileIndex as unknown as { instance?: FileIndex }).instance = new (
+            FileIndex as unknown as new (app: App, plugin: unknown) => FileIndex
+        )(app as unknown as App, plugin);
+
+        const addSpy = vi.spyOn(popoutDocument, 'addEventListener');
+        const removeSpy = vi.spyOn(popoutDocument, 'removeEventListener');
+
+        try {
+            const suggester = new FileSuggester(app as unknown as App, inputEl);
+            const makeRows = (batch: number) =>
+                Array.from({ length: 50 }, (_, i) => {
+                    const path = `Notes/File${batch}-${i}.md`;
+                    runtimeFiles.set(path, createRuntimeFile(path, `File${batch}-${i}`));
+                    return {
+                        file: createIndexedFile(path, `File${batch}-${i}`),
+                        score: 0,
+                        matchType: 'exact' as const,
+                        displayText: `File${batch}-${i}`,
+                    };
+                });
+            const suggest = (suggester as unknown as {
+                suggest: { setSuggestions(values: unknown[]): void };
+            }).suggest;
+
+            suggest.setSuggestions(makeRows(1));
+            suggester.open(document.body, inputEl);
+            suggest.setSuggestions(makeRows(2));
+            suggester.open(document.body, inputEl);
+            suggest.setSuggestions(makeRows(3));
+            suggester.open(document.body, inputEl);
+
+            const scrollAdds = addSpy.mock.calls.filter(([type]) => type === 'scroll').length;
+            expect(scrollAdds).toBe(1);
+
+            const suggestion = popoutDocument.querySelector<HTMLElement>('.suggestion-item')!;
+            expect(suggestion).not.toBeNull();
+            suggestion.dispatchEvent(new MouseEvent('mouseenter', {
+                bubbles: true,
+                view: popoutWindow,
+            }));
+            vi.advanceTimersByTime(200);
+
+            expect(popoutDocument.querySelector('.qa-file-tooltip')).not.toBeNull();
+            popoutDocument.dispatchEvent(new Event('scroll'));
+            expect(popoutDocument.querySelector('.qa-file-tooltip')).toBeNull();
+
+            suggester.close();
+            const scrollRemoves = removeSpy.mock.calls.filter(([type]) => type === 'scroll').length;
+            expect(scrollRemoves).toBe(1);
+
+            suggester.destroy();
+            expect(removeSpy.mock.calls.filter(([type]) => type === 'scroll')).toHaveLength(1);
+        } finally {
+            addSpy.mockRestore();
+            removeSpy.mockRestore();
+            frame.remove();
+            vi.useRealTimers();
+        }
+    });
+
     it('keeps malicious suggestions selectable by keyboard navigation', async () => {
         const payload = '<img src=x onerror=globalThis.__qaXss=1>';
         const insertedValues: string[] = [];

--- a/src/gui/suggesters/fileSuggester.ts
+++ b/src/gui/suggesters/fileSuggester.ts
@@ -9,10 +9,6 @@ import { normalizeForSearch } from "./utils";
 import { getQuickAddInstance } from "../../quickAddInstance";
 import { createOwnedElement, getOwnerDocument, getOwnerWindow } from "../../utils/activeWindow";
 
-interface HTMLElementWithTooltipCleanup extends HTMLElement {
-	_tooltipCleanup?: () => void;
-}
-
 function createSuggestionPill(
 	owner: Node,
 	matchType: SearchResult["matchType"],
@@ -46,6 +42,9 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 	private lastInput = "";
 	private fileIndex: FileIndex;
 	private sourcePathOverride?: string;
+	private tooltipTimeout: number | undefined;
+	private scrollListener: (() => void) | undefined;
+	private scrollListenerDocument: Document | undefined;
 
 	constructor(
 		public app: App,
@@ -355,23 +354,35 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 		this.addHoverTooltip(el, file);
 	}
 
+	open(container: HTMLElement, inputEl: HTMLElement): void {
+		super.open(container, inputEl);
+		if (!this.scrollListener) {
+			const activeDocument = getOwnerDocument(this.inputEl);
+			const listener = () => this.hideTooltip();
+			activeDocument.addEventListener('scroll', listener, { passive: true });
+			this.scrollListener = listener;
+			this.scrollListenerDocument = activeDocument;
+		}
+	}
+
+	private hideTooltip(): void {
+		const activeWindow = getOwnerWindow(this.inputEl);
+		const activeDocument = getOwnerDocument(this.inputEl);
+
+		if (this.tooltipTimeout !== undefined) {
+			activeWindow.clearTimeout(this.tooltipTimeout);
+			this.tooltipTimeout = undefined;
+		}
+		activeDocument.querySelector('.qa-file-tooltip')?.remove();
+	}
+
 	private addHoverTooltip(el: HTMLElement, file: { path: string; }): void {
-		let tooltipTimeout: number | undefined;
 		const activeDocument = getOwnerDocument(el);
 		const activeWindow = getOwnerWindow(el);
 
-		const cleanup = () => {
-			if (tooltipTimeout !== undefined) {
-				activeWindow.clearTimeout(tooltipTimeout);
-				tooltipTimeout = undefined;
-			}
-			const existingTooltip = activeDocument.querySelector('.qa-file-tooltip');
-			existingTooltip?.remove();
-		};
-
 		el.addEventListener('mouseenter', () => {
-			cleanup(); // Remove any existing tooltips
-			tooltipTimeout = activeWindow.setTimeout(() => {
+			this.hideTooltip();
+			this.tooltipTimeout = activeWindow.setTimeout(() => {
 				const tooltip = this.createTooltip(file);
 				if (tooltip) {
 					activeDocument.body.appendChild(tooltip);
@@ -380,19 +391,8 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 			}, 200);
 		});
 
-		// Clean up on multiple events to prevent leaks
-		el.addEventListener('mouseleave', cleanup);
-		el.addEventListener('blur', cleanup);
-
-		// Clean up on scroll to prevent misplaced tooltips
-		const cleanupOnScroll = () => cleanup();
-		activeDocument.addEventListener('scroll', cleanupOnScroll, { passive: true });
-
-		// Store cleanup function for later removal
-		(el as HTMLElementWithTooltipCleanup)._tooltipCleanup = () => {
-			cleanup();
-			activeDocument.removeEventListener('scroll', cleanupOnScroll);
-		};
+		el.addEventListener('mouseleave', () => this.hideTooltip());
+		el.addEventListener('blur', () => this.hideTooltip());
 	}
 
 	private createTooltip(file: { path: string; }): HTMLElement | null {
@@ -432,19 +432,12 @@ export class FileSuggester extends TextInputSuggest<SearchResult> {
 	}
 
 	close(): void {
-		// Clean up any tooltip listeners before closing
-		const activeDocument = getOwnerDocument(this.inputEl);
-		const tooltipElements = activeDocument.querySelectorAll('.qaFileSuggestionItem');
-		tooltipElements.forEach(el => {
-			const elementWithCleanup = el as HTMLElementWithTooltipCleanup;
-			if (elementWithCleanup._tooltipCleanup) {
-				elementWithCleanup._tooltipCleanup();
-			}
-		});
-
-		// Remove any existing tooltips
-		const existingTooltips = activeDocument.querySelectorAll('.qa-file-tooltip');
-		existingTooltips.forEach(tooltip => tooltip.remove());
+		this.hideTooltip();
+		if (this.scrollListener && this.scrollListenerDocument) {
+			this.scrollListenerDocument.removeEventListener('scroll', this.scrollListener);
+			this.scrollListener = undefined;
+			this.scrollListenerDocument = undefined;
+		}
 
 		super.close();
 	}


### PR DESCRIPTION
Refactor FileSuggester tooltip cleanup so each instance owns one document-level scroll listener instead of registering one listener per rendered suggestion row. Repeated suggestion batches still replace rows normally, but the scroll listener now lives on the suggester lifecycle and is removed by `close()`.

This fixes unbounded listener accumulation when typing through file-link autocomplete result batches, while preserving the 200ms hover tooltip behavior and owner-document safety for pop-out windows.

Verification:
- `bun run test -- src/gui/suggesters/fileSuggester.test.ts`
- `bun run test`
- `bunx tsc -noEmit -skipLibCheck`
- `bun run lint`
- `bun run check`
- Structural greps: exactly one `addEventListener('scroll'` in `fileSuggester.ts`, no `_tooltipCleanup`
- Dev vault proof in `vault=dev`: temporarily pointed `main.js` at this worktree bundle, reloaded QuickAdd, drove `plugin.api.inputPrompt` with four 50-row `[[qa...` FileSuggester batches, observed one document scroll listener throughout, verified hover tooltip appears and document scroll removes it, then blur removed the single listener. Restored `/Users/christian/Developer/dev_vault/dev/.obsidian/plugins/quickadd/main.js` to `/Users/christian/Developer/quickadd/main.js` and reloaded QuickAdd afterward.

Generated artifacts:
- Ran `bun run build` only for dev-vault proof. It generated local `main.js` and `styles.css` in the worktree; they are ignored/uncommitted and were not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file suggester tooltip behavior for improved reliability and proper event cleanup.

* **Tests**
  * Added test coverage to verify correct tooltip lifecycle management and event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->