### PR TITLE
feat(templates): support multiple template folder paths (#1170)

### DIFF
--- a/src/engine/CaptureChoiceEngine.merge.test.ts
+++ b/src/engine/CaptureChoiceEngine.merge.test.ts
@@ -9,7 +9,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		choices: [],
 		inputPrompt: "single-line",
 		devMode: false,
-		templateFolderPath: "",
+		templateFolderPaths: [],
 		useSelectionAsCaptureValue: true,
 		announceUpdates: "major",
 		version: "0.0.0",

--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -5,7 +5,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		choices: [],
 		inputPrompt: "single-line",
 		devMode: false,
-		templateFolderPath: "",
+		templateFolderPaths: [],
 		useSelectionAsCaptureValue: true,
 		announceUpdates: "major",
 		version: "0.0.0",

--- a/src/engine/CaptureChoiceEngine.template-property-types.test.ts
+++ b/src/engine/CaptureChoiceEngine.template-property-types.test.ts
@@ -10,7 +10,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		choices: [],
 		inputPrompt: "single-line",
 		devMode: false,
-		templateFolderPath: "",
+		templateFolderPaths: [],
 		useSelectionAsCaptureValue: true,
 		announceUpdates: "major",
 		version: "0.0.0",

--- a/src/engine/MacroChoiceEngine.notice.test.ts
+++ b/src/engine/MacroChoiceEngine.notice.test.ts
@@ -5,7 +5,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		choices: [],
 		inputPrompt: "single-line",
 		devMode: false,
-		templateFolderPath: "",
+		templateFolderPaths: [],
 		useSelectionAsCaptureValue: true,
 		announceUpdates: "major",
 		version: "0.0.0",

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -5,7 +5,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		choices: [],
 		inputPrompt: "single-line",
 		devMode: false,
-		templateFolderPath: "",
+		templateFolderPaths: [],
 		useSelectionAsCaptureValue: true,
 		announceUpdates: "major",
 		version: "0.0.0",

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -5,7 +5,7 @@ vi.mock("../quickAddSettingsTab", () => {
 		choices: [],
 		inputPrompt: "single-line",
 		devMode: false,
-		templateFolderPath: "",
+		templateFolderPaths: [],
 		useSelectionAsCaptureValue: true,
 		announceUpdates: "major",
 		version: "0.0.0",

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -4,10 +4,11 @@ import type {
 	LinkToCurrentFileBehavior,
 	TemplateInclusionState,
 } from "../formatters/formatter";
-import type { App } from "obsidian";
-import { Notice, TFile, TFolder } from "obsidian";
+import type { App, TFile } from "obsidian";
+import { Notice, TFolder } from "obsidian";
 import type QuickAdd from "../main";
 import {
+	getTemplateFile,
 	getTemplater,
 	overwriteTemplaterOnce,
 	templaterParseTemplate,
@@ -669,18 +670,11 @@ export abstract class TemplateEngine extends QuickAddEngine {
 	}
 
 	protected async getTemplateContent(templatePath: string): Promise<string> {
-		let correctTemplatePath: string = this.stripLeadingSlash(templatePath);
-		if (!MARKDOWN_FILE_EXTENSION_REGEX.test(templatePath) && 
-			!CANVAS_FILE_EXTENSION_REGEX.test(templatePath) &&
-			!BASE_FILE_EXTENSION_REGEX.test(templatePath))
-			correctTemplatePath += ".md";
+		const templateFile = getTemplateFile(this.app, templatePath);
 
-		const templateFile =
-			this.app.vault.getAbstractFileByPath(correctTemplatePath);
-
-		if (!(templateFile instanceof TFile))
+		if (!templateFile)
 			throw new Error(
-				`Template file not found at path "${correctTemplatePath}".`
+				`Template file not found at path "${templatePath}".`
 			);
 
 		return await this.app.vault.cachedRead(templateFile);

--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -16,7 +16,7 @@ import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
 } from "../../types/linkPlacement";
-import { getAllFolderPathsInVault } from "../../utilityObsidian";
+import { getAllFolderPathsInVault, getTemplateFile } from "../../utilityObsidian";
 import { sortFolderPathsByTree } from "../../utils/folder-sorting";
 import { createValidatedInput } from "../components/validatedInput";
 import { FormatSyntaxSuggester } from "../suggesters/formatSyntaxSuggester";
@@ -1437,10 +1437,13 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			validator: (raw) => {
 				const v = raw.trim();
 				if (!v) return true;
-				return templateFilePaths.includes(v) || "Template not found";
+				// Resolve like the engine does at run time rather than requiring
+				// suggestion-list membership (templates outside the configured
+				// folders are valid). Mirrors templateChoiceBuilder.
+				return getTemplateFile(this.app, v) !== null || "Template not found";
 			},
 			onChange: (value) => {
-				this.choice.createFileIfItDoesntExist.template = value;
+				this.choice.createFileIfItDoesntExist.template = value.trim();
 			},
 		});
 

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -23,7 +23,7 @@ import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
 } from "../../types/linkPlacement";
-import { getAllFolderPathsInVault } from "../../utilityObsidian";
+import { getAllFolderPathsInVault, getTemplateFile } from "../../utilityObsidian";
 import { sortFolderPathsByTree } from "../../utils/folder-sorting";
 import { createValidatedInput } from "../components/validatedInput";
 import { ExclusiveSuggester } from "../suggesters/exclusiveSuggester";
@@ -93,10 +93,13 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 			validator: (raw) => {
 				const v = raw.trim();
 				if (!v) return true;
-				return templates.includes(v) || "Template not found";
+				// Validate against the same resolution the engine uses at run time,
+				// not suggestion-list membership: a template outside the configured
+				// folders still runs fine and must not be flagged "not found".
+				return getTemplateFile(this.app, v) !== null || "Template not found";
 			},
 			onChange: (value) => {
-				this.choice.templatePath = value;
+				this.choice.templatePath = value.trim();
 			},
 		});
 	}

