### PR TITLE
test(migrations): cover provider API-key SecretStorage migration branches

### DIFF
--- a/src/migrations/migrateProviderApiKeysToSecretStorage.test.ts
+++ b/src/migrations/migrateProviderApiKeysToSecretStorage.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type QuickAdd from "src/main";
+import type { AIProvider } from "src/ai/Provider";
+import { DEFAULT_SETTINGS } from "src/settings";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+
+const { logWarningMock } = vi.hoisted(() => ({
+	logWarningMock: vi.fn(),
+}));
+
+vi.mock("src/logger/logManager", () => ({
+	log: {
+		logWarning: logWarningMock,
+		logMessage: vi.fn(),
+		logError: vi.fn(),
+	},
+}));
+
+const migration = await import("./migrateProviderApiKeysToSecretStorage");
+
+type SecretStorageStub = {
+	getSecret?: (name: string) => Promise<string | null> | string | null;
+	setSecret?: (name: string, value: string) => Promise<void> | void;
+};
+
+function createProvider(overrides: Partial<AIProvider> = {}): AIProvider {
+	return {
+		name: "OpenAI",
+		endpoint: "https://api.openai.com/v1",
+		apiKey: "fake-test-key",
+		models: [],
+		modelSource: "providerApi",
+		...overrides,
+	};
+}
+
+function setup(
+	providers: AIProvider[],
+	secretStorage: SecretStorageStub | undefined,
+): QuickAdd {
+	const base = deepClone(DEFAULT_SETTINGS);
+	settingsStore.replaceState({
+		...base,
+		ai: { ...base.ai, providers },
+	});
+
+	return {
+		app: secretStorage ? { secretStorage } : {},
+		saveSettings: vi.fn(),
+	} as unknown as QuickAdd;
+}
+
+function readProviders(): AIProvider[] {
+	return settingsStore.getState().ai.providers;
+}
+
+describe("migrateProviderApiKeysToSecretStorage migration", () => {
+	beforeEach(() => {
+		logWarningMock.mockReset();
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	afterEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	it("skips and warns when SecretStorage is unavailable, leaving keys untouched", async () => {
+		const plugin = setup([createProvider({ apiKey: "fake-test-key" })], undefined);
+
+		await migration.default.migrate(plugin);
+
+		expect(readProviders()[0].apiKey).toBe("fake-test-key");
+		expect(logWarningMock).toHaveBeenCalledWith(
+			expect.stringContaining("SecretStorage unavailable"),
+		);
+	});
+
+	it("clears the legacy key without overwriting an existing secret when apiKeyRef and secret exist", async () => {
+		const getSecret = vi.fn().mockResolvedValue("fake-existing-secret");
+		const setSecret = vi.fn();
+		const plugin = setup(
+			[createProvider({ apiKeyRef: "provider-secret", apiKey: "fake-test-key" })],
+			{ getSecret, setSecret },
+		);
+
+		await migration.default.migrate(plugin);
+
+		expect(setSecret).not.toHaveBeenCalled();
+		expect(readProviders()[0].apiKey).toBe("");
+		expect(readProviders()[0].apiKeyRef).toBe("provider-secret");
+	});
+
+	it("stores then clears when apiKeyRef is set but no secret exists yet", async () => {
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const setSecret = vi.fn().mockResolvedValue(undefined);
+		const plugin = setup(
+			[createProvider({ apiKeyRef: "provider-secret", apiKey: "fake-test-key" })],
+			{ getSecret, setSecret },
+		);
+
+		await migration.default.migrate(plugin);
+
+		expect(setSecret).toHaveBeenCalledWith("provider-secret", "fake-test-key");
+		expect(readProviders()[0].apiKey).toBe("");
+		expect(readProviders()[0].apiKeyRef).toBe("provider-secret");
+	});
+
+	it("stores via helper, sets apiKeyRef, and clears the key when no apiKeyRef exists", async () => {
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const setSecret = vi.fn().mockResolvedValue(undefined);
+		const plugin = setup(
+			[createProvider({ name: "OpenAI", apiKey: "fake-test-key" })],
+			{ getSecret, setSecret },
+		);
+
+		await migration.default.migrate(plugin);
+
+		expect(setSecret).toHaveBeenCalledWith("quickadd-ai-openai", "fake-test-key");
+		expect(readProviders()[0].apiKeyRef).toBe("quickadd-ai-openai");
+		expect(readProviders()[0].apiKey).toBe("");
+	});
+
+	it("is a no-op for a provider with no legacy key", async () => {
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const setSecret = vi.fn();
+		const plugin = setup(
+			[createProvider({ apiKey: "", apiKeyRef: undefined })],
+			{ getSecret, setSecret },
+		);
+
+		await migration.default.migrate(plugin);
+
+		expect(setSecret).not.toHaveBeenCalled();
+		expect(readProviders()[0].apiKey).toBe("");
+		expect(readProviders()[0].apiKeyRef).toBeUndefined();
+	});
+
+	it("does not clear the key when setSecret throws", async () => {
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const setSecret = vi.fn().mockRejectedValue(new Error("write failed"));
+		const plugin = setup(
+			[createProvider({ name: "OpenAI", apiKey: "fake-test-key" })],
+			{ getSecret, setSecret },
+		);
+
+		await migration.default.migrate(plugin);
+
+		expect(readProviders()[0].apiKey).toBe("fake-test-key");
+		expect(readProviders()[0].apiKeyRef).toBeUndefined();
+		expect(logWarningMock).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Adds focused unit coverage for the AI provider API-key SecretStorage migration.

The new spec seeds settingsStore directly and verifies the migration preserves or clears legacy plaintext keys across the SecretStorage availability, existing-secret, missing-secret, helper-store, no-legacy-key, and setSecret-failure branches. This protects the one-way credential migration from silently wiping keys if SecretStorage writes fail.

Verification:
- bun run test -- migrateProviderApiKeysToSecretStorage
- bun run test
- bunx tsc -noEmit -skipLibCheck
- bun run lint
- bun run check
- grep -niE "sk-|api[_-]?key.*=.*[a-z0-9]{16,}" src/migrations/migrateProviderApiKeysToSecretStorage.test.ts
- git show --stat HEAD

Release impact: tests only; no runtime behavior or generated artifacts changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for provider API key migration functionality across multiple provider and account configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->