### PR TITLE
feat(uri): support x-callback-url for the QuickAdd URI (#1070)

### DIFF
--- a/docs/docs/Advanced/ObsidianUri.md
+++ b/docs/docs/Advanced/ObsidianUri.md
@@ -31,6 +31,101 @@ Like every Obsidian URI, you can use the special `vault` parameter to specify wh
 obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-contents=Lorem%20ipsum.
 ```
 
+## Getting a result back (x-callback-url)
+
+QuickAdd can open a callback URL after a choice finishes, so an external caller (for
+example an Apple Shortcut) can react to the result and receive the path of the affected
+note. This follows the [x-callback-url](http://x-callback-url.com/) convention.
+
+:::info Off by default
+
+This is opt-in. Enable **Settings → AI & Online → Allow URI x-callback-url** first. It is
+off by default because the callback URL is controlled by whoever creates the
+`obsidian://` link, and the callback can carry your note's vault path.
+
+:::
+
+:::note Template and Capture only
+
+Callbacks are supported for **Template** and **Capture** choices. Triggering a Macro or
+Multi choice with a callback fires `x-error` with `errorCode=unsupported-choice-type`
+instead. (You can still trigger Macro/Multi choices via the URI without a callback.)
+
+:::
+
+### Callback parameters
+
+| Parameter        | Fired when                                                       |
+| ---------------- | ---------------------------------------------------------------- |
+| `x-success`      | the choice completed successfully                                |
+| `x-error`        | the choice failed, was aborted, was not found, or is unsupported |
+| `x-cancel`       | you cancelled a prompt while the choice was running              |
+| `x-callback-url` | legacy shorthand — used only when none of the above are present; it then fires for **success and cancel** (never error) |
+
+If a slot is not provided, nothing is opened for that outcome (there is no fallback — a
+cancel with no `x-cancel` opens nothing).
+
+Only `shortcuts:` and `obsidian:` callback URLs are permitted; any other scheme (such as
+`https:`, `file:`, or `javascript:`) is rejected and the choice is not run.
+
+### Result parameters
+
+QuickAdd appends these query parameters to your callback URL:
+
+- On `x-success`: `status=success`, and — for Template/Capture — `path=<vault-relative
+  path>` and `url=<obsidian://open…>` pointing at the affected note.
+- On `x-error`: `status=error` and a stable `errorCode` (one of `choice-not-found`,
+  `unsupported-choice-type`, `execution-failed`, `execution-aborted`, `bad-callback-url`).
+  The detailed error message is kept in Obsidian's log and is never sent to the callback.
+- On `x-cancel`: `status=cancel`.
+
+### Encoding your callback URL (important)
+
+Your callback URL is itself a value inside the `obsidian://` query string, so it **must be
+fully percent-encoded** (double-encoded). If you leave a `=` or `&` un-encoded, Obsidian's
+URI parser silently truncates the callback before QuickAdd ever sees it.
+
+For example, this looks reasonable but is **broken** — the `=My%20Cool%20Shortcut` part is
+dropped, leaving `shortcuts://run-shortcut?name`:
+
+```
+obsidian://quickadd?choice=Daily%20log&x-success=shortcuts://run-shortcut?name=My%20Cool%20Shortcut
+```
+
+The **correct** form encodes the entire `x-success` value:
+
+```
+obsidian://quickadd?choice=Daily%20log&x-success=shortcuts%3A%2F%2Frun-shortcut%3Fname%3DMy%2520Cool%2520Shortcut
+```
+
+(Note the `%2520` — the spaces inside the shortcut name are encoded twice because the value
+is decoded once by Obsidian and once by Shortcuts.)
+
+### Example
+
+Trigger a capture and run a shortcut on success, passing the created note's path:
+
+```
+obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-contents=Lorem%20ipsum&x-success=shortcuts%3A%2F%2Frun-shortcut%3Fname%3DLog%2520Saved
+```
+
+On success QuickAdd opens your `x-success` URL with these extra query parameters appended
+(shown here decoded — they are percent-encoded on the wire):
+
+- `status` = `success`
+- `path` = `Daily/2026-06-14.md`
+- `url` = `obsidian://open?vault=My Vault&file=Daily/2026-06-14.md`
+
+Your shortcut reads them from the URL it was opened with.
+
+:::note Mobile
+
+QuickAdd opens callbacks with `window.open`, exactly like Obsidian's own x-callback
+support. Whether a custom scheme such as `shortcuts:` launches reliably on iOS is a
+platform behaviour shared with Obsidian core — verify on your device.
+
+:::
+
 ## Important: Sync Service Limitations
 
 :::warning

--- a/docs/docs/Advanced/ObsidianUri.md
+++ b/docs/docs/Advanced/ObsidianUri.md
@@ -88,13 +88,13 @@ URI parser silently truncates the callback before QuickAdd ever sees it.
 For example, this looks reasonable but is **broken** — the `=My%20Cool%20Shortcut` part is
 dropped, leaving `shortcuts://run-shortcut?name`:
 
-```
+```text
 obsidian://quickadd?choice=Daily%20log&x-success=shortcuts://run-shortcut?name=My%20Cool%20Shortcut
 ```
 
 The **correct** form encodes the entire `x-success` value:
 
-```
+```text
 obsidian://quickadd?choice=Daily%20log&x-success=shortcuts%3A%2F%2Frun-shortcut%3Fname%3DMy%2520Cool%2520Shortcut
 ```
 
@@ -105,7 +105,7 @@ is decoded once by Obsidian and once by Shortcuts.)
 
 Trigger a capture and run a shortcut on success, passing the created note's path:
 
