### PR TITLE
fix(macro): harden user-script member access conflicts (#964)

### DIFF
--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -412,12 +412,15 @@ that uniquely exports the requested member across all scripts in the macro.
 QuickAdd resolves `Macro::member` like this:
 - If exactly one script exports the requested member, QuickAdd uses it.
 - If no script exports the requested member, QuickAdd stops and shows an error.
+  - Exception: if the macro has no user-script commands at all, QuickAdd cannot
+    satisfy member access — it logs a warning and returns an empty result instead
+    of stopping the macro.
 - If multiple scripts export the requested member, QuickAdd stops and lists the
   conflicting script names instead of guessing.
-- Exception: the convention keys `settings` and `entry` (which many scripts export)
-  resolve to the **first** script that exports them and show a one-time notice
-  pointing at the selector form below, rather than stopping. Use the selector if you
-  need a different script.
+- Exception: the convention keys `settings`, `entry`, and `quickadd` (which many
+  scripts export as metadata rather than entrypoints) resolve to the **first** script
+  that exports them and show a one-time notice pointing at the selector form below,
+  rather than stopping. Use the selector if you need a different script.
 
 If there is a conflict, you can target a specific script by name:
 - `{{MACRO:MyMacro::Script 1::option1}}`

--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -414,6 +414,10 @@ QuickAdd resolves `Macro::member` like this:
 - If no script exports the requested member, QuickAdd stops and shows an error.
 - If multiple scripts export the requested member, QuickAdd stops and lists the
   conflicting script names instead of guessing.
+- Exception: the convention keys `settings` and `entry` (which many scripts export)
+  resolve to the **first** script that exports them and show a one-time notice
+  pointing at the selector form below, rather than stopping. Use the selector if you
+  need a different script.
 
 If there is a conflict, you can target a specific script by name:
 - `{{MACRO:MyMacro::Script 1::option1}}`

--- a/src/engine/SingleMacroEngine.member-access.test.ts
+++ b/src/engine/SingleMacroEngine.member-access.test.ts
@@ -578,6 +578,38 @@ describe("SingleMacroEngine member access", () => {
 		warnSpy.mockRestore();
 	});
 
+	it("treats `quickadd` (declared-inputs metadata convention) as a reserved key too", async () => {
+		const scriptA = createUserScript("script-a", "a.js", {
+			name: "Alpha Script",
+		});
+		const scriptB = createUserScript("script-b", "b.js", {
+			name: "Beta Script",
+		});
+
+		const engineInstance = macroEngineFactory();
+		macroEngineFactory = () => engineInstance;
+
+		mockGetUserScript.mockImplementation(async (command: IUserScript) => ({
+			quickadd: { tag: command.id === "script-a" ? "FIRST" : "SECOND" },
+		}));
+
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+
+		const engine = new SingleMacroEngine(
+			app,
+			plugin,
+			[baseMacroChoice([scriptA, scriptB])],
+			choiceExecutor,
+		);
+
+		const result = await engine.runAndGetOutput("My Macro::quickadd");
+
+		expect(result).toBe('{"tag":"FIRST"}');
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+
+		warnSpy.mockRestore();
+	});
+
 	it("still aborts on a non-reserved member conflict (regression guard for the deliberate hard-abort)", async () => {
 		const scriptA = createUserScript("script-a", "a.js", {
 			name: "Alpha Script",
@@ -688,12 +720,22 @@ describe("SingleMacroEngine member access", () => {
 		const target = createUserScript("script-target", "target.js", {
 			name: "Target Script",
 		});
-		const macroChoice = baseMacroChoice([preScript, target]);
+		// A trailing user script means the target's original index still points at a real
+		// user-script command AFTER the target is removed — so a buggy stale-index fallback
+		// would silently route to this neighbour instead of aborting. The id-based refresh
+		// must abort regardless.
+		const tail = createUserScript("script-tail", "tail.js", {
+			name: "Tail Script",
+		});
+		const macroChoice = baseMacroChoice([preScript, target, tail]);
 
 		const exportFn = vi.fn().mockReturnValue("target-result");
 		mockGetUserScript.mockImplementation(async (command: IUserScript) => {
 			if (command.id === "script-target") {
 				return { settings: {}, beta: exportFn };
+			}
+			if (command.id === "script-tail") {
+				return { settings: {}, gamma: vi.fn() };
 			}
 			return { settings: {}, alpha: vi.fn() };
 		});
@@ -701,7 +743,7 @@ describe("SingleMacroEngine member access", () => {
 		const engineInstance = macroEngineFactory();
 		// A pre-command deletes the selected target command by id. The id can no longer be
 		// found, so the engine must abort instead of falling back to the (now stale) index,
-		// which would point at a different user script.
+		// which after removal points at the Tail Script.
 		engineInstance.runSubset = vi.fn().mockImplementation(async () => {
 			macroChoice.macro.commands = macroChoice.macro.commands.filter(
 				(command) => command.id !== "script-target",

--- a/src/engine/SingleMacroEngine.member-access.test.ts
+++ b/src/engine/SingleMacroEngine.member-access.test.ts
@@ -9,6 +9,7 @@ import type { IMacro } from "../types/macros/IMacro";
 import type { ICommand } from "../types/macros/ICommand";
 import type { IUserScript } from "../types/macros/IUserScript";
 import { CommandType } from "../types/macros/CommandType";
+import { log } from "../logger/logManager";
 import { SingleMacroEngine } from "./SingleMacroEngine";
 
 const { mockInitializeUserScriptSettings, mockGetUserScript } = vi.hoisted(
@@ -538,5 +539,186 @@ describe("SingleMacroEngine member access", () => {
 		await expect(engine.runAndGetOutput("My Macro")).rejects.toBe(abortError);
 		expect(engineInstance.run).toHaveBeenCalledTimes(1);
 		expect(engineInstance.getOutput).not.toHaveBeenCalled();
+	});
+
+	it("resolves a reserved convention key (settings) to the first exporter instead of aborting", async () => {
+		const scriptA = createUserScript("script-a", "a.js", {
+			name: "Alpha Script",
+		});
+		const scriptB = createUserScript("script-b", "b.js", {
+			name: "Beta Script",
+		});
+
+		const engineInstance = macroEngineFactory();
+		macroEngineFactory = () => engineInstance;
+
+		mockGetUserScript.mockImplementation(async (command: IUserScript) => ({
+			settings: { tag: command.id === "script-a" ? "FIRST" : "SECOND" },
+		}));
+
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+
+		const engine = new SingleMacroEngine(
+			app,
+			plugin,
+			[baseMacroChoice([scriptA, scriptB])],
+			choiceExecutor,
+		);
+
+		const result = await engine.runAndGetOutput("My Macro::settings");
+
+		// First-declared exporter wins (was a hard abort before this fix).
+		expect(result).toBe('{"tag":"FIRST"}');
+		// And the user is warned (once) about the ambiguity + the selector escape hatch.
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0][0]).toContain("settings");
+		expect(warnSpy.mock.calls[0][0]).toContain("Alpha Script");
+		expect(warnSpy.mock.calls[0][0]).toContain("<Script Name>");
+
+		warnSpy.mockRestore();
+	});
+
+	it("still aborts on a non-reserved member conflict (regression guard for the deliberate hard-abort)", async () => {
+		const scriptA = createUserScript("script-a", "a.js", {
+			name: "Alpha Script",
+		});
+		const scriptB = createUserScript("script-b", "b.js", {
+			name: "Beta Script",
+		});
+
+		mockGetUserScript.mockResolvedValue({ beta: vi.fn() });
+
+		const engine = new SingleMacroEngine(
+			app,
+			plugin,
+			[baseMacroChoice([scriptA, scriptB])],
+			choiceExecutor,
+		);
+
+		await expect(engine.runAndGetOutput("My Macro::beta")).rejects.toThrow(
+			"multiple user scripts exporting 'beta'",
+		);
+	});
+
+	it("warns instead of silently returning empty when member access targets a macro with no user scripts", async () => {
+		const waitCommand = {
+			id: "wait-1",
+			name: "Wait",
+			type: CommandType.Wait,
+		} as ICommand;
+
+		const engineInstance = macroEngineFactory();
+		engineInstance.run = vi.fn().mockResolvedValue(undefined);
+		engineInstance.getOutput = vi.fn().mockReturnValue("plain output");
+		macroEngineFactory = () => engineInstance;
+
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+
+		const engine = new SingleMacroEngine(
+			app,
+			plugin,
+			[baseMacroChoice([waitCommand])],
+			choiceExecutor,
+		);
+
+		const result = await engine.runAndGetOutput("My Macro::start");
+
+		expect(engineInstance.run).toHaveBeenCalledTimes(1);
+		expect(mockGetUserScript).not.toHaveBeenCalled();
+		// Member could not be satisfied -> empty string, but the user is warned (not silent).
+		expect(result).toBe("");
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy.mock.calls[0][0]).toContain("no user script exporting");
+
+		warnSpy.mockRestore();
+	});
+
+	it("refreshes the selected command by id (not index) when pre-commands mutate the command list", async () => {
+		const preScript = createUserScript("script-pre", "pre.js", {
+			name: "Pre Script",
+		});
+		const target = createUserScript("script-target", "target.js", {
+			name: "Target Script",
+		});
+		const macroChoice = baseMacroChoice([preScript, target]);
+
+		const exportFn = vi.fn().mockReturnValue("target-result");
+		mockGetUserScript.mockImplementation(async (command: IUserScript) => {
+			if (command.id === "script-target") {
+				return { settings: {}, beta: exportFn };
+			}
+			return { settings: {}, alpha: vi.fn() };
+		});
+
+		const engineInstance = macroEngineFactory();
+		// runSubset(preCommands) mutates the live command array by inserting a command
+		// before the target, shifting the target's index from 1 to 2.
+		engineInstance.runSubset = vi.fn().mockImplementation(async () => {
+			macroChoice.macro.commands.unshift({
+				id: "injected",
+				name: "Injected",
+				type: CommandType.Wait,
+			} as ICommand);
+		});
+		macroEngineFactory = () => engineInstance;
+
+		const engine = new SingleMacroEngine(
+			app,
+			plugin,
+			[macroChoice],
+			choiceExecutor,
+		);
+
+		const result = await engine.runAndGetOutput("My Macro::beta");
+
+		expect(result).toBe("target-result");
+		expect(exportFn).toHaveBeenCalledTimes(1);
+		// Pre-slice ([preScript]) is captured before the mutation; the post-slice is
+		// computed from the id-refreshed index (2 -> slice(3) = []), so the target is NOT
+		// re-run as a post-command. With the old index-based refresh the post-slice would
+		// have been [target], re-running it (and mis-identifying the command).
+		expect(engineInstance.runSubset).toHaveBeenCalledTimes(1);
+		expect(engineInstance.runSubset).toHaveBeenCalledWith([preScript]);
+	});
+
+	it("aborts (does not route to a neighbour) when a pre-command removes the selected command", async () => {
+		const preScript = createUserScript("script-pre", "pre.js", {
+			name: "Pre Script",
+		});
+		const target = createUserScript("script-target", "target.js", {
+			name: "Target Script",
+		});
+		const macroChoice = baseMacroChoice([preScript, target]);
+
+		const exportFn = vi.fn().mockReturnValue("target-result");
+		mockGetUserScript.mockImplementation(async (command: IUserScript) => {
+			if (command.id === "script-target") {
+				return { settings: {}, beta: exportFn };
+			}
+			return { settings: {}, alpha: vi.fn() };
+		});
+
+		const engineInstance = macroEngineFactory();
+		// A pre-command deletes the selected target command by id. The id can no longer be
+		// found, so the engine must abort instead of falling back to the (now stale) index,
+		// which would point at a different user script.
+		engineInstance.runSubset = vi.fn().mockImplementation(async () => {
+			macroChoice.macro.commands = macroChoice.macro.commands.filter(
+				(command) => command.id !== "script-target",
+			);
+		});
+		macroEngineFactory = () => engineInstance;
+
+		const engine = new SingleMacroEngine(
+			app,
+			plugin,
+			[macroChoice],
+			choiceExecutor,
+		);
+
+		await expect(engine.runAndGetOutput("My Macro::beta")).rejects.toThrow(
+			"Could not resolve the member-access script",
+		);
+		expect(exportFn).not.toHaveBeenCalled();
 	});
 });

--- a/src/engine/SingleMacroEngine.ts
+++ b/src/engine/SingleMacroEngine.ts
@@ -13,12 +13,17 @@ import { MacroChoiceEngine } from "./MacroChoiceEngine";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { MacroAbortError } from "../errors/MacroAbortError";
 
-// Member names that QuickAdd itself treats as conventions rather than entrypoints
-// (`settings` is consumed by initializeUserScriptSettings; `entry` is the object-export
-// entrypoint handled by MacroChoiceEngine). They are exported by many scripts, so a
-// `{{MACRO:Name::settings}}` reference must keep resolving (first-declared exporter wins,
-// as it did before 2.12.1) instead of hard-aborting on a conflict like a real entrypoint.
-const RESERVED_CONVENTION_KEYS = new Set<string>(["settings", "entry"]);
+// Member names that QuickAdd itself treats as conventions/metadata rather than entrypoints:
+// `settings` (consumed by initializeUserScriptSettings), `entry` (the object-export entrypoint
+// handled by MacroChoiceEngine), and `quickadd` (read by collectChoiceRequirements for declared
+// inputs). They are exported by many scripts, so a `{{MACRO:Name::settings}}` reference must keep
+// resolving (first-declared exporter wins, as it did before 2.12.1) instead of hard-aborting on a
+// conflict the way a real, ambiguous entrypoint should.
+const RESERVED_CONVENTION_KEYS = new Set<string>([
+	"settings",
+	"entry",
+	"quickadd",
+]);
 
 type UserScriptCandidate = {
 	command: IUserScript;
@@ -165,15 +170,17 @@ export class SingleMacroEngine {
 		// no user-script command that could provide the member — so a failed lookup would
 		// otherwise resolve to an empty string silently. Warn instead of guessing.
 		if (memberAccess?.length) {
-			const resolved = this.applyMemberAccess(result, memberAccess);
-			if (resolved === undefined) {
+			// Use the found/value distinction so a member that genuinely exists but holds
+			// `undefined` is not mistaken for a missing one (which would warn spuriously).
+			const lookup = this.resolveMemberAccess(result, memberAccess);
+			if (!lookup.found) {
 				log.logWarning(
 					`Macro '${macroChoice.name}' was asked for member '${memberAccess.join(
 						"::",
 					)}', but it has no user script exporting it; the result is empty.`,
 				);
 			}
-			result = resolved;
+			result = lookup.value;
 		}
 
 		// Handle functions and objects properly
@@ -519,33 +526,6 @@ export class SingleMacroEngine {
 			index: matchingScripts[0].index,
 			memberAccess: memberAccess.slice(1),
 		};
-	}
-
-	private applyMemberAccess(
-		result: unknown,
-		memberAccess: string[],
-	): unknown {
-		let current = result;
-
-		for (const key of memberAccess) {
-			if (
-				current === undefined ||
-				current === null ||
-				(typeof current !== "object" && typeof current !== "function")
-			) {
-				return undefined;
-			}
-
-			const container = current as Record<string, unknown>;
-
-			if (!(key in container)) {
-				return undefined;
-			}
-
-			current = container[key];
-		}
-
-		return current;
 	}
 
 	private syncVariablesFromParams(engine: MacroChoiceEngine) {

--- a/src/engine/SingleMacroEngine.ts
+++ b/src/engine/SingleMacroEngine.ts
@@ -13,6 +13,13 @@ import { MacroChoiceEngine } from "./MacroChoiceEngine";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { MacroAbortError } from "../errors/MacroAbortError";
 
+// Member names that QuickAdd itself treats as conventions rather than entrypoints
+// (`settings` is consumed by initializeUserScriptSettings; `entry` is the object-export
+// entrypoint handled by MacroChoiceEngine). They are exported by many scripts, so a
+// `{{MACRO:Name::settings}}` reference must keep resolving (first-declared exporter wins,
+// as it did before 2.12.1) instead of hard-aborting on a conflict like a real entrypoint.
+const RESERVED_CONVENTION_KEYS = new Set<string>(["settings", "entry"]);
+
 type UserScriptCandidate = {
 	command: IUserScript;
 	index: number;
@@ -50,6 +57,8 @@ function formatMacroOutput(value: unknown): string {
 export class SingleMacroEngine {
 	private readonly choiceExecutor: IChoiceExecutor;
 	private readonly variables: Map<string, unknown>;
+	// Guards the reserved-key conflict notice so a single macro run surfaces it at most once.
+	private emittedConflictNotice = false;
 
 	constructor(
 		private readonly app: App,
@@ -79,6 +88,7 @@ export class SingleMacroEngine {
 		macroName: string,
 		context?: { label?: string },
 	): Promise<string> {
+		this.emittedConflictNotice = false;
 		const { basename, memberAccess } = getUserScriptMemberAccess(macroName);
 
 		// ------------------------------------------------------------------
@@ -150,9 +160,20 @@ export class SingleMacroEngine {
 		this.ensureNotAborted();
 		let result: unknown = engine.getOutput();
 
-		// Apply member access afterwards (if requested)
+		// Apply member access afterwards (if requested). Reaching this fallback with a
+		// member path means tryExecuteExport returned executed:false, i.e. the macro has
+		// no user-script command that could provide the member — so a failed lookup would
+		// otherwise resolve to an empty string silently. Warn instead of guessing.
 		if (memberAccess?.length) {
-			result = this.applyMemberAccess(result, memberAccess);
+			const resolved = this.applyMemberAccess(result, memberAccess);
+			if (resolved === undefined) {
+				log.logWarning(
+					`Macro '${macroChoice.name}' was asked for member '${memberAccess.join(
+						"::",
+					)}', but it has no user script exporting it; the result is empty.`,
+				);
+			}
+			result = resolved;
 		}
 
 		// Handle functions and objects properly
@@ -195,6 +216,7 @@ export class SingleMacroEngine {
 			userScriptCommands,
 			memberAccess,
 		);
+		const candidateId = selection.candidate.command.id;
 		const preCommands = originalCommands.slice(0, selection.candidate.index);
 
 		try {
@@ -204,7 +226,25 @@ export class SingleMacroEngine {
 			}
 
 			const updatedCommands = macroChoice.macro?.commands ?? originalCommands;
-			const refreshedCandidate = updatedCommands[selection.candidate.index];
+			// Pre-commands may have mutated the commands array, so re-resolve the selected
+			// command by its stable id. Both the candidate and the post-command slice are
+			// derived from this refreshed index so they cannot drift apart. The original
+			// positional index is only a fallback for legacy commands that genuinely have
+			// no id; if the command HAD an id but it is now gone (removed mid-run), leave
+			// the index unresolved so the guard below aborts rather than silently routing
+			// to a neighbouring script.
+			let refreshedIndex: number;
+			if (candidateId !== undefined) {
+				refreshedIndex = updatedCommands.findIndex(
+					(command) =>
+						command.id === candidateId &&
+						command.type === CommandType.UserScript,
+				);
+			} else {
+				refreshedIndex = selection.candidate.index;
+			}
+			const refreshedCandidate =
+				refreshedIndex >= 0 ? updatedCommands[refreshedIndex] : undefined;
 			if (!refreshedCandidate || refreshedCandidate.type !== CommandType.UserScript) {
 				throw new MacroAbortError(
 					`Could not resolve the member-access script for '${macroChoice.name}'.`,
@@ -251,7 +291,7 @@ export class SingleMacroEngine {
 				);
 			}
 
-			const postCommands = updatedCommands.slice(selection.candidate.index + 1);
+			const postCommands = updatedCommands.slice(refreshedIndex + 1);
 
 			const result = await this.executeResolvedMember(
 				resolvedMember.value,
@@ -398,6 +438,21 @@ export class SingleMacroEngine {
 			);
 		}
 
+		// Convention keys (settings/entry) are exported by many scripts and were resolved
+		// against the first script before 2.12.1. Preserve that — pick the first-declared
+		// exporter (matchingCandidates preserves command order) and surface a one-time
+		// notice pointing at the selector — rather than hard-aborting like a real entrypoint.
+		if (RESERVED_CONVENTION_KEYS.has(memberAccess[0])) {
+			const chosen = matchingCandidates[0];
+			this.warnReservedKeyConflict(
+				macroChoice,
+				memberAccess,
+				chosen,
+				matchingCandidates,
+			);
+			return { candidate: chosen, memberAccess };
+		}
+
 		const matchingNames = matchingCandidates
 			.map((candidate) => `'${candidate.command.name}'`)
 			.join(", ");
@@ -406,6 +461,28 @@ export class SingleMacroEngine {
 			`Macro '${macroChoice.name}' has multiple user scripts exporting '${memberAccess.join(
 				"::",
 			)}': ${matchingNames}. Disambiguate with '{{MACRO:${macroChoice.name}::<Script Name>::${memberAccess.join(
+				"::",
+			)}}}'.`,
+		);
+	}
+
+	private warnReservedKeyConflict(
+		macroChoice: IMacroChoice,
+		memberAccess: string[],
+		chosen: UserScriptCandidate,
+		all: UserScriptCandidate[],
+	): void {
+		if (this.emittedConflictNotice) return;
+		this.emittedConflictNotice = true;
+
+		const names = all
+			.map((candidate) => `'${candidate.command.name}'`)
+			.join(", ");
+
+		log.logWarning(
+			`Macro '${macroChoice.name}': multiple user scripts export '${memberAccess.join(
+				"::",
+			)}' (${names}); using '${chosen.command.name}'. Disambiguate with '{{MACRO:${macroChoice.name}::<Script Name>::${memberAccess.join(
 				"::",
 			)}}}'.`,
 		);


### PR DESCRIPTION
## Summary

Follow-up **hardening** for macro member access (`{{MACRO:Name::member}}`). The original #964 bug — member access silently short-circuiting to the *first* user script — was already fixed and shipped in **2.12.1** (merged-namespace model in `SingleMacroEngine.ts`). This PR fixes three residual issues that investigation + adversarial review surfaced in that model, scoped to the safe, regression-free subset.

### What changes

- **F5 — convention-key conflict (the one real regression).** Since 2.12.1, `{{MACRO:M::settings}}` *hard-aborts* whenever two or more user scripts export the same member. `settings` is a documented convention export (consumed by `initializeUserScriptSettings`) and `entry` is the object-export entrypoint — both are exported by many scripts, so this broke macros that worked before 2.12.1. Now the **reserved convention keys `settings` and `entry`** resolve to the **first-declared exporter** (pre-2.12.1 behavior) and surface a **one-time notice** pointing at the `::<Script Name>::` selector. Genuine entrypoint conflicts (`start`, `run`, custom names) still hard-abort — the deliberate “abort instead of guessing” behavior is preserved.
- **F6 — candidate refresh by id.** After pre-commands run, the selected user-script command is re-resolved by `command.id` (not by numeric index), and the post-command slice is derived from the refreshed index. Hardens against a pre-command mutating the macro's command list (latent today; defensive).
- **F4 — no silent empty string.** Requesting a member on a macro that has no user scripts now logs a clear warning instead of silently resolving to `""`.

Deliberately **out of scope** (deferred — riskier than the bugs they fix, see review notes): F1/F2 (probe executes every script's module body — fixing via a load-cache risks *stale* execution), F3 (selector fall-through), F7 (unifying the `getUserScript` `command.name` grammar — that grammar is load-bearing for the documented `myScript::start` command form).

## Reproduction / verification

Verified end-to-end in a real Obsidian dev vault (v2.13.1) via `api.format(...)`:

| Scenario | Result |
|---|---|
| `::settings` with 2 exporters | resolves to first exporter **+ notice** (was: hard abort) |
| `::beta` ambiguous (non-reserved) | still aborts (deliberate behavior preserved) |
| single-script `::beta` | unchanged |
| later-script `::beta` | `SECOND_BETA` (original #964 fix intact) |
| `::start` on a script-less macro | empty **+ warning** (was: silent `""`) |

`pnpm test` (1816 pass), `pnpm lint`, and `tsc --noEmit` all green; added 4 unit tests (reserved-key resolution, preserved non-reserved abort, zero-user-script warning, id-based refresh under command-list mutation).

## Release / migration impact

`fix:` → patch release. No data migration. Behavior change is limited to `{{MACRO:M::settings}}` / `{{MACRO:M::entry}}` when 2+ scripts export them (now resolves + warns instead of aborting) and a new diagnostic notice for script-less member access.

Refs #964 (literal bug fixed in 2.12.1; this is the residual hardening).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded macro member-selection docs with warnings and reserved-key behavior.

* **Bug Fixes**
  * Reserved convention keys (`settings`, `entry`, `quickadd`) now pick the first matching script and emit a one-time notice pointing to the selector option.
  * Ambiguity for non-reserved members still errors as before.
  * Macros that export no user-script commands now warn and return an empty result.
  * Script selection remains correct when pre-commands modify the command list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->