### PR TITLE
fix: frontmatter-aware top insertion for capture and apply-template

### DIFF
--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -158,6 +158,18 @@ function makeHarness(options: {
 					? options.templateContent
 					: options.noteContent,
 			modify,
+			// Mirror Obsidian's atomic read-modify-write: read current content,
+			// apply the transform, then write via the same `modify` spy so existing
+			// modify-call assertions continue to hold.
+			process: async (file: TFile, fn: (data: string) => string) => {
+				const data =
+					file.path === TEMPLATE_PATH
+						? options.templateContent
+						: options.noteContent;
+				const next = fn(data);
+				modify(file, next);
+				return next;
+			},
 		},
 		fileManager: {
 			processFrontMatter: async (

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -260,6 +260,32 @@ describe("insertBodyIntoNoteContent", () => {
 			"---\ntitle: Note\n---\nnew\nexisting",
 		);
 	});
+
+	it("does not glue onto the fence for a frontmatter-only note with no trailing newline (#526 regression)", () => {
+		expect(insertBodyIntoNoteContent("---\ntitle: Note\n---", "new", "top")).toBe(
+			"---\ntitle: Note\n---\nnew\n",
+		);
+		expect(insertBodyIntoNoteContent("---\n---", "new", "top")).toBe(
+			"---\n---\nnew\n",
+		);
+	});
+
+	it("ends the inserted block on its own line, with a blank-line separation when the body already ends in a newline", () => {
+		// A single-line body (no trailing newline) lands tight against the next line...
+		expect(
+			insertBodyIntoNoteContent("---\nt: 1\n---\nExisting body", "## Block\nLine", "top"),
+		).toBe("---\nt: 1\n---\n## Block\nLine\nExisting body");
+		// ...but a body that already ends in a newline keeps a blank-line separation.
+		expect(insertBodyIntoNoteContent("Existing", "Block\n", "top")).toBe(
+			"Block\n\nExisting",
+		);
+	});
+
+	it("preserves CRLF frontmatter when inserting at top", () => {
+		expect(
+			insertBodyIntoNoteContent("---\r\nt: 1\r\n---\r\nBody", "new", "top"),
+		).toBe("---\r\nt: 1\r\n---\r\nnew\nBody");
+	});
 });
 
 describe("TemplateInsertEngine.apply", () => {

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -219,13 +219,11 @@ export class TemplateInsertEngine extends TemplateEngine {
 		const { frontmatterYaml, body } = splitTemplateFrontmatter(formatted);
 
 		if (body.trim().length > 0) {
-			const noteContent = await this.app.vault.cachedRead(this.targetFile);
-			const newContent = insertBodyIntoNoteContent(
-				noteContent,
-				body,
-				position,
+			// vault.process is Obsidian's atomic read-modify-write; the docs recommend
+			// it over read+modify, and it reads fresh from disk (unlike cachedRead).
+			await this.app.vault.process(this.targetFile, (noteContent) =>
+				insertBodyIntoNoteContent(noteContent, body, position),
 			);
-			await this.app.vault.modify(this.targetFile, newContent);
 		}
 
 		await this.mergeFrontmatterProperties(

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -12,6 +12,7 @@ import invariant from "../utils/invariant";
 import { TemplatePropertyCollector } from "../utils/TemplatePropertyCollector";
 import { coerceYamlValue } from "../utils/yamlValues";
 import { parentFolderPath } from "../utils/pathUtils";
+import { insertAtNoteBodyStart } from "../utils/noteContentInsertion";
 import { TemplateEngine } from "./TemplateEngine";
 
 export const templateInsertModes = [
@@ -66,6 +67,13 @@ export function splitTemplateFrontmatter(content: string): {
 /**
  * Inserts a template body into existing note content. "top" is
  * frontmatter-aware: the body lands below the note's frontmatter block.
+ *
+ * The "top" branch reuses the shared, fence-safe `insertAtNoteBodyStart`
+ * (src/utils/noteContentInsertion.ts). Appending a newline to the body expresses
+ * the template-apply policy that the inserted block always ends on its own line —
+ * leaving a blank-line separation from the existing content when the body itself
+ * already ends in a newline. (Capture callers use the same primitive WITHOUT the
+ * extra newline, for tight single-snippet insertion.)
  */
 export function insertBodyIntoNoteContent(
 	noteContent: string,
@@ -76,14 +84,7 @@ export function insertBodyIntoNoteContent(
 		return `${noteContent}\n${body}`;
 	}
 
-	const info = getFrontMatterInfo(noteContent);
-	if (!info.exists) {
-		return `${body}\n${noteContent}`;
-	}
-
-	const head = noteContent.slice(0, info.contentStart);
-	const rest = noteContent.slice(info.contentStart);
-	return `${head}${body}\n${rest}`;
+	return insertAtNoteBodyStart(noteContent, `${body}\n`);
 }
 
 /**

--- a/src/formatters/captureChoiceFormatter-frontmatter.test.ts
+++ b/src/formatters/captureChoiceFormatter-frontmatter.test.ts
@@ -794,3 +794,118 @@ describe('CaptureChoiceFormatter append task newline regression (issue #124)', (
     expect(result).toBe('- [ ] Old task\n- [ ] New task\n');
   });
 });
+
+describe('CaptureChoiceFormatter #647 frontmatter-aware top insertion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (global as any).navigator = {
+      clipboard: {
+        readText: vi.fn().mockResolvedValue(''),
+      },
+    };
+  });
+
+  const makeFormatter = () => {
+    const app = createMockApp();
+    const plugin = {
+      settings: {
+        enableTemplatePropertyTypes: false,
+        globalVariables: {},
+        showCaptureNotification: false,
+        showInputCancellationNotification: true,
+      },
+    } as any;
+    return new CaptureChoiceFormatter(app, plugin);
+  };
+
+  // Capture payload with NO trailing newline — the common single-line format case
+  // that previously glued onto the first body line / above the frontmatter.
+  const topInsert = (content: string, payload = 'INSERTED') =>
+    makeFormatter().formatContentWithFile(
+      payload,
+      createChoice({ captureToActiveFile: false }),
+      content,
+      createTFile('Note.md'),
+    );
+
+  it('inserts BELOW empty frontmatter instead of above it (the literal #647 bug)', async () => {
+    expect(await topInsert('---\n---\n# Body')).toBe('---\n---\nINSERTED\n# Body');
+  });
+
+  it('separates the capture from an immediately-following body line (no glue)', async () => {
+    expect(await topInsert('---\ntitle: A\n---\n# Heading')).toBe(
+      '---\ntitle: A\n---\nINSERTED\n# Heading',
+    );
+  });
+
+  it('inserts at the very top when there is no frontmatter, on its own line', async () => {
+    expect(await topInsert('# Heading\nBody')).toBe('INSERTED\n# Heading\nBody');
+  });
+
+  it('keeps the closing fence intact for an empty frontmatter-only note (no trailing newline)', async () => {
+    expect(await topInsert('---\n---')).toBe('---\n---\nINSERTED');
+  });
+
+  it('keeps the closing fence intact for a frontmatter-only note with no trailing newline', async () => {
+    expect(await topInsert('---\ntitle: A\n---')).toBe('---\ntitle: A\n---\nINSERTED');
+  });
+
+  it('preserves CRLF frontmatter and inserts after the closing fence', async () => {
+    expect(await topInsert('---\r\ntitle: A\r\n---\r\n# Body\r\n')).toBe(
+      '---\r\ntitle: A\r\n---\r\nINSERTED\n# Body\r\n',
+    );
+  });
+
+  it('absorbs an existing CRLF blank line after the fence instead of doubling it', async () => {
+    expect(await topInsert('---\r\ntitle: A\r\n---\r\n\r\nBody')).toBe(
+      '---\r\ntitle: A\r\n---\r\nINSERTED\r\nBody',
+    );
+  });
+
+  it('treats a "..."-closed block as no frontmatter (Obsidian-consistent) and inserts at top', async () => {
+    expect(await topInsert('---\ntitle: A\n...\n# Body')).toBe(
+      'INSERTED\n---\ntitle: A\n...\n# Body',
+    );
+  });
+
+  it('treats a leading-blank-line fence as no frontmatter (Obsidian-consistent) and inserts at absolute top', async () => {
+    // exists:false (fence not at offset 0) -> capture lands at the very top; the
+    // note's existing leading blank line is reused as the separator, not doubled.
+    expect(await topInsert('\n---\ntitle: A\n---\n# Body')).toBe(
+      'INSERTED\n---\ntitle: A\n---\n# Body',
+    );
+  });
+
+  it('does not add a double newline when the capture already ends with one (task payload) into frontmatter-only note', async () => {
+    const result = await makeFormatter().formatContentWithFile(
+      '- [ ] TASK\n',
+      createChoice({ captureToActiveFile: false, task: true }),
+      '---\n---',
+      createTFile('Note.md'),
+    );
+    expect(result).toBe('---\n---\n- [ ] TASK\n');
+  });
+
+  it('separates a task create-if-not-found-at-top from the body (previously glued)', async () => {
+    const result = await makeFormatter().formatContentWithFile(
+      '- [ ] CAP',
+      createChoice({
+        task: true,
+        insertAfter: {
+          enabled: true,
+          after: '## Missing',
+          insertAtEnd: false,
+          considerSubsections: false,
+          createIfNotFound: true,
+          createIfNotFoundLocation: 'top',
+          inline: false,
+          replaceExisting: false,
+          blankLineAfterMatchMode: 'auto',
+        },
+      }),
+      '# Header',
+      createTFile('Note.md'),
+    );
+    expect(result).toBe('## Missing\n- [ ] CAP\n# Header');
+  });
+});

--- a/src/formatters/captureChoiceFormatter-linebreak.test.ts
+++ b/src/formatters/captureChoiceFormatter-linebreak.test.ts
@@ -239,9 +239,9 @@ describe("capture linebreak escapes only apply to the format string (issue #527)
 			createFile(),
 		);
 
-		// Top insertion without frontmatter concatenates capture + body directly;
-		// the point here is that the literal backslash-n survives untouched.
-		expect(result).toBe("\\nablaexisting");
+		// Top insertion places the capture on its own line above the body (#647); the
+		// point here is that the literal backslash-n in the payload survives untouched.
+		expect(result).toBe("\\nabla\nexisting");
 	});
 
 	it("preserves backslash sequences in path-like selected text", async () => {

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -5,7 +5,6 @@ import {
 	CREATE_IF_NOT_FOUND_CURSOR,
 	CREATE_IF_NOT_FOUND_TOP,
 } from "../constants";
-import { log } from "../logger/logManager";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { BlankLineAfterMatchMode } from "../types/choices/ICaptureChoice";
 import { templaterParseTemplate } from "../utilityObsidian";
@@ -13,7 +12,7 @@ import { reportError } from "../utils/errorUtils";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { CompleteFormatter } from "./completeFormatter";
 import getEndOfSection, { getMarkdownHeadings } from "./helpers/getEndOfSection";
-import { findYamlFrontMatterRange } from "../utils/yamlContext";
+import { insertAtNoteBodyStart } from "../utils/noteContentInsertion";
 import { parentFolderPath } from "../utils/pathUtils";
 
 /**
@@ -178,22 +177,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			return await this.insertBeforeHandler(formatted);
 		}
 
-		const frontmatterEndPosition = this.file
-			? this.getFrontmatterEndPosition(this.file, this.fileContent)
-			: null;
-		if (
-			frontmatterEndPosition === null ||
-			frontmatterEndPosition === undefined ||
-			frontmatterEndPosition < 0
-		)
-			return `${formatted}${this.fileContent}`;
-
-		return this.insertTextAfterPositionInBody(
-			formatted,
-			this.fileContent,
-
-			frontmatterEndPosition,
-		);
+		// Default "write to top" path: insert after any frontmatter so the YAML block
+		// is never broken, and never glue the capture onto the first body line (#647).
+		return insertAtNoteBodyStart(this.fileContent, formatted);
 	}
 
 	async formatContentOnly(input: string): Promise<string> {
@@ -652,14 +638,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_TOP
 		) {
-			const frontmatterEndPosition = this.file
-				? this.getFrontmatterEndPosition(this.file, this.fileContent)
-				: -1;
-			return this.insertTextAfterPositionInBody(
-				insertAfterLineAndFormatted,
+			return insertAtNoteBodyStart(
 				this.fileContent,
-
-				frontmatterEndPosition,
+				insertAfterLineAndFormatted,
 			);
 		}
 
@@ -743,20 +724,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			insertBefore.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_TOP
 		) {
-			const frontmatterEndPosition = this.file
-				? this.getFrontmatterEndPosition(this.file, this.fileContent)
-				: -1;
-			const needsTrailingSeparator =
-				frontmatterEndPosition >= 0 || this.choice.task;
-			const textAtTop =
-				needsTrailingSeparator && !formattedAndInsertBeforeLine.endsWith("\n")
-					? `${formattedAndInsertBeforeLine}\n`
-					: formattedAndInsertBeforeLine;
-			return this.insertTextAfterPositionInBody(
-				textAtTop,
+			return insertAtNoteBodyStart(
 				this.fileContent,
-
-				frontmatterEndPosition,
+				formattedAndInsertBeforeLine,
 			);
 		}
 
@@ -807,13 +777,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_TOP
 		) {
-			const frontmatterEndPosition = this.file
-				? this.getFrontmatterEndPosition(this.file, this.fileContent)
-				: -1;
-			return this.insertTextAfterPositionInBody(
-				insertAfterLineAndFormatted,
+			return insertAtNoteBodyStart(
 				this.fileContent,
-				frontmatterEndPosition,
+				insertAfterLineAndFormatted,
 			);
 		}
 
@@ -855,51 +821,13 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		);
 	}
 
-	private getFrontmatterEndPosition(file: TFile, fallbackContent?: string) {
-		const fileCache = this.app.metadataCache.getFileCache(file);
-
-		if (fileCache?.frontmatterPosition) {
-			return fileCache.frontmatterPosition.end.line;
-		}
-
-		if (fallbackContent) {
-			const inferred = this.inferFrontmatterEndLineFromContent(fallbackContent);
-			if (inferred !== null) {
-				return inferred;
-			}
-		}
-
-		log.logMessage("could not get frontmatter. Maybe there isn't any.");
-		return -1;
-	}
-
-	private inferFrontmatterEndLineFromContent(content: string): number | null {
-		const yamlRange = findYamlFrontMatterRange(content);
-		if (!yamlRange) return null;
-
-		const prefix = content.slice(0, yamlRange[1]);
-		const lines = prefix.split(/\r?\n/);
-		if (lines.length === 0) return null;
-
-		if (prefix.endsWith("\n")) {
-			return lines.length - 2;
-		}
-
-		return lines.length - 1;
-	}
-
 	private insertTextAfterPositionInBody(
 		text: string,
 		body: string,
 		pos: number,
 	): string {
-		if (pos === -1) {
-			// For the case that there is no frontmatter and we're adding to the top of the file.
-			// We already add a linebreak for the task in CaptureChoiceEngine.tsx in getCapturedContent.
-			const shouldAddLinebreak = !this.choice.task;
-			return `${text}${shouldAddLinebreak ? "\n" : ""}${body}`;
-		}
-
+		// Line-matched insertAfter callers always pass a real line index (>= 0); the
+		// frontmatter-aware "top" insertion lives in insertAtNoteBodyStart instead.
 		const splitContent = body.split("\n");
 		const pre = splitContent.slice(0, pos + 1).join("\n");
 		const post = splitContent.slice(pos + 1).join("\n");

--- a/src/utils/noteContentInsertion.test.ts
+++ b/src/utils/noteContentInsertion.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { getBodyStartOffset, insertAtNoteBodyStart } from "./noteContentInsertion";
+
+describe("getBodyStartOffset", () => {
+	it("returns 0 when there is no frontmatter", () => {
+		expect(getBodyStartOffset("# Heading\nBody")).toBe(0);
+	});
+
+	it("returns the offset just after the closing fence for normal frontmatter", () => {
+		const content = "---\ntitle: A\n---\n# Body";
+		expect(getBodyStartOffset(content)).toBe("---\ntitle: A\n---\n".length);
+	});
+
+	it("detects empty frontmatter", () => {
+		expect(getBodyStartOffset("---\n---\n# Body")).toBe("---\n---\n".length);
+	});
+
+	it("treats a non-offset-0 fence as no frontmatter", () => {
+		expect(getBodyStartOffset("\n---\ntitle: A\n---\nBody")).toBe(0);
+	});
+
+	it("treats a '...'-closed block as no frontmatter (Obsidian-consistent)", () => {
+		expect(getBodyStartOffset("---\ntitle: A\n...\nBody")).toBe(0);
+	});
+});
+
+describe("insertAtNoteBodyStart", () => {
+	it("inserts below normal frontmatter, on its own line", () => {
+		expect(insertAtNoteBodyStart("---\ntitle: A\n---\n# Heading", "INSERTED")).toBe(
+			"---\ntitle: A\n---\nINSERTED\n# Heading",
+		);
+	});
+
+	it("inserts below empty frontmatter instead of above it (issue #647)", () => {
+		expect(insertAtNoteBodyStart("---\n---\n# Body", "INSERTED")).toBe(
+			"---\n---\nINSERTED\n# Body",
+		);
+	});
+
+	it("keeps the closing fence intact for a frontmatter-only note with no trailing newline", () => {
+		expect(insertAtNoteBodyStart("---\ntitle: A\n---", "INSERTED")).toBe(
+			"---\ntitle: A\n---\nINSERTED",
+		);
+		expect(insertAtNoteBodyStart("---\n---", "INSERTED")).toBe("---\n---\nINSERTED");
+	});
+
+	it("inserts at the top of a note with no frontmatter without gluing", () => {
+		expect(insertAtNoteBodyStart("# Heading\nBody", "INSERTED")).toBe(
+			"INSERTED\n# Heading\nBody",
+		);
+	});
+
+	it("does not add a separator when the payload already ends with a newline", () => {
+		expect(insertAtNoteBodyStart("# Body", "- [ ] task\n")).toBe("- [ ] task\n# Body");
+		expect(insertAtNoteBodyStart("---\n---", "- [ ] task\n")).toBe(
+			"---\n---\n- [ ] task\n",
+		);
+	});
+
+	it("absorbs an existing blank line after the fence rather than doubling it", () => {
+		expect(insertAtNoteBodyStart("---\ntitle: A\n---\n\nBody", "INSERTED")).toBe(
+			"---\ntitle: A\n---\nINSERTED\nBody",
+		);
+	});
+
+	it("preserves CRLF frontmatter and absorbs a CRLF blank line", () => {
+		expect(
+			insertAtNoteBodyStart("---\r\ntitle: A\r\n---\r\n# Body\r\n", "INSERTED"),
+		).toBe("---\r\ntitle: A\r\n---\r\nINSERTED\n# Body\r\n");
+		expect(
+			insertAtNoteBodyStart("---\r\ntitle: A\r\n---\r\n\r\nBody", "INSERTED"),
+		).toBe("---\r\ntitle: A\r\n---\r\nINSERTED\r\nBody");
+	});
+
+	it("treats a CRLF-leading payload as already newline-started (no doubled blank line)", () => {
+		expect(insertAtNoteBodyStart("---\n---", "\r\nCAP")).toBe("---\n---\r\nCAP");
+	});
+
+	it("handles empty content", () => {
+		expect(insertAtNoteBodyStart("", "INSERTED")).toBe("INSERTED");
+	});
+
+	it("returns the note unchanged when the payload is empty", () => {
+		expect(insertAtNoteBodyStart("---\na: 1\n---\nBody", "")).toBe(
+			"---\na: 1\n---\nBody",
+		);
+	});
+
+	it("stacks repeated top captures newest-first, below frontmatter, without gluing", () => {
+		const r1 = insertAtNoteBodyStart("---\ntitle: A\n---\nBody", "A");
+		expect(r1).toBe("---\ntitle: A\n---\nA\nBody");
+		const r2 = insertAtNoteBodyStart(r1, "B");
+		expect(r2).toBe("---\ntitle: A\n---\nB\nA\nBody");
+	});
+
+	it("keeps the fence intact for a CRLF frontmatter-only note with no trailing newline (EOF + leading separator)", () => {
+		expect(insertAtNoteBodyStart("---\r\ntitle: A\r\n---", "INSERTED")).toBe(
+			"---\r\ntitle: A\r\n---\nINSERTED",
+		);
+	});
+
+	it("inserts on its own line for a frontmatter-only note WITH a trailing newline (empty body)", () => {
+		expect(insertAtNoteBodyStart("---\ntitle: A\n---\n", "INSERTED")).toBe(
+			"---\ntitle: A\n---\nINSERTED",
+		);
+	});
+});

--- a/src/utils/noteContentInsertion.ts
+++ b/src/utils/noteContentInsertion.ts
@@ -1,0 +1,51 @@
+import { getFrontMatterInfo } from "obsidian";
+
+/**
+ * Offset at which the note body begins — immediately after the YAML frontmatter
+ * block when present, otherwise 0.
+ *
+ * Uses Obsidian's own `getFrontMatterInfo`, so detection matches what Obsidian
+ * shows the user exactly: empty frontmatter (`---\n---`) is recognised, a `---`
+ * fence that is not at offset 0 is not, and `...`-style closes are rejected. This
+ * is deliberately content-based (the metadata cache is not consulted) so a stale
+ * or cold cache cannot place text in the wrong spot.
+ */
+export function getBodyStartOffset(content: string): number {
+	const info = getFrontMatterInfo(content);
+	return info.exists ? info.contentStart : 0;
+}
+
+/**
+ * Insert `text` at the start of the note body — after frontmatter when present —
+ * guaranteeing the inserted text occupies its own line(s):
+ *
+ *  - a leading newline when the preceding block (frontmatter, or nothing) does not
+ *    already end with one. This protects frontmatter-only notes whose closing fence
+ *    sits at EOF (`---\n---`), where the body offset lands on the fence itself.
+ *  - a trailing newline when body content would otherwise follow on the same line.
+ *
+ * The trailing check is CRLF-aware so an existing blank line is absorbed rather
+ * than doubled. The injected separator is a lone `\n` (matching the existing
+ * capture/template insertion helpers); Obsidian tolerates the resulting mixed EOL.
+ *
+ * `TemplateInsertEngine.insertBodyIntoNoteContent` reuses this same primitive for its
+ * "top" insert, but passes `body + "\n"` so an applied template block always ends on its
+ * own line (leaving a blank-line separation when the body already ends in a newline).
+ * Capture callers pass the payload as-is for tight single-snippet insertion.
+ */
+export function insertAtNoteBodyStart(content: string, text: string): string {
+	// Inserting nothing leaves the note untouched (defensive: capture callers
+	// already drop empty payloads upstream, but keep the helper safe in isolation).
+	if (text.length === 0) return content;
+
+	const start = getBodyStartOffset(content);
+	const head = content.slice(0, start);
+	const rest = content.slice(start);
+
+	const leadingSeparator =
+		head.length > 0 && !head.endsWith("\n") && !/^\r?\n/.test(text) ? "\n" : "";
+	const trailingSeparator =
+		rest.length > 0 && !text.endsWith("\n") && !/^\r?\n/.test(rest) ? "\n" : "";
+
+	return `${head}${leadingSeparator}${text}${trailingSeparator}${rest}`;
+}

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -351,6 +351,7 @@ export class App {
     read: async () => "",
     modify: async () => {},
     cachedRead: async () => "",
+    process: async (_file: any, fn: (data: string) => string) => fn(""),
   };
   metadataCache: any = {
     getFileCache: () => undefined,


### PR DESCRIPTION
## Summary
Capture's *write to top* and *apply template to active note → top* could insert content **above** a note's YAML frontmatter (corrupting it) and/or glue the inserted text onto the first line of the body. This routes both paths through one frontmatter-aware insertion primitive.

## The bug (two manifestations, one root cause)
A note whose frontmatter the old code couldn't see — most commonly **empty frontmatter** (`---\n---`, e.g. after all properties are removed) — or a **frontmatter-only note with no trailing newline** (`---\ntitle\n---`) had the captured/template text written onto or above the `---`, breaking the block.

- **Capture (#647):** detected frontmatter via the metadata cache + a custom regex. Empty/cold-cache frontmatter was missed → capture prepended *above* the fence. Even when detected, a single-line capture was glued onto the first body line.
- **Apply template (top):** `insertBodyIntoNoteContent` glued the body onto the closing fence for a frontmatter-only target with no trailing newline.

## Fix
New pure helper `src/utils/noteContentInsertion.ts` (`getBodyStartOffset` / `insertAtNoteBodyStart`) built on Obsidian's own `getFrontMatterInfo` — content-based (a stale/cold metadata cache can no longer misplace text), with leading + trailing CRLF-aware separators so the text always lands on its own line and never touches the fence.

Both paths use it:
- The 4 capture "top" sites (default top + the 3 *create-if-not-found at top* branches) — tight insertion.
- `TemplateInsertEngine.insertBodyIntoNoteContent`'s top branch passes `body + "\n"`, preserving its deliberate block separation.

The two callers keep distinct *spacing policies* (capture = tight snippet; template = separated block) over **one** shared, fence-safe implementation. Removed the old cache+regex detector (`getFrontmatterEndPosition`, `inferFrontmatterEndLineFromContent`) and the now-dead `pos === -1` branch.

## Behavior change (Obsidian-consistent)
A `---` fence not at offset 0 (e.g. preceded by a blank line) or closed with `...` is now treated as *no frontmatter* — matching Obsidian's own parser — so the capture lands at the very top.

## Testing / validation
- New unit tests for the helper + capture/template frontmatter cases: empty FM, FM-only-no-newline (the fence-glue), CRLF body + blank-line absorption, leading-blank, `...`-close, task, repeated stacking, block-separation. Updated one capture test that had codified the old glued output.
- Full suite green (**1954 tests**); `pnpm run build-with-lint` clean.
- Verified live in a dev vault (real Obsidian) for both paths — including the empty-frontmatter and frontmatter-only-no-trailing-newline cases that previously corrupted the note, and `applyTemplateToActiveFile(..., { mode: "top" })`.

Also fixes a latent fence-glue bug in the apply-template-to-active-note path (the feature shipped for #526).

Closes #647

## Checklist
- [x] PR title follows Conventional Commits
- [x] Linked the related issue
- [x] Release impact: `fix:` (patch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capture and template insertion at note start to properly respect YAML frontmatter boundaries.
  * Fixed line-break handling and CRLF preservation when inserting content above existing note body.
  * Ensured insertions run as atomic read-modify-write updates to avoid partial writes during insertion.
  * Enhanced consistency in insertion behavior across different note configurations.

* **Tests**
  * Added comprehensive tests covering frontmatter-edge cases, CRLF handling, and top-insertion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->