### PR TITLE
fix: make the update modal closable on iPhone (#635)

### DIFF
--- a/src/gui/UpdateModal/UpdateModal.dismiss.test.ts
+++ b/src/gui/UpdateModal/UpdateModal.dismiss.test.ts
@@ -1,0 +1,207 @@
+import type { App } from "obsidian";
+import { requestUrl } from "obsidian";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// vi.mock is hoisted above imports by vitest, so UpdateModal binds to the mocked
+// obsidian exports below. The element helpers are installed before any test runs.
+import { UpdateModal } from "./UpdateModal";
+
+// The UpdateModal's whole reason to exist (#635) is a self-owned exit: on iPhone the
+// system close button (the X) sits in the status-bar/Dynamic-Island safe-area zone and
+// can be untappable, and this modal has no other dismiss on mobile (no Esc, no backdrop).
+// These tests pin that escape hatch so it can't silently regress. Isolated in its own
+// file with a local obsidian mock so it doesn't disturb the renderVideoAttachments suite.
+
+vi.mock("obsidian", () => {
+	class Modal {
+		app: App;
+		containerEl: HTMLElement;
+		contentEl: HTMLElement;
+
+		constructor(app: App) {
+			this.app = app;
+			this.containerEl = document.createElement("div");
+			this.contentEl = document.createElement("div");
+			this.containerEl.appendChild(this.contentEl);
+			document.body.appendChild(this.containerEl);
+		}
+
+		open() {
+			this.onOpen();
+		}
+
+		close() {
+			this.onClose();
+		}
+
+		onOpen() {}
+		onClose() {}
+	}
+
+	class Component {
+		load() {}
+		unload() {}
+	}
+
+	class ButtonComponent {
+		buttonEl: HTMLButtonElement;
+
+		constructor(containerEl: HTMLElement) {
+			this.buttonEl = document.createElement("button");
+			containerEl.appendChild(this.buttonEl);
+		}
+
+		setButtonText(text: string): this {
+			this.buttonEl.textContent = text;
+			return this;
+		}
+
+		setCta(): this {
+			this.buttonEl.classList.add("mod-cta");
+			return this;
+		}
+
+		onClick(cb: () => void): this {
+			this.buttonEl.addEventListener("click", cb);
+			return this;
+		}
+	}
+
+	const MarkdownRenderer = { render: vi.fn(async () => {}) };
+	const requestUrl = vi.fn();
+
+	return { Modal, Component, ButtonComponent, MarkdownRenderer, requestUrl };
+});
+
+function installObsidianElementHelpers(): void {
+	const proto = HTMLElement.prototype as unknown as {
+		addClass?: (this: HTMLElement, ...classes: string[]) => HTMLElement;
+		createDiv?: (
+			this: HTMLElement,
+			cls?: string | { cls?: string },
+		) => HTMLDivElement;
+		createEl?: (
+			this: HTMLElement,
+			tag: string,
+			options?: { text?: string },
+		) => HTMLElement;
+		empty?: (this: HTMLElement) => void;
+	};
+
+	proto.addClass ??= function (...classes: string[]) {
+		this.classList.add(...classes);
+		return this;
+	};
+
+	proto.createDiv ??= function (cls?: string | { cls?: string }) {
+		const div = document.createElement("div");
+		const className = typeof cls === "string" ? cls : cls?.cls;
+		if (className) div.className = className;
+		this.appendChild(div);
+		return div;
+	};
+
+	proto.createEl ??= function (tag: string, options?: { text?: string }) {
+		const el = document.createElement(tag);
+		if (options?.text) el.textContent = options.text;
+		this.appendChild(el);
+		return el;
+	};
+
+	proto.empty ??= function () {
+		this.replaceChildren();
+	};
+}
+
+installObsidianElementHelpers();
+
+const app = {
+	vault: { getRoot: () => ({ path: "/" }) },
+} as unknown as App;
+
+/** Two releases so getReleaseNotesAfter("1.0.0") returns one note (the 1.2.0 release). */
+function mockReleasesFetch(): void {
+	vi.mocked(requestUrl).mockResolvedValue({
+		status: 200,
+		json: [
+			{ tag_name: "1.2.0", body: "notes", draft: false, prerelease: false },
+			{ tag_name: "1.0.0", body: "", draft: false, prerelease: false },
+		],
+	} as unknown as ReturnType<typeof requestUrl> extends Promise<infer R>
+		? R
+		: never);
+}
+
+/** Let the constructor's requestUrl → getReleaseNotesAfter → .then chain settle. */
+function flushAsync(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function footerButtons(modal: { contentEl: HTMLElement }): HTMLButtonElement[] {
+	return Array.from(
+		modal.contentEl.querySelectorAll<HTMLButtonElement>(
+			".quickadd-update-modal-footer button",
+		),
+	);
+}
+
+describe("UpdateModal dismiss affordance (#635)", () => {
+	beforeEach(() => {
+		document.body.replaceChildren();
+		vi.mocked(requestUrl).mockReset();
+		// Default: a fetch that never settles, so onOpen-only tests stay synchronous.
+		vi.mocked(requestUrl).mockReturnValue(
+			new Promise(() => {}) as ReturnType<typeof requestUrl>,
+		);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("renders exactly one reachable 'Done' exit while fetching", () => {
+		const modal = new UpdateModal(app, "0.0.1");
+		modal.onOpen();
+
+		const buttons = footerButtons(modal);
+		expect(buttons).toHaveLength(1);
+		expect(buttons[0].textContent).toBe("Done");
+	});
+
+	it("closes the modal when the 'Done' button is clicked", () => {
+		const modal = new UpdateModal(app, "0.0.1");
+		const closeSpy = vi.spyOn(modal, "close");
+		modal.onOpen();
+
+		footerButtons(modal)[0].click();
+
+		expect(closeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders the notes and a single Done exit once the fetch resolves", async () => {
+		mockReleasesFetch();
+
+		const modal = new UpdateModal(app, "1.0.0");
+		modal.onOpen();
+		await flushAsync();
+
+		expect(modal.contentEl.querySelector(".quickadd-update-modal")).not.toBeNull();
+		expect(footerButtons(modal)).toHaveLength(1);
+	});
+
+	it("does not render notes if the fetch resolves after the modal is closed", async () => {
+		mockReleasesFetch();
+
+		const modal = new UpdateModal(app, "1.0.0");
+		const displaySpy = vi.spyOn(
+			modal as unknown as { display: () => void },
+			"display",
+		);
+		modal.onOpen();
+		modal.close(); // user dismisses before the fetch resolves
+
+		await flushAsync();
+
+		expect(displaySpy).not.toHaveBeenCalled();
+		expect(modal.contentEl.querySelector(".quickadd-update-modal")).toBeNull();
+	});
+});

--- a/src/gui/UpdateModal/UpdateModal.ts
+++ b/src/gui/UpdateModal/UpdateModal.ts
@@ -1,5 +1,11 @@
 import type { App } from "obsidian";
-import { Component, MarkdownRenderer, Modal, requestUrl } from "obsidian";
+import {
+	ButtonComponent,
+	Component,
+	MarkdownRenderer,
+	Modal,
+	requestUrl,
+} from "obsidian";
 import { log } from "src/logger/logManager";
 
 type Release = {
@@ -162,6 +168,11 @@ export class UpdateModal extends Modal {
 	// Owns the lifecycle of the markdown render's child components so they are
 	// torn down on close, rather than leaking onto a longer-lived owner.
 	private readonly markdownComponent = new Component();
+	// The release-notes fetch can resolve after the user has already dismissed the
+	// modal (the in-content Done button makes closing-while-fetching easy). Without
+	// this guard, the late display() would re-load markdownComponent (already
+	// unloaded in onClose) and render into a detached contentEl.
+	private isClosed = false;
 
 	constructor(app: App, previousQAVersion: string) {
 		super(app);
@@ -174,6 +185,8 @@ export class UpdateModal extends Modal {
 		);
 		this.releaseNotesPromise
 			.then((releases) => {
+				if (this.isClosed) return;
+
 				this.releases = releases;
 
                 if (this.releases.length === 0) {
@@ -194,10 +207,29 @@ export class UpdateModal extends Modal {
 		contentEl.createEl("h1", {
 			text: "Fetching release notes...",
 		});
+		// Always offer a reachable exit, even while fetching or if the fetch fails.
+		this.addCloseFooter();
+	}
+
+	/**
+	 * A self-owned dismiss control. On phones the system close (X) sits in the top
+	 * safe-area zone (status bar / Dynamic Island) where it can be untappable, and
+	 * this modal has no other exit (no Esc key, no backdrop to tap) — so it must
+	 * always offer a reachable Close. The footer follows the (internally scrollable)
+	 * release notes in normal flow so it stays visible, and clears the bottom
+	 * home-indicator inset on mobile (#635).
+	 */
+	private addCloseFooter(): void {
+		const footer = this.contentEl.createDiv("quickadd-update-modal-footer");
+		new ButtonComponent(footer)
+			.setButtonText("Done")
+			.setCta()
+			.onClick(() => this.close());
 	}
 
 	onClose() {
 		const { contentEl } = this;
+		this.isClosed = true;
 		this.markdownComponent.unload();
 		contentEl.empty();
 	}
@@ -230,5 +262,7 @@ export class UpdateModal extends Modal {
 			this.app.vault.getRoot().path,
 			this.markdownComponent,
 		);
+
+		this.addCloseFooter();
 	}
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1212,6 +1212,10 @@
 	min-width: 35%;
 	max-width: 90%;
 	max-height: 70%;
+	/* Let the scroll region shrink below its content height so the non-shrinking
+	   footer always fits inside the centered column — otherwise tall notes on a
+	   short viewport could overflow and clip the Done button out of view (#635). */
+	min-height: 0;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 	word-break: break-word;
@@ -1236,6 +1240,23 @@
 	width: 100%;
 	height: auto;
 	margin: 5px;
+}
+
+/* A guaranteed, always-reachable dismiss for the (mobile-)X-only update modal.
+   Follows the scrollable release notes in normal flow so it stays visible, and on
+   mobile clears the bottom home-indicator inset (var(--safe-area-inset-bottom),
+   floored so it still has breathing room on devices with no inset). (#635) */
+.quickadd-update-modal-footer {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+	/* Never let the centered column compress the exit out of reach. */
+	flex-shrink: 0;
+	margin-top: 1rem;
+	padding-bottom: max(
+		var(--size-4-4, 16px),
+		var(--safe-area-inset-bottom, 0px)
+	);
 }
 
 /* Buy me a coffee */


### PR DESCRIPTION
Closes #635.

## Problem
On iPhone, the "New in QuickAdd vX" update modal can't be closed. The modal renders full-screen on phones, and Obsidian's close button (the **X**) is positioned top-right at `top: var(--size-4-3)` (12px) with **no top safe-area inset** for plain modals — so on an iPhone 15 Pro it lands inside the status-bar / Dynamic Island zone (top inset ≈ 59px) where it's effectively untappable. Because the modal has **no other exit on mobile** (no Esc key, no backdrop to tap), an unreachable X = a stuck modal requiring a force-quit.

(Verified against the installed Obsidian 1.13 `app.css`: only `.mod-settings.mod-sidebar-layout` gets `top: var(--safe-area-inset-top)`; plain modals like this one don't.)

## Fix
Give the modal a **self-owned, always-reachable exit** rather than fighting Obsidian's core close-button position:

- Add a CTA **"Done"** button to the modal content (`addCloseFooter()`) that calls `this.close()`. It's rendered in **both** the fetching/error state (`onOpen`) and the loaded release-notes state (`display`), so the modal is dismissable at every stage.
- **Layout contract** so the exit can never be clipped: the scroll region gets `min-height: 0` and the footer `flex-shrink: 0`, so on a short viewport / long changelog the notes scroll internally while the footer stays on-screen. The footer clears the bottom home-indicator inset via `padding-bottom: max(var(--size-4-4), var(--safe-area-inset-bottom))`.
- **Async guard**: an `isClosed` flag prevents a late release-notes fetch from re-`load()`ing the markdown component and rendering into an already-closed (detached) modal — a latent race the easy in-content dismiss made reachable.

Scope note: repositioning Obsidian's core `.modal-close-button` via safe-area CSS for *all* QuickAdd modals was considered and **deliberately deferred** — it risked CSS bleed from the shared `.quickAddModal` rules and a centered-modal double-inset that would push the X onto the title. This PR fixes the reported bug with zero Obsidian-internal coupling.

## Verification
- `tsc` ✓, eslint ✓, full vitest suite **1816 passed** ✓, build ✓.
- New `UpdateModal.dismiss.test.ts` (4 tests): one "Done" exit while fetching, click→`close()`, notes+single-exit on resolve, and the close-before-resolve guard.
- Live in the dev vault under `emulate-mobile`: footer always visible below the internally-scrolling notes; `padding-bottom` 34px mobile / 16px desktop; worst case (300px modal, 120 paragraphs) keeps the Done button fully inside the modal; no console errors.

## Reviews
Design stress-tested by 3 repo-grounded reviewers (1 thorough + 2 adversarial); implementation then run through an adversarial (opposite-model) review. All findings addressed: the centered-flex clip risk (layout contract), the fetch-after-close race (`isClosed` guard), and a regression test for the escape hatch.

## ⚠️ Out of scope — heads up
While reviewing, the adversarial pass flagged a **pre-existing** working-tree change in `package.json` (not part of this PR): it moves `obsidian-calendar-ui>svelte: ^3.59.2` from `pnpm.overrides` to a root-level `overrides`. I verified empirically (regenerating the lockfile) that **pnpm ignores the top-level `overrides`** and drops the pin, while `pnpm.overrides` keeps it. That change is a regression — I left it out of this PR and reverted it locally; worth confirming it isn't lurking elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update modal now always displays a reachable "Done" button, improving dismissal accessibility on mobile devices and small screens.

* **Style**
  * Enhanced modal footer styling to ensure the dismiss button remains visible across all viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->