-```
+```text
 obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-contents=Lorem%20ipsum&x-success=shortcuts%3A%2F%2Frun-shortcut%3Fname%3DLog%2520Saved
 ```
 

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -1,9 +1,19 @@
 import type IChoice from "./types/choices/IChoice";
 import type { MacroAbortError } from "./errors/MacroAbortError";
+import type { ChoiceOutcome } from "./types/ChoiceOutcome";
 
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
 	variables: Map<string, unknown>;
+	/**
+	 * Records the structured outcome of the current execution so an orchestrator
+	 * (the URI x-callback handler, via {@link ChoiceExecutor.executeWithOutcome}) can
+	 * report success/failure/cancel to an external caller. Optional — engines call it
+	 * via `?.`, so existing stubs and the legacy void {@link execute} path are
+	 * unaffected. Record `success` at the content-commit point, before any cosmetic
+	 * step, so a later cosmetic failure cannot downgrade the outcome.
+	 */
+	recordExecutionResult?(result: ChoiceOutcome): void;
 	/**
 	 * Records that the most recent choice execution aborted so orchestrators can react.
 	 * Engines that handle cancellations without throwing should call this immediately after

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -1,6 +1,6 @@
 import type { App } from "obsidian";
 import { TFile } from "obsidian";
-import { MacroAbortError } from "src/errors/MacroAbortError";
+import { UserCancelError } from "src/errors/UserCancelError";
 import GenericSuggester from "src/gui/GenericSuggester/genericSuggester";
 import { settingsStore } from "src/settingsStore";
 import { getMarkdownFilesInFolder } from "src/utilityObsidian";
@@ -308,7 +308,7 @@ export async function runAIAssistant(
 		window.setTimeout(() => notice.hide(), 5000);
 		// Always abort on cancelled input
 		if (isCancellationError(error)) {
-			throw new MacroAbortError("Input cancelled by user");
+			throw new UserCancelError("Input cancelled by user");
 		}
 		throw error;
 	}

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -13,13 +13,16 @@ import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
 import { settingsStore } from "./settingsStore";
 import { runOnePagePreflight } from "./preflight/runOnePagePreflight";
 import { MacroAbortError } from "./errors/MacroAbortError";
-import { isCancellationError } from "./utils/errorUtils";
+import { UserCancelError } from "./errors/UserCancelError";
+import { isCancellationError, reportError } from "./utils/errorUtils";
 import { getOpenFileOriginLeaf } from "./utilityObsidian";
 import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
+import type { ChoiceOutcome } from "./types/ChoiceOutcome";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
 	private pendingAbort: MacroAbortError | null = null;
+	private pendingResult: ChoiceOutcome | null = null;
 
 	constructor(private app: App, private plugin: QuickAdd) {}
 
@@ -33,37 +36,22 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		return abort ?? null;
 	}
 
+	recordExecutionResult(result: ChoiceOutcome) {
+		this.pendingResult = result;
+	}
+
 	async execute(choice: IChoice): Promise<void> {
 		this.pendingAbort = null;
+		// Keep a nested execute() (e.g. a {{MACRO}} in a Template/Capture body that runs
+		// another choice through this same executor) transparent to the outcome slot of an
+		// enclosing executeWithOutcome(): snapshot and restore pendingResult so the nested
+		// choice's recorded result never leaks into the outer choice's reported outcome.
+		const savedResult = this.pendingResult;
 		const originLeaf = getOpenFileOriginLeaf(this.app);
 		const promptDraftStore = InputPromptDraftStore.getInstance();
 		promptDraftStore.beginExecutionScope();
 		try {
-			// One-page preflight honoring per-choice override.
-			const globalEnabled = settingsStore.getState().onePageInputEnabled;
-			const override = choice.onePageInput;
-			const shouldUseOnePager =
-				override === "always" || (override !== "never" && globalEnabled);
-			if (
-				shouldUseOnePager &&
-				(choice.type === "Template" ||
-					choice.type === "Capture" ||
-					choice.type === "Macro")
-			) {
-				try {
-					await runOnePagePreflight(
-						this.app,
-						this.plugin as unknown as QuickAdd,
-						this,
-						choice,
-					);
-				} catch (error) {
-					if (isCancellationError(error)) {
-						throw new MacroAbortError("One-page input cancelled by user");
-					}
-					throw error;
-				}
-			}
+			await this.runOnePagePreflightIfEnabled(choice);
 
 			switch (choice.type) {
 				case "Template": {
@@ -100,6 +88,91 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		} catch (error) {
 			promptDraftStore.rollbackExecutionScope();
 			throw error;
+		} finally {
+			this.pendingResult = savedResult;
+		}
+	}
+
+	/**
+	 * Executes a Template or Capture choice and returns a structured
+	 * {@link ChoiceOutcome} (used by the URI x-callback handler). Mirrors
+	 * {@link execute}'s envelope (one-page preflight + prompt-draft scope) so behaviour
+	 * is identical to the legacy void path; the only addition is surfacing the outcome.
+	 *
+	 * Nesting-safe: Template/Capture never run nested choices through this executor, so
+	 * the single result slot cannot be clobbered. An engine that completed without
+	 * recording success (and without aborting/throwing) hit a swallowed-failure branch,
+	 * which is reported as `error` — never silently as success.
+	 */
+	async executeWithOutcome(
+		choice: ITemplateChoice | ICaptureChoice,
+	): Promise<ChoiceOutcome> {
+		this.pendingAbort = null;
+		this.pendingResult = null;
+		const originLeaf = getOpenFileOriginLeaf(this.app);
+		const promptDraftStore = InputPromptDraftStore.getInstance();
+		promptDraftStore.beginExecutionScope();
+		try {
+			await this.runOnePagePreflightIfEnabled(choice);
+
+			if (choice.type === "Template") {
+				await this.onChooseTemplateType(choice as ITemplateChoice, originLeaf);
+			} else {
+				await this.onChooseCaptureType(choice as ICaptureChoice, originLeaf);
+			}
+
+			if (this.pendingAbort) {
+				promptDraftStore.rollbackExecutionScope();
+				const abort = this.consumeAbortSignal();
+				return {
+					status: "cancelled",
+					cancelKind: abort instanceof UserCancelError ? "user" : "aborted",
+				};
+			}
+
+			promptDraftStore.commitExecutionScope();
+			const result = this.pendingResult;
+			this.pendingResult = null;
+			// No success recorded and no abort => the engine swallowed a failure.
+			return result ?? { status: "error" };
+		} catch (error) {
+			promptDraftStore.rollbackExecutionScope();
+			if (error instanceof UserCancelError) {
+				return { status: "cancelled", cancelKind: "user" };
+			}
+			if (error instanceof MacroAbortError) {
+				return { status: "cancelled", cancelKind: "aborted" };
+			}
+			reportError(error, "Error executing choice from URI");
+			return { status: "error" };
+		}
+	}
+
+	private async runOnePagePreflightIfEnabled(choice: IChoice): Promise<void> {
+		// One-page preflight honoring per-choice override.
+		const globalEnabled = settingsStore.getState().onePageInputEnabled;
+		const override = choice.onePageInput;
+		const shouldUseOnePager =
+			override === "always" || (override !== "never" && globalEnabled);
+		if (
+			shouldUseOnePager &&
+			(choice.type === "Template" ||
+				choice.type === "Capture" ||
+				choice.type === "Macro")
+		) {
+			try {
+				await runOnePagePreflight(
+					this.app,
+					this.plugin as unknown as QuickAdd,
+					this,
+					choice,
+				);
+			} catch (error) {
+				if (isCancellationError(error)) {
+					throw new UserCancelError("One-page input cancelled by user");
+				}
+				throw error;
+			}
 		}
 	}
 

--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -107,6 +107,7 @@ import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { settingsStore } from "../settingsStore";
 
@@ -204,7 +205,7 @@ describe("CaptureChoiceEngine cancellation notices", () => {
 			...settingsStore.getState(),
 			showInputCancellationNotification: true,
 		});
-		const engine = createEngine(new MacroAbortError("Input cancelled by user"));
+		const engine = createEngine(new UserCancelError("Input cancelled by user"));
 
 		await engine.run();
 
@@ -220,7 +221,7 @@ describe("CaptureChoiceEngine cancellation notices", () => {
 			showInputCancellationNotification: false,
 		});
 
-		const engine = createEngine(new MacroAbortError("Input cancelled by user"));
+		const engine = createEngine(new UserCancelError("Input cancelled by user"));
 
 		await engine.run();
 

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -77,12 +77,14 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 }));
 
 vi.mock("../utilityObsidian", () => ({
-	appendToCurrentLine: vi.fn(),
+	// Editor-insertion helpers return true when the insertion lands; default the mocks
+	// to "inserted" so capture-to-active-file paths proceed to the cosmetic/openFile steps.
+	appendToCurrentLine: vi.fn(() => true),
 	getMarkdownFilesInFolder: vi.fn(() => []),
 	getMarkdownFilesWithTag: vi.fn(() => []),
 	insertFileLinkToActiveView: vi.fn(),
-	insertOnNewLineAbove: vi.fn(),
-	insertOnNewLineBelow: vi.fn(),
+	insertOnNewLineAbove: vi.fn(() => true),
+	insertOnNewLineBelow: vi.fn(() => true),
 	isFolder: vi.fn(() => false),
 	isTemplaterTriggerOnCreateEnabled: vi.fn(() => false),
 	jumpToNextTemplaterCursorIfPossible: vi.fn(),

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -43,7 +43,7 @@ import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
 import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
-import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { SingleTemplateEngine } from "./SingleTemplateEngine";
 import { getCaptureAction, type CaptureAction } from "./captureAction";
 import {
@@ -285,16 +285,28 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					file,
 				);
 
+				let inserted = false;
 				switch (action) {
 					case "currentLine":
-						appendToCurrentLine(content, this.app);
+						inserted = appendToCurrentLine(content, this.app);
 						break;
 					case "newLineAbove":
-						insertOnNewLineAbove(content, this.app);
+						inserted = insertOnNewLineAbove(content, this.app);
 						break;
 					case "newLineBelow":
-						insertOnNewLineBelow(content, this.app);
+						inserted = insertOnNewLineBelow(content, this.app);
 						break;
+				}
+
+				if (!inserted) {
+					// No active Markdown editor — the capture did not land. Report a
+					// failure instead of falling through to the success notice/callback.
+					InputPromptDraftStore.getInstance().markExecutionScopeFailed();
+					log.logError(
+						`Capture "${this.choice.name}": no active Markdown editor to insert into.`,
+					);
+					this.choiceExecutor.recordExecutionResult?.({ status: "error" });
+					return;
 				}
 			} else {
 				await this.app.vault.modify(file, newFileContent);
@@ -303,6 +315,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				}
 				await this.applyCapturePropertyVars(file);
 			}
+
+			// Content is committed. Record success BEFORE the cosmetic steps below
+			// (notice / link / open / cursor jump) so a later cosmetic failure cannot
+			// downgrade the outcome — otherwise an x-callback caller would see an error,
+			// retry, and duplicate the capture.
+			this.choiceExecutor.recordExecutionResult?.({ status: "success", file });
 
 			// Show success notification
 			if (this.plugin.settings.showCaptureNotification) {
@@ -388,6 +406,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		);
 
 		await setCanvasTextCaptureContent(this.app, target, nextText);
+
+		// Committed; record success before cosmetic steps (see run() for rationale).
+		this.choiceExecutor.recordExecutionResult?.({ status: "success", file });
 
 		if (this.plugin.settings.showCaptureNotification) {
 			this.showSuccessNotice(file, {
@@ -590,7 +611,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}
@@ -625,7 +646,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}

--- a/src/engine/MacroChoiceEngine.notice.test.ts
+++ b/src/engine/MacroChoiceEngine.notice.test.ts
@@ -63,6 +63,7 @@ import type { IMacro } from "../types/macros/IMacro";
 import { CommandType } from "../types/macros/CommandType";
 import { MacroChoiceEngine } from "./MacroChoiceEngine";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { settingsStore } from "../settingsStore";
 import type IChoice from "../types/choices/IChoice";
 
@@ -90,7 +91,11 @@ class CancellationTestMacroChoiceEngine extends MacroChoiceEngine {
 	}
 
 	protected override executeObsidianCommand(): void {
-		throw new MacroAbortError(this.abortMessage);
+		// A user prompt-dismissal surfaces as UserCancelError in production; other
+		// aborts stay plain MacroAbortError.
+		throw this.abortMessage.toLowerCase().includes("cancelled by user")
+			? new UserCancelError(this.abortMessage)
+			: new MacroAbortError(this.abortMessage);
 	}
 }
 

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -47,6 +47,7 @@ import type { IOpenFileCommand } from "../types/macros/QuickCommands/IOpenFileCo
 import { openFile } from "../utilityObsidian";
 import { TFile } from "obsidian";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { initializeUserScriptSettings } from "../utils/userScriptSettings";
 import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
 import type { ScriptCondition } from "../types/macros/Conditional/types";
@@ -470,7 +471,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 				throw err;
 			}
 			if (isCancellationError(err)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw err;
 		}
@@ -567,7 +568,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 				modelName = await GenericSuggester.Suggest(this.app, options, options);
 			} catch (error) {
 				if (isCancellationError(error)) {
-					throw new MacroAbortError("Input cancelled by user");
+					throw new UserCancelError("Input cancelled by user");
 				}
 				throw error;
 			}

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -111,6 +111,7 @@ import { TemplateChoiceEngine } from "./TemplateChoiceEngine";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { settingsStore } from "../settingsStore";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 
@@ -196,7 +197,11 @@ const createEngine = (
 
 	if (options.throwDuringFileName !== false) {
 		formatFileNameMock.mockImplementation(async () => {
-			throw new MacroAbortError(abortMessage);
+			// A genuine user prompt-dismissal surfaces as UserCancelError in production
+			// (the formatter converts the cancellation); other aborts stay plain.
+			throw abortMessage.toLowerCase().includes("cancelled by user")
+				? new UserCancelError(abortMessage)
+				: new MacroAbortError(abortMessage);
 		});
 	} else {
 		formatFileNameMock.mockResolvedValue("Test Template");
@@ -275,7 +280,7 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 			stubTemplateContent: true,
 		});
 		formatFileContentMock.mockRejectedValueOnce(
-			new MacroAbortError("Input cancelled by user"),
+			new UserCancelError("Input cancelled by user"),
 		);
 
 		await engine.run();

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -29,7 +29,7 @@ import {
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { TemplateEngine } from "./TemplateEngine";
-import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 
 export class TemplateChoiceEngine extends TemplateEngine {
@@ -148,6 +148,14 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				}
 			}
 
+			// File is created/resolved (the commit point). Record success BEFORE the
+			// cosmetic steps below (link / open / templater jump) so a later cosmetic
+			// failure cannot downgrade the outcome for an x-callback caller.
+			this.choiceExecutor.recordExecutionResult?.({
+				status: "success",
+				file: createdFile,
+			});
+
 			if (linkOptions.enabled && createdFile) {
 			insertFileLinkToActiveView(this.app, createdFile, linkOptions);
 			}
@@ -204,7 +212,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -29,6 +29,7 @@ import {
 	isReservedWindowsDeviceName,
 } from "../utils/pathValidation";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { isCancellationError } from "../utils/errorUtils";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
@@ -185,7 +186,7 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}

--- a/src/errors/UserCancelError.ts
+++ b/src/errors/UserCancelError.ts
@@ -1,0 +1,16 @@
+import { MacroAbortError } from "./MacroAbortError";
+
+/**
+ * Thrown when execution stops because the user dismissed a prompt (Escape / Cancel),
+ * as opposed to a script- or config-initiated abort (`params.abort(...)`, a missing
+ * target file, etc.).
+ *
+ * Extends {@link MacroAbortError} so every existing `instanceof MacroAbortError` guard
+ * and abort-handling path keeps treating it as an abort. The distinct subclass lets the
+ * URI x-callback handler classify a genuine user cancellation (`x-cancel`) apart from an
+ * involuntary abort (`x-error`).
+ *
+ * Keeps `name = "MacroAbortError"` (inherited) so duck-typed checks that match on the
+ * error name continue to recognise it.
+ */
+export class UserCancelError extends MacroAbortError {}

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -22,7 +22,7 @@ import {
 } from "../utils/FieldValueCollector";
 import { FieldValueProcessor } from "../utils/FieldValueProcessor";
 import { Formatter, type PromptContext } from "./formatter";
-import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { isCancellationError } from "../utils/errorUtils";
 
 export class CompleteFormatter extends Formatter {
@@ -209,7 +209,7 @@ export class CompleteFormatter extends Formatter {
 				}
 			} catch (error) {
 				if (isCancellationError(error)) {
-					throw new MacroAbortError("Input cancelled by user");
+					throw new UserCancelError("Input cancelled by user");
 				}
 				throw error;
 			}
@@ -247,7 +247,7 @@ export class CompleteFormatter extends Formatter {
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}
@@ -258,7 +258,7 @@ export class CompleteFormatter extends Formatter {
 			return await MathModal.Prompt();
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}
@@ -299,7 +299,7 @@ export class CompleteFormatter extends Formatter {
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}
@@ -349,7 +349,7 @@ export class CompleteFormatter extends Formatter {
 			});
 		} catch (error) {
 			if (isCancellationError(error)) {
-				throw new MacroAbortError("Input cancelled by user");
+				throw new UserCancelError("Input cancelled by user");
 			}
 			throw error;
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { log } from "./logger/logManager";
 import { ConsoleErrorLogger } from "./logger/consoleErrorLogger";
 import { GuiLogger } from "./logger/guiLogger";
 import { LogManager } from "./logger/logManager";
-import { reportError } from "./utils/errorUtils";
+import { reportError, withErrorHandling } from "./utils/errorUtils";
 import { StartupMacroEngine } from "./engine/StartupMacroEngine";
 import { ChoiceExecutor } from "./choiceExecutor";
 import type IChoice from "./types/choices/IChoice";
@@ -32,6 +32,16 @@ import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
 import { setQuickAddInstance } from "./quickAddInstance";
 import { applyTemplateToNote } from "./engine/applyTemplateToActiveNote";
+import type ITemplateChoice from "./types/choices/ITemplateChoice";
+import type ICaptureChoice from "./types/choices/ICaptureChoice";
+import {
+	buildCallbackUrl,
+	buildObsidianOpenUrl,
+	callbackUrls,
+	isCallbackUrlAllowed,
+	parseCallbackTargets,
+	type CallbackTargets,
+} from "./uri/uriCallback";
 
 // Parameters prefixed with `value-` get used as named values for the executed choice
 type CaptureValueParameters = { [key in `value-${string}`]?: string };
@@ -40,7 +50,18 @@ interface DefinedUriParameters {
 	choice?: string; // Name
 }
 
-type UriParameters = DefinedUriParameters & CaptureValueParameters;
+// x-callback-url parameters (Apple Shortcuts, etc.). The hyphenated keys arrive
+// verbatim from the obsidian:// query string.
+interface XCallbackParameters {
+	"x-success"?: string;
+	"x-error"?: string;
+	"x-cancel"?: string;
+	"x-callback-url"?: string;
+}
+
+type UriParameters = DefinedUriParameters &
+	CaptureValueParameters &
+	XCallbackParameters;
 
 // The settingsStore subscriber fires on every store change — including high-frequency
 // ones like folder collapse toggles. Coalesce those full-settings disk writes into one
@@ -171,33 +192,82 @@ export default class QuickAdd extends Plugin {
 
 		this.registerObsidianProtocolHandler("quickadd", async (e) => {
 			const parameters = e as unknown as UriParameters;
-			if (!parameters.choice) {
-				log.logWarning("URI was executed without a `choice` parameter.");
+
+			// Resolve callback targets only when the feature is enabled. With it off (or
+			// no x-* params) we run the exact legacy path — zero behavioural change.
+			const targets: CallbackTargets = this.settings.enableUriCallbacks
+				? parseCallbackTargets(parameters)
+				: { any: false };
+
+			if (!targets.any) {
+				await this.runUriChoiceLegacy(parameters);
 				return;
 			}
-			const choice = this.getChoice("name", parameters.choice);
 
-			if (!choice) {
-				reportError(
-					new Error(
-						`URI could not find any choice named '${parameters.choice}'`,
-					),
-					"URI handler error",
+			// Validate every provided callback URL BEFORE running anything, so a bad URL
+			// can't half-execute and make an external caller retry (and duplicate work).
+			const disallowed = callbackUrls(targets).filter(
+				(url) => !isCallbackUrlAllowed(url),
+			);
+			if (disallowed.length > 0) {
+				log.logWarning(
+					`QuickAdd URI: ignoring disallowed callback URL(s): ${disallowed.join(", ")}`,
 				);
+				// Notify via x-error only if it is itself allowed; never open a disallowed
+				// URL. Nothing was executed, so the caller can safely retry.
+				if (targets.error && isCallbackUrlAllowed(targets.error)) {
+					this.openUriCallback(targets.error, {
+						status: "error",
+						errorCode: "bad-callback-url",
+					});
+				}
+				return;
+			}
+
+			if (!parameters.choice) {
+				log.logWarning("URI was executed without a `choice` parameter.");
+				this.fireUriError(targets, "choice-not-found");
+				return;
+			}
+
+			const choice = this.getChoice("name", parameters.choice);
+			if (!choice) {
+				log.logWarning(
+					`URI could not find any choice named '${parameters.choice}'`,
+				);
+				this.fireUriError(targets, "choice-not-found");
+				return;
+			}
+
+			if (choice.type !== "Template" && choice.type !== "Capture") {
+				log.logWarning(
+					`QuickAdd URI x-callback supports Template and Capture choices only ('${choice.name}' is ${choice.type}).`,
+				);
+				this.fireUriError(targets, "unsupported-choice-type");
 				return;
 			}
 
 			const choiceExecutor = new ChoiceExecutor(this.app, this);
-			Object.entries(parameters)
-				.filter(([key]) => key.startsWith("value-"))
-				.forEach(([key, value]) => {
-					choiceExecutor.variables.set(key.slice(6), value);
-				});
+			this.applyUriValueParameters(choiceExecutor, parameters);
 
-			try {
-				await choiceExecutor.execute(choice);
-			} catch (err) {
-				reportError(err, "Error executing choice from URI");
+			const outcome = await choiceExecutor.executeWithOutcome(
+				choice as ITemplateChoice | ICaptureChoice,
+			);
+
+			switch (outcome.status) {
+				case "success":
+					this.fireUriSuccess(targets, outcome.file);
+					break;
+				case "cancelled":
+					if (outcome.cancelKind === "user") {
+						this.fireUriCancel(targets);
+					} else {
+						this.fireUriError(targets, "execution-aborted");
+					}
+					break;
+				case "error":
+					this.fireUriError(targets, "execution-failed");
+					break;
 			}
 		});
 
@@ -240,6 +310,75 @@ export default class QuickAdd extends Plugin {
 			this.app.workspace.onLayoutReady(launchStartupMacros);
 		}
 		this.announceUpdate();
+	}
+
+	/** Today's URI behaviour: run the choice, report errors to the log. Used when URI
+	 * callbacks are disabled or no x-* params were provided (backward-compatible). */
+	private async runUriChoiceLegacy(parameters: UriParameters): Promise<void> {
+		if (!parameters.choice) {
+			log.logWarning("URI was executed without a `choice` parameter.");
+			return;
+		}
+		const choice = this.getChoice("name", parameters.choice);
+		if (!choice) {
+			reportError(
+				new Error(
+					`URI could not find any choice named '${parameters.choice}'`,
+				),
+				"URI handler error",
+			);
+			return;
+		}
+		const choiceExecutor = new ChoiceExecutor(this.app, this);
+		this.applyUriValueParameters(choiceExecutor, parameters);
+		try {
+			await choiceExecutor.execute(choice);
+		} catch (err) {
+			reportError(err, "Error executing choice from URI");
+		}
+	}
+
+	private applyUriValueParameters(
+		choiceExecutor: ChoiceExecutor,
+		parameters: UriParameters,
+	): void {
+		Object.entries(parameters)
+			.filter(([key]) => key.startsWith("value-"))
+			.forEach(([key, value]) => {
+				if (typeof value === "string") {
+					choiceExecutor.variables.set(key.slice(6), value);
+				}
+			});
+	}
+
+	private fireUriSuccess(targets: CallbackTargets, file?: TFile): void {
+		const params: Record<string, string> = { status: "success" };
+		if (file) {
+			params.path = file.path;
+			params.url = buildObsidianOpenUrl(this.app.vault.getName(), file.path);
+		}
+		if (targets.success) this.openUriCallback(targets.success, params);
+	}
+
+	private fireUriError(targets: CallbackTargets, errorCode: string): void {
+		if (targets.error) {
+			this.openUriCallback(targets.error, { status: "error", errorCode });
+		}
+	}
+
+	private fireUriCancel(targets: CallbackTargets): void {
+		if (targets.cancel) {
+			this.openUriCallback(targets.cancel, { status: "cancel" });
+		}
+	}
+
+	/** Opens a callback URL with the result params appended. No-throw, no-recursion:
+	 * a failed window.open must never break the (already-completed) choice or fire
+	 * another callback. */
+	private openUriCallback(url: string, params: Record<string, string>): void {
+		withErrorHandling(() => {
+			window.open(buildCallbackUrl(url, params));
+		}, "QuickAdd URI: failed to open callback URL");
 	}
 
 	onunload() {

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -40,6 +40,7 @@ import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { FieldSuggestionFileFilter } from "./utils/FieldSuggestionFileFilter";
 import { InlineFieldParser } from "./utils/InlineFieldParser";
 import { MacroAbortError } from "./errors/MacroAbortError";
+import { UserCancelError } from "./errors/UserCancelError";
 import { formatISODate } from "./utils/dateParser";
 import type { InputPromptOptions } from "./types/inputPrompt";
 import {
@@ -861,6 +862,6 @@ function throwIfPromptCancelled(error: unknown): void {
 		throw error;
 	}
 	if (isCancellationError(error)) {
-		throw new MacroAbortError("Input cancelled by user");
+		throw new UserCancelError("Input cancelled by user");
 	}
 }

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -284,6 +284,11 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					desc: "This prevents the plugin from making requests to external providers like OpenAI. You can still use User Scripts to execute arbitrary code, including contacting external providers. However, this setting disables plugin features like the AI Assistant from doing so. You need to disable this setting to use the AI Assistant.",
 					control: { type: "toggle", key: "disableOnlineFeatures" },
 				},
+				{
+					name: "Allow URI x-callback-url",
+					desc: "When on, an obsidian://quickadd URI may open a callback URL (x-success / x-error / x-cancel) after a Template or Capture choice finishes — sending the outcome and the affected note's vault path and URL to that callback. Off by default because the callback URL is set by whoever creates the obsidian:// link. Only shortcuts: and obsidian: callback URLs are permitted.",
+					control: { type: "toggle", key: "enableUriCallbacks" },
+				},
 			],
 		};
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,6 +37,15 @@ export interface QuickAddSettings {
 		* Users _can_ still use User Scripts to do so by executing arbitrary JavaScript, but that is not something the plugin controls.
 		*/
 	disableOnlineFeatures: boolean;
+	/**
+	 * When enabled, the `obsidian://quickadd` URI may open an x-callback-url
+	 * (`x-success`/`x-error`/`x-cancel`) after a Template/Capture choice completes,
+	 * sending the outcome and the affected note's vault path + URL to that URL.
+	 * Default off because the callback URL is controlled by whoever crafts the
+	 * `obsidian://` link. (Opposite default polarity to `disableOnlineFeatures`,
+	 * which defaults true — both are the conservative, locked-down choice.)
+	 */
+	enableUriCallbacks: boolean;
 	enableRibbonIcon: boolean;
 	showCaptureNotification: boolean;
 	showInputCancellationNotification: boolean;
