### PR TITLE
feat(formatters): add {{FOLDER}} token for file names and paths

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -148,6 +148,26 @@ The basename (without extension) of the file from which the template or capture 
 
 Example: `Notes from {{FILENAMECURRENT}}`.
 
+## `{{FOLDER}}` {#folder}
+
+The folder the note is being created in, as a vault-relative path (no trailing slash). For a note created at the vault root this resolves to an empty string.
+
+Where it has a value:
+
+- **Template choices** — in the file name format (the folder is resolved before the name is built) and in the template body.
+- **Capture** — in the capture body, where it resolves to the destination file's folder.
+- **Apply template to a note** — the target note's folder.
+
+Where it resolves to an empty string: the capture **Capture to** field (that field is what *chooses* the folder, so there is nothing to reference yet), the `format` JavaScript API, and macro file-path commands.
+
+### `{{FOLDER|name}}` — just the folder name
+
+Add the `|name` modifier to get only the last path segment. For a target folder `Projects/Acme`, `{{FOLDER}}` is `Projects/Acme` while `{{FOLDER|name}}` is `Acme`. Use `{{FOLDER|name}}` when you want the folder's name reflected in a file name; use the bare `{{FOLDER}}` in note bodies where you want the full path.
+
+> Note: in a Template file name format, prefixing with the full path (e.g. `{{FOLDER}}/{{VALUE}}`) is redundant — the note is already placed in the target folder, so the leading path is stripped. Use `{{FOLDER|name}}` to put the folder's name *into* the file name.
+
+Examples: `Filed under {{FOLDER}}`, `{{FOLDER|name}} - {{VALUE}}`.
+
 ## `{{MACRO:<MACRONAME>}}` {#macro}
 
 Execute a macro and write the return value here.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export const FIELD_VAR_SYNTAX = "{{field:<field name>}}";
 export const MATH_VALUE_SYNTAX = "{{mvalue}}";
 export const LINKCURRENT_SYNTAX = "{{linkcurrent}}";
 export const FILENAMECURRENT_SYNTAX = "{{filenamecurrent}}";
+export const FOLDER_SYNTAX = "{{folder}}";
 export const TITLE_SYNTAX = "{{title}}";
 export const SELECTED_SYNTAX = "{{selected}}";
 export const CLIPBOARD_SYNTAX = "{{clipboard}}";
@@ -51,6 +52,8 @@ export const FORMAT_SYNTAX: string[] = [
 	"{{field:<fieldname>|inline:true|inline-code-blocks:ad-note}}",
 	LINKCURRENT_SYNTAX,
 	FILENAMECURRENT_SYNTAX,
+	FOLDER_SYNTAX,
+	"{{folder|name}}",
 	"{{macro:<macroname>}}",
 	"{{macro:<macroname>|label:<label>}}",
 	"{{template:<templatepath>}}",
@@ -112,6 +115,9 @@ export const DATE_VARIABLE_REGEX = new RegExp(
 );
 export const LINK_TO_CURRENT_FILE_REGEX = new RegExp(/{{LINKCURRENT}}/i);
 export const FILE_NAME_OF_CURRENT_FILE_REGEX = new RegExp(/{{FILENAMECURRENT}}/i);
+// {{FOLDER}} resolves to the target folder the note is being created in.
+// The optional |name modifier yields just the leaf folder segment.
+export const TARGET_FOLDER_REGEX = new RegExp(/{{FOLDER(\|name)?}}/i);
 export const MARKDOWN_FILE_EXTENSION_REGEX = new RegExp(/\.md$/i);
 export const CANVAS_FILE_EXTENSION_REGEX = new RegExp(/\.canvas$/i);
 export const BASE_FILE_EXTENSION_REGEX = new RegExp(/\.base$/i);
@@ -159,6 +165,9 @@ export const LINKCURRENT_SYNTAX_SUGGEST_REGEX = new RegExp(
 );
 export const FILENAMECURRENT_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[F]?[I]?[L]?[E]?[N]?[A]?[M]?[E]?[C]?[U]?[R]?[R]?[E]?[N]?[T]?[}]?[}]?$/i,
+);
+export const FOLDER_SYNTAX_SUGGEST_REGEX = new RegExp(
+	/{{[F]?[O]?[L]?[D]?[E]?[R]?[}]?[}]?$/i,
 );
 export const TEMPLATE_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[T]?[E]?[M]?[P]?[L]?[A]?[T]?[E]?[:]?$|{{TEMPLATE:[^\n\r}]*[}]?[}]?$/i,

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -40,7 +40,7 @@ import {
 import { isCancellationError, reportError } from "../utils/errorUtils";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
-import { basenameWithoutMdOrCanvas } from "../utils/pathUtils";
+import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
 import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { MacroAbortError } from "../errors/MacroAbortError";
@@ -735,6 +735,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			if (linkOptions?.enabled && !linkOptions.requireActiveFile) {
 				singleTemplateEngine.setLinkToCurrentFileBehavior("optional");
 			}
+
+			// The SingleTemplateEngine has its own formatter; give it the
+			// destination folder so {{FOLDER}} resolves in the template body.
+			singleTemplateEngine.setTargetFolderPath(parentFolderPath(filePath));
 
 			fileContent = await singleTemplateEngine.run();
 

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -60,6 +60,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		constructor() {}
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setTargetFolderPath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
 		}

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -60,6 +60,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		constructor() {}
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setTargetFolderPath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
 		}

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -76,6 +76,9 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				folderPath = parent === this.app.vault.getRoot() ? "" : parent.path;
 			}
 
