### PR TITLE
perf: recompute FileIndex unresolved links lazily

### DIFF
--- a/src/gui/suggesters/FileIndex.test.ts
+++ b/src/gui/suggesters/FileIndex.test.ts
@@ -259,6 +259,43 @@ describe('FileIndex', () => {
 			// Should be treated as update
 			expect(indexWithPrivates.pendingFuseUpdates.get('file.md')).toBe('update');
 		});
+
+		it('should not rescan unresolved links on every file update, only lazily in search', () => {
+			const indexWithPrivates = fileIndex as unknown as {
+				updateUnresolvedLinks: () => void;
+				updateFile: (file: TFile) => void;
+				unresolvedLinksDirty: boolean;
+			};
+
+			// Force a clean starting state so update-driven calls are measured directly.
+			indexWithPrivates.updateUnresolvedLinks();
+			expect(indexWithPrivates.unresolvedLinksDirty).toBe(false);
+
+			const spy = vi.spyOn(indexWithPrivates, 'updateUnresolvedLinks');
+
+			const file = {
+				path: 'note.md',
+				basename: 'note',
+				extension: 'md',
+				parent: { path: '' },
+				stat: { mtime: Date.now() }
+			} as TFile;
+			for (let i = 0; i < 5; i++) {
+				indexWithPrivates.updateFile(file);
+			}
+
+			expect(spy).not.toHaveBeenCalled();
+			expect(indexWithPrivates.unresolvedLinksDirty).toBe(true);
+
+			fileIndex.search('no', {}, 10);
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(indexWithPrivates.unresolvedLinksDirty).toBe(false);
+
+			fileIndex.search('no', {}, 10);
+			expect(spy).toHaveBeenCalledTimes(1);
+
+			spy.mockRestore();
+		});
 	});
 
 	describe('alias improvements', () => {

--- a/src/gui/suggesters/FileIndex.ts
+++ b/src/gui/suggesters/FileIndex.ts
@@ -115,6 +115,7 @@ export class FileIndex {
 	private fuseRelaxed: Fuse<IndexedFile>;
 	private recentFiles = new LRUCache<number>();
 	private unresolvedLinks: Set<string> = new Set();
+	private unresolvedLinksDirty = true;
 	private isIndexing = false;
 	private indexPromise: Promise<void> | null = null;
 	private reindexTimeout: number | null = null;
@@ -189,6 +190,7 @@ export class FileIndex {
 		// Fallback for resolved event (less frequent, full reindex only if needed)
 		this.plugin.registerEvent(
 			this.app.metadataCache.on('resolved', () => {
+				this.unresolvedLinksDirty = true;
 				// Only schedule reindex if we don't have any files indexed yet
 				if (this.fileMap.size === 0) {
 					this.scheduleReindex();
@@ -367,7 +369,7 @@ export class FileIndex {
 		const indexedFile = this.createIndexedFile(file);
 		this.fileMap.set(file.path, indexedFile);
 		this.scheduleFuseUpdate(file.path, 'update');
-		this.updateUnresolvedLinks();
+		this.unresolvedLinksDirty = true;
 	}
 
 	private removeFile(file: TFile): void {
@@ -484,9 +486,15 @@ export class FileIndex {
 				this.unresolvedLinks.add(link);
 			}
 		}
+
+		this.unresolvedLinksDirty = false;
 	}
 
 	search(query: string, context: SearchContext = {}, limit = 50): SearchResult[] {
+		if (this.unresolvedLinksDirty) {
+			this.updateUnresolvedLinks();
+		}
+
 		const results: SearchResult[] = [];
 		const queryNormalized = normalizeForSearch(query);
 


### PR DESCRIPTION
Defer FileIndex unresolved-link rescans until search actually needs the set.

The metadata `changed` and `resolved` paths now mark unresolved links dirty instead of rebuilding the whole unresolved-link set eagerly. `search()` refreshes the set once when dirty, and full reindex still refreshes it immediately.

Verification:
- `bunx tsc -noEmit -skipLibCheck`
- `bun run test -- src/gui/suggesters/FileIndex.test.ts`
- `bun run test`
- `bun run lint`
- `bun run check`
- structural grep: `updateUnresolvedLinks()` is called only from full reindex and the search dirty guard, not from `updateFile()`

Dev-vault proof was not run because this worker did not hold the dev-vault lock. The plan marks the repo/unit gates as the primary done criterion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Unresolved link scanning now occurs on-demand during searches rather than continuously, improving performance during file editing and updates.

* **Tests**
  * Added tests verifying on-demand unresolved link rescanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->