@@ -83,6 +92,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	globalVariables: {},
 	onePageInputEnabled: false,
 	disableOnlineFeatures: true,
+	enableUriCallbacks: false,
 	enableRibbonIcon: false,
 	showCaptureNotification: true,
 	showInputCancellationNotification: false,

--- a/src/types/ChoiceOutcome.ts
+++ b/src/types/ChoiceOutcome.ts
@@ -1,0 +1,17 @@
+import type { TFile } from "obsidian";
+
+/**
+ * The result of executing a single choice, surfaced by
+ * {@link ChoiceExecutor.executeWithOutcome} for callers (e.g. the URI x-callback
+ * handler) that must report success / failure / cancellation back to an external
+ * caller.
+ *
+ * `success` carries the affected file when one is known (Template, Capture).
+ * `cancelled` distinguishes a genuine user prompt-dismissal (`"user"`) from an
+ * involuntary script/config abort (`"aborted"`). `error` means the choice failed
+ * (the detailed message is kept in the internal log, never surfaced externally).
+ */
+export type ChoiceOutcome =
+	| { status: "success"; file?: TFile }
+	| { status: "error" }
+	| { status: "cancelled"; cancelKind: "user" | "aborted" };

--- a/src/uri/uriCallback.test.ts
+++ b/src/uri/uriCallback.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCallbackUrl,
+	buildObsidianOpenUrl,
+	callbackUrls,
+	isCallbackUrlAllowed,
+	parseCallbackTargets,
+} from "./uriCallback";
+
+describe("parseCallbackTargets", () => {
+	it("reads explicit x-success / x-error / x-cancel", () => {
+		const t = parseCallbackTargets({
+			"x-success": "shortcuts://ok",
+			"x-error": "shortcuts://err",
+			"x-cancel": "shortcuts://cancel",
+		});
+		expect(t).toEqual({
+			success: "shortcuts://ok",
+			error: "shortcuts://err",
+			cancel: "shortcuts://cancel",
+			any: true,
+		});
+	});
+
+	it("uses x-callback-url as the success AND cancel target (never error) when no explicit slot is present", () => {
+		const t = parseCallbackTargets({ "x-callback-url": "shortcuts://done" });
+		expect(t.success).toBe("shortcuts://done");
+		expect(t.cancel).toBe("shortcuts://done");
+		expect(t.error).toBeUndefined();
+		expect(t.any).toBe(true);
+	});
+
+	it("ignores x-callback-url when any explicit slot is present", () => {
+		const t = parseCallbackTargets({
+			"x-success": "shortcuts://ok",
+			"x-callback-url": "shortcuts://legacy",
+		});
+		expect(t.success).toBe("shortcuts://ok");
+		expect(t.cancel).toBeUndefined();
+	});
+
+	it("treats empty strings as absent and reports any:false when nothing is provided", () => {
+		expect(parseCallbackTargets({ "x-success": "" }).any).toBe(false);
+		expect(parseCallbackTargets({}).any).toBe(false);
+	});
+});
+
+describe("isCallbackUrlAllowed", () => {
+	it("allows shortcuts: and obsidian: schemes", () => {
+		expect(isCallbackUrlAllowed("shortcuts://run-shortcut?name=Foo")).toBe(true);
+		expect(isCallbackUrlAllowed("obsidian://open?vault=v&file=f")).toBe(true);
+	});
+
+	it("rejects dangerous and non-allowlisted schemes", () => {
+		for (const url of [
+			"https://evil.example/cb",
+			"http://evil.example/cb",
+			"file:///etc/passwd",
+			"javascript:alert(1)",
+			"data:text/html,<script>",
+			"sms:+15555550123?body=secret",
+			"tel:+15555550123",
+			"mailto:attacker@example.com",
+		]) {
+			expect(isCallbackUrlAllowed(url)).toBe(false);
+		}
+	});
+
+	it("rejects leading-whitespace dangerous schemes (URL normalises them, allowlist still excludes)", () => {
+		// new URL(" javascript:...") normalises to protocol "javascript:" which is not allow-listed.
+		expect(isCallbackUrlAllowed(" javascript:alert(1)")).toBe(false);
+		expect(isCallbackUrlAllowed("\tfile:///x")).toBe(false);
+	});
+
+	it("rejects unparseable URLs", () => {
+		expect(isCallbackUrlAllowed("not a url")).toBe(false);
+		expect(isCallbackUrlAllowed("")).toBe(false);
+	});
+});
+
+describe("buildCallbackUrl", () => {
+	it("appends percent-encoded params and preserves the existing query", () => {
+		const out = buildCallbackUrl("shortcuts://run-shortcut?name=Foo", {
+			status: "success",
+			path: "Daily/My Note.md",
+		});
+		const url = new URL(out);
+		expect(url.searchParams.get("name")).toBe("Foo");
+		expect(url.searchParams.get("status")).toBe("success");
+		expect(url.searchParams.get("path")).toBe("Daily/My Note.md");
+		// the serialized string must not contain a raw space (URLSearchParams encodes
+		// space as "+" and "/" as "%2F"; both round-trip correctly via new URL above)
+		expect(out).not.toContain(" ");
+		expect(out).toContain("Daily%2FMy+Note.md");
+	});
+
+	it("overrides a caller-supplied reserved param instead of duplicating it", () => {
+		const out = buildCallbackUrl("shortcuts://run-shortcut?name=X&status=old", {
+			status: "success",
+		});
+		const url = new URL(out);
+		// QuickAdd's status wins; no duplicate status param a consumer could read first
+		expect(url.searchParams.getAll("status")).toEqual(["success"]);
+		expect(url.searchParams.get("name")).toBe("X");
+	});
+});
+
+describe("buildObsidianOpenUrl", () => {
+	it("percent-encodes the vault name and file path", () => {
+		const out = buildObsidianOpenUrl("My Vault", "Folder/Sub/Note.md");
+		expect(out).toBe(
+			"obsidian://open?vault=My%20Vault&file=Folder%2FSub%2FNote.md",
+		);
+	});
+});
+
+describe("callbackUrls", () => {
+	it("collects the non-empty targets", () => {
+		const t = parseCallbackTargets({
+			"x-success": "shortcuts://ok",
+			"x-error": "shortcuts://err",
+		});
+		expect(callbackUrls(t)).toEqual(["shortcuts://ok", "shortcuts://err"]);
+	});
+});

