### PR TITLE
fix: render list front matter as real properties out of the box (#662)

### DIFF
--- a/docs/docs/Examples/Macro_MovieAndSeriesScript.md
+++ b/docs/docs/Examples/Macro_MovieAndSeriesScript.md
@@ -49,24 +49,37 @@ You can now use the macro to create notes with movie or TV show information in y
 
 ### Example template
 
+This template stores the movie's metadata as Obsidian **front matter properties**. The
+multi-value fields (`cast`, `genre`, `director`) come from the script as lists and become
+proper **List** properties with clickable links. Scalar link/text values are wrapped in
+quotes so the front matter stays valid, and the plot lives in the note body so longer text
+(with punctuation or quotes) can't break the front matter.
+
 ```markdown
 ---
-cover: { { VALUE:Poster } }
+category: "{{VALUE:typeLink}}"
+director: {{VALUE:directorLink}}
+genre: {{VALUE:genreLinks}}
+cast: {{VALUE:actorLinks}}
+year: "{{VALUE:Year}}"
+imdbId: "{{VALUE:imdbID}}"
+imdb: "[IMDb]({{VALUE:imdbUrl}})"
+ratingImdb: "{{VALUE:imdbRating}}"
+rating: 
+cover: "{{VALUE:Poster}}"
 ---
 
-category:: {{VALUE:typeLink}}
-director:: {{VALUE:directorLink}}
-genre:: {{VALUE:genreLinks}}
-imdbId:: {{VALUE:imdbID}}
-imdb:: [IMDb]({{VALUE:imdbUrl}})
-ratingImdb:: {{VALUE:imdbRating}}
-rating::
-year:: {{VALUE:Year}}
-cast:: {{VALUE:actorLinks}}
-plot:: {{VALUE:Plot}}
-
 ![poster]({{VALUE:Poster}})
+
+{{VALUE:Plot}}
 ```
+
+:::tip
+Keep the quotes around single-link and text values (for example `category` and `imdbId`).
+A bare `[[Movies]]` in front matter is read by Obsidian as a nested list rather than a link.
+The list fields (`cast`, `genre`, `director`) don't need quotes — QuickAdd writes them as
+real list properties for you.
+:::
 
 ## Usage
 

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -24,7 +24,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 ## Templates & Properties
 
 - **Template Folder Path** — Path to the folder where templates are stored. Used to suggest template files when configuring QuickAdd.
-- **Format template variables as proper property types (Beta)** — When enabled, template variables in front matter will be formatted as proper Obsidian property types. Arrays become List properties, numbers become Number properties, booleans become Checkbox properties, etc. This is a beta feature that may have edge cases. See [Template Property Types (Beta)](./TemplatePropertyTypes).
+- **Convert string front matter variables to typed properties (Beta)** — List/object values from scripts are **always** written as proper Obsidian properties (a list value becomes a List property), so templates produce valid front matter out of the box. This toggle **additionally** converts string values into typed properties: a comma or bullet-list string becomes a List, `"42"` becomes a Number, `"true"` becomes a Checkbox, etc. Disabled by default; the string conversion is a beta heuristic that may have edge cases. See [Template Property Types (Beta)](./TemplatePropertyTypes).
 
 ## Notifications
 

--- a/docs/docs/TemplatePropertyTypes.md
+++ b/docs/docs/TemplatePropertyTypes.md
@@ -10,9 +10,13 @@ Native support for proper Obsidian property types in QuickAdd template front mat
 
 ## Overview
 
-QuickAdd now supports automatic property type formatting for template variables in front matter. Instead of converting everything to text, template variables become proper Obsidian property types: arrays become List properties, numbers become Number properties, booleans become Checkbox properties, and so on.
+QuickAdd writes proper Obsidian property types for template variables in front matter.
 
-The goal is to make note creation easier and more intuitive. When we've reached that point, the option to disable this feature will be removed. While we're in beta, we appreciate your feedback and suggestions.
+**Always on (no setting required):** when a script provides a **list (array)** or **object** value for a front matter field, QuickAdd writes it as a real Obsidian List/object property through Obsidian's own YAML serializer. This is what makes templates like the [Movie & Series script](./Examples/Macro_MovieAndSeriesScript) produce valid front matter out of the box — a returned array of links becomes a List of links instead of broken YAML.
+
+**Behind the beta toggle:** the setting below *additionally* converts **string** values into typed properties — a comma or bullet-list string becomes a List, `"42"` becomes a Number, `"true"` becomes a Checkbox, and so on. This string conversion is the beta part because it changes a value's type based on its contents; it is disabled by default.
+
+The goal is to make note creation easier and more intuitive. While the string conversion is in beta, we appreciate your feedback and suggestions.
 
 **Before:**
 ```yaml
@@ -27,13 +31,13 @@ authors:
   - Bob Wilson
 ```
 
-## Enabling the Feature
+## Enabling the String Conversion (Beta)
 
-⚠️ **This is a beta feature** - enable it in settings:
+List/object handling needs no setting. To also convert **string** values into typed properties, enable the beta toggle:
 
 1. Open **Settings → QuickAdd**
-2. Toggle **"Format template variables as proper property types (Beta)"**
-3. The feature is **disabled by default** for safety
+2. Toggle **"Convert string front matter variables to typed properties (Beta)"**
+3. String conversion is **disabled by default** for safety
 
 ## Basic Usage
 

--- a/docs/static/scripts/movies.js
+++ b/docs/static/scripts/movies.js
@@ -117,10 +117,16 @@ async function getByImdbId(id) {
 }
 
 function linkifyList(list) {
-    if (!Array.isArray(list) || list.length === 0) return "";
-    if (list.length === 1) return `\n  - "[[${list[0].trim()}]]"`;
+    // Return a real array of wikilink strings. QuickAdd writes arrays in a
+    // template's front matter as proper Obsidian List properties (each item a
+    // clickable link) via Obsidian's own YAML serializer. Returning a string
+    // here would instead break the YAML (see issue #662).
+    if (!Array.isArray(list)) return [];
 
-    return list.map(item => `\n  - "[[${item.trim()}]]"`).join("");
+    return list
+        .map(item => String(item).trim())
+        .filter(item => item.length > 0)
+        .map(item => `[[${item}]]`);
 }
 
 function replaceIllegalFileNameCharactersInString(input) {

--- a/src/engine/CaptureChoiceEngine.template-property-types.test.ts
+++ b/src/engine/CaptureChoiceEngine.template-property-types.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { App, TFile, TFolder } from "obsidian";
-import { TFolder as ObsidianTFolder } from "obsidian";
+import { TFile as ObsidianTFile, TFolder as ObsidianTFolder } from "obsidian";
 import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
+import { insertOnNewLineBelow } from "../utilityObsidian";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 
@@ -374,5 +375,89 @@ describe("CaptureChoiceEngine template property types", () => {
 
 		expect(modify).not.toHaveBeenCalled();
 		expect(applyCapturePropertyVars).not.toHaveBeenCalled();
+	});
+
+	it("editor-insertion (newLineBelow) inlines container values as text instead of stranding a placeholder", async () => {
+		// Regression: editor-insertion writes to the body, where front matter
+		// property types are meaningless. Collection must be suppressed so a
+		// collected array is NOT left as a "[]" placeholder with no apply step.
+		const activeFilePath = "Daily/Today.md";
+		const tFile = {
+			path: activeFilePath,
+			name: "Today.md",
+			basename: "Today",
+			extension: "md",
+		} as unknown as TFile;
+		if (typeof ObsidianTFile === "function") {
+			Object.setPrototypeOf(tFile as unknown as object, ObsidianTFile.prototype);
+		}
+
+		const processFrontMatter = vi.fn();
+		const app = {
+			vault: {
+				adapter: { exists: vi.fn(async (p: string) => p === activeFilePath) },
+				getAbstractFileByPath: vi.fn((p: string) => (p === activeFilePath ? tFile : null)),
+				create: vi.fn(),
+				read: vi.fn(async () => "existing body\n"),
+				cachedRead: vi.fn(async () => "existing body\n"),
+				modify: vi.fn(),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn().mockReturnValue(""),
+				processFrontMatter,
+			},
+			workspace: {
+				getActiveFile: vi.fn().mockReturnValue(tFile),
+				getActiveViewOfType: vi.fn().mockReturnValue(null),
+				activeLeaf: null,
+				getMostRecentLeaf: vi.fn().mockReturnValue(null),
+			},
+			metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		} as unknown as App;
+
+		const plugin = {
+			settings: {
+				enableTemplatePropertyTypes: true, // even with the toggle ON, body insertion must not collect
+				globalVariables: {},
+				showCaptureNotification: false,
+				showInputCancellationNotification: false,
+			},
+		} as any;
+
+		const choice = {
+			id: "capture",
+			name: "Insertion Capture",
+			type: "Capture",
+			command: false,
+			captureTo: "",
+			captureToActiveFile: true,
+			newLineCapture: { enabled: true, direction: "below" },
+			createFileIfItDoesntExist: { enabled: false, createWithTemplate: false, template: "" },
+			format: { enabled: true, format: ["---", "cast: {{VALUE:cast}}", "---", ""].join("\n") },
+			prepend: false,
+			appendLink: false,
+			task: false,
+			insertAfter: {
+				enabled: false, after: "", insertAtEnd: false, considerSubsections: false,
+				createIfNotFound: false, createIfNotFoundLocation: "",
+			},
+			openFile: false,
+			fileOpening: { location: "tab", direction: "vertical", mode: "source", focus: false },
+		} as unknown as ICaptureChoice;
+
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>([["cast", ["[[A]]", "[[B]]"]]]),
+		};
+
+		const engine = new CaptureChoiceEngine(app, plugin, choice, choiceExecutor);
+		await engine.run();
+
+		// The array is inlined as text (no data loss), not collected -> no placeholder, no processFrontMatter.
+		expect(insertOnNewLineBelow).toHaveBeenCalledTimes(1);
+		const inserted = (insertOnNewLineBelow as any).mock.calls[0][0] as string;
+		expect(inserted).toContain("cast: [[A]],[[B]]");
+		expect(inserted).not.toContain("cast: []");
+		expect(processFrontMatter).not.toHaveBeenCalled();
 	});
 });

