### PR TITLE
feat(macro): run a user script from a note's ```js code block (#1065)

### DIFF
--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -75,13 +75,14 @@ In the Macro Builder, you can add different types of commands:
 
 ### Add a User Script Command
 
-Macros do not contain JavaScript code directly. Your code lives in a `.js` file
-inside your vault, and the macro simply runs that file.
+Macros do not contain JavaScript code directly. Your code lives either in a
+`.js` file inside your vault **or** in a ` ```js ` code block inside a note, and
+the macro simply runs it. The note option is handy on mobile, where Obsidian
+cannot open `.js` files — see [User Scripts](../UserScripts.md#scripts-in-a-note-code-block).
 
-Create a new script file such as `scripts/my-macro.js`. Make sure the file is
-really a JavaScript file whose name ends in `.js`. If you create it from inside
-Obsidian, check that Obsidian did not create a Markdown note named
-`my-macro.js.md`; QuickAdd only discovers files ending in `.js`.
+Create a new script file such as `scripts/my-macro.js`, or a note such as
+`Scripts/my-macro.md` with your code in a ` ```js ` block. QuickAdd runs the
+**first** ` ```js ` block in a note and ignores surrounding prose.
 
 Keep the script inside your vault, but not inside `.obsidian` or any folder
 whose name starts with a dot. Obsidian may exclude hidden folders from its file
@@ -90,15 +91,14 @@ normal folder such as `scripts/` or a visible underscore-prefixed folder such as
 `_quickadd/scripts/`.
 
 Open the Macro Builder and add a **User Script** command. The **Browse** button
-opens QuickAdd's script picker, not a native file picker. It searches the `.js`
-files Obsidian has already discovered in the vault, so it cannot pick files
-outside the vault, files hidden from Obsidian's index, or files whose extension
-is really `.md`.
+opens QuickAdd's script picker, not a native file picker. It lists the `.js`
+files and notes-with-a-code-block Obsidian has already discovered in the vault,
+so it cannot pick files outside the vault or hidden from Obsidian's index.
 
-You can also type the script into the text field and click **Add**. Type the
-script basename, not a vault-relative path: for `scripts/my-macro.js`, enter
-`my-macro`. To run a specific exported member, append it with `::`, such as
-`my-macro::start`. Do not enter `scripts/my-macro.js` in the manual field.
+You can also type the script into the text field and click **Add**. For a `.js`
+file, type its basename — for `scripts/my-macro.js`, enter `my-macro`. For a
+note, type its vault path, e.g. `Scripts/my-macro.md`. To run a specific exported
+member, append it with `::`, such as `my-macro::start`.
 
 If the script exports multiple functions and you do not specify a member,
 QuickAdd will ask which export to run. You can also set an output variable name
@@ -162,14 +162,15 @@ The **Paste with format** command preserves rich formatting when pasting content
 
 ## User Scripts
 
-User scripts are JavaScript files that extend macro functionality. They have access to:
+User scripts extend macro functionality with custom JavaScript — written in a
+`.js` file or in a ` ```js ` code block inside a note. They have access to:
 - The Obsidian app object
 - The QuickAdd API
 - A variables object for passing data between commands
 
 :::warning Script Placement Requirements
 
