### PR TITLE
fix(capture): find multi-line insert-after/before targets instead of duplicating them

### DIFF
--- a/src/formatters/capture-insert-after-linkcurrent.test.ts
+++ b/src/formatters/capture-insert-after-linkcurrent.test.ts
@@ -21,13 +21,12 @@ async function replaceLinkToCurrentFileInString(
   return output;
 }
 
-// Helper mirroring CaptureChoiceFormatter logic for finding insertion index
-function normalizeTarget(target: string): string {
-  return target.replace('\\n', '').trimEnd();
-}
-
+// Helper mirroring CaptureChoiceFormatter.findSingleLineIndex (single-line
+// matching). `\n` escapes are expanded upstream in the real formatter before
+// search (issue #742), so there is no escape-stripping here — only a trimEnd,
+// matching production exactly. These cases use single-line, escape-free targets.
 function findInsertAfterIndex(lines: string[], rawTarget: string): number {
-  const target = normalizeTarget(rawTarget);
+  const target = rawTarget.trimEnd();
   let partialIndex = -1;
 
   for (let i = 0; i < lines.length; i++) {

--- a/src/formatters/captureChoiceFormatter-742-multiline-insert.test.ts
+++ b/src/formatters/captureChoiceFormatter-742-multiline-insert.test.ts
@@ -1,0 +1,369 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+
+// Mocks mirror captureChoiceFormatter-linebreak.test.ts so the formatter can run
+// under jsdom without real Obsidian/Templater.
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory() {
+			return {
+				Prompt: vi.fn().mockResolvedValue(""),
+				PromptWithContext: vi.fn().mockResolvedValue(""),
+			} as any;
+		}
+	},
+}));
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: class {
+		constructor() {}
+	},
+}));
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../utils/errorUtils", () => ({
+	__esModule: true,
+	reportError: vi.fn(),
+	isCancellationError: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+	},
+}));
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+vi.mock("../main", () => ({
+	__esModule: true,
+	default: class QuickAdd {
+		static instance = {
+			settings: { inputPrompt: "single-line" },
+			app: {
+				workspace: { getActiveViewOfType: vi.fn().mockReturnValue(null) },
+			},
+		};
+		settings = QuickAdd.instance.settings;
+		app = QuickAdd.instance.app;
+	},
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+const baseInsertAfter = {
+	enabled: true,
+	after: "",
+	insertAtEnd: true,
+	considerSubsections: false,
+	createIfNotFound: true,
+	createIfNotFoundLocation: "bottom",
+	inline: false,
+	replaceExisting: false,
+	blankLineAfterMatchMode: "auto" as const,
+};
+
+const createChoice = (
+	overrides: Partial<ICaptureChoice> = {},
+): ICaptureChoice =>
+	({
+		id: "test",
+		name: "Test Choice",
+		type: "Capture",
+		command: false,
+		captureTo: "Target.md",
+		captureToActiveFile: false,
+		captureToCanvasNodeId: "",
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: false,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: false, format: "" },
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: { ...baseInsertAfter },
+		insertBefore: {
+			enabled: false,
+			before: "",
+			createIfNotFound: false,
+			createIfNotFoundLocation: "top",
+		},
+		newLineCapture: { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: true,
+		},
+		...overrides,
+	}) as ICaptureChoice;
+
+const createMockApp = (): App =>
+	({
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(null),
+		},
+		metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		fileManager: {
+			generateMarkdownLink: vi.fn().mockReturnValue(""),
+			processFrontMatter: vi.fn(),
+		},
+		vault: { adapter: { exists: vi.fn() }, cachedRead: vi.fn() },
+	}) as unknown as App;
+
+const createFile = (path = "Target.md"): TFile =>
+	({
+		path,
+		name: path.split("/").pop() ?? path,
+		basename: (path.split("/").pop() ?? path).replace(/\.(md|canvas)$/i, ""),
+		extension: "md",
+	}) as unknown as TFile;
+
+const createFormatter = () =>
+	new CaptureChoiceFormatter(createMockApp(), {
+		settings: {
+			inputPrompt: "single-line",
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any);
+
+beforeEach(() => {
+	(global as any).navigator = {
+		clipboard: { readText: vi.fn().mockResolvedValue("") },
+	};
+});
+
+/**
+ * Runs the capture insert flow `n` times, feeding each run's output back as the
+ * next run's file content — exactly how repeated captures behave in Obsidian.
+ * A fresh formatter per run mirrors CaptureChoiceEngine (one formatter/capture).
+ */
+async function runCaptures(
+	choice: ICaptureChoice,
+	seed: string,
+	n: number,
+	capture = "- task\n",
+): Promise<string> {
+	let content = seed;
+	for (let i = 0; i < n; i++) {
+		const formatter = createFormatter();
+		content = await formatter.formatContentWithFile(
+			capture,
+			choice,
+			content,
+			createFile(),
+		);
+	}
+	return content;
+}
+
+const count = (haystack: string, needle: string) =>
+	haystack.split(needle).length - 1;
+
+describe("#742 — multi-line insert-after target + createIfNotFound must not duplicate the block", () => {
+	const SEED = "# Daily Notes\n";
+
+	it("does NOT duplicate a mid-newline multi-line block across runs", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, after: "**Today**\\n***" },
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "**Today**")).toBe(1);
+		expect(count(result, "***")).toBe(1);
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("does NOT duplicate a double-newline block across runs", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, after: "**Today**\\n\\n" },
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "**Today**")).toBe(1);
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("preserves single-trailing-newline behavior (control): 1 block", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, after: "**Today**\\n" },
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "**Today**")).toBe(1);
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("preserves single-line behavior (control): 1 block", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, after: "**Today**" },
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "**Today**")).toBe(1);
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("matches a heading-led multi-line block with an interior blank and keeps the blank", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, after: "## D\\n\\n**Tasks**" },
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "## D")).toBe(1);
+		expect(count(result, "**Tasks**")).toBe(1);
+		// Interior blank between heading and **Tasks** is required for the match
+		// and must survive every run.
+		expect(result).toContain("## D\n\n**Tasks**");
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("immediate-insert (insertAtEnd=false) finds the block and does not split it", async () => {
+		const choice = createChoice({
+			insertAfter: {
+				...baseInsertAfter,
+				after: "**Today**\\n***",
+				insertAtEnd: false,
+			},
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "**Today**")).toBe(1);
+		// Block stays contiguous (heading line immediately followed by ***).
+		expect(result).toContain("**Today**\n***");
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("does not false-match flat content for an indented multi-line target, and round-trips", async () => {
+		const choice = createChoice({
+			insertAfter: {
+				...baseInsertAfter,
+				after: "  - Parent\\n    - Child",
+				insertAtEnd: false,
+			},
+		});
+		// Pre-existing FLAT list that must NOT be treated as the indented anchor.
+		const seed = "# Notes\n- Parent\n- Child\n";
+		const result = await runCaptures(choice, seed, 2);
+		// The indented anchor is created (leading indentation is significant)...
+		expect(result).toContain("  - Parent\n    - Child");
+		// ...and found on run 2 (round-trip), so the 4-space child appears once.
+		expect(count(result, "    - Child")).toBe(1);
+		// The original flat block is left untouched.
+		expect(result).toContain("# Notes\n- Parent\n- Child");
+		expect(count(result, "- task")).toBe(2);
+	});
+
+	it("does not throw on considerSubsections + insertAtEnd with a non-heading multi-line anchor", async () => {
+		const choice = createChoice({
+			insertAfter: {
+				...baseInsertAfter,
+				after: "**Today**\\n***",
+				insertAtEnd: true,
+				considerSubsections: true,
+			},
+		});
+		// considerSubsections only applies to headings; a non-heading anchor must
+		// degrade gracefully instead of throwing in getEndOfSection (issue #742).
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "**Today**")).toBe(1);
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("still honors considerSubsections for a heading-led multi-line anchor", async () => {
+		const choice = createChoice({
+			insertAfter: {
+				...baseInsertAfter,
+				after: "## D\\n**Tasks**",
+				insertAtEnd: true,
+				considerSubsections: true,
+			},
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "## D")).toBe(1);
+		expect(count(result, "**Tasks**")).toBe(1);
+		expect(count(result, "- task")).toBe(3);
+	});
+
+	it("matches a CRLF file (trailing carriage returns are normalized)", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, after: "**Today**\\n***" },
+		});
+		// Pre-create the block with CRLF line endings; the LF target must still find it.
+		const seed = "# Daily Notes\r\n\r\n**Today**\r\n***\r\n";
+		const result = await runCaptures(choice, seed, 2);
+		expect(count(result, "**Today**")).toBe(1);
+		expect(count(result, "- task")).toBe(2);
+	});
+
+	it("aborts on an empty target instead of silently anchoring the top of the file", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, after: "" },
+		});
+		const formatter = createFormatter();
+		await expect(
+			formatter.formatContentWithFile("- task\n", choice, SEED, createFile()),
+		).rejects.toThrow();
+	});
+});
+
+describe("#742 — insert-before multi-line target + createIfNotFound", () => {
+	const SEED = "# Daily Notes\n";
+
+	it("anchors at the block start and does not duplicate or split across runs", async () => {
+		const choice = createChoice({
+			insertAfter: { ...baseInsertAfter, enabled: false },
+			insertBefore: {
+				enabled: true,
+				before: "**Today**\\n***",
+				createIfNotFound: true,
+				createIfNotFoundLocation: "bottom",
+			},
+		});
+		const result = await runCaptures(choice, SEED, 3);
+		expect(count(result, "**Today**")).toBe(1);
+		// The anchor block stays contiguous — capture lands before it, not inside.
+		expect(result).toContain("**Today**\n***");
+		expect(count(result, "- task")).toBe(3);
+	});
+});

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -12,7 +12,7 @@ import { templaterParseTemplate } from "../utilityObsidian";
 import { reportError } from "../utils/errorUtils";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { CompleteFormatter } from "./completeFormatter";