--- a/src/engine/CaptureChoiceEngine.template-property-types.test.ts
+++ b/src/engine/CaptureChoiceEngine.template-property-types.test.ts
@@ -460,4 +460,78 @@ describe("CaptureChoiceEngine template property types", () => {
 		expect(inserted).not.toContain("cast: []");
 		expect(processFrontMatter).not.toHaveBeenCalled();
 	});
+
+	it("append into an EXISTING file inlines a frontmatter-shaped capture in the body, never collecting it", async () => {
+		// Regression for the reviewer finding: a frontmatter-shaped capture appended
+		// to an existing file lands in the BODY. It must NOT be collected (which would
+		// leave a "[]" placeholder in the body AND write the value to the wrong note's
+		// real front matter).
+		const targetPath = "Notes/Existing.md";
+		const existing = "---\ntitle: Keep\n---\nbody line\n";
+		let written = "";
+
+		const tFile = {
+			path: targetPath, name: "Existing.md", basename: "Existing", extension: "md",
+		} as unknown as TFile;
+		if (typeof ObsidianTFile === "function") {
+			Object.setPrototypeOf(tFile as unknown as object, ObsidianTFile.prototype);
+		}
+
+		const processFrontMatter = vi.fn();
+		const app = {
+			vault: {
+				adapter: { exists: vi.fn(async (p: string) => p === targetPath) },
+				getAbstractFileByPath: vi.fn((p: string) => (p === targetPath ? tFile : null)),
+				create: vi.fn(),
+				read: vi.fn(async () => existing),
+				cachedRead: vi.fn(async () => existing),
+				modify: vi.fn(async (_f: TFile, content: string) => { written = content; }),
+			},
+			fileManager: { generateMarkdownLink: vi.fn().mockReturnValue(""), processFrontMatter },
+			workspace: {
+				getActiveFile: vi.fn().mockReturnValue(null),
+				getActiveViewOfType: vi.fn().mockReturnValue(null),
+				activeLeaf: null,
+				getMostRecentLeaf: vi.fn().mockReturnValue(null),
+			},
+			metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		} as unknown as App;
+
+		const plugin = {
+			settings: {
+				enableTemplatePropertyTypes: true,
+				globalVariables: {},
+				showCaptureNotification: false,
+				showInputCancellationNotification: false,
+			},
+		} as any;
+
+		const choice = {
+			id: "capture", name: "Append Capture", type: "Capture", command: false,
+			captureTo: targetPath, captureToActiveFile: false,
+			createFileIfItDoesntExist: { enabled: false, createWithTemplate: false, template: "" },
+			format: { enabled: true, format: ["---", "cast: {{VALUE:cast}}", "---", ""].join("\n") },
+			prepend: false, appendLink: false, task: false,
+			insertAfter: {
+				enabled: false, after: "", insertAtEnd: false, considerSubsections: false,
+				createIfNotFound: false, createIfNotFoundLocation: "",
+			},
+			openFile: false,
+			fileOpening: { location: "tab", direction: "vertical", mode: "source", focus: false },
+			useSelectionAsCaptureValue: false,
+		} as unknown as ICaptureChoice;
+
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>([["cast", ["[[A]]", "[[B]]"]]]),
+		};
+
+		const engine = new CaptureChoiceEngine(app, plugin, choice, choiceExecutor);
+		await engine.run();
+
+		expect(written).toContain("cast: [[A]],[[B]]"); // inlined in the body
+		expect(written).not.toContain("cast: []"); // not a stranded placeholder
+		expect(written).toContain("title: Keep"); // existing front matter untouched
+		expect(processFrontMatter).not.toHaveBeenCalled(); // no misplaced front matter write
+	});
 });

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -64,10 +64,11 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	private readonly plugin: QuickAdd;
 	private templatePropertyVars?: Map<string, unknown>;
 	private capturePropertyVars: Map<string, unknown> = new Map();
