### PR TITLE
perf(ai): remove bundled tiktoken

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@popperjs/core": "^2.11.8",
         "chrono-node": "^2.9.1",
         "fuse.js": "7",
-        "js-tiktoken": "^1.0.21",
         "obsidian-dataview": "^0.5.68",
         "svelte-dnd-action": "0.9.69",
         "three-way-merge": "^0.1.0",
@@ -919,8 +918,6 @@
     "java-properties": ["java-properties@1.0.2", "", {}, "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
-
-    "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -638,9 +638,10 @@ if (tokenCount > 4000) {
 }
 ```
 
-### `countTokens(text: string, model: string): number`
-Compatibility alias for `estimateTokens`. The `model` argument is accepted for
-existing scripts, but QuickAdd no longer bundles model-specific tokenizers.
+### `countTokens(text: string, model: string | {name: string}): number`
+Compatibility alias for `estimateTokens`. The `model` argument (a model name or
+object) is accepted for existing scripts but ignored, since QuickAdd no longer
+bundles model-specific tokenizers. Prefer `estimateTokens(text)`.
 
 ### `getRequestLogs(limit?: number): Array<object>`
 Returns recent in-memory AI request logs (newest first).

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -584,21 +584,27 @@ const selectedModel = await quickAddApi.suggester(models, models);
 ### `getMaxTokens(model: string): number`
 Gets the maximum token limit for a model.
 
-### `countTokens(text: string, model: string): number`
-Counts tokens in text according to model's tokenization.
+### `estimateTokens(text: string): number`
+Estimates the token count for text using QuickAdd's provider-agnostic estimator.
+This is useful for rough prompt sizing, but the configured AI provider remains
+the source of truth for exact context limits and usage.
 
 **Example:**
 ```javascript
 const text = await quickAddApi.utility.getClipboard();