-User scripts (.js files) must be placed in your Obsidian vault, but **NOT** in the `.obsidian` directory or in hidden folders (folders starting with a dot).
+User scripts (a `.js` file, or a note with a ` ```js ` block) must be placed in your Obsidian vault, but **NOT** in the `.obsidian` directory or in hidden folders (folders starting with a dot).
 
 ✅ **Valid locations:**
 - `/scripts/myScript.js`

--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -81,8 +81,9 @@ the macro simply runs it. The note option is handy on mobile, where Obsidian
 cannot open `.js` files — see [User Scripts](../UserScripts.md#scripts-in-a-note-code-block).
 
 Create a new script file such as `scripts/my-macro.js`, or a note such as
-`Scripts/my-macro.md` with your code in a ` ```js ` block. QuickAdd runs the
-**first** ` ```js ` block in a note and ignores surrounding prose.
+`Scripts/my-macro.md` with your code in a ` ```js ` (or ` ```javascript `)
+block. QuickAdd runs the **first** matching JavaScript fence in a note and
+ignores surrounding prose.
 
 Keep the script inside your vault, but not inside `.obsidian` or any folder
 whose name starts with a dot. Obsidian may exclude hidden folders from its file

--- a/docs/docs/UserScripts.md
+++ b/docs/docs/UserScripts.md
@@ -7,23 +7,54 @@ decision path, then use this page as the detailed reference.
 
 :::
 
-User scripts are JavaScript files that extend QuickAdd's functionality with custom code. They can be used within macros to perform complex operations, integrate with external APIs, and automate sophisticated workflows.
+User scripts extend QuickAdd's functionality with custom code. They can be used within macros to perform complex operations, integrate with external APIs, and automate sophisticated workflows. A user script can be a standalone `.js` file **or** a ` ```js ` code block inside a regular note — the latter is editable on mobile, where Obsidian cannot open `.js` files.
 
 > **Obsidian API Reference**: This guide references the [Obsidian API](https://docs.obsidian.md/Home). Familiarize yourself with the [App](https://docs.obsidian.md/Reference/TypeScript+API/App), [Vault](https://docs.obsidian.md/Reference/TypeScript+API/Vault), and [Workspace](https://docs.obsidian.md/Reference/TypeScript+API/Workspace) modules for advanced scripting.
 
 ## Adding Scripts to Macros
 
-User scripts must be real `.js` files inside your vault. Avoid `.obsidian` and
-hidden dot-folders such as `.scripts`, because Obsidian may exclude them from
-the vault file index QuickAdd uses for script discovery. If you create a script
-from inside Obsidian, confirm the file did not become a Markdown note such as
-`script.js.md`.
+A user script can live in either of two places inside your vault:
 
-In the Macro Builder, **Browse** opens QuickAdd's picker of discovered `.js`
-files; it is not a native file picker. If you add a script manually, type the
-script basename, not the relative path. For `scripts/my-script.js`, enter
-`my-script`; for a specific export, enter a member expression such as
-`my-script::start`.
+- a standalone `.js` file, or
+- a note (`.md`) containing a ` ```js ` (or ` ```javascript `) code block.
+
+Avoid `.obsidian` and hidden dot-folders such as `.scripts`, because Obsidian
+may exclude them from the vault file index QuickAdd uses for script discovery.
+
+In the Macro Builder, **Browse** opens QuickAdd's picker of discovered scripts
+(both `.js` files and notes that contain a code block); it is not a native file
+picker. If you add a script manually, type a `.js` script's basename — for
+`scripts/my-script.js`, enter `my-script` — or, for a note, type its vault path
+(e.g. `Scripts/my-script.md`). For a specific export, append a member expression
+such as `my-script::start` (or `Scripts/my-script.md::start`).
+
+### Scripts in a note code block
+
+Write your script in a ` ```js ` code block inside any note; QuickAdd runs the
+**first** ` ```js ` (or ` ```javascript `) block in the note and ignores all
+prose and other code blocks. The block is a CommonJS module exactly like a `.js`
+file — it must assign `module.exports` / `exports.default` (a top-level `return`
+the way [inline scripts](./InlineScripts.md) work will **not** export anything):
+
+````markdown
+# My script
+
+Notes about what this does — ignored by QuickAdd.
+
+```js
+module.exports = async (params) => {
+    // Your code here
+};
+```
+````
+
+If the note has no ` ```js ` block, QuickAdd shows a notice and skips the script.
+
+:::note
+Only plain ` ```js ` fences are recognized — blocks nested inside callouts or
+blockquotes (`> ```js`) and `~~~` fences are not. To embed a literal ` ``` ` line
+inside the script body, open the block with four or more backticks.
+:::
 
 ## Basic Structure
 

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -2,9 +2,8 @@ import type {
 	App,
 	DropdownComponent,
 	TextComponent,
-	TFile,
 } from "obsidian";
-import { ButtonComponent, Setting } from "obsidian";
+import { ButtonComponent, Notice, Setting } from "obsidian";
 import CommandList from "./CommandList.svelte";
 import {
 	createCommandListProps,
@@ -21,7 +20,13 @@ import { WaitCommand } from "../../types/macros/QuickCommands/WaitCommand";
 import { NestedChoiceCommand } from "../../types/macros/QuickCommands/NestedChoiceCommand";
 import { CaptureChoice } from "../../types/choices/CaptureChoice";
 import { TemplateChoice } from "../../types/choices/TemplateChoice";
-import { JAVASCRIPT_FILE_EXTENSION_REGEX } from "../../constants";
+import {
+	type ScriptCandidate,
+	candidateLabel,
+	loadScriptCandidates,
+	noteScriptError,
+	resolveScriptSelector,
+} from "./scriptCandidates";
 import { UserScript } from "../../types/macros/UserScript";
 import { GenericTextSuggester } from "../suggesters/genericTextSuggester";
 import GenericYesNoPrompt from "../GenericYesNoPrompt/GenericYesNoPrompt";
@@ -74,7 +79,7 @@ export class CommandSequenceEditor {
 
 	private commandsRef: ICommand[];
 	private obsidianCommands: IObsidianCommand[] = [];
-	private javascriptFiles: TFile[] = [];
+	private scriptCandidates: ScriptCandidate[] = [];
 	private commandListHandle: MountHandle | null = null;
 	private commandListProps: CommandListProps | null = null;
 	private containerEl: HTMLElement | null = null;
@@ -88,7 +93,7 @@ export class CommandSequenceEditor {
 		this.conditionalHandlers = options.conditionalHandlers;
 
 		this.loadObsidianCommands();
-		this.loadJavascriptFiles();
+		this.loadScriptCandidates();
 	}
 
 	public render(containerEl: HTMLElement) {
@@ -122,10 +127,8 @@ export class CommandSequenceEditor {
 		});
 	}
 
-	private loadJavascriptFiles(): void {
-		this.javascriptFiles = this.app.vault
-			.getFiles()
-			.filter((file) => JAVASCRIPT_FILE_EXTENSION_REGEX.test(file.path));
+	private loadScriptCandidates(): void {
+		this.scriptCandidates = loadScriptCandidates(this.app);
 	}
 
 	private renderCommandList(parent: HTMLElement) {
@@ -334,16 +337,30 @@ export class CommandSequenceEditor {
 		let input!: TextComponent;
 		let addButton: ButtonComponent | null = null;
 
-		const addUserScriptFromInput = () => {
-			const value: string = input.getValue();
-			const scriptBasename = getUserScriptMemberAccess(value).basename;
+		const addUserScriptFromInput = async () => {
+			const value: string = input.getValue().trim();
+			if (!value) return;
+			const selector = getUserScriptMemberAccess(value).basename ?? value;
 
-			const file = this.javascriptFiles.find(
-				(f) => f.basename === scriptBasename
+			// Notes resolve by path (so a bare basename never picks a note over a
+			// same-named .js); .js keeps basename matching. Member access (`::`) is
+			// preserved in `value`, which becomes the command name.
+			const resolved = resolveScriptSelector(
+				this.app,
+				this.scriptCandidates,
+				selector,
 			);
-			if (!file) return;
+			if (!resolved) return;
 
-			this.addCommand(new UserScript(value, file.path));
+			if (resolved.isMarkdown) {
+				const reason = await noteScriptError(this.app, resolved.file);
+				if (reason) {
+					new Notice(`QuickAdd: "${resolved.file.path}" — ${reason}`);
+					return;
+				}
+			}
+
+			this.addCommand(new UserScript(value, resolved.file.path));
 
 			input.setValue("");
 			if (addButton) {
@@ -353,7 +370,7 @@ export class CommandSequenceEditor {
 
 		new Setting(parent)
 			.setName("User Scripts")
-			.setDesc("Add user script - type the name or click Browse")
+			.setDesc("Add a .js file or a note with a ```js code block - type the name or click Browse")
 			.addText((textComponent) => {
 				input = textComponent;
 				textComponent.inputEl.addClass("qa-command-sequence-input");
@@ -362,14 +379,14 @@ export class CommandSequenceEditor {
 				new GenericTextSuggester(
 					this.app,
 					textComponent.inputEl,
-					this.javascriptFiles.map((f) => f.basename)
+					this.scriptCandidates.map((c) => candidateLabel(c))
 				);
 
 				textComponent.inputEl.addEventListener(
 					"keypress",
 					(e: KeyboardEvent) => {
 						if (e.key === "Enter") {
-							addUserScriptFromInput();
+							void addUserScriptFromInput();
 						}
 					}
 				);
@@ -377,17 +394,23 @@ export class CommandSequenceEditor {
 			.addButton((button) =>
 				button
 					.setButtonText("Browse")
-					.setTooltip("Browse and select a script file")
+					.setTooltip("Browse and select a script (.js file or note)")
 					.onClick(async () => {
 						const selected = await this.showScriptPicker();
 						if (selected) {
-							this.addCommand(new UserScript(selected.basename, selected.path));
+							const name = selected.isMarkdown
+								? selected.file.path
+								: selected.file.basename;
+							this.addCommand(new UserScript(name, selected.file.path));
 						}
 					})
 			)
 			.addButton((button) => {
 				addButton = button;
-				button.setButtonText("Add").setCta().onClick(addUserScriptFromInput);
+				button
+					.setButtonText("Add")
+					.setCta()
+					.onClick(() => void addUserScriptFromInput());
 				button.buttonEl.addClass("qa-hidden");
 			});
 
@@ -489,26 +512,41 @@ export class CommandSequenceEditor {
 			});
 	}
 
-	private async showScriptPicker(): Promise<TFile | null> {
-		if (this.javascriptFiles.length === 0) {
+	private async showScriptPicker(): Promise<ScriptCandidate | null> {
+		if (this.scriptCandidates.length === 0) {
 			showNoScriptsFoundNotice(this.app);
 			return null;
 		}
 
-		const scriptNames = this.javascriptFiles.map((f) => f.basename);
-		const selected = await InputSuggester.Suggest(
+		// One unified list: .js paths and notes-with-a-code-block, keyed by path.
+		const paths = this.scriptCandidates.map((c) => c.file.path);
+		const labels = this.scriptCandidates.map((c) => candidateLabel(c));
+		const selectedPath = await InputSuggester.Suggest(
 			this.app,
-			scriptNames,
-			scriptNames,
+			labels,
+			paths,
 			{
-				placeholder: "Select a JavaScript file",
-				emptyStateText: "No .js files found in your vault",
+				placeholder: "Select a script (.js file or note with a ```js block)",
+				emptyStateText: "No scripts found in your vault",
 			}
 		);
 
-		if (!selected) return null;
+		if (!selectedPath) return null;
 
-		return this.javascriptFiles.find((f) => f.basename === selected) ?? null;
+		const candidate = this.scriptCandidates.find(
+			(c) => c.file.path === selectedPath
+		);
+		if (!candidate) return null;
+
+		if (candidate.isMarkdown) {
+			const reason = await noteScriptError(this.app, candidate.file);
+			if (reason) {
+				new Notice(`QuickAdd: "${candidate.file.path}" — ${reason}`);
+				return null;
+			}
+		}
+
+		return candidate;
 	}
 
 	private addCommand(command: ICommand) {

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -338,6 +338,8 @@ export class CommandSequenceEditor {
 		let addButton: ButtonComponent | null = null;
 
 		const addUserScriptFromInput = async () => {
+			// Refresh so scripts/notes created while this editor is open resolve.
+			this.loadScriptCandidates();
 			const value: string = input.getValue().trim();
 			if (!value) return;
 			const selector = getUserScriptMemberAccess(value).basename ?? value;
@@ -513,6 +515,8 @@ export class CommandSequenceEditor {
 	}
 
 	private async showScriptPicker(): Promise<ScriptCandidate | null> {
+		// Refresh so scripts/notes created while this editor is open are listed.
+		this.loadScriptCandidates();
 		if (this.scriptCandidates.length === 0) {
 			showNoScriptsFoundNotice(this.app);
 			return null;

--- a/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
@@ -15,7 +15,6 @@ import InputSuggester from "../InputSuggester/inputSuggester";
 import { showNoScriptsFoundNotice } from "./noScriptsFoundNotice";
 import {
 	type ScriptCandidate,
-	candidateLabel,
 	loadScriptCandidates,
 	noteScriptError,
 } from "./scriptCandidates";
@@ -260,18 +259,19 @@ export class ConditionalCommandSettingsModal extends Modal {
 					.setButtonText("Browse")
 					.setTooltip("Select a script (.js file or note)")
 					.onClick(async () => {
+						// Refresh so notes/scripts created while this modal is open appear.
+						this.loadScriptCandidates();
 						if (this.scriptCandidates.length === 0) {
 							showNoScriptsFoundNotice(this.app);
 							return;
 						}
 
+						// This picker stores condition.scriptPath, so show full paths for
+						// every entry (a vault can have several same-basename scripts).
 						const paths = this.scriptCandidates.map((c) => c.file.path);
-						const labels = this.scriptCandidates.map((c) =>
-							candidateLabel(c)
-						);
 						const selected = await InputSuggester.Suggest(
 							this.app,
-							labels,
+							paths,
 							paths,
 							{
 								placeholder:

--- a/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
@@ -1,5 +1,5 @@
-import type { App, DropdownComponent, TextComponent, TFile } from "obsidian";
-import { ButtonComponent, Modal, Setting } from "obsidian";
+import type { App, DropdownComponent, TextComponent } from "obsidian";
+import { ButtonComponent, Modal, Notice, Setting } from "obsidian";
 import type { IConditionalCommand } from "../../types/macros/Conditional/IConditionalCommand";
 import type {
 	ConditionalCondition,
@@ -11,11 +11,14 @@ import {
 	getDefaultValueTypeForOperator,
 	requiresExpectedValue,
 } from "../../utils/conditionalHelpers";
-import {
-	JAVASCRIPT_FILE_EXTENSION_REGEX
-} from "../../constants";
 import InputSuggester from "../InputSuggester/inputSuggester";
 import { showNoScriptsFoundNotice } from "./noScriptsFoundNotice";
+import {
+	type ScriptCandidate,
+	candidateLabel,
+	loadScriptCandidates,
+	noteScriptError,
+} from "./scriptCandidates";
 
 function cloneCondition(condition: ConditionalCondition): ConditionalCondition {
 	return condition.mode === "variable"
@@ -45,7 +48,7 @@ export class ConditionalCommandSettingsModal extends Modal {
 	private readonly originalCommand: IConditionalCommand;
 	private workingCommand: IConditionalCommand;
 	private isResolved = false;
-	private javascriptFiles: TFile[] = [];
+	private scriptCandidates: ScriptCandidate[] = [];
 
 	constructor(app: App, command: IConditionalCommand) {
 		super(app);
@@ -59,7 +62,7 @@ export class ConditionalCommandSettingsModal extends Modal {
 			this.resolvePromise = resolve;
 		});
 
-		this.loadJavascriptFiles();
+		this.loadScriptCandidates();
 		this.display();
 		this.open();
 	}
@@ -77,10 +80,8 @@ export class ConditionalCommandSettingsModal extends Modal {
 		this.resolvePromise(value);
 	}
 
-	private loadJavascriptFiles() {
-		this.javascriptFiles = this.app.vault
-			.getFiles()
-			.filter((file) => JAVASCRIPT_FILE_EXTENSION_REGEX.test(file.path));
+	private loadScriptCandidates() {
+		this.scriptCandidates = loadScriptCandidates(this.app);
 	}
 
 	private reload() {
@@ -244,11 +245,11 @@ export class ConditionalCommandSettingsModal extends Modal {
 
 		new Setting(this.contentEl)
 			.setName("Script path")
-			.setDesc("Vault-relative path to the JavaScript file.")
+			.setDesc("Vault-relative path to a .js file or a note with a ```js code block.")
 			.addText((text) => {
 				input = text;
 				text
-					.setPlaceholder("scripts/myCheck.js")
+					.setPlaceholder("scripts/myCheck.js or Notes/myCheck.md")
 					.setValue(condition.scriptPath)
 					.onChange((value) => {
 						condition.scriptPath = value.trim();
@@ -257,25 +258,45 @@ export class ConditionalCommandSettingsModal extends Modal {
 			.addButton((button) =>
 				button
 					.setButtonText("Browse")
-					.setTooltip("Select a script file")
+					.setTooltip("Select a script (.js file or note)")
 					.onClick(async () => {
-						if (this.javascriptFiles.length === 0) {
+						if (this.scriptCandidates.length === 0) {
 							showNoScriptsFoundNotice(this.app);
 							return;
 						}
 
-						const scriptNames = this.javascriptFiles.map((f) => f.path);
+						const paths = this.scriptCandidates.map((c) => c.file.path);
+						const labels = this.scriptCandidates.map((c) =>
+							candidateLabel(c)
+						);
 						const selected = await InputSuggester.Suggest(
 							this.app,
-							scriptNames,
-							scriptNames,
+							labels,
+							paths,
 							{
-								placeholder: "Select a JavaScript file",
-								emptyStateText: "No .js files found in your vault",
+								placeholder:
+									"Select a script (.js file or note with a ```js block)",
+								emptyStateText: "No scripts found in your vault",
 							}
 						);
 
 						if (!selected) return;
+
+						const candidate = this.scriptCandidates.find(
+							(c) => c.file.path === selected
+						);
+						if (candidate?.isMarkdown) {
+							const reason = await noteScriptError(
+								this.app,
+								candidate.file
+							);
+							if (reason) {
+								new Notice(
+									`QuickAdd: "${candidate.file.path}" — ${reason}`,
+								);
+								return;
+							}
+						}
 
 						condition.scriptPath = selected;
 						input.setValue(selected);

--- a/src/gui/MacroGUIs/noScriptsFoundNotice.ts
+++ b/src/gui/MacroGUIs/noScriptsFoundNotice.ts
@@ -2,26 +2,32 @@ import type { App } from "obsidian";
 import { Notice } from "obsidian";
 
 /**
- * Shows a notice to the user when no JavaScript files are found in their vault.
+ * Shows a notice to the user when no user scripts are found in their vault.
  * Provides helpful guidance on where to place scripts and links to documentation.
  */
 export function showNoScriptsFoundNotice(app: App): void {
 	const notice = new Notice("", 10000);
 	const messageEl = notice.messageEl;
 	messageEl.replaceChildren();
-	appendDiv(messageEl, "No JavaScript files found", "quickadd-notice-title");
+	appendDiv(messageEl, "No scripts found", "quickadd-notice-title");
 
 	// Use the notice element's owning document (popout-aware) instead of the bare
 	// `document` global.
 	const doc = messageEl.ownerDocument;
 	const content = doc.createElement("div");
 	messageEl.append(content);
-	appendDiv(content, "QuickAdd cannot find any .js files in your vault.");
+	appendDiv(
+		content,
+		"QuickAdd cannot find any .js files or notes with a ```js code block in your vault.",
+	);
 	content.append(doc.createElement("br"));
 	appendDiv(content, "Please make sure your scripts are:");
 	appendDiv(content, `✓ In your vault (not in ${app.vault.configDir} folder)`);
 	appendDiv(content, "✓ Not in hidden folders (starting with a dot)");
-	appendDiv(content, "✓ Have a .js extension");
+	appendDiv(
+		content,
+		"✓ A .js file, or a note containing a ```js code block",
+	);
 	content.append(doc.createElement("br"));
 
 	const link = doc.createElement("a");

--- a/src/gui/MacroGUIs/scriptCandidates.test.ts
+++ b/src/gui/MacroGUIs/scriptCandidates.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { TFile, type App } from "obsidian";
+import {
+	type ScriptCandidate,
+	noteScriptError,
+	resolveScriptSelector,
+} from "./scriptCandidates";
+
+function file(path: string): TFile {
+	const f = new TFile();
+	f.path = path;
+	f.name = path.split("/").pop() ?? path;
+	f.extension = path.split(".").pop() ?? "";
+	f.basename = f.name.replace(/\.[^.]+$/, "");
+	return f;
+}
+
+function candidate(path: string, isMarkdown: boolean): ScriptCandidate {
+	return { file: file(path), isMarkdown };
+}
+
+function appWith(
+	files: TFile[],
+	contents: Record<string, string> = {},
+): App {
+	const byPath = new Map(files.map((f) => [f.path, f]));
+	return {
+		vault: {
+			getAbstractFileByPath: vi.fn((p: string) => byPath.get(p) ?? null),
+			read: vi.fn(async (f: TFile) => contents[f.path] ?? ""),
+		},
+	} as unknown as App;
+}
+
+describe("resolveScriptSelector", () => {
+	it("matches a bare basename to the .js file, never a same-named note (#1065 collision)", () => {
+		const candidates = [
+			candidate("Notes/foo.md", true),
+			candidate("Scripts/foo.js", false),
+		];
+		// Note appears first in the list; a bare basename must still pick the .js.
+		const resolved = resolveScriptSelector(
+			appWith(candidates.map((c) => c.file)),
+			candidates,
+			"foo",
+		);
+		expect(resolved?.file.path).toBe("Scripts/foo.js");
+		expect(resolved?.isMarkdown).toBe(false);
+	});
+
+	it("matches a note by its full path", () => {
+		const candidates = [
+			candidate("Notes/foo.md", true),
+			candidate("Scripts/foo.js", false),
+		];
+		const resolved = resolveScriptSelector(
+			appWith(candidates.map((c) => c.file)),
+			candidates,
+			"Notes/foo.md",
+		);
+		expect(resolved?.file.path).toBe("Notes/foo.md");
+		expect(resolved?.isMarkdown).toBe(true);
+	});
+
+	it("falls back to a direct vault lookup when the candidate list is cold", () => {
+		const noteFile = file("Notes/fresh.md");
+		const resolved = resolveScriptSelector(
+			appWith([noteFile]),
+			[], // pre-filter hasn't indexed it yet
+			"Notes/fresh.md",
+		);
+		expect(resolved?.file.path).toBe("Notes/fresh.md");
+		expect(resolved?.isMarkdown).toBe(true);
+	});
+
+	it("returns null for a non-script file or a missing path", () => {
+		const app = appWith([file("Notes/plain.txt")]);
+		expect(resolveScriptSelector(app, [], "Notes/plain.txt")).toBeNull();
+		expect(resolveScriptSelector(app, [], "does/not/exist.md")).toBeNull();
+	});
+});
+
+describe("noteScriptError", () => {
+	it("returns null for a note with a runnable js fence", async () => {
+		const f = file("Notes/ok.md");
+		const app = appWith([f], {
+			"Notes/ok.md": "intro\n\n```js\nmodule.exports = () => 1;\n```",
+		});
+		expect(await noteScriptError(app, f)).toBeNull();
+	});
+
+	it("returns a no-fence reason for a note without a js block", async () => {
+		const f = file("Notes/none.md");
+		const app = appWith([f], { "Notes/none.md": "# just prose" });
+		expect(await noteScriptError(app, f)).toMatch(/no .*code block/i);
+	});
+
+	it("returns an empty-fence reason for an empty js block", async () => {
+		const f = file("Notes/empty.md");
+		const app = appWith([f], { "Notes/empty.md": "```js\n\n```" });
+		expect(await noteScriptError(app, f)).toMatch(/empty/i);
+	});
+});

--- a/src/gui/MacroGUIs/scriptCandidates.ts
+++ b/src/gui/MacroGUIs/scriptCandidates.ts
@@ -1,0 +1,93 @@
+import type { App } from "obsidian";
+import { TFile } from "obsidian";
+import {
+	JAVASCRIPT_FILE_EXTENSION_REGEX,
+	MARKDOWN_FILE_EXTENSION_REGEX,
+} from "../../constants";
+import { extractScriptFromMarkdown } from "../../utils/extractScriptFromMarkdown";
+
+/** A file selectable as a user script: a .js file, or a note with a ```js block. */
+export interface ScriptCandidate {
+	file: TFile;
+	isMarkdown: boolean;
+}
+
+/**
+ * Files a user can pick as a script: every `.js` file, plus notes that have at
+ * least one code block. The code-block check is cache-only (cheap, no reads) and
+ * can't see the fence language — so a note whose only block is non-JS still shows
+ * up; `noteScriptError` is the validate-on-select backstop.
+ */
+export function loadScriptCandidates(app: App): ScriptCandidate[] {
+	const candidates: ScriptCandidate[] = [];
+	for (const file of app.vault.getFiles()) {
+		if (JAVASCRIPT_FILE_EXTENSION_REGEX.test(file.path)) {
+			candidates.push({ file, isMarkdown: false });
+		} else if (
+			MARKDOWN_FILE_EXTENSION_REGEX.test(file.path) &&
+			noteHasCodeBlock(app, file)
+		) {
+			candidates.push({ file, isMarkdown: true });
+		}
+	}
+	return candidates;
+}
+
+function noteHasCodeBlock(app: App, file: TFile): boolean {
+	const cache = app.metadataCache.getFileCache(file);
+	return cache?.sections?.some((section) => section.type === "code") ?? false;
+}
+
+/**
+ * Resolve a user-typed selector to a script file.
+ *
+ * Notes resolve by PATH only, so typing a bare basename never picks a note over a
+ * same-named `.js` file — preserving the legacy `.js` typed-add behavior. Falls
+ * back to a direct vault lookup so a runnable note (or `.js`) still resolves even
+ * when the cache-based candidate pre-filter hasn't indexed it yet (cold cache /
+ * freshly created note).
+ */
+export function resolveScriptSelector(
+	app: App,
+	candidates: ScriptCandidate[],
+	selector: string,
+): ScriptCandidate | null {
+	const byPath = candidates.find((c) => c.file.path === selector);
+	if (byPath) return byPath;
+
+	const byJsBasename = candidates.find(
+		(c) => !c.isMarkdown && c.file.basename === selector,
+	);
+	if (byJsBasename) return byJsBasename;
+
+	const file = app.vault.getAbstractFileByPath(selector);
+	if (file instanceof TFile) {
+		if (JAVASCRIPT_FILE_EXTENSION_REGEX.test(file.path)) {
+			return { file, isMarkdown: false };
+		}
+		if (MARKDOWN_FILE_EXTENSION_REGEX.test(file.path)) {
+			return { file, isMarkdown: true };
+		}
+	}
+	return null;
+}
+
+/**
+ * Validate a note can be used as a script (validate-on-select). Returns the reason
+ * it cannot — the same message the runtime loader surfaces — or `null` when the
+ * note has a runnable ```js fence.
+ */
+export async function noteScriptError(
+	app: App,
+	file: TFile,
+): Promise<string | null> {
+	const content = await app.vault.read(file);
+	const { code, error } = extractScriptFromMarkdown(content);
+	if (code !== null && code.length > 0) return null;
+	return error ?? "No ```js code block found in the note.";
+}
+
+/** Suggester label: basename for .js (legacy), full path for notes. */
+export function candidateLabel(candidate: ScriptCandidate): string {
+	return candidate.isMarkdown ? candidate.file.path : candidate.file.basename;
+}

--- a/src/gui/apiModernization.test.ts
+++ b/src/gui/apiModernization.test.ts
@@ -65,7 +65,7 @@ describe("API modernization", () => {
 		expect(notice).toMatchObject({ message: "", timeout: 10000 });
 		const noticeEl = notice?.messageEl;
 
-		expect(noticeEl?.textContent).toContain("No JavaScript files found");
+		expect(noticeEl?.textContent).toContain("No scripts found");
 		expect(noticeEl?.textContent).toContain(
 			"✓ In your vault (not in .custom-obsidian folder)",
 		);

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -1119,6 +1119,62 @@ describe("applyPackageImport - assets", () => {
 		);
 	});
 
+	it("remaps a note-script command name (=path) when the asset is rewritten (#1065)", async () => {
+		const { app } = createFakeApp();
+		const macroChoice = {
+			...makeChoice("macro", "Macro choice", "Macro"),
+			macro: {
+				id: "macro-id",
+				name: "M",
+				commands: [
+					{
+						id: "us",
+						// Note-backed scripts carry the vault path as their name (+ member).
+						name: "scripts/orig.md::run",
+						type: CommandType.UserScript,
+						path: "scripts/orig.md",
+						settings: {},
+					} as IUserScript,
+				],
+			},
+			runOnStartup: false,
+		} as IMacroChoice;
+
+		const pkg = makePackage({
+			choices: [makePackageChoice(macroChoice)],
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "scripts/orig.md",
+					contentEncoding: "base64",
+					content: encodeToBase64("```js\nmodule.exports={run:()=>1}\n```"),
+				},
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([["macro", "import"]]),
+			assetDecisions: [
+				{
+					originalPath: "scripts/orig.md",
+					destinationPath: "scripts/new.md",
+					mode: "write",
+				},
+			],
+		});
+
+		const insertedMacro = result.updatedChoices.find(
+			(c) => c.id === "macro",
+		) as IMacroChoice;
+		const userScript = insertedMacro.macro.commands[0] as IUserScript;
+		expect(userScript.path).toBe("scripts/new.md");
+		// name must track the new path so member access + UI stay correct.
+		expect(userScript.name).toBe("scripts/new.md::run");
+	});
+
 	it("does not throw when adapter.exists rejects while checking an asset", async () => {
 		const { app, state } = createFakeApp();
 		state.existThrowsFor = new Set(["scripts/run.js"]);

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -713,6 +713,16 @@ function applyOverridesToCommands(
 				const userScript = command as IUserScript;
 				const replacement = pathOverrides.get(userScript.path);
 				if (replacement) {
+					// Note-backed scripts use the vault path as their command name
+					// (and member selector, `path::member`); keep it in sync when the
+					// asset is written to a different destination on import. `.js`
+					// scripts use a basename name (!= path), so this leaves them alone.
+					if (userScript.name === userScript.path) {
+						userScript.name = replacement;
+					} else if (userScript.name.startsWith(`${userScript.path}::`)) {
+						userScript.name =
+							replacement + userScript.name.slice(userScript.path.length);
+					}
 					userScript.path = replacement;
 				}
 				break;

--- a/src/services/packagePreview.test.ts
+++ b/src/services/packagePreview.test.ts
@@ -472,6 +472,46 @@ describe("buildPackagePreview - files manifest, overwrites, orphans, captures", 
 		).toBe(true);
 	});
 
+	it("flags an orphan .md note-script that lies about its kind (#1065)", () => {
+		// A bundled note labeled "template" and referenced by no choice would slip
+		// the disclosure gate, land on disk, and run via any macro pointing at its
+		// path. Since a note's ```js fence is now executable, the gate must catch it.
+		const m = macro("m1", "Empty", []);
+		const note = asset(
+			"template",
+			"Notes/payload.md",
+			"# Looks harmless\n\n```js\nmodule.exports = () => exfiltrate();\n```\n",
+		);
+		const pkg = makePackage([pkgChoice(m, ["Empty"])], [note]);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+
+		const file = preview.files.find(
+			(f) => f.originalPath === "Notes/payload.md",
+		);
+		expect(file?.orphan).toBe(true);
+		expect(file?.requiresReview).toBe(true);
+		expect(requiresAcknowledgement(preview)).toBe(true);
+		expect(preview.criticalScriptPaths).toContain("Notes/payload.md");
+		expect(isFullyReviewed(preview, NONE)).toBe(false);
+	});
+
+	it("does not flag a plain .md template with no js code block", () => {
+		const m = macro("m1", "Empty", []);
+		const note = asset(
+			"template",
+			"Templates/daily.md",
+			"# Daily\n\n- [ ] task\n\n```python\nprint('not js')\n```\n",
+		);
+		const pkg = makePackage([pkgChoice(m, ["Empty"])], [note]);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+
+		const file = preview.files.find(
+			(f) => f.originalPath === "Templates/daily.md",
+		);
+		expect(file?.requiresReview).toBe(false);
+		expect(preview.criticalScriptPaths).not.toContain("Templates/daily.md");
+	});
+
 	it("treats a bundled script that overwrites an existing file as critical", () => {
 		const m = macro("m1", "Empty", []);
 		const pkg = makePackage(

--- a/src/services/packagePreview.ts
+++ b/src/services/packagePreview.ts
@@ -16,6 +16,8 @@ import type {
 } from "../types/packages/QuickAddPackage";
 import { flattenChoices } from "../utils/choiceUtils";
 import { decodeFromBase64 } from "../utils/base64";
+import { extractScriptFromMarkdown } from "../utils/extractScriptFromMarkdown";
+import { MARKDOWN_FILE_EXTENSION_REGEX } from "../constants";
 
 /**
  * Pure, App-free analysis of a QuickAdd package for the import preview.
@@ -170,6 +172,28 @@ function isExecutableBundledAsset(
 	originalPath: string,
 ): boolean {
 	return isScriptKind(kind) || EXECUTABLE_ASSET_PATH_REGEX.test(originalPath);
+}
+
+// Since #1065 a `.md` note is loadable as a user script (its first ```js fence
+// runs). The `.js` path check above can't see that, so a bundled note that lies
+// about its `kind` (e.g. "template") and is referenced by no choice would slip the
+// disclosure gate, land on disk, and run via any macro pointing at its path.
+// Decode the bundled content and run the SAME extractor the loader uses: only a
+// note that actually contains a runnable js fence is treated as executable, so
+// plain `.md` templates are not flagged. Pure/App-free — operates on the payload.
+function markdownAssetIsExecutable(
+	originalPath: string,
+	content: string,
+): boolean {
+	if (!MARKDOWN_FILE_EXTENSION_REGEX.test(originalPath)) return false;
+	let decoded: string;
+	try {
+		decoded = decodeFromBase64(content);
+	} catch {
+		return false;
+	}
+	const { code } = extractScriptFromMarkdown(decoded);
+	return code !== null && code.length > 0;
 }
 
 const SEVERITY_ORDER: Record<PreviewSeverity, number> = {
@@ -685,7 +709,9 @@ export function buildPackagePreview(
 		const usages = usagesByPath.get(asset.originalPath) ?? [];
 		const executable = referencedAsScript.has(asset.originalPath);
 		const requiresReview =
-			executable || isExecutableBundledAsset(asset.kind, asset.originalPath);
+			executable ||
+			isExecutableBundledAsset(asset.kind, asset.originalPath) ||
+			markdownAssetIsExecutable(asset.originalPath, asset.content);
 		return {
 			originalPath: asset.originalPath,
 			kind: asset.kind,

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -1,4 +1,5 @@
 import {
+	Notice,
 	TFolder,
 	type App,
 	TFile,
@@ -227,8 +228,11 @@ describe("getUserScript", () => {
 		};
 	}
 
-	function createUserScriptApp(fileContent: string) {
-		const file = createFile("Scripts/script.js");
+	function createUserScriptApp(
+		fileContent: string,
+		path = "Scripts/script.js",
+	) {
+		const file = createFile(path);
 		return {
 			vault: {
 				getAbstractFileByPath: vi.fn(() => file),
@@ -308,6 +312,92 @@ describe("getUserScript", () => {
 				command.settings,
 			),
 		).rejects.toThrow("script rejected");
+	});
+
+	it("loads a user script from a note's ```js code block (#1065)", async () => {
+		const app = createUserScriptApp(
+			[
+				"# My script note",
+				"",
+				"Some prose that should be ignored.",
+				"",
+				"```js",
+				'module.exports = () => "hi from a note";',
+				"```",
+				"",
+				"More prose.",
+			].join("\n"),
+			"Scripts/note-script.md",
+		);
+		const command = createUserScriptCommand({
+			path: "Scripts/note-script.md",
+			name: "note-script",
+		});
+
+		const script = await getUserScript(command, app);
+		expect(typeof script).toBe("function");
+		expect((script as () => unknown)()).toBe("hi from a note");
+	});
+
+	it("resolves ::member access for a note-based script", async () => {
+		const app = createUserScriptApp(
+			[
+				"```js",
+				"module.exports = {",
+				"  run: async (params) => params.token,",
+				"};",
+				"```",
+			].join("\n"),
+			"Scripts/note-script.md",
+		);
+		const command = createUserScriptCommand({
+			path: "Scripts/note-script.md",
+			name: "Scripts/note-script.md::run",
+		});
+
+		const script = await getUserScript(command, app);
+		expect(typeof script).toBe("function");
+		await expect(
+			(script as (params: unknown) => unknown)({ token: "ok" }),
+		).resolves.toBe("ok");
+	});
+
+	it("returns undefined and shows a notice when a note has no ```js block", async () => {
+		const noticeStub = Notice as unknown as {
+			instances: Array<{ message: string }>;
+		};
+		const before = noticeStub.instances.length;
+		const app = createUserScriptApp(
+			"# Just prose\n\nNo code block here.\n",
+			"Scripts/no-fence.md",
+		);
+		const command = createUserScriptCommand({
+			path: "Scripts/no-fence.md",
+			name: "no-fence",
+		});
+
+		const script = await getUserScript(command, app);
+		expect(script).toBeUndefined();
+
+		const added = noticeStub.instances.slice(before);
+		expect(added).toHaveLength(1);
+		expect(added[0].message).toContain("Scripts/no-fence.md");
+	});
+
+	it("treats a note fence without module.exports as a non-runnable export", async () => {
+		const app = createUserScriptApp(
+			"```js\nconst notExported = 1;\n```",
+			"Scripts/inline-style.md",
+		);
+		const command = createUserScriptCommand({
+			path: "Scripts/inline-style.md",
+			name: "inline-style",
+		});
+
+		const script = await getUserScript(command, app);
+		// CommonJS contract: a note script must assign module.exports/exports.default.
+		// Without it, the export is the empty module object, never a runnable function.
+		expect(typeof script).not.toBe("function");
 	});
 });
 

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -5,12 +5,20 @@ import type {
 	WorkspaceLeaf,
 	WorkspaceParent,
 } from "obsidian";
-import { FileView, MarkdownView, normalizePath, TFile, TFolder } from "obsidian";
+import {
+	FileView,
+	MarkdownView,
+	Notice,
+	normalizePath,
+	TFile,
+	TFolder,
+} from "obsidian";
 import {
 	BASE_FILE_EXTENSION_REGEX,
 	CANVAS_FILE_EXTENSION_REGEX,
 	MARKDOWN_FILE_EXTENSION_REGEX,
 } from "./constants";
+import { extractScriptFromMarkdown } from "./utils/extractScriptFromMarkdown";
 import { log } from "./logger/logManager";
 import { NLDParser } from "./parsers/NLDParser";
 import type { CaptureChoice } from "./types/choices/CaptureChoice";
@@ -1150,11 +1158,27 @@ export async function getUserScript(command: IUserScript, app: App) {
 
 		const fileContent = await app.vault.read(file);
 
+		// A user script can live in a `.js` file OR inside a ```js fenced code block
+		// in a note (#1065) — the latter is editable on mobile. For a note we run the
+		// first js fence and ignore surrounding prose; the .js path is byte-identical.
+		let scriptSource = fileContent;
+		if (MARKDOWN_FILE_EXTENSION_REGEX.test(file.path)) {
+			const { code, error } = extractScriptFromMarkdown(fileContent);
+			if (code === null || code.length === 0) {
+				// Surface a visible, actionable reason (the caller's generic "failed to
+				// load" log alone is easy to miss) and fall through to the established
+				// "return undefined" contract — do not double-log here.
+				new Notice(`QuickAdd: ${error} (${command.path})`);
+				return;
+			}
+			scriptSource = code;
+		}
+
 		// User scripts are CommonJS modules. Wrap the file body in a Function whose
 		// parameters are the module globals, instead of `eval`-ing a wrapper string.
 		// This executes the (trusted, user-authored) script identically to the
 		// previous `(function(require, module, exports){ ... })` eval form.
-		const fn = new Function("require", "module", "exports", fileContent);
+		const fn = new Function("require", "module", "exports", scriptSource);
 
 		fn(req, mod, exp);
 

--- a/src/utils/extractScriptFromMarkdown.test.ts
+++ b/src/utils/extractScriptFromMarkdown.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { extractScriptFromMarkdown } from "./extractScriptFromMarkdown";
+
+/**
+ * Strip the line-number-preserving leading newlines and the single structural
+ * trailing newline (the terminator of the last body line) so assertions read
+ * cleanly. Byte-exact preservation is asserted separately in the CRLF test.
+ */
+function body(content: string): string | null {
+	const { code } = extractScriptFromMarkdown(content);
+	return code === null ? null : code.replace(/^\n+/, "").replace(/\r?\n$/, "");
+}
+
+describe("extractScriptFromMarkdown", () => {
+	it("returns null when there is no code fence", () => {
+		const res = extractScriptFromMarkdown("Just some prose.\n\nNo code here.");
+		expect(res.code).toBeNull();
+		expect(res.error).toMatch(/no .*code block/i);
+	});
+
+	it("returns null when the only fence is not JavaScript", () => {
+		const res = extractScriptFromMarkdown("```python\nprint('hi')\n```\n");
+		expect(res.code).toBeNull();
+	});
+
+	it("extracts a single ```js block and ignores surrounding prose", () => {
+		const content = [
+			"# Title",
+			"",
+			"Some notes before.",
+			"",
+			"```js",
+			'module.exports = () => "hi";',
+			"```",
+			"",
+			"Notes after.",
+		].join("\n");
+		expect(body(content)).toBe('module.exports = () => "hi";');
+	});
+
+	it("matches ```javascript (case-insensitive) and ignores trailing info tokens", () => {
+		expect(body("```JavaScript foo bar\nconst a = 1;\n```")).toBe("const a = 1;");
+		expect(body("```JS\nconst b = 2;\n```")).toBe("const b = 2;");
+	});
+
+	it("does not match look-alike languages (jsx/json/typescript)", () => {
+		expect(extractScriptFromMarkdown("```jsx\nx\n```").code).toBeNull();
+		expect(extractScriptFromMarkdown("```json\n{}\n```").code).toBeNull();
+		expect(extractScriptFromMarkdown("```typescript\nx\n```").code).toBeNull();
+	});
+
+	it("runs the FIRST js block when several exist", () => {
+		const content = [
+			"```js",
+			"const first = 1;",
+			"```",
+			"",
+			"```js",
+			"const second = 2;",
+			"```",
+		].join("\n");
+		expect(body(content)).toBe("const first = 1;");
+	});
+
+	it("does not close on a line with trailing content after the backticks", () => {
+		const content = [
+			"```js",
+			'const fence = "```";',
+			'module.exports = () => fence;',
+			"```",
+		].join("\n");
+		expect(body(content)).toBe(
+			'const fence = "```";\nmodule.exports = () => fence;',
+		);
+	});
+
+	it("a bare same-length fence inside the body DOES close it (documented)", () => {
+		const content = ["```js", "const a = 1;", "```", "const ignored = 2;"].join(
+			"\n",
+		);
+		expect(body(content)).toBe("const a = 1;");
+	});
+
+	it("lets a 4-backtick wrapper embed a bare 3-backtick line", () => {
+		const content = [
+			"````js",
+			"const md = `",
+			"```",
+			"`;",
+			"````",
+		].join("\n");
+		expect(body(content)).toBe("const md = `\n```\n`;");
+	});
+
+	it("reports an empty fence distinctly from a missing fence", () => {
+		const empty = extractScriptFromMarkdown("```js\n\n```");
+		expect(empty.code).toBe("");
+		expect(empty.error).toMatch(/empty/i);
+
+		const whitespace = extractScriptFromMarkdown("```js\n   \n\t\n```");
+		expect(whitespace.code).toBe("");
+		expect(whitespace.error).toMatch(/empty/i);
+	});
+
+	it("preserves CRLF line endings inside the body byte-for-byte", () => {
+		const content = "```js\r\nconst a = `x\r\ny`;\r\n```\r\n";
+		const { code } = extractScriptFromMarkdown(content);
+		expect(code).not.toBeNull();
+		expect((code as string).replace(/^\n+/, "")).toBe("const a = `x\r\ny`;\r\n");
+	});
+
+	it("ignores YAML frontmatter before the fence", () => {
+		const content = [
+			"---",
+			"title: My Script",
+			"---",
+			"",
+			"```js",
+			"const a = 1;",
+			"```",
+		].join("\n");
+		expect(body(content)).toBe("const a = 1;");
+	});
+
+	it("handles an indented opening fence (<=3 spaces)", () => {
+		expect(body("   ```js\n   const a = 1;\n   ```")).toBe("   const a = 1;");
+	});
+
+	it("does not treat a callout/blockquote fence as a script (out of scope)", () => {
+		const content = ["> ```js", "> const a = 1;", "> ```"].join("\n");
+		expect(extractScriptFromMarkdown(content).code).toBeNull();
+	});
+
+	it("preserves note line numbers via leading blank-line padding", () => {
+		const content = [
+			"# Heading", // line 1
+			"prose", // line 2
+			"```js", // line 3
+			"throw new Error('x');", // line 4 in the note
+			"```",
+		].join("\n");
+		const { code } = extractScriptFromMarkdown(content);
+		// Body starts after 3 preceding lines -> 3 leading newlines, so the throw is
+		// on source line 4, matching the note. The trailing newline is the body
+		// line's own terminator (preserved byte-for-byte).
+		expect(code).toBe("\n\n\nthrow new Error('x');\n");
+	});
+
+	it("tolerates an unclosed fence by taking the rest of the note", () => {
+		expect(body("```js\nconst a = 1;\nconst b = 2;")).toBe(
+			"const a = 1;\nconst b = 2;",
+		);
+	});
+});

--- a/src/utils/extractScriptFromMarkdown.ts
+++ b/src/utils/extractScriptFromMarkdown.ts
@@ -1,0 +1,100 @@
+export interface ScriptExtractionResult {
+	/**
+	 * The runnable JavaScript body, or `null` when the note has no JS fence.
+	 *
+	 * On success the body is prefixed with one blank line per source line that
+	 * precedes the fence body. This shifts runtime stack-trace line numbers to
+	 * roughly the note's own line numbers (so an error points near the right line
+	 * when editing the script in Obsidian) — it removes the prose/frontmatter
+	 * offset, modulo the small constant the `new Function` wrapper adds. The
+	 * original line endings inside the body are preserved byte-for-byte.
+	 *
+	 * An empty/whitespace-only fence resolves to `""` (with `error` set) so callers
+	 * can reject it with the same `code` falsiness check as the no-fence case.
+	 */
+	code: string | null;
+	/** Human-readable reason, set whenever `code` is `null` or empty. */
+	error?: string;
+}
+
+// A fenced-code line: up to 3 leading spaces (CommonMark), then >=3 backticks,
+// then the info string. Spaces only — tabs/blockquote(`>`)/callout prefixes are
+// intentionally NOT treated as fences (documented as out of scope for v1).
+const FENCE_LINE = /^ {0,3}(`{3,})(.*)$/;
+
+const NO_FENCE_ERROR =
+	"No ```js (or ```javascript) code block found in the note.";
+const EMPTY_FENCE_ERROR = "The ```js code block is empty.";
+
+/**
+ * Extract the script body from a markdown note for use as a QuickAdd user script.
+ *
+ * Selection rule (v1): run the FIRST ```js / ```javascript fenced block; prose and
+ * any other blocks are ignored ("one note = one script"). The info string is
+ * matched on its first whitespace-delimited token (case-insensitive), so
+ * ```js, ```javascript, and ```js extra all qualify while ```jsx / ```json do not.
+ *
+ * Fence rules follow CommonMark: the block closes at the first line that is a bare
+ * run of >= the opening backtick count with nothing but whitespace after it. A line
+ * with trailing content (e.g. `console.log("```")`) therefore does NOT close the
+ * block; a bare ``` line inside a template literal WILL — wrap the body in 4+
+ * backticks to embed a 3-backtick line.
+ *
+ * Pure and App-free: safe to call from the package-preview module and from unit
+ * tests under jsdom.
+ */
+export function extractScriptFromMarkdown(
+	content: string,
+): ScriptExtractionResult {
+	let pos = 0;
+	let lineIndex = 0;
+	let inFence = false;
+	let openLen = 0;
+	let bodyStartOffset = 0;
+	let linesBeforeBody = 0;
+
+	while (pos <= content.length) {
+		const nl = content.indexOf("\n", pos);
+		const lineEnd = nl === -1 ? content.length : nl;
+		const lineText = content.slice(pos, lineEnd).replace(/\r$/, "");
+		const nextPos = nl === -1 ? content.length + 1 : nl + 1;
+
+		const match = FENCE_LINE.exec(lineText);
+
+		if (!inFence) {
+			if (match) {
+				const firstToken = match[2].trim().split(/\s+/)[0]?.toLowerCase();
+				if (firstToken === "js" || firstToken === "javascript") {
+					inFence = true;
+					openLen = match[1].length;
+					bodyStartOffset = nextPos;
+					linesBeforeBody = lineIndex + 1;
+				}
+			}
+		} else if (
+			match &&
+			match[1].length >= openLen &&
+			match[2].trim().length === 0
+		) {
+			return finish(content.slice(bodyStartOffset, pos), linesBeforeBody);
+		}
+
+		pos = nextPos;
+		lineIndex++;
+		if (nl === -1) break;
+	}
+
+	if (inFence) {
+		// Unclosed fence: treat the remainder of the note as the body.
+		return finish(content.slice(bodyStartOffset), linesBeforeBody);
+	}
+
+	return { code: null, error: NO_FENCE_ERROR };
+}
+
+function finish(body: string, linesBeforeBody: number): ScriptExtractionResult {
+	if (body.trim().length === 0) {
+		return { code: "", error: EMPTY_FENCE_ERROR };
+	}
+	return { code: "\n".repeat(linesBeforeBody) + body };
+}


### PR DESCRIPTION
Closes #1065.

## What & why
A Macro user script currently must be a standalone `.js` file, which Obsidian can't open or edit natively — especially painful on mobile. This lets a user script live in a regular note instead: QuickAdd runs the **first** ` ```js ` (or ` ```javascript `) fenced block and ignores the surrounding prose and any other code blocks.

Verified in the dev vault (QuickAdd 2.13.1) that the gap was real before this change: the picker's `/\.js$/` filter excluded notes, and pointing a command at a `.md` fed raw markdown to `new Function` → `SyntaxError`.

## How
- **`extractScriptFromMarkdown`** (new, pure, App-free line scanner): first js fence wins; CommonMark fence rules (a line with trailing content like `console.log("```")` doesn't close the block; wrap with 4+ backticks to embed a bare ` ``` `); CRLF preserved byte-for-byte; empty-vs-missing fence distinguished; leading blank-line padding keeps runtime error line numbers near the note's own.
- **`getUserScript`** branches on `.md` and feeds the extracted body to the *same* CommonJS `Function` shim. So `module.exports` / `exports.default` / `settings` / `entry` / `name::member` and **all five** `getUserScript` callers (macro command, conditional script-condition, `::member`, single-macro entry, and the one-page **preflight** scanner) work unchanged. The `.js` path is byte-identical → zero regression. A note with no runnable fence shows a `Notice` and the macro continues (no silent failure, no crash).
- **Script pickers** (Macro Builder + Conditional modal): one unified list of `.js` files **and** notes-that-have-a-code-block (cheap metadata-cache pre-filter), with a validate-on-select backstop that reads the note and reports the precise reason if there's no runnable fence. Notes resolve by **path** so a bare basename never picks a note over a same-named `.js`; a direct-vault fallback covers a cold cache.
- **Package transparency** (`packagePreview`): a bundled `.md` whose content has a runnable js fence is now treated as executable, closing a disclosure-gate bypass (an orphan note labeled `template` would otherwise slip the gate, land on disk, and run via any macro pointing at its path). Plain `.md` templates are *not* flagged.
- **Package import** (`packageImportService`): a note script's command name (= its vault path, optionally `path::member`) is kept in sync when the asset is written to a new destination on import.

## Design & review
Designed and reviewed before implementation (gap confirmed live; design challenged by an ultracode multi-lens pass + adversarial reviewers). Decisions: unified single picker; no-fence ⇒ Notice + continue; precise decode-and-extract for the transparency gate. The implementation diff was then put through a second adversarial review — its findings (typed-resolution basename collision, import name staleness, and *not* documenting the feature in the stable 2.13.1 docs snapshot) are all addressed here.

## Tests
- `extractScriptFromMarkdown.test.ts` — 16 cases (selection rule, fence edges, CRLF, frontmatter, callout/tilde rejected, empty vs missing, padding).
- `getUserScript` — `.md` load + `::member` + no-fence Notice + non-`module.exports` body.
- `scriptCandidates.test.ts` — resolver picks `.js` over a same-named note; path/cold-cache resolution; validate-on-select reasons.
- `packagePreview.test.ts` — orphan `.md` with a js fence is critical/review-required; plain `.md` template is not.
- `packageImportService.test.ts` — note-script `name` tracks a remapped asset path.
- Full suite green (1976 passing); `tsc` + ESLint clean; production build OK; docs build (Next) OK.

## Verification (dev vault, real Obsidian)
- A macro pointing at a note ran its ` ```js ` block; the side effect **persisted** and the decoy ` ```python ` block was correctly ignored.
- A no-fence note was graceful — the macro continued to its next command, no error thrown.

## Notes
- `main.js` / `styles.css` are gitignored here and built in CI/release, so they're not in this diff.
- Feature docs are in `docs/docs/` (Next) only; they'll snapshot into the version docs when the next release is cut (documenting it in the stable 2.13.1 snapshot would claim support that release doesn't have).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User scripts can now be stored either as standalone `.js` files or inside a note’s first `js`/`javascript` code block.
  * Script pickers and prompts now recognize both formats with clearer labels and guidance.
  * Imported packages keep note-based script references in sync when script destinations change.
* **Bug Fixes**
  * Improved detection and user-facing messaging when no runnable script block is found.
  * Package import preview more accurately flags markdown notes that contain executable JavaScript.
* **Documentation**
  * Updated user guidance for placing and referencing note-embedded scripts and macro script commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->