### PR TITLE
perf(latex-suggester): render math previews lazily

### DIFF
--- a/src/gui/suggesters/LaTeXSuggester.test.ts
+++ b/src/gui/suggesters/LaTeXSuggester.test.ts
@@ -1,0 +1,110 @@
+import Fuse from "fuse.js";
+import { renderMath } from "obsidian";
+import { describe, expect, it, vi } from "vitest";
+import { LaTeXSuggester } from "./LaTeXSuggester";
+
+vi.mock("obsidian", async (importOriginal) => ({
+	...(await importOriginal<object>()),
+	renderMath: vi.fn(() => {
+		const el = document.createElement("span");
+		el.className = "math-preview";
+		return el;
+	}),
+}));
+
+const symbols = [
+	"\\alpha",
+	"\\Alpha",
+	"\\aleph",
+	"\\beta",
+	"\\gamma",
+	"\\mathcal{A}",
+	"\\notalpha",
+];
+
+function ensureContainsPolyfill(): void {
+	const stringPrototype = String.prototype as typeof String.prototype & {
+		contains?: (searchString: string) => boolean;
+	};
+
+	if (!stringPrototype.contains) {
+		stringPrototype.contains = String.prototype.includes;
+	}
+}
+
+function oldTwoStageSuggestions(inputStr: string): string[] {
+	const inputBeforeCursor = inputStr.slice(0, inputStr.length);
+	const lastBackslashPos = inputBeforeCursor.lastIndexOf("\\");
+	const commandText = inputBeforeCursor.slice(lastBackslashPos);
+	const match = /\\([a-z{}A-Z0-9]*)$/.exec(commandText);
+
+	let lastInput = "";
+	let suggestions: string[] = [];
+
+	if (match) {
+		lastInput = match[1];
+		suggestions = symbols.filter((val) =>
+			//@ts-ignore
+			val.toLowerCase().contains(lastInput)
+		);
+	}
+
+	const fuse = new Fuse(suggestions, {
+		findAllMatches: true,
+		threshold: 0.8,
+	});
+	return fuse.search(lastInput).map((value) => value.item);
+}
+
+function getSuggestions(inputStr: string): string[] {
+	return LaTeXSuggester.prototype.getSuggestions.call(
+		{
+			inputEl: {
+				selectionStart: inputStr.length,
+			},
+			lastInput: "",
+			symbols,
+		},
+		inputStr,
+	);
+}
+
+describe("LaTeXSuggester", () => {
+	describe("getSuggestions", () => {
+		it("preserves the old two-stage Fuse ranking after reusing a shared full index", () => {
+			ensureContainsPolyfill();
+
+			for (const input of ["\\al", "\\alpha", "\\A", "prefix \\ma"]) {
+				expect(getSuggestions(input)).toEqual(oldTwoStageSuggestions(input));
+			}
+		});
+
+		it("returns no suggestions when there is no LaTeX command match", () => {
+			ensureContainsPolyfill();
+
+			expect(getSuggestions("alpha")).toEqual([]);
+		});
+	});
+
+	describe("renderSuggestion", () => {
+		it("clones cached rendered previews for each row", () => {
+			const rowA = document.createElement("div");
+			const rowB = document.createElement("div");
+			const setText = vi.fn(function (this: HTMLElement, text: string) {
+				this.textContent = text;
+			});
+			rowA.setText = setText;
+			rowB.setText = setText;
+
+			LaTeXSuggester.prototype.renderSuggestion("\\alpha", rowA);
+			LaTeXSuggester.prototype.renderSuggestion("\\alpha", rowB);
+
+			const rendered = vi.mocked(renderMath).mock.results[0].value;
+			expect(renderMath).toHaveBeenCalledTimes(1);
+			expect(rowA.lastChild).not.toBe(rendered);
+			expect(rowB.lastChild).not.toBe(rendered);
+			expect(rowA.lastChild).not.toBe(rowB.lastChild);
+			expect(rendered.parentElement).toBeNull();
+		});
+	});
+});

--- a/src/gui/suggesters/LaTeXSuggester.ts
+++ b/src/gui/suggesters/LaTeXSuggester.ts
@@ -6,24 +6,50 @@ import { getQuickAddInstance } from "../../quickAddInstance";
 
 const LATEX_REGEX = new RegExp(/\\([a-z{}A-Z0-9]*)$/);
 