-	// Editor-insertion actions (currentLine / newLineAbove / newLineBelow) write
-	// the capture into the note BODY at the cursor, where front matter property
-	// types are meaningless. Collecting there would only strand a "[]" placeholder
-	// (the collected value is never applied), so collection is suppressed for them.
+	// Set per run: true when the capture content lands in a note BODY (any capture
+	// into an existing file, into a template's body, or an editor insertion) rather
+	// than becoming the file's own front matter. Front matter property collection is
+	// suppressed in that case so collected containers aren't stranded as "[]"
+	// placeholders (and written to the wrong note's front matter). See run().
 	private suppressFrontmatterCollection = false;
 
 	constructor(
@@ -210,10 +211,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				action === "currentLine" ||
 				action === "newLineAbove" ||
 				action === "newLineBelow";
-			// Editor-insertion writes to the note body; suppress front matter
-			// property collection so collected containers aren't stranded as
-			// placeholders that never get applied (see collectIfFrontmatter).
-			this.suppressFrontmatterCollection = isEditorInsertionAction;
 			const activeCanvasTarget = this.choice.captureToActiveFile
 				? resolveActiveCanvasCaptureTarget(this.app, action)
 				: null;
@@ -266,6 +263,19 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			) => Promise<{ file: TFile; newFileContent: string; captureContent: string }>;
 			let getFileAndAddContentFn: GetFileAndAddContentFn;
 			const fileAlreadyExists = await this.fileExists(filePath);
