### PR TITLE
feat(format): named suggester reuse via {{VALUE:options|name:x}} (#148)

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -105,6 +105,27 @@ Example: `{{DATE:YYYY-MM-DD}}-{{VALUE:title|case:slug}}.md`.
 
 Allows you to type custom values in addition to selecting from the provided options. Example: `{{VALUE:Red,Green,Blue|custom}}` will suggest Red, Green, and Blue, but also allows you to type any other value like "Purple". This is useful when you have common options but want flexibility for edge cases. **Note:** You cannot combine `|custom` with a shorthand default value - use `|default:` if you need both.
 
+## `{{VALUE:<options>|name:<variable name>}}` {#value-name}
+
+Gives a suggester a reusable **name**, so the value you pick can be inserted again elsewhere without prompting a second time. Pick from the options once at the definition, then reuse the choice anywhere with `{{VALUE:<variable name>}}`.
+
+This is what makes a single choice drive multiple places — for example choosing a category in the file name and reusing it as a tag in the body:
+
+```markdown
+File name: {{VALUE:Personal,Work,Errand|name:category}} - {{VALUE:title}}
+
+tags: #{{VALUE:category}}
+```
+
+You choose `category` once from the suggester; both the file name and the `tags` line use that selection.
+
+Notes:
+
+- Reuse is always `{{VALUE:category}}`. A bare `{{category}}` is **not** a QuickAdd token and is left untouched (it would collide with Templater/Dataview syntax).
+- `|name` combines with the other options, e.g. `{{VALUE:🔽,🔼,⏫|name:priority|text:Low,Normal,High|label:Pick a priority}}`.
+- Define before you reuse: with the one-page input form (Settings → QuickAdd) order doesn't matter, but in the default one-prompt-at-a-time flow the named suggester should appear before its first bare reuse (e.g. in the file name, which is resolved before the body). A bare reuse encountered first falls back to a text prompt.
+- `value` and `title` are reserved and can't be used as a name.
+
 ## Optional fields: `|optional` {#optional-fields}
 
 Marks a prompt as optional, so it can be skipped and resolve to nothing. Works on `{{VALUE}}`/`{{NAME}}`, `{{VALUE:<variable>}}`, option lists, and `{{VDATE:...}}`.

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -123,7 +123,7 @@ Notes:
 
 - Reuse is always `{{VALUE:category}}`. A bare `{{category}}` is **not** a QuickAdd token and is left untouched (it would collide with Templater/Dataview syntax).
 - `|name` combines with the other options, e.g. `{{VALUE:🔽,🔼,⏫|name:priority|text:Low,Normal,High|label:Pick a priority}}`.
-- Define before you reuse: with the one-page input form (Settings → QuickAdd) order doesn't matter, but in the default one-prompt-at-a-time flow the named suggester should appear before its first bare reuse (e.g. in the file name, which is resolved before the body). A bare reuse encountered first falls back to a text prompt.
+- Within a single field the order is free — the definition and its `{{VALUE:category}}` reuses can appear in any order, because the named suggester is resolved before the field's other prompts. Across fields in the default one-prompt-at-a-time flow, define the named suggester in the field that is resolved first (the file name is resolved before the body); a reuse in an earlier field than its definition falls back to a text prompt. The one-page input form (Settings → QuickAdd) removes this caveat entirely.
 - `value` and `title` are reserved and can't be used as a name.
 
 ## Optional fields: `|optional` {#optional-fields}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,8 @@ export const VARIABLE_LABEL_SYNTAX =
 	"{{value:<variable name>|label:<helper text>}}";
 export const VARIABLE_TEXT_SYNTAX =
 	"{{value:<items>|text:<display items>}}";
+export const VARIABLE_NAME_SYNTAX =
+	"{{value:<options>|name:<variable name>}}";
 export const VARIABLE_OPTIONAL_SYNTAX =
 	"{{value:<variable name>|optional}}";
 export const VDATE_OPTIONAL_SYNTAX =
@@ -44,6 +46,7 @@ export const FORMAT_SYNTAX: string[] = [
 	VARIABLE_DEFAULT_OPTION_SYNTAX,
 	VARIABLE_LABEL_SYNTAX,
 	VARIABLE_TEXT_SYNTAX,
+	VARIABLE_NAME_SYNTAX,
 	VARIABLE_OPTIONAL_SYNTAX,
 	FIELD_VAR_SYNTAX,
 	"{{field:<fieldname>|folder:<path>}}",
@@ -78,6 +81,7 @@ export const FILE_NAME_FORMAT_SYNTAX: string[] = [
 	VARIABLE_DEFAULT_OPTION_SYNTAX,
 	VARIABLE_LABEL_SYNTAX,
 	VARIABLE_TEXT_SYNTAX,
+	VARIABLE_NAME_SYNTAX,
 	FIELD_VAR_SYNTAX,
 	RANDOM_SYNTAX,
 ];

--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -21,6 +21,7 @@ const CURRENT_AND_2120_EXAMPLES = [
 	"## Summary\n{{VALUE:summary|type:multiline|label:Summary}}",
 	"{{DATE:YYYY-MM-DD}}-{{VALUE:title|case:slug}}.md",
 	"{{VALUE:Red,Green,Blue|custom}}",
+	"{{VALUE:Personal,Work,Errand|name:category}} - {{VALUE:title}}\ntags: #{{VALUE:category}}",
 	"{{VALUE:reminder|optional}}",
 	"{{VALUE:reminder|call mom|optional}}",
 	"- [ ] {{VALUE|label:Task}} {{VDATE:followup,[📅 ]YYYY-MM-DD|optional}}",

--- a/src/formatters/formatter-named-suggester.test.ts
+++ b/src/formatters/formatter-named-suggester.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Formatter, type PromptContext } from "./formatter";
+
+/**
+ * Exercises the REAL Formatter.replaceVariableInString (two-pass named-suggester
+ * resolution + ensureValueVariableResolved) for issue #148. Only the abstract
+ * UI/IO hooks are stubbed; prompt/suggest calls are logged so we can assert that
+ * a named suggester is shown exactly once and reused without a free-text prompt.
+ */
+class TestFormatter extends Formatter {
+	public calls: string[] = [];
+	public suggestReturns = new Map<string, string>();
+	public promptReturns = new Map<string, string>();
+
+	constructor() {
+		super(undefined);
+	}
+
+	public run(input: string): Promise<string> {
+		return this.replaceVariableInString(input);
+	}
+
+	public getVar(key: string): unknown {
+		return this.variables.get(key);
+	}
+
+	public seed(key: string, value: unknown): void {
+		this.variables.set(key, value);
+	}
+
+	protected async format(input: string): Promise<string> {
+		return input;
+	}
+	protected async promptForValue(): Promise<string> {
+		return "";
+	}
+	protected async promptForVariable(
+		variableName?: string,
+		context?: PromptContext,
+	): Promise<string> {
+		const key = context?.variableKey ?? variableName ?? "";
+		this.calls.push(`prompt:${key}`);
+		return this.promptReturns.get(key) ?? `typed(${variableName})`;
+	}
+	protected async suggestForValue(
+		suggestedValues: string[],
+		_allowCustomInput?: boolean,
+		context?: {
+			placeholder?: string;
+			variableKey?: string;
+			displayValues?: string[];
+			optional?: boolean;
+		},
+	): Promise<string> {
+		const key = context?.variableKey ?? "";
+		this.calls.push(
+			`suggest:${key}:[${suggestedValues.join(",")}]:ph=${context?.placeholder ?? ""}`,
+		);
+		return this.suggestReturns.get(key) ?? suggestedValues[0];
+	}
+	protected async suggestForField(): Promise<string> {
+		return "";
+	}
+	protected async getMacroValue(): Promise<string> {
+		return "";
+	}
+	protected async getTemplateContent(): Promise<string> {
+		return "";
+	}
+	protected async getSelectedText(): Promise<string> {
+		return "";
+	}
+	protected async getClipboardContent(): Promise<string> {
+		return "";
+	}
+	protected getCurrentFileLink(): string | null {
+		return null;
+	}
+	protected getCurrentFileName(): string | null {
+		return null;
+	}
+	protected getVariableValue(variableName: string): string {
+		return String(this.variables.get(variableName) ?? "");
+	}
+	protected async promptForMathValue(): Promise<string> {
+		return "";
+	}
+	protected isTemplatePropertyTypesEnabled(): boolean {
+		return false;
+	}
+}
+
+describe("named suggester (#148)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("stores the suggester pick under the name and reuses it without re-prompting", async () => {
+		const f = new TestFormatter();
+		f.suggestReturns.set("category", "work");
+
+		const out = await f.run(
+			"# {{VALUE:work,home,errand|name:category}}\ntags: #{{VALUE:category}}",
+		);
+
+		expect(out).toBe("# work\ntags: #work");
+		// Exactly one suggester, no free-text prompt for the reuse site.
+		expect(f.calls.filter((c) => c.startsWith("suggest:"))).toHaveLength(1);
+		expect(f.calls.some((c) => c.startsWith("prompt:"))).toBe(false);
+		expect(f.getVar("category")).toBe("work");
+	});
+
+	it("is order-independent within a string: reuse BEFORE definition still shows the suggester", async () => {
+		const f = new TestFormatter();
+		f.suggestReturns.set("category", "home");
+
+		const out = await f.run(
+			"tags: #{{VALUE:category}}\ntitle: {{VALUE:work,home|name:category}}",
+		);
+
+		expect(out).toBe("tags: #home\ntitle: home");
+		// The named definition was hoisted; the reuse never became a text prompt.
+		expect(f.calls.filter((c) => c.startsWith("suggest:"))).toHaveLength(1);
+		expect(f.calls.some((c) => c.startsWith("prompt:"))).toBe(false);
+	});
+
+	it("does NOT hoist a single-use named suggester ahead of an earlier prompt", async () => {
+		const f = new TestFormatter();
+		f.promptReturns.set("first", "A");
+		f.suggestReturns.set("kind", "x");
+
+		await f.run("{{VALUE:first}} then {{VALUE:x,y|name:kind}}");
+
+		// No reuse of `kind`, so document order is preserved: prompt before suggest.
+		expect(f.calls).toEqual([
+			"prompt:first",
+			"suggest:kind:[x,y]:ph=",
+		]);
+	});
+
+	it("does NOT hoist when the reuse comes AFTER the definition (document order kept)", async () => {
+		const f = new TestFormatter();
+		f.promptReturns.set("first", "A");
+		f.suggestReturns.set("kind", "x");
+
+		// def at pos 2, reuse at pos 3 — no use precedes the def, so document
+		// order resolves it; `first` must still be prompted before the suggester.
+		await f.run(
+			"{{VALUE:first}} {{VALUE:x,y|name:kind}} {{VALUE:kind}}",
+		);
+
+		expect(f.calls).toEqual(["prompt:first", "suggest:kind:[x,y]:ph="]);
+	});
+
+	it("warns when the same name differs only by the custom flag", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const f = new TestFormatter();
+		f.suggestReturns.set("kind", "a");
+
+		await f.run("{{VALUE:a,b|name:kind}} {{VALUE:a,b|name:kind|custom}}");
+
+		expect(
+			warn.mock.calls.some((c) =>
+				String(c[0]).includes("different option lists"),
+			),
+		).toBe(true);
+	});
+
+	it("does not show a suggester when an earlier token is malformed (aborts hoisting)", async () => {
+		const f = new TestFormatter();
+		f.suggestReturns.set("cat", "p");
+
+		// The first token is invalid (text mapping on a single value); the pre-pass
+		// must abort so the main pass throws before any suggester is shown.
+		await expect(
+			f.run("{{VALUE:bad|text:Only}} {{VALUE:p,q|name:cat}} {{VALUE:cat}}"),
+		).rejects.toThrow();
+		expect(f.calls.some((c) => c.startsWith("suggest:"))).toBe(false);
+	});
+
+	it("uses |label as the suggester placeholder while keying on |name", async () => {
+		const f = new TestFormatter();
+		f.suggestReturns.set("category", "home");
+
+		await f.run(
+			"{{VALUE:work,home|name:category|label:Pick a category}}\n{{VALUE:category}}",
+		);
+
+		expect(f.calls[0]).toBe(
+			"suggest:category:[work,home]:ph=Pick a category",
+		);
+		expect(f.getVar("category")).toBe("home");
+	});
+
+	it("warns and keeps the first value when a name is reused with different options", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const f = new TestFormatter();
+		f.suggestReturns.set("type", "bug");
+
+		const out = await f.run(
+			"a={{VALUE:bug,feature|name:type}} b={{VALUE:book,movie|name:type}}",
+		);
+
+		// First-write-wins; the second definition reuses "bug" (out of its own
+		// option set) and emits a warning rather than re-prompting.
+		expect(out).toBe("a=bug b=bug");
+		expect(f.calls.filter((c) => c.startsWith("suggest:"))).toHaveLength(1);
+		expect(
+			warn.mock.calls.some((c) =>
+				String(c[0]).includes("different option lists"),
+			),
+		).toBe(true);
+	});
+
+	it("does NOT warn when a seeded value is not one of the options (no false positive)", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const f = new TestFormatter();
+		// Simulate api.format / a script / the one-page form pre-seeding the name
+		// with a value outside the literal option list.
+		f.seed("category", "work-from-home");
+
+		const out = await f.run(
+			"# {{VALUE:work,home|name:category}}\ntags: #{{VALUE:category}}",
+		);
+
+		expect(out).toBe("# work-from-home\ntags: #work-from-home");
+		expect(f.calls).toHaveLength(0); // fully resolved from the seed, no prompts
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("reuses across separate format passes that share the variables map", async () => {
+		const f = new TestFormatter();
+		f.suggestReturns.set("category", "errand");
+
+		// Simulate filename pass then body pass on the same formatter instance.
+		const name = await f.run("{{VALUE:work,home,errand|name:category}}");
+		const body = await f.run("category: {{VALUE:category}}");
+
+		expect(name).toBe("errand");
+		expect(body).toBe("category: errand");
+		expect(f.calls.filter((c) => c.startsWith("suggest:"))).toHaveLength(1);
+	});
+});