+			// Make the resolved folder available to {{FOLDER}} in the file name.
+			this.formatter.setTargetFolderPath(folderPath);
+
 			const format = this.choice.fileNameFormat.enabled
 				? this.choice.fileNameFormat.format
 				: VALUE_SYNTAX;

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -20,7 +20,7 @@ import {
 	MARKDOWN_FILE_EXTENSION_REGEX,
 } from "../constants";
 import { reportError } from "../utils/errorUtils";
-import { basenameWithoutMdOrCanvas } from "../utils/pathUtils";
+import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
 import {
 	INVALID_FOLDER_CHARS_REGEX,
 	INVALID_FOLDER_CONTROL_CHARS_REGEX,
@@ -535,6 +535,8 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Extract filename without extension from the full path.
 			const fileBasename = basenameWithoutMdOrCanvas(filePath);
 			this.formatter.setTitle(fileBasename);
+			// {{FOLDER}} in the body reflects the file's actual on-disk folder.
+			this.formatter.setTargetFolderPath(parentFolderPath(filePath));
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
@@ -580,6 +582,16 @@ export abstract class TemplateEngine extends QuickAddEngine {
 		this.formatter.setLinkToCurrentFileBehavior(behavior);
 	}
 
+	/**
+	 * Sets the folder {{FOLDER}} resolves to for this engine's formatter. Used by
+	 * callers that drive an engine they don't own the formatter of — notably
+	 * CaptureChoiceEngine threading the destination folder into the
+	 * SingleTemplateEngine that renders a "create with template" body.
+	 */
+	public setTargetFolderPath(path: string | null) {
+		this.formatter.setTargetFolderPath(path);
+	}
+
 
 
 	protected async overwriteFileWithTemplate(
@@ -594,6 +606,9 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Use the existing file's basename as the title
 			const fileBasename = file.basename;
 			this.formatter.setTitle(fileBasename);
+			// {{FOLDER}} reflects the existing file's folder, which can differ
+			// from the choice's configured folder.
+			this.formatter.setTargetFolderPath(parentFolderPath(file.path));
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
@@ -641,6 +656,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// Use the existing file's basename as the title
 			const fileBasename = file.basename;
 			this.formatter.setTitle(fileBasename);
+			this.formatter.setTargetFolderPath(parentFolderPath(file.path));
 
 			let formattedTemplateContent: string =
 				await this.formatter.formatFileContent(templateContent);

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -8,16 +8,31 @@ const { collectedPropertyVars } = vi.hoisted(() => ({
 
 vi.mock("../formatters/completeFormatter", () => {
 	class CompleteFormatterMock {
+		targetFolderPath: string | null = null;
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setTargetFolderPath(path: string | null) {
+			this.targetFolderPath = path;
+		}
+		// Minimal {{FOLDER}} resolution mirroring the real formatter so the
+		// move-path computation can be exercised end-to-end.
+		private resolveFolder(input: string): string {
+			const full = this.targetFolderPath ?? "";
+			const leaf = full.includes("/")
+				? full.slice(full.lastIndexOf("/") + 1)
+				: full;
+			return input
+				.replace(/{{FOLDER\|name}}/gi, leaf)
+				.replace(/{{FOLDER}}/gi, full);
+		}
 		async formatFileContent(input: string) {
 			return input;
 		}
 		async formatFileName(format: string) {
-			return format;
+			return this.resolveFolder(format);
 		}
 		async formatFolderPath(folder: string) {
-			return folder;
+			return this.resolveFolder(folder);
 		}
 		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
 			return await work();
@@ -439,6 +454,35 @@ describe("TemplateInsertEngine.computeChoiceTargetPath", () => {
 		).computeChoiceTargetPath(choice);
 
 		expect(target).toBe("Meetings/My note.md");
+	});
+
+	it("ignores a stale {{FOLDER}} target left by apply() when computing the move path (#1258)", async () => {
+		const harness = makePathHarness();
+		const file = makeFile({ parent: { path: "Inbox" } as TFile["parent"] });
+		const choice = makeTemplateChoice({
+			folder: {
+				enabled: true,
+				folders: ["Projects/Acme"],
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			},
+			fileNameFormat: { enabled: true, format: "{{FOLDER|name}} - Renamed" },
+		});
+
+		const engine = makeEngine(harness, file, "replace");
+		// Simulate apply() having pointed {{FOLDER}} at the note's own folder.
+		(
+			engine as unknown as {
+				formatter: { setTargetFolderPath(p: string | null): void };
+			}
+		).formatter.setTargetFolderPath("Inbox");
+
+		const target = await engine.computeChoiceTargetPath(choice);
+
+		// {{FOLDER|name}} must reflect the choice's destination folder (Acme),
+		// not the stale note folder (Inbox).
+		expect(target).toBe("Projects/Acme/Acme - Renamed.md");
 	});
 
 	it("returns null when the folder requires a runtime picker", async () => {

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -11,6 +11,7 @@ import {
 import invariant from "../utils/invariant";
 import { TemplatePropertyCollector } from "../utils/TemplatePropertyCollector";
 import { coerceYamlValue } from "../utils/yamlValues";
+import { parentFolderPath } from "../utils/pathUtils";
 import { TemplateEngine } from "./TemplateEngine";
 
 export const templateInsertModes = [
@@ -140,6 +141,12 @@ export class TemplateInsertEngine extends TemplateEngine {
 		const folderSettings = choice.folder;
 		let folderPath: string;
 
+		// This engine's formatter was already used by apply() with the note's
+		// own folder as the {{FOLDER}} target. Clear it so folder-definition
+		// formatting below treats {{FOLDER}} as self-referential (empty) rather
+		// than inheriting that stale value.
+		this.formatter.setTargetFolderPath(null);
+
 		if (folderSettings?.enabled) {
 			if (
 				folderSettings.chooseWhenCreatingNote ||
@@ -166,6 +173,10 @@ export class TemplateInsertEngine extends TemplateEngine {
 		let fileName = this.targetFile.basename;
 		let treatAsVaultRelativePath = false;
 		if (choice.fileNameFormat?.enabled && choice.fileNameFormat.format) {
+			// The file name's {{FOLDER}} reflects the folder this choice would
+			// create the note in (the path just computed), matching what
+			// TemplateChoiceEngine produces.
+			this.formatter.setTargetFolderPath(folderPath);
 			const formattedName = await this.formatter.formatFileName(
 				choice.fileNameFormat.format,
 				choice.name,
@@ -252,6 +263,8 @@ export class TemplateInsertEngine extends TemplateEngine {
 		const templateContent = await this.getTemplateContent(this.templatePath);
 
 		this.formatter.setTitle(this.targetFile.basename);
+		// {{FOLDER}} resolves to the note's own folder when applying a template.
+		this.formatter.setTargetFolderPath(parentFolderPath(this.targetFile.path));
 
 		let formatted = await this.formatter.withTemplatePropertyCollection(() =>
 			this.formatter.formatFileContent(templateContent),

--- a/src/engine/templateEngine-title.test.ts
+++ b/src/engine/templateEngine-title.test.ts
@@ -11,6 +11,7 @@ vi.mock('../formatters/completeFormatter', () => {
             let title = '';
             return {
                 setTitle: vi.fn((t: string) => { title = t; }),
+                setTargetFolderPath: vi.fn(),
                 getTitle: () => title,
                 withTemplatePropertyCollection: vi.fn(
                     async (work: () => Promise<unknown>) => await work(),

--- a/src/formatters/captureChoiceFormatter-folder.test.ts
+++ b/src/formatters/captureChoiceFormatter-folder.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+
+vi.mock("../utilityObsidian", () => ({
+  templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+  __esModule: true,
+  default: class {
+    factory() {
+      return { Prompt: vi.fn().mockResolvedValue("") } as any;
+    }
+  },
+}));
+
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({
+  __esModule: true,
+  default: class {
+    constructor() {}
+  },
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+  __esModule: true,
+  default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({
+  __esModule: true,
+  default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../utils/errorUtils", () => ({
+  __esModule: true,
+  reportError: vi.fn(),
+}));
+
+vi.mock("../gui/MathModal", () => ({
+  __esModule: true,
+  MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+  __esModule: true,
+  SingleInlineScriptEngine: class {
+    public params = { variables: {} as Record<string, unknown> };
+    constructor() {}
+    async runAndGetOutput() {
+      return "";
+    }
+  },
+}));
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+  __esModule: true,
+  SingleMacroEngine: class {
+    constructor() {}
+    async runAndGetOutput() {
+      return "";
+    }
+  },
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+  __esModule: true,
+  SingleTemplateEngine: class {
+    constructor() {}
+    async run() {
+      return "";
+    }
+    getAndClearTemplatePropertyVars() {
+      return new Map();
+    }
+    setLinkToCurrentFileBehavior() {}
+  },
+}));
+
+vi.mock("obsidian-dataview", () => ({
+  __esModule: true,
+  getAPI: vi.fn().mockReturnValue(null),
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+const createMockApp = (): App =>
+  ({
+    workspace: {
+      getActiveFile: vi.fn().mockReturnValue(null),
+      getActiveViewOfType: vi.fn().mockReturnValue(null),
+    },
+    metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+    fileManager: {
+      generateMarkdownLink: vi.fn().mockReturnValue(""),
+      processFrontMatter: vi.fn(),
+    },
+    vault: { adapter: { exists: vi.fn() }, cachedRead: vi.fn() },
+  }) as unknown as App;
+
+const createTFile = (path: string): TFile => {
+  const name = path.split("/").pop() ?? path;
+  return {
+    path,
+    name,
+    basename: name.replace(/\.(md|canvas)$/i, ""),
+    extension: path.endsWith(".md") ? "md" : "canvas",
+  } as unknown as TFile;
+};
+
+const createFormatter = () => {
+  const app = createMockApp();
+  const plugin = {
+    settings: {
+      enableTemplatePropertyTypes: false,
+      globalVariables: {},
+      showCaptureNotification: false,
+    },
+  } as any;
+  return new CaptureChoiceFormatter(app, plugin);
+};
+
+describe("CaptureChoiceFormatter {{FOLDER}} resolves to the destination folder", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (global as any).navigator = {
+      clipboard: { readText: vi.fn().mockResolvedValue("") },
+    };
+  });
+
+  it("derives {{FOLDER}} from a destination source path (file not yet created)", async () => {
+    const formatter = createFormatter();
+    formatter.setDestinationSourcePath("Journal/2024/Inbox.md");
+
+    const result = await formatter.formatContentOnly("Filed under {{FOLDER}}");
+
+    expect(result).toBe("Filed under Journal/2024");
+  });
+
+  it("derives {{FOLDER|name}} from an existing destination file", async () => {
+    const formatter = createFormatter();
+    formatter.setDestinationFile(createTFile("Areas/Health/Log.md"));
+
+    const result = await formatter.formatContentOnly("{{FOLDER|name}} log");
+
+    expect(result).toBe("Health log");
+  });
+
+  it("resolves {{FOLDER}} to empty for a destination at the vault root", async () => {
+    const formatter = createFormatter();
+    formatter.setDestinationSourcePath("Inbox.md");
+
+    const result = await formatter.formatContentOnly("[{{FOLDER}}]note");
+
+    expect(result).toBe("[]note");
+  });
+});

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -14,6 +14,7 @@ import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { CompleteFormatter } from "./completeFormatter";
 import getEndOfSection from "./helpers/getEndOfSection";
 import { findYamlFrontMatterRange } from "../utils/yamlContext";
+import { parentFolderPath } from "../utils/pathUtils";
 
 /**
 	* Only ASCII whitespace counts as "nothing to capture". Unicode spaces such as
@@ -53,11 +54,14 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	public setDestinationFile(file: TFile): void {
 		this.file = file;
 		this.sourcePath = file.path;
+		// {{FOLDER}} in a capture body resolves to the destination file's folder.
+		this.setTargetFolderPath(parentFolderPath(file.path));
 	}
 
 	public setDestinationSourcePath(path: string): void {
 		this.sourcePath = path;
 		this.file = null;
+		this.setTargetFolderPath(parentFolderPath(path));
 	}
 
 	public setUseSelectionAsCaptureValue(value: boolean): void {
@@ -99,6 +103,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		this.file = file;
 		this.fileContent = fileContent;
 		if (!choice || !file || fileContent === null) return input;
+		// Keep {{FOLDER}} pointed at the definitive destination file's folder.
+		this.setTargetFolderPath(parentFolderPath(file.path));
 
 		// Process templater here if we're using insert after or prepend or not capturing to active file
 		// This is needed because in these cases, the content won't be processed by templaterParseTemplate in CaptureChoiceEngine

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -53,6 +53,7 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 	SingleTemplateEngine: class {
 		templatePath: string;
 		inclusion?: TemplateInclusionState;
+		targetFolderPath: string | null = null;
 
 		constructor(
 			_app: unknown,
@@ -63,6 +64,10 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 		) {
 			this.templatePath = templatePath;
 			this.inclusion = inclusion;
+		}
+
+		setTargetFolderPath(path: string | null) {
+			this.targetFolderPath = path;
 		}
 
 		run() {
@@ -203,11 +208,15 @@ function mockTemplateVault(templates: Record<string, string>) {
 	mocks.templateRun.mockImplementation(async function (this: {
 		templatePath: string;
 		inclusion?: TemplateInclusionState;
+		targetFolderPath?: string | null;
 	}) {
 		const child = defaultFormatter();
 		if (this.inclusion) {
 			child.setTemplateInclusionState(this.inclusion);
 		}
+		// Mirror SingleTemplateEngine: the child renders with the target folder
+		// propagated from the including formatter (so {{FOLDER}} resolves).
+		child.setTargetFolderPath(this.targetFolderPath ?? null);
 
 		return await child.formatFileContent(templates[this.templatePath] ?? "");
 	});
@@ -333,6 +342,18 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 		await expect(
 			f.formatFolderPath("{{TEMPLATE:notes/a.md}}"),
 		).resolves.toBe("TEMPLATE_BODY");
+	});
+
+	it("propagates the target folder into included templates so {{FOLDER}} resolves", async () => {
+		mockTemplateVault({
+			"Partials/Filing.md": "folder={{FOLDER}} name={{FOLDER|name}}",
+		});
+		const f = defaultFormatter();
+		f.setTargetFolderPath("Projects/Acme");
+
+		const result = await f.formatFileContent("{{TEMPLATE:Partials/Filing.md}}");
+
+		expect(result).toBe("folder=Projects/Acme name=Acme");
 	});
 
 	it("terminates self-including templates with a visible placeholder", async () => {

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -91,6 +91,7 @@ export class CompleteFormatter extends Formatter {
 		this.valueHeader = valueHeader;
 		let output = await this.format(input);
 		output = await this.replaceCurrentFileNameInString(output);
+		output = this.replaceTargetFolderInString(output);
 		return output;
 	}
 
@@ -100,6 +101,7 @@ export class CompleteFormatter extends Formatter {
 		output = await this.format(output);
 		output = await this.replaceLinkToCurrentFileInString(output);
 		output = await this.replaceCurrentFileNameInString(output);
+		output = this.replaceTargetFolderInString(output);
 		output = this.replaceTitleInString(output);
 
 		return output;
@@ -113,7 +115,10 @@ export class CompleteFormatter extends Formatter {
 			);
 		}
 
-		return await this.format(folderName);
+		// {{FOLDER}} in a folder definition is self-referential: the target
+		// folder isn't known while folders are being resolved, so it collapses
+		// to an empty string rather than leaking the literal token into a path.
+		return this.replaceTargetFolderInString(await this.format(folderName));
 	}
 
 	/**
@@ -126,6 +131,9 @@ export class CompleteFormatter extends Formatter {
 		let output = await this.format(input);
 		output = await this.replaceLinkToCurrentFileInString(output);
 		output = await this.replaceCurrentFileNameInString(output);
+		// Note: {{FOLDER}} is deliberately NOT resolved in location selectors
+		// (insert-after/before targets) — an empty resolution would match the
+		// first line, and folder reflection isn't meaningful for a line target.
 		output = this.replaceTitleInString(output);
 		return output;
 	}
@@ -389,13 +397,18 @@ export class CompleteFormatter extends Formatter {
 			visited: this.templateInclusion.visited,
 			depth: this.templateInclusion.depth + 1,
 		};
-		return await new SingleTemplateEngine(
+		const childEngine = new SingleTemplateEngine(
 			this.app,
 			this.plugin,
 			templatePath,
 			this.choiceExecutor,
 			childInclusion,
-		).run();
+		);
+		// Propagate the target folder so {{FOLDER}} resolves inside included
+		// templates ({{TEMPLATE:...}}), which render via this child engine's own
+		// formatter.
+		childEngine.setTargetFolderPath(this.targetFolderPath);
+		return await childEngine.run();
 	}
 
 	protected async getSelectedText(): Promise<string> {

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -42,6 +42,7 @@ export class FileNameDisplayFormatter extends Formatter {
 			output = await this.replaceVariableInString(output);
 			output = await this.replaceFieldVarInString(output);
 			output = await this.replaceCurrentFileNameInString(output);
+			output = this.replaceTargetFolderInString(output);
 			output = this.replaceRandomInString(output);
 		} catch {
 			// Return the input as-is if formatting fails during preview

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -46,6 +46,7 @@ export class FormatDisplayFormatter extends Formatter {
 			output = await this.replaceVariableInString(output);
 			output = await this.replaceLinkToCurrentFileInString(output);
 			output = await this.replaceCurrentFileNameInString(output);
+			output = this.replaceTargetFolderInString(output);
 			output = await this.replaceMacrosInString(output);
 			output = await this.replaceTemplateInString(output);
 			output = await this.replaceFieldVarInString(output);

--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -26,6 +26,8 @@ const CURRENT_AND_2120_EXAMPLES = [
 	"- [ ] {{VALUE|label:Task}} {{VDATE:followup,[📅 ]YYYY-MM-DD|optional}}",
 	"Source: {{LINKCURRENT}}",
 	"Notes from {{FILENAMECURRENT}}",
+	"Filed under {{FOLDER}}",
+	"{{FOLDER|name}} - {{VALUE:title}}",
 	"{{MACRO:Generate summary}}",
 	"{{MACRO:Choose project|label:Project}}",
 	"{{TEMPLATE:Templates/Meeting.md}}",
@@ -122,6 +124,7 @@ class DocsExampleFormatter extends Formatter {
 			}),
 		};
 		this.variables.set("title", "Project Update");
+		this.setTargetFolderPath("Projects/Acme");
 	}
 
 	public async render(input: string): Promise<string> {
@@ -143,6 +146,7 @@ class DocsExampleFormatter extends Formatter {
 		output = await this.replaceMathValueInString(output);
 		output = await this.replaceLinkToCurrentFileInString(output);
 		output = await this.replaceCurrentFileNameInString(output);
+		output = this.replaceTargetFolderInString(output);
 		output = this.replaceRandomInString(output);
 		output = this.replaceTitleInString(output);
 		return output;

--- a/src/formatters/formatter-folder.test.ts
+++ b/src/formatters/formatter-folder.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { Formatter } from "./formatter";
+
+class StubFormatter extends Formatter {
+  constructor() {
+    super();
+  }
+
+  protected async format(input: string): Promise<string> {
+    return input;
+  }
+
+  protected getCurrentFileLink(): string | null {
+    return null;
+  }
+
+  protected getCurrentFileName(): string | null {
+    return null;
+  }
+
+  protected async promptForValue(): Promise<string> {
+    return "";
+  }
+
+  protected async promptForMathValue(): Promise<string> {
+    return "";
+  }
+
+  protected getVariableValue(_variableName: string): string {
+    return "";
+  }
+
+  protected async suggestForValue(): Promise<string> {
+    return "";
+  }
+
+  protected async suggestForField(): Promise<string> {
+    return "";
+  }
+
+  protected async getMacroValue(): Promise<string> {
+    return "";
+  }
+
+  protected async promptForVariable(): Promise<string> {
+    return "";
+  }
+
+  protected async getTemplateContent(): Promise<string> {
+    return "";
+  }
+
+  protected async getSelectedText(): Promise<string> {
+    return "";
+  }
+
+  protected async getClipboardContent(): Promise<string> {
+    return "";
+  }
+
+  protected isTemplatePropertyTypesEnabled(): boolean {
+    return false;
+  }
+
+  public process(input: string): string {
+    return this.replaceTargetFolderInString(input);
+  }
+}
+
+describe("Formatter {{FOLDER}} token", () => {
+  it("resolves {{FOLDER}} to the full target folder path", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("Projects/Acme");
+    expect(formatter.process("Filed under {{FOLDER}}")).toBe(
+      "Filed under Projects/Acme",
+    );
+  });
+
+  it("resolves {{FOLDER|name}} to the leaf folder segment", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("Projects/Acme");
+    expect(formatter.process("{{FOLDER|name}} - note")).toBe("Acme - note");
+  });
+
+  it("resolves {{FOLDER}} to an empty string when no target folder is set", () => {
+    const formatter = new StubFormatter();
+    expect(formatter.process("a/{{FOLDER}}b")).toBe("a/b");
+  });
+
+  it("treats a single-segment folder name as both full path and leaf", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("Meetings");
+    expect(formatter.process("{{FOLDER}}|{{FOLDER|name}}")).toBe(
+      "Meetings|Meetings",
+    );
+  });
+
+  it("normalizes the vault root '/' to an empty string", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("/");
+    expect(formatter.process("[{{FOLDER}}]")).toBe("[]");
+  });
+
+  it("strips leading and trailing slashes from the target folder", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("/A/B/");
+    expect(formatter.process("{{FOLDER}}")).toBe("A/B");
+    expect(formatter.process("{{FOLDER|name}}")).toBe("B");
+  });
+
+  it("is case-insensitive for the token and the modifier", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("Projects/Acme");
+    expect(formatter.process("{{folder}} / {{FOLDER|NAME}}")).toBe(
+      "Projects/Acme / Acme",
+    );
+  });
+
+  it("replaces multiple occurrences in one pass", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("Inbox");
+    expect(formatter.process("{{FOLDER}}-{{FOLDER}}")).toBe("Inbox-Inbox");
+  });
+
+  it("treats '$' in a folder name literally (no regex re-expansion)", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("Cash$Money");
+    expect(formatter.process("{{FOLDER}}")).toBe("Cash$Money");
+  });
+
+  it("clears the target folder when set to null", () => {
+    const formatter = new StubFormatter();
+    formatter.setTargetFolderPath("Projects");
+    formatter.setTargetFolderPath(null);
+    expect(formatter.process("x{{FOLDER}}y")).toBe("xy");
+  });
+});

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -5,6 +5,7 @@ import {
 	DATE_VARIABLE_REGEX,
 	LINK_TO_CURRENT_FILE_REGEX,
 	FILE_NAME_OF_CURRENT_FILE_REGEX,
+	TARGET_FOLDER_REGEX,
 	MACRO_REGEX,
 	MATH_VALUE_REGEX,
 	NAME_VALUE_REGEX,
@@ -65,6 +66,11 @@ export abstract class Formatter {
 	protected variables: Map<string, unknown> = new Map<string, unknown>();
 	protected dateParser: IDateParser | undefined;
 	private linkToCurrentFileBehavior: LinkToCurrentFileBehavior = "required";
+	// The folder the note is being created in, supplied by the engine before
+	// formatting a file name / body. `null` means "no target folder known"
+	// (e.g. the QuickAdd API, the capture "Capture to" field) — {{FOLDER}}
+	// then resolves to an empty string rather than throwing.
+	protected targetFolderPath: string | null = null;
 	protected valuePromptContext?: PromptContext;
 	protected templateInclusion?: TemplateInclusionState;
 
@@ -312,6 +318,42 @@ export abstract class Formatter {
 
 	public setLinkToCurrentFileBehavior(behavior: LinkToCurrentFileBehavior) {
 		this.linkToCurrentFileBehavior = behavior;
+	}
+
+	/**
+	 * Records the folder the note is being created in so {{FOLDER}} can resolve
+	 * to it. The path is normalized to a clean vault-relative form: leading and
+	 * trailing slashes are stripped and the Obsidian vault root ("/" or "")
+	 * collapses to an empty string. Pass `null` to clear it.
+	 */
+	public setTargetFolderPath(path: string | null): void {
+		if (path == null) {
+			this.targetFolderPath = null;
+			return;
+		}
+		const trimmed = path.trim();
+		this.targetFolderPath =
+			trimmed === "/" ? "" : trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
+	}
+
+	/**
+	 * Resolves {{FOLDER}} to the target folder's vault-relative path, and
+	 * {{FOLDER|name}} to just its leaf segment. Uses a replacer function so any
+	 * `$` in a folder name is treated literally (consistent with the other
+	 * tokens). Runs as a contextual pass (from formatFileName / formatFileContent
+	 * / formatFolderPath), not from the core format() pipeline. When no target
+	 * folder is known it resolves to an empty string (matching runtime in the
+	 * capture "Capture to" field, the API, and macro paths).
+	 */
+	protected replaceTargetFolderInString(input: string): string {
+		const fullPath = this.targetFolderPath ?? "";
+		const slashIndex = fullPath.lastIndexOf("/");
+		const leafName =
+			slashIndex === -1 ? fullPath : fullPath.slice(slashIndex + 1);
+		const regex = new RegExp(TARGET_FOLDER_REGEX.source, "gi");
+		return input.replace(regex, (_match, modifier) =>
+			modifier ? leafName : fullPath,
+		);
 	}
 
 	/**

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -9,7 +9,6 @@ import {
 	LINKCURRENT_SYNTAX_SUGGEST_REGEX,
 	FILENAMECURRENT_SYNTAX,
 	FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
-	FOLDER_SYNTAX,
 	FOLDER_SYNTAX_SUGGEST_REGEX,
 	MACRO_SYNTAX_SUGGEST_REGEX,
 	MATH_VALUE_SYNTAX,
@@ -167,15 +166,19 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 		},
 	];
 
-	// Shown only in the file-name context (suggestForFileNames). {{FOLDER}} is
-	// the target folder the note is created in — meaningful in a Template file
-	// name, but not in the capture "Capture to" field (where it would resolve to
-	// empty), so it is deliberately kept out of the always-shown definitions.
+	// Shown only in the file-name context (suggestForFileNames). The target
+	// folder is meaningful in a Template file name, but the LEAF form is offered
+	// here: the bare {{FOLDER}} expands to the full path, so `{{FOLDER}} - Note`
+	// with a nested target like Projects/Acme would yield
+	// `Projects/Acme/Projects/Acme - Note.md`. {{FOLDER|name}} avoids that
+	// duplicated-segment footgun. {{FOLDER}} is kept out of the always-shown
+	// definitions because it would resolve to "" in the capture "Capture to"
+	// field.
 	private readonly fileNameTokens: TokenDefinition[] = [
 		{
 			regex: FOLDER_SYNTAX_SUGGEST_REGEX,
 			token: FormatSyntaxToken.FolderTarget,
-			suggestion: FOLDER_SYNTAX,
+			suggestion: "{{folder|name}}",
 		},
 	];
 

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -9,6 +9,8 @@ import {
 	LINKCURRENT_SYNTAX_SUGGEST_REGEX,
 	FILENAMECURRENT_SYNTAX,
 	FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
+	FOLDER_SYNTAX,
+	FOLDER_SYNTAX_SUGGEST_REGEX,
 	MACRO_SYNTAX_SUGGEST_REGEX,
 	MATH_VALUE_SYNTAX,
 	MATH_VALUE_SYNTAX_SUGGEST_REGEX,
@@ -42,6 +44,7 @@ enum FormatSyntaxToken {
 	Variable,
 	LinkCurrent,
 	FilenameCurrent,
+	FolderTarget,
 	Macro,
 	Template,
 	MathValue,
@@ -164,6 +167,18 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 		},
 	];
 
+	// Shown only in the file-name context (suggestForFileNames). {{FOLDER}} is
+	// the target folder the note is created in — meaningful in a Template file
+	// name, but not in the capture "Capture to" field (where it would resolve to
+	// empty), so it is deliberately kept out of the always-shown definitions.
+	private readonly fileNameTokens: TokenDefinition[] = [
+		{
+			regex: FOLDER_SYNTAX_SUGGEST_REGEX,
+			token: FormatSyntaxToken.FolderTarget,
+			suggestion: FOLDER_SYNTAX,
+		},
+	];
+
 	constructor(
 		public app: App,
 		public inputEl: HTMLInputElement | HTMLTextAreaElement,
@@ -234,7 +249,7 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 		// Check all token definitions
 		const allTokens = [
 			...this.tokenDefinitions,
-			...(this.suggestForFileNames ? [] : this.contextualTokens)
+			...(this.suggestForFileNames ? this.fileNameTokens : this.contextualTokens)
 		];
 
 		for (const tokenDef of allTokens) {
@@ -326,7 +341,7 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 	}
 
 	private getTokenDefinition(token: FormatSyntaxToken): TokenDefinition | undefined {
-		return [...this.tokenDefinitions, ...this.contextualTokens]
+		return [...this.tokenDefinitions, ...this.contextualTokens, ...this.fileNameTokens]
 			.find(def => def.token === token);
 	}
 }

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -5,3 +5,13 @@ export function basenameWithoutMdOrCanvas(path: string): string {
   const base = normalized.split('/').pop() ?? '';
   return base.replace(/\.(md|canvas|base)$/i, '');
 }
+
+/**
+ * Returns the parent folder of a vault file path as a clean vault-relative
+ * path (no trailing slash). A file at the vault root yields an empty string.
+ */
+export function parentFolderPath(path: string): string {
+  const normalized = normalizePath(path);
+  const slashIndex = normalized.lastIndexOf('/');
+  return slashIndex === -1 ? '' : normalized.slice(0, slashIndex);
+}


### PR DESCRIPTION
Closes #1258

## Summary
Adds a `{{FOLDER}}` format token that resolves to the **target folder** a note is being created in (vault-relative path; the vault root resolves to `""`), plus a `{{FOLDER|name}}` modifier that yields just the **leaf** folder segment.

- **Full path** (`{{FOLDER}}`) is the primitive for note bodies (e.g. `folder: {{FOLDER}}`, breadcrumbs).
- **Leaf** (`{{FOLDER|name}}`) is what you want when reflecting the folder *in a file name* (e.g. `{{FOLDER|name}} - {{VALUE}}`).

### Where it resolves
| Context | Value |
|---|---|
| Template choice — file name & body | the resolved target folder (known before the name is formatted) |
| Capture — body (incl. *create with template* and `{{TEMPLATE:...}}` includes) | the destination file's folder |
| Apply template to a note | the note's own folder |
| Capture **"Capture to"** field, `quickAddApi.format()`, macro file paths, folder definitions | `""` (degrades cleanly — never throws, never leaks the literal token) |

Autocomplete offers `{{FOLDER}}` **only** in the file-name context, so it never appears in fields where it would resolve empty.

## Design & review
Design was drafted, then run through an ultracode review + 2 adversarial reviewers, then implemented to the agreed v1 scope (`{{FOLDER}}` + `|name`; deferred `{{FOLDERCURRENT}}` and a 3-way suggester context). After implementation, a 3-lens adversarial review (Skeptic / Architect / Minimalist) surfaced and fixed:
- `{{FOLDER}}` was lost inside `{{TEMPLATE:...}}` includes (child engine now receives the folder).
- apply-template's move-offer reused stale folder state (`computeChoiceTargetPath` now manages it explicitly).
- removed the token pass from insert-after/before **selectors** (out of scope + empty-match footgun).
- dropped a misleading preview placeholder (previews now match runtime).

## Verification
- `pnpm run test` — **1827 passed**, 31 skipped. Lint + `tsc --noEmit` clean.
- New tests: token/leaf/root-normalization/`$`-literal, real-`CaptureChoiceFormatter` body resolution, `{{TEMPLATE}}` propagation, apply-template stale-state regression, and docs-example coverage.
- **End-to-end in the dev vault** (real Obsidian): a Template choice with folder `e2e/Projects/Acme`, file name `{{FOLDER|name}} note`, body `Folder: {{FOLDER}}` / `Name: {{FOLDER|name}}` created `e2e/Projects/Acme/Acme note.md` containing `Folder: e2e/Projects/Acme` / `Name: Acme`. No runtime errors; `format()` with no target resolved to `""`.

## Release / migration impact
- `feat:` — minor version bump via semantic-release. Purely additive; no migration. No changes to `manifest.json`/`versions.json` (release-time only).
- Docs updated in `docs/docs/FormatSyntax.md` (current/"Next" docs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added {{FOLDER}} token and {{FOLDER|name}} modifier for templates, captures, and filename formatting.
  * Filename/preview formatting now resolves folder placeholders so previews match actual outputs.
  * Filename suggestion behavior updated to include folder-target tokens.

* **Documentation**
  * Added usage notes and examples; {{FOLDER}} becomes empty at vault root and |name yields the final path segment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->