-const tokenCount = quickAddApi.ai.countTokens(text, "gpt-4");
+const tokenCount = quickAddApi.ai.estimateTokens(text);
 
 if (tokenCount > 4000) {
     await quickAddApi.infoDialog(
-        "Text Too Long",
-        `The text contains ${tokenCount} tokens, which exceeds the model limit.`
+        "Text Might Be Too Long",
+        `The text is estimated at ${tokenCount} tokens.`
     );
 }
 ```
+
+### `countTokens(text: string, model: string): number`
+Compatibility alias for `estimateTokens`. The `model` argument is accepted for
+existing scripts, but QuickAdd no longer bundles model-specific tokenizers.
 
 ### `getRequestLogs(limit?: number): Array<object>`
 Returns recent in-memory AI request logs (newest first).

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -572,6 +572,42 @@ const result = await quickAddApi.ai.prompt(
 
 **Note:** For newer models like `gpt-4o` or custom provider models, add them in Settings → QuickAdd → AI → Providers. Some providers support auto-sync to automatically update available models.
 
+### `chunkedPrompt(text: string, promptTemplate: string, model: string | {name: string}, settings?: object): Promise<object>`
+Splits `text` into chunks, runs `promptTemplate` once per chunk, and joins the
+results. Use this for inputs that are too large for a single request.
+
+**Parameters:**
+- `text`: The full input text to process.
+- `promptTemplate`: The prompt run for each chunk. Reference the current chunk with `{{value:chunk}}`.
+- `model`: Model identifier (string or `{name}`), as for `prompt`.
+- `settings`: (Optional) Configuration object:
+  - `variableName`: Output variable name (default: "output")
+  - `shouldAssignVariables`: Auto-assign to variables (default: false)
+  - `modelOptions`: Model parameters (temperature, max_tokens, etc.)
+  - `showAssistantMessages`: Show AI responses in UI (default: true)
+  - `systemPrompt`: Override system prompt
+  - `chunkSeparator`: `RegExp` used to split `text` (default: `/\n/`)
+  - `chunkJoiner`: String inserted between chunk results (default: `"\n"`)
+  - `shouldMerge`: Merge small adjacent chunks up to the budget (default: `true`)
+  - `maxChunkTokens`: Maximum **estimated** tokens for each chunk's text (the `{{value:chunk}}` portion only — the system prompt and prompt template are budgeted separately). Token counts are estimated locally; values above the model's estimated input budget are capped automatically.
+
+**Behavior:**
+- Chunk sizes are estimated locally (QuickAdd no longer bundles model-specific tokenizers); the configured provider remains the source of truth for exact limits.
+- A chunk larger than the budget is split near a natural boundary (paragraph, sentence, or space) so it still fits — including when `shouldMerge` is `false`.
+- If the provider still rejects a prompt because the **input** exceeds its context window, that chunk is split and retried automatically. Output/completion-budget and quota errors are surfaced as-is (splitting cannot fix them).
+- The prompt template is rendered through the formatter once per chunk (plus once for sizing), so side-effectful tokens such as `{{MACRO:…}}` run on every render — avoid them inside a `chunkedPrompt` template.
+
+**Returns:** Object with `[variableName]` (joined results) and `[variableName]-quoted`.
+
+```javascript
+const result = await quickAddApi.ai.chunkedPrompt(
+    longText,
+    "Summarize this section:\n{{value:chunk}}",
+    "gpt-4o",
+    { variableName: "summary", chunkJoiner: "\n\n" }
+);
+```
+
 ### `getModels(): string[]`
 Returns available AI models.
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@popperjs/core": "^2.11.8",
     "chrono-node": "^2.9.1",
     "fuse.js": "7",
-    "js-tiktoken": "^1.0.21",
     "obsidian-dataview": "^0.5.68",
     "svelte-dnd-action": "0.9.69",
     "three-way-merge": "^0.1.0",

--- a/src/ai/AIAssistant.chunkedPrompt.test.ts
+++ b/src/ai/AIAssistant.chunkedPrompt.test.ts
@@ -61,7 +61,7 @@ function makeSettings(overrides: Partial<Parameters<typeof ChunkedPrompt>[1]> = 
 		systemPrompt: "system",
 		modelOptions: {},
 		text: "alpha beta",
-		promptTemplate: "Chunk: {{chunk}}",
+		promptTemplate: "Chunk: {{VALUE:chunk}}",
 		chunkSeparator: /\n/g,
 		resultJoiner: "|",
 		shouldMerge: true,
@@ -82,12 +82,15 @@ beforeEach(() => {
 	);
 });
 
+// Prompts are produced by the formatter (serialized), one call per chunk, so a
+// simple interpolating formatter is all most of these tests need.
+const chunkFormatter = vi.fn(
+	async (_template: string, variables: { [k: string]: unknown }) =>
+		`Chunk: ${variables.chunk}`
+);
+
 describe("ChunkedPrompt", () => {
 	it("splits over-budget chunks by estimate before sending", async () => {
-		const formatter = vi.fn(async (_template: string, variables) =>
-			variables.chunk === " " ? "Chunk: " : `Chunk: ${variables.chunk}`
-		);
-
 		await ChunkedPrompt(
 			makeApp(),
 			makeSettings({
@@ -95,7 +98,7 @@ describe("ChunkedPrompt", () => {
 				maxChunkTokens: 8,
 				shouldMerge: false,
 			}),
-			formatter
+			chunkFormatter
 		);
 
 		const sentPrompts = mocks.makeRequest.mock.calls.map(([prompt]) => prompt);
@@ -104,25 +107,21 @@ describe("ChunkedPrompt", () => {
 		expect(sentPrompts.join("")).toContain("delta");
 	});
 
-	it("throws before dispatch when prompt overhead leaves no usable chunk budget", async () => {
-		mocks.getModelMaxTokens.mockReturnValue(20);
-		const formatter = vi.fn(async (_template: string, variables) =>
-			variables.chunk === " "
-				? "static prompt overhead that consumes most of the model budget"
-				: `Chunk: ${variables.chunk}`
+	it("throws before dispatch when prompt overhead exceeds the whole context window", async () => {
+		mocks.getModelMaxTokens.mockReturnValue(10);
+		// Overhead-heavy template: the rendered template alone exceeds the model's
+		// entire context window, so no completion could ever fit.
+		const overheadFormatter = vi.fn(
+			async () => "static prompt overhead that consumes the whole model budget"
 		);
 
 		await expect(
-			ChunkedPrompt(makeApp(), makeSettings(), formatter)
-		).rejects.toThrow("too little room for text chunks");
+			ChunkedPrompt(makeApp(), makeSettings(), overheadFormatter)
+		).rejects.toThrow(/exceeds the model's entire context window/);
 		expect(mocks.makeRequest).not.toHaveBeenCalled();
 	});
 
 	it("splits and retries a chunk when the provider rejects it for context length", async () => {
-		const formatter = vi.fn(async (_template: string, variables) =>
-			variables.chunk === " " ? "Chunk: " : `Chunk: ${variables.chunk}`
-		);
-
 		mocks.makeRequest.mockImplementation(async (prompt: string) => {
 			if (prompt === "Chunk: alpha beta") {
 				throw new Error("maximum context length exceeded");
@@ -131,7 +130,11 @@ describe("ChunkedPrompt", () => {
 			return response(`response:${prompt}`);
 		});
 
-		const result = await ChunkedPrompt(makeApp(), makeSettings(), formatter);
+		const result = await ChunkedPrompt(
+			makeApp(),
+			makeSettings(),
+			chunkFormatter
+		);
 
 		expect(result.output).toBe("response:Chunk: alpha |response:Chunk: beta");
 		expect(mocks.makeRequest).toHaveBeenCalledTimes(3);
@@ -141,14 +144,177 @@ describe("ChunkedPrompt", () => {
 	});
 
 	it("does not split non-context provider errors", async () => {
-		const formatter = vi.fn(async (_template: string, variables) =>
-			variables.chunk === " " ? "Chunk: " : `Chunk: ${variables.chunk}`
-		);
 		mocks.makeRequest.mockRejectedValue(new Error("network down"));
 
 		await expect(
-			ChunkedPrompt(makeApp(), makeSettings(), formatter)
+			ChunkedPrompt(makeApp(), makeSettings(), chunkFormatter)
 		).rejects.toThrow("network down");
 		expect(mocks.makeRequest).toHaveBeenCalledTimes(1);
+	});
+
+	// Finding #1 (regression): the formatter must not be re-entered concurrently.
+	// A formatter that mutates a shared variables map (as the real quickAddApi
+	// formatter does) would otherwise let concurrent chunks overwrite each other's
+	// `chunk` value before it is read.
+	it("renders each chunk into its own prompt even with a shared-map formatter", async () => {
+		const shared = { chunk: "" };
+		const sharedMapFormatter = vi.fn(
+			async (_template: string, variables: { [k: string]: unknown }) => {
+				shared.chunk = String(variables.chunk);
+				// Async work between write and read — a sibling render would
+				// overwrite shared.chunk here if the formatter were re-entered.
+				await Promise.resolve();
+				await Promise.resolve();
+				return `Chunk: ${shared.chunk}`;
+			}
+		);
+
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "alpha\nbeta",
+				chunkSeparator: /\n/g,
+				shouldMerge: false,
+			}),
+			sharedMapFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(new Set(sentPrompts)).toEqual(
+			new Set(["Chunk: alpha", "Chunk: beta"])
+		);
+	});
+
+	// Finding #9 (regression): a tiny-context model with tiny input must not be
+	// rejected locally — the provider is the source of truth.
+	it("attempts tiny input on a tiny-context model instead of failing locally", async () => {
+		mocks.getModelMaxTokens.mockReturnValue(16);
+
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				systemPrompt: "",
+				text: "ok",
+				promptTemplate: "{{VALUE:chunk}}",
+			}),
+			chunkFormatter
+		);
+
+		expect(mocks.makeRequest.mock.calls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	// Finding #4 (regression): a separator-poor over-budget input must bail via the
+	// safety cap (during splitting) without dispatching any provider request.
+	it("bails via the safety cap without dispatching for over-budget input", async () => {
+		await expect(
+			ChunkedPrompt(
+				makeApp(),
+				makeSettings({
+					text: "a".repeat(4000),
+					maxChunkTokens: 1,
+					shouldMerge: false,
+					chunkSeparator: /\n/g,
+				}),
+				chunkFormatter
+			)
+		).rejects.toThrow(/safety limit/i);
+		expect(mocks.makeRequest).not.toHaveBeenCalled();
+	});
+
+	// Iter-2 regression: the cap must count FINAL (post-merge) prompts, not raw
+	// pre-merge line fragments. Many short lines should merge into a few prompts.
+	it("merges many short lines into a few prompts instead of hitting the cap", async () => {
+		const text = Array.from({ length: 501 }, () => "x").join("\n");
+
+		const result = await ChunkedPrompt(
+			makeApp(),
+			makeSettings({ text, shouldMerge: true, chunkSeparator: /\n/g }),
+			chunkFormatter
+		);
+
+		expect(result.output).toBeDefined();
+		const calls = mocks.makeRequest.mock.calls.length;
+		expect(calls).toBeGreaterThanOrEqual(1);
+		expect(calls).toBeLessThan(501);
+	});
+
+	// Iter-2 consensus regression: VALUE modifiers (e.g. case:upper) must apply to
+	// the real chunk value — the previous sentinel approach sent the placeholder.
+	it("applies VALUE modifiers to each chunk's real text", async () => {
+		const upperCasingFormatter = vi.fn(
+			async (_template: string, variables: { [k: string]: unknown }) =>
+				`Slug: ${String(variables.chunk).toUpperCase()}`
+		);
+
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "alpha\nbeta",
+				promptTemplate: "Slug: {{VALUE:chunk|case:upper}}",
+				chunkSeparator: /\n/g,
+				shouldMerge: false,
+			}),
+			upperCasingFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(new Set(sentPrompts)).toEqual(
+			new Set(["Slug: ALPHA", "Slug: BETA"])
+		);
+	});
+
+	// Iter-2 regression: fail fast when the template can't reference the chunk,
+	// rather than silently sending the same chunk-less prompt for every chunk.
+	it("throws when the template does not reference the chunk", async () => {
+		await expect(
+			ChunkedPrompt(
+				makeApp(),
+				makeSettings({ promptTemplate: "Summarize the document." }),
+				chunkFormatter
+			)
+		).rejects.toThrow(/does not reference the chunk/);
+		expect(mocks.makeRequest).not.toHaveBeenCalled();
+	});
+
+	// Iter-3 regression: a similarly-named but distinct variable is not the chunk.
+	it("throws when the template references a different variable, not chunk", async () => {
+		await expect(
+			ChunkedPrompt(
+				makeApp(),
+				makeSettings({ promptTemplate: "Summarize {{VALUE:chunk-id}}" }),
+				chunkFormatter
+			)
+		).rejects.toThrow(/does not reference the chunk/);
+		expect(mocks.makeRequest).not.toHaveBeenCalled();
+	});
+
+	// Iter-3 regression (high): a formatter failure on one chunk must trip the
+	// terminal-failure gate so sibling chunks stop instead of dispatching.
+	it("stops sibling chunks when a formatter render fails", async () => {
+		const failingFormatter = vi.fn(
+			async (_template: string, variables: { [k: string]: unknown }) => {
+				if (variables.chunk === "beta") throw new Error("macro blew up");
+				return `Chunk: ${variables.chunk}`;
+			}
+		);
+
+		await expect(
+			ChunkedPrompt(
+				makeApp(),
+				makeSettings({
+					text: "alpha\nbeta\ngamma",
+					chunkSeparator: /\n/g,
+					shouldMerge: false,
+				}),
+				failingFormatter
+			)
+		).rejects.toThrow("macro blew up");
+
+		// gamma must not dispatch after beta's render failed terminally.
+		expect(mocks.makeRequest.mock.calls.length).toBeLessThan(3);
 	});
 });

--- a/src/ai/AIAssistant.chunkedPrompt.test.ts
+++ b/src/ai/AIAssistant.chunkedPrompt.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { App } from "obsidian";
 import type { CommonResponse } from "./OpenAIRequest";
 
@@ -31,6 +31,10 @@ vi.mock("./aiHelpers", () => ({
 const { ChunkedPrompt } = await import("./AIAssistant");
 
 vi.stubGlobal("sleep", async () => {});
+
+afterAll(() => {
+	vi.unstubAllGlobals();
+});
 
 function makeApp(): App {
 	return {} as App;

--- a/src/ai/AIAssistant.chunkedPrompt.test.ts
+++ b/src/ai/AIAssistant.chunkedPrompt.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type { CommonResponse } from "./OpenAIRequest";
+
+const storeState = vi.hoisted(() => ({
+	disableOnlineFeatures: false,
+}));
+
+const mocks = vi.hoisted(() => ({
+	makeRequest: vi.fn(),
+	openAIRequest: vi.fn(),
+	isLikelyContextLimitError: vi.fn(),
+	getModelMaxTokens: vi.fn(),
+}));
+
+vi.mock("src/settingsStore", () => ({
+	settingsStore: {
+		getState: () => storeState,
+	},
+}));
+
+vi.mock("./OpenAIRequest", () => ({
+	OpenAIRequest: mocks.openAIRequest,
+	isLikelyContextLimitError: mocks.isLikelyContextLimitError,
+}));
+
+vi.mock("./aiHelpers", () => ({
+	getModelMaxTokens: mocks.getModelMaxTokens,
+}));
+
+const { ChunkedPrompt } = await import("./AIAssistant");
+
+vi.stubGlobal("sleep", async () => {});
+
+function makeApp(): App {
+	return {} as App;
+}
+
+function response(content: string): CommonResponse {
+	return {
+		id: content,
+		model: "test-model",
+		content,
+		usage: {
+			promptTokens: 1,
+			completionTokens: 1,
+			totalTokens: 2,
+		},
+		stopReason: "stop",
+		stopSequence: null,
+		created: Date.now(),
+	};
+}
+
+function makeSettings(overrides: Partial<Parameters<typeof ChunkedPrompt>[1]> = {}) {
+	return {
+		apiKey: "key",
+		model: { name: "test-model", maxTokens: 1000 },
+		outputVariableName: "output",
+		showAssistantMessages: false,
+		systemPrompt: "system",
+		modelOptions: {},
+		text: "alpha beta",
+		promptTemplate: "Chunk: {{chunk}}",
+		chunkSeparator: /\n/g,
+		resultJoiner: "|",
+		shouldMerge: true,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	storeState.disableOnlineFeatures = false;
+	mocks.openAIRequest.mockReturnValue(mocks.makeRequest);
+	mocks.isLikelyContextLimitError.mockImplementation((error: unknown) =>
+		error instanceof Error && /context/i.test(error.message)
+	);
+	mocks.getModelMaxTokens.mockReturnValue(1000);
+	mocks.makeRequest.mockImplementation(async (prompt: string) =>
+		response(`response:${prompt}`)
+	);
+});
+
+describe("ChunkedPrompt", () => {
+	it("splits over-budget chunks by estimate before sending", async () => {
+		const formatter = vi.fn(async (_template: string, variables) =>
+			variables.chunk === " " ? "Chunk: " : `Chunk: ${variables.chunk}`
+		);
+
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "alpha beta gamma delta epsilon zeta eta theta",
+				maxChunkTokens: 8,
+				shouldMerge: false,
+			}),
+			formatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(([prompt]) => prompt);
+		expect(sentPrompts.length).toBeGreaterThan(1);
+		expect(sentPrompts.join("")).toContain("alpha");
+		expect(sentPrompts.join("")).toContain("delta");
+	});
+
+	it("throws before dispatch when prompt overhead leaves no usable chunk budget", async () => {
+		mocks.getModelMaxTokens.mockReturnValue(20);
+		const formatter = vi.fn(async (_template: string, variables) =>
+			variables.chunk === " "
+				? "static prompt overhead that consumes most of the model budget"
+				: `Chunk: ${variables.chunk}`
+		);
+
+		await expect(
+			ChunkedPrompt(makeApp(), makeSettings(), formatter)
+		).rejects.toThrow("too little room for text chunks");
+		expect(mocks.makeRequest).not.toHaveBeenCalled();
+	});
+
+	it("splits and retries a chunk when the provider rejects it for context length", async () => {
+		const formatter = vi.fn(async (_template: string, variables) =>
+			variables.chunk === " " ? "Chunk: " : `Chunk: ${variables.chunk}`
+		);
+
+		mocks.makeRequest.mockImplementation(async (prompt: string) => {
+			if (prompt === "Chunk: alpha beta") {
+				throw new Error("maximum context length exceeded");
+			}
+
+			return response(`response:${prompt}`);
+		});
+
+		const result = await ChunkedPrompt(makeApp(), makeSettings(), formatter);
+
+		expect(result.output).toBe("response:Chunk: alpha |response:Chunk: beta");
+		expect(mocks.makeRequest).toHaveBeenCalledTimes(3);
+		expect(mocks.makeRequest).toHaveBeenNthCalledWith(1, "Chunk: alpha beta");
+		expect(mocks.makeRequest).toHaveBeenNthCalledWith(2, "Chunk: alpha ");
+		expect(mocks.makeRequest).toHaveBeenNthCalledWith(3, "Chunk: beta");
+	});
+
+	it("does not split non-context provider errors", async () => {
+		const formatter = vi.fn(async (_template: string, variables) =>
+			variables.chunk === " " ? "Chunk: " : `Chunk: ${variables.chunk}`
+		);
+		mocks.makeRequest.mockRejectedValue(new Error("network down"));
+
+		await expect(
+			ChunkedPrompt(makeApp(), makeSettings(), formatter)
+		).rejects.toThrow("network down");
+		expect(mocks.makeRequest).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/ai/AIAssistant.chunkedPrompt.test.ts
+++ b/src/ai/AIAssistant.chunkedPrompt.test.ts
@@ -21,6 +21,9 @@ vi.mock("src/settingsStore", () => ({
 
 vi.mock("./OpenAIRequest", () => ({
 	OpenAIRequest: mocks.openAIRequest,
+}));
+
+vi.mock("./providerErrors", () => ({
 	isLikelyContextLimitError: mocks.isLikelyContextLimitError,
 }));
 
@@ -294,6 +297,71 @@ describe("ChunkedPrompt", () => {
 			)
 		).rejects.toThrow(/does not reference the chunk/);
 		expect(mocks.makeRequest).not.toHaveBeenCalled();
+	});
+
+	// Iter-4 regression: a dynamic token alone is not enough to prove the chunk is
+	// inserted. The rendered prompt must include the injected chunk value.
+	it("throws when a dynamic token renders a prompt without the chunk", async () => {
+		const dynamicFormatter = vi.fn(async () => "Summarize today's notes.");
+
+		await expect(
+			ChunkedPrompt(
+				makeApp(),
+				makeSettings({ promptTemplate: "Summarize {{MACRO:today}}" }),
+				dynamicFormatter
+			)
+		).rejects.toThrow(/does not reference the chunk/);
+		expect(mocks.makeRequest).not.toHaveBeenCalled();
+	});
+
+	it("allows a dynamic token when rendering injects the chunk value", async () => {
+		const dynamicFormatter = vi.fn(
+			async (_template: string, variables: { [k: string]: unknown }) =>
+				`Dynamic: ${variables.chunk}`
+		);
+
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "alpha\nbeta",
+				promptTemplate: "{{MACRO:chunk-template}}",
+				chunkSeparator: /\n/g,
+				shouldMerge: false,
+			}),
+			dynamicFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(new Set(sentPrompts)).toEqual(
+			new Set(["Dynamic: alpha", "Dynamic: beta"])
+		);
+	});
+
+	it("allows a dynamic token when rendering injects a transformed chunk value", async () => {
+		const dynamicFormatter = vi.fn(
+			async (_template: string, variables: { [k: string]: unknown }) =>
+				`Dynamic: ${String(variables.chunk).toUpperCase()}`
+		);
+
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "alpha\nbeta",
+				promptTemplate: "{{MACRO:chunk-template}}",
+				chunkSeparator: /\n/g,
+				shouldMerge: false,
+			}),
+			dynamicFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(new Set(sentPrompts)).toEqual(
+			new Set(["Dynamic: ALPHA", "Dynamic: BETA"])
+		);
 	});
 
 	// Iter-3 regression (high): a formatter failure on one chunk must trip the

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -1,7 +1,3 @@
-import type { TiktokenModel } from "js-tiktoken";
-import { Tiktoken, getEncodingNameForModel } from "js-tiktoken/lite";
-import cl100k_base from "js-tiktoken/ranks/cl100k_base";
-import o200k_base from "js-tiktoken/ranks/o200k_base";
 import type { App } from "obsidian";
 import { TFile } from "obsidian";
 import { MacroAbortError } from "src/errors/MacroAbortError";
@@ -11,46 +7,14 @@ import { getMarkdownFilesInFolder } from "src/utilityObsidian";
 import invariant from "src/utils/invariant";
 import { isCancellationError } from "src/utils/errorUtils";
 import type { OpenAIModelParameters } from "./OpenAIModelParameters";
-import { OpenAIRequest } from "./OpenAIRequest";
+import { OpenAIRequest, isLikelyContextLimitError } from "./OpenAIRequest";
 import type { Model } from "./Provider";
 import { getModelMaxTokens } from "./aiHelpers";
 import { makeNoticeHandler } from "./makeNoticeHandler";
+import { estimateModelInputBudget, estimateTokenCount } from "./tokenEstimator";
 
-type Encoding = ConstructorParameters<typeof Tiktoken>[0];
-
-const encodings: Record<string, Encoding> = {
-	cl100k_base,
-	o200k_base,
-};
-const encodingCache = new Map<string, Tiktoken>();
-
-function getEncoding(name: string) {
-	const encodingName = name in encodings ? name : "cl100k_base";
-	const cached = encodingCache.get(encodingName);
-	if (cached) return cached;
-
-	const encoding = new Tiktoken(encodings[encodingName]);
-	encodingCache.set(encodingName, encoding);
-	return encoding;
-}
-
-export const getTokenCount = (text: string, model: Model) => {
-	// Use best-effort for non-OpenAI/unknown models by falling back to cl100k.
-	let encodingName = "cl100k_base";
-	try {
-		encodingName = getEncodingNameForModel(model.name as TiktokenModel);
-	} catch {
-		encodingName = "cl100k_base";
-	}
-
-	if (encodingName === "p50k_base" || encodingName === "p50k_edit") {
-		encodingName = "cl100k_base";
-	} else if (encodingName === "r50k_base" || encodingName === "gpt2") {
-		encodingName = "cl100k_base";
-	}
-
-	return getEncoding(encodingName).encode(text).length;
-};
+export const getTokenCount = (text: string, _model: Model | string) =>
+	estimateTokenCount(text);
 
 export interface AIRequestLogEntry {
 	id: string;
@@ -506,9 +470,150 @@ type ChunkedPromptParams = Omit<
 		text: string;
 		promptTemplate: string;
 		shouldMerge: boolean;
+		maxChunkTokens?: number;
 	},
 	"prompt"
 >;
+
+const MAX_CONTEXT_RETRY_DEPTH = 12;
+const MIN_USABLE_ESTIMATED_CHUNK_TOKENS = 8;
+const MAX_CHUNKED_PROMPTS = 500;
+
+function splitChunkNearMiddle(chunk: string): [string, string] | null {
+	const chars = Array.from(chunk);
+	if (chars.length <= 1) return null;
+
+	const midpoint = Math.floor(chunk.length / 2);
+	const separators = ["\n\n", "\n", ". ", " "];
+
+	let bestIndex = -1;
+	let bestDistance = Number.POSITIVE_INFINITY;
+
+	for (const separator of separators) {
+		const before = chunk.lastIndexOf(separator, midpoint);
+		const after = chunk.indexOf(separator, midpoint);
+		const candidates = [before, after].filter((index) => index > 0);
+
+		for (const index of candidates) {
+			const splitIndex = index + separator.length;
+			if (splitIndex <= 0 || splitIndex >= chunk.length) continue;
+
+			const distance = Math.abs(splitIndex - midpoint);
+			if (distance < bestDistance) {
+				bestDistance = distance;
+				bestIndex = splitIndex;
+			}
+		}
+	}
+
+	if (bestIndex > 0 && bestIndex < chunk.length) {
+		return [chunk.slice(0, bestIndex), chunk.slice(bestIndex)];
+	}
+
+	const charMidpoint = Math.floor(chars.length / 2);
+	return [
+		chars.slice(0, charMidpoint).join(""),
+		chars.slice(charMidpoint).join(""),
+	];
+}
+
+function splitChunkToEstimatedBudget(
+	chunk: string,
+	model: Model,
+	maxEstimatedTokens: number
+): string[] {
+	const budget = Math.max(1, Math.floor(maxEstimatedTokens));
+	const output: string[] = [];
+	const queue = [chunk];
+
+	while (queue.length > 0) {
+		const current = queue.shift() ?? "";
+		const currentEstimate = getTokenCount(current, model);
+
+		if (currentEstimate <= budget) {
+			output.push(current);
+			continue;
+		}
+
+		const split = splitChunkNearMiddle(current);
+		if (!split) {
+			output.push(current);
+			continue;
+		}
+
+		queue.unshift(split[1]);
+		queue.unshift(split[0]);
+	}
+
+	return output;
+}
+
+function buildEstimatedPromptChunks(
+	chunks: string[],
+	model: Model,
+	maxEstimatedChunkTokens: number,
+	shouldMerge: boolean
+): string[] {
+	const preparedChunks = chunks.flatMap((chunk) =>
+		splitChunkToEstimatedBudget(chunk, model, maxEstimatedChunkTokens)
+	);
+
+	if (!shouldMerge) return preparedChunks;
+
+	const output: string[] = [];
+	let combinedChunk = "";
+	let combinedChunkSize = 0;
+
+	for (const chunk of preparedChunks) {
+		const strSize = getTokenCount(chunk, model) + 1; // +1 for the separator removed by split().
+
+		if (
+			combinedChunk !== "" &&
+			combinedChunkSize + strSize >= maxEstimatedChunkTokens
+		) {
+			output.push(combinedChunk);
+			combinedChunk = "";
+			combinedChunkSize = 0;
+		}
+
+		combinedChunk += chunk;
+		combinedChunkSize += strSize;
+	}
+
+	if (combinedChunk !== "") {
+		output.push(combinedChunk);
+	}
+
+	return output;
+}
+
+function getEstimatedChunkBudget(
+	model: Model,
+	systemPrompt: string,
+	renderedPromptTemplate: string,
+	configuredMaxChunkTokens?: number
+) {
+	const estimatedInputBudget = estimateModelInputBudget(
+		getModelMaxTokens(model.name)
+	);
+	const promptOverhead =
+		getTokenCount(systemPrompt, model) +
+		getTokenCount(renderedPromptTemplate, model);
+	const modelBudget = Math.max(1, estimatedInputBudget - promptOverhead);
+
+	if (
+		configuredMaxChunkTokens !== undefined &&
+		Number.isFinite(configuredMaxChunkTokens) &&
+		configuredMaxChunkTokens > 0
+	) {
+		return Math.max(
+			1,
+			Math.min(modelBudget, Math.floor(configuredMaxChunkTokens))
+		);
+	}
+
+	return modelBudget;
+}
 
 export async function ChunkedPrompt(
 	app: App,
@@ -545,78 +650,37 @@ export async function ChunkedPrompt(
 		const chunkSeparator = settings.chunkSeparator || /\n/g;
 		const chunks = text.split(chunkSeparator);
 
-		const systemPromptLength = getTokenCount(systemPrompt, model);
-		// We need the prompt template to be rendered to get the token count of it, except the chunk variable.
+		// Render the prompt template once so the estimator includes static prompt overhead.
 		const renderedPromptTemplate = await formatter(promptTemplate, {
 			chunk: " ", // empty would make QA ask for a value, which we don't want
 		});
-		const promptTemplateTokenCount = getTokenCount(
+		const maxEstimatedChunkTokens = getEstimatedChunkBudget(
+			model,
+			systemPrompt,
 			renderedPromptTemplate,
-			model
+			settings.maxChunkTokens
 		);
 
-		const maxChunkTokenSize =
-			getModelMaxTokens(model.name) / 2 - systemPromptLength; // temp, need to impl. config
+		if (maxEstimatedChunkTokens < MIN_USABLE_ESTIMATED_CHUNK_TOKENS) {
+			throw new Error(
+				`The estimated prompt overhead leaves too little room for text chunks (${maxEstimatedChunkTokens} estimated tokens). Shorten the system prompt or prompt template, increase the max chunk tokens setting, or use a model with a larger context window.`
+			);
+		}
 
-		// Whether we should strictly enforce the chunking rules or we should merge chunks that are too small
+		// Whether we should merge chunks that are too small.
 		const shouldMerge = settings.shouldMerge ?? true; // temp, need to impl. config
 
-		const chunkedPrompts = [];
-		const maxCombinedChunkSize =
-			maxChunkTokenSize - promptTemplateTokenCount;
+		const chunkedText = buildEstimatedPromptChunks(
+			chunks,
+			model,
+			maxEstimatedChunkTokens,
+			shouldMerge
+		);
 
-		if (shouldMerge) {
-			const output: string[] = [];
-			let combinedChunk = "";
-			let combinedChunkSize = 0;
-
-			for (const chunk of chunks) {
-				const strSize = getTokenCount(chunk, model) + 1; // +1 for the newline
-
-				if (strSize > maxCombinedChunkSize) {
-					throw new Error(
-						`The chunk "${chunk.slice(
-							0,
-							25
-						)}..." is too large to fit in a single prompt.`
-					);
-				}
-
-				if (combinedChunkSize + strSize < maxCombinedChunkSize) {
-					// Add string to the current chunk and increase its size
-					combinedChunk += chunk;
-					combinedChunkSize += strSize;
-				} else {
-					// Push the current chunk to the output array
-					output.push(combinedChunk);
-
-					// Start a new chunk with the current string
-					combinedChunk = chunk;
-					combinedChunkSize = strSize;
-				}
-			}
-
-			if (combinedChunk !== "") {
-				output.push(combinedChunk);
-			}
-
-			for (const chunk of output) {
-				const prompt = await formatter(promptTemplate, { chunk });
-				chunkedPrompts.push(prompt);
-			}
-		} else {
-			for (const chunk of chunks) {
-				const tokenCount = getTokenCount(chunk, model);
-
-				if (tokenCount > maxChunkTokenSize) {
-					throw new Error(
-						`Chunk size (${tokenCount}) is larger than the maximum chunk size (${maxChunkTokenSize}). Please check your chunk separator.`
-					);
-				}
-
-				const prompt = await formatter(promptTemplate, { chunk });
-				chunkedPrompts.push(prompt);
-			}
+		if (chunkedText.length > MAX_CHUNKED_PROMPTS) {
+			throw new Error(
+				`QuickAdd estimated ${chunkedText.length} prompts for this chunked AI request, which exceeds the safety limit of ${MAX_CHUNKED_PROMPTS}. Increase the chunk size, use a larger chunk separator, or reduce the input text.`
+			);
 		}
 
 		const makeRequest = OpenAIRequest(
@@ -629,15 +693,67 @@ export async function ChunkedPrompt(
 
 		const promptingMsg = [
 			"prompting",
-			`${chunkedPrompts.length} prompts being sent.`,
+			`${chunkedText.length} prompts being sent.`,
 		];
 		notice.setMessage(promptingMsg[0], promptingMsg[1]);
 
 		const rateLimiter = new RateLimiter(5, 1000 * 30); // 5 requests per half minute
+		let hasTerminalFailure = false;
+		let providerRequestCount = 0;
+
+		const requestChunk = async (
+			chunk: string,
+			depth = 0
+		): Promise<string[]> => {
+			if (hasTerminalFailure) {
+				throw new Error("Chunked prompt stopped after an earlier failure.");
+			}
+
+			const prompt = await formatter(promptTemplate, { chunk });
+
+			try {
+				const response = await rateLimiter.add(() => {
+					if (hasTerminalFailure) {
+						throw new Error(
+							"Chunked prompt stopped after an earlier failure."
+						);
+					}
+
+					providerRequestCount += 1;
+					if (providerRequestCount > MAX_CHUNKED_PROMPTS) {
+						throw new Error(
+							`Chunked AI request exceeded the safety limit of ${MAX_CHUNKED_PROMPTS} provider requests.`
+						);
+					}
+
+					return makeRequest(prompt);
+				});
+				return [response.content];
+			} catch (error) {
+				const split = splitChunkNearMiddle(chunk);
+				if (
+					depth >= MAX_CONTEXT_RETRY_DEPTH ||
+					!split ||
+					!isLikelyContextLimitError(error)
+				) {
+					hasTerminalFailure = true;
+					throw error;
+				}
+
+				notice.setMessage(
+					"prompting",
+					"Provider rejected a prompt for context length. Retrying with smaller chunks."
+				);
+
+				const [left, right] = split;
+				const leftOutput = await requestChunk(left, depth + 1);
+				const rightOutput = await requestChunk(right, depth + 1);
+				return [...leftOutput, ...rightOutput];
+			}
+		};
+
 		const results = Promise.all(
-			chunkedPrompts.map((prompt) =>
-				rateLimiter.add(() => makeRequest(prompt))
-			)
+			chunkedText.map((chunk) => requestChunk(chunk))
 		);
 
 		const result = await timePromise(
@@ -657,7 +773,7 @@ export async function ChunkedPrompt(
 			}
 		);
 
-		const outputs = result.map((r) => r.content);
+		const outputs = result.flat();
 
 		const output = outputs.join(settings.resultJoiner);
 		const outputInMarkdownBlockQuote = ("> " + output).replace(

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -21,6 +21,7 @@ import {
 	TEMPLATE_REGEX,
 	VARIABLE_REGEX,
 } from "src/constants";
+import { transformCase } from "src/utils/caseTransform";
 
 export interface AIRequestLogEntry {
 	id: string;
@@ -483,6 +484,27 @@ type ChunkedPromptParams = Omit<
 
 const MAX_CONTEXT_RETRY_DEPTH = 12;
 const MAX_CHUNKED_PROMPTS = 500;
+const CHUNK_PROBE_VALUE = "quickadd_chunk_probe_123456789";
+
+function getChunkProbeVariants(): string[] {
+	return Array.from(
+		new Set([
+			CHUNK_PROBE_VALUE,
+			...[
+				"kebab",
+				"snake",
+				"camel",
+				"pascal",
+				"title",
+				"lower",
+				"upper",
+				"slug",
+			].map((style) => transformCase(CHUNK_PROBE_VALUE, style)),
+		])
+	).filter(Boolean);
+}
+
+const CHUNK_PROBE_VARIANTS = getChunkProbeVariants();
 
 // Split a chunk near its middle, preferring a natural boundary (paragraph,
 // sentence, then space). Works on UTF-16 indices directly — no Array.from — so it
@@ -541,15 +563,31 @@ function templateReferencesChunk(template: string): boolean {
 	return false;
 }
 
-// Tokens that can expand into a {{VALUE:chunk}} reference at format time, so the
-// static guard shouldn't reject a template that uses them.
-function templateMayInjectChunk(template: string): boolean {
+// Tokens that can expand into a {{VALUE:chunk}} reference at format time. The
+// rendered probe below must still prove that the chunk value was actually used.
+function templateHasDynamicExpansionSite(template: string): boolean {
 	return (
 		TEMPLATE_REGEX.test(template) ||
 		MACRO_REGEX.test(template) ||
 		GLOBAL_VAR_REGEX.test(template) ||
 		INLINE_JAVASCRIPT_REGEX.test(template)
 	);
+}
+
+function renderedPromptContainsChunk(renderedPrompt: string): boolean {
+	return CHUNK_PROBE_VARIANTS.some((variant) =>
+		renderedPrompt.includes(variant)
+	);
+}
+
+function removeChunkProbeFromRenderedPrompt(renderedPrompt: string): string {
+	return CHUNK_PROBE_VARIANTS
+		.slice()
+		.sort((a, b) => b.length - a.length)
+		.reduce(
+			(output, variant) => output.split(variant).join(" "),
+			renderedPrompt
+		);
 }
 
 function assertWithinChunkBudget(count: number): void {
@@ -690,27 +728,28 @@ export async function ChunkedPrompt(
 		const chunkSeparator = settings.chunkSeparator || /\n/g;
 		const rawChunks = text.split(chunkSeparator);
 
-		// The chunk text is inserted by the formatter via {{VALUE:chunk}}. Fail fast
-		// if the template can't reference it — otherwise every chunk would render to
-		// the same prompt and the input would be silently dropped. Skip the check
-		// when the template may inject the reference dynamically (nested
-		// template/macro/inline JS), which we can't detect statically.
-		if (
-			!templateReferencesChunk(promptTemplate) &&
-			!templateMayInjectChunk(promptTemplate)
-		) {
+		// Estimate the static prompt overhead by rendering the template once with a
+		// probe chunk value. This also validates dynamic expansions: templates,
+		// macros, globals, and inline JS are allowed to inject {{VALUE:chunk}}, but
+		// they only pass if the rendered prompt actually contains the probe.
+		const overheadProbe = await formatter(promptTemplate, {
+			chunk: CHUNK_PROBE_VALUE,
+		});
+		const hasChunkReference =
+			templateReferencesChunk(promptTemplate) ||
+			(templateHasDynamicExpansionSite(promptTemplate) &&
+				renderedPromptContainsChunk(overheadProbe));
+		if (!hasChunkReference) {
 			throw new Error(
 				"The chunked prompt template does not reference the chunk text. Add {{VALUE:chunk}} to your prompt template so each chunk is inserted."
 			);
 		}
 
-		// Estimate the static prompt overhead by rendering the template once with a
-		// throwaway chunk value (a space avoids QuickAdd prompting for a value).
-		const overheadProbe = await formatter(promptTemplate, { chunk: " " });
 		const fullContextTokens = getModelMaxTokens(model.name);
 		const estimatedInputBudget = estimateModelInputBudget(fullContextTokens);
+		const overheadPrompt = removeChunkProbeFromRenderedPrompt(overheadProbe);
 		const promptOverhead =
-			estimateTokenCount(systemPrompt) + estimateTokenCount(overheadProbe);
+			estimateTokenCount(systemPrompt) + estimateTokenCount(overheadPrompt);
 
 		// Only hard-stop when the static overhead exceeds the model's ENTIRE context
 		// window (truly no room). If it merely exceeds the 45% planning budget, we

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -7,14 +7,20 @@ import { getMarkdownFilesInFolder } from "src/utilityObsidian";
 import invariant from "src/utils/invariant";
 import { isCancellationError } from "src/utils/errorUtils";
 import type { OpenAIModelParameters } from "./OpenAIModelParameters";
-import { OpenAIRequest, isLikelyContextLimitError } from "./OpenAIRequest";
+import { OpenAIRequest } from "./OpenAIRequest";
+import { isLikelyContextLimitError } from "./providerErrors";
 import type { Model } from "./Provider";
 import { getModelMaxTokens } from "./aiHelpers";
 import { makeNoticeHandler } from "./makeNoticeHandler";
 import { estimateModelInputBudget, estimateTokenCount } from "./tokenEstimator";
-
-export const getTokenCount = (text: string, _model: Model | string) =>
-	estimateTokenCount(text);
+import { log } from "src/logger/logManager";
+import {
+	GLOBAL_VAR_REGEX,
+	INLINE_JAVASCRIPT_REGEX,
+	MACRO_REGEX,
+	TEMPLATE_REGEX,
+	VARIABLE_REGEX,
+} from "src/constants";
 
 export interface AIRequestLogEntry {
 	id: string;
@@ -476,12 +482,14 @@ type ChunkedPromptParams = Omit<
 >;
 
 const MAX_CONTEXT_RETRY_DEPTH = 12;
-const MIN_USABLE_ESTIMATED_CHUNK_TOKENS = 8;
 const MAX_CHUNKED_PROMPTS = 500;
 
+// Split a chunk near its middle, preferring a natural boundary (paragraph,
+// sentence, then space). Works on UTF-16 indices directly — no Array.from — so it
+// stays cheap on multi-megabyte inputs; the fallback only nudges off a surrogate
+// pair so a code point is never split.
 function splitChunkNearMiddle(chunk: string): [string, string] | null {
-	const chars = Array.from(chunk);
-	if (chars.length <= 1) return null;
+	if (chunk.length <= 1) return null;
 
 	const midpoint = Math.floor(chunk.length / 2);
 	const separators = ["\n\n", "\n", ". ", " "];
@@ -510,53 +518,89 @@ function splitChunkNearMiddle(chunk: string): [string, string] | null {
 		return [chunk.slice(0, bestIndex), chunk.slice(bestIndex)];
 	}
 
-	const charMidpoint = Math.floor(chars.length / 2);
-	return [
-		chars.slice(0, charMidpoint).join(""),
-		chars.slice(charMidpoint).join(""),
-	];
+	// No separator: split at the UTF-16 midpoint, nudging forward if it lands on
+	// the low half of a surrogate pair so we never cut a code point in two.
+	let splitIndex = midpoint;
+	const code = chunk.charCodeAt(splitIndex);
+	if (code >= 0xdc00 && code <= 0xdfff) splitIndex += 1;
+	if (splitIndex <= 0 || splitIndex >= chunk.length) return null;
+
+	return [chunk.slice(0, splitIndex), chunk.slice(splitIndex)];
 }
 
-function splitChunkToEstimatedBudget(
-	chunk: string,
-	model: Model,
-	maxEstimatedTokens: number
-): string[] {
-	const budget = Math.max(1, Math.floor(maxEstimatedTokens));
-	const output: string[] = [];
-	const queue = [chunk];
-
-	while (queue.length > 0) {
-		const current = queue.shift() ?? "";
-		const currentEstimate = getTokenCount(current, model);
-
-		if (currentEstimate <= budget) {
-			output.push(current);
-			continue;
-		}
-
-		const split = splitChunkNearMiddle(current);
-		if (!split) {
-			output.push(current);
-			continue;
-		}
-
-		queue.unshift(split[1]);
-		queue.unshift(split[0]);
+// Does the template reference the injected `chunk` variable via {{VALUE:chunk}}?
+// Matches the formatter's own parsing: the variable name is the text before the
+// first `|`, so {{VALUE:chunk-id}} / {{VALUE:chunk,other}} are correctly excluded.
+function templateReferencesChunk(template: string): boolean {
+	const regex = new RegExp(VARIABLE_REGEX.source, "gi");
+	let match: RegExpExecArray | null;
+	while ((match = regex.exec(template)) !== null) {
+		const variableName = match[1].split("|")[0].trim().toLowerCase();
+		if (variableName === "chunk") return true;
 	}
+	return false;
+}
 
-	return output;
+// Tokens that can expand into a {{VALUE:chunk}} reference at format time, so the
+// static guard shouldn't reject a template that uses them.
+function templateMayInjectChunk(template: string): boolean {
+	return (
+		TEMPLATE_REGEX.test(template) ||
+		MACRO_REGEX.test(template) ||
+		GLOBAL_VAR_REGEX.test(template) ||
+		INLINE_JAVASCRIPT_REGEX.test(template)
+	);
+}
+
+function assertWithinChunkBudget(count: number): void {
+	if (count > MAX_CHUNKED_PROMPTS) {
+		throw new Error(
+			`QuickAdd would split this chunked AI request into more than ${MAX_CHUNKED_PROMPTS} prompts, which exceeds the safety limit. Increase the chunk size, use a larger chunk separator, or reduce the input text.`
+		);
+	}
+}
+
+// Split one chunk down to the estimated budget and append the pieces to `out`.
+// Uses a depth-first stack (push right then left so pieces emit left-to-right),
+// which keeps the working set bounded by recursion depth (~log2 of the chunk
+// length). The cap is enforced on the pieces produced *from this one chunk*, so a
+// pathological separator-poor input bails out immediately instead of materialising
+// hundreds of thousands of pieces — without penalising many small chunks that will
+// later merge (the final post-merge count is capped separately by the caller).
+function appendSplitToBudget(
+	chunk: string,
+	budgetTokens: number,
+	out: string[]
+): void {
+	const budget = Math.max(1, Math.floor(budgetTokens));
+	const stack = [chunk];
+	let producedFromChunk = 0;
+
+	while (stack.length > 0) {
+		const current = stack.pop() as string;
+		const fitsBudget = estimateTokenCount(current) <= budget;
+		const split = fitsBudget ? null : splitChunkNearMiddle(current);
+
+		if (!split) {
+			out.push(current);
+			producedFromChunk += 1;
+			assertWithinChunkBudget(producedFromChunk);
+			continue;
+		}
+
+		stack.push(split[1], split[0]);
+	}
 }
 
 function buildEstimatedPromptChunks(
 	chunks: string[],
-	model: Model,
 	maxEstimatedChunkTokens: number,
 	shouldMerge: boolean
 ): string[] {
-	const preparedChunks = chunks.flatMap((chunk) =>
-		splitChunkToEstimatedBudget(chunk, model, maxEstimatedChunkTokens)
-	);
+	const preparedChunks: string[] = [];
+	for (const chunk of chunks) {
+		appendSplitToBudget(chunk, maxEstimatedChunkTokens, preparedChunks);
+	}
 
 	if (!shouldMerge) return preparedChunks;
 
@@ -565,7 +609,7 @@ function buildEstimatedPromptChunks(
 	let combinedChunkSize = 0;
 
 	for (const chunk of preparedChunks) {
-		const strSize = getTokenCount(chunk, model) + 1; // +1 for the separator removed by split().
+		const strSize = estimateTokenCount(chunk) + 1; // +1 for the separator consumed by split().
 
 		if (
 			combinedChunk !== "" &&
@@ -587,32 +631,28 @@ function buildEstimatedPromptChunks(
 	return output;
 }
 
-function getEstimatedChunkBudget(
-	model: Model,
-	systemPrompt: string,
-	renderedPromptTemplate: string,
-	configuredMaxChunkTokens?: number
-) {
-	const estimatedInputBudget = estimateModelInputBudget(
-		getModelMaxTokens(model.name)
-	);
-	const promptOverhead =
-		getTokenCount(systemPrompt, model) +
-		getTokenCount(renderedPromptTemplate, model);
-	const modelBudget = Math.max(1, estimatedInputBudget - promptOverhead);
+// Clamp the user-configured `maxChunkTokens` to the model's derived input budget.
+// Returns whether clamping occurred so the caller can surface the effective value
+// instead of silently shrinking the user's setting.
+function clampChunkBudget(
+	rawChunkBudget: number,
+	configuredMaxChunkTokens: number | undefined
+): { budget: number; clamped: boolean } {
+	const budget = Math.max(1, Math.floor(rawChunkBudget));
 
 	if (
 		configuredMaxChunkTokens !== undefined &&
 		Number.isFinite(configuredMaxChunkTokens) &&
 		configuredMaxChunkTokens > 0
 	) {
-		return Math.max(
-			1,
-			Math.min(modelBudget, Math.floor(configuredMaxChunkTokens))
-		);
+		const configured = Math.floor(configuredMaxChunkTokens);
+		return {
+			budget: Math.min(budget, configured),
+			clamped: configured > budget,
+		};
 	}
 
-	return modelBudget;
+	return { budget, clamped: false };
 }
 
 export async function ChunkedPrompt(
@@ -648,40 +688,60 @@ export async function ChunkedPrompt(
 		);
 
 		const chunkSeparator = settings.chunkSeparator || /\n/g;
-		const chunks = text.split(chunkSeparator);
+		const rawChunks = text.split(chunkSeparator);
 
-		// Render the prompt template once so the estimator includes static prompt overhead.
-		const renderedPromptTemplate = await formatter(promptTemplate, {
-			chunk: " ", // empty would make QA ask for a value, which we don't want
-		});
-		const maxEstimatedChunkTokens = getEstimatedChunkBudget(
-			model,
-			systemPrompt,
-			renderedPromptTemplate,
-			settings.maxChunkTokens
-		);
-
-		if (maxEstimatedChunkTokens < MIN_USABLE_ESTIMATED_CHUNK_TOKENS) {
+		// The chunk text is inserted by the formatter via {{VALUE:chunk}}. Fail fast
+		// if the template can't reference it — otherwise every chunk would render to
+		// the same prompt and the input would be silently dropped. Skip the check
+		// when the template may inject the reference dynamically (nested
+		// template/macro/inline JS), which we can't detect statically.
+		if (
+			!templateReferencesChunk(promptTemplate) &&
+			!templateMayInjectChunk(promptTemplate)
+		) {
 			throw new Error(
-				`The estimated prompt overhead leaves too little room for text chunks (${maxEstimatedChunkTokens} estimated tokens). Shorten the system prompt or prompt template, increase the max chunk tokens setting, or use a model with a larger context window.`
+				"The chunked prompt template does not reference the chunk text. Add {{VALUE:chunk}} to your prompt template so each chunk is inserted."
 			);
 		}
 
-		// Whether we should merge chunks that are too small.
-		const shouldMerge = settings.shouldMerge ?? true; // temp, need to impl. config
+		// Estimate the static prompt overhead by rendering the template once with a
+		// throwaway chunk value (a space avoids QuickAdd prompting for a value).
+		const overheadProbe = await formatter(promptTemplate, { chunk: " " });
+		const fullContextTokens = getModelMaxTokens(model.name);
+		const estimatedInputBudget = estimateModelInputBudget(fullContextTokens);
+		const promptOverhead =
+			estimateTokenCount(systemPrompt) + estimateTokenCount(overheadProbe);
+
+		// Only hard-stop when the static overhead exceeds the model's ENTIRE context
+		// window (truly no room). If it merely exceeds the 45% planning budget, we
+		// still proceed with a minimal chunk budget and let the provider decide.
+		if (promptOverhead >= fullContextTokens) {
+			throw new Error(
+				`The estimated prompt overhead (${promptOverhead} tokens) exceeds the model's entire context window (${fullContextTokens} tokens). Shorten the system prompt or prompt template, or use a model with a larger context window.`
+			);
+		}
+
+		const { budget: maxEstimatedChunkTokens, clamped } = clampChunkBudget(
+			estimatedInputBudget - promptOverhead,
+			settings.maxChunkTokens
+		);
+		if (clamped) {
+			log.logMessage(
+				`[ChunkedPrompt] Requested max chunk tokens (${settings.maxChunkTokens}) exceeds this model's estimated input budget; using ${maxEstimatedChunkTokens} estimated tokens per chunk instead.`
+			);
+		}
+
+		// Whether we should merge chunks that are smaller than the budget.
+		const shouldMerge = settings.shouldMerge ?? true;
 
 		const chunkedText = buildEstimatedPromptChunks(
-			chunks,
-			model,
+			rawChunks,
 			maxEstimatedChunkTokens,
 			shouldMerge
 		);
 
-		if (chunkedText.length > MAX_CHUNKED_PROMPTS) {
-			throw new Error(
-				`QuickAdd estimated ${chunkedText.length} prompts for this chunked AI request, which exceeds the safety limit of ${MAX_CHUNKED_PROMPTS}. Increase the chunk size, use a larger chunk separator, or reduce the input text.`
-			);
-		}
+		// Final safety cap on the number of prompts actually dispatched (post-merge).
+		assertWithinChunkBudget(chunkedText.length);
 
 		const makeRequest = OpenAIRequest(
 			app,
@@ -701,6 +761,30 @@ export async function ChunkedPrompt(
 		let hasTerminalFailure = false;
 		let providerRequestCount = 0;
 
+		// Render prompts through the formatter, but serialize the calls so the
+		// formatter's shared variables map is never mutated concurrently: concurrent
+		// chunks and recursive retries would otherwise race on `chunk`. Serializing
+		// (rather than substituting into a once-rendered template) also keeps
+		// {{VALUE:chunk|case:...}} and other modifiers working, since the real chunk
+		// value flows through the formatter each time. Queued renders short-circuit
+		// once an earlier chunk has failed terminally.
+		let renderChain: Promise<unknown> = Promise.resolve();
+		const renderChunkPrompt = (chunk: string): Promise<string> => {
+			const rendered = renderChain.then(() => {
+				if (hasTerminalFailure) {
+					throw new Error(
+						"Chunked prompt stopped after an earlier failure."
+					);
+				}
+				return formatter(promptTemplate, { chunk });
+			});
+			renderChain = rendered.then(
+				() => undefined,
+				() => undefined
+			);
+			return rendered;
+		};
+
 		const requestChunk = async (
 			chunk: string,
 			depth = 0
@@ -709,7 +793,16 @@ export async function ChunkedPrompt(
 				throw new Error("Chunked prompt stopped after an earlier failure.");
 			}
 
-			const prompt = await formatter(promptTemplate, { chunk });
+			// Render failures (e.g. a macro/inline-JS error in the template) are
+			// always terminal — they can't be fixed by splitting, so they trip the
+			// gate and stop siblings rather than entering the context-limit retry.
+			let prompt: string;
+			try {
+				prompt = await renderChunkPrompt(chunk);
+			} catch (error) {
+				hasTerminalFailure = true;
+				throw error;
+			}
 
 			try {
 				const response = await rateLimiter.add(() => {

--- a/src/ai/OpenAIRequest.test.ts
+++ b/src/ai/OpenAIRequest.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { App } from "obsidian";
 import type { Model } from "./Provider";
+import {
+	classifyProviderError,
+	isLikelyContextLimitError,
+} from "./providerErrors";
 
 const storeState = vi.hoisted(() => ({
 	disableOnlineFeatures: false,
@@ -49,7 +53,7 @@ const {
 	logErrorMock,
 } = mocks;
 
-const { OpenAIRequest, isLikelyContextLimitError } = await import("./OpenAIRequest");
+const { OpenAIRequest } = await import("./OpenAIRequest");
 
 // A minimal app whose activeEditor is undefined so preventCursorChange becomes a no-op.
 function makeApp(): App {
@@ -190,44 +194,85 @@ describe("OpenAIRequest", () => {
 		});
 	});
 
-	describe("context limit detection", () => {
-		it("matches common provider context-limit messages", () => {
-			expect(
-				isLikelyContextLimitError(
-					new Error("maximum context length exceeded")
-				)
-			).toBe(true);
-			expect(isLikelyContextLimitError("too many input tokens")).toBe(true);
+	describe("provider error body capture", () => {
+		beforeEach(() => {
+			getModelProviderMock.mockReturnValue(openAIProvider);
 		});
 
-		it("walks wrapped causes and ignores unrelated errors", () => {
-			const cause = new Error("context_length_exceeded");
-			const wrapped = new Error("Error while making request", { cause });
-
-			expect(isLikelyContextLimitError(wrapped)).toBe(true);
-			expect(isLikelyContextLimitError(new Error("network down"))).toBe(false);
-		});
-
-		it("walks response body shapes from requestUrl failures", () => {
-			const error = {
-				message: "Request failed, status 400",
-				response: {
-					json: {
-						error: {
-							code: "context_length_exceeded",
-							message: "maximum context length exceeded",
-						},
+		it("surfaces a 4xx provider body so the error is classifiable as a context limit", async () => {
+			requestUrlMock.mockResolvedValue({
+				status: 400,
+				json: {
+					error: {
+						code: "context_length_exceeded",
+						message: "maximum context length exceeded",
 					},
 				},
-			};
+				text: '{"error":{"code":"context_length_exceeded"}}',
+			});
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
 
-			expect(isLikelyContextLimitError(error)).toBe(true);
+			let thrown: unknown;
+			try {
+				await makeRequest("prompt");
+			} catch (error) {
+				thrown = error;
+			}
+
+			expect(thrown).toBeInstanceOf(Error);
+			expect(String((thrown as Error).message)).toMatch(
+				/context_length_exceeded|maximum context length/i
+			);
+			// The real provider body now reaches the classifier (it did not before).
+			expect(isLikelyContextLimitError(thrown)).toBe(true);
+			expect(((thrown as Error).cause as { status?: number }).status).toBe(400);
 		});
 
-		it("does not classify quota or output token errors as input context errors", () => {
-			expect(isLikelyContextLimitError("rate limit exceeded")).toBe(false);
-			expect(isLikelyContextLimitError("token limit quota exceeded")).toBe(false);
-			expect(isLikelyContextLimitError("max output tokens exceeded")).toBe(false);
+		it("does not classify a non-context 4xx (auth) as a context-limit error", async () => {
+			requestUrlMock.mockResolvedValue({
+				status: 401,
+				json: {
+					error: {
+						code: "invalid_api_key",
+						message: "Incorrect API key provided",
+					},
+				},
+			});
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+
+			let thrown: unknown;
+			await expect(makeRequest("prompt")).rejects.toThrow(
+				/Incorrect API key|invalid_api_key/i
+			);
+			try {
+				await makeRequest("prompt");
+			} catch (error) {
+				thrown = error;
+			}
+			expect(isLikelyContextLimitError(thrown)).toBe(false);
+		});
+
+		it("treats a 4xx whose completion alone exceeds context as output-budget (no retry)", async () => {
+			requestUrlMock.mockResolvedValue({
+				status: 400,
+				json: {
+					error: {
+						code: "context_length_exceeded",
+						message:
+							"maximum context length is 8192 tokens; you requested 9500 (500 in the messages, 9000 in the completion)",
+					},
+				},
+			});
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+
+			let thrown: unknown;
+			try {
+				await makeRequest("prompt");
+			} catch (error) {
+				thrown = error;
+			}
+			expect(classifyProviderError(thrown)).toBe("output_budget");
+			expect(isLikelyContextLimitError(thrown)).toBe(false);
 		});
 	});
 

--- a/src/ai/OpenAIRequest.test.ts
+++ b/src/ai/OpenAIRequest.test.ts
@@ -8,7 +8,6 @@ const storeState = vi.hoisted(() => ({
 
 const mocks = vi.hoisted(() => ({
 	requestUrlMock: vi.fn(),
-	getTokenCountMock: vi.fn(),
 	beginAIRequestLogEntryMock: vi.fn(),
 	finishAIRequestLogEntryMock: vi.fn(),
 	getModelProviderMock: vi.fn(),
@@ -27,7 +26,6 @@ vi.mock("src/settingsStore", () => ({
 }));
 
 vi.mock("./AIAssistant", () => ({
-	getTokenCount: mocks.getTokenCountMock,
 	beginAIRequestLogEntry: mocks.beginAIRequestLogEntryMock,
 	finishAIRequestLogEntry: mocks.finishAIRequestLogEntryMock,
 }));
@@ -45,14 +43,13 @@ vi.mock("src/logger/logManager", () => ({
 
 const {
 	requestUrlMock,
-	getTokenCountMock,
 	beginAIRequestLogEntryMock,
 	finishAIRequestLogEntryMock,
 	getModelProviderMock,
 	logErrorMock,
 } = mocks;
 
-const { OpenAIRequest } = await import("./OpenAIRequest");
+const { OpenAIRequest, isLikelyContextLimitError } = await import("./OpenAIRequest");
 
 // A minimal app whose activeEditor is undefined so preventCursorChange becomes a no-op.
 function makeApp(): App {
@@ -130,8 +127,6 @@ function openAIResponse(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
 	vi.clearAllMocks();
 	storeState.disableOnlineFeatures = false;
-	// Default token count keeps every prompt well under any maxTokens limit.
-	getTokenCountMock.mockReturnValue(1);
 	beginAIRequestLogEntryMock.mockReturnValue("log-id-1");
 });
 
@@ -153,21 +148,20 @@ describe("OpenAIRequest", () => {
 			expect(beginAIRequestLogEntryMock).not.toHaveBeenCalled();
 		});
 
-		it("throws when the combined token count exceeds the model limit", async () => {
-			// prompt + system both contribute; sum (60000+60000) > 100000.
-			getTokenCountMock.mockReturnValue(60000);
-			const model: Model = { name: "gpt-4o", maxTokens: 100000 };
+		it("sends requests even when the local estimate exceeds the configured token limit", async () => {
+			const model: Model = { name: "gpt-4o", maxTokens: 1 };
+			getModelProviderMock.mockReturnValue(openAIProvider);
+			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
 			const makeRequest = OpenAIRequest(makeApp(), "key", model, "system");
 
-			await expect(makeRequest("prompt")).rejects.toThrow(
-				"The gpt-4o API has a token limit of 100000. Your prompt has 120000 tokens."
+			await expect(makeRequest("prompt")).resolves.toBeDefined();
+			expect(requestUrlMock).toHaveBeenCalledTimes(1);
+			expect(mocks.logMessageMock).toHaveBeenCalledWith(
+				expect.stringContaining("Estimated prompt size")
 			);
-			expect(requestUrlMock).not.toHaveBeenCalled();
 		});
 
-		it("allows requests exactly at the token limit (boundary)", async () => {
-			// 2 * 50000 = 100000, not strictly greater than the limit.
-			getTokenCountMock.mockReturnValue(50000);
+		it("does not log an estimate warning when the estimate is within the configured limit", async () => {
 			const model: Model = { name: "gpt-4o", maxTokens: 100000 };
 			getModelProviderMock.mockReturnValue(openAIProvider);
 			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
@@ -175,6 +169,9 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(makeApp(), "key", model, "system");
 			await expect(makeRequest("prompt")).resolves.toBeDefined();
 			expect(requestUrlMock).toHaveBeenCalledTimes(1);
+			expect(mocks.logMessageMock).not.toHaveBeenCalledWith(
+				expect.stringContaining("Estimated prompt size")
+			);
 		});
 
 		it("throws when no provider is found for the model", async () => {
@@ -190,6 +187,47 @@ describe("OpenAIRequest", () => {
 				"Model gpt-4o not found with any provider."
 			);
 			expect(requestUrlMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("context limit detection", () => {
+		it("matches common provider context-limit messages", () => {
+			expect(
+				isLikelyContextLimitError(
+					new Error("maximum context length exceeded")
+				)
+			).toBe(true);
+			expect(isLikelyContextLimitError("too many input tokens")).toBe(true);
+		});
+
+		it("walks wrapped causes and ignores unrelated errors", () => {
+			const cause = new Error("context_length_exceeded");
+			const wrapped = new Error("Error while making request", { cause });
+
+			expect(isLikelyContextLimitError(wrapped)).toBe(true);
+			expect(isLikelyContextLimitError(new Error("network down"))).toBe(false);
+		});
+
+		it("walks response body shapes from requestUrl failures", () => {
+			const error = {
+				message: "Request failed, status 400",
+				response: {
+					json: {
+						error: {
+							code: "context_length_exceeded",
+							message: "maximum context length exceeded",
+						},
+					},
+				},
+			};
+
+			expect(isLikelyContextLimitError(error)).toBe(true);
+		});
+
+		it("does not classify quota or output token errors as input context errors", () => {
+			expect(isLikelyContextLimitError("rate limit exceeded")).toBe(false);
+			expect(isLikelyContextLimitError("token limit quota exceeded")).toBe(false);
+			expect(isLikelyContextLimitError("max output tokens exceeded")).toBe(false);
 		});
 	});
 

--- a/src/ai/OpenAIRequest.ts
+++ b/src/ai/OpenAIRequest.ts
@@ -11,6 +11,7 @@ import type { AIProvider, Model } from "./Provider";
 import { getModelProvider } from "./aiHelpers";
 import { log } from "src/logger/logManager";
 import { estimateTokenCount } from "./tokenEstimator";
+import { buildProviderError, classifyProviderError } from "./providerErrors";
 
 export interface CommonResponse {
 	id: string;
@@ -26,62 +27,24 @@ export interface CommonResponse {
 	created: number;
 }
 
-const CONTEXT_LIMIT_ERROR_PATTERNS = [
-	/context[_ -]?length[_ -]?exceeded/i,
-	/maximum context length/i,
-	/context window/i,
-	/too many input tokens/i,
-	/input(?: is)? too long/i,
-	/prompt(?: is)? too long/i,
-	/exceeds? (?:the )?(?:maximum )?(?:input )?(?:token|context)/i,
-	/context[_ -]?window[_ -]?exceeded/i,
-];
+// Shared request execution for all providers: call `requestUrl` with
+// `throw: false` so we can read the response body ourselves, run the
+// post-request callback (cursor restore), and turn any 4xx/5xx into a
+// structured, classifiable error before returning the parsed JSON.
+async function dispatchProviderRequest<T>(
+	params: Parameters<typeof requestUrl>[0] & object,
+	providerName: string,
+	afterRequestCallback?: () => void
+): Promise<T> {
+	const _response = requestUrl({ ...params, throw: false });
 
-function collectErrorMessages(
-	error: unknown,
-	seen = new Set<unknown>()
-): string[] {
-	if (error === null || error === undefined || seen.has(error)) return [];
-	seen.add(error);
+	if (afterRequestCallback) afterRequestCallback();
 
-	if (typeof error === "string") return [error];
-	if (typeof error !== "object") return [String(error)];
-
-	const record = error as Record<string, unknown>;
-	const messages: string[] = [];
-
-	for (const key of [
-		"message",
-		"code",
-		"type",
-		"statusText",
-		"text",
-		"body",
-		"data",
-		"details",
-		"json",
-		"response",
-		"error",
-		"cause",
-	]) {
-		const value = record[key];
-		if (value !== undefined) {
-			messages.push(...collectErrorMessages(value, seen));
-		}
+	const response = await _response;
+	if (response.status >= 400) {
+		throw buildProviderError(providerName, response);
 	}
-
-	if (Array.isArray(error)) {
-		for (const value of error) {
-			messages.push(...collectErrorMessages(value, seen));
-		}
-	}
-
-	return messages;
-}
-
-export function isLikelyContextLimitError(error: unknown): boolean {
-	const message = collectErrorMessages(error).join(" ");
-	return CONTEXT_LIMIT_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+	return response.json as T;
 }
 
 function mapOpenAIResponseToCommon(
@@ -175,27 +138,26 @@ async function makeOpenAIRequest(
 	prompt: string,
 	afterRequestCallback?: () => void
 ): Promise<OpenAIReqResponse> {
-	const _response = requestUrl({
-		url: `${modelProvider.endpoint}/chat/completions`,
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${apiKey}`,
+	return dispatchProviderRequest<OpenAIReqResponse>(
+		{
+			url: `${modelProvider.endpoint}/chat/completions`,
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${apiKey}`,
+			},
+			body: JSON.stringify({
+				model: model.name,
+				...modelParams,
+				messages: [
+					{ role: "system", content: systemPrompt },
+					{ role: "user", content: prompt },
+				],
+			}),
 		},
-		body: JSON.stringify({
-			model: model.name,
-			...modelParams,
-			messages: [
-				{ role: "system", content: systemPrompt },
-				{ role: "user", content: prompt },
-			],
-		}),
-	});
-
-	if (afterRequestCallback) afterRequestCallback();
-
-	const response = await _response;
-	return response.json as OpenAIReqResponse;
+		modelProvider.name,
+		afterRequestCallback
+	);
 }
 
 async function makeAnthropicRequest(
@@ -206,26 +168,25 @@ async function makeAnthropicRequest(
 	prompt: string,
 	afterRequestCallback?: () => void
 ): Promise<AnthropicResponse> {
-	const _response = requestUrl({
-		url: `${modelProvider.endpoint}/v1/messages`,
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			"x-api-key": apiKey,
-			"anthropic-version": "2023-06-01",
-			"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15"
+	return dispatchProviderRequest<AnthropicResponse>(
+		{
+			url: `${modelProvider.endpoint}/v1/messages`,
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-api-key": apiKey,
+				"anthropic-version": "2023-06-01",
+				"anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15"
+			},
+			body: JSON.stringify({
+				model: model.name,
+				max_tokens: 4096,
+				messages: [{ role: "user", content: prompt }],
+			}),
 		},
-		body: JSON.stringify({
-			model: model.name,
-			max_tokens: 4096,
-			messages: [{ role: "user", content: prompt }],
-		}),
-	});
-
-	if (afterRequestCallback) afterRequestCallback();
-
-	const response = await _response;
-	return response.json as AnthropicResponse;
+		modelProvider.name,
+		afterRequestCallback
+	);
 }
 
 async function makeGeminiRequest(
@@ -272,19 +233,18 @@ async function makeGeminiRequest(
     body["generationConfig"] = generationConfig;
   }
 
-  const _response = requestUrl({
-    url,
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
+  return dispatchProviderRequest<GeminiResponse>(
+    {
+      url,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify(body),
-  });
-
-  if (afterRequestCallback) afterRequestCallback();
-
-  const response = await _response;
-  return response.json as GeminiResponse;
+    modelProvider.name,
+    afterRequestCallback
+  );
 }
 
 function mapGeminiResponseToCommon(response: GeminiResponse): CommonResponse {
@@ -419,8 +379,17 @@ export function OpenAIRequest(
 			);
 
 			log.logError(error as Error);
+
+			// Help users act on the most common failure: a prompt that overflows
+			// the model's context window. (ChunkedPrompt retries these automatically;
+			// the single-prompt path cannot, so we point the user at a remedy.)
+			const guidance =
+				classifyProviderError(error) === "input_context"
+					? " The prompt likely exceeds the model's context window — shorten it, choose a model with a larger context, or use the chunked AI prompt API."
+					: "";
+
 			throw new Error(
-				`Error while making request to ${modelProvider.name}: ${errorMessage}`,
+				`Error while making request to ${modelProvider.name}: ${errorMessage}${guidance}`,
 				{ cause: error }
 			);
 		}

--- a/src/ai/OpenAIRequest.ts
+++ b/src/ai/OpenAIRequest.ts
@@ -5,12 +5,12 @@ import { settingsStore } from "src/settingsStore";
 import {
 	beginAIRequestLogEntry,
 	finishAIRequestLogEntry,
-	getTokenCount,
 } from "./AIAssistant";
 import { preventCursorChange } from "./preventCursorChange";
 import type { AIProvider, Model } from "./Provider";
 import { getModelProvider } from "./aiHelpers";
 import { log } from "src/logger/logManager";
+import { estimateTokenCount } from "./tokenEstimator";
 
 export interface CommonResponse {
 	id: string;
@@ -24,6 +24,64 @@ export interface CommonResponse {
 	stopReason: string;
 	stopSequence: string | null;
 	created: number;
+}
+
+const CONTEXT_LIMIT_ERROR_PATTERNS = [
+	/context[_ -]?length[_ -]?exceeded/i,
+	/maximum context length/i,
+	/context window/i,
+	/too many input tokens/i,
+	/input(?: is)? too long/i,
+	/prompt(?: is)? too long/i,
+	/exceeds? (?:the )?(?:maximum )?(?:input )?(?:token|context)/i,
+	/context[_ -]?window[_ -]?exceeded/i,
+];
+
+function collectErrorMessages(
+	error: unknown,
+	seen = new Set<unknown>()
+): string[] {
+	if (error === null || error === undefined || seen.has(error)) return [];
+	seen.add(error);
+
+	if (typeof error === "string") return [error];
+	if (typeof error !== "object") return [String(error)];
+
+	const record = error as Record<string, unknown>;
+	const messages: string[] = [];
+
+	for (const key of [
+		"message",
+		"code",
+		"type",
+		"statusText",
+		"text",
+		"body",
+		"data",
+		"details",
+		"json",
+		"response",
+		"error",
+		"cause",
+	]) {
+		const value = record[key];
+		if (value !== undefined) {
+			messages.push(...collectErrorMessages(value, seen));
+		}
+	}
+
+	if (Array.isArray(error)) {
+		for (const value of error) {
+			messages.push(...collectErrorMessages(value, seen));
+		}
+	}
+
+	return messages;
+}
+
+export function isLikelyContextLimitError(error: unknown): boolean {
+	const message = collectErrorMessages(error).join(" ");
+	return CONTEXT_LIMIT_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 function mapOpenAIResponseToCommon(
@@ -265,15 +323,8 @@ export function OpenAIRequest(
 			);
 		}
 
-		const tokenCount =
-			getTokenCount(prompt, model) + getTokenCount(systemPrompt, model);
-		const { maxTokens } = model;
-
-		if (tokenCount > maxTokens) {
-			throw new Error(
-				`The ${model.name} API has a token limit of ${maxTokens}. Your prompt has ${tokenCount} tokens.`
-			);
-		}
+		const estimatedTokenCount =
+			estimateTokenCount(prompt) + estimateTokenCount(systemPrompt);
 
 		const modelProvider = getModelProvider(model.name);
 
@@ -293,6 +344,15 @@ export function OpenAIRequest(
 		log.logMessage(
 			`[AI Request ${requestLogId}] Started ${modelProvider.name}/${model.name}`
 		);
+		if (
+			Number.isFinite(model.maxTokens) &&
+			model.maxTokens > 0 &&
+			estimatedTokenCount > model.maxTokens
+		) {
+			log.logMessage(
+				`[AI Request ${requestLogId}] Estimated prompt size is ${estimatedTokenCount} tokens, above the configured ${model.maxTokens} token context. Sending anyway; the provider will enforce the exact limit.`
+			);
+		}
 
 		try {
 			const restoreCursor = preventCursorChange(app);

--- a/src/ai/providerErrors.test.ts
+++ b/src/ai/providerErrors.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildProviderError,
+	classifyProviderError,
+	isLikelyContextLimitError,
+} from "./providerErrors";
+
+describe("classifyProviderError", () => {
+	it("classifies common input-context messages as input_context", () => {
+		expect(
+			isLikelyContextLimitError(new Error("maximum context length exceeded"))
+		).toBe(true);
+		expect(isLikelyContextLimitError("too many input tokens")).toBe(true);
+		expect(
+			classifyProviderError({
+				response: { json: { error: { code: "context_length_exceeded" } } },
+			})
+		).toBe("input_context");
+	});
+
+	it("classifies Gemini input-token overflow as input_context", () => {
+		// Real Gemini 400 shape.
+		const geminiError = new Error(
+			"The input token count (2551556) exceeds the maximum number of tokens allowed (1048576)."
+		);
+		expect(classifyProviderError(geminiError)).toBe("input_context");
+	});
+
+	it("walks wrapped causes and ignores unrelated errors", () => {
+		const cause = new Error("context_length_exceeded");
+		const wrapped = new Error("Error while making request", { cause });
+		expect(isLikelyContextLimitError(wrapped)).toBe(true);
+		expect(isLikelyContextLimitError(new Error("network down"))).toBe(false);
+	});
+
+	it("does not classify quota or explicit output-token errors as input_context", () => {
+		expect(classifyProviderError("rate limit exceeded")).toBe("other");
+		expect(classifyProviderError("token limit quota exceeded")).toBe("other");
+		expect(classifyProviderError("max output tokens exceeded")).toBe(
+			"output_budget"
+		);
+		expect(
+			classifyProviderError("max_tokens is too large: 200000")
+		).toBe("output_budget");
+	});
+
+	it("treats a completion that alone exceeds the context as output_budget (no retry)", () => {
+		// completion 9000 >= context 8192 → no input reduction can ever make it fit.
+		const completionExceedsContext = new Error(
+			"This model's maximum context length is 8192 tokens. However, you requested 9500 tokens (500 in the messages, 9000 in the completion). Please reduce the length of the messages or completion."
+		);
+		expect(classifyProviderError(completionExceedsContext)).toBe(
+			"output_budget"
+		);
+		expect(isLikelyContextLimitError(completionExceedsContext)).toBe(false);
+	});
+
+	it("treats a mixed overflow whose completion fits the context as input_context", () => {
+		// completion 4500 < context 8192 → shrinking the input can bring it under.
+		const mixedButRetryable = new Error(
+			"This model's maximum context length is 8192 tokens. However, you requested 8500 tokens (4000 in the messages, 4500 in the completion)."
+		);
+		expect(classifyProviderError(mixedButRetryable)).toBe("input_context");
+		expect(isLikelyContextLimitError(mixedButRetryable)).toBe(true);
+	});
+
+	it("treats a messages-dominated overflow as input_context (retry can help)", () => {
+		const messagesDominated = new Error(
+			"This model's maximum context length is 8192 tokens. However, you requested 9100 tokens (9000 in the messages, 100 in the completion). Please reduce the length of the messages or completion."
+		);
+		expect(classifyProviderError(messagesDominated)).toBe("input_context");
+		expect(isLikelyContextLimitError(messagesDominated)).toBe(true);
+	});
+
+	it("parses the completion/context comparison regardless of clause order", () => {
+		const completionFirst = new Error(
+			"maximum context length is 8192 tokens; requested 12,000 tokens (11,000 in the completion and 1,000 in the messages)"
+		);
+		expect(classifyProviderError(completionFirst)).toBe("output_budget");
+	});
+
+	it("treats an Anthropic input-dominated arithmetic overflow as input_context", () => {
+		// max_tokens (4096) < context (204698): shrinking the input can fit it.
+		const anthropic = new Error(
+			"input length and max_tokens exceed context limit: 202000 + 4096 > 204698, decrease input length or max_tokens"
+		);
+		expect(classifyProviderError(anthropic)).toBe("input_context");
+	});
+
+	it("treats an Anthropic overflow whose max_tokens alone exceeds context as output_budget", () => {
+		const anthropic = new Error(
+			"input length and max_tokens exceed context limit: 1000 + 300000 > 204698, decrease input length or max_tokens"
+		);
+		expect(classifyProviderError(anthropic)).toBe("output_budget");
+	});
+
+	it("treats an oversized max_tokens (no breakdown) as output_budget", () => {
+		const tooLarge = new Error(
+			"max_tokens is too large: 200000. This model supports at most 16384 completion tokens"
+		);
+		expect(classifyProviderError(tooLarge)).toBe("output_budget");
+	});
+
+	it("ignores echoed prompt text in request-payload fields", () => {
+		// Real error is a 500; the user's prompt (mentioning "context window") is
+		// echoed in request-payload containers we deliberately do not walk.
+		const echoed500 = {
+			message: "Request failed, status 500",
+			response: {
+				json: {
+					error: { message: "Internal server error", code: "internal_error" },
+				},
+			},
+			data: { message: "Explain the context window of GPT-4" },
+			body: "prompt: explain the context window",
+		};
+		expect(isLikelyContextLimitError(echoed500)).toBe(false);
+	});
+});
+
+describe("buildProviderError", () => {
+	it("embeds the provider code and message and exposes status", () => {
+		const err = buildProviderError("OpenAI", {
+			status: 400,
+			json: {
+				error: {
+					code: "context_length_exceeded",
+					message: "maximum context length exceeded",
+				},
+			},
+		});
+		expect(err.message).toContain("context_length_exceeded");
+		expect(err.message).toContain("maximum context length exceeded");
+		expect(err.status).toBe(400);
+		expect(err.providerCode).toBe("context_length_exceeded");
+		expect(isLikelyContextLimitError(err)).toBe(true);
+	});
+
+	it("falls back to response text when the body is not JSON", () => {
+		const err = buildProviderError("Gemini", {
+			status: 503,
+			get json() {
+				throw new Error("not json");
+			},
+			text: "upstream connect error",
+		});
+		expect(err.message).toContain("upstream connect error");
+		expect(err.status).toBe(503);
+	});
+});

--- a/src/ai/providerErrors.test.ts
+++ b/src/ai/providerErrors.test.ts
@@ -18,6 +18,23 @@ describe("classifyProviderError", () => {
 		).toBe("input_context");
 	});
 
+	it("classifies 'exceeded the … token/context' messages from compatible servers", () => {
+		// Past-tense "exceeded" and input-token phrasings common to OpenAI-compatible
+		// / local LLM servers must still be detected as input-context.
+		expect(
+			classifyProviderError(new Error("Request exceeded the maximum token limit"))
+		).toBe("input_context");
+		expect(
+			classifyProviderError(
+				new Error("This request exceeded the allowed input context")
+			)
+		).toBe("input_context");
+		// An output-token error must NOT be caught by it.
+		expect(
+			classifyProviderError(new Error("max output tokens exceeded"))
+		).toBe("output_budget");
+	});
+
 	it("classifies Gemini input-token overflow as input_context", () => {
 		// Real Gemini 400 shape.
 		const geminiError = new Error(

--- a/src/ai/providerErrors.ts
+++ b/src/ai/providerErrors.ts
@@ -17,6 +17,9 @@ const INPUT_CONTEXT_LIMIT_PATTERNS = [
 	/prompt(?: is)? too long/i,
 	/input token count/i, // Gemini: "The input token count (N) exceeds the maximum number of tokens allowed (M)."
 	/reduce the length of (?:the |your )?(?:messages|prompt|input)/i,
+	// OpenAI-compatible / local servers: "exceeded the maximum (input) token/context …".
+	// Output-budget errors are matched earlier, so this stays input-specific.
+	/exceed(?:s|ed|ing)? (?:the )?(?:maximum |allowed )?(?:input |prompt )?(?:token|context)/i,
 ];
 
 // Signals that the failure is about the *output*/completion budget itself (the

--- a/src/ai/providerErrors.ts
+++ b/src/ai/providerErrors.ts
@@ -1,0 +1,201 @@
+// Provider-agnostic normalization and classification of AI provider/HTTP errors.
+//
+// Obsidian's `requestUrl` rejects a failed request with a bare
+// `"Request failed, status N"` error that carries no response body, so the
+// request layer captures the body itself (see `buildProviderError`) and the
+// classification below reasons over the resulting structured error.
+
+// Signals that the *input* (prompt/messages) exceeded the model's context window
+// — the only failure that retrying with smaller chunks can fix.
+const INPUT_CONTEXT_LIMIT_PATTERNS = [
+	/context[_ -]?length[_ -]?exceeded/i,
+	/context[_ -]?window[_ -]?exceeded/i,
+	/maximum context length/i,
+	/context window/i,
+	/too many input tokens/i,
+	/input(?: is)? too long/i,
+	/prompt(?: is)? too long/i,
+	/input token count/i, // Gemini: "The input token count (N) exceeds the maximum number of tokens allowed (M)."
+	/reduce the length of (?:the |your )?(?:messages|prompt|input)/i,
+];
+
+// Signals that the failure is about the *output*/completion budget itself (the
+// named parameter), which shrinking the input cannot fix.
+const OUTPUT_BUDGET_PATTERNS = [
+	/max_tokens/i,
+	/max_completion_tokens/i,
+	/max(?:imum)? output tokens/i,
+	/output token limit/i,
+];
+
+// Only walk fields that legitimately carry provider/HTTP error information. We
+// deliberately exclude request-echo containers (e.g. `data`, `body`, request
+// payloads) so an echoed user prompt can never be mistaken for a provider error.
+const ERROR_MESSAGE_KEYS = [
+	"message",
+	"code",
+	"type",
+	"status",
+	"statusText",
+	"providerCode",
+	"error",
+	"response",
+	"json",
+	"cause",
+] as const;
+
+function collectErrorMessages(
+	error: unknown,
+	seen = new Set<unknown>()
+): string[] {
+	if (error === null || error === undefined || seen.has(error)) return [];
+	seen.add(error);
+
+	if (typeof error === "string") return [error];
+	if (typeof error !== "object") return [String(error)];
+
+	const record = error as Record<string, unknown>;
+	const messages: string[] = [];
+
+	for (const key of ERROR_MESSAGE_KEYS) {
+		const value = record[key];
+		if (value !== undefined) {
+			messages.push(...collectErrorMessages(value, seen));
+		}
+	}
+
+	return messages;
+}
+
+function parseTokenCount(raw: string): number {
+	return Number(raw.replace(/,/g, ""));
+}
+
+function parseContextLimit(message: string): number | null {
+	const match = message.match(
+		/context (?:length|window)(?:\s+is)?(?:\s+of)?\s*(\d[\d,]*)/i
+	);
+	return match ? parseTokenCount(match[1]) : null;
+}
+
+// When a provider spells out the token breakdown, decide whether shrinking the
+// input can help. The blocker isn't "which side is bigger" — it's whether the
+// requested *output*/completion alone already meets or exceeds the context
+// window (in which case no input reduction can ever make it fit). Handles, in
+// any clause order:
+//   OpenAI:    "...maximum context length is 8192... (1000 in the messages, 8000 in the completion)"
+//   Anthropic: "input length and max_tokens exceed context limit: 202000 + 4096 > 204698"
+function analyzeTokenBreakdown(message: string): "input" | "output" | null {
+	const completionMatch = message.match(
+		/(\d[\d,]*)\s*(?:tokens?\s+)?in the completion\b/i
+	);
+	if (completionMatch) {
+		const completion = parseTokenCount(completionMatch[1]);
+		const context = parseContextLimit(message);
+		// Without a stated context we can't be sure; prefer a (cap-bounded) retry.
+		if (context === null) return "input";
+		return completion >= context ? "output" : "input";
+	}
+
+	const arithmetic = message.match(
+		/input length and max_tokens exceed context limit:?\s*(\d[\d,]*)\s*\+\s*(\d[\d,]*)(?:\s*>\s*(\d[\d,]*))?/i
+	);
+	if (arithmetic) {
+		const maxTokens = parseTokenCount(arithmetic[2]);
+		const context = arithmetic[3] ? parseTokenCount(arithmetic[3]) : null;
+		if (context === null) return "input";
+		return maxTokens >= context ? "output" : "input";
+	}
+
+	return null;
+}
+
+export type ProviderErrorKind = "input_context" | "output_budget" | "other";
+
+/**
+ * Classify a provider/HTTP error. A spelled-out token breakdown (which side
+ * dominates) is authoritative; otherwise fall back to keyword signals, where
+ * output/quota signals win over input-context signals because a request that
+ * fails on the completion budget cannot be salvaged by sending less input.
+ */
+export function classifyProviderError(error: unknown): ProviderErrorKind {
+	const message = collectErrorMessages(error).join(" ");
+
+	const breakdown = analyzeTokenBreakdown(message);
+	if (breakdown === "output") return "output_budget";
+	if (breakdown === "input") return "input_context";
+
+	if (OUTPUT_BUDGET_PATTERNS.some((pattern) => pattern.test(message))) {
+		return "output_budget";
+	}
+
+	if (INPUT_CONTEXT_LIMIT_PATTERNS.some((pattern) => pattern.test(message))) {
+		return "input_context";
+	}
+
+	return "other";
+}
+
+/**
+ * True only when the provider rejected the request because the *input* exceeded
+ * the model's context window — the one case where retrying with smaller chunks
+ * can help.
+ */
+export function isLikelyContextLimitError(error: unknown): boolean {
+	return classifyProviderError(error) === "input_context";
+}
+
+export interface NormalizedProviderError extends Error {
+	status: number;
+	providerCode?: string;
+}
+
+type MinimalRequestUrlResponse = {
+	status: number;
+	json?: unknown;
+	text?: string;
+};
+
+/**
+ * Build a structured error from a failed `requestUrl` response (called with
+ * `throw: false`). The provider's real `code`/`message` are embedded in the
+ * thrown error's message and `providerCode`, so classification and user-facing
+ * messaging both work.
+ */
+export function buildProviderError(
+	providerName: string,
+	response: MinimalRequestUrlResponse
+): NormalizedProviderError {
+	let detail = "";
+	let code = "";
+
+	let parsed: unknown;
+	try {
+		parsed = response.json;
+	} catch {
+		parsed = undefined;
+	}
+
+	if (parsed && typeof parsed === "object") {
+		const root = parsed as Record<string, unknown>;
+		const errObj = (root.error ?? root) as Record<string, unknown>;
+		detail = String(errObj.message ?? root.message ?? "");
+		code = String(errObj.code ?? errObj.type ?? errObj.status ?? "");
+	}
+
+	if (!detail) {
+		detail =
+			typeof response.text === "string" && response.text.length > 0
+				? response.text
+				: `HTTP ${response.status}`;
+	}
+
+	const err = new Error(
+		`${providerName} request failed (HTTP ${response.status})${
+			code ? ` [${code}]` : ""
+		}: ${detail}`
+	) as NormalizedProviderError;
+	err.status = response.status;
+	if (code) err.providerCode = code;
+	return err;
+}

--- a/src/ai/tokenEstimator.test.ts
+++ b/src/ai/tokenEstimator.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { estimateModelInputBudget, estimateTokenCount } from "./tokenEstimator";
+
+describe("tokenEstimator", () => {
+	it("estimates empty input as zero tokens", () => {
+		expect(estimateTokenCount("")).toBe(0);
+	});
+
+	it("uses a lightweight ASCII estimate", () => {
+		expect(estimateTokenCount("abcdefghijklmnop")).toBe(4);
+	});
+
+	it("uses UTF-8 byte length for non-ASCII text", () => {
+		expect(estimateTokenCount("日本語")).toBe(3);
+		expect(estimateTokenCount("😀")).toBe(2);
+	});
+
+	it("reserves less than the full model context for prompt input", () => {
+		expect(estimateModelInputBudget(1000)).toBe(450);
+		expect(estimateModelInputBudget(0)).toBe(1);
+	});
+});

--- a/src/ai/tokenEstimator.ts
+++ b/src/ai/tokenEstimator.ts
@@ -1,0 +1,21 @@
+const ASCII_BYTES_PER_TOKEN_ESTIMATE = 4;
+const MIXED_BYTES_PER_TOKEN_ESTIMATE = 3;
+const DEFAULT_INPUT_BUDGET_RATIO = 0.45;
+
+export function estimateTokenCount(text: string): number {
+	if (text.length === 0) return 0;
+
+	const bytes = new TextEncoder().encode(text).length;
+	const hasNonAscii = /[^\x00-\x7F]/.test(text);
+	const bytesPerToken = hasNonAscii
+		? MIXED_BYTES_PER_TOKEN_ESTIMATE
+		: ASCII_BYTES_PER_TOKEN_ESTIMATE;
+
+	return Math.max(1, Math.ceil(bytes / bytesPerToken));
+}
+
+export function estimateModelInputBudget(maxTokens: number): number {
+	if (!Number.isFinite(maxTokens) || maxTokens <= 0) return 1;
+
+	return Math.max(1, Math.floor(maxTokens * DEFAULT_INPUT_BUDGET_RATIO));
+}

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -186,7 +186,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			cls: "qa-ai-token-count",
 		});
 		const tokenCountNote = container.createEl("div", {
-			text: "Exact for OpenAI models; estimates for others.",
+			text: "Estimated locally. Providers enforce exact context limits.",
 			cls: "qa-ai-token-note",
 		});
 
@@ -217,7 +217,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 
 		const formatDisplay = this.contentEl.createEl("span");
 		const updateTokenCount = debounce(() => {
-			tokenCount.innerText = `Token count: ${
+			tokenCount.innerText = `Estimated tokens: ${
 				this.systemPromptTokenLength !== Number.POSITIVE_INFINITY
 					? this.systemPromptTokenLength
 					: "select a model to calculate"

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -15,7 +15,7 @@ import {
 	DEFAULT_TOP_P,
 } from "src/ai/OpenAIModelParameters";
 import { estimateTokenCount } from "src/ai/tokenEstimator";
-import { getModelByName, getModelNames } from "src/ai/aiHelpers";
+import { getModelNames } from "src/ai/aiHelpers";
 
 export class AIAssistantCommandSettingsModal extends Modal {
 	public waitForClose: Promise<IAIAssistantCommand>;
@@ -27,11 +27,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 	private showAdvancedSettings = false;
 
 	private get systemPromptTokenLength(): number {
-		if (this.settings.model === "Ask me") return Number.POSITIVE_INFINITY;
-
-		const model = getModelByName(this.settings.model);
-		if (!model) return Number.POSITIVE_INFINITY;
-
+		// The estimate is provider-agnostic, so it no longer depends on the model.
 		return estimateTokenCount(this.settings.systemPrompt);
 	}
 
@@ -217,11 +213,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 
 		const formatDisplay = this.contentEl.createEl("span");
 		const updateTokenCount = debounce(() => {
-			tokenCount.innerText = `Estimated tokens: ${
-				this.systemPromptTokenLength !== Number.POSITIVE_INFINITY
-					? this.systemPromptTokenLength
-					: "select a model to calculate"
-			}`;
+			tokenCount.innerText = `Estimated tokens: ${this.systemPromptTokenLength}`;
 		}, 50);
 
 		updateTokenCount();

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -14,7 +14,7 @@ import {
 	DEFAULT_TEMPERATURE,
 	DEFAULT_TOP_P,
 } from "src/ai/OpenAIModelParameters";
-import { getTokenCount } from "src/ai/AIAssistant";
+import { estimateTokenCount } from "src/ai/tokenEstimator";
 import { getModelByName, getModelNames } from "src/ai/aiHelpers";
 
 export class AIAssistantCommandSettingsModal extends Modal {
@@ -32,7 +32,7 @@ export class AIAssistantCommandSettingsModal extends Modal {
 		const model = getModelByName(this.settings.model);
 		if (!model) return Number.POSITIVE_INFINITY;
 
-		return getTokenCount(this.settings.systemPrompt, model);
+		return estimateTokenCount(this.settings.systemPrompt);
 	}
 
 	constructor(app: App, settings: IAIAssistantCommand) {

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -27,8 +27,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 	private showAdvancedSettings = false;
 
 	private get systemPromptTokenLength(): number {
-		const model = getModelByName(this.settings.model);
-		if (!model) return Number.POSITIVE_INFINITY;
+		// The estimate is provider-agnostic, so it no longer depends on the model.
 		return estimateTokenCount(this.settings.systemPrompt);
 	}
 

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -11,7 +11,10 @@ import {
 	DEFAULT_TEMPERATURE,
 	DEFAULT_TOP_P,
 } from "src/ai/OpenAIModelParameters";
-import { getTokenCount } from "src/ai/AIAssistant";
+import {
+	estimateModelInputBudget,
+	estimateTokenCount,
+} from "src/ai/tokenEstimator";
 import { getModelByName, getModelNames } from "src/ai/aiHelpers";
 
 export class InfiniteAIAssistantCommandSettingsModal extends Modal {
@@ -26,7 +29,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 	private get systemPromptTokenLength(): number {
 		const model = getModelByName(this.settings.model);
 		if (!model) return Number.POSITIVE_INFINITY;
-		return getTokenCount(this.settings.systemPrompt, model);
+		return estimateTokenCount(this.settings.systemPrompt);
 	}
 
 	constructor(app: App, settings: IInfiniteAIAssistantCommand) {
@@ -314,7 +317,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 		new Setting(container)
 			.setName("Max Chunk Tokens")
 			.setDesc(
-				"The maximum number of tokens in each chunk, calculated as the chunk token size + prompt template token size + system prompt token size. Make sure you leave room for the model to respond to the prompt."
+				"Maximum estimated tokens for each chunk of your text (the {{chunk}} portion only — the system prompt and prompt template are accounted for separately). Counts are estimated locally; the provider enforces the exact limit. Leave room for the model's response. Values above the model's estimated input budget are capped automatically."
 			)
 			.addSlider((slider) => {
 				const model = getModelByName(this.settings.model);
@@ -325,7 +328,14 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 					);
 				}
 
-				slider.setLimits(1, model.maxTokens - this.systemPromptTokenLength, 1);
+				// Upper bound mirrors the runtime budget: the model's estimated
+				// input budget minus the (estimated) system prompt overhead.
+				const sliderMax = Math.max(
+					1,
+					estimateModelInputBudget(model.maxTokens) -
+						this.systemPromptTokenLength
+				);
+				slider.setLimits(1, sliderMax, 1);
 				slider.setDynamicTooltip();
 
 				slider.setValue(this.settings.maxChunkTokens);

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -150,7 +150,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			cls: "qa-ai-token-count",
 		});
 		const tokenCountNote = container.createEl("div", {
-			text: "Exact for OpenAI models; estimates for others.",
+			text: "Estimated locally. Providers enforce exact context limits.",
 			cls: "qa-ai-token-note",
 		});
 
@@ -181,7 +181,7 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 
 		const formatDisplay = this.contentEl.createEl("span");
 		const updateTokenCount = debounce(() => {
-			tokenCount.innerText = `Token count: ${this.systemPromptTokenLength}`;
+			tokenCount.innerText = `Estimated tokens: ${this.systemPromptTokenLength}`;
 		}, 50);
 
 		updateTokenCount();

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
 	// AI
 	prompt: vi.fn(),
 	chunkedPrompt: vi.fn(),
-	getTokenCount: vi.fn(),
+	estimateTokenCount: vi.fn(),
 	getAIRequestLogEntries: vi.fn(),
 	getAIRequestLogEntryById: vi.fn(),
 	getLastAIRequestLogEntry: vi.fn(),
@@ -83,11 +83,13 @@ vi.mock("./preflight/OnePageInputModal", () => ({
 vi.mock("./ai/AIAssistant", () => ({
 	Prompt: mocks.prompt,
 	ChunkedPrompt: mocks.chunkedPrompt,
-	getTokenCount: mocks.getTokenCount,
 	getAIRequestLogEntries: mocks.getAIRequestLogEntries,
 	getAIRequestLogEntryById: mocks.getAIRequestLogEntryById,
 	getLastAIRequestLogEntry: mocks.getLastAIRequestLogEntry,
 	clearAIRequestLogEntries: mocks.clearAIRequestLogEntries,
+}));
+vi.mock("./ai/tokenEstimator", () => ({
+	estimateTokenCount: mocks.estimateTokenCount,
 }));
 vi.mock("./ai/aiHelpers", () => ({
 	getModelByName: mocks.getModelByName,
@@ -665,19 +667,19 @@ describe("ai sync helpers", () => {
 		expect(() => api.ai.getMaxTokens("nope")).toThrow("Model nope not found.");
 	});
 
-	it("estimateTokens delegates to the compatibility token estimator", () => {
-		mocks.getTokenCount.mockReturnValue(5);
+	it("estimateTokens delegates to the provider-agnostic estimator", () => {
+		mocks.estimateTokenCount.mockReturnValue(5);
 		const { api } = getApi();
 		expect(api.ai.estimateTokens("hi")).toBe(5);
-		expect(mocks.getTokenCount).toHaveBeenCalledWith("hi", "estimate");
+		expect(mocks.estimateTokenCount).toHaveBeenCalledWith("hi");
 	});
 
-	it("countTokens delegates to getTokenCount", () => {
-		mocks.getTokenCount.mockReturnValue(7);
+	it("countTokens is a compatibility alias that ignores the model arg", () => {
+		mocks.estimateTokenCount.mockReturnValue(7);
 		const { api } = getApi();
 		const model = { name: "m", maxTokens: 1 } as never;
 		expect(api.ai.countTokens("hi", model)).toBe(7);
-		expect(mocks.getTokenCount).toHaveBeenCalledWith("hi", model);
+		expect(mocks.estimateTokenCount).toHaveBeenCalledWith("hi");
 	});
 
 	it("getRequestLogs delegates with a default limit of 10", () => {

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -644,7 +644,7 @@ describe("utility selection helpers", () => {
 });
 
 // ===========================================================================
-// AI sync helpers (getModels / getMaxTokens / countTokens / logs)
+// AI sync helpers (getModels / getMaxTokens / estimateTokens / countTokens / logs)
 // ===========================================================================
 describe("ai sync helpers", () => {
 	it("getModels delegates to getModelNames", () => {
@@ -663,6 +663,13 @@ describe("ai sync helpers", () => {
 		mocks.getModelByName.mockReturnValue(undefined);
 		const { api } = getApi();
 		expect(() => api.ai.getMaxTokens("nope")).toThrow("Model nope not found.");
+	});
+
+	it("estimateTokens delegates to the compatibility token estimator", () => {
+		mocks.getTokenCount.mockReturnValue(5);
+		const { api } = getApi();
+		expect(api.ai.estimateTokens("hi")).toBe(5);
+		expect(mocks.getTokenCount).toHaveBeenCalledWith("hi", "estimate");
 	});
 
 	it("countTokens delegates to getTokenCount", () => {
@@ -850,6 +857,7 @@ describe("ai.chunkedPrompt validation", () => {
 			promptTemplate: "tmpl",
 			resultJoiner: "\n",
 			shouldMerge: true,
+			maxChunkTokens: undefined,
 		});
 		expect(opts.chunkSeparator).toBeInstanceOf(RegExp);
 	});

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -6,9 +6,9 @@ import {
 	getAIRequestLogEntryById,
 	getAIRequestLogEntries,
 	getLastAIRequestLogEntry,
-	getTokenCount,
 	Prompt,
 } from "./ai/AIAssistant";
+import { estimateTokenCount } from "./ai/tokenEstimator";
 import {
 	getModelByName,
 	getModelNames,
@@ -544,10 +544,13 @@ export class QuickAddApi {
 					return model.maxTokens;
 				},
 				estimateTokens(text: string) {
-					return getTokenCount(text, "estimate");
+					return estimateTokenCount(text);
 				},
-				countTokens(text: string, model: Model | string) {
-					return getTokenCount(text, model);
+				// `model` is accepted for backward compatibility but ignored:
+				// QuickAdd no longer bundles model-specific tokenizers, so this is
+				// a thin alias for the provider-agnostic estimator.
+				countTokens(text: string, _model?: Model | string) {
+					return estimateTokenCount(text);
 				},
 				getRequestLogs(limit = 10) {
 					return getAIRequestLogEntries(limit);

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -32,6 +32,7 @@ import type QuickAdd from "./main";
 import { OnePageInputModal } from "./preflight/OnePageInputModal";
 import type { FieldRequirement } from "./preflight/RequirementCollector";
 import { settingsStore } from "./settingsStore";
+import { log } from "./logger/logManager";
 import type IChoice from "./types/choices/IChoice";
 import { getDate } from "./utilityObsidian";
 import { isCancellationError, reportError } from "./utils/errorUtils";
@@ -50,6 +51,10 @@ import {
 	templateInsertModes,
 	type TemplateInsertModeId,
 } from "./engine/TemplateInsertEngine";
+
+// Emit the countTokens deprecation hint at most once per session (console only,
+// via log.logMessage — never a Notice — so scripts calling it in a loop aren't spammed).
+let warnedCountTokensDeprecated = false;
 
 function snapshotVariables(
 	vars: Map<string, unknown>,
@@ -550,6 +555,12 @@ export class QuickAddApi {
 				// QuickAdd no longer bundles model-specific tokenizers, so this is
 				// a thin alias for the provider-agnostic estimator.
 				countTokens(text: string, _model?: Model | string) {
+					if (!warnedCountTokensDeprecated) {
+						warnedCountTokensDeprecated = true;
+						log.logMessage(
+							"quickAddApi.ai.countTokens is deprecated and now returns a provider-agnostic estimate (the model argument is ignored). Use estimateTokens(text) instead.",
+						);
+					}
 					return estimateTokenCount(text);
 				},
 				getRequestLogs(limit = 10) {

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -439,6 +439,7 @@ export class QuickAddApi {
 						chunkSeparator: RegExp;
 						chunkJoiner: string;
 						shouldMerge: boolean;
+						maxChunkTokens: number;
 					}>,
 					existingVariables?: Record<string, unknown>,
 				) => {
@@ -501,6 +502,7 @@ export class QuickAddApi {
 								settings?.systemPrompt ?? AISettings.defaultSystemPrompt,
 							resultJoiner: settings?.chunkJoiner ?? "\n",
 							shouldMerge: settings?.shouldMerge ?? true,
+							maxChunkTokens: settings?.maxChunkTokens,
 						},
 						(txt: string, variables?: Record<string, unknown>) => {
 							const mergedVariables = {
@@ -541,7 +543,10 @@ export class QuickAddApi {
 
 					return model.maxTokens;
 				},
-				countTokens(text: string, model: Model) {
+				estimateTokens(text: string) {
+					return getTokenCount(text, "estimate");
+				},
+				countTokens(text: string, model: Model | string) {
 					return getTokenCount(text, model);
 				},
 				getRequestLogs(limit = 10) {


### PR DESCRIPTION
Remove the bundled `js-tiktoken` dependency and replace model-specific local tokenization with a provider-agnostic estimate.

QuickAdd supports OpenAI, Anthropic, Gemini, OpenAI-compatible providers, and custom model directories, so a bundled OpenAI tokenizer was only exact for part of the supported surface while adding several MB of rank data to the plugin bundle. This keeps token counting as an estimate for planning/UI, lets providers enforce exact context limits, and preserves successful usage accounting from provider responses.

The chunked AI prompt path now plans chunks with the estimator, retries provider context-limit failures by splitting the rejected chunk, and guards against runaway fan-out. `quickAddApi.ai.estimateTokens(text)` is the preferred API; `countTokens` remains as a compatibility alias (its `model` argument is ignored, and it logs a one-time console deprecation hint).

### Highlights
- `main.js` production build drops to ~984 KB locally.
- Exact context enforcement moves to providers; local checks are estimates/warnings only.
- New `src/ai/providerErrors.ts` normalizes provider/HTTP errors and classifies them as input-context vs output/completion-budget (by comparing the requested completion/`max_tokens` against the parsed context window), so only genuinely retryable input overflows are split-and-retried.

### Review & hardening
Several rounds of adversarial review (cross-model reviewers across Skeptic/Architect/Minimalist lenses) drove the following fixes, each with regression tests:
- **Chunked-prompt render race:** formatter renders are serialized so concurrent chunks and recursive retries can't cross-talk on the shared `chunk` variable (previously caused silent chunk loss/duplication). Render failures are terminal and stop sibling chunks; templates that omit `{{VALUE:chunk}}` fail fast.
- **Provider error capture:** `requestUrl` is called with `throw:false` and the real response body is parsed into a structured error, so context-limit detection actually fires in production (it never reached the classifier before).
- **Safety cap:** enforced during splitting (per original chunk) plus a post-merge cap; `splitChunkNearMiddle` avoids `Array.from` on large inputs.
- **Budgeting:** hard-stop only when prompt overhead exceeds the full model context (not the 45% planning budget); `maxChunkTokens` is consistent across UI, API, docs, and runtime.
- **Cleanup:** removed the model-shaped `getTokenCount` alias; collapsed the three provider request functions into one dispatch helper.
- Resolved the inline PR review comments (context-limit regex coverage for compat/local servers, the misleading "select a model" UI text, the `countTokens` doc signature, and a leaking test stub).

### Validation
- `bun run test` (1805 passing)
- `bun run build-with-lint`
- `git diff --check`
- `obsidian vault=dev plugin:reload id=quickadd` / `dev:errors` -> no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ai.estimateTokens() for provider-agnostic local token estimates
  * chunkedPrompt supports maxChunkTokens to control chunking

* **Improvements**
  * countTokens retained as a compatibility alias (now uses local estimates; model arg ignored)
  * Smarter chunking with bounded retries, safer request limits, and serialized rendering
  * Improved provider error classification and clearer guidance on context limits
  * UI labels and sliders now show estimated token values

* **Tests**
  * Expanded test coverage for chunking, token estimation, and provider errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