--- a/src/uri/uriCallback.ts
+++ b/src/uri/uriCallback.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure, Obsidian-free helpers for the `obsidian://quickadd` x-callback-url support.
+ *
+ * Keeping all decision logic here (target selection, scheme allow-listing, URL
+ * building) makes the security-critical parts unit-testable under jsdom without a
+ * real Obsidian environment. The impure layer (main.ts) only resolves the affected
+ * file's URL and calls `window.open`.
+ */
+
+/** Schemes a callback URL is allowed to use. Narrow on purpose: covers the issue's
+ * Apple Shortcuts use case (`shortcuts:`) and `obsidian://` round-trips. `http(s)`
+ * web callbacks are intentionally excluded for now — they would send vault-relative
+ * paths to an incoming-URI-controlled destination. */
+const ALLOWED_CALLBACK_SCHEMES = new Set(["shortcuts:", "obsidian:"]);
+
+export interface CallbackTargets {
+	success?: string;
+	error?: string;
+	cancel?: string;
+	/** True when at least one callback target was provided. */
+	any: boolean;
+}
+
+/** The x-callback-url-related fields read off the incoming obsidian:// params. */
+export interface RawCallbackParams {
+	"x-success"?: string;
+	"x-error"?: string;
+	"x-cancel"?: string;
+	"x-callback-url"?: string;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Resolves which callback URL fires for each outcome from the incoming URI params.
+ *
+ * `x-success` / `x-error` / `x-cancel` are the canonical x-callback-url params. The
+ * legacy single-URL `x-callback-url` shorthand is honoured ONLY when none of the
+ * three explicit params is present; it then fires for both success AND cancel (both
+ * are "completed actions"), never for error.
+ */
+export function parseCallbackTargets(
+	params: RawCallbackParams,
+): CallbackTargets {
+	const success = nonEmpty(params["x-success"]);
+	const error = nonEmpty(params["x-error"]);
+	const cancel = nonEmpty(params["x-cancel"]);
+
+	if (success || error || cancel) {
+		return { success, error, cancel, any: true };
+	}
+
+	const legacy = nonEmpty(params["x-callback-url"]);
+	if (legacy) {
+		return { success: legacy, cancel: legacy, any: true };
+	}
+
+	return { any: false };
+}
+
+/** All non-empty callback URLs across the resolved targets (deduped order: success, error, cancel). */
+export function callbackUrls(targets: CallbackTargets): string[] {
+	return [targets.success, targets.error, targets.cancel].filter(
+		(url): url is string => typeof url === "string" && url.length > 0,
+	);
+}
+
+/**
+ * True if `url` parses and uses an allow-listed scheme. Scheme extraction goes
+ * through `new URL().protocol` (which normalises leading whitespace/control chars
+ * per the URL Standard), so allow-listing — not naive string matching — is what
+ * keeps `file:`/`javascript:`/`sms:`/etc. out. Unparseable URLs are rejected.
+ */
+export function isCallbackUrlAllowed(url: string): boolean {
+	try {
+		const protocol = new URL(url).protocol.toLowerCase();
+		return ALLOWED_CALLBACK_SCHEMES.has(protocol);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Appends `params` as query parameters to `base` (percent-encoded). `base` is the
+ * caller-provided callback URL, already validated by {@link isCallbackUrlAllowed}.
+ */
+export function buildCallbackUrl(
+	base: string,
+	params: Record<string, string>,
+): string {
+	const url = new URL(base);
+	for (const [key, value] of Object.entries(params)) {
+		// `set` (not `append`) so QuickAdd's reserved result keys (status/path/url/
+		// errorCode) override any same-named param the caller already put on the URL,
+		// rather than producing a duplicate that consumers may read first.
+		url.searchParams.set(key, value);
+	}
+	return url.toString();
+}
+
+/**
+ * Builds an `obsidian://open?vault=…&file=…` URL from public vault/file data.
+ * (Obsidian's internal `app.getObsidianUrl` is not part of the public typings, so we
+ * construct it ourselves.)
+ */
+export function buildObsidianOpenUrl(
+	vaultName: string,
+	filePath: string,
+): string {
+	return (
+		"obsidian://open?vault=" +
+		encodeURIComponent(vaultName) +
+		"&file=" +
+		encodeURIComponent(filePath)
+	);
+}

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -502,28 +502,36 @@ export function getMarkdownEditorViewForFile(
 	return null;
 }
 
-export function appendToCurrentLine(toAppend: string, app: App) {
+/**
+ * @returns true if the text was inserted, false if there was no active Markdown
+ * editor to insert into (or insertion threw). Callers that need to know whether
+ * the capture actually landed (e.g. the URI x-callback handler) must check this.
+ */
+export function appendToCurrentLine(toAppend: string, app: App): boolean {
 	try {
 		const activeView = app.workspace.getActiveViewOfType(MarkdownView);
 
 		if (!activeView) {
 			log.logError(`unable to append '${toAppend}' to current line.`);
-			return;
+			return false;
 		}
 
 		activeView.editor.replaceSelection(toAppend);
+		return true;
 	} catch {
 		log.logError(`unable to append '${toAppend}' to current line.`);
+		return false;
 	}
 }
 
-export function insertOnNewLine(toInsert: string, direction: "above" | "below", app: App) {
+/** @returns true if inserted, false if no active Markdown editor (or it threw). */
+export function insertOnNewLine(toInsert: string, direction: "above" | "below", app: App): boolean {
 	try {
 		const activeView = app.workspace.getActiveViewOfType(MarkdownView);
 
 		if (!activeView) {
 			log.logError(`unable to insert '${toInsert}' on new line ${direction}.`);
-			return;
+			return false;
 		}
 
 		const editor = activeView.editor;
@@ -545,17 +553,19 @@ export function insertOnNewLine(toInsert: string, direction: "above" | "below", 
 			// Move cursor to end of inserted content
 			editor.setCursor({ line: lineNumber + insertedLineCount, ch: lastInsertedLineLength });
 		}
+		return true;
 	} catch {
 		log.logError(`unable to insert '${toInsert}' on new line ${direction}.`);
+		return false;
 	}
 }
 
-export function insertOnNewLineAbove(toInsert: string, app: App) {
-	insertOnNewLine(toInsert, "above", app);
+export function insertOnNewLineAbove(toInsert: string, app: App): boolean {
+	return insertOnNewLine(toInsert, "above", app);
 }
 
-export function insertOnNewLineBelow(toInsert: string, app: App) {
-	insertOnNewLine(toInsert, "below", app);
+export function insertOnNewLineBelow(toInsert: string, app: App): boolean {
+	return insertOnNewLine(toInsert, "below", app);
 }
 
 /**

--- a/src/utils/macroAbortHandler.ts
+++ b/src/utils/macroAbortHandler.ts
@@ -1,5 +1,6 @@
 import { Notice } from "obsidian";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { UserCancelError } from "../errors/UserCancelError";
 import { settingsStore } from "../settingsStore";
 import { log } from "../logger/logManager";
 
@@ -31,9 +32,14 @@ export function handleMacroAbort(
 
 	log.logMessage(`${logPrefix}: ${message}`);
 
+	// A genuine user prompt-dismissal is a UserCancelError (a MacroAbortError subclass).
+	// Keep the legacy message-string check as a fallback so a user script that aborts with
+	// `params.abort("...cancelled by user")` still gets its notice suppressed as before
+	// (the strict subclass check is only what the URI x-cancel classification relies on).
 	const isUserCancellation =
-		typeof error.message === "string" &&
-		error.message.toLowerCase().includes("cancelled by user");
+		error instanceof UserCancelError ||
+		(typeof error.message === "string" &&
+			error.message.toLowerCase().includes("cancelled by user"));
 
 	if (
 		!isUserCancellation ||


### PR DESCRIPTION
Closes #1070.

Lets external callers (e.g. Apple Shortcuts) trigger a **Template** or **Capture** choice via `obsidian://quickadd` and receive a callback when it finishes — the [x-callback-url](http://x-callback-url.com/) convention.

## What it does
- New **default-off** setting **Allow URI x-callback-url** (`enableUriCallbacks`). With it off, or when no `x-*` params are present, the handler runs the exact legacy path — **no behaviour change**.
- `x-success` / `x-error` / `x-cancel` (plus a legacy single-URL `x-callback-url` shorthand that fires on success and cancel).
- **Result payload:** `x-success` → `status=success` + the affected note's `path` and an `obsidian://open` `url`. `x-error` → `status=error` + a stable `errorCode` (`choice-not-found`, `unsupported-choice-type`, `execution-failed`, `execution-aborted`, `bad-callback-url`) — never the raw message, so vault internals don't leak. `x-cancel` → `status=cancel`.
- **Scope:** Template + Capture. Macro/Multi return `x-error` `unsupported-choice-type` (full propagation needs a larger refactor — tracked as follow-up).

## How it works
- New `ChoiceExecutor.executeWithOutcome()` returns a typed `ChoiceOutcome`; `IChoiceExecutor.execute()` is unchanged (no stub churn). Engines record success at the **content-commit point** (before cosmetic steps), so a later cosmetic failure can't downgrade the outcome and make a caller retry/duplicate.
- New `UserCancelError` distinguishes a genuine user prompt-dismissal (`x-cancel`) from a script/config abort (`x-error execution-aborted`); `handleMacroAbort` classifies via `instanceof` with a message-string fallback for back-compat.
- Editor-insertion helpers now report whether the insertion landed, so a capture with no active editor reports failure instead of a false success.
- **Security:** all provided callback URLs are validated **before** anything runs (a bad URL can't half-execute), and restricted to an allow-list of `shortcuts:` and `obsidian:` schemes.
- Pure URL logic in `src/uri/uriCallback.ts` (unit-tested).

## Verification
- `tsc`, `eslint`, **1934 vitest tests**, production build, and docs build all pass.
- Dev-vault e2e against the real plugin: success (+`path`/`url`), `unsupported-choice-type`, `choice-not-found`, **bad-scheme → no execution**, gate-off / no-callback → legacy, and caller-supplied `status` correctly overridden — all behave as designed.
- Reviewed via an adversarial diff pass; the one substantive finding (a nested `{{MACRO}}` could leak its outcome into the outer choice) is fixed by scoping the result slot per `execute()` frame.

## Docs
Full section added to `docs/docs/Advanced/ObsidianUri.md`, including the **double-encoding requirement** (Obsidian's URI parser truncates an under-encoded callback value — the issue's own example is affected).

## Release / migration
- `feat:` → minor release. New setting defaults off; `Object.assign` supplies it for existing users (no migration).
- `obsidian://quickadd` behaviour is unchanged unless a user opts in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in `Allow URI x-callback-url` setting enabling `obsidian://quickadd` result callbacks for **Template** and **Capture** choices (success, error, cancel).
* **Documentation**
  * Documented callback parameter behavior, required percent-encoding rules, supported callback URL schemes, and mobile notes.
* **Bug Fixes**
  * Improved user-cancellation handling and outcome reporting so cancellation and insertion failures behave more predictably.
* **Tests**
  * Updated and added coverage for cancellation notices and URI callback parsing/encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->