+// Module-level cache of rendered MathJax preview nodes, keyed by symbol.
+// Survives LaTeXSuggester re-construction so the render burst is paid at most
+// once per symbol per session, and only for symbols the user actually sees.
+// `null` records a symbol Obsidian's renderer cannot handle, so it is not
+// retried on every modal open.
+const renderedMathCache = new Map<string, HTMLElement | null>();
+
+let fuseIndex: Fuse<string> | null = null;
+
+function getRenderedMath(symbol: string): HTMLElement | null {
+	if (renderedMathCache.has(symbol)) {
+		return renderedMathCache.get(symbol) ?? null;
+	}
+
+	let rendered: HTMLElement | null = null;
+	try {
+		rendered = renderMath(symbol, true);
+	} catch {
+		// Symbols Obsidian's math renderer cannot render are cached as null.
+		rendered = null;
+	}
+
+	renderedMathCache.set(symbol, rendered);
+	return rendered;
+}
+
+function getFuseIndex(symbols: string[]): Fuse<string> {
+	if (fuseIndex === null) {
+		fuseIndex = new Fuse(symbols, {
+			findAllMatches: true,
+			threshold: 0.8,
+		});
+	}
+
+	return fuseIndex;
+}
+
 export class LaTeXSuggester extends TextInputSuggest<string> {
 	private lastInput = "";
 	private symbols: string[];
-	private elementsRendered: Record<string, HTMLElement>;
 
 	constructor(public inputEl: HTMLInputElement | HTMLTextAreaElement) {
 		super(getQuickAddInstance().app, inputEl);
 		this.symbols = Object.assign([], LaTeXSymbols);
-
-		this.elementsRendered = this.symbols.reduce<Record<string, HTMLElement>>((elements, symbol) => {
-			try {
-				elements[symbol.toString()] = renderMath(symbol, true);
-			} catch {
-				// Ignore symbols that Obsidian's math renderer cannot render.
-			}
-
-			return elements;
-		}, {});
 	}
 
 	getSuggestions(inputStr: string): string[] {
@@ -49,20 +75,20 @@ export class LaTeXSuggester extends TextInputSuggest<string> {
 			);
 		}
 
-		const fuse = new Fuse(suggestions, {
-			findAllMatches: true,
-			threshold: 0.8,
-		});
-		const searchResults = fuse.search(this.lastInput);
-		return searchResults.map((value) => value.item);
+		const allowed = new Set(suggestions);
+		const searchResults = getFuseIndex(this.symbols).search(this.lastInput);
+		return searchResults
+			.map((value) => value.item)
+			.filter((item) => allowed.has(item));
 	}
 
 	renderSuggestion(item: string, el: HTMLElement): void {
 		if (item) {
 			el.setText(item);
-			//@ts-ignore
-			 
-			el.append(this.elementsRendered[item]);
+			const rendered = getRenderedMath(item);
+			if (rendered) {
+				el.append(rendered.cloneNode(true));
+			}
 		}
 	}
 


### PR DESCRIPTION
Render LaTeX suggester MathJax previews on demand instead of eagerly rendering every symbol during modal construction. The rendered previews are cached per plugin session and cloned per suggestion row so reopening the math modal avoids the repeated render burst without moving cached DOM nodes between rows.

Reuse one lazy Fuse index over the symbol corpus while preserving the existing two-stage behavior: substring filter first, then keep shared-index Fuse results that are in the allowed subset.

Verification:
- bunx tsc -noEmit -skipLibCheck
- bun run test -- LaTeXSuggester
- bun run test
- bun run lint
- bun run check
- grep -n "reduce" src/gui/suggesters/LaTeXSuggester.ts: no matches
- grep -n "new Fuse" src/gui/suggesters/LaTeXSuggester.ts: one match in getFuseIndex
- grep -n "renderMath" src/gui/suggesters/LaTeXSuggester.ts: import plus getRenderedMath only

Dev-vault proof:
- Built this worktree with the owner-authorized dev-vault proof override.
- Temporarily repointed dev vault QuickAdd main.js from /Users/christian/Developer/quickadd/main.js to this worktree main.js, reloaded quickadd, opened the real math modal through plugin.api.format("{{MVALUE}}"), typed \al, and confirmed suggestion rows included \alpha with preview nodes.
- Repeated the math modal open once more and confirmed the same first-row suggestion behavior.
- Restored the dev-vault main.js symlink to /Users/christian/Developer/quickadd/main.js, reloaded quickadd, verified data.json SHA-256 stayed unchanged, and dev:errors reported no errors.

Reviewer focus: the behavior-preservation test compares the new shared-index path against the old two-stage Fuse pipeline for representative queries, and renderSuggestion now clones cached preview nodes so row previews are not moved between DOM parents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for LaTeX suggestions, validating symbol matching, preview rendering accuracy, and caching behavior across multiple input scenarios.

* **Refactor**
  * Optimized LaTeX suggestion system with intelligent caching for rendered previews and enhanced matching algorithms for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->