### PR TITLE
feat(capture): order note picker by recency like Quick Switcher (#745, #539)

### DIFF
--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -413,6 +413,81 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(resolved).toBe("Inbox/note.md");
 	});
 
+	it("orders the folder picker by recency and gates the create row when enabled", async () => {
+		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([
+			{ path: "Inbox/Apple.md", basename: "Apple" },
+			{ path: "Inbox/Zebra.md", basename: "Zebra" },
+			{ path: "Inbox/Mango.md", basename: "Mango" },
+		] as any);
+
+		const suggestSpy = vi.fn(async () => "Inbox/Apple.md");
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const app = createApp() as any;
+		app.workspace.getLastOpenFiles = () => ["Inbox/Zebra.md"];
+
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "Inbox/",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			createExecutor(),
+		);
+
+		await (engine as any).selectFileInFolder("Inbox/", false);
+
+		expect(suggestSpy).toHaveBeenCalledTimes(1);
+		const [, displayItems, items, options] = suggestSpy.mock
+			.calls[0] as unknown as [
+			unknown,
+			string[],
+			string[],
+			{
+				allowCustomValue: boolean;
+				customValueLabel: (value: string) => string;
+			},
+		];
+
+		// Recently opened (Zebra) first, then the rest alphabetically.
+		expect(items).toEqual([
+			"Inbox/Zebra.md",
+			"Inbox/Apple.md",
+			"Inbox/Mango.md",
+		]);
+		expect(displayItems).toEqual(["Zebra.md", "Apple.md", "Mango.md"]);
+		expect(options.allowCustomValue).toBe(true);
+		expect(options.customValueLabel("New")).toBe("Create new note: New");
+	});
+
+	it("disables the create row when create-if-not-exists is off", async () => {
+		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([
+			{ path: "Inbox/Apple.md", basename: "Apple" },
+		] as any);
+
+		const suggestSpy = vi.fn(async () => "Inbox/Apple.md");
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "Inbox/" }),
+			createExecutor(),
+		);
+
+		await (engine as any).selectFileInFolder("Inbox/", false);
+
+		const options = (suggestSpy.mock.calls[0] as unknown[])[3] as {
+			allowCustomValue: boolean;
+		};
+		expect(options.allowCustomValue).toBe(false);
+	});
+
 	it("uses extensionless title for created .canvas capture files", async () => {
 		const app = createApp() as any;
 		app.vault.read = vi.fn(async () => "");

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -6,6 +6,9 @@ import {
 	type WorkspaceLeaf,
 } from "obsidian";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
+import { renderNotePathSuggestion } from "src/gui/InputSuggester/renderNotePathSuggestion";
+import { orderFilesForPicker } from "src/utils/fileOrdering";
+import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
 import invariant from "src/utils/invariant";
 import merge from "three-way-merge";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
@@ -568,6 +571,25 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		return { kind: "file", path: normalizedCaptureTo };
 	}
 
+	/**
+	 * Whether a typed picker value already resolves to an existing note, so the
+	 * "Create new note" affordance can be suppressed for it. The value is the
+	 * displayed name (folder-stripped for folder captures), so the folder prefix is
+	 * re-applied and a markdown extension is tried when none is present.
+	 */
+	private captureTargetExists(folderPathSlash: string, value: string): boolean {
+		const withinScope = value.startsWith(folderPathSlash)
+			? value
+			: `${folderPathSlash}${value}`;
+		const candidates = [withinScope];
+		if (!/\.(md|canvas)$/i.test(withinScope)) {
+			candidates.push(`${withinScope}.md`);
+		}
+		return candidates.some(
+			(path) => !!this.app.vault.getAbstractFileByPath(path),
+		);
+	}
+
 	private async selectFileInFolder(
 		folderPath: string,
 		captureAnywhereInVault: boolean,
@@ -580,13 +602,24 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 		invariant(filesInFolder.length > 0, `Folder ${folderPathSlash} is empty.`);
 
-		const filePaths = filesInFolder.map((f) => f.path);
+		// Quick-Switcher-style ordering: recent first, excluded sunk, alphabetical tail.
+		const filePaths = orderFilesForPicker(
+			filesInFolder,
+			buildPickerOrderingDeps(this.app),
+		).map((f) => f.path);
+		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 		let targetFilePath: string;
 		try {
 			targetFilePath = await InputSuggester.Suggest(
 				this.app,
 				filePaths.map((item) => item.replace(folderPathSlash, "")),
 				filePaths,
+				{
+					allowCustomValue: allowCreate,
+					customValueLabel: (value) => `Create new note: ${value}`,
+					valueExists: (value) =>
+						this.captureTargetExists(folderPathSlash, value),
+				},
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
@@ -615,13 +648,34 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 		invariant(filesWithTag.length > 0, `No files with tag ${tag}.`);
 
-		const filePaths = filesWithTag.map((f) => f.path);
+		// Quick-Switcher-style ordering; show note names (not raw paths) for tag scope.
+		const filePaths = orderFilesForPicker(
+			filesWithTag,
+			buildPickerOrderingDeps(this.app),
+		).map((f) => f.path);
+		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
+		// Tagged notes can live anywhere, so existence is matched by basename/path
+		// across the tagged set rather than by re-prefixing a folder.
+		const existingTagged = new Set<string>();
+		for (const f of filesWithTag) {
+			existingTagged.add(f.path);
+			existingTagged.add(f.basename);
+		}
 		let targetFilePath: string;
 		try {
 			targetFilePath = await InputSuggester.Suggest(
 				this.app,
 				filePaths,
 				filePaths,
+				{
+					renderItem: (path, el) =>
+						renderNotePathSuggestion(el, path),
+					allowCustomValue: allowCreate,
+					customValueLabel: (value) => `Create new note: ${value}`,
+					valueExists: (value) =>
+						existingTagged.has(value) ||
+						existingTagged.has(value.replace(/\.md$/i, "")),
+				},
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -583,7 +583,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			: `${folderPathSlash}${value}`;
 		const candidates = [withinScope];
 		if (!/\.(md|canvas)$/i.test(withinScope)) {
-			candidates.push(`${withinScope}.md`);
+			candidates.push(`${withinScope}.md`, `${withinScope}.canvas`);
 		}
 		return candidates.some(
 			(path) => !!this.app.vault.getAbstractFileByPath(path),

--- a/src/gui/InputSuggester/inputSuggester.test.ts
+++ b/src/gui/InputSuggester/inputSuggester.test.ts
@@ -71,21 +71,23 @@ describe("InputSuggester", () => {
 		).toBe(false);
 	});
 
-	it("suppresses the custom row when the typed value matches a displayed name", () => {
-		// Folder picker shape: items are full paths, displayItems are the folder-stripped
-		// names actually shown to the user (extension preserved, e.g. "note.md").
+	it("keeps a typed display label submittable for generic callers (no valueExists)", () => {
+		// Public api.suggester / |text format syntax shape: display labels differ from
+		// the underlying values, and allowCustomInput lets the user submit typed text
+		// that is NOT an actual item. Typing a string equal to a display LABEL (not a
+		// value) must still yield a submittable custom row — it is not an existing target.
 		const suggester = new InputSuggester(
 			app,
-			["note.md"],
-			["Inbox/note.md"],
+			["Apple Label", "Banana Label"],
+			["apple-id", "banana-id"],
 		);
 
-		suggester.inputEl.value = "note.md";
+		suggester.inputEl.value = "Apple Label";
 
-		const suggestions = suggester.getSuggestions("note.md");
+		const suggestions = suggester.getSuggestions("Apple Label");
 
-		// "note.md" already maps to Inbox/note.md, so no create row should be synthesized.
-		expect(suggestions.some((s) => s.item === "note.md")).toBe(false);
+		// The literal typed label is still offered as a custom value (regression guard).
+		expect(suggestions[suggestions.length - 1]?.item).toBe("Apple Label");
 	});
 
 	it("suppresses the custom row when valueExists reports an existing target", () => {

--- a/src/gui/InputSuggester/inputSuggester.test.ts
+++ b/src/gui/InputSuggester/inputSuggester.test.ts
@@ -54,6 +54,65 @@ describe("InputSuggester", () => {
 		).not.toThrow();
 	});
 
+	it("omits the custom create row when allowCustomValue is false", () => {
+		const suggester = new InputSuggester(
+			app,
+			["Existing note"],
+			["Existing note"],
+			{ allowCustomValue: false },
+		);
+
+		suggester.inputEl.value = "Brand new note";
+
+		const suggestions = suggester.getSuggestions("Brand new note");
+
+		expect(
+			suggestions.some((s) => s.item === "Brand new note"),
+		).toBe(false);
+	});
+
+	it("suppresses the custom row when the typed value matches a displayed name", () => {
+		// Folder picker shape: items are full paths, displayItems are the folder-stripped
+		// names actually shown to the user (extension preserved, e.g. "note.md").
+		const suggester = new InputSuggester(
+			app,
+			["note.md"],
+			["Inbox/note.md"],
+		);
+
+		suggester.inputEl.value = "note.md";
+
+		const suggestions = suggester.getSuggestions("note.md");
+
+		// "note.md" already maps to Inbox/note.md, so no create row should be synthesized.
+		expect(suggestions.some((s) => s.item === "note.md")).toBe(false);
+	});
+
+	it("suppresses the custom row when valueExists reports an existing target", () => {
+		const suggester = new InputSuggester(app, ["Alpha"], ["Alpha"], {
+			valueExists: (value) => value === "Existing",
+		});
+
+		suggester.inputEl.value = "Existing";
+
+		const suggestions = suggester.getSuggestions("Existing");
+
+		expect(suggestions.some((s) => s.item === "Existing")).toBe(false);
+	});
+
+	it("still offers a create row for a genuinely new value when allowed", () => {
+		const suggester = new InputSuggester(app, ["Alpha"], ["Inbox/Alpha.md"], {
+			allowCustomValue: true,
+			valueExists: () => false,
+		});
+
+		suggester.inputEl.value = "Brand new";
+
+		const suggestions = suggester.getSuggestions("Brand new");
+
+		expect(suggestions[suggestions.length - 1]?.item).toBe("Brand new");
+	});
+
 	it("aligns displayItems length with items length", () => {
 		const shortDisplay = ["Alpha"];
 		const shortItems = ["Alpha", "Beta", "Gamma"];

--- a/src/gui/InputSuggester/inputSuggester.ts
+++ b/src/gui/InputSuggester/inputSuggester.ts
@@ -157,13 +157,11 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 			return suggestions;
 		}
 
-		// The user types/sees displayItems (e.g. folder-stripped note names), so a
-		// value that matches an existing target must be suppressed against those too,
-		// not just the raw items — otherwise the "create" row lies about existing notes.
-		if (this.displayItems.includes(customValue)) {
-			return suggestions;
-		}
-
+		// Capture pickers pass valueExists to suppress the "create" row when the typed
+		// value already resolves to an existing note (by basename or full path, with or
+		// without extension). This is intentionally NOT a displayItems check: generic
+		// callers (e.g. api.suggester, |text format syntax) use arbitrary display labels
+		// that are not existing targets, and must keep their typed value submittable.
 		if (this.valueExists?.(customValue)) {
 			return suggestions;
 		}

--- a/src/gui/InputSuggester/inputSuggester.ts
+++ b/src/gui/InputSuggester/inputSuggester.ts
@@ -1,4 +1,4 @@
-import { FuzzySuggestModal } from "obsidian";
+import { FuzzySuggestModal, setIcon } from "obsidian";
 import type { FuzzyMatch, App } from "obsidian";
 import { log, toError } from "src/logger/logManager";
 import {
@@ -20,6 +20,21 @@ type Options = {
 	renderItem: SuggestRender<string> | undefined;
 	/** Adds a "skip" affordance that resolves "" (for optional tokens). */
 	skippable: boolean;
+	/**
+	 * When false, the typed value is not offered as a custom ("create") suggestion.
+	 * Defaults to true to preserve the historical "type your own input" behaviour.
+	 */
+	allowCustomValue: boolean;
+	/**
+	 * Renders the typed-but-unmatched custom row with a label, e.g.
+	 * `(value) => \`Create new note: ${value}\``. Implies a "create" affordance.
+	 */
+	customValueLabel: (value: string) => string;
+	/**
+	 * Suppresses the custom row when the typed value already maps to a selectable
+	 * target the caller recognises (e.g. an existing file reached by basename).
+	 */
+	valueExists: (value: string) => boolean;
 };
 
 /**
@@ -35,6 +50,9 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 	private displayItems: string[];
 	private items: string[];
 	private warnedOnEmptyDisplay = false;
+	private allowCustomValue = true;
+	private customValueLabel?: (value: string) => string;
+	private valueExists?: (value: string) => boolean;
 
 	public static Suggest(
 		app: App,
@@ -68,6 +86,9 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 		});
 
 		this.renderItem = options.renderItem;
+		this.allowCustomValue = options.allowCustomValue ?? true;
+		this.customValueLabel = options.customValueLabel;
+		this.valueExists = options.valueExists;
 
 		this.inputEl.addEventListener("keydown", (event: KeyboardEvent) => {
 			// chooser is undocumented & not officially a part of the Obsidian API, hence the precautions in using it.
@@ -125,11 +146,25 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 	getSuggestions(query: string): FuzzyMatch<string>[] {
 		const safeQuery = normalizeQuery(query);
 		const suggestions = super.getSuggestions(safeQuery);
+
+		if (!this.allowCustomValue) return suggestions;
+
 		const customValue = normalizeQuery(this.inputEl.value);
 
 		if (!customValue) return suggestions;
 
 		if (this.items.includes(customValue)) {
+			return suggestions;
+		}
+
+		// The user types/sees displayItems (e.g. folder-stripped note names), so a
+		// value that matches an existing target must be suppressed against those too,
+		// not just the raw items — otherwise the "create" row lies about existing notes.
+		if (this.displayItems.includes(customValue)) {
+			return suggestions;
+		}
+
+		if (this.valueExists?.(customValue)) {
 			return suggestions;
 		}
 
@@ -161,6 +196,16 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 	}
 
 	renderSuggestion(value: FuzzyMatch<string>, el: HTMLElement): void {
+		// The custom ("create") row is the only entry scored -Infinity; when a label
+		// is configured it takes precedence over any caller-provided renderItem.
+		if (
+			this.customValueLabel &&
+			value.match.score === Number.NEGATIVE_INFINITY
+		) {
+			this.renderCustomValue(value.item, el);
+			return;
+		}
+
 		if (!this.renderItem) {
 			super.renderSuggestion(value, el);
 			return;
@@ -175,6 +220,29 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 			log.logWarning(err);
 			el.empty();
 			super.renderSuggestion(value, el);
+		}
+	}
+
+	private renderCustomValue(value: string, el: HTMLElement): void {
+		try {
+			el.empty();
+			el.addClass("mod-complex");
+			const content = el.createDiv({ cls: "suggestion-content" });
+			content.createDiv({
+				cls: "suggestion-title",
+				text: this.customValueLabel?.(value) ?? value,
+			});
+			const aux = el.createDiv({ cls: "suggestion-aux" });
+			setIcon(aux.createSpan({ cls: "suggestion-flair" }), "file-plus");
+		} catch (error) {
+			const err = toError(error);
+			err.message = `Custom create-row rendering threw an error; falling back to default rendering. ${err.message}`;
+			log.logWarning(err);
+			el.empty();
+			super.renderSuggestion(
+				{ item: value, match: { score: 0, matches: [] } },
+				el,
+			);
 		}
 	}
 

--- a/src/gui/InputSuggester/renderNotePathSuggestion.ts
+++ b/src/gui/InputSuggester/renderNotePathSuggestion.ts
@@ -1,0 +1,22 @@
+import { stripMdExtensionForDisplay } from "../suggesters/utils";
+
+/**
+ * Renders a vault file path as a Quick-Switcher-style row: the note name on the
+ * title line, the parent folder as a muted note line beneath it. Runtime/DOM-only
+ * (never invoked in unit tests). Used by the tag-scoped capture picker so it shows
+ * note names instead of raw `Some/Deep/Folder/Note.md` paths (issue #745).
+ */
+export function renderNotePathSuggestion(el: HTMLElement, path: string): void {
+	const lastSlash = path.lastIndexOf("/");
+	const parent = lastSlash >= 0 ? path.slice(0, lastSlash) : "";
+	const basename = stripMdExtensionForDisplay(
+		lastSlash >= 0 ? path.slice(lastSlash + 1) : path,
+	);
+
+	el.addClass("mod-complex");
+	const content = el.createDiv({ cls: "suggestion-content" });
+	content.createDiv({ cls: "suggestion-title", text: basename });
+	if (parent) {
+		content.createDiv({ cls: "suggestion-note", text: parent });
+	}
+}

--- a/src/gui/suggesters/FileIndex.test.ts
+++ b/src/gui/suggesters/FileIndex.test.ts
@@ -567,3 +567,49 @@ describe('FileIndex', () => {
 		});
 	});
 });
+
+describe('FileIndex recency accessors (note-picker seam)', () => {
+	let mockApp: App;
+	let fileIndex: FileIndex;
+	let fireFileOpen: (file: TFile | null) => void;
+
+	beforeEach(() => {
+		TestableFileIndex.reset();
+		mockApp = createMockApp();
+		// Capture the 'file-open' handler the index registers so we can drive it.
+		(mockApp.workspace.on as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+			(event: string, handler: (file: TFile | null) => void) => {
+				if (event === 'file-open') fireFileOpen = handler;
+				return {} as never;
+			},
+		);
+		const mockPlugin = {
+			registerEvent: vi.fn((eventRef) => eventRef),
+		} as any;
+		fileIndex = FileIndex.getInstance(mockApp, mockPlugin);
+	});
+
+	it('getInstanceIfExists returns the singleton, and undefined after reset', () => {
+		expect(FileIndex.getInstanceIfExists()).toBe(fileIndex);
+		TestableFileIndex.reset();
+		expect(FileIndex.getInstanceIfExists()).toBeUndefined();
+	});
+
+	it('getLastOpenedAt reports the open timestamp and undefined for unopened files', () => {
+		expect(typeof fireFileOpen).toBe('function');
+		expect(fileIndex.getLastOpenedAt('Opened.md')).toBeUndefined();
+
+		fireFileOpen({ path: 'Opened.md' } as TFile);
+
+		expect(typeof fileIndex.getLastOpenedAt('Opened.md')).toBe('number');
+		expect(fileIndex.getLastOpenedAt('Never.md')).toBeUndefined();
+	});
+
+	it('getLastOpenedAt is a non-mutating peek (stable across repeated reads)', () => {
+		fireFileOpen({ path: 'A.md' } as TFile);
+		const first = fileIndex.getLastOpenedAt('A.md');
+		const second = fileIndex.getLastOpenedAt('A.md');
+		expect(first).toBe(second);
+		expect(typeof first).toBe('number');
+	});
+});

--- a/src/gui/suggesters/FileIndex.ts
+++ b/src/gui/suggesters/FileIndex.ts
@@ -49,6 +49,11 @@ class LRUCache<T> {
 		return value;
 	}
 
+	/** Reads a value without affecting recency ordering (safe inside sort comparators). */
+	peek(key: string): T | undefined {
+		return this.cache.get(key);
+	}
+
 	set(key: string, value: T): void {
 		if (this.cache.has(key)) {
 			this.cache.delete(key);
@@ -160,6 +165,24 @@ export class FileIndex {
 			FileIndex.instance = new FileIndex(app, plugin);
 		}
 		return FileIndex.instance;
+	}
+
+	/**
+	 * Returns the existing singleton without constructing one. Lets recency-aware
+	 * callers (e.g. the capture note-picker) reuse the index when it is already
+	 * warm, without paying any startup/indexing cost when it is not.
+	 */
+	static getInstanceIfExists(): FileIndex | undefined {
+		return FileIndex.instance ?? undefined;
+	}
+
+	/**
+	 * Session recency for a path: the timestamp it was last opened this session, or
+	 * undefined if never opened. Sourced from the file-open listener's LRU, so it is
+	 * available regardless of whether the search index has finished building.
+	 */
+	getLastOpenedAt(path: string): number | undefined {
+		return this.recentFiles.peek(path);
 	}
 
 

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -18,6 +18,8 @@ import {
 	isFolder,
 } from "src/utilityObsidian";
 import { log } from "src/logger/logManager";
+import { orderFilesForPicker } from "src/utils/fileOrdering";
+import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
 import { resolveExistingVariableKey } from "src/utils/valueSyntax";
 import {
 	RequirementCollector,
@@ -181,7 +183,10 @@ async function collectForCaptureChoice(
 			files = getMarkdownFilesInFolder(app, base);
 		}
 
-		const options = files.map((file) => file.path);
+		const options = orderFilesForPicker(
+			files,
+			buildPickerOrderingDeps(app),
+		).map((file) => file.path);
 		collector.requirements.set(QA_INTERNAL_CAPTURE_TARGET_FILE_PATH, {
 			id: QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
 			label: "Select capture target file",

--- a/src/utils/fileOrdering.test.ts
+++ b/src/utils/fileOrdering.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { TFile } from "obsidian";
+import { orderFilesForPicker, type PickerOrderingDeps } from "./fileOrdering";
+
+const file = (path: string, basename?: string): TFile =>
+	({
+		path,
+		basename: basename ?? path.split("/").pop()?.replace(/\.md$/, "") ?? path,
+	}) as TFile;
+
+const paths = (files: TFile[]): string[] => files.map((f) => f.path);
+
+describe("orderFilesForPicker", () => {
+	it("falls back to a stable alphabetical order with no deps", () => {
+		const files = [file("Charlie.md"), file("alpha.md"), file("Bravo.md")];
+		expect(paths(orderFilesForPicker(files))).toEqual([
+			"alpha.md",
+			"Bravo.md",
+			"Charlie.md",
+		]);
+	});
+
+	it("sorts session-recency (openedAt) newest-first, ahead of non-recent files", () => {
+		const files = [file("a.md"), file("b.md"), file("c.md")];
+		const openedAt: Record<string, number> = { "b.md": 100, "c.md": 200 };
+		const deps: PickerOrderingDeps = {
+			openedAtOf: (p) => openedAt[p],
+		};
+		// c (200) and b (100) are recent (newest first); a has no openedAt -> tail.
+		expect(paths(orderFilesForPicker(files, deps))).toEqual([
+			"c.md",
+			"b.md",
+			"a.md",
+		]);
+	});
+
+	it("uses getLastOpenFiles rank as the cross-session baseline when openedAt is absent", () => {
+		const files = [file("a.md"), file("b.md"), file("c.md")];
+		const recent = ["c.md", "a.md"]; // c most recent, then a, b not recent
+		const deps: PickerOrderingDeps = {
+			recentRankOf: (p) => {
+				const i = recent.indexOf(p);
+				return i === -1 ? undefined : i;
+			},
+		};
+		expect(paths(orderFilesForPicker(files, deps))).toEqual([
+			"c.md",
+			"a.md",
+			"b.md",
+		]);
+	});
+
+	it("prefers session recency over cross-session recents", () => {
+		const files = [file("opened.md"), file("recent.md")];
+		const deps: PickerOrderingDeps = {
+			openedAtOf: (p) => (p === "opened.md" ? 500 : undefined),
+			recentRankOf: (p) => (p === "recent.md" ? 0 : undefined),
+		};
+		// opened.md wins on the session-recency tier even though recent.md is rank 0.
+		expect(paths(orderFilesForPicker(files, deps))).toEqual([
+			"opened.md",
+			"recent.md",
+		]);
+	});
+
+	it("sinks excluded files to the bottom but keeps them present", () => {
+		const files = [file("Excluded.md"), file("alpha.md"), file("beta.md")];
+		const deps: PickerOrderingDeps = {
+			isExcluded: (p) => p === "Excluded.md",
+		};
+		expect(paths(orderFilesForPicker(files, deps))).toEqual([
+			"alpha.md",
+			"beta.md",
+			"Excluded.md",
+		]);
+	});
+
+	it("keeps an excluded recent file below non-excluded files", () => {
+		const files = [file("normal.md"), file("excludedRecent.md")];
+		const deps: PickerOrderingDeps = {
+			openedAtOf: (p) => (p === "excludedRecent.md" ? 999 : undefined),
+			isExcluded: (p) => p === "excludedRecent.md",
+		};
+		expect(paths(orderFilesForPicker(files, deps))).toEqual([
+			"normal.md",
+			"excludedRecent.md",
+		]);
+	});
+
+	it("does not mutate the input array", () => {
+		const files = [file("b.md"), file("a.md")];
+		const snapshot = paths(files);
+		orderFilesForPicker(files);
+		expect(paths(files)).toEqual(snapshot);
+	});
+
+	it("tolerates files lacking a basename by falling back to the path", () => {
+		const partial = [{ path: "z/Note.md" }, { path: "a/Note.md" }] as TFile[];
+		// localeCompare on the full path: "a/Note.md" < "z/Note.md".
+		expect(paths(orderFilesForPicker(partial))).toEqual([
+			"a/Note.md",
+			"z/Note.md",
+		]);
+	});
+});

--- a/src/utils/fileOrdering.ts
+++ b/src/utils/fileOrdering.ts
@@ -1,0 +1,69 @@
+import type { TFile } from "obsidian";
+
+/**
+ * Injected, Obsidian-free inputs for ordering a note-picker candidate list the
+ * way Obsidian's Quick Switcher does. Kept as plain functions so the ordering
+ * logic stays unit-testable without the Obsidian runtime.
+ */
+export interface PickerOrderingDeps {
+	/**
+	 * Session recency timestamp (ms epoch) for a path, from the warm FileIndex,
+	 * or undefined when the file has not been opened this session / the index is cold.
+	 */
+	openedAtOf?: (path: string) => number | undefined;
+	/**
+	 * Cross-session recency rank for a path (0 = most recent), from
+	 * app.workspace.getLastOpenFiles(). The always-available baseline used before
+	 * (and alongside) the session-recency index.
+	 */
+	recentRankOf?: (path: string) => number | undefined;
+	/** Obsidian "Excluded files" predicate (app.metadataCache.isUserIgnored). */
+	isExcluded?: (path: string) => boolean;
+}
+
+/**
+ * Orders files for a capture note-picker to mirror the Quick Switcher:
+ *  1. excluded ("Excluded files") sink to the bottom but stay selectable,
+ *  2. most-recently-opened first (session recency, then cross-session recents),
+ *  3. everything else alphabetically — a predictable tail that never re-surfaces
+ *     the sync/import noise that motivated issue #745 (deliberately not mtime).
+ *
+ * Pure: all Obsidian access is injected via {@link PickerOrderingDeps}, so the
+ * empty-deps case degrades to a stable alphabetical order.
+ */
+export function orderFilesForPicker(
+	files: TFile[],
+	deps: PickerOrderingDeps = {},
+): TFile[] {
+	const { openedAtOf, recentRankOf, isExcluded } = deps;
+
+	return files
+		.map((file) => ({
+			file,
+			name: file.basename || file.path,
+			excluded: isExcluded?.(file.path) ?? false,
+			openedAt: openedAtOf?.(file.path),
+			recentRank: recentRankOf?.(file.path),
+		}))
+		.sort((a, b) => {
+			// 1. Excluded files always sink (but remain selectable).
+			if (a.excluded !== b.excluded) return a.excluded ? 1 : -1;
+
+			// 2a. Session recency (FileIndex): opened-this-session first, newest first.
+			const aOpened = a.openedAt != null;
+			const bOpened = b.openedAt != null;
+			if (aOpened !== bOpened) return aOpened ? -1 : 1;
+			if (aOpened && bOpened && a.openedAt !== b.openedAt) {
+				return (b.openedAt as number) - (a.openedAt as number);
+			}
+
+			// 2b. Cross-session recents (getLastOpenFiles): lower rank = more recent.
+			const aRank = a.recentRank ?? Number.POSITIVE_INFINITY;
+			const bRank = b.recentRank ?? Number.POSITIVE_INFINITY;
+			if (aRank !== bRank) return aRank - bRank;
+
+			// 3. Predictable alphabetical tail.
+			return a.name.localeCompare(b.name);
+		})
+		.map((entry) => entry.file);
+}

--- a/src/utils/pickerOrderingDeps.ts
+++ b/src/utils/pickerOrderingDeps.ts
@@ -1,0 +1,38 @@
+import type { App } from "obsidian";
+import { FileIndex } from "src/gui/suggesters/FileIndex";
+import type { PickerOrderingDeps } from "./fileOrdering";
+
+/**
+ * Builds Quick-Switcher-style ordering deps from the live Obsidian app, defensively:
+ * every Obsidian touch is guarded so unit tests with bare app stubs degrade to a
+ * stable alphabetical order instead of throwing.
+ *
+ * Recency reuses the warm FileIndex session-recency (LRU, up to 100) when the index
+ * already exists, and always layers app.workspace.getLastOpenFiles() as the
+ * cross-session baseline. `isUserIgnored` is a real-but-undocumented Obsidian
+ * internal (absent from obsidian.d.ts), so it is reached through a narrow local cast.
+ */
+export function buildPickerOrderingDeps(app: App): PickerOrderingDeps {
+	const recents = app.workspace?.getLastOpenFiles?.() ?? [];
+	const recentRank = new Map<string, number>();
+	recents.forEach((path, index) => {
+		if (!recentRank.has(path)) recentRank.set(path, index);
+	});
+
+	let fileIndex: FileIndex | undefined;
+	try {
+		fileIndex = FileIndex.getInstanceIfExists();
+	} catch {
+		fileIndex = undefined;
+	}
+
+	const metadataCache = app.metadataCache as
+		| { isUserIgnored?: (path: string) => boolean }
+		| undefined;
+
+	return {
+		openedAtOf: (path) => fileIndex?.getLastOpenedAt(path),
+		recentRankOf: (path) => recentRank.get(path),
+		isExcluded: (path) => metadataCache?.isUserIgnored?.(path) ?? false,
+	};
+}

--- a/src/utils/pickerOrderingDeps.ts
+++ b/src/utils/pickerOrderingDeps.ts
@@ -13,7 +13,8 @@ import type { PickerOrderingDeps } from "./fileOrdering";
  * internal (absent from obsidian.d.ts), so it is reached through a narrow local cast.
  */
 export function buildPickerOrderingDeps(app: App): PickerOrderingDeps {
-	const recents = app.workspace?.getLastOpenFiles?.() ?? [];
+	const rawRecents = app.workspace?.getLastOpenFiles?.();
+	const recents = Array.isArray(rawRecents) ? rawRecents : [];
 	const recentRank = new Map<string, number>();
 	recents.forEach((path, index) => {
 		if (!recentRank.has(path)) recentRank.set(path, index);

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -340,6 +340,7 @@ export class App {
     getLeaf: () => ({}),
     setActiveLeaf: () => {},
     iterateRootLeaves: () => {},
+    getLastOpenFiles: () => [],
   };
   vault: any = {
     configDir: ".obsidian",
@@ -354,6 +355,7 @@ export class App {
   };
   metadataCache: any = {
     getFileCache: () => undefined,
+    isUserIgnored: () => false,
   };
   commands: any = {
     commands: {},


### PR DESCRIPTION
## What & why

Closes #745 · Closes #539

The capture file picker listed notes in **vault-registry order**, so it surfaced whatever sorted first (often a `Scripts` folder no one opens) instead of the notes you actually use — and typing a name offered a confusing "create" row even for notes that exist. This makes the picker mirror Obsidian's **Quick Switcher**:

- **Recently-opened notes first**, then a predictable **alphabetical** tail; **Excluded files** sink to the bottom (still selectable).
- Typing fuzzy-ranks the best match to the top (press Enter to pick it).
- A gated, clearly-labelled **"Create new note: X"** row that only appears when *Create file if it doesn't exist* is on **and** the typed name isn't an existing note.
- The **tag** picker now shows note names instead of raw `Some/Deep/Folder/Note.md` paths.

## How

- **New pure `orderFilesForPicker`** (`src/utils/fileOrdering.ts`): excluded sink → session recency (`FileIndex.openedAt`) → cross-session recents (`getLastOpenFiles`, cold-start seed) → alphabetical. Deliberately **not** `mtime` (sync/import/Templater bumps it and would re-surface noise). All Obsidian access is injected (`buildPickerOrderingDeps`), so the logic is unit-testable and degrades to alphabetical on older/missing APIs.
- **Recency reuse, no startup cost**: `FileIndex.getInstanceIfExists()` (never constructs) + `getLastOpenedAt()` via a new non-mutating `LRUCache.peek()`.
- **`InputSuggester`** gains **opt-in** `allowCustomValue` / `customValueLabel` / `valueExists`; defaults preserve today's behaviour, so the 6 non-capture callers are untouched. Create-row suppression now checks `displayItems` + `valueExists`, fixing a case where an existing in-folder note typed by basename showed a mislabelled "create" row.
- Wired into the **folder, vault, and tag** pickers in `CaptureChoiceEngine` plus the **one-page preflight** dropdown.

## Verification

- `tsc` + `eslint` clean; **full vitest 1901 passed** (new: `fileOrdering`, InputSuggester gating/suppression, engine ordering+gating, `FileIndex` recency seam; import-cycle invariant green).
- **Live dev-vault e2e**: the picker's empty state now renders recents-first (`QuickAdd-Repros/662-native.md`, `QA-620-GVAR-Output.md`, `Templates/Games Template.md`, …) instead of the old `qa-trace-*` registry junk — verified equal to the expected recency order, not the raw `getMarkdownFiles()` order.
- Multi-agent review (design + post-implementation adversarial passes); all surfaced blockers/majors addressed.

## Notes / not in scope

- No new setting (no migration). This **changes the default order** — worth a release-note callout. Today's order is arbitrary registry order, so there's no alphabetical contract being broken.
- Pre-existing behaviours left as-is: tag-scope "create" makes a vault-root note that won't carry the tag; the empty-folder invariant aborts before the picker even when *create* is on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suggestions now order by recent opens first, then alphabetically.
  * Pickers gain options to enable/disable a custom "create" row and to customize its label.
  * Note-path suggestions render clearer title/parent metadata.

* **Bug Fixes**
  * "Create new note" is suppressed when an equivalent target already exists (folders and tags).
  * Picker ordering correctly handles recency tiers and excluded files.

* **Tests**
  * New unit tests cover create-row behavior, picker ordering, and file-recency accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->