--- a/src/formatters/formatter-named-suggester.test.ts
+++ b/src/formatters/formatter-named-suggester.test.ts
@@ -152,6 +152,28 @@ describe("named suggester (#148)", () => {
 		expect(f.calls).toEqual(["prompt:first", "suggest:kind:[x,y]:ph="]);
 	});
 
+	it("keeps the FIRST definition when two same-name defs have no preceding reuse", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const f = new TestFormatter();
+		f.suggestReturns.set("type", "a");
+
+		// No bare reuse precedes either definition, so neither is hoisted; document
+		// order wins → the first definition's options/value are used for both.
+		const out = await f.run(
+			"x={{VALUE:a,b|name:type}} y={{VALUE:c,d|name:type}}",
+		);
+
+		expect(out).toBe("x=a y=a");
+		// Only the first definition's suggester is shown ([a,b], not [c,d]).
+		const suggests = f.calls.filter((c) => c.startsWith("suggest:"));
+		expect(suggests).toEqual(["suggest:type:[a,b]:ph="]);
+		expect(
+			warn.mock.calls.some((c) =>
+				String(c[0]).includes("different option lists"),
+			),
+		).toBe(true);
+	});
+
 	it("warns when the same name differs only by the custom flag", async () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const f = new TestFormatter();

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -31,6 +31,7 @@ import { normalizeDateInput } from "../utils/dateAliases";
 import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
 import {
+	type ParsedValueToken,
 	parseAnonymousValueOptions,
 	parseValueToken,
 	resolveExistingVariableKey,
@@ -77,6 +78,13 @@ export abstract class Formatter {
 	// Tracks variables collected for YAML property post-processing
 	private readonly propertyCollector: TemplatePropertyCollector;
 	private templatePropertyCollectionDepth = 0;
+
+	// Detects the same |name being defined with conflicting option lists across
+	// one execution (filename + body share this instance). Keyed name -> option
+	// signature; conflicts warn once. Value-independent so externally-seeded or
+	// custom-typed values never produce a false positive.
+	private readonly namedSuggesterOptionSigs = new Map<string, string>();
+	private readonly namedSuggesterConflictsWarned = new Set<string>();
 
 	protected constructor(protected readonly app?: App) {
 		this.propertyCollector = new TemplatePropertyCollector(app);
@@ -386,8 +394,163 @@ export abstract class Formatter {
 
 
 
+	/**
+	 * Warn once when the same `|name` is given two different option lists in one
+	 * execution (e.g. {{VALUE:bug,feature|name:type}} and
+	 * {{VALUE:book,movie|name:type}}). Named reuse is first-write-wins, so the
+	 * second definition silently reuses the first value; the warning surfaces the
+	 * likely mistake. Uses the option list itself (not the resolved value), so
+	 * seeded/scripted/custom values never trip it.
+	 */
+	private warnOnNamedOptionConflict(parsed: ParsedValueToken): void {
+		if (!parsed.aliasName || !parsed.hasOptions) return;
+		const nameKey = parsed.variableKey.toLowerCase();
+		// Capture everything that changes the suggester behaviour — the
+		// options, the custom-input flag, and the display mapping — so a
+		// reordered definition that differs in any of these is flagged.
+		const signature = JSON.stringify([
+			parsed.suggestedValues,
+			parsed.allowCustomInput,
+			parsed.displayValues ?? null,
+		]);
+		const previous = this.namedSuggesterOptionSigs.get(nameKey);
+		if (previous === undefined) {
+			this.namedSuggesterOptionSigs.set(nameKey, signature);
+			return;
+		}
+		if (previous !== signature && !this.namedSuggesterConflictsWarned.has(nameKey)) {
+			this.namedSuggesterConflictsWarned.add(nameKey);
+			console.warn(
+				`QuickAdd: named value "${parsed.variableKey}" is defined with different option lists; the first definition's value is reused.`,
+			);
+		}
+	}
+
+	/**
+	 * Resolve a parsed VALUE token into `this.variables` (prompting/suggesting
+	 * only if it isn't already cached) and return the key its value lives under.
+	 * Shared by the named-definition pre-pass and the main replacement loop so
+	 * the prompt/suggest/default/store logic has a single source of truth.
+	 */
+	private async ensureValueVariableResolved(
+		parsed: ParsedValueToken,
+	): Promise<string> {
+		const {
+			variableName,
+			variableKey,
+			label,
+			defaultValue,
+			allowCustomInput,
+			suggestedValues,
+			displayValues,
+			hasOptions,
+		} = parsed;
+
+		this.warnOnNamedOptionConflict(parsed);
+
+		const resolvedKey = resolveExistingVariableKey(
+			this.variables,
+			variableKey,
+		);
+
+		if (resolvedKey) return resolvedKey;
+
+		let variableValue = "";
+		const helperText = !hasOptions && label ? label : undefined;
+		const suggesterPlaceholder = hasOptions && label ? label : undefined;
+
+		if (!hasOptions) {
+			// For single-value prompts, pass default value to pre-populate the input
+			variableValue = await this.promptForVariable(variableName, {
+				defaultValue,
+				description: helperText,
+				inputTypeOverride: parsed.inputTypeOverride,
+				variableKey,
+				optional: parsed.optional,
+			});
+		} else {
+			variableValue = await this.suggestForValue(
+				suggestedValues,
+				allowCustomInput,
+				{
+					placeholder: suggesterPlaceholder,
+					variableKey,
+					displayValues,
+					optional: parsed.optional,
+				},
+			);
+		}
+
+		// Use default value if no input provided (applies to both prompt and suggester).
+		// Optional tokens take the empty submission at face value: the default is
+		// visibly pre-filled, so an empty box means the user cleared it.
+		if (!variableValue && defaultValue && !parsed.optional) {
+			variableValue = defaultValue;
+		}
+
+		this.variables.set(variableKey, variableValue);
+		return variableKey;
+	}
+
+	/**
+	 * Two-pass support: resolve named suggester DEFINITIONS
+	 * ({{VALUE:a,b,c|name:x}}) before the main pass so a bare reuse site
+	 * ({{VALUE:x}}) earlier in the same string resolves from cache instead of
+	 * silently degrading to a free-text prompt. A definition is hoisted ONLY
+	 * when a reference to its name appears BEFORE it; otherwise document order
+	 * already resolves it, so unrelated prompts are never reordered.
+	 */
+	private async resolveNamedSuggesterDefinitions(
+		input: string,
+	): Promise<void> {
+		// Fast path: nothing to hoist unless a |name: option is present.
+		if (!/\|\s*name\s*:/i.test(input)) return;
+
+		const regex = new RegExp(VARIABLE_REGEX.source, "gi");
+		const tokens: { parsed: ParsedValueToken; index: number }[] = [];
+		let match: RegExpExecArray | null;
+
+		while ((match = regex.exec(input)) !== null) {
+			if (!match[1]) continue;
+			let parsed: ParsedValueToken | null;
+			try {
+				// Quiet: the main pass parses again and owns the user-facing warnings.
+				parsed = parseValueToken(match[1], { quiet: true });
+			} catch {
+				// A malformed token throws in the main pass; abort hoisting so the
+				// error surfaces before any suggester is shown.
+				return;
+			}
+			if (parsed) tokens.push({ parsed, index: match.index });
+		}
+
+		// Earliest index each (case-insensitive) key is referenced at — mirrors
+		// resolveExistingVariableKey's case-insensitive matching.
+		const firstIndex = new Map<string, number>();
+		for (const { parsed, index } of tokens) {
+			const key = parsed.variableKey.toLowerCase();
+			if (!firstIndex.has(key)) firstIndex.set(key, index);
+		}
+
+		const seen = new Set<string>();
+		for (const { parsed, index } of tokens) {
+			if (!parsed.hasOptions || !parsed.aliasName) continue;
+			const key = parsed.variableKey.toLowerCase();
+			// Only hoist when a use precedes this definition.
+			if ((firstIndex.get(key) ?? index) >= index) continue;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			await this.ensureValueVariableResolved(parsed);
+		}
+	}
+
 	protected async replaceVariableInString(input: string) {
 		let output = input;
+
+		// Pass 1: resolve named suggester definitions up front (see above).
+		await this.resolveNamedSuggesterDefinitions(output);
+
+		// Pass 2: replace every VALUE token in document order.
 		const regex = new RegExp(VARIABLE_REGEX.source, 'gi'); // preserve case-insensitive + global
 		const propertyTypesEnabled = this.isTemplatePropertyTypesEnabled();
 		let match: RegExpExecArray | null;
@@ -404,62 +567,10 @@ export abstract class Formatter {
 
 			const {
 				variableName,
-				variableKey,
-				label,
 				caseStyle,
-				defaultValue,
-				allowCustomInput,
-				suggestedValues,
-				displayValues,
-				hasOptions,
 			} = parsed;
 
-			const resolvedKey = resolveExistingVariableKey(
-				this.variables,
-				variableKey,
-			);
-
-			// Ensure variable is set (prompt if needed)
-			if (!resolvedKey) {
-				let variableValue = "";
-				const helperText =
-					!hasOptions && label ? label : undefined;
-				const suggesterPlaceholder =
-					hasOptions && label ? label : undefined;
-
-				if (!hasOptions) {
-					// For single-value prompts, pass default value to pre-populate the input
-					variableValue = await this.promptForVariable(variableName, {
-						defaultValue,
-						description: helperText,
-						inputTypeOverride: parsed.inputTypeOverride,
-						variableKey,
-						optional: parsed.optional,
-					});
-				} else {
-					variableValue = await this.suggestForValue(
-						suggestedValues,
-						allowCustomInput,
-						{
-							placeholder: suggesterPlaceholder,
-							variableKey,
-							displayValues,
-							optional: parsed.optional,
-						},
-					);
-				}
-
-				// Use default value if no input provided (applies to both prompt and suggester).
-				// Optional tokens take the empty submission at face value: the default is
-				// visibly pre-filled, so an empty box means the user cleared it.
-				if (!variableValue && defaultValue && !parsed.optional) {
-					variableValue = defaultValue;
-				}
-
-				this.variables.set(variableKey, variableValue);
-			}
-
-			const effectiveKey = resolvedKey ?? variableKey;
+			const effectiveKey = await this.ensureValueVariableResolved(parsed);
 
 			// Get the raw value from variables
 			const rawValue = this.variables.get(effectiveKey);

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -524,20 +524,23 @@ export abstract class Formatter {
 			if (parsed) tokens.push({ parsed, index: match.index });
 		}
 
-		// Earliest index each (case-insensitive) key is referenced at — mirrors
-		// resolveExistingVariableKey's case-insensitive matching.
-		const firstIndex = new Map<string, number>();
+		// Earliest index each (case-insensitive) key is referenced by a NON-
+		// definition token (a bare reuse). A prior definition must not count as a
+		// "use", else two conflicting definitions of the same name would hoist the
+		// later one ahead of the earlier — the first definition must win.
+		const firstUseIndex = new Map<string, number>();
 		for (const { parsed, index } of tokens) {
+			if (parsed.hasOptions && parsed.aliasName) continue; // skip definitions
 			const key = parsed.variableKey.toLowerCase();
-			if (!firstIndex.has(key)) firstIndex.set(key, index);
+			if (!firstUseIndex.has(key)) firstUseIndex.set(key, index);
 		}
 
 		const seen = new Set<string>();
 		for (const { parsed, index } of tokens) {
 			if (!parsed.hasOptions || !parsed.aliasName) continue;
 			const key = parsed.variableKey.toLowerCase();
-			// Only hoist when a use precedes this definition.
-			if ((firstIndex.get(key) ?? index) >= index) continue;
+			// Only hoist when a bare reuse precedes this definition.
+			if ((firstUseIndex.get(key) ?? index) >= index) continue;
 			if (seen.has(key)) continue;
 			seen.add(key);
 			await this.ensureValueVariableResolved(parsed);

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -252,6 +252,62 @@ Body`);
   });
 });
 
+describe("RequirementCollector — named suggester (issue #148)", () => {
+  it("keys a named suggester on the name and dedups with the reuse site", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    await rc.scanString(
+      "# {{VALUE:work,home,errand|name:category}}\ntags: #{{VALUE:category}}",
+    );
+
+    // Exactly one requirement, keyed by the name, rendered as a dropdown.
+    expect(rc.requirements.has("category")).toBe(true);
+    expect(rc.requirements.get("category")).toMatchObject({
+      id: "category",
+      type: "dropdown",
+      options: ["work", "home", "errand"],
+    });
+    // No stray requirement under the option-list string.
+    expect(rc.requirements.has("work,home,errand")).toBe(false);
+  });
+
+  it("upgrades a reuse-first requirement to a dropdown (order-independent)", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    // Bare reuse appears BEFORE the definition.
+    await rc.scanString(
+      "tags: #{{VALUE:category}}\ntitle: {{VALUE:work,home|name:category}}",
+    );
+
+    expect(rc.requirements.get("category")).toMatchObject({
+      type: "dropdown",
+      options: ["work", "home"],
+    });
+  });
+
+  it("upgrades across separate scanned strings (filename then body)", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    await rc.scanString("{{VALUE:category}}"); // filename: reuse first
+    await rc.scanString("{{VALUE:a,b,c|name:category}}"); // body: definition
+
+    expect(rc.requirements.get("category")).toMatchObject({
+      type: "dropdown",
+      options: ["a", "b", "c"],
+    });
+  });
+
+  it("records a custom-input named list as a suggester", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    await rc.scanString("{{VALUE:a,b|name:category|custom}}");
+
+    expect(rc.requirements.get("category")).toMatchObject({
+      type: "suggester",
+      options: ["a", "b"],
+    });
+    expect(rc.requirements.get("category")?.suggesterConfig).toMatchObject({
+      allowCustomInput: true,
+    });
+  });
+});
+
 describe("RequirementCollector — optional fields (issue #1259)", () => {
   it("flags a VALUE requirement optional when its only occurrence is flagged", async () => {
     const rc = new RequirementCollector(makeApp(), makePlugin());

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -155,8 +155,6 @@ export class RequirementCollector extends Formatter {
 				variableKey,
 				label,
 				defaultValue,
-				allowCustomInput,
-				suggestedValues,
 				displayValues,
 				hasOptions,
 			} = parsed;
@@ -177,28 +175,38 @@ export class RequirementCollector extends Formatter {
 					id: requirementId,
 					label: displayLabel,
 					type: hasOptions
-						? allowCustomInput
-							? "suggester"
-							: "dropdown"
+						? this.optionFieldType(parsed)
 						: baseInputType,
 					description,
 					optional: parsed.optional,
 				};
-				if (hasOptions) {
-					req.options = suggestedValues;
-					if (displayValues) req.displayOptions = displayValues;
-					if (allowCustomInput) {
-						req.suggesterConfig = {
-							allowCustomInput: true,
-							caseSensitive: false,
-							multiSelect: false,
-						};
-					}
-				}
+				if (hasOptions) this.applyOptionFields(req, parsed);
 				if (defaultValue) req.defaultValue = defaultValue;
 				this.requirements.set(requirementId, req);
 			} else {
 				const existing = this.requirements.get(requirementId)!;
+				// Order-independent named reuse: when a later occurrence carries
+				// the option list ({{VALUE:a,b|name:x}}) but the requirement was
+				// first recorded option-less (a bare {{VALUE:x}} reuse seen
+				// earlier, in this or a prior scanned string), upgrade it in place
+				// so the one-page form renders the dropdown/suggester either way.
+				if (hasOptions && !this.hasOptionList(existing)) {
+					existing.type = this.optionFieldType(parsed);
+					existing.label = displayLabel;
+					this.applyOptionFields(existing, parsed);
+					// Drop a stale text-era default the upgraded control can't keep.
+					// A non-custom dropdown stores raw option values, so a default
+					// that isn't one (incl. a display label) would be normalized to
+					// the first option anyway — clear it for an honest empty start.
+					// The suggester/custom path accepts free text, so keep it.
+					if (
+						existing.defaultValue !== undefined &&
+						!parsed.allowCustomInput &&
+						!parsed.suggestedValues.includes(existing.defaultValue)
+					) {
+						existing.defaultValue = undefined;
+					}
+				}
 				if (defaultValue && existing.defaultValue === undefined)
 					existing.defaultValue = defaultValue;
 				if (!existing.displayOptions && displayValues) {
@@ -207,6 +215,37 @@ export class RequirementCollector extends Formatter {
 				// AND rule: the field is optional only if every occurrence is.
 				existing.optional = (existing.optional ?? false) && parsed.optional;
 			}
+		}
+	}
+
+	private optionFieldType(parsed: {
+		allowCustomInput: boolean;
+	}): FieldType {
+		return parsed.allowCustomInput ? "suggester" : "dropdown";
+	}
+
+	private hasOptionList(req: FieldRequirement): boolean {
+		return Array.isArray(req.options) && req.options.length > 0;
+	}
+
+	private applyOptionFields(
+		req: FieldRequirement,
+		parsed: {
+			suggestedValues: string[];
+			displayValues?: string[];
+			allowCustomInput: boolean;
+		},
+	): void {
+		req.options = parsed.suggestedValues;
+		if (parsed.displayValues) req.displayOptions = parsed.displayValues;
+		if (parsed.allowCustomInput) {
+			req.suggesterConfig = {
+				allowCustomInput: true,
+				caseSensitive: false,
+				multiSelect: false,
+			};
+		} else {
+			delete req.suggesterConfig;
 		}
 	}
 

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -149,6 +149,85 @@ describe("parseAnonymousValueOptions", () => {
 			/only supported for option-list/i,
 		);
 	});
+
+	it("does NOT treat name: as an option (anonymous path is unchanged by #148)", () => {
+		// `name` is gated to the named {{VALUE:...}} grammar; on the anonymous
+		// {{VALUE|...}} grammar it stays an ordinary legacy default value.
+		const parsed = parseAnonymousValueOptions("|name:John");
+		expect(parsed.defaultValue).toBe("name:John");
+	});
+});
+
+describe("named variables (|name:, issue #148)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("keys an option list on the explicit name and exposes aliasName", () => {
+		const parsed = parseValueToken("work,home,errand|name:category");
+		expect(parsed?.hasOptions).toBe(true);
+		expect(parsed?.aliasName).toBe("category");
+		expect(parsed?.variableKey).toBe("category");
+		expect(parsed?.suggestedValues).toEqual(["work", "home", "errand"]);
+	});
+
+	it("bypasses label scoping when a name is given", () => {
+		const parsed = parseValueToken("a,b|name:category|label:Pick");
+		expect(parsed?.variableKey).toBe("category");
+		expect(parsed?.label).toBe("Pick");
+	});
+
+	it("coexists with text and custom options", () => {
+		const parsed = parseValueToken(
+			"a,b|name:category|text:Alpha,Beta|custom",
+		);
+		expect(parsed?.aliasName).toBe("category");
+		expect(parsed?.variableKey).toBe("category");
+		expect(parsed?.displayValues).toEqual(["Alpha", "Beta"]);
+		expect(parsed?.allowCustomInput).toBe(true);
+	});
+
+	it("warns and ignores reserved names", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("a,b|name:title");
+		expect(parsed?.aliasName).toBeUndefined();
+		// Falls back to the option-list key (no alias).
+		expect(parsed?.variableKey).toBe("a,b");
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it("warns and ignores a name containing the reserved key delimiter", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("a,b|name:foo\u001Fbar")
+		expect(parsed?.aliasName).toBeUndefined();
+		expect(parsed?.variableKey).toBe("a,b");
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it("stays silent when parsed in quiet mode", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		// Reserved name would normally warn; quiet mode (the pre-pass) suppresses it.
+		const parsed = parseValueToken("a,b|name:title", { quiet: true });
+		expect(parsed?.aliasName).toBeUndefined();
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("warns and ignores an empty name", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("a,b|name:");
+		expect(parsed?.aliasName).toBeUndefined();
+		expect(parsed?.variableKey).toBe("a,b");
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it("honors but warns about name on a single value", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("Some prompt|name:bar");
+		expect(parsed?.hasOptions).toBe(false);
+		expect(parsed?.aliasName).toBe("bar");
+		expect(parsed?.variableKey).toBe("bar");
+		expect(warnSpy).toHaveBeenCalled();
+	});
 });
 
 describe("resolveExistingVariableKey", () => {

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -21,10 +21,20 @@ const VALUE_OPTION_KEYS = new Set([
 	"optional",
 ]);
 
+// `name` is recognized ONLY on the named `{{VALUE:...}}` grammar, never on the
+// anonymous `{{VALUE|...}}` grammar (which shares parseOptions). Gating it here
+// keeps `{{VALUE|name:x}}` parsing its old "name:x" default unchanged.
+const NAMED_VALUE_OPTION_KEYS = new Set([...VALUE_OPTION_KEYS, "name"]);
+
+// Variable keys QuickAdd populates itself; a `|name:` alias must not hijack them.
+const RESERVED_VALUE_NAMES = new Set(["value", "title"]);
+
 export type ParsedValueToken = {
 	raw: string;
 	variableName: string;
 	variableKey: string;
+	/** Explicit reusable key from `|name:`; undefined when not provided. */
+	aliasName?: string;
 	label?: string;
 	caseStyle?: string;
 	defaultValue: string;
@@ -100,6 +110,7 @@ type ParsedOptions = {
 	inputTypeOverride?: string;
 	displayValuesRaw?: string;
 	optionalExplicit?: boolean;
+	name?: string;
 };
 
 /**
@@ -116,15 +127,21 @@ function extractBareOptionalFlag(parts: string[]): {
 	return { remaining, optional: found };
 }
 
-function hasRecognizedOption(part: string): boolean {
+function hasRecognizedOption(part: string, allowName: boolean): boolean {
 	const trimmed = part.trim();
 	if (!trimmed) return false;
 	const parsed = parsePipeKeyValue(trimmed);
 	if (!parsed) return false;
-	return VALUE_OPTION_KEYS.has(parsed.key);
+	const keys = allowName ? NAMED_VALUE_OPTION_KEYS : VALUE_OPTION_KEYS;
+	return keys.has(parsed.key);
 }
 
-function parseOptions(optionParts: string[], hasOptions: boolean): ParsedOptions {
+function parseOptions(
+	optionParts: string[],
+	hasOptions: boolean,
+	allowName: boolean,
+	quiet = false,
+): ParsedOptions {
 	if (optionParts.length === 0) {
 		return {
 			defaultValue: "",
@@ -133,7 +150,10 @@ function parseOptions(optionParts: string[], hasOptions: boolean): ParsedOptions
 		};
 	}
 
-	const hasExplicitOption = optionParts.some(hasRecognizedOption);
+	const optionKeys = allowName ? NAMED_VALUE_OPTION_KEYS : VALUE_OPTION_KEYS;
+	const hasExplicitOption = optionParts.some((part) =>
+		hasRecognizedOption(part, allowName),
+	);
 	const hasCustomFlag =
 		hasOptions &&
 		optionParts.some(
@@ -156,6 +176,7 @@ function parseOptions(optionParts: string[], hasOptions: boolean): ParsedOptions
 	let inputTypeOverride: string | undefined;
 	let displayValuesRaw: string | undefined;
 	let optionalExplicit: boolean | undefined;
+	let name: string | undefined;
 
 	for (const part of optionParts) {
 		const trimmed = part.trim();
@@ -169,7 +190,7 @@ function parseOptions(optionParts: string[], hasOptions: boolean): ParsedOptions
 		const parsed = parsePipeKeyValue(trimmed);
 		if (!parsed) continue;
 		const { key, value } = parsed;
-		if (!VALUE_OPTION_KEYS.has(key)) continue;
+		if (!optionKeys.has(key)) continue;
 
 		switch (key) {
 			case "label":
@@ -193,6 +214,15 @@ function parseOptions(optionParts: string[], hasOptions: boolean): ParsedOptions
 			case "optional":
 				optionalExplicit = parseBooleanFlag(value);
 				break;
+			case "name":
+				// Gated to the named grammar via optionKeys; empty `|name:` is a
+				// no-op alias and warns so the author notices the typo.
+				if (value) name = value;
+				else if (!quiet)
+					console.warn(
+						`QuickAdd: empty |name: ignored; provide a variable name, e.g. {{VALUE:a,b|name:category}}.`,
+					);
+				break;
 			default:
 				break;
 		}
@@ -203,6 +233,7 @@ function parseOptions(optionParts: string[], hasOptions: boolean): ParsedOptions
 		caseStyle,
 		defaultValue,
 		allowCustomInput,
+		name,
 		usesOptions: true,
 		inputTypeOverride,
 		displayValuesRaw,
@@ -217,26 +248,33 @@ function resolveInputType(
 		hasOptions,
 		allowCustomInput,
 	}: { tokenDisplay: string; hasOptions: boolean; allowCustomInput: boolean },
+	quiet = false,
 ): ValueInputType | undefined {
 	if (!rawType) return undefined;
 	const normalized = rawType.trim().toLowerCase();
 	if (normalized !== "multiline") {
-		console.warn(
-			`QuickAdd: Unsupported VALUE type "${rawType}" in token "${tokenDisplay}". Supported types: multiline.`,
-		);
+		if (!quiet)
+			console.warn(
+				`QuickAdd: Unsupported VALUE type "${rawType}" in token "${tokenDisplay}". Supported types: multiline.`,
+			);
 		return undefined;
 	}
 	if (hasOptions || allowCustomInput) {
-		console.warn(
-			`QuickAdd: Ignoring type:multiline for option-list VALUE token "${tokenDisplay}".`,
-		);
+		if (!quiet)
+			console.warn(
+				`QuickAdd: Ignoring type:multiline for option-list VALUE token "${tokenDisplay}".`,
+			);
 		return undefined;
 	}
 	return "multiline";
 }
 
-export function parseValueToken(raw: string): ParsedValueToken | null {
+export function parseValueToken(
+	raw: string,
+	opts?: { quiet?: boolean },
+): ParsedValueToken | null {
 	if (!raw) return null;
+	const quiet = opts?.quiet ?? false;
 
 	const parts = splitPipeParts(raw);
 	const variablePart = (parts.shift() ?? "").trim();
@@ -250,7 +288,7 @@ export function parseValueToken(raw: string): ParsedValueToken | null {
 
 	const { remaining: optionParts, optional: bareOptional } =
 		extractBareOptionalFlag(parts);
-	const options = parseOptions(optionParts, hasOptions);
+	const options = parseOptions(optionParts, hasOptions, true, quiet);
 	let { label, caseStyle, defaultValue, allowCustomInput } = options;
 	const optional = options.optionalExplicit ?? bareOptional;
 
@@ -261,11 +299,15 @@ export function parseValueToken(raw: string): ParsedValueToken | null {
 	}
 
 	const tokenDisplay = `{{VALUE:${raw}}}`;
-	const inputTypeOverride = resolveInputType(options.inputTypeOverride, {
-		tokenDisplay,
-		hasOptions,
-		allowCustomInput,
-	});
+	const inputTypeOverride = resolveInputType(
+		options.inputTypeOverride,
+		{
+			tokenDisplay,
+			hasOptions,
+			allowCustomInput,
+		},
+		quiet,
+	);
 	let displayValues: string[] | undefined;
 
 	if (options.displayValuesRaw !== undefined) {
@@ -293,11 +335,39 @@ export function parseValueToken(raw: string): ParsedValueToken | null {
 		}
 	}
 
-	const variableKey = buildValueVariableKey(variablePart, label, hasOptions);
+	let aliasName = options.name?.trim() || undefined;
+	if (aliasName && aliasName.includes(VALUE_LABEL_KEY_DELIMITER)) {
+		// The delimiter is reserved for label-scoped keys; an alias containing it
+		// would corrupt resolveExistingVariableKey's base-name stripping.
+		if (!quiet)
+			console.warn(
+				`QuickAdd: |name in "${tokenDisplay}" contains a reserved control character and was ignored.`,
+			);
+		aliasName = undefined;
+	}
+	if (aliasName && RESERVED_VALUE_NAMES.has(aliasName.toLowerCase())) {
+		if (!quiet)
+			console.warn(
+				`QuickAdd: |name:${aliasName} is reserved and was ignored in "${tokenDisplay}". Choose a different name.`,
+			);
+		aliasName = undefined;
+	}
+	if (aliasName && !hasOptions && !quiet) {
+		// A named single value is just a renamed prompt; the option list is what
+		// makes |name useful. Honor it but steer authors to the simpler form.
+		console.warn(
+			`QuickAdd: |name on a single value in "${tokenDisplay}" is redundant — use {{VALUE:${aliasName}}} directly.`,
+		);
+	}
+
+	const variableKey = aliasName
+		? aliasName
+		: buildValueVariableKey(variablePart, label, hasOptions);
 
 	return {
 		raw,
 		variableName: variablePart,
+		aliasName,
 		variableKey,
 		label,
 		caseStyle,
@@ -332,7 +402,7 @@ export function parseAnonymousValueOptions(
 		return { defaultValue: "", optional: bareOptional };
 	}
 
-	const options = parseOptions(parts, false);
+	const options = parseOptions(parts, false, false);
 	const tokenDisplay = `{{VALUE${rawOptions}}}`;
 	if (options.displayValuesRaw !== undefined) {
 		throw new Error(


### PR DESCRIPTION
Closes #148

## What & why
You can show a `{{VALUE:opt1,opt2}}` suggester, but the chosen value can't be **reused** — the suggester's variable key is forced to be the whole option-list string, so there's no way to name a pick and insert it again. This adds a `|name:` pipe option:

```markdown
File name: {{VALUE:Personal,Work,Errand|name:category}} - {{VALUE:title}}

tags: #{{VALUE:category}}
```

You choose `category` once; both the file name and the `tags` line use that selection. Reuse is `{{VALUE:category}}` (a bare `{{category}}` is intentionally **not** a token — no regex anchor, and it would collide with Templater/Dataview).

## How it works
- **Parser (`valueSyntax.ts`)** — `|name` is gated to the named `{{VALUE:...}}` grammar via `allowName`/`NAMED_VALUE_OPTION_KEYS`, so the anonymous `{{VALUE|name:x}}` legacy default is unchanged. New `aliasName` field; `variableKey = aliasName ?? buildValueVariableKey(...)`. Warns on reserved (`value`/`title`), empty, single-value, and delimiter names. A `quiet` flag suppresses warnings during the pre-pass.
- **Runtime (`formatter.ts`)** — `replaceVariableInString` is two-pass. `resolveNamedSuggesterDefinitions` pre-resolves a named definition **only when a use precedes it** (earliest-index, case-insensitive), so unrelated prompts are never reordered and it aborts cleanly on a malformed token. `ensureValueVariableResolved` centralizes resolve/prompt/suggest/default/store. `warnOnNamedOptionConflict` warns once when the same name gets different options/custom/text, using a **value-independent** signature (so seeded/scripted/one-page values never false-positive).
- **Preflight (`RequirementCollector.ts`)** — the one-page form is order-independent: a previously option-less requirement is upgraded to a dropdown/suggester when a later occurrence carries the options. Shared classification helpers; stale text-era defaults are reconciled against the new options.
- **Docs + discoverability** — new `#value-name` section in `FormatSyntax.md` and a `FORMAT_SYNTAX` hint.

## Reproduction / verification
Verified in the real dev vault via `api.format` (seeded, deterministic):
- `{{VALUE:a,b,c|name:category}} {{VALUE:category}}` with `{category:"work"}` → `work` / `work` (one seed resolves both).
- Reuse-before-definition → resolves via the two-pass.
- Anonymous `{{VALUE|...}}` parsing unchanged.

## Tests
- New `src/formatters/formatter-named-suggester.test.ts` (store-under-name, order-independence both directions, single-use-no-hoist, label-placeholder, conflict-warn, no-false-positive-on-seed, cross-pass reuse, malformed-abort).
- Added cases to `valueSyntax`, `RequirementCollector`, and `formatSyntax.docs-examples` tests.
- Full suite: **1907 passing**, lint clean, docs build clean.

## Review
Designed and implemented with an ultracode multi-agent review (5 lenses, adversarially verified) plus 2 cross-model adversarial reviewers → **FIX-THEN-SHIP**; all findings folded in (notably: replaced a value-based conflict check that false-positived on seeded values with a value-independent signature).

## Notes / limitations (by design)
- Reuse syntax is `{{VALUE:category}}`, not bare `{{category}}`.
- Sequential (non-one-page) mode is order-independent **within** a string; across surfaces, define the named suggester in the earlier surface (e.g. the file name) — same as existing named-variable behavior. The one-page input form is fully order-independent.
- `|name:x` previously parsed as a literal default `"name:x"` (named-list/single-value only); now it's the name. Contrived; noted for the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Named value suggesters: pick once and reuse a saved value across a template, including reuse-before-definition and persistent reuse across runs.

* **Bug Fixes**
  * Requirement collection now upgrades placeholder fields to dropdowns/suggesters when definitions appear later, preserving defaults and optional rules.

* **Documentation**
  * Added detailed docs and examples for named value syntax, reuse, and naming rules.

* **Tests**
  * Added extensive tests covering parsing, hoisting, reuse, conflicts, warnings, and collector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->