-import getEndOfSection from "./helpers/getEndOfSection";
+import getEndOfSection, { getMarkdownHeadings } from "./helpers/getEndOfSection";
 import { findYamlFrontMatterRange } from "../utils/yamlContext";
 import { parentFolderPath } from "../utils/pathUtils";
 
@@ -232,12 +232,57 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		return this.expandLinebreakEscapesOutsideTokens(withGlobals);
 	}
 
-	private normalizeTarget(target: string): string {
-		return target.replace("\\n", "").trimEnd();
+	/**
+	 * Splits a fully-expanded insert target into the anchor lines used for
+	 * matching. `\n` escapes in the target have already been turned into real
+	 * newlines (symmetric with the create-if-not-found path, which writes the
+	 * same expansion to disk), so a multi-line target like `**Today**\n***`
+	 * becomes `["**Today**", "***"]`.
+	 *
+	 * Trailing blank lines come from a trailing `\n` escape and are not part of
+	 * the anchor, so they are dropped: `**Today**\n` and `**Today**\n\n` both
+	 * collapse to the single-line anchor `["**Today**"]`. Interior blank lines
+	 * are preserved so a `## D\n\n**Tasks**` anchor still requires the blank.
+	 */
+	private toTargetLines(expandedTarget: string): string[] {
+		const lines = expandedTarget.split("\n");
+		while (lines.length > 1 && lines[lines.length - 1].trim() === "") {
+			lines.pop();
+		}
+		return lines;
 	}
 
-	private findInsertAfterIndex(lines: string[], rawTarget: string): number {
-		const target = this.normalizeTarget(rawTarget);
+	private isBlankTarget(targetLines: string[]): boolean {
+		return (
+			targetLines.length === 0 ||
+			(targetLines.length === 1 && targetLines[0].trim() === "")
+		);
+	}
+
+	/**
+	 * Locates the insert target in the file. Returns the inclusive line range
+	 * `{ start, end }` the target occupies, or `{ start: -1, end: -1 }` when not
+	 * found. For a single-line target `start === end`, preserving historical
+	 * single-line behavior exactly. Callers pick which boundary to anchor on:
+	 * insert-after-immediate uses `end`, insert-before uses `start`,
+	 * insert-after-at-end derives the section end from `start` (issue #742).
+	 */
+	private findInsertAfterRange(
+		lines: string[],
+		targetLines: string[],
+	): { start: number; end: number } {
+		if (targetLines.length <= 1) {
+			const start = this.findSingleLineIndex(lines, targetLines[0] ?? "");
+			return { start, end: start };
+		}
+		return this.findMultiLineRange(lines, targetLines);
+	}
+
+	private findSingleLineIndex(lines: string[], rawTarget: string): number {
+		// `\n` escapes are already expanded upstream, so no escape stripping
+		// happens here — stripping would desync search from the create path,
+		// which writes the unstripped string (issue #742).
+		const target = rawTarget.trimEnd();
 		let partialIndex = -1;
 
 		for (let i = 0; i < lines.length; i++) {
@@ -281,8 +326,56 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		return partialIndex; // -1 if no match at all
 	}
 
-	private findInsertBeforeIndex(lines: string[], rawTarget: string): number {
-		return this.findInsertAfterIndex(lines, rawTarget);
+	/**
+	 * Matches a multi-line target as a consecutive run of file lines. Only
+	 * TRAILING whitespace is stripped before comparison (on both sides), which
+	 * normalizes CRLF carriage returns and trailing spaces while preserving
+	 * LEADING indentation — `  - Parent\n    - Child` must not match a flat
+	 * `- Parent\n- Child`. Because the create path writes the target verbatim,
+	 * an indented anchor still round-trips. No fuzzy/partial fallback: a
+	 * multi-line anchor must match verbatim to avoid false positives.
+	 */
+	private findMultiLineRange(
+		lines: string[],
+		targetLines: string[],
+	): { start: number; end: number } {
+		const n = targetLines.length;
+		const normalizedTargets = targetLines.map((line) =>
+			this.stripTrailingWhitespace(line),
+		);
+
+		for (let i = 0; i + n <= lines.length; i++) {
+			let matched = true;
+			for (let k = 0; k < n; k++) {
+				if (this.stripTrailingWhitespace(lines[i + k]) !== normalizedTargets[k]) {
+					matched = false;
+					break;
+				}
+			}
+			if (matched) return { start: i, end: i + n - 1 };
+		}
+
+		return { start: -1, end: -1 };
+	}
+
+	private stripTrailingWhitespace(line: string): string {
+		return line.replace(/\s+$/, "");
+	}
+
+	/**
+	 * `considerSubsections` only has meaning for a heading anchor — a non-heading
+	 * line has no section whose subsections could be included, and
+	 * getEndOfSection() throws if asked to consider subsections of a non-heading
+	 * line. Multi-line anchors made non-heading start lines newly matchable
+	 * (issue #742), so degrade to false when the anchor is not a heading
+	 * (using getEndOfSection's own heading definition) instead of throwing.
+	 */
+	private considerSubsectionsForAnchor(
+		lines: string[],
+		anchorLine: number,
+	): boolean {
+		if (!this.choice.insertAfter?.considerSubsections) return false;
+		return getMarkdownHeadings([lines[anchorLine] ?? ""]).length > 0;
 	}
 
 	private shouldSkipBlankLinesAfterMatch(
@@ -367,24 +460,38 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	private async insertAfterHandler(formatted: string) {
-		// Use centralized location formatting for selector strings
+		// Inline targets are single-line by definition and use a separate
+		// indexOf-based path; keep their selector unexpanded (out of scope #742).
+		if (this.choice.insertAfter?.inline) {
+			const inlineTarget: string = await this.formatLocationString(
+				this.choice.insertAfter.after,
+			);
+			return await this.insertAfterInlineHandler(formatted, inlineTarget);
+		}
+
+		// Expand `\n` escapes BEFORE searching so the search target is identical
+		// to what createInsertAfterIfNotFound writes to disk. Computed once and
+		// reused for the create path so the two can never diverge (issue #742).
 		const targetString: string = await this.formatLocationString(
-			this.choice.insertAfter.after,
+			await this.expandFormatTemplateEscapes(this.choice.insertAfter.after),
 		);
 
-		if (this.choice.insertAfter?.inline) {
-			return await this.insertAfterInlineHandler(formatted, targetString);
+		const targetLines = this.toTargetLines(targetString);
+		if (this.isBlankTarget(targetLines)) {
+			throw new ChoiceAbortError(
+				"Insert-after target is empty after formatting.",
+			);
 		}
 
 		const fileContentLines: string[] = getLinesInString(this.fileContent);
-		let targetPosition = this.findInsertAfterIndex(
+		const { start, end } = this.findInsertAfterRange(
 			fileContentLines,
-			targetString,
+			targetLines,
 		);
-		const targetNotFound = targetPosition === -1;
+		const targetNotFound = start === -1;
 		if (targetNotFound) {
 			if (this.choice.insertAfter?.createIfNotFound) {
-				return await this.createInsertAfterIfNotFound(formatted);
+				return await this.createInsertAfterIfNotFound(formatted, targetString);
 			}
 
 			throw new ChoiceAbortError(
@@ -392,27 +499,36 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			);
 		}
 
+		let targetPosition: number;
 		if (this.choice.insertAfter?.insertAtEnd) {
 			if (!this.file) throw new Error("Tried to get sections without file.");
 
+			// Anchor section detection on the block's first line (a heading there
+			// gets correct section semantics), then clamp to the block's last line
+			// so we never insert INSIDE the matched multi-line anchor.
 			const endOfSectionIndex = getEndOfSection(
 				fileContentLines,
-				targetPosition,
-				!!this.choice.insertAfter.considerSubsections,
+				start,
+				this.considerSubsectionsForAnchor(fileContentLines, start),
+			);
+			const sectionEnd = Math.max(
+				endOfSectionIndex ?? fileContentLines.length - 1,
+				end,
 			);
 
 			targetPosition = this.findInsertAfterPositionAtSectionEnd(
 				fileContentLines,
-				endOfSectionIndex ?? fileContentLines.length - 1,
+				sectionEnd,
 				this.fileContent,
 				formatted,
 			);
 		} else {
 			const blankLineMode =
 				this.choice.insertAfter?.blankLineAfterMatchMode ?? "auto";
+			// Insert after the block's last line; blank-line skipping keys off it.
 			targetPosition = this.findInsertAfterPositionWithBlankLines(
 				fileContentLines,
-				targetPosition,
+				end,
 				this.fileContent,
 				blankLineMode,
 			);
@@ -431,19 +547,27 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			throw new ChoiceAbortError("Insert-before settings are missing.");
 		}
 
+		// Expand `\n` escapes before searching (symmetric with the create path)
+		// and reuse the resolved string for create so they cannot diverge.
 		const targetString: string = await this.formatLocationString(
-			insertBefore.before,
+			await this.expandFormatTemplateEscapes(insertBefore.before),
 		);
 
+		const targetLines = this.toTargetLines(targetString);
+		if (this.isBlankTarget(targetLines)) {
+			throw new ChoiceAbortError(
+				"Insert-before target is empty after formatting.",
+			);
+		}
+
 		const fileContentLines: string[] = getLinesInString(this.fileContent);
-		const targetPosition = this.findInsertBeforeIndex(
-			fileContentLines,
-			targetString,
-		);
-		const targetNotFound = targetPosition === -1;
+		// Insert-before anchors on the block's FIRST line so the capture lands
+		// before the whole multi-line anchor (never inside it — issue #742).
+		const { start } = this.findInsertAfterRange(fileContentLines, targetLines);
+		const targetNotFound = start === -1;
 		if (targetNotFound) {
 			if (insertBefore.createIfNotFound) {
-				return await this.createInsertBeforeIfNotFound(formatted);
+				return await this.createInsertBeforeIfNotFound(formatted, targetString);
 			}
 
 			throw new ChoiceAbortError(
@@ -454,7 +578,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		return this.insertTextBeforePositionInBody(
 			formatted,
 			this.fileContent,
-			targetPosition,
+			start,
 		);
 	}
 
@@ -514,14 +638,14 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		);
 	}
 
-	private async createInsertAfterIfNotFound(formatted: string) {
-		// Build the line to insert using centralized location formatting.
-		// Linebreak escapes are expanded on the raw setting (with globals injected
-		// first), before substitution, so backslash sequences in substituted
-		// values stay verbatim (issue #527).
-		const insertAfterLine: string = await this.formatLocationString(
-			await this.expandFormatTemplateEscapes(this.choice.insertAfter.after),
-		);
+	private async createInsertAfterIfNotFound(
+		formatted: string,
+		insertAfterLine: string,
+	) {
+		// `insertAfterLine` is the resolved+escape-expanded target already computed
+		// by insertAfterHandler. Reusing it (rather than re-deriving) guarantees the
+		// created block is byte-identical to what the search will look for on the
+		// next run, which is the actual fix for the duplication (issues #742, #527).
 		const insertAfterLineAndFormatted = `${insertAfterLine}\n${formatted}`;
 
 		if (
@@ -569,7 +693,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 					const endOfSectionIndex = getEndOfSection(
 						fileContentLines,
 						targetPosition,
-						!!this.choice.insertAfter.considerSubsections,
+						this.considerSubsectionsForAnchor(fileContentLines, targetPosition),
 					);
 
 					targetPosition = this.findInsertAfterPositionAtSectionEnd(
@@ -599,15 +723,17 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		);
 	}
 
-	private async createInsertBeforeIfNotFound(formatted: string) {
+	private async createInsertBeforeIfNotFound(
+		formatted: string,
+		insertBeforeLine: string,
+	) {
 		const insertBefore = this.choice.insertBefore;
 		if (!insertBefore) {
 			throw new ChoiceAbortError("Insert-before settings are missing.");
 		}
 
-		const insertBeforeLine: string = await this.formatLocationString(
-			await this.expandFormatTemplateEscapes(insertBefore.before),
-		);
+		// `insertBeforeLine` is the resolved+escape-expanded target from
+		// insertBeforeHandler, reused so create and search stay byte-identical.
 		const formattedAndInsertBeforeLine =
 			formatted.endsWith("\n") || formatted.length === 0
 				? `${formatted}${insertBeforeLine}`


### PR DESCRIPTION
## Summary

Fixes #742. A Capture choice whose **insert after** (or **insert before**) target contains a newline escape (`\n`) — producing a *multi-line* block — combined with **Create line if not found** kept re-creating the block on every run instead of finding the existing block and appending under it.

### Root cause
The create-if-not-found path expanded `\n` escapes and wrote a multi-line block to disk, while the **search** path did *not* expand escapes and matched only single lines (`normalizeTarget` stripped just the first `\n`). A multi-line block could therefore never be re-found → recreated every run. A single *trailing* `\n` worked only by accident.

### Fix
Make the search target byte-identical to what the create path writes:
- Resolve the target **once** (`formatLocationString(expandFormatTemplateEscapes(after))`) and pass it into the create-if-not-found path — no re-derivation/drift.
- `toTargetLines`: split on `\n`, drop **trailing** blanks only (interior blanks preserved).
- `findInsertAfterRange` returns `{start, end}`: single-line keeps the existing exact/prefix/substring algorithm (minus the obsolete escape strip); multi-line matches a consecutive run, stripping **trailing whitespace only** (CRLF/trailing-space tolerant, leading indentation preserved, so an indented anchor can't false-match flat content and still round-trips).
- Anchoring: insert-before → `start`; insert-after immediate → `end`; insert-at-end → `Math.max(getEndOfSection(start), end)` (never splits the block).
- `considerSubsections` degrades to `false` for non-heading anchors (previously a newly-reachable `getEndOfSection` throw).

Insert-before shared the same matcher and had the identical bug — fixed too.

## Reproduction / verification

Verified end-to-end in the real dev vault (capture run 3×). Before the fix the multi-line block duplicated 3×; after, it stays a single block and tasks accumulate:

| `insert after` target | blocks after 3 runs (before → after) |
|---|---|
| `**Today**` (single line) | 1 → 1 |
| `**Today**\n` (trailing `\n`) | 1 → 1 |
| `**Today**\n***` (multi-line) | **3 → 1** |
| `**Today**\n\n` (double `\n`) | **3 → 1** |
| `## D\n\n**Tasks**` (heading-led) | n/a → 1 |
| insert-before `**Today**\n***` | n/a → 1 (block intact) |
| `considerSubsections` + non-heading multi-line | threw → 1 |

- `tsc --noEmit` clean, ESLint clean.
- Full test suite: **1872 passed**, 31 skipped — including **12 new regression tests** in `captureChoiceFormatter-742-multiline-insert.test.ts` (second-run dedup for every variant, insert-before, indentation false-match guard, CRLF round-trip, `considerSubsections`).

## Behavior change to note

An insert-after/before target that resolves to **empty** now aborts with a clear error instead of silently anchoring the top of the file. (An empty selector previously matched line 0, which is itself a form of the duplication bug.)

## Out of scope (unchanged, documented)
- Inline insert-after (`insertAfter.inline`) — separate single-line `indexOf` path that rejects real newlines.
- An inline-JS fence used *inside* a target selector still has its `\n` expanded (pre-existing on the create side).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-line insert-after and insert-before anchoring to prevent block duplication when using createIfNotFound.
  * Improved anchor matching to consistently handle indentation and trailing whitespace normalization.

* **Tests**
  * Added comprehensive test coverage for multi-line anchor scenarios with repeated formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->