+
+			// Collect front matter property types only when the capture content
+			// becomes the file's OWN front matter — i.e. a brand-new file created
+			// from the capture with no template. Captures into an existing file
+			// (append / bottom / insert-after/before / editor insertion), or into a
+			// template's body, place the snippet in the BODY: collecting there would
+			// strand a "[]" placeholder in the body AND write the values to the wrong
+			// note's front matter. Suppress collection for those.
+			const captureBecomesOwnFrontmatter =
+				!fileAlreadyExists &&
+				!!this.choice?.createFileIfItDoesntExist?.enabled &&
+				!this.choice?.createFileIfItDoesntExist?.createWithTemplate;
+			this.suppressFrontmatterCollection = !captureBecomesOwnFrontmatter;
 
 			if (fileAlreadyExists) {
 				getFileAndAddContentFn =

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -64,6 +64,11 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	private readonly plugin: QuickAdd;
 	private templatePropertyVars?: Map<string, unknown>;
 	private capturePropertyVars: Map<string, unknown> = new Map();
+	// Editor-insertion actions (currentLine / newLineAbove / newLineBelow) write
+	// the capture into the note BODY at the cursor, where front matter property
+	// types are meaningless. Collecting there would only strand a "[]" placeholder
+	// (the collected value is never applied), so collection is suppressed for them.
+	private suppressFrontmatterCollection = false;
 
 	constructor(
 		app: App,
@@ -201,6 +206,14 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			this.formatter.setUseSelectionAsCaptureValue(useSelectionAsCaptureValue);
 
 			const action = getCaptureAction(this.choice);
+			const isEditorInsertionAction =
+				action === "currentLine" ||
+				action === "newLineAbove" ||
+				action === "newLineBelow";
+			// Editor-insertion writes to the note body; suppress front matter
+			// property collection so collected containers aren't stranded as
+			// placeholders that never get applied (see collectIfFrontmatter).
+			this.suppressFrontmatterCollection = isEditorInsertionAction;
 			const activeCanvasTarget = this.choice.captureToActiveFile
 				? resolveActiveCanvasCaptureTarget(this.app, action)
 				: null;
@@ -269,11 +282,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 			const { file, newFileContent, captureContent } =
 				await getFileAndAddContentFn(filePath, content);
-
-			const isEditorInsertionAction =
-				action === "currentLine" ||
-				action === "newLineAbove" ||
-				action === "newLineBelow";
 
 			// Handle capture to active file with special actions
 			if (isEditorInsertionAction) {
@@ -656,7 +664,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		this.formatter.setDestinationFile(file);
 
 		// First format pass...
-		const formatted = await this.formatter.withTemplatePropertyCollection(
+		const formatted = await this.collectIfFrontmatter(
 			() => this.formatter.formatContentOnly(content),
 		);
 		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
@@ -665,7 +673,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		// Second format pass, with the file content... User input (long running) should have been captured during first pass
 		// So this pass is to insert the formatted capture value into the file content, depending on the user's settings
 		const formattedFileContent: string =
-			await this.formatter.withTemplatePropertyCollection(() =>
+			await this.collectIfFrontmatter(() =>
 				this.formatter.formatContentWithFile(
 					formatted,
 					this.choice,
@@ -717,7 +725,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		// This mirrors the logic used when the target file already exists and prevents the timing issue
 		// where templater would run before the {{value}} placeholder is substituted (Issue #809).
 		const formattedCaptureContent: string =
-			await this.formatter.withTemplatePropertyCollection(() =>
+			await this.collectIfFrontmatter(() =>
 				this.formatter.formatContentOnly(captureContent),
 			);
 		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
@@ -782,7 +790,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const updatedFileContent: string = await this.app.vault.read(file);
 		// Second formatting pass: embed the already-resolved capture content into the newly created file
 		const newFileContent: string =
-			await this.formatter.withTemplatePropertyCollection(() =>
+			await this.collectIfFrontmatter(() =>
 				this.formatter.formatContentWithFile(
 					formattedCaptureContent,
 					this.choice,
@@ -827,6 +835,19 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		}
 
 		return finalPath;
+	}
+
+	/**
+	 * Runs a formatting pass, collecting structured front matter values for a
+	 * later processFrontMatter pass — unless collection is suppressed (editor
+	 * insertion actions), in which case the value is substituted inline as text
+	 * so nothing is left stranded as a placeholder.
+	 */
+	private collectIfFrontmatter<T>(work: () => Promise<T>): Promise<T> {
+		if (this.suppressFrontmatterCollection) {
+			return work();
+		}
+		return this.formatter.withTemplatePropertyCollection(work);
 	}
 
 	private mergeCapturePropertyVars(vars: Map<string, unknown>): void {

--- a/src/engine/template-property-types-feature-flag.test.ts
+++ b/src/engine/template-property-types-feature-flag.test.ts
@@ -60,20 +60,34 @@ describe('Template Property Types Feature Flag & Edge Cases', () => {
 	});
 
 	describe('Feature Flag Behavior', () => {
-		it('should not collect templatePropertyVars when flag is disabled', () => {
+		it('does not collect bare scalars (strings/numbers) when the flag is disabled', () => {
 			mockPlugin.settings.enableTemplatePropertyTypes = false;
-			
+
 			const formatter = new TestFormatter(mockApp, mockPlugin);
 			const templateContent = 'title: {{testValue}}\ncount: {{testCount}}';
-			
+
 			formatter.setVariable('testValue', 'My Title');
 			formatter.setVariable('testCount', 42);
-			
+
 			const result = formatter.formatContent(templateContent);
 			const vars = formatter.getAndClearTemplatePropertyVars();
-			
+
+			// Scalars are YAML-safe inline, so they stay raw (no whole-frontmatter rewrite).
 			expect(result).toBe('title: My Title\ncount: 42');
 			expect(vars.size).toBe(0);
+		});
+
+		it('collects container values (arrays/objects) even when the flag is disabled', () => {
+			mockPlugin.settings.enableTemplatePropertyTypes = false;
+
+			const formatter = new TestFormatter(mockApp, mockPlugin);
+			formatter.setVariable('cast', ['[[A]]', '[[B]]']);
+
+			formatter.formatContent('cast: {{cast}}');
+			const vars = formatter.getAndClearTemplatePropertyVars();
+
+			// This is the #662 fix: arrays become real List properties regardless of the toggle.
+			expect(vars.get('cast')).toEqual(['[[A]]', '[[B]]']);
 		});
 		
 		it('should collect templatePropertyVars when flag is enabled', () => {
@@ -93,13 +107,20 @@ describe('Template Property Types Feature Flag & Edge Cases', () => {
 			expect(vars.get('date')).toEqual(new Date('2024-01-01'));
 		});
 		
-		it('should not post-process when flag is disabled', async () => {
+		it('post-processes whenever there are collected vars (flag-independent)', async () => {
 			mockPlugin.settings.enableTemplatePropertyTypes = false;
-			
+
 			const engine = new TestTemplateEngine(mockApp, mockPlugin);
-			const templateVars = new Map<string, unknown>([['title', 'Test'], ['count', 42]]);
-			
+			const templateVars = new Map<string, unknown>([['cast', ['[[A]]']]]);
+
 			const shouldProcess = await engine.testShouldProcessFrontMatter(mockFile, templateVars);
+			expect(shouldProcess).toBe(true);
+		});
+
+		it('does not post-process when there are no collected vars', async () => {
+			const engine = new TestTemplateEngine(mockApp, mockPlugin);
+
+			const shouldProcess = await engine.testShouldProcessFrontMatter(mockFile, new Map());
 			expect(shouldProcess).toBe(false);
 			expect(mockFileManager.processFrontMatter).not.toHaveBeenCalled();
 		});
@@ -395,10 +416,11 @@ class TestFormatter {
 			const variableName = match[1].trim();
 			const rawValue = this.variables.get(variableName);
 			
-			// Check if we're in a YAML key-value position and flag is enabled
-			if (this.plugin.settings.enableTemplatePropertyTypes && this.isInYamlKeyValuePosition(output, match.index)) {
+			// Containers (arrays/objects) are tracked regardless of the flag;
+			// scalars only under the opt-in flag. Mirrors the real collector.
+			if (this.isInYamlKeyValuePosition(output, match.index)) {
 				const propertyKey = this.extractPropertyKey(output, match.index);
-				if (propertyKey && this.shouldTrackAsProperty(rawValue)) {
+				if (propertyKey && this.shouldTrackAsProperty(rawValue, this.plugin.settings.enableTemplatePropertyTypes)) {
 					this.templatePropertyVars.set(propertyKey, rawValue);
 				}
 			}
@@ -434,12 +456,13 @@ class TestFormatter {
 		return match ? match[1].trim() : null;
 	}
 	
-	private shouldTrackAsProperty(value: unknown): boolean {
-		// Template property types feature tracks any non-string value
-		// OR string values when used with VALUE: prefix (which indicates raw value handling)
-		return typeof value !== 'string' && (
-			Array.isArray(value) || 
-			(typeof value === 'object' && value !== null) ||
+	private shouldTrackAsProperty(value: unknown, flagEnabled: boolean): boolean {
+		if (typeof value === 'string') return false;
+		// Containers break when inlined as text -> always tracked.
+		if (Array.isArray(value) || (typeof value === 'object' && value !== null)) return true;
+		// Scalars (number/boolean/null/undefined) are YAML-safe inline -> only
+		// tracked under the opt-in beta flag.
+		return flagEnabled && (
 			typeof value === 'number' ||
 			typeof value === 'boolean' ||
 			value === null ||
@@ -482,8 +505,8 @@ class TestTemplateEngine {
 	}
 	
 	async testShouldProcessFrontMatter(file: TFile, templateVars: Map<string, unknown>): Promise<boolean> {
-		return templateVars.size > 0 && 
-		       file.extension === 'md' && 
-		       this.plugin.settings.enableTemplatePropertyTypes;
+		// Post-processing runs whenever there are collected vars (flag-independent),
+		// matching the real QuickAddEngine.shouldPostProcessFrontMatter.
+		return templateVars.size > 0 && file.extension === 'md';
 	}
 }

--- a/src/formatters/formatter-template-property-types.test.ts
+++ b/src/formatters/formatter-template-property-types.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { Formatter } from './formatter';
 
 class TemplatePropertyTypesTestFormatter extends Formatter {
+	public propertyTypesEnabled = true;
+
 	constructor(app?: App) {
 		super(app);
 	}
@@ -78,7 +80,7 @@ class TemplatePropertyTypesTestFormatter extends Formatter {
 	}
 
 	protected isTemplatePropertyTypesEnabled(): boolean {
-		return true;
+		return this.propertyTypesEnabled;
 	}
 
 	public async testFormat(input: string): Promise<string> {
@@ -181,5 +183,51 @@ describe('Formatter template property type inference', () => {
 		);
 		const vars = formatter.getAndClearTemplatePropertyVars();
 		expect(vars.has('source')).toBe(false);
+	});
+
+	// Issue #662: container (array/object) values become real properties even
+	// with the beta toggle OFF; scalars and strings stay raw (byte-identical).
+	describe('with the beta toggle OFF (real Formatter)', () => {
+		beforeEach(() => {
+			formatter.propertyTypesEnabled = false;
+		});
+
+		it('collects array values into a List property and leaves a [] placeholder', async () => {
+			(formatter as any).variables.set('cast', ['[[Ewan McGregor]]', '[[Liam Neeson]]']);
+			const output = await formatter.testFormatWithTemplatePropertyCollection(
+				'---\ncast: {{VALUE:cast}}\n---',
+			);
+			const vars = formatter.getAndClearTemplatePropertyVars();
+			expect(output).toBe('---\ncast: []\n---');
+			expect(vars.get('cast')).toEqual(['[[Ewan McGregor]]', '[[Liam Neeson]]']);
+		});
+
+		it('does NOT collect bare numbers (YAML-safe inline, byte-identical)', async () => {
+			(formatter as any).variables.set('rating', 8.5);
+			const output = await formatter.testFormatWithTemplatePropertyCollection(
+				'---\nrating: {{VALUE:rating}}\n---',
+			);
+			const vars = formatter.getAndClearTemplatePropertyVars();
+			expect(output).toBe('---\nrating: 8.5\n---');
+			expect(vars.size).toBe(0);
+		});
+
+		it('does NOT collect plain strings (stays raw)', async () => {
+			(formatter as any).variables.set('title', 'Phantom Menace');
+			const output = await formatter.testFormatWithTemplatePropertyCollection(
+				'---\ntitle: {{VALUE:title}}\n---',
+			);
+			const vars = formatter.getAndClearTemplatePropertyVars();
+			expect(output).toBe('---\ntitle: Phantom Menace\n---');
+			expect(vars.size).toBe(0);
+		});
+
+		it('coerces non-string values when substituting raw so the scanner stays aligned (replacement.length fix)', async () => {
+			// Two array tokens on the same non-frontmatter line: both must substitute.
+			(formatter as any).variables.set('a', ['p', 'q']);
+			(formatter as any).variables.set('b', ['r', 's']);
+			const output = await formatter.testFormat('x {{VALUE:a}} y {{VALUE:b}} z');
+			expect(output).toBe('x p,q y r,s z');
+		});
 	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -468,23 +468,30 @@ export abstract class Formatter {
 					? transformCase(rawValue, caseStyle)
 					: rawValue;
 
-			// Offer this variable to the property collector for YAML post-processing
+			// Offer this variable to the property collector for YAML post-processing.
+			// Collecting structured values (arrays/objects/numbers/booleans) into a
+			// processFrontMatter pass is always-on inside a collection scope so that
+			// scripts returning real arrays produce valid YAML regardless of the
+			// beta toggle. Only the string -> structured *heuristic* is flag-gated.
+			const collectionActive = this.templatePropertyCollectionDepth > 0;
 			const structuredYamlValue = this.propertyCollector.maybeCollect({
 				input: output,
 				matchStart: match.index,
 				matchEnd: match.index + match[0].length,
 				rawValue: rawValueForCollector,
 				fallbackKey: variableName,
-				featureEnabled:
-					propertyTypesEnabled &&
-					this.templatePropertyCollectionDepth > 0,
+				collectionActive,
+				heuristicEnabled: propertyTypesEnabled && collectionActive,
 			});
 
 			// Keep the interim frontmatter YAML-parseable until post-processing
-			// writes the real structured value back through Obsidian.
+			// writes the real structured value back through Obsidian. Coerce the
+			// fallback replacement to a string so non-string variable values (e.g.
+			// arrays from scripts on the non-collected path) don't desync the scanner.
 			const placeholder = getYamlPlaceholder(structuredYamlValue);
-			const replacement = placeholder ??
-				transformCase(this.getVariableValue(effectiveKey), caseStyle);
+			const replacement =
+				placeholder ??
+				String(transformCase(this.getVariableValue(effectiveKey), caseStyle) ?? "");
 
 			// Replace in output and adjust regex position
 			output = output.slice(0, match.index) + replacement + output.slice(match.index + match[0].length);

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -213,11 +213,11 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					render: (setting) => this.renderTemplateFolderPaths(setting),
 				},
 				{
-					name: "Format template variables as proper property types (Beta)",
+					name: "Convert string front matter variables to typed properties (Beta)",
 					desc:
-						"When enabled, template variables in front matter will be formatted as proper Obsidian property types. " +
-						"Arrays become List properties, numbers become Number properties, booleans become Checkbox properties, etc. " +
-						"This is a beta feature that may have edge cases.",
+						"List/object values from scripts are always written as proper Obsidian properties (a list becomes a List). " +
+						"This toggle additionally converts string values into typed properties: a comma or bullet-list string becomes a List, " +
+						"\"42\" becomes a Number, \"true\" becomes a Checkbox, etc. Disabled by default; the string conversion is a beta heuristic that may have edge cases.",
 					control: { type: "toggle", key: "enableTemplatePropertyTypes" },
 				},
 			],

--- a/src/utils/TemplatePropertyCollector.test.ts
+++ b/src/utils/TemplatePropertyCollector.test.ts
@@ -38,7 +38,7 @@ describe("TemplatePropertyCollector", () => {
       matchEnd: tEnd,
       rawValue: ["A"],
       fallbackKey: "title",
-      featureEnabled: true,
+      collectionActive: true, heuristicEnabled: true,
     });
 
     const [aStart, aEnd] = idxRange(yaml, "{{VALUE:authors}}");
@@ -48,7 +48,7 @@ describe("TemplatePropertyCollector", () => {
       matchEnd: aEnd,
       rawValue: ["John"],
       fallbackKey: "authors",
-      featureEnabled: true,
+      collectionActive: true, heuristicEnabled: true,
     });
 
     const result = c.drain();
@@ -64,7 +64,7 @@ describe("TemplatePropertyCollector", () => {
       matchEnd: iEnd,
       rawValue: [1],
       fallbackKey: "inline",
-      featureEnabled: true,
+      collectionActive: true, heuristicEnabled: true,
     });
     expect(c.drain().size).toBe(0);
   });
@@ -72,9 +72,9 @@ describe("TemplatePropertyCollector", () => {
   it("collects multiple keys", () => {
     const c = new TemplatePropertyCollector();
     const [aStart, aEnd] = idxRange(yaml, "{{VALUE:authors}}");
-    c.maybeCollect({ input: yaml, matchStart: aStart, matchEnd: aEnd, rawValue: ["J"], fallbackKey: "authors", featureEnabled: true });
+    c.maybeCollect({ input: yaml, matchStart: aStart, matchEnd: aEnd, rawValue: ["J"], fallbackKey: "authors", collectionActive: true, heuristicEnabled: true });
     const [yStart, yEnd] = idxRange(yaml, "{{VALUE:year}}");
-    c.maybeCollect({ input: yaml, matchStart: yStart, matchEnd: yEnd, rawValue: 2024, fallbackKey: "year", featureEnabled: true });
+    c.maybeCollect({ input: yaml, matchStart: yStart, matchEnd: yEnd, rawValue: 2024, fallbackKey: "year", collectionActive: true, heuristicEnabled: true });
     const result = c.drain();
     expect(result.get("authors")).toEqual(["J"]);
     expect(result.get("year")).toBe(2024);
@@ -97,7 +97,7 @@ describe("TemplatePropertyCollector", () => {
       matchEnd: sourcesEnd,
       rawValue: "[[alpha]], [[beta]]",
       fallbackKey: "sources",
-      featureEnabled: true,
+      collectionActive: true, heuristicEnabled: true,
     });
 
     const [descStart, descEnd] = idxRange(listYaml, "{{VALUE:description}}");
@@ -107,7 +107,7 @@ describe("TemplatePropertyCollector", () => {
       matchEnd: descEnd,
       rawValue: "Hello, world",
       fallbackKey: "description",
-      featureEnabled: true,
+      collectionActive: true, heuristicEnabled: true,
     });
 
     const result = collector.drain();
@@ -132,11 +132,84 @@ describe("TemplatePropertyCollector", () => {
       matchEnd: end,
       rawValue: "alpha, beta",
       fallbackKey: "sources",
-      featureEnabled: true,
+      collectionActive: true, heuristicEnabled: true,
     });
 
     const result = collector.drain();
     const key = ['project', 'sources'].join(TemplatePropertyCollector.PATH_SEPARATOR);
     expect(result.get(key)).toEqual(['alpha', 'beta']);
+  });
+});
+
+// Regression coverage for issue #662: structured-value collection is decoupled
+// from the `enableTemplatePropertyTypes` beta flag, while the string -> structured
+// heuristic stays gated. Uses a stub matching the REAL runtime where
+// metadataTypeManager.getTypeInfo always returns a type (never null) - the
+// condition under which the old string heuristic is effectively dead.
+describe("TemplatePropertyCollector #662 flag decoupling", () => {
+  const yaml = `---\ncast: {{VALUE:cast}}\n---\nbody`;
+  const [start, end] = idxRange(yaml, "{{VALUE:cast}}");
+  const realRuntimeApp = {
+    metadataCache: {
+      app: {
+        metadataTypeManager: {
+          // Real Obsidian defaults every key to "text", even never-seen keys.
+          getTypeInfo: () => ({ expected: { type: "text" }, inferred: { type: "text" } }),
+        },
+      },
+    },
+  } as unknown as App;
+
+  function collectCast(args: Partial<Parameters<TemplatePropertyCollector["maybeCollect"]>[0]> & { rawValue: unknown }) {
+    const c = new TemplatePropertyCollector(realRuntimeApp);
+    c.maybeCollect({
+      input: yaml,
+      matchStart: start,
+      matchEnd: end,
+      fallbackKey: "cast",
+      collectionActive: true,
+      heuristicEnabled: false,
+      ...args,
+    });
+    return c.drain();
+  }
+
+  it("collects real arrays with the beta flag OFF (heuristicEnabled false)", () => {
+    const result = collectCast({ rawValue: ["[[A]]", "[[B]]"] });
+    expect(result.get("cast")).toEqual(["[[A]]", "[[B]]"]);
+  });
+
+  it("collects plain objects with the flag OFF (containers break when inlined)", () => {
+    expect(collectCast({ rawValue: { a: 1 } }).get("cast")).toEqual({ a: 1 });
+  });
+
+  it("does NOT collect bare numbers/booleans with the flag OFF (YAML-safe inline, avoids churn)", () => {
+    expect(collectCast({ rawValue: 42 }).size).toBe(0);
+    expect(collectCast({ rawValue: true }).size).toBe(0);
+  });
+
+  it("DOES collect numbers/booleans when the heuristic flag is ON (preserves beta behaviour)", () => {
+    expect(collectCast({ rawValue: 42, heuristicEnabled: true }).get("cast")).toBe(42);
+    expect(collectCast({ rawValue: true, heuristicEnabled: true }).get("cast")).toBe(true);
+  });
+
+  it("does NOT collect plain strings (left raw so valid frontmatter stays byte-identical)", () => {
+    expect(collectCast({ rawValue: "[[A]]" }).size).toBe(0);
+  });
+
+  it("does NOT run the string->list heuristic when the flag is OFF", () => {
+    // A comma string that the heuristic WOULD split, but the flag is off.
+    expect(collectCast({ rawValue: "[[A]], [[B]]" }).size).toBe(0);
+  });
+
+  it("still will not split a string under the real-runtime 'text' type even with the flag ON (heuristic is type-gated)", () => {
+    // Pins the known limitation that motivated the array-based fix: with
+    // getTypeInfo() -> 'text', the bullet/comma heuristic cannot fire.
+    const result = collectCast({ rawValue: "[[A]], [[B]]", heuristicEnabled: true });
+    expect(result.size).toBe(0);
+  });
+
+  it("collects nothing when collection is not active", () => {
+    expect(collectCast({ rawValue: ["[[A]]"], collectionActive: false }).size).toBe(0);
   });
 });

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -4,7 +4,7 @@ import {
 	parseStructuredPropertyValueFromString,
 	type ParseOptions,
 } from "./templatePropertyStringParser";
-import { isStructuredYamlValue } from "./yamlValues";
+import { isContainerYamlValue, isStructuredYamlValue } from "./yamlValues";
 
 const PATH_SEPARATOR = "\u0000";
 
@@ -14,7 +14,19 @@ type CollectArgs = {
   matchEnd: number;
   rawValue: unknown;
   fallbackKey: string;
-  featureEnabled: boolean;
+  /**
+   * Whether collection is active at all (inside a withTemplatePropertyCollection
+   * scope). Collecting already-structured values (arrays/objects/numbers/booleans)
+   * for a native processFrontMatter pass is always-on so scripts that return real
+   * arrays produce valid Obsidian properties regardless of the beta toggle.
+   */
+  collectionActive: boolean;
+  /**
+   * Whether the opt-in string -> structured heuristic may run (turning a comma /
+   * bullet-list string into a List, "42" into a Number, etc.). Gated by the
+   * `enableTemplatePropertyTypes` setting because it changes a value's type.
+   */
+  heuristicEnabled: boolean;
 };
 
 export class TemplatePropertyCollector {
@@ -28,8 +40,8 @@ export class TemplatePropertyCollector {
    * and the raw value is a structured type (object/array/number/boolean/null).
    */
   public maybeCollect(args: CollectArgs): unknown {
-    const { input, matchStart, matchEnd, rawValue, fallbackKey, featureEnabled } = args;
-    if (!featureEnabled) return undefined;
+    const { input, matchStart, matchEnd, rawValue, fallbackKey, collectionActive, heuristicEnabled } = args;
+    if (!collectionActive) return undefined;
     const yamlRange = findYamlFrontMatterRange(input);
     const context = getYamlContextForMatch(input, matchStart, matchEnd, yamlRange);
 
@@ -55,7 +67,10 @@ export class TemplatePropertyCollector {
 
     let structuredValue = rawValue;
 
-    if (typeof rawValue === "string") {
+    // The string -> structured heuristic is opt-in: it changes a value's type
+    // (comma/bullet string -> List, "42" -> Number). Real arrays/objects from
+    // scripts skip this branch and are collected as-is below.
+    if (heuristicEnabled && typeof rawValue === "string") {
       const parsed = parseStructuredPropertyValueFromString(rawValue, this.buildParseOptions(effectiveKey));
       if (parsed !== undefined) {
         structuredValue = parsed;
@@ -63,6 +78,13 @@ export class TemplatePropertyCollector {
     }
 
     if (!isStructuredYamlValue(structuredValue)) return undefined;
+
+    // Always-on (flag-off) collection is limited to container types
+    // (arrays/objects) that break when inlined as text. Scalars
+    // (number/boolean/null) are already YAML-safe inline, so they are only
+    // collected under the opt-in heuristic to avoid forcing a whole-frontmatter
+    // rewrite (which would strip comments / normalise quoting) for no benefit.
+    if (!heuristicEnabled && !isContainerYamlValue(structuredValue)) return undefined;
 
     const mapKey = propertyPath.join(PATH_SEPARATOR);
     this.map.set(mapKey, structuredValue);

--- a/src/utils/yamlValues.ts
+++ b/src/utils/yamlValues.ts
@@ -53,6 +53,17 @@ export function isStructuredYamlValue(v: unknown): boolean {
 }
 
 /**
+ * Returns whether a value is a *container* (array or plain object) — the kinds
+ * that produce invalid YAML when inlined as text and therefore must be written
+ * through Obsidian's serializer. Scalars (number/boolean/null) are excluded
+ * because they are already YAML-safe inline, so collecting them would only force
+ * a needless whole-frontmatter rewrite (stripping comments, normalising quotes).
+ */
+export function isContainerYamlValue(v: unknown): boolean {
+  return Array.isArray(v) || (typeof v === "object" && v !== null);
+}
+
+/**
  * Produces a YAML-parseable placeholder for structured values so frontmatter
  * stays valid until processFrontMatter rewrites the final value.
  */


### PR DESCRIPTION
Closes #662

## Problem

Since Obsidian's properties update, the documented **Movie & Series** script produced invalid YAML front matter. Multi-value fields (`cast`, `genre`, `director`) came from the script as a YAML-bullet-list-shaped *string* and were inlined into a quoted scalar, e.g.:

```yaml
cast: "
  - "[[Ewan McGregor]]"
  - "[[Liam Neeson]]""
```

…so the property stayed "red" / didn't render. The "Template Property Types" handling that should fix this was gated behind a default-off beta toggle, and its string→list heuristic is effectively **dead in the real runtime** (`metadataTypeManager.getTypeInfo` never returns `null`), so even enabling the toggle didn't help.

## Fix

**Decouple structured-value collection from the beta flag.** Container values (arrays/objects) provided by scripts are now written as real Obsidian **List/object properties** through the native `processFrontMatter` serializer — **with the toggle off**. The toggle now only gates the opt-in *string → type* heuristic.

- **Narrowed to containers.** Numbers/booleans/null are already YAML-safe inlined, so they stay raw — valid front matter (and any comments) stays **byte-identical**; `processFrontMatter` only runs when a value genuinely needs it.
- **`movies.js`**: `linkifyList` returns a real array, so `cast`/`genre`/`director` become List properties of links.
- **Example template** rewritten to YAML front matter with quoted scalar wikilinks and the plot in the note body (avoids quote/colon breakage).
- **Latent bug fix**: coerce non-string variable values to a string before substitution so the `{{VALUE}}` scanner doesn't desync (`replacement.length`).
- **Beta-toggle copy + docs** updated to reflect that lists are always handled; the toggle controls string conversion.

### Follow-up (also in this PR): capture editor-insertion data-loss

Editor-insertion capture actions (`currentLine` / `newLineAbove` / `newLineBelow`) write to the note **body**, where front matter property types are meaningless. They formatted inside a collection scope, so after the change above a frontmatter-shaped capture with an array value would be replaced by a `[]` placeholder that's never applied — silently dropping the value. Collection is now **suppressed** for these actions, so the value inlines as text (matching pre-change behaviour). File-write capture paths are unchanged.

## Verification

- **Dev-vault e2e (toggle OFF):** the documented movie template renders `cast`/`genre`/`director` as List-of-link properties; scalars valid; a plot containing `"` and `:` is safe in the body; front-matter **comments are preserved** for scalar-only templates (no needless rewrite). Screenshot-confirmed.
- **Unit:** new real-`Formatter` flag-off regressions (array → List + placeholder, scalars stay raw, same-line coercion), collector `getTypeInfo→text` cases, and a capture insertion-mode regression on the real `run()` path. Updated the feature-flag mock tests to match the narrowed behaviour.
- Full suite: **1899 passed**, 0 failed. `tsc` + `eslint` clean.

## Review

Two design rounds + an adversarial review (3 opposite-model lenses) on the diff. Their findings drove the narrowing-to-containers, the docs/setting-copy correction, the real-`Formatter` tests, and this capture follow-up.

## Known limitations (pre-existing, narrow — not changed here)

- **Append-mode** template choices (`appendTop`/`appendBottom`) concatenate the template into the note **body**, so a front-matter block there is body text (arrays inline as plain text). Append can't produce front-matter properties.
- **Unquoted scalar + array** in a user's own template: if a raw scalar makes the interim YAML unparseable, `processFrontMatter` can't apply the collected list (logged warning). The example template + a docs tip show quoting scalar wikilinks.
- **Canvas text** capture isn't a property store; containers inline as text there.

## Release impact

`fix:` — patch release. No migration required; existing valid templates are unaffected (byte-identical). Users on the old `movies.js` should re-download the updated script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated template/property-type docs and the Templates & Properties settings text to clarify that list/object values are always typed, while string-to-typed conversion is a beta option disabled by default.
  * Revised the macro movie/series example to improve YAML front matter usage and move the plot into the note body.

* **Bug Fixes**
  * Fixed editor insertion so inline template property values are inserted correctly without leaving empty placeholders.
  * Improved template property collection behavior to prevent unwanted structured-value collection in body-only captures and to ensure consistent typed output for arrays/objects. 
  * Improved list wikilink formatting for template/YAML serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->