--- a/src/gui/PackageManager/ImportPackageModal.svelte
+++ b/src/gui/PackageManager/ImportPackageModal.svelte
@@ -2,6 +2,7 @@
 	import type { App } from "obsidian";
 	import { Notice } from "obsidian";
 	import { settingsStore } from "../../settingsStore";
+	import { normalizeTemplateFolderPaths } from "../../utilityObsidian";
 	import type {
 		LoadedQuickAddPackage,
 		PackageAnalysis,
@@ -179,9 +180,12 @@
 	);
 
 	function defaultAssetDestination(conflict: AssetConflict): string {
-		const templateFolder = settingsStore
-			.getState()
-			.templateFolderPath?.trim();
+		// Default imported templates into the first configured template folder.
+		// normalizeTemplateFolderPaths drops blanks and trailing slashes, so the
+		// primary entry is already a clean folder path.
+		const [templateFolder] = normalizeTemplateFolderPaths(
+			settingsStore.getState().templateFolderPaths,
+		);
 		const needsTemplateFolder =
 			conflict.kind === "template" ||
 			conflict.kind === "capture-template";
@@ -189,10 +193,7 @@
 		if (templateFolder && needsTemplateFolder) {
 			const baseName =
 				conflict.originalPath.split("/").pop() ?? conflict.originalPath;
-			const sanitizedFolder = templateFolder.replace(/\/+$/, "");
-			return sanitizedFolder
-				? `${sanitizedFolder}/${baseName}`
-				: baseName;
+			return `${templateFolder}/${baseName}`;
 		}
 
 		return conflict.originalPath;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,12 @@ import { StartupMacroEngine } from "./engine/StartupMacroEngine";
 import { ChoiceExecutor } from "./choiceExecutor";
 import type IChoice from "./types/choices/IChoice";
 import type IMultiChoice from "./types/choices/IMultiChoice";
-import { deleteObsidianCommand } from "./utilityObsidian";
+import {
+	deleteObsidianCommand,
+	hasTemplateExtension,
+	isPathWithinTemplateFolders,
+	normalizeTemplateFolderPaths,
+} from "./utilityObsidian";
 import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
 import { QuickAddApi } from "./quickAddApi";
 import migrate from "./migrations/migrate";
@@ -358,11 +363,15 @@ export default class QuickAdd extends Plugin {
 	}
 
 	public getTemplateFiles(): TFile[] {
-		if (!String.isString(this.settings.templateFolderPath)) return [];
-
+		const folders = normalizeTemplateFolderPaths(
+			this.settings.templateFolderPaths,
+		);
+		// Only files the engine can actually resolve are useful suggestions; an
+		// empty folder list means "suggest every template file in the vault".
 		return this.app.vault
 			.getFiles()
-			.filter((file) => file.path.startsWith(this.settings.templateFolderPath));
+			.filter((file) => hasTemplateExtension(file.path))
+			.filter((file) => isPathWithinTemplateFolders(file.path, folders));
 	}
 
 	private announceUpdate() {

--- a/src/migrations/migrate.ts
+++ b/src/migrations/migrate.ts
@@ -14,6 +14,7 @@ import backfillFileOpeningDefaults from "./backfillFileOpeningDefaults";
 import setProviderModelDiscoveryMode from "./setProviderModelDiscoveryMode";
 import { deepClone } from "src/utils/deepClone";
 import migrateProviderApiKeysToSecretStorage from "./migrateProviderApiKeysToSecretStorage";
+import migrateToMultipleTemplateFolders from "./migrateToMultipleTemplateFolders";
 import { settingsStore } from "src/settingsStore";
 
 const migrations: Migrations = {
@@ -29,6 +30,7 @@ const migrations: Migrations = {
 	backfillFileOpeningDefaults,
 	setProviderModelDiscoveryMode,
 	migrateProviderApiKeysToSecretStorage,
+	migrateToMultipleTemplateFolders,
 };
 
 async function migrate(plugin: QuickAdd): Promise<void> {

--- a/src/migrations/migrateToMultipleTemplateFolders.test.ts
+++ b/src/migrations/migrateToMultipleTemplateFolders.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type QuickAdd from "src/main";
+import migrateToMultipleTemplateFolders from "./migrateToMultipleTemplateFolders";
+
+function pluginWith(settings: Record<string, unknown>): QuickAdd {
+	return { settings } as unknown as QuickAdd;
+}
+
+const run = (plugin: QuickAdd) =>
+	migrateToMultipleTemplateFolders.migrate(plugin);
+
+describe("migrateToMultipleTemplateFolders", () => {
+	it("folds a legacy single path into the list and drops the dead key", async () => {
+		const plugin = pluginWith({ templateFolderPath: "templates" });
+
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual(["templates"]);
+		expect(
+			(plugin.settings as { templateFolderPath?: unknown }).templateFolderPath,
+		).toBeUndefined();
+	});
+
+	it("stores the legacy value in canonical (normalized) form", async () => {
+		const plugin = pluginWith({ templateFolderPath: "  /templates/ " });
+
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual(["templates"]);
+	});
+
+	it("does not let a blank-only array shadow a valid legacy value", async () => {
+		const plugin = pluginWith({
+			templateFolderPath: "Templates",
+			templateFolderPaths: [" ", null],
+		});
+
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual(["Templates"]);
+	});
+
+	it("canonicalizes an existing populated list", async () => {
+		const plugin = pluginWith({
+			templateFolderPaths: ["/a/", "a", "b/"],
+		});
+
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual(["a", "b"]);
+	});
+
+	it("yields an empty list on a fresh install (no legacy value)", async () => {
+		const plugin = pluginWith({});
+
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual([]);
+	});
+
+	it("treats a blank legacy value as no folder", async () => {
+		const plugin = pluginWith({ templateFolderPath: "   " });
+
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual([]);
+		expect(
+			(plugin.settings as { templateFolderPath?: unknown }).templateFolderPath,
+		).toBeUndefined();
+	});
+
+	it("does not overwrite an already-populated list", async () => {
+		const plugin = pluginWith({
+			templateFolderPath: "legacy",
+			templateFolderPaths: ["a", "b"],
+		});
+
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual(["a", "b"]);
+	});
+
+	it("is idempotent across repeated runs", async () => {
+		const plugin = pluginWith({ templateFolderPath: "templates" });
+
+		await run(plugin);
+		await run(plugin);
+
+		expect(plugin.settings.templateFolderPaths).toEqual(["templates"]);
+	});
+});

--- a/src/migrations/migrateToMultipleTemplateFolders.ts
+++ b/src/migrations/migrateToMultipleTemplateFolders.ts
@@ -1,0 +1,32 @@
+import type QuickAdd from "src/main";
+import { normalizeTemplateFolderPaths } from "src/utilityObsidian";
+
+/**
+ * Fold the legacy single `templateFolderPath` string into the multi-folder
+ * `templateFolderPaths` list (issue #1170). Stores the canonical (normalized)
+ * form so the data model is clean at rest, not just at read time. Idempotent
+ * and safe on fresh installs: a missing/blank legacy value just leaves an empty
+ * list. The dead key is dropped afterwards so it does not linger in data.json.
+ */
+export default {
+	description:
+		"Move the single template folder path into the multi-folder list.",
+	migrate: async (plugin: QuickAdd): Promise<void> => {
+		const settings = plugin.settings as typeof plugin.settings & {
+			templateFolderPath?: unknown;
+		};
+
+		// Gate on the normalized list, not the raw array length: a corrupt or
+		// whitespace-only array must not shadow a valid legacy value.
+		const existing = normalizeTemplateFolderPaths(settings.templateFolderPaths);
+		if (existing.length > 0) {
+			settings.templateFolderPaths = existing;
+		} else {
+			settings.templateFolderPaths = normalizeTemplateFolderPaths([
+				settings.templateFolderPath,
+			]);
+		}
+
+		delete settings.templateFolderPath;
+	},
+};

--- a/src/migrations/useQuickAddTemplateFolder.ts
+++ b/src/migrations/useQuickAddTemplateFolder.ts
@@ -53,7 +53,16 @@ export default {
 				}
 			}
 
-			const normalizedFolders = normalizeTemplateFolderPaths(folders);
+			// Merge with any already-configured folders rather than replacing them,
+			// so this can't clobber values set by another migration regardless of
+			// run order; normalizeTemplateFolderPaths de-duplicates.
+			const existing = normalizeTemplateFolderPaths(
+				plugin.settings.templateFolderPaths,
+			);
+			const normalizedFolders = normalizeTemplateFolderPaths([
+				...existing,
+				...folders,
+			]);
 			if (normalizedFolders.length > 0) {
 				plugin.settings.templateFolderPaths = normalizedFolders;
 			}

--- a/src/migrations/useQuickAddTemplateFolder.ts
+++ b/src/migrations/useQuickAddTemplateFolder.ts
@@ -1,10 +1,11 @@
 import { log } from "src/logger/logManager";
 import type QuickAdd from "src/main";
+import { normalizeTemplateFolderPaths } from "src/utilityObsidian";
 
 export default {
 	description:
 		"Use QuickAdd template folder instead of Obsidian templates plugin folder / Templater templates folder.",
-	 
+
 	migrate: async (plugin: QuickAdd): Promise<void> => {
 		try {
 			const templaterPlugin = plugin.app.plugins.plugins["templater"];
@@ -17,17 +18,19 @@ export default {
 				return;
 			}
 
+			// Collect a folder from each source. QuickAdd now supports multiple
+			// template folders, so keep both rather than letting one overwrite the
+			// other; normalizeTemplateFolderPaths de-duplicates if they coincide.
+			const folders: string[] = [];
+
 			if (obsidianTemplatesPlugin) {
-				 
+
 				const obsidianTemplatesSettings =
 					//@ts-ignore
 					obsidianTemplatesPlugin.instance.options;
-				 
+
 				if (obsidianTemplatesSettings["folder"]) {
-					 
-					plugin.settings.templateFolderPath =
-						 
-						obsidianTemplatesSettings["folder"];
+					folders.push(obsidianTemplatesSettings["folder"]);
 
 					log.logMessage(
 						"Migrated template folder path to Obsidian Templates' setting."
@@ -39,15 +42,20 @@ export default {
 				const templaterSettings = templaterPlugin.settings;
 					//@ts-ignore
 				if (templaterSettings["template_folder"]) {
-					 
-					plugin.settings.templateFolderPath =
+					folders.push(
 						//@ts-ignore
-						templaterSettings["template_folder"];
+						templaterSettings["template_folder"],
+					);
 
 					log.logMessage(
 						"Migrated template folder path to Templaters setting."
 					);
 				}
+			}
+
+			if (folders.length > 0) {
+				plugin.settings.templateFolderPaths =
+					normalizeTemplateFolderPaths(folders);
 			}
 		} catch (error) {
 			log.logError("Failed to migrate template folder path.");

--- a/src/migrations/useQuickAddTemplateFolder.ts
+++ b/src/migrations/useQuickAddTemplateFolder.ts
@@ -53,9 +53,9 @@ export default {
 				}
 			}
 
-			if (folders.length > 0) {
-				plugin.settings.templateFolderPaths =
-					normalizeTemplateFolderPaths(folders);
+			const normalizedFolders = normalizeTemplateFolderPaths(folders);
+			if (normalizedFolders.length > 0) {
+				plugin.settings.templateFolderPaths = normalizedFolders;
 			}
 		} catch (error) {
 			log.logError("Failed to migrate template folder path.");

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -1,12 +1,7 @@
-import type { App } from "obsidian";
-import { MarkdownView, TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
+import { MarkdownView } from "obsidian";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
-import {
-	BASE_FILE_EXTENSION_REGEX,
-	CANVAS_FILE_EXTENSION_REGEX,
-	MARKDOWN_FILE_EXTENSION_REGEX,
-	QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
-} from "src/constants";
+import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "src/constants";
 import type QuickAdd from "src/main";
 import type ICaptureChoice from "src/types/choices/ICaptureChoice";
 import type IChoice from "src/types/choices/IChoice";
@@ -18,6 +13,7 @@ import type { IUserScript } from "src/types/macros/IUserScript";
 import {
 	getMarkdownFilesInFolder,
 	getMarkdownFilesWithTag,
+	getTemplateFile,
 	getUserScript,
 	isFolder,
 } from "src/utilityObsidian";
@@ -100,16 +96,8 @@ function getQuickAddScriptInputs(userScript: unknown): unknown[] {
 }
 
 async function readTemplate(app: App, path: string): Promise<string> {
-	const addExt =
-		!MARKDOWN_FILE_EXTENSION_REGEX.test(path) &&
-		!CANVAS_FILE_EXTENSION_REGEX.test(path) &&
-		!BASE_FILE_EXTENSION_REGEX.test(path);
-	const normalized = addExt ? `${path}.md` : path;
-	const file = app.vault.getAbstractFileByPath(normalized);
-	if (file instanceof TFile) {
-		return await app.vault.cachedRead(file);
-	}
-	return "";
+	const file = getTemplateFile(app, path);
+	return file ? await app.vault.cachedRead(file) : "";
 }
 
 async function collectForTemplateChoice(

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -34,20 +34,25 @@ vi.mock("obsidian-dataview", () => ({
 	getAPI: vi.fn().mockReturnValue(null),
 }));
 
-vi.mock("src/utilityObsidian", () => ({
-	getMarkdownFilesInFolder: vi.fn(() => []),
-	getMarkdownFilesWithTag: vi.fn(() => []),
-	getUserScript: vi.fn(),
-	isFolder: vi.fn(() => false),
-	// Faithful to the real resolver: strip a leading slash, append .md only when
-	// no template extension is present, then resolve against the vault.
-	getTemplateFile: vi.fn((app: App, path: string) => {
-		const stripped = path.replace(/^\/+/, "");
-		const hasTemplateExt = /\.(md|canvas|base)$/i.test(stripped);
-		const resolved = hasTemplateExt ? stripped : `${stripped}.md`;
-		return app.vault.getAbstractFileByPath(resolved) ?? null;
-	}),
-}));
+vi.mock("src/utilityObsidian", async () => {
+	const { TFile } = await import("obsidian");
+	return {
+		getMarkdownFilesInFolder: vi.fn(() => []),
+		getMarkdownFilesWithTag: vi.fn(() => []),
+		getUserScript: vi.fn(),
+		isFolder: vi.fn(() => false),
+		// Faithful to the real resolver: trim, strip a leading slash, append .md
+		// only when no template extension is present, then resolve to a TFile.
+		getTemplateFile: vi.fn((app: App, path: string) => {
+			const stripped = path.trim().replace(/^\/+/, "");
+			if (!stripped) return null;
+			const hasTemplateExt = /\.(md|canvas|base)$/i.test(stripped);
+			const resolved = hasTemplateExt ? stripped : `${stripped}.md`;
+			const f = app.vault.getAbstractFileByPath(resolved);
+			return f instanceof TFile ? f : null;
+		}),
+	};
+});
 
 const createApp = (selection: string | null) =>
 	({

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -39,6 +39,14 @@ vi.mock("src/utilityObsidian", () => ({
 	getMarkdownFilesWithTag: vi.fn(() => []),
 	getUserScript: vi.fn(),
 	isFolder: vi.fn(() => false),
+	// Faithful to the real resolver: strip a leading slash, append .md only when
+	// no template extension is present, then resolve against the vault.
+	getTemplateFile: vi.fn((app: App, path: string) => {
+		const stripped = path.replace(/^\/+/, "");
+		const hasTemplateExt = /\.(md|canvas|base)$/i.test(stripped);
+		const resolved = hasTemplateExt ? stripped : `${stripped}.md`;
+		return app.vault.getAbstractFileByPath(resolved) ?? null;
+	}),
 }));
 
 const createApp = (selection: string | null) =>

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -3,10 +3,14 @@ import type {
 	Setting,
 	SettingDefinitionGroup,
 	SettingDefinitionItem,
-	TAbstractFile,
 	TextAreaComponent,
 } from "obsidian";
-import { PluginSettingTab, TFolder } from "obsidian";
+import {
+	ButtonComponent,
+	ExtraButtonComponent,
+	PluginSettingTab,
+	TextComponent,
+} from "obsidian";
 import type QuickAdd from "./main";
 import type IChoice from "./types/choices/IChoice";
 import ChoiceView from "./gui/choiceList/ChoiceView.svelte";
@@ -15,6 +19,11 @@ import type { Plain } from "./gui/svelte/persist.svelte";
 import { GenericTextSuggester } from "./gui/suggesters/genericTextSuggester";
 import GlobalVariablesView from "./gui/GlobalVariables/GlobalVariablesView.svelte";
 import { settingsStore } from "./settingsStore";
+import {
+	getAllFolderPathsInVault,
+	normalizeTemplateFolderPaths,
+} from "./utilityObsidian";
+import { sortFolderPathsByTree } from "./utils/folder-sorting";
 import { ExportPackageModal } from "./gui/PackageManager/ExportPackageModal";
 import { ImportPackageModal } from "./gui/PackageManager/ImportPackageModal";
 import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
@@ -199,9 +208,9 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			heading: "Templates & Properties",
 			items: [
 				{
-					name: "Template Folder Path",
-					desc: "Path to the folder where templates are stored. Used to suggest template files when configuring QuickAdd.",
-					render: (setting) => this.renderTemplateFolderPath(setting),
+					name: "Template folder paths",
+					desc: "Folders where templates are stored. Used to suggest template files when configuring QuickAdd. Add as many as you like; leave empty to suggest every template file in the vault.",
+					render: (setting) => this.renderTemplateFolderPaths(setting),
 				},
 				{
 					name: "Format template variables as proper property types (Beta)",
@@ -421,26 +430,93 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		});
 	}
 
-	private renderTemplateFolderPath(setting: Setting): void {
-		setting.addText((text) => {
-			text
-				.setPlaceholder("templates/")
-				.setValue(settingsStore.getState().templateFolderPath)
-				.onChange((value) => {
-					settingsStore.setState({ templateFolderPath: value });
-				});
+	private renderTemplateFolderPaths(setting: Setting): () => void {
+		// Let this row span the full pane (label/desc stacked above a full-width
+		// list) instead of cramming a growing list into the narrow control column.
+		setting.settingEl.addClass("qa-template-folders-setting");
 
-			new GenericTextSuggester(
-				this.app,
-				text.inputEl,
-				this.app.vault
-					.getAllLoadedFiles()
-					.filter(
-						(f: TAbstractFile) => f instanceof TFolder && f.path !== "/",
-					)
-					.map((f: TAbstractFile) => f.path),
-			);
-		});
+		const container = setting.controlEl.createDiv("qa-template-folders");
+		const listEl = container.createDiv("qa-template-folder-list");
+
+		const getPaths = (): string[] =>
+			normalizeTemplateFolderPaths(settingsStore.getState().templateFolderPaths);
+		const setPaths = (paths: string[]): void => {
+			settingsStore.setState({ templateFolderPaths: paths });
+		};
+
+		const renderList = (): void => {
+			listEl.empty();
+			const paths = getPaths();
+			if (paths.length === 0) {
+				listEl.createDiv({
+					cls: "qa-template-folder-empty",
+					text: "No folders added yet.",
+				});
+				return;
+			}
+			for (const folder of paths) {
+				const row = listEl.createDiv("qa-template-folder-row");
+				// title gives desktop a hover tooltip for paths truncated by ellipsis;
+				// on mobile (no hover) the path wraps instead — see styles.css.
+				row.createSpan({
+					cls: "qa-template-folder-name",
+					text: folder,
+					attr: { title: folder },
+				});
+				new ExtraButtonComponent(row)
+					.setIcon("trash-2")
+					.setTooltip(`Remove ${folder}`)
+					.onClick(() => {
+						setPaths(getPaths().filter((f) => f !== folder));
+						renderList();
+					});
+			}
+		};
+
+		const inputRow = container.createDiv("qa-template-folder-input-row");
+		const input = new TextComponent(inputRow);
+		input.setPlaceholder("templates/");
+		input.inputEl.addClass("qa-template-folder-input");
+		const suggester = new GenericTextSuggester(
+			this.app,
+			input.inputEl,
+			sortFolderPathsByTree(getAllFolderPathsInVault(this.app)).filter(
+				(path) => path !== "/",
+			),
+		);
+
+		const addFolder = (): void => {
+			// Store the canonical (normalized) form so "templates" and "templates/"
+			// can't both be added, and dedupe against the existing list.
+			const [folder] = normalizeTemplateFolderPaths([input.inputEl.value]);
+			input.inputEl.value = "";
+			if (!folder) return;
+			const paths = getPaths();
+			if (paths.includes(folder)) return;
+			setPaths([...paths, folder]);
+			renderList();
+		};
+
+		const onKeydown = (e: KeyboardEvent): void => {
+			if (e.key === "Enter") {
+				e.preventDefault();
+				addFolder();
+			}
+		};
+		input.inputEl.addEventListener("keydown", onKeydown);
+		new ButtonComponent(inputRow)
+			.setCta()
+			.setButtonText("Add")
+			.onClick(() => addFolder());
+
+		renderList();
+
+		// The suggester registers global (document/window) listeners while open;
+		// tear it down when the row is rebuilt or the tab hides so nothing leaks.
+		return () => {
+			input.inputEl.removeEventListener("keydown", onKeydown);
+			suggester.destroy();
+		};
 	}
 
 	private renderDevInfo(setting: Setting): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,7 +17,13 @@ export interface QuickAddSettings {
 		*/
 	searchNestedChoices: boolean;
 	devMode: boolean;
-	templateFolderPath: string;
+	/**
+		* Folders whose files are offered as template suggestions when configuring
+		* QuickAdd. An empty list suggests every template file in the vault. The
+		* legacy single `templateFolderPath` is folded into this by the
+		* `migrateToMultipleTemplateFolders` migration.
+		*/
+	templateFolderPaths: string[];
 	announceUpdates: "all" | "major" | "none";
 	version: string;
 	globalVariables: Record<string, string>;
@@ -60,6 +66,7 @@ export interface QuickAddSettings {
 		backfillFileOpeningDefaults: boolean;
 		setProviderModelDiscoveryMode: boolean;
 		migrateProviderApiKeysToSecretStorage: boolean;
+		migrateToMultipleTemplateFolders: boolean;
 	};
 }
 
@@ -70,7 +77,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	useSelectionAsCaptureValue: true,
 	searchNestedChoices: true,
 	devMode: false,
-	templateFolderPath: "",
+	templateFolderPaths: [],
 	announceUpdates: "major",
 	version: "0.0.0",
 	globalVariables: {},
@@ -109,5 +116,6 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 		backfillFileOpeningDefaults: false,
 		setProviderModelDiscoveryMode: false,
 		migrateProviderApiKeysToSecretStorage: false,
+		migrateToMultipleTemplateFolders: false,
 	},
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -251,6 +251,83 @@
 	white-space: nowrap;
 }
 
+/* Multi-folder list for the "Template folder paths" setting. The setting row
+   stacks vertically so the label/description sit above a full-width list, which
+   keeps long paths readable and scales to many folders without crowding the
+   narrow control column. */
+.qa-template-folders-setting {
+	display: block;
+}
+
+.qa-template-folders-setting .setting-item-control {
+	margin-top: 12px;
+	justify-content: flex-start;
+}
+
+.qa-template-folders {
+	width: 100%;
+}
+
+.qa-template-folder-list {
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.qa-template-folder-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 6px 4px;
+	border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.qa-template-folder-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.qa-template-folder-empty {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	padding: 6px 4px;
+}
+
+.qa-template-folder-input-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 12px;
+}
+
+.qa-template-folder-input {
+	flex: 1 1 auto;
+}
+
+/* Mobile: comfortable touch targets and full-path readability (no hover there).
+   Grow the remove control to the 44px tap-target minimum, let long paths wrap
+   instead of truncating behind an unreachable tooltip, and stack the input above
+   a full-width Add button so the path field gets the whole row. */
+.is-mobile .qa-template-folder-row {
+	min-height: 44px;
+}
+
+.is-mobile .qa-template-folder-row .clickable-icon {
+	width: 44px;
+	height: 44px;
+}
+
+.is-mobile .qa-template-folder-name {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.is-mobile .qa-template-folder-input-row {
+	flex-direction: column;
+	align-items: stretch;
+}
+
 .quickAddModal .qa-modal-title,
 .quickAddModal .qa-clickable-modal-title,
 .qa-modal-title,

--- a/src/styles.css
+++ b/src/styles.css
@@ -283,6 +283,10 @@
 }
 
 .qa-template-folder-name {
+	/* flex + min-width:0 let the name shrink so the ellipsis triggers instead of
+	   pushing the remove control off the row. */
+	flex: 1 1 auto;
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/src/utilityObsidian.templateFolders.test.ts
+++ b/src/utilityObsidian.templateFolders.test.ts
@@ -1,0 +1,126 @@
+import { type App, TFile, TFolder } from "obsidian";
+import { describe, expect, it } from "vitest";
+import {
+	getTemplateFile,
+	isPathWithinTemplateFolders,
+	normalizeTemplateFolderPaths,
+} from "./utilityObsidian";
+
+function file(path: string): TFile {
+	const f = new TFile();
+	f.path = path;
+	f.name = path.split("/").pop() ?? path;
+	f.extension = path.split(".").pop() ?? "";
+	f.basename = f.name.replace(/\.[^.]+$/, "");
+	return f;
+}
+
+function folder(path: string): TFolder {
+	const f = new TFolder();
+	f.path = path;
+	f.name = path.split("/").pop() ?? path;
+	return f;
+}
+
+/** Minimal App whose vault resolves a fixed set of abstract files by path. */
+function appWith(entries: Array<TFile | TFolder>): App {
+	const byPath = new Map(entries.map((e) => [e.path, e]));
+	return {
+		vault: {
+			getAbstractFileByPath: (path: string) => byPath.get(path) ?? null,
+		},
+	} as unknown as App;
+}
+
+describe("normalizeTemplateFolderPaths", () => {
+	it("returns an empty array for non-array input", () => {
+		expect(normalizeTemplateFolderPaths(undefined)).toEqual([]);
+		expect(normalizeTemplateFolderPaths(null)).toEqual([]);
+		expect(normalizeTemplateFolderPaths("templates")).toEqual([]);
+	});
+
+	it("trims, strips leading/trailing slashes, and drops blanks", () => {
+		expect(
+			normalizeTemplateFolderPaths(["  templates/  ", "/notes/templates/"]),
+		).toEqual(["templates", "notes/templates"]);
+		expect(normalizeTemplateFolderPaths(["", "   ", "/"])).toEqual([]);
+	});
+
+	it("de-duplicates by canonical form, preserving first-seen order", () => {
+		expect(
+			normalizeTemplateFolderPaths(["templates", "templates/", "/templates"]),
+		).toEqual(["templates"]);
+		expect(normalizeTemplateFolderPaths(["b", "a", "b"])).toEqual(["b", "a"]);
+	});
+
+	it("ignores non-string entries", () => {
+		expect(
+			normalizeTemplateFolderPaths(["templates", 5, null, { x: 1 }]),
+		).toEqual(["templates"]);
+	});
+});
+
+describe("isPathWithinTemplateFolders", () => {
+	it("matches everything when no folders are configured", () => {
+		expect(isPathWithinTemplateFolders("anything/x.md", [])).toBe(true);
+	});
+
+	it("matches files inside a folder but not sibling-prefix folders", () => {
+		expect(isPathWithinTemplateFolders("templates/a.md", ["templates"])).toBe(
+			true,
+		);
+		// boundary-aware: "templates" must not match "templates-old"
+		expect(
+			isPathWithinTemplateFolders("templates-old/a.md", ["templates"]),
+		).toBe(false);
+	});
+
+	it("matches a file whose path equals the folder", () => {
+		expect(isPathWithinTemplateFolders("templates", ["templates"])).toBe(true);
+	});
+
+	it("matches any of several folders", () => {
+		const folders = ["templates", "notes/tpl"];
+		expect(isPathWithinTemplateFolders("notes/tpl/a.md", folders)).toBe(true);
+		expect(isPathWithinTemplateFolders("other/a.md", folders)).toBe(false);
+	});
+});
+
+describe("getTemplateFile", () => {
+	it("appends .md when no template extension is present", () => {
+		const app = appWith([file("Templates/Daily.md")]);
+		expect(getTemplateFile(app, "Templates/Daily")?.path).toBe(
+			"Templates/Daily.md",
+		);
+	});
+
+	it("strips a leading slash before resolving (preflight bug fix)", () => {
+		const app = appWith([file("Templates/Daily.md")]);
+		expect(getTemplateFile(app, "/Templates/Daily")?.path).toBe(
+			"Templates/Daily.md",
+		);
+	});
+
+	it("resolves canvas and base templates without appending .md", () => {
+		const app = appWith([
+			file("Templates/Board.canvas"),
+			file("Templates/View.base"),
+		]);
+		expect(getTemplateFile(app, "Templates/Board.canvas")?.path).toBe(
+			"Templates/Board.canvas",
+		);
+		expect(getTemplateFile(app, "Templates/View.base")?.path).toBe(
+			"Templates/View.base",
+		);
+	});
+
+	it("returns null when the path resolves to nothing", () => {
+		const app = appWith([]);
+		expect(getTemplateFile(app, "Templates/Missing")).toBeNull();
+	});
+
+	it("returns null when the path resolves to a folder, not a file", () => {
+		const app = appWith([folder("Templates")]);
+		expect(getTemplateFile(app, "Templates.md")).toBeNull();
+	});
+});

--- a/src/utilityObsidian.templateFolders.test.ts
+++ b/src/utilityObsidian.templateFolders.test.ts
@@ -114,6 +114,19 @@ describe("getTemplateFile", () => {
 		);
 	});
 
+	it("trims surrounding whitespace before resolving", () => {
+		const app = appWith([file("Templates/Daily.md")]);
+		expect(getTemplateFile(app, "  /Templates/Daily  ")?.path).toBe(
+			"Templates/Daily.md",
+		);
+	});
+
+	it("returns null for blank/whitespace-only input", () => {
+		const app = appWith([file("Templates/Daily.md")]);
+		expect(getTemplateFile(app, "")).toBeNull();
+		expect(getTemplateFile(app, "   ")).toBeNull();
+	});
+
 	it("returns null when the path resolves to nothing", () => {
 		const app = appWith([]);
 		expect(getTemplateFile(app, "Templates/Missing")).toBeNull();

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -802,7 +802,8 @@ export function hasTemplateExtension(path: string): boolean {
  * their own near-copy, and the preflight copy skipped the leading-slash strip).
  */
 export function getTemplateFile(app: App, templatePath: string): TFile | null {
-	const stripped = templatePath.replace(/^\/+/, "");
+	const stripped = templatePath.trim().replace(/^\/+/, "");
+	if (!stripped) return null;
 	const resolved = hasTemplateExtension(stripped) ? stripped : `${stripped}.md`;
 	const file = app.vault.getAbstractFileByPath(resolved);
 	return file instanceof TFile ? file : null;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -6,6 +6,11 @@ import type {
 	WorkspaceParent,
 } from "obsidian";
 import { FileView, MarkdownView, normalizePath, TFile, TFolder } from "obsidian";
+import {
+	BASE_FILE_EXTENSION_REGEX,
+	CANVAS_FILE_EXTENSION_REGEX,
+	MARKDOWN_FILE_EXTENSION_REGEX,
+} from "./constants";
 import { log } from "./logger/logManager";
 import { NLDParser } from "./parsers/NLDParser";
 import type { CaptureChoice } from "./types/choices/CaptureChoice";
@@ -770,6 +775,73 @@ export function getAllFolderPathsInVault(app: App): string[] {
 		.getAllLoadedFiles()
 		.filter((f) => f instanceof TFolder)
 		.map((folder) => folder.path);
+}
+
+/**
+ * Whether a path already carries a template extension the engine can read
+ * (`.md`/`.canvas`/`.base`). The three extension regexes are the single source
+ * of truth; both {@link getTemplateFile} (to decide whether to append `.md`)
+ * and the suggestion filter consume this so they can never disagree.
+ */
+export function hasTemplateExtension(path: string): boolean {
+	return (
+		MARKDOWN_FILE_EXTENSION_REGEX.test(path) ||
+		CANVAS_FILE_EXTENSION_REGEX.test(path) ||
+		BASE_FILE_EXTENSION_REGEX.test(path)
+	);
+}
+
+/**
+ * Resolve a template path to its vault file exactly the way the template engine
+ * does at run time: strip a leading slash, append `.md` when no template
+ * extension is present, then look the file up. Returns null when nothing
+ * resolves.
+ *
+ * Single source of truth shared by engine execution, choice-builder validation,
+ * and preflight scanning so the three never drift (they previously each had
+ * their own near-copy, and the preflight copy skipped the leading-slash strip).
+ */
+export function getTemplateFile(app: App, templatePath: string): TFile | null {
+	const stripped = templatePath.replace(/^\/+/, "");
+	const resolved = hasTemplateExtension(stripped) ? stripped : `${stripped}.md`;
+	const file = app.vault.getAbstractFileByPath(resolved);
+	return file instanceof TFile ? file : null;
+}
+
+/**
+ * Canonical, order-preserving normalization for the configured template folder
+ * list: trims each entry, strips leading/trailing slashes, drops blanks and
+ * non-strings, and de-duplicates. Non-array input yields an empty list. Used by
+ * both the suggestion query and the package-import default so they never desync.
+ */
+export function normalizeTemplateFolderPaths(paths: unknown): string[] {
+	if (!Array.isArray(paths)) return [];
+	const seen = new Set<string>();
+	const normalized: string[] = [];
+	for (const path of paths) {
+		if (typeof path !== "string") continue;
+		const folder = path.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+		if (!folder || seen.has(folder)) continue;
+		seen.add(folder);
+		normalized.push(folder);
+	}
+	return normalized;
+}
+
+/**
+ * Whether a file path lives within one of the (already normalized) template
+ * folders. Boundary-aware: `templates` matches `templates/x.md` but not
+ * `templates-old/x.md`. An empty folder list matches everything (the "no
+ * folders configured = suggest the whole vault" default).
+ */
+export function isPathWithinTemplateFolders(
+	filePath: string,
+	normalizedFolders: string[],
+): boolean {
+	if (normalizedFolders.length === 0) return true;
+	return normalizedFolders.some(
+		(folder) => filePath === folder || filePath.startsWith(`${folder}/`),
+	);
 }
 
 export function getUserScriptMemberAccess(fullMemberPath: string): {


### PR DESCRIPTION
Closes #1170

## Problem
QuickAdd had a single global **Template folder path**. It drove template-file *suggestions/validation* in the choice builders and the format-syntax suggester. Users who keep templates in more than one folder couldn't get suggestions for templates outside that one folder — and, as the issue reporter (@karmeye) noted, pointing a choice at a valid template *outside* the folder still ran fine but painted a red **"Template not found"**.

## What changed
**Multiple folders**
- `settings.templateFolderPath: string` → **`templateFolderPaths: string[]`** (default `[]`).
- `getTemplateFiles()` now draws from *any* configured folder, **boundary-aware** (`templates` no longer matches `templates-old`), restricted to engine-resolvable extensions (`.md` / `.canvas` / `.base`). An empty list preserves the existing "suggest the whole vault" default.

**The bug fix (+ a latent one)**
- Consolidated **three drifting** template-path resolvers — engine `getTemplateContent`, the builder validators, and preflight `readTemplate` — into one shared **`getTemplateFile()`**. This also fixed a preflight bug where a leading-slash path (`/Templates/Daily`) silently read as empty content.
- Both builder validators now resolve a path the way the engine does at run time instead of requiring suggestion-list membership, so a valid out-of-folder template is no longer flagged. They also store the trimmed value.

**Settings UI**
- Replaced the single text field with a **full-width add/remove folder list** (folder autocomplete, per-row remove, canonical de-dupe so `templates` and `templates/` can't both be added).
- **Mobile**: 44px tap targets, paths wrap instead of truncating behind an unreachable tooltip, and the input + Add stack full-width.

## Migration & release impact
- New migration **`migrateToMultipleTemplateFolders`** folds the legacy `templateFolderPath` into the list (canonical at rest) and drops the dead key; idempotent and safe on fresh installs. The legacy Templater / core-Templates importer was retargeted to the array and now **merges both sources** instead of last-wins.
- `feat` → minor version bump via semantic-release. No breaking changes for existing users (data migrated on load).

## Verification
**Automated:** `bun run test` — 1833 passed (+22 new for the helpers + migration); `svelte-check` 0 errors; `eslint` clean; production build OK.

**End-to-end in the dev vault** (drove the real Obsidian app):

| Check | Result |
|---|---|
| Migration on real `data.json` | legacy key → `templateFolderPaths`, flag set, no load errors |
| Add / remove / dedupe via UI | rows + live store update; trailing-slash dup rejected |
| Persist to disk | `data.json` reflects the list |
| Multi-folder `getTemplateFiles()` | 6 files = 3 + 3 across both folders, 0 leak, 0 non-template ext |
| **Out-of-folder template** (the bug) | builder Template Path: `is-invalid:false`, empty hint — **no red error** |
| Negative control (missing template) | `is-invalid:true`, hint = "Template not found" |

**Mobile best-practice pass** (measured at 430px, `is-mobile`):

| Aspect | Before | After |
|---|---|---|
| Trash tap target | 28×28px | **44×44px** |
| Long folder path | `nowrap` + ellipsis, no tooltip → unreadable on touch | **wraps**; `title` tooltip on desktop |
| Input vs Add | ~50/50 (input cramped) | **stacked full-width** |

## Screenshots
<!-- drag the files from ~/Desktop/qa-1170-screenshots/ into the slots below -->
**Desktop — before → after**

_before_ (cramped right column) → _after_ (`desktop-after-fullwidth-list.png`)

**Mobile — before → after**

_before_ (28px trash, truncated path) → _after_ (`mobile-after-fixed.png`)

**The fix** — out-of-folder template, no red error (`builder-no-red-out-of-folder.png`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure multiple template folder paths via a new full-width settings UI with folder suggestions, add/remove controls, normalization and dedupe.

* **Behavior Changes**
  * Template resolution and validation now consistently trim/normalize paths, respect multiple folders, and resolve templates at runtime for more reliable results.
  * Import destination logic for package assets uses normalized template folder paths.

* **Migrations**
  * Added and registered migration to convert legacy single-template-folder setting to the new multi-folder format.

* **Tests**
  * New and updated tests covering template-folder utilities, template resolution, and the migration.

* **Style**
  * UI styles added for the template-folder paths setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->