### PR TITLE
feat(prompt): insert tab character in multi-line input prompt (#764)

### DIFF
--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.test.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.test.ts
@@ -104,6 +104,14 @@ describe("GenericWideInputPrompt - Escape Backslashes", () => {
 			const result = prompt.escapeBackslashes(input);
 			expect(result).toBe("Line1\nLine2\nLine3");
 		});
+
+		it("should not affect literal tab characters (issue #764)", () => {
+			// A real tab (0x09) inserted via Tab is not a backslash, so it passes
+			// through untouched and renders as indentation in the capture.
+			const input = "- item\n\tsub-item";
+			const result = prompt.escapeBackslashes(input);
+			expect(result).toBe("- item\n\tsub-item");
+		});
 	});
 
 	describe("Issue #799 test case", () => {

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -5,6 +5,7 @@ import { TagSuggester } from "../suggesters/tagSuggester";
 import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
 import type { InputPromptOptions } from "../../types/inputPrompt";
 import { positionInputPromptCursor } from "../inputPromptCursor";
+import { attachTextareaIndent } from "../components/textareaIndent";
 
 export default class GenericWideInputPrompt extends Modal {
 	public waitForClose: Promise<string>;
@@ -19,6 +20,7 @@ export default class GenericWideInputPrompt extends Modal {
 	private readonly description?: string;
 	private fileSuggester: FileSuggester;
 	private tagSuggester: TagSuggester;
+	private disposeIndent?: () => void;
 
 	public static Prompt(
 		app: App,
@@ -142,6 +144,9 @@ export default class GenericWideInputPrompt extends Modal {
 			.onChange((value) => this.onInputChanged(value))
 			.inputEl.addEventListener("keydown", this.submitEnterCallback);
 
+		// Tab inserts a tab / indents instead of moving focus (issue #764).
+		this.disposeIndent = attachTextareaIndent(textComponent.inputEl);
+
 		return textComponent;
 	}
 
@@ -258,6 +263,7 @@ export default class GenericWideInputPrompt extends Modal {
 			"keydown",
 			this.submitEnterCallback,
 		);
+		this.disposeIndent?.();
 	}
 
 	onOpen() {

--- a/src/gui/components/textareaIndent.test.ts
+++ b/src/gui/components/textareaIndent.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+	computeIndentEdit,
+	applyIndentEdit,
+	attachTextareaIndent,
+} from "./textareaIndent";
+
+const TAB = "\t";
+
+/** Apply a computed edit to a plain string the same way the DOM applier does. */
+function applyToString(value: string, selStart: number, selEnd: number): string {
+	const edit = computeIndentEdit(value, selStart, selEnd);
+	return (
+		value.slice(0, edit.regionStart) +
+		edit.replacement +
+		value.slice(edit.regionEnd)
+	);
+}
+
+describe("computeIndentEdit", () => {
+	describe("collapsed caret — insert a tab", () => {
+		it("inserts at the caret in the middle of a line", () => {
+			const edit = computeIndentEdit("alpha", 2, 2);
+			expect(edit.replacement).toBe(TAB);
+			expect(edit.regionStart).toBe(2);
+			expect(edit.regionEnd).toBe(2);
+			expect(edit.selectionStart).toBe(3);
+			expect(edit.selectionEnd).toBe(3);
+			expect(applyToString("alpha", 2, 2)).toBe("al\tpha");
+		});
+
+		it("inserts at the start (caret 0)", () => {
+			expect(applyToString("alpha", 0, 0)).toBe("\talpha");
+		});
+
+		it("inserts at the end", () => {
+			expect(applyToString("alpha", 5, 5)).toBe("alpha\t");
+		});
+
+		it("inserts into an empty value", () => {
+			const edit = computeIndentEdit("", 0, 0);
+			expect(edit.replacement).toBe(TAB);
+			expect(applyToString("", 0, 0)).toBe("\t");
+		});
+
+		it("honours a custom tab string", () => {
+			const edit = computeIndentEdit("ab", 1, 1, { tab: "  " });
+			expect(edit.replacement).toBe("  ");
+			expect(edit.selectionStart).toBe(3);
+		});
+	});
+
+	describe("selection — block-indent, never destroy", () => {
+		it("indents a single fully-selected line instead of replacing it", () => {
+			// The wide prompt opens with the whole value selected; the first Tab
+			// must not wipe it.
+			expect(applyToString("alpha", 0, 5)).toBe("\talpha");
+		});
+
+		it("indents a within-line selection's line (no data loss)", () => {
+			expect(applyToString("alpha", 1, 3)).toBe("\talpha");
+		});
+
+		it("indents every line of a multi-line selection", () => {
+			expect(applyToString("a\nb\nc", 0, 5)).toBe("\ta\n\tb\n\tc");
+		});
+
+		it("indents from the start of the first touched line even if selection starts mid-line", () => {
+			// value: "a\nbcd", select "cd" (indices 3..5) -> still indents the whole "bcd" line
+			expect(applyToString("a\nbcd", 3, 5)).toBe("a\n\tbcd");
+		});
+
+		it("does NOT indent the next line when the selection ends on a newline", () => {
+			// select "a\n" (indices 0..2) in "a\nb" -> only line "a" is indented
+			expect(applyToString("a\nb", 0, 2)).toBe("\ta\nb");
+		});
+
+		it("does NOT indent the trailing unselected line for a multi-line selection ending at a line start", () => {
+			// select "a\nb\n" (0..4) in "a\nb\nc" -> indent a and b, not c
+			expect(applyToString("a\nb\nc", 0, 4)).toBe("\ta\n\tb\nc");
+		});
+
+		it("indents interior blank lines but not a trailing empty segment", () => {
+			expect(applyToString("a\n\nb", 0, 4)).toBe("\ta\n\t\n\tb");
+		});
+
+		it("indents the leading line when the value starts with a newline (selStart 0)", () => {
+			// Regression: lastIndexOf("\n", -1) clamps to 0 and would match the
+			// leading newline, dropping the first (blank) line from the region.
+			expect(applyToString("\nabc", 0, 4)).toBe("\t\n\tabc");
+		});
+
+		it("handles selecting only a leading newline", () => {
+			const edit = computeIndentEdit("\nabc", 0, 1);
+			expect(edit.regionStart).toBe(0);
+			expect(applyToString("\nabc", 0, 1)).toBe("\t\nabc");
+		});
+
+		it("treats CRLF \\r as an ordinary character (offsets stay aligned)", () => {
+			// "a\r\nb": select all (0..4). lastIndexOf finds the \n; \r rides along on its line.
+			expect(applyToString("a\r\nb", 0, 4)).toBe("\ta\r\n\tb");
+		});
+
+		it("shifts the selection to cover the same text after indenting", () => {
+			const edit = computeIndentEdit("a\nb", 0, 3); // select "a\nb"
+			expect(edit.regionStart).toBe(0);
+			expect(edit.regionEnd).toBe(3);
+			expect(edit.replacement).toBe("\ta\n\tb");
+			expect(edit.selectionStart).toBe(1); // 0 + one tab
+			expect(edit.selectionEnd).toBe(5); // 3 + two tabs
+		});
+	});
+});
+
+describe("applyIndentEdit (jsdom fallback path)", () => {
+	let textarea: HTMLTextAreaElement;
+
+	beforeEach(() => {
+		textarea = document.createElement("textarea");
+		document.body.appendChild(textarea);
+	});
+
+	it("inserts the tab and fires an input event (keeps onChange in sync)", () => {
+		textarea.value = "alpha";
+		textarea.setSelectionRange(2, 2);
+		let inputFired = 0;
+		textarea.addEventListener("input", () => inputFired++);
+
+		applyIndentEdit(textarea, computeIndentEdit("alpha", 2, 2));
+
+		expect(textarea.value).toBe("al\tpha");
+		expect(inputFired).toBe(1);
+		expect(textarea.selectionStart).toBe(3);
+		expect(textarea.selectionEnd).toBe(3);
+	});
+
+	it("block-indents a selection without destroying it", () => {
+		textarea.value = "a\nb";
+		textarea.setSelectionRange(0, 3);
+		applyIndentEdit(textarea, computeIndentEdit("a\nb", 0, 3));
+		expect(textarea.value).toBe("\ta\n\tb");
+	});
+});
+
+describe("attachTextareaIndent", () => {
+	let textarea: HTMLTextAreaElement;
+	let dispose: () => void;
+
+	function dispatch(opts: Partial<KeyboardEventInit>) {
+		const evt = new KeyboardEvent("keydown", {
+			bubbles: true,
+			cancelable: true,
+			...opts,
+		});
+		textarea.dispatchEvent(evt);
+		return evt;
+	}
+
+	const pressTab = (opts: Partial<KeyboardEventInit> = {}) =>
+		dispatch({ key: "Tab", ...opts });
+
+	beforeEach(() => {
+		textarea = document.createElement("textarea");
+		document.body.appendChild(textarea);
+		dispose = attachTextareaIndent(textarea);
+	});
+
+	it("inserts a tab on plain Tab and prevents default", () => {
+		textarea.value = "alpha";
+		textarea.setSelectionRange(5, 5);
+		const evt = pressTab();
+		expect(evt.defaultPrevented).toBe(true);
+		expect(textarea.value).toBe("alpha\t");
+	});
+
+	it("ignores Shift+Tab so focus navigation still works", () => {
+		textarea.value = "alpha";
+		textarea.setSelectionRange(5, 5);
+		const evt = pressTab({ shiftKey: true });
+		expect(evt.defaultPrevented).toBe(false);
+		expect(textarea.value).toBe("alpha");
+	});
+
+	it.each([
+		["ctrlKey", { ctrlKey: true }],
+		["metaKey", { metaKey: true }],
+		["altKey", { altKey: true }],
+	])("ignores Tab with %s held", (_label, mods) => {
+		textarea.value = "x";
+		textarea.setSelectionRange(1, 1);
+		const evt = pressTab(mods);
+		expect(evt.defaultPrevented).toBe(false);
+		expect(textarea.value).toBe("x");
+	});
+
+	it("ignores non-Tab keys", () => {
+		textarea.value = "x";
+		textarea.setSelectionRange(1, 1);
+		const evt = dispatch({ key: "a" });
+		expect(evt.defaultPrevented).toBe(false);
+		expect(textarea.value).toBe("x");
+	});
+
+	it("stops inserting after the disposer runs (idempotent)", () => {
+		textarea.value = "x";
+		textarea.setSelectionRange(1, 1);
+		dispose();
+		dispose(); // idempotent — must not throw
+		const evt = pressTab();
+		expect(evt.defaultPrevented).toBe(false);
+		expect(textarea.value).toBe("x");
+	});
+});

--- a/src/gui/components/textareaIndent.ts
+++ b/src/gui/components/textareaIndent.ts
@@ -1,0 +1,163 @@
+/**
+ * Tab-to-indent for multi-line text fields (issue #764).
+ *
+ * A plain textarea lets the browser move focus on Tab, so users can't indent to
+ * build markdown sublists. {@link attachTextareaIndent} captures Tab and inserts
+ * a tab character instead. The transform is split into a pure, unit-testable
+ * {@link computeIndentEdit} (no DOM) and a thin DOM applier so the host textarea
+ * keeps native undo and fires a real `input` event (so onChange/draft/validation
+ * stay in sync).
+ *
+ * Scope is deliberately minimal: only Tab is captured. Shift+Tab is left alone so
+ * it still moves focus — that keeps both surfaces free of any keyboard trap.
+ */
+
+const DEFAULT_TAB = "\t";
+
+export interface IndentEdit {
+	/** Region of the current value to replace (applied via one undoable edit). */
+	regionStart: number;
+	regionEnd: number;
+	/** Text the region is replaced with. */
+	replacement: string;
+	/** Where the selection should land afterward. */
+	selectionStart: number;
+	selectionEnd: number;
+}
+
+/**
+ * Compute the edit for pressing Tab with the given selection.
+ *
+ * - Collapsed caret: insert a single tab at the caret.
+ * - Any selection: block-indent every line the selection touches. We never
+ *   replace the selected text with a single tab — that would lose data (the wide
+ *   prompt opens with its whole value selected, so the first Tab would wipe it).
+ */
+export function computeIndentEdit(
+	value: string,
+	selStart: number,
+	selEnd: number,
+	opts: { tab?: string } = {},
+): IndentEdit {
+	const tab = opts.tab ?? DEFAULT_TAB;
+
+	if (selStart === selEnd) {
+		const caret = selStart + tab.length;
+		return {
+			regionStart: selStart,
+			regionEnd: selStart,
+			replacement: tab,
+			selectionStart: caret,
+			selectionEnd: caret,
+		};
+	}
+
+	// Block-indent: grow the region back to the start of the first touched line so
+	// we prefix whole lines. The selStart === 0 guard is load-bearing: JS clamps a
+	// negative fromIndex to 0, so lastIndexOf("\n", -1) would match a leading "\n"
+	// at index 0 and push firstLineStart to 1, dropping the first line.
+	const firstLineStart =
+		selStart === 0 ? 0 : value.lastIndexOf("\n", selStart - 1) + 1;
+	const region = value.slice(firstLineStart, selEnd);
+	const segments = region.split("\n");
+	const lastIndex = segments.length - 1;
+
+	let added = 0;
+	const indented = segments.map((segment, i) => {
+		// A trailing empty segment is the start of the line AFTER the selection
+		// (the selection ended on a newline) — the user didn't select it, so leave
+		// it alone instead of indenting the next line.
+		if (i === lastIndex && segment === "") return segment;
+		added += tab.length;
+		return tab + segment;
+	});
+
+	return {
+		regionStart: firstLineStart,
+		regionEnd: selEnd,
+		replacement: indented.join("\n"),
+		// Keep the user's selection over the same text, shifted by the inserted
+		// tabs. The first touched line always gets a tab at/<= selStart.
+		selectionStart: selStart + tab.length,
+		selectionEnd: selEnd + added,
+	};
+}
+
+/** Apply an {@link IndentEdit} to a textarea, preserving native undo when possible. */
+export function applyIndentEdit(
+	inputEl: HTMLTextAreaElement,
+	edit: IndentEdit,
+): void {
+	inputEl.setSelectionRange(edit.regionStart, edit.regionEnd);
+
+	const doc = inputEl.ownerDocument;
+	let inserted = false;
+	try {
+		// execCommand is the only way to mutate a textarea while keeping the native
+		// undo stack (one step) and firing a trusted input event. It is deprecated
+		// but fully supported in Obsidian's Electron/Chromium runtime.
+		inserted =
+			typeof doc.execCommand === "function" &&
+			doc.execCommand("insertText", false, edit.replacement);
+	} catch {
+		inserted = false;
+	}
+
+	if (!inserted) {
+		// Fallback for runtimes without execCommand (e.g. jsdom in tests). Native
+		// undo is lost, but onChange/draft stay in sync via the dispatched event.
+		// Restore the final selection BEFORE dispatching so any listener that reads
+		// the selection during `input` sees the settled state, not an interim one.
+		const value = inputEl.value;
+		inputEl.value =
+			value.slice(0, edit.regionStart) +
+			edit.replacement +
+			value.slice(edit.regionEnd);
+		inputEl.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+		inputEl.dispatchEvent(new Event("input", { bubbles: true }));
+		return;
+	}
+
+	inputEl.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+}
+
+/**
+ * Capture Tab on a textarea so it inserts/indents instead of moving focus.
+ * Returns a disposer that removes the listener (idempotent).
+ */
+export function attachTextareaIndent(
+	inputEl: HTMLTextAreaElement,
+	opts: { tab?: string } = {},
+): () => void {
+	const onKeyDown = (evt: KeyboardEvent) => {
+		// Only plain Tab. Shift+Tab keeps native focus traversal (no trap), and
+		// modifier combos stay reserved for OS/Obsidian shortcuts. Skip IME
+		// composition, and yield if an earlier listener already handled the event.
+		if (
+			evt.key !== "Tab" ||
+			evt.shiftKey ||
+			evt.ctrlKey ||
+			evt.metaKey ||
+			evt.altKey ||
+			evt.isComposing ||
+			evt.defaultPrevented
+		) {
+			return;
+		}
+
+		evt.preventDefault();
+
+		const start = inputEl.selectionStart ?? inputEl.value.length;
+		const end = inputEl.selectionEnd ?? start;
+		applyIndentEdit(inputEl, computeIndentEdit(inputEl.value, start, end, opts));
+	};
+
+	inputEl.addEventListener("keydown", onKeyDown);
+
+	let disposed = false;
+	return () => {
+		if (disposed) return;
+		disposed = true;
+		inputEl.removeEventListener("keydown", onKeyDown);
+	};
+}


### PR DESCRIPTION
## What & why

Pressing **Tab** in QuickAdd's multi-line ("wide") input prompt moved focus to the **Ok** button instead of indenting, so users couldn't build markdown sublists. Two commenters on #764 called the multi-line prompt *"completely useless for 80% of my use cases"* because of this.

This captures Tab on the prompt's textarea and inserts a tab instead.

## Behavior

- **Plain Tab** → insert `\t` at the caret. With a selection, **block-indent every touched line** (never replaces the selection — the prompt opens with its whole value selected, so a naive replace would wipe it).
- **Shift+Tab is intentionally *not* captured** → it keeps native focus navigation, so the field is **not** a keyboard trap (WCAG 2.1.2). Esc still cancels, Ctrl/Cmd+Enter still submits.
- Applied via `ownerDocument.execCommand("insertText")` to preserve **one-step native undo** and fire a real `input` event (so `onChange`/draft/validation stay in sync), with a value-assign fallback for runtimes without `execCommand` (e.g. jsdom).
- Single-line prompt (`GenericInputPrompt`, an `<input>`) is unchanged — Tab-to-next is correct there. Follows the existing in-repo pattern (`MathModal` already captures Tab on a textarea-with-suggester).

The transform lives in a pure, unit-tested helper: `src/gui/components/textareaIndent.ts`.

## Scope note

Issue #764 spans two surfaces: the **runtime multi-line prompt** (the commenters' daily pain, fixed here) and the **Capture-format config field** (the OP's literal "tab in the Capture Format"). The format field sits in a multi-field settings modal where capturing Tab is a real focus-trap risk; the clean path there is **not** Tab-capture but a `\t`→tab escape token in the formatter (it already expands `\n`→newline and `\\`→`\`; `\t` just falls through). That's a small, separate follow-up — tracked outside this issue.

## Verification

- **Unit:** new `textareaIndent.test.ts` (block-indent, boundary/leading-newline/CRLF cases, fallback path, modifier/composition guards). Full suite **1886 pass**; `tsc` + ESLint clean.
- **Dev-vault e2e (trusted CDP keys):** collapsed insert; multi-line block-indent; select-all-on-open + Tab is non-destructive; one-step undo; Shift+Tab moves focus (no trap); Ctrl/Cmd+Enter submits; Esc cancels; a **real capture wrote `- parent⇥- child`** (literal tab) to a note.
- Design + implementation each went through an adversarial review on the opposing model; the leading-newline `lastIndexOf` off-by-one it caught is fixed and covered by a regression test.

Closes #764