### PR TITLE
fix: append link respects caret when focused in a frontmatter property (#768)

### DIFF
--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -1,9 +1,16 @@
 import type IChoice from "./types/choices/IChoice";
 import type { MacroAbortError } from "./errors/MacroAbortError";
+import type { FrontmatterPropertyTarget } from "./utilityObsidian";
 
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
 	variables: Map<string, unknown>;
+	/**
+	 * The frontmatter property the caret was in when the choice was triggered,
+	 * captured before any QuickAdd UI opens. Used by Append Link to write into the
+	 * property instead of the (stale) body caret. Null when not in a property.
+	 */
+	focusedProperty?: FrontmatterPropertyTarget | null;
 	/**
 	 * Records that the most recent choice execution aborted so orchestrators can react.
 	 * Engines that handle cancellations without throwing should call this immediately after

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -24,7 +24,7 @@ import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
 	public focusedProperty: FrontmatterPropertyTarget | null = null;
-	private focusCaptured = false;
+	private executionDepth = 0;
 	private pendingAbort: MacroAbortError | null = null;
 
 	constructor(private app: App, private plugin: QuickAdd) {}
@@ -41,13 +41,15 @@ export class ChoiceExecutor implements IChoiceExecutor {
 
 	async execute(choice: IChoice): Promise<void> {
 		this.pendingAbort = null;
-		// Capture the focused frontmatter property BEFORE any prompt/suggester
-		// steals focus, so Append Link can target it later (#768). Captured once per
-		// execution chain so nested Multi choices keep the original caret.
-		if (!this.focusCaptured) {
-			this.focusCaptured = true;
+		// Capture the focused frontmatter property at the start of the OUTERMOST
+		// execution — before any prompt/suggester steals focus — so Append Link can
+		// target it later (#768). Nested Multi/Macro executions keep the original
+		// capture; it's cleared when the chain unwinds (finally), so a reused
+		// executor doesn't leak a stale target into the next top-level call.
+		if (this.executionDepth === 0) {
 			this.focusedProperty = getFocusedPropertyTarget(this.app);
 		}
+		this.executionDepth++;
 		const originLeaf = getOpenFileOriginLeaf(this.app);
 		const promptDraftStore = InputPromptDraftStore.getInstance();
 		promptDraftStore.beginExecutionScope();
@@ -113,6 +115,11 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		} catch (error) {
 			promptDraftStore.rollbackExecutionScope();
 			throw error;
+		} finally {
+			this.executionDepth--;
+			if (this.executionDepth === 0) {
+				this.focusedProperty = null;
+			}
 		}
 	}
 

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -14,11 +14,17 @@ import { settingsStore } from "./settingsStore";
 import { runOnePagePreflight } from "./preflight/runOnePagePreflight";
 import { MacroAbortError } from "./errors/MacroAbortError";
 import { isCancellationError } from "./utils/errorUtils";
-import { getOpenFileOriginLeaf } from "./utilityObsidian";
+import {
+	getFocusedPropertyTarget,
+	getOpenFileOriginLeaf,
+	type FrontmatterPropertyTarget,
+} from "./utilityObsidian";
 import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
+	public focusedProperty: FrontmatterPropertyTarget | null = null;
+	private focusCaptured = false;
 	private pendingAbort: MacroAbortError | null = null;
 
 	constructor(private app: App, private plugin: QuickAdd) {}
@@ -35,6 +41,13 @@ export class ChoiceExecutor implements IChoiceExecutor {
 
 	async execute(choice: IChoice): Promise<void> {
 		this.pendingAbort = null;
+		// Capture the focused frontmatter property BEFORE any prompt/suggester
+		// steals focus, so Append Link can target it later (#768). Captured once per
+		// execution chain so nested Multi choices keep the original caret.
+		if (!this.focusCaptured) {
+			this.focusCaptured = true;
+			this.focusedProperty = getFocusedPropertyTarget(this.app);
+		}
 		const originLeaf = getOpenFileOriginLeaf(this.app);
 		const promptDraftStore = InputPromptDraftStore.getInstance();
 		promptDraftStore.beginExecutionScope();

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -26,6 +26,7 @@ import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import { normalizeAppendLinkOptions, type AppendLinkOptions } from "../types/linkPlacement";
 import {
 	appendToCurrentLine,
+	appendLinkToFrontmatterProperty,
 	getMarkdownFilesInFolder,
 	getMarkdownFilesWithTag,
 	insertFileLinkToActiveView,
@@ -160,12 +161,25 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		);
 	}
 
-	private insertCaptureLink(
+	private async insertCaptureLink(
 		file: TFile,
 		linkOptions: AppendLinkOptions,
 		{ isCanvasTriggered }: { isCanvasTriggered: boolean },
-	): void {
+	): Promise<void> {
 		if (!linkOptions.enabled) {
+			return;
+		}
+
+		// #768: if the caret was in a frontmatter property when triggered, write
+		// the link there (persisted via processFrontMatter) instead of the body.
+		const propertyTarget = this.choiceExecutor.focusedProperty;
+		if (propertyTarget) {
+			await appendLinkToFrontmatterProperty(
+				this.app,
+				propertyTarget,
+				file,
+				linkOptions,
+			);
 			return;
 		}
 
@@ -315,7 +329,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				});
 			}
 
-			this.insertCaptureLink(file, linkOptions, {
+			await this.insertCaptureLink(file, linkOptions, {
 				isCanvasTriggered: !!canvasTarget,
 			});
 
@@ -399,7 +413,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			});
 		}
 
-		this.insertCaptureLink(file, linkOptions, {
+		await this.insertCaptureLink(file, linkOptions, {
 			isCanvasTriggered: true,
 		});
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -174,12 +174,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		// the link there (persisted via processFrontMatter) instead of the body.
 		const propertyTarget = this.choiceExecutor.focusedProperty;
 		if (propertyTarget) {
-			await appendLinkToFrontmatterProperty(
-				this.app,
-				propertyTarget,
-				file,
-				linkOptions,
-			);
+			await appendLinkToFrontmatterProperty(this.app, propertyTarget, file);
 			return;
 		}
 

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -158,7 +158,6 @@ export class TemplateChoiceEngine extends TemplateEngine {
 						this.app,
 						propertyTarget,
 						createdFile,
-						linkOptions,
 					);
 				} else {
 					insertFileLinkToActiveView(this.app, createdFile, linkOptions);

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -15,6 +15,7 @@ import {
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { normalizeAppendLinkOptions } from "../types/linkPlacement";
 import {
+	appendLinkToFrontmatterProperty,
 	getAllFolderPathsInVault,
 	insertFileLinkToActiveView,
 	jumpToNextTemplaterCursorIfPossible,
@@ -149,7 +150,19 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			}
 
 			if (linkOptions.enabled && createdFile) {
-			insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+				// #768: target the focused frontmatter property (captured before any
+				// QuickAdd UI opened) when there is one; otherwise body insertion.
+				const propertyTarget = this.choiceExecutor.focusedProperty;
+				if (propertyTarget) {
+					await appendLinkToFrontmatterProperty(
+						this.app,
+						propertyTarget,
+						createdFile,
+						linkOptions,
+					);
+				} else {
+					insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+				}
 			}
 
 			if ((this.choice.openFile || shouldAutoOpen) && createdFile) {

--- a/src/utilityObsidian.appendLink-768.test.ts
+++ b/src/utilityObsidian.appendLink-768.test.ts
@@ -1,0 +1,120 @@
+import { MarkdownView, type App } from "obsidian";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __test, insertLinkWithPlacement } from "./utilityObsidian";
+
+const { getFocusedEditablePropertyEl, insertTextIntoEditableEl } = __test;
+
+/**
+ * Regression tests for issue #768: "Append link to current file in properties".
+ *
+ * When the caret is in a frontmatter property field, Obsidian's body editor is
+ * not focused and its reported cursor is stale, so the link used to land at the
+ * first body line. The fix routes insertion into the focused property element.
+ */
+
+afterEach(() => {
+	document.body.innerHTML = "";
+	vi.restoreAllMocks();
+});
+
+/** Builds a fake App whose active MarkdownView records editor mutations. */
+function makeApp() {
+	const calls = { replaceSelection: [] as string[], replaceRange: [] as unknown[] };
+	const editor = {
+		listSelections: () => [
+			{ anchor: { line: 3, ch: 0 }, head: { line: 3, ch: 0 } },
+		],
+		getCursor: () => ({ line: 3, ch: 0 }),
+		getLine: () => "",
+		posToOffset: ({ line, ch }: { line: number; ch: number }) => line * 100 + ch,
+		replaceSelection: (text: string) => calls.replaceSelection.push(text),
+		replaceRange: (...args: unknown[]) => calls.replaceRange.push(args),
+		setCursor: () => {},
+	};
+	const view = { editor } as unknown as MarkdownView;
+	const app = {
+		workspace: {
+			getActiveViewOfType: (ctor: unknown) =>
+				ctor === MarkdownView ? view : null,
+		},
+	} as unknown as App;
+	return { app, calls };
+}
+
+/** Mounts an Obsidian-like Properties widget with one focused text property. */
+function mountFocusedTextProperty(initialValue = ""): HTMLInputElement {
+	const container = document.createElement("div");
+	container.className = "metadata-properties-container";
+	const row = document.createElement("div");
+	row.className = "metadata-property";
+	const input = document.createElement("input");
+	input.type = "text";
+	input.value = initialValue;
+	row.appendChild(input);
+	container.appendChild(row);
+	document.body.appendChild(container);
+	input.focus();
+	const caret = initialValue.length;
+	input.setSelectionRange(caret, caret);
+	return input;
+}
+
+describe("getFocusedEditablePropertyEl", () => {
+	it("returns the focused input when it's inside the Properties widget", () => {
+		const input = mountFocusedTextProperty("status: ");
+		expect(getFocusedEditablePropertyEl()).toBe(input);
+	});
+
+	it("returns null when the focused element is outside the Properties widget", () => {
+		const input = document.createElement("input");
+		document.body.appendChild(input);
+		input.focus();
+		expect(getFocusedEditablePropertyEl()).toBeNull();
+	});
+
+	it("returns null when nothing relevant is focused", () => {
+		expect(getFocusedEditablePropertyEl()).toBeNull();
+	});
+});
+
+describe("insertTextIntoEditableEl", () => {
+	it("inserts at the caret of an input and fires an input event", () => {
+		const input = mountFocusedTextProperty("ab");
+		input.setSelectionRange(1, 1); // caret between 'a' and 'b'
+		const onInput = vi.fn();
+		input.addEventListener("input", onInput);
+
+		const ok = insertTextIntoEditableEl(input, "[[X]]");
+
+		expect(ok).toBe(true);
+		expect(input.value).toBe("a[[X]]b");
+		expect(onInput).toHaveBeenCalledOnce();
+	});
+
+	it("returns false for a non-editable element", () => {
+		const div = document.createElement("div");
+		expect(insertTextIntoEditableEl(div, "[[X]]")).toBe(false);
+	});
+});
+
+describe("insertLinkWithPlacement (#768 property-field routing)", () => {
+	it("inserts into the focused property field, not the body editor", () => {
+		const input = mountFocusedTextProperty("links: ");
+		const { app, calls } = makeApp();
+
+		insertLinkWithPlacement(app, "[[Created Note]]", "replaceSelection");
+
+		expect(input.value).toBe("links: [[Created Note]]");
+		// The body editor must be left untouched.
+		expect(calls.replaceSelection).toHaveLength(0);
+		expect(calls.replaceRange).toHaveLength(0);
+	});
+
+	it("still uses the body editor when no property field is focused", () => {
+		const { app, calls } = makeApp();
+
+		insertLinkWithPlacement(app, "[[Created Note]]", "replaceSelection");
+
+		expect(calls.replaceSelection).toEqual(["[[Created Note]]"]);
+	});
+});

--- a/src/utilityObsidian.appendLink-768.test.ts
+++ b/src/utilityObsidian.appendLink-768.test.ts
@@ -2,7 +2,7 @@ import { MarkdownView, type App } from "obsidian";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __test, insertLinkWithPlacement } from "./utilityObsidian";
 
-const { getFocusedEditablePropertyEl, insertTextIntoEditableEl } = __test;
+const { tryInsertIntoFocusedProperty, insertTextAtCaret } = __test;
 
 /**
  * Regression tests for #768: with the caret in a frontmatter property field the
@@ -16,39 +16,43 @@ afterEach(() => {
 
 /** Builds a fake App whose active MarkdownView records editor mutations. */
 function makeApp() {
-	const calls = { replaceSelection: [] as string[], replaceRange: [] as unknown[] };
+	const calls = {
+		replaceSelection: [] as string[],
+		replaceRange: [] as unknown[],
+	};
 	const editor = {
 		listSelections: () => [
 			{ anchor: { line: 3, ch: 0 }, head: { line: 3, ch: 0 } },
 		],
 		getCursor: () => ({ line: 3, ch: 0 }),
 		getLine: () => "",
-		posToOffset: ({ line, ch }: { line: number; ch: number }) => line * 100 + ch,
+		posToOffset: ({ line, ch }: { line: number; ch: number }) =>
+			line * 100 + ch,
 		replaceSelection: (text: string) => calls.replaceSelection.push(text),
 		replaceRange: (...args: unknown[]) => calls.replaceRange.push(args),
 		setCursor: () => {},
 	};
 	const view = { editor } as unknown as MarkdownView;
-	const app = {
+	const fakeApp = {
 		workspace: {
-			getActiveViewOfType: (ctor: unknown) =>
-				ctor === MarkdownView ? view : null,
+			getActiveViewOfType: (constructor: unknown) =>
+				constructor === MarkdownView ? view : null,
 		},
 	} as unknown as App;
-	return { app, calls };
+	return { fakeApp, calls };
 }
 
 /** Mounts an Obsidian-like Properties widget with one focused text property. */
 function mountFocusedTextProperty(initialValue = ""): HTMLInputElement {
 	const container = document.createElement("div");
 	container.className = "metadata-properties-container";
-	const row = document.createElement("div");
-	row.className = "metadata-property";
+	const propertyRow = document.createElement("div");
+	propertyRow.className = "metadata-property";
 	const input = document.createElement("input");
 	input.type = "text";
 	input.value = initialValue;
-	row.appendChild(input);
-	container.appendChild(row);
+	propertyRow.appendChild(input);
+	container.appendChild(propertyRow);
 	document.body.appendChild(container);
 	input.focus();
 	const caret = initialValue.length;
@@ -56,50 +60,53 @@ function mountFocusedTextProperty(initialValue = ""): HTMLInputElement {
 	return input;
 }
 
-describe("getFocusedEditablePropertyEl", () => {
-	it("returns the focused input when it's inside the Properties widget", () => {
+describe("tryInsertIntoFocusedProperty", () => {
+	it("inserts into a focused property field and returns true", () => {
 		const input = mountFocusedTextProperty("status: ");
-		expect(getFocusedEditablePropertyEl()).toBe(input);
+		const inserted = tryInsertIntoFocusedProperty("[[X]]");
+		expect(inserted).toBe(true);
+		expect(input.value).toBe("status: [[X]]");
 	});
 
-	it("returns null when the focused element is outside the Properties widget", () => {
-		const input = document.createElement("input");
-		document.body.appendChild(input);
-		input.focus();
-		expect(getFocusedEditablePropertyEl()).toBeNull();
+	it("returns false and inserts nothing when focus is outside the widget", () => {
+		const stray = document.createElement("input");
+		document.body.appendChild(stray);
+		stray.focus();
+		expect(tryInsertIntoFocusedProperty("[[X]]")).toBe(false);
+		expect(stray.value).toBe("");
 	});
 
-	it("returns null when nothing relevant is focused", () => {
-		expect(getFocusedEditablePropertyEl()).toBeNull();
+	it("returns false when nothing relevant is focused", () => {
+		expect(tryInsertIntoFocusedProperty("[[X]]")).toBe(false);
 	});
 });
 
-describe("insertTextIntoEditableEl", () => {
+describe("insertTextAtCaret", () => {
 	it("inserts at the caret of an input and fires an input event", () => {
 		const input = mountFocusedTextProperty("ab");
 		input.setSelectionRange(1, 1); // caret between 'a' and 'b'
 		const onInput = vi.fn();
 		input.addEventListener("input", onInput);
 
-		const ok = insertTextIntoEditableEl(input, "[[X]]");
+		const inserted = insertTextAtCaret(input, "[[X]]");
 
-		expect(ok).toBe(true);
+		expect(inserted).toBe(true);
 		expect(input.value).toBe("a[[X]]b");
 		expect(onInput).toHaveBeenCalledOnce();
 	});
 
 	it("returns false for a non-editable element", () => {
-		const div = document.createElement("div");
-		expect(insertTextIntoEditableEl(div, "[[X]]")).toBe(false);
+		const plainDiv = document.createElement("div");
+		expect(insertTextAtCaret(plainDiv, "[[X]]")).toBe(false);
 	});
 });
 
 describe("insertLinkWithPlacement (#768 property-field routing)", () => {
 	it("inserts into the focused property field, not the body editor", () => {
 		const input = mountFocusedTextProperty("links: ");
-		const { app, calls } = makeApp();
+		const { fakeApp, calls } = makeApp();
 
-		insertLinkWithPlacement(app, "[[Created Note]]", "replaceSelection");
+		insertLinkWithPlacement(fakeApp, "[[Created Note]]", "replaceSelection");
 
 		expect(input.value).toBe("links: [[Created Note]]");
 		// The body editor must be left untouched.
@@ -108,9 +115,9 @@ describe("insertLinkWithPlacement (#768 property-field routing)", () => {
 	});
 
 	it("still uses the body editor when no property field is focused", () => {
-		const { app, calls } = makeApp();
+		const { fakeApp, calls } = makeApp();
 
-		insertLinkWithPlacement(app, "[[Created Note]]", "replaceSelection");
+		insertLinkWithPlacement(fakeApp, "[[Created Note]]", "replaceSelection");
 
 		expect(calls.replaceSelection).toEqual(["[[Created Note]]"]);
 	});

--- a/src/utilityObsidian.appendLink-768.test.ts
+++ b/src/utilityObsidian.appendLink-768.test.ts
@@ -5,7 +5,6 @@ import {
 	getFocusedPropertyTarget,
 	type FrontmatterPropertyTarget,
 } from "./utilityObsidian";
-import type { AppendLinkOptions } from "./types/linkPlacement";
 
 /**
  * Regression tests for #768. The link must follow the caret into a frontmatter
@@ -118,15 +117,9 @@ describe("getFocusedPropertyTarget", () => {
 
 describe("appendLinkToFrontmatterProperty", () => {
 	const target: FrontmatterPropertyTarget = { file: makeFile("Note.md"), key: "links" };
-	const linkOptions: AppendLinkOptions = {
-		enabled: true,
-		placement: "replaceSelection",
-		requireActiveFile: true,
-		linkType: "link",
-	};
 
 	/** Runs the helper against an initial frontmatter object and returns the mutated value. */
-	async function runWith(initial: Record<string, unknown>, options = linkOptions) {
+	async function runWith(initial: Record<string, unknown>) {
 		const frontmatter = { ...initial };
 		const app = {
 			fileManager: {
@@ -137,7 +130,7 @@ describe("appendLinkToFrontmatterProperty", () => {
 				) => fn(frontmatter),
 			},
 		} as unknown as App;
-		await appendLinkToFrontmatterProperty(app, target, makeFile("Created.md"), options);
+		await appendLinkToFrontmatterProperty(app, target, makeFile("Created.md"));
 		return frontmatter.links;
 	}
 
@@ -156,13 +149,5 @@ describe("appendLinkToFrontmatterProperty", () => {
 
 	it("preserves a number value as a string instead of wiping it", async () => {
 		expect(await runWith({ links: 5 })).toBe("5 [[Created]]");
-	});
-
-	it("embeds when linkType is embed and placement supports it", async () => {
-		const embedded = await runWith(
-			{ links: "" },
-			{ ...linkOptions, linkType: "embed" },
-		);
-		expect(embedded).toBe("![[Created]]");
 	});
 });

--- a/src/utilityObsidian.appendLink-768.test.ts
+++ b/src/utilityObsidian.appendLink-768.test.ts
@@ -5,11 +5,8 @@ import { __test, insertLinkWithPlacement } from "./utilityObsidian";
 const { getFocusedEditablePropertyEl, insertTextIntoEditableEl } = __test;
 
 /**
- * Regression tests for issue #768: "Append link to current file in properties".
- *
- * When the caret is in a frontmatter property field, Obsidian's body editor is
- * not focused and its reported cursor is stale, so the link used to land at the
- * first body line. The fix routes insertion into the focused property element.
+ * Regression tests for #768: with the caret in a frontmatter property field the
+ * link used to land at the first body line; the fix routes it to the property.
  */
 
 afterEach(() => {

--- a/src/utilityObsidian.appendLink-768.test.ts
+++ b/src/utilityObsidian.appendLink-768.test.ts
@@ -1,12 +1,17 @@
-import { MarkdownView, type App } from "obsidian";
+import { MarkdownView, TFile, type App } from "obsidian";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { __test, insertLinkWithPlacement } from "./utilityObsidian";
-
-const { tryInsertIntoFocusedProperty, insertTextAtCaret } = __test;
+import {
+	appendLinkToFrontmatterProperty,
+	getFocusedPropertyTarget,
+	type FrontmatterPropertyTarget,
+} from "./utilityObsidian";
+import type { AppendLinkOptions } from "./types/linkPlacement";
 
 /**
- * Regression tests for #768: with the caret in a frontmatter property field the
- * link used to land at the first body line; the fix routes it to the property.
+ * Regression tests for #768. The link must follow the caret into a frontmatter
+ * property. Detection reads which property is focused (popout-aware, value side
+ * only) and persistence goes through processFrontMatter — verified live in a
+ * real Obsidian vault; see PR notes.
  */
 
 afterEach(() => {
@@ -14,111 +19,150 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-/** Builds a fake App whose active MarkdownView records editor mutations. */
-function makeApp() {
-	const calls = {
-		replaceSelection: [] as string[],
-		replaceRange: [] as unknown[],
-	};
-	const editor = {
-		listSelections: () => [
-			{ anchor: { line: 3, ch: 0 }, head: { line: 3, ch: 0 } },
-		],
-		getCursor: () => ({ line: 3, ch: 0 }),
-		getLine: () => "",
-		posToOffset: ({ line, ch }: { line: number; ch: number }) =>
-			line * 100 + ch,
-		replaceSelection: (text: string) => calls.replaceSelection.push(text),
-		replaceRange: (...args: unknown[]) => calls.replaceRange.push(args),
-		setCursor: () => {},
-	};
-	const view = { editor } as unknown as MarkdownView;
-	const fakeApp = {
-		workspace: {
-			getActiveViewOfType: (constructor: unknown) =>
-				constructor === MarkdownView ? view : null,
-		},
-	} as unknown as App;
-	return { fakeApp, calls };
+function makeFile(path: string): TFile {
+	const file = new TFile();
+	file.path = path;
+	file.basename = path.replace(/\.md$/, "");
+	return file;
 }
 
-/** Mounts an Obsidian-like Properties widget with one focused text property. */
-function mountFocusedTextProperty(initialValue = ""): HTMLInputElement {
+/** Mounts a Markdown view container with one property row and returns its app. */
+function mountViewWithProperty(opts: {
+	key: string;
+	/** Which sub-cell to focus: the value editor or the key input. */
+	focus: "value" | "key" | "none";
+	file: TFile;
+	/** Input `type` for the value field (e.g. "number"); default text-like. */
+	valueType?: string;
+}) {
 	const container = document.createElement("div");
-	container.className = "metadata-properties-container";
-	const propertyRow = document.createElement("div");
-	propertyRow.className = "metadata-property";
-	const input = document.createElement("input");
-	input.type = "text";
-	input.value = initialValue;
-	propertyRow.appendChild(input);
-	container.appendChild(propertyRow);
+	const propertiesEl = document.createElement("div");
+	propertiesEl.className = "metadata-properties";
+	const row = document.createElement("div");
+	row.className = "metadata-property";
+	row.setAttribute("data-property-key", opts.key);
+
+	const keyInput = document.createElement("input");
+	keyInput.className = "metadata-property-key-input";
+	const keyCell = document.createElement("div");
+	keyCell.className = "metadata-property-key";
+	keyCell.appendChild(keyInput);
+
+	const valueCell = document.createElement("div");
+	valueCell.className = "metadata-property-value";
+	const valueInput = document.createElement("input");
+	if (opts.valueType) valueInput.type = opts.valueType;
+	valueCell.appendChild(valueInput);
+
+	row.append(keyCell, valueCell);
+	propertiesEl.appendChild(row);
+	container.appendChild(propertiesEl);
 	document.body.appendChild(container);
-	input.focus();
-	const caret = initialValue.length;
-	input.setSelectionRange(caret, caret);
-	return input;
+
+	if (opts.focus === "value") valueInput.focus();
+	else if (opts.focus === "key") keyInput.focus();
+
+	const view = Object.create(MarkdownView.prototype) as MarkdownView;
+	(view as unknown as { containerEl: HTMLElement }).containerEl = container;
+	(view as unknown as { file: TFile }).file = opts.file;
+	const leaf = { view };
+
+	const app = {
+		workspace: { getLeavesOfType: (type: string) => (type === "markdown" ? [leaf] : []) },
+	} as unknown as App;
+	return { app, valueInput, keyInput };
 }
 
-describe("tryInsertIntoFocusedProperty", () => {
-	it("inserts into a focused property field and returns true", () => {
-		const input = mountFocusedTextProperty("status: ");
-		const inserted = tryInsertIntoFocusedProperty("[[X]]");
-		expect(inserted).toBe(true);
-		expect(input.value).toBe("status: [[X]]");
+describe("getFocusedPropertyTarget", () => {
+	it("returns the focused property's key and owning file", () => {
+		const file = makeFile("Note.md");
+		const { app } = mountViewWithProperty({ key: "authors", focus: "value", file });
+		expect(getFocusedPropertyTarget(app)).toEqual<FrontmatterPropertyTarget>({
+			file,
+			key: "authors",
+		});
 	});
 
-	it("returns false and inserts nothing when focus is outside the widget", () => {
+	it("returns null when the caret is in the property KEY field (not the value)", () => {
+		const file = makeFile("Note.md");
+		const { app } = mountViewWithProperty({ key: "authors", focus: "key", file });
+		expect(getFocusedPropertyTarget(app)).toBeNull();
+	});
+
+	it("returns null for typed inputs (number/date) so they fall back to body", () => {
+		const file = makeFile("Note.md");
+		const { app } = mountViewWithProperty({
+			key: "count",
+			focus: "value",
+			file,
+			valueType: "number",
+		});
+		expect(getFocusedPropertyTarget(app)).toBeNull();
+	});
+
+	it("returns null when no property is focused", () => {
+		const file = makeFile("Note.md");
+		const { app } = mountViewWithProperty({ key: "authors", focus: "none", file });
+		expect(getFocusedPropertyTarget(app)).toBeNull();
+	});
+
+	it("returns null when the focused element is outside any markdown view", () => {
+		const file = makeFile("Note.md");
+		const { app } = mountViewWithProperty({ key: "authors", focus: "none", file });
 		const stray = document.createElement("input");
 		document.body.appendChild(stray);
 		stray.focus();
-		expect(tryInsertIntoFocusedProperty("[[X]]")).toBe(false);
-		expect(stray.value).toBe("");
-	});
-
-	it("returns false when nothing relevant is focused", () => {
-		expect(tryInsertIntoFocusedProperty("[[X]]")).toBe(false);
+		expect(getFocusedPropertyTarget(app)).toBeNull();
 	});
 });
 
-describe("insertTextAtCaret", () => {
-	it("inserts at the caret of an input and fires an input event", () => {
-		const input = mountFocusedTextProperty("ab");
-		input.setSelectionRange(1, 1); // caret between 'a' and 'b'
-		const onInput = vi.fn();
-		input.addEventListener("input", onInput);
+describe("appendLinkToFrontmatterProperty", () => {
+	const target: FrontmatterPropertyTarget = { file: makeFile("Note.md"), key: "links" };
+	const linkOptions: AppendLinkOptions = {
+		enabled: true,
+		placement: "replaceSelection",
+		requireActiveFile: true,
+		linkType: "link",
+	};
 
-		const inserted = insertTextAtCaret(input, "[[X]]");
+	/** Runs the helper against an initial frontmatter object and returns the mutated value. */
+	async function runWith(initial: Record<string, unknown>, options = linkOptions) {
+		const frontmatter = { ...initial };
+		const app = {
+			fileManager: {
+				generateMarkdownLink: (file: TFile) => `[[${file.basename}]]`,
+				processFrontMatter: async (
+					_file: TFile,
+					fn: (fm: Record<string, unknown>) => void,
+				) => fn(frontmatter),
+			},
+		} as unknown as App;
+		await appendLinkToFrontmatterProperty(app, target, makeFile("Created.md"), options);
+		return frontmatter.links;
+	}
 
-		expect(inserted).toBe(true);
-		expect(input.value).toBe("a[[X]]b");
-		expect(onInput).toHaveBeenCalledOnce();
+	it("pushes a new item onto a list property", async () => {
+		expect(await runWith({ links: ["[[A]]"] })).toEqual(["[[A]]", "[[Created]]"]);
 	});
 
-	it("returns false for a non-editable element", () => {
-		const plainDiv = document.createElement("div");
-		expect(insertTextAtCaret(plainDiv, "[[X]]")).toBe(false);
-	});
-});
-
-describe("insertLinkWithPlacement (#768 property-field routing)", () => {
-	it("inserts into the focused property field, not the body editor", () => {
-		const input = mountFocusedTextProperty("links: ");
-		const { fakeApp, calls } = makeApp();
-
-		insertLinkWithPlacement(fakeApp, "[[Created Note]]", "replaceSelection");
-
-		expect(input.value).toBe("links: [[Created Note]]");
-		// The body editor must be left untouched.
-		expect(calls.replaceSelection).toHaveLength(0);
-		expect(calls.replaceRange).toHaveLength(0);
+	it("appends to a non-empty scalar without destroying it", async () => {
+		expect(await runWith({ links: "[[A]]" })).toBe("[[A]] [[Created]]");
 	});
 
-	it("still uses the body editor when no property field is focused", () => {
-		const { fakeApp, calls } = makeApp();
+	it("sets an empty or missing property to the link", async () => {
+		expect(await runWith({ links: "" })).toBe("[[Created]]");
+		expect(await runWith({})).toBe("[[Created]]");
+	});
 
-		insertLinkWithPlacement(fakeApp, "[[Created Note]]", "replaceSelection");
+	it("preserves a number value as a string instead of wiping it", async () => {
+		expect(await runWith({ links: 5 })).toBe("5 [[Created]]");
+	});
 
-		expect(calls.replaceSelection).toEqual(["[[Created Note]]"]);
+	it("embeds when linkType is embed and placement supports it", async () => {
+		const embedded = await runWith(
+			{ links: "" },
+			{ ...linkOptions, linkType: "embed" },
+		);
+		expect(embedded).toBe("![[Created]]");
 	});
 });

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -559,21 +559,15 @@ export function insertOnNewLineBelow(toInsert: string, app: App) {
 }
 
 /**
- * When the caret is inside Obsidian's Properties widget, returns the focused
- * editable property element; otherwise null.
- *
- * Obsidian renders YAML frontmatter as a Properties UI built from separate
- * input elements (`.metadata-property` rows), not the CodeMirror document.
- * Focusing one of these blurs the markdown body editor, so the Editor API
- * reports a stale body caret and any insertion lands at the first body line
- * instead of at the user's cursor (issue #768). Detecting the focused DOM
- * element lets us insert at the real caret instead.
+ * Returns the focused editable element when the caret is inside Obsidian's
+ * Properties widget, else null. The widget is separate inputs, not the
+ * CodeMirror document, so a focused property leaves the body editor reporting a
+ * stale caret — without this the link lands in the body (#768).
  */
 function getFocusedEditablePropertyEl(): HTMLElement | null {
 	if (typeof document === "undefined") return null;
 	const active = document.activeElement;
 	if (!(active instanceof HTMLElement)) return null;
-	// Must live inside the Properties widget.
 	if (!active.closest(".metadata-property, .metadata-properties-container")) {
 		return null;
 	}
@@ -585,10 +579,9 @@ function getFocusedEditablePropertyEl(): HTMLElement | null {
 }
 
 /**
- * Inserts `text` at the caret of a focused <input>/<textarea> or contenteditable
- * element and fires an "input" event so Obsidian persists the change to the
- * frontmatter. Returns false if the element type isn't supported (caller then
- * falls back to normal body insertion).
+ * Inserts `text` at the caret of a focused input/textarea/contenteditable and
+ * fires an "input" event so Obsidian persists it. Returns false for unsupported
+ * elements so the caller can fall back to body insertion.
  */
 function insertTextIntoEditableEl(el: HTMLElement, text: string): boolean {
 	if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
@@ -599,8 +592,7 @@ function insertTextIntoEditableEl(el: HTMLElement, text: string): boolean {
 		try {
 			el.setSelectionRange(caret, caret);
 		} catch {
-			// Some input types don't allow selection ranges; caret position is
-			// non-critical, so ignore.
+			// Some input types reject selection ranges; caret position is non-critical.
 		}
 		el.dispatchEvent(new Event("input", { bubbles: true }));
 		return true;
@@ -654,12 +646,9 @@ export function insertLinkWithPlacement(
 		return;
 	}
 
-	// #768: If the caret is inside a frontmatter *property* field (Obsidian's
-	// Properties widget), the markdown body editor isn't focused, so
-	// editor.getCursor()/listSelections() report a stale body caret and the link
-	// would land at the first body line instead of at the user's cursor. Insert
-	// into the focused property value at its caret instead. Placement modes only
-	// describe body insertion, so they don't apply here.
+	// #768: a focused frontmatter property field leaves the body editor's caret
+	// stale; insert into the property at its caret instead. Placement modes only
+	// apply to body insertion.
 	const propertyEl = getFocusedEditablePropertyEl();
 	if (propertyEl && insertTextIntoEditableEl(propertyEl, text)) {
 		return;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -559,6 +559,76 @@ export function insertOnNewLineBelow(toInsert: string, app: App) {
 }
 
 /**
+ * When the caret is inside Obsidian's Properties widget, returns the focused
+ * editable property element; otherwise null.
+ *
+ * Obsidian renders YAML frontmatter as a Properties UI built from separate
+ * input elements (`.metadata-property` rows), not the CodeMirror document.
+ * Focusing one of these blurs the markdown body editor, so the Editor API
+ * reports a stale body caret and any insertion lands at the first body line
+ * instead of at the user's cursor (issue #768). Detecting the focused DOM
+ * element lets us insert at the real caret instead.
+ */
+function getFocusedEditablePropertyEl(): HTMLElement | null {
+	if (typeof document === "undefined") return null;
+	const active = document.activeElement;
+	if (!(active instanceof HTMLElement)) return null;
+	// Must live inside the Properties widget.
+	if (!active.closest(".metadata-property, .metadata-properties-container")) {
+		return null;
+	}
+	const isEditable =
+		active.isContentEditable ||
+		active instanceof HTMLInputElement ||
+		active instanceof HTMLTextAreaElement;
+	return isEditable ? active : null;
+}
+
+/**
+ * Inserts `text` at the caret of a focused <input>/<textarea> or contenteditable
+ * element and fires an "input" event so Obsidian persists the change to the
+ * frontmatter. Returns false if the element type isn't supported (caller then
+ * falls back to normal body insertion).
+ */
+function insertTextIntoEditableEl(el: HTMLElement, text: string): boolean {
+	if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+		const start = el.selectionStart ?? el.value.length;
+		const end = el.selectionEnd ?? el.value.length;
+		el.value = el.value.slice(0, start) + text + el.value.slice(end);
+		const caret = start + text.length;
+		try {
+			el.setSelectionRange(caret, caret);
+		} catch {
+			// Some input types don't allow selection ranges; caret position is
+			// non-critical, so ignore.
+		}
+		el.dispatchEvent(new Event("input", { bubbles: true }));
+		return true;
+	}
+
+	if (el.isContentEditable) {
+		const doc = el.ownerDocument;
+		const sel = doc.getSelection();
+		if (sel && sel.rangeCount > 0 && el.contains(sel.anchorNode)) {
+			const range = sel.getRangeAt(0);
+			range.deleteContents();
+			const node = doc.createTextNode(text);
+			range.insertNode(node);
+			range.setStartAfter(node);
+			range.collapse(true);
+			sel.removeAllRanges();
+			sel.addRange(range);
+		} else {
+			el.textContent = `${el.textContent ?? ""}${text}`;
+		}
+		el.dispatchEvent(new Event("input", { bubbles: true }));
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Core routine that inserts a link (or any text) in the active markdown
  * editor according to the chosen placement mode.
  *
@@ -581,6 +651,17 @@ export function insertLinkWithPlacement(
 			throw new Error(message);
 		}
 		log.logMessage(message);
+		return;
+	}
+
+	// #768: If the caret is inside a frontmatter *property* field (Obsidian's
+	// Properties widget), the markdown body editor isn't focused, so
+	// editor.getCursor()/listSelections() report a stale body caret and the link
+	// would land at the first body line instead of at the user's cursor. Insert
+	// into the focused property value at its caret instead. Placement modes only
+	// describe body insertion, so they don't apply here.
+	const propertyEl = getFocusedEditablePropertyEl();
+	if (propertyEl && insertTextIntoEditableEl(propertyEl, text)) {
 		return;
 	}
 
@@ -1283,4 +1364,6 @@ export function getMarkdownFilesWithTag(app: App, tag: string): TFile[] {
 export const __test = {
 	convertLinkToEmbed,
 	extractMarkdownLinkTarget,
+	getFocusedEditablePropertyEl,
+	insertTextIntoEditableEl,
 } as const;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -593,7 +593,10 @@ export function getFocusedPropertyTarget(
 		const focused = getOwnerDocument(view.containerEl).activeElement;
 		if (!focused || !view.containerEl.contains(focused)) continue;
 
-		// Must be the value side of a property row, not the key field.
+		// Must be the value side of a property row, not the key field. These class
+		// names / data attributes are Obsidian Properties-widget internals (verified
+		// against Obsidian 1.9.x); if a future release renames them, detection
+		// silently falls back to body insertion rather than misfiring.
 		if (!focused.closest(".metadata-property-value")) continue;
 
 		// Only text and list properties can sensibly hold a link. Typed inputs
@@ -618,32 +621,28 @@ export function getFocusedPropertyTarget(
 
 /**
  * Appends a link to `fileToLink` into the frontmatter property identified by
- * `target`, via Obsidian's `processFrontMatter` API (the only reliable way to
- * persist a property value — direct DOM mutation of the Properties widget is
- * discarded on re-render, and typed inputs reject sliced text). List properties
- * get a new item; non-empty scalars get the link appended to their string form;
- * empty properties are set to the link.
+ * `target`, via Obsidian's `processFrontMatter` API — the reliable way to persist
+ * a property value (direct DOM mutation of the Properties widget is discarded on
+ * re-render). List properties get a new item; non-empty scalars get the link
+ * appended to their string form; empty/missing properties are set to the link.
+ *
+ * Always a plain link: an embed (`![[…]]`) in a YAML value isn't rendered by
+ * Obsidian, so `linkType: "embed"` doesn't apply to properties.
  */
 export async function appendLinkToFrontmatterProperty(
 	app: App,
 	target: FrontmatterPropertyTarget,
 	fileToLink: TFile,
-	linkOptions: AppendLinkOptions,
 ): Promise<void> {
-	const baseLink = app.fileManager.generateMarkdownLink(
+	const linkText = app.fileManager.generateMarkdownLink(
 		fileToLink,
 		target.file.path,
 	);
-	const linkText =
-		linkOptions.linkType === "embed" &&
-		placementSupportsEmbed(linkOptions.placement)
-			? convertLinkToEmbed(baseLink)
-			: baseLink;
 
 	await app.fileManager.processFrontMatter(target.file, (frontmatter) => {
 		const existing = frontmatter[target.key];
 		if (Array.isArray(existing)) {
-			existing.push(linkText);
+			existing.push(linkText); // leave existing items untouched
 		} else if (existing === undefined || existing === null || existing === "") {
 			frontmatter[target.key] = linkText;
 		} else {

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -558,62 +558,81 @@ export function insertOnNewLineBelow(toInsert: string, app: App) {
 	insertOnNewLine(toInsert, "below", app);
 }
 
-/**
- * Returns the focused editable element when the caret is inside Obsidian's
- * Properties widget, else null. The widget is separate inputs, not the
- * CodeMirror document, so a focused property leaves the body editor reporting a
- * stale caret — without this the link lands in the body (#768).
- */
-function getFocusedEditablePropertyEl(): HTMLElement | null {
-	if (typeof document === "undefined") return null;
-	const active = document.activeElement;
-	if (!(active instanceof HTMLElement)) return null;
-	if (!active.closest(".metadata-property, .metadata-properties-container")) {
-		return null;
-	}
-	const isEditable =
-		active.isContentEditable ||
-		active instanceof HTMLInputElement ||
-		active instanceof HTMLTextAreaElement;
-	return isEditable ? active : null;
+// Obsidian renders YAML frontmatter as the Properties widget — separate input
+// elements, not the CodeMirror document.
+const PROPERTY_WIDGET_SELECTOR =
+	".metadata-property, .metadata-properties-container";
+
+function isEditableElement(element: Element): element is HTMLElement {
+	return (
+		element instanceof HTMLInputElement ||
+		element instanceof HTMLTextAreaElement ||
+		(element instanceof HTMLElement && element.isContentEditable)
+	);
 }
 
 /**
- * Inserts `text` at the caret of a focused input/textarea/contenteditable and
- * fires an "input" event so Obsidian persists it. Returns false for unsupported
- * elements so the caller can fall back to body insertion.
+ * When the caret is in a focused frontmatter property field, inserts `text` at
+ * that caret and returns true. Returns false otherwise so the caller falls back
+ * to body insertion.
+ *
+ * A focused property blurs the markdown body editor, so its reported caret is
+ * stale — without this the link lands at the first body line instead (#768).
  */
-function insertTextIntoEditableEl(el: HTMLElement, text: string): boolean {
-	if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
-		const start = el.selectionStart ?? el.value.length;
-		const end = el.selectionEnd ?? el.value.length;
-		el.value = el.value.slice(0, start) + text + el.value.slice(end);
-		const caret = start + text.length;
+function tryInsertIntoFocusedProperty(text: string): boolean {
+	if (typeof document === "undefined") return false;
+	const focused = document.activeElement;
+	if (!(focused instanceof HTMLElement)) return false;
+	if (!focused.closest(PROPERTY_WIDGET_SELECTOR)) return false;
+	if (!isEditableElement(focused)) return false;
+	return insertTextAtCaret(focused, text);
+}
+
+/**
+ * Inserts `text` at the caret of an input/textarea/contenteditable and fires an
+ * "input" event so Obsidian persists it. Returns false for unsupported elements.
+ */
+function insertTextAtCaret(element: HTMLElement, text: string): boolean {
+	if (
+		element instanceof HTMLInputElement ||
+		element instanceof HTMLTextAreaElement
+	) {
+		const startOffset = element.selectionStart ?? element.value.length;
+		const endOffset = element.selectionEnd ?? element.value.length;
+		const before = element.value.slice(0, startOffset);
+		const after = element.value.slice(endOffset);
+		element.value = before + text + after;
+		const caretOffset = startOffset + text.length;
 		try {
-			el.setSelectionRange(caret, caret);
+			element.setSelectionRange(caretOffset, caretOffset);
 		} catch {
 			// Some input types reject selection ranges; caret position is non-critical.
 		}
-		el.dispatchEvent(new Event("input", { bubbles: true }));
+		element.dispatchEvent(new Event("input", { bubbles: true }));
 		return true;
 	}
 
-	if (el.isContentEditable) {
-		const doc = el.ownerDocument;
-		const sel = doc.getSelection();
-		if (sel && sel.rangeCount > 0 && el.contains(sel.anchorNode)) {
-			const range = sel.getRangeAt(0);
+	if (element.isContentEditable) {
+		const ownerDocument = element.ownerDocument;
+		const selection = ownerDocument.getSelection();
+		if (
+			selection &&
+			selection.rangeCount > 0 &&
+			element.contains(selection.anchorNode)
+		) {
+			// Replace the selection with a text node and put the caret after it.
+			const range = selection.getRangeAt(0);
 			range.deleteContents();
-			const node = doc.createTextNode(text);
-			range.insertNode(node);
-			range.setStartAfter(node);
+			const textNode = ownerDocument.createTextNode(text);
+			range.insertNode(textNode);
+			range.setStartAfter(textNode);
 			range.collapse(true);
-			sel.removeAllRanges();
-			sel.addRange(range);
+			selection.removeAllRanges();
+			selection.addRange(range);
 		} else {
-			el.textContent = `${el.textContent ?? ""}${text}`;
+			element.textContent = `${element.textContent ?? ""}${text}`;
 		}
-		el.dispatchEvent(new Event("input", { bubbles: true }));
+		element.dispatchEvent(new Event("input", { bubbles: true }));
 		return true;
 	}
 
@@ -649,10 +668,7 @@ export function insertLinkWithPlacement(
 	// #768: a focused frontmatter property field leaves the body editor's caret
 	// stale; insert into the property at its caret instead. Placement modes only
 	// apply to body insertion.
-	const propertyEl = getFocusedEditablePropertyEl();
-	if (propertyEl && insertTextIntoEditableEl(propertyEl, text)) {
-		return;
-	}
+	if (tryInsertIntoFocusedProperty(text)) return;
 
 	const editor = view.editor;
 
@@ -1353,6 +1369,6 @@ export function getMarkdownFilesWithTag(app: App, tag: string): TFile[] {
 export const __test = {
 	convertLinkToEmbed,
 	extractMarkdownLinkTarget,
-	getFocusedEditablePropertyEl,
-	insertTextIntoEditableEl,
+	tryInsertIntoFocusedProperty,
+	insertTextAtCaret,
 } as const;

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -28,6 +28,7 @@ import { placementSupportsEmbed } from "./types/linkPlacement";
 import type { IUserScript } from "./types/macros/IUserScript";
 import { reportError } from "./utils/errorUtils";
 import { deepClone } from "./utils/deepClone";
+import { getOwnerDocument } from "./utils/activeWindow";
 
 export type TemplaterPluginLike = {
 	settings?: {
@@ -558,85 +559,97 @@ export function insertOnNewLineBelow(toInsert: string, app: App) {
 	insertOnNewLine(toInsert, "below", app);
 }
 
-// Obsidian renders YAML frontmatter as the Properties widget — separate input
-// elements, not the CodeMirror document.
-const PROPERTY_WIDGET_SELECTOR =
-	".metadata-property, .metadata-properties-container";
-
-function isEditableElement(element: Element): element is HTMLElement {
-	return (
-		element instanceof HTMLInputElement ||
-		element instanceof HTMLTextAreaElement ||
-		(element instanceof HTMLElement && element.isContentEditable)
-	);
+/**
+ * Identifies the frontmatter property whose value field has the caret, plus the
+ * file that owns it. Captured *before* QuickAdd opens any UI (see #768) so the
+ * link can be written even though the choice's prompts later move focus.
+ */
+export interface FrontmatterPropertyTarget {
+	file: TFile;
+	/** The property name (frontmatter key) being edited. */
+	key: string;
 }
 
 /**
- * When the caret is in a focused frontmatter property field, inserts `text` at
- * that caret and returns true. Returns false otherwise so the caller falls back
- * to body insertion.
+ * If the caret is in a frontmatter property *value* field, returns that property
+ * and its owning file; otherwise null.
  *
- * A focused property blurs the markdown body editor, so its reported caret is
- * stale — without this the link lands at the first body line instead (#768).
+ * Obsidian's Properties widget is a separate set of inputs, not the CodeMirror
+ * document, so when one is focused `editor.getCursor()` reports a stale body
+ * caret and an appended link would land at the first body line (#768). We detect
+ * the focused element via each Markdown view's own document (popout-aware) and
+ * bind to that view's file (so split panes / pop-out windows write to the right
+ * note). Detection is scoped to `.metadata-property-value` — never the key field
+ * — and we read the property name from the row's `data-property-key`.
  */
-function tryInsertIntoFocusedProperty(text: string): boolean {
-	if (typeof document === "undefined") return false;
-	const focused = document.activeElement;
-	if (!(focused instanceof HTMLElement)) return false;
-	if (!focused.closest(PROPERTY_WIDGET_SELECTOR)) return false;
-	if (!isEditableElement(focused)) return false;
-	return insertTextAtCaret(focused, text);
+export function getFocusedPropertyTarget(
+	app: App,
+): FrontmatterPropertyTarget | null {
+	for (const leaf of app.workspace.getLeavesOfType("markdown")) {
+		const view = leaf.view;
+		if (!(view instanceof MarkdownView) || !view.file) continue;
+
+		// Use the view's own document so popped-out windows are handled.
+		const focused = getOwnerDocument(view.containerEl).activeElement;
+		if (!focused || !view.containerEl.contains(focused)) continue;
+
+		// Must be the value side of a property row, not the key field.
+		if (!focused.closest(".metadata-property-value")) continue;
+
+		// Only text and list properties can sensibly hold a link. Typed inputs
+		// (number/date/checkbox/…) would coerce or reject it, so leave them to the
+		// body fallback. Matched by attribute (duck-typed) to stay cross-realm safe.
+		if (
+			focused.matches(
+				'input[type="number"], input[type="date"], input[type="datetime-local"], input[type="time"], input[type="month"], input[type="checkbox"]',
+			)
+		) {
+			continue;
+		}
+
+		const row = focused.closest(".metadata-property");
+		const key = row?.getAttribute("data-property-key");
+		if (!key) continue;
+
+		return { file: view.file, key };
+	}
+	return null;
 }
 
 /**
- * Inserts `text` at the caret of an input/textarea/contenteditable and fires an
- * "input" event so Obsidian persists it. Returns false for unsupported elements.
+ * Appends a link to `fileToLink` into the frontmatter property identified by
+ * `target`, via Obsidian's `processFrontMatter` API (the only reliable way to
+ * persist a property value — direct DOM mutation of the Properties widget is
+ * discarded on re-render, and typed inputs reject sliced text). List properties
+ * get a new item; non-empty scalars get the link appended to their string form;
+ * empty properties are set to the link.
  */
-function insertTextAtCaret(element: HTMLElement, text: string): boolean {
-	if (
-		element instanceof HTMLInputElement ||
-		element instanceof HTMLTextAreaElement
-	) {
-		const startOffset = element.selectionStart ?? element.value.length;
-		const endOffset = element.selectionEnd ?? element.value.length;
-		const before = element.value.slice(0, startOffset);
-		const after = element.value.slice(endOffset);
-		element.value = before + text + after;
-		const caretOffset = startOffset + text.length;
-		try {
-			element.setSelectionRange(caretOffset, caretOffset);
-		} catch {
-			// Some input types reject selection ranges; caret position is non-critical.
-		}
-		element.dispatchEvent(new Event("input", { bubbles: true }));
-		return true;
-	}
+export async function appendLinkToFrontmatterProperty(
+	app: App,
+	target: FrontmatterPropertyTarget,
+	fileToLink: TFile,
+	linkOptions: AppendLinkOptions,
+): Promise<void> {
+	const baseLink = app.fileManager.generateMarkdownLink(
+		fileToLink,
+		target.file.path,
+	);
+	const linkText =
+		linkOptions.linkType === "embed" &&
+		placementSupportsEmbed(linkOptions.placement)
+			? convertLinkToEmbed(baseLink)
+			: baseLink;
 
-	if (element.isContentEditable) {
-		const ownerDocument = element.ownerDocument;
-		const selection = ownerDocument.getSelection();
-		if (
-			selection &&
-			selection.rangeCount > 0 &&
-			element.contains(selection.anchorNode)
-		) {
-			// Replace the selection with a text node and put the caret after it.
-			const range = selection.getRangeAt(0);
-			range.deleteContents();
-			const textNode = ownerDocument.createTextNode(text);
-			range.insertNode(textNode);
-			range.setStartAfter(textNode);
-			range.collapse(true);
-			selection.removeAllRanges();
-			selection.addRange(range);
+	await app.fileManager.processFrontMatter(target.file, (frontmatter) => {
+		const existing = frontmatter[target.key];
+		if (Array.isArray(existing)) {
+			existing.push(linkText);
+		} else if (existing === undefined || existing === null || existing === "") {
+			frontmatter[target.key] = linkText;
 		} else {
-			element.textContent = `${element.textContent ?? ""}${text}`;
+			frontmatter[target.key] = `${existing} ${linkText}`;
 		}
-		element.dispatchEvent(new Event("input", { bubbles: true }));
-		return true;
-	}
-
-	return false;
+	});
 }
 
 /**
@@ -664,11 +677,6 @@ export function insertLinkWithPlacement(
 		log.logMessage(message);
 		return;
 	}
-
-	// #768: a focused frontmatter property field leaves the body editor's caret
-	// stale; insert into the property at its caret instead. Placement modes only
-	// apply to body insertion.
-	if (tryInsertIntoFocusedProperty(text)) return;
 
 	const editor = view.editor;
 
@@ -1369,6 +1377,4 @@ export function getMarkdownFilesWithTag(app: App, tag: string): TFile[] {
 export const __test = {
 	convertLinkToEmbed,
 	extractMarkdownLinkTarget,
-	tryInsertIntoFocusedProperty,
-	insertTextAtCaret,
 } as const;


### PR DESCRIPTION
## Problem

Fixes #768. When **Append link to current file** runs while the caret is in a
**frontmatter property field** (Obsidian's Properties widget), the link is
inserted at the first body line (right after the YAML) instead of at the
cursor. It works fine when the caret is in the document body.

## Steps to reproduce (on `master`)

Manual, in a live vault:

1. Settings → QuickAdd: create (or edit) a Template or Capture choice and enable
   **Append link to current file**.
2. Open any note that has frontmatter, so the **Properties** panel renders in
   Live Preview, e.g.:
   ```md
   ---
   title: My Note
   ---
   some existing text
   ```
3. Click into a **property value** field (e.g. `title`) so the caret is inside
   the Properties widget — not the note body.
4. Run the QuickAdd choice.

**Expected:** the link is appended at the caret (in the property).
**Actual:** the link is inserted on the first body line, right after the `---`:
```md
---
title: My Note
---
[[Created Note]]      <-- inserted here instead of at the caret
some existing text
```

Automated (no Obsidian needed) — the new test doubles as a repro:

```bash
pnpm install
pnpm exec vitest run src/utilityObsidian.appendLink-768.test.ts
```
On `master` the `insertLinkWithPlacement (#768 property-field routing)` case
fails (the body editor's `replaceSelection` is called instead of the focused
property); with this PR all 7 cases pass.

## Root cause

The whole append-link path reads the cursor from the markdown body editor:

`insertFileLinkToActiveView` (`src/utilityObsidian.ts`) →
`insertLinkWithPlacement`, which uses `editor.listSelections()` /
`editor.getCursor()`.

In Live Preview the Properties panel is a separate set of input elements, not
the CodeMirror document. When a property is focused, the body editor isn't, so
`getCursor()` returns a stale body caret (the first line after the frontmatter).
There was no check for this case, so the link landed in the body.

## Fix

`insertLinkWithPlacement` now detects when focus is inside the Properties widget
(the focused DOM element under `.metadata-property` /
`.metadata-properties-container`) and inserts the link at **that element's
caret**, dispatching an `input` event so Obsidian persists it to the
frontmatter. It falls back to the existing body-editor behavior when no property
field is focused or the element type is unsupported. Placement modes
(`replaceSelection`, etc.) only describe body insertion, so they don't apply in
the property case.

Two small helpers (`getFocusedEditablePropertyEl`, `insertTextIntoEditableEl`)
are added and exported via `__test` for unit coverage.

## Validation

- `pnpm exec vitest run src/utilityObsidian.appendLink-768.test.ts` → **7 passed**
  (focus detection, editable-element insertion, and property-vs-body routing).
- Regression check on related suites
  (`utilityObsidian`, `linkPlacement`, `engine/`, `formatter-linkcurrent`) →
  **345 passed, 2 skipped**, no regressions.
- `eslint` on the changed files → clean; `tsc -noEmit -skipLibCheck` → no `src/` errors.
- Also reproduced/confirmed at runtime by driving the real
  `insertFileLinkToActiveView` over a frontmatter document with a jsdom
  Properties widget: pre-fix the link lands at the first body line; post-fix it
  lands in the focused property and the body editor is left untouched.

> Note: automated tests + a jsdom-level runtime repro are green, but I have not
> yet clicked through this in a live Obsidian vault. A manual check (the steps
> above) would be good before merge.

## Notes for reviewers

- `main.js` / `styles.css` are gitignored in this repo, so only source is included.
- The contenteditable branch of `insertTextIntoEditableEl` covers Obsidian's
  rich text/list property inputs; the `<input>`/`<textarea>` branch covers the
  simpler ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Choice and capture link insertion now targets the active frontmatter Properties widget when the caret is in a property value field, correctly merging/appending links (including list, empty/missing, and embedded behavior).
  * Avoids inserting links when focus is in the property key field, in typed/number-like inputs, outside a markdown view, or when no property is focused.

* **Tests**
  * Added DOM-mounting and assertions covering property focus detection and link placement/combining, including numeric values preserved as strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->