### PR TITLE
fix(choices): assign unique default names for new choices (#1318)

### DIFF
--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -25,6 +25,7 @@
 	import ObsidianIcon from "../components/ObsidianIcon.svelte";
 	import { promptRenameChoice } from "../choiceRename";
 	import AddChoiceControls from "./AddChoiceControls.svelte";
+	import { uniqueDefaultChoiceName } from "./choiceTypeMeta";
 	import ChoiceList from "./ChoiceList.svelte";
 	import type { ChoiceListActions } from "./choiceListActions";
 	import { type Plain, snapshot } from "../svelte/persist.svelte";
@@ -109,11 +110,12 @@
 	}
 
 	async function addChoiceToList(
-		name: string,
+		_name: string,
 		type: ChoiceType,
 		targetFolderId?: string,
 		skipConfigure = false,
 	): Promise<void> {
+		const name = uniqueDefaultChoiceName(type, choices);
 		const newChoice = createChoice(type, name);
 		choices = addChoiceToTree(choices, newChoice, targetFolderId);
 

--- a/src/gui/choiceList/choiceTypeMeta.test.ts
+++ b/src/gui/choiceList/choiceTypeMeta.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type IChoice from "../../types/choices/IChoice";
+import { defaultChoiceName, uniqueDefaultChoiceName } from "./choiceTypeMeta";
+
+const choice = (name: string, type: IChoice["type"] = "Template"): IChoice =>
+	({ id: name, name, type, command: false }) as unknown as IChoice;
+
+const folder = (name: string, children: IChoice[]): IChoice =>
+	({
+		id: name,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: children,
+	}) as unknown as IChoice;
+
+describe("uniqueDefaultChoiceName", () => {
+	it("returns the base name when no collision exists", () => {
+		expect(uniqueDefaultChoiceName("Template", [])).toBe("New template");
+		expect(uniqueDefaultChoiceName("Template", [choice("Other")])).toBe(
+			"New template",
+		);
+	});
+
+	it("appends a counter when the base name is already taken", () => {
+		const existing = [choice("New template")];
+		expect(uniqueDefaultChoiceName("Template", existing)).toBe("New template 2");
+		expect(
+			uniqueDefaultChoiceName("Template", [
+				choice("New template"),
+				choice("New template 2"),
+			]),
+		).toBe("New template 3");
+	});
+
+	it("checks names anywhere in the tree, including nested folders", () => {
+		const existing = [folder("Folder", [choice("New template")])];
+		expect(uniqueDefaultChoiceName("Template", existing)).toBe("New template 2");
+	});
+
+	it("disambiguates every choice type independently", () => {
+		for (const type of ["Template", "Capture", "Macro", "Multi"] as const) {
+			const base = defaultChoiceName(type);
+			expect(uniqueDefaultChoiceName(type, [choice(base, type)])).toBe(
+				`${base} 2`,
+			);
+		}
+	});
+});

--- a/src/gui/choiceList/choiceTypeMeta.ts
+++ b/src/gui/choiceList/choiceTypeMeta.ts
@@ -1,4 +1,6 @@
 import type { ChoiceType } from "../../types/choices/choiceType";
+import type IChoice from "../../types/choices/IChoice";
+import { flattenChoices } from "../../utils/choiceUtils";
 
 export interface ChoiceTypeMeta {
 	type: ChoiceType;
@@ -53,4 +55,22 @@ export function defaultChoiceName(type: ChoiceType): string {
 		case "Multi":
 			return "New folder";
 	}
+}
+
+/**
+ * Default name for a freshly added choice, disambiguated from existing siblings.
+ * Every new choice starts from {@link defaultChoiceName}; when that label is
+ * already taken anywhere in the tree, appends " 2", " 3", … so rows stay
+ * distinguishable in the list and drag pill (fixes #1318).
+ */
+export function uniqueDefaultChoiceName(
+	type: ChoiceType,
+	existing: IChoice[],
+): string {
+	const base = defaultChoiceName(type);
+	const names = new Set(flattenChoices(existing).map((c) => c.name));
+	if (!names.has(base)) return base;
+	let i = 2;
+	while (names.has(`${base} ${i}`)) i++;
+	return `${base} ${i}`;
 }


### PR DESCRIPTION
## Summary
- New template/capture/macro/folder choices now get disambiguated default names (`"New template 2"`, etc.) when the base label is already in use anywhere in the tree.
- Fixes the confusion reported in #1318 where multiple identical `"New template"` rows made drag-and-drop nesting hard to complete — rows and the drag pill were indistinguishable.
- Renamed issue #1318 from `[BUG]` to a descriptive title.

## Test plan
- [x] `npm test -- --run src/gui/choiceList/choiceTypeMeta.test.ts src/gui/choiceList/ChoiceView.test.ts`
- [ ] Create two template choices in QuickAdd settings and confirm the second is named `"New template 2"`.
- [ ] Drag the second choice into a folder and confirm nesting completes cleanly.
- [ ] Verify folders still prompt for rename on add (unchanged behavior).

Closes #1318


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New choices now automatically receive unique names. When naming conflicts occur, numeric suffixes are automatically appended, ensuring no duplicate choice names exist across all choice types and nested structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->