### PR TITLE
feat: icon for choice commands on the mobile toolbar (#766)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import { CommandType } from "./types/macros/CommandType";
 import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { isMajorUpdate } from "./utils/semver";
+import { resolveChoiceIcon } from "./utils/choiceUtils";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
 import { setQuickAddInstance } from "./quickAddInstance";
@@ -302,6 +303,7 @@ export default class QuickAdd extends Plugin {
 			this.addCommand({
 				id: `choice:${choiceId}`,
 				name: choice.name,
+				icon: resolveChoiceIcon(choice),
 				callback: async () => {
 					try {
 						const current = this.getChoiceById(choiceId);

--- a/src/types/choices/Choice.ts
+++ b/src/types/choices/Choice.ts
@@ -8,6 +8,7 @@ export abstract class Choice implements IChoice {
 	type: ChoiceType;
 	command: boolean;
 	onePageInput?: "always" | "never" | undefined;
+	icon?: string;
 
 	protected constructor(name: string, type: ChoiceType) {
 		this.id = uuidv4();

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -7,4 +7,10 @@ export default interface IChoice {
 	command: boolean;
 	/** Per-choice override for one-page flow. undefined = follow global setting */
 	onePageInput?: "always" | "never" | undefined;
+	/**
+	 * Optional per-choice icon id (lucide/Obsidian) for the registered command,
+	 * shown on the mobile toolbar and in the command palette. undefined = use the
+	 * per-type default (see resolveChoiceIcon). Never persisted as a default.
+	 */
+	icon?: string;
 }

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type IChoice from "src/types/choices/IChoice";
 import type IMultiChoice from "src/types/choices/IMultiChoice";
-import { flattenChoices, flattenChoicesWithPath } from "./choiceUtils";
+import type { ChoiceType } from "src/types/choices/choiceType";
+import {
+	defaultIconForChoiceType,
+	flattenChoices,
+	flattenChoicesWithPath,
+	resolveChoiceIcon,
+} from "./choiceUtils";
 
 let idCounter = 0;
 function choice(name: string): IChoice {
@@ -77,5 +83,63 @@ describe("flattenChoicesWithPath", () => {
 		const broken = multi("Broken", undefined as unknown as IChoice[]);
 
 		expect(flattenChoicesWithPath([broken])).toHaveLength(1);
+	});
+});
+
+describe("defaultIconForChoiceType", () => {
+	it("maps each choice type to a meaningful lucide id", () => {
+		expect(defaultIconForChoiceType("Template")).toBe("file-text");
+		expect(defaultIconForChoiceType("Capture")).toBe("pencil");
+		expect(defaultIconForChoiceType("Macro")).toBe("terminal");
+		expect(defaultIconForChoiceType("Multi")).toBe("folder");
+	});
+
+	it("falls back to a valid icon for an unexpected runtime type", () => {
+		// data.json is not runtime-validated; an imported/hand-edited choice could
+		// carry a type outside the union. The default arm must never return
+		// undefined, or Obsidian re-renders the question-mark glyph.
+		expect(defaultIconForChoiceType("Script" as ChoiceType)).toBe("file-plus");
+		expect(defaultIconForChoiceType(undefined as unknown as ChoiceType)).toBe(
+			"file-plus",
+		);
+	});
+});
+
+describe("resolveChoiceIcon", () => {
+	function choiceWith(type: ChoiceType, icon?: string): IChoice {
+		return { name: "c", id: `c-${idCounter++}`, type, command: true, icon };
+	}
+
+	it("uses the per-type default when no override is set", () => {
+		expect(resolveChoiceIcon(choiceWith("Template"))).toBe("file-text");
+		expect(resolveChoiceIcon(choiceWith("Capture"))).toBe("pencil");
+		expect(resolveChoiceIcon(choiceWith("Macro"))).toBe("terminal");
+		expect(resolveChoiceIcon(choiceWith("Multi"))).toBe("folder");
+	});
+
+	it("prefers a non-empty per-choice override", () => {
+		expect(resolveChoiceIcon(choiceWith("Template", "star"))).toBe("star");
+		expect(resolveChoiceIcon(choiceWith("Macro", "rocket"))).toBe("rocket");
+	});
+
+	it("falls back to the default for a blank or whitespace-only override", () => {
+		expect(resolveChoiceIcon(choiceWith("Template", ""))).toBe("file-text");
+		expect(resolveChoiceIcon(choiceWith("Capture", "   "))).toBe("pencil");
+	});
+
+	it("trims a padded override", () => {
+		expect(resolveChoiceIcon(choiceWith("Template", "  star  "))).toBe("star");
+	});
+
+	it("ignores a non-string override from malformed data without throwing", () => {
+		const bad = {
+			name: "c",
+			id: `c-${idCounter++}`,
+			type: "Template" as ChoiceType,
+			command: true,
+			icon: 123 as unknown as string,
+		};
+		expect(() => resolveChoiceIcon(bad)).not.toThrow();
+		expect(resolveChoiceIcon(bad)).toBe("file-text");
 	});
 });

--- a/src/utils/choiceUtils.ts
+++ b/src/utils/choiceUtils.ts
@@ -1,8 +1,53 @@
 import type IMultiChoice from "src/types/choices/IMultiChoice";
 import type IChoice from "../types/choices/IChoice";
+import type { ChoiceType } from "../types/choices/choiceType";
 
 function isMultiChoice(choice: IChoice): choice is IMultiChoice {
 	return choice.type === "Multi";
+}
+
+/**
+ * Per-type default icon for a choice's registered command. Obsidian renders the
+ * "question-mark-glyph" ("?") fallback for any command added without an `icon`,
+ * which is what QuickAdd commands showed on the mobile editing toolbar (#766).
+ * Each choice type maps to a semantically meaningful lucide id.
+ *
+ * The `default` arm is load-bearing, not decorative: `data.json` is not
+ * runtime-validated before commands are registered, and the repo compiles with
+ * `strict: false` and no switch-exhaustiveness lint — so an imported or
+ * hand-edited choice carrying an unexpected `type` would otherwise fall through
+ * to `undefined` and silently re-introduce the "?".
+ */
+export function defaultIconForChoiceType(type: ChoiceType): string {
+	switch (type) {
+		case "Template":
+			return "file-text";
+		case "Capture":
+			return "pencil";
+		case "Macro":
+			return "terminal";
+		case "Multi":
+			return "folder";
+		default:
+			return "file-plus";
+	}
+}
+
+/**
+ * Resolve the icon id used when registering a choice's command. A non-empty
+ * per-choice override wins; otherwise the per-type default. Resolved at
+ * registration time only — defaults are never written to `data.json`, so the
+ * settings payload stays clean and the defaults can evolve freely. `choice.icon`
+ * is an optional override (absent for every choice unless explicitly set).
+ *
+ * The `typeof` guard (not just `?.`) is deliberate: `data.json` is not
+ * runtime-validated, so a hand-edited or imported choice could carry a
+ * non-string `icon` (e.g. a number or object). Optional chaining alone would
+ * let `.trim()` throw and abort command registration / plugin load.
+ */
+export function resolveChoiceIcon(choice: IChoice): string {
+	const override = typeof choice.icon === "string" ? choice.icon.trim() : "";
+	return override || defaultIconForChoiceType(choice.type);
 }
 
 /**


### PR DESCRIPTION
Closes #766

## Problem

On the Obsidian **mobile editing toolbar**, every QuickAdd command showed the default question-mark glyph instead of a meaningful icon.

**Root cause (still live):** `addCommandForChoice` registered each choice command with no `icon`. Obsidian's mobile toolbar builder falls back to `question-mark-glyph` for any iconless command:

```js
// Obsidian compileToolbar()
var i = n.icon;  i || (i = "question-mark-glyph");  tv(t, i)
```

Verified in the dev vault before the fix: all 26 `quickadd:choice:*` commands had `icon: null`.

## Fix

Resolve a **per-type default icon at registration time** and pass it to `addCommand`:

| Choice type | Icon |
|---|---|
| Template | `file-text` |
| Capture | `pencil` |
| Macro | `terminal` |
| Multi | `folder` |
| _(unexpected runtime type)_ | `file-plus` |

- **No migration, no `data.json` bloat** — defaults are resolved at registration time only, never persisted. Every existing choice gains an icon for free.
- **`default` arm is load-bearing**, not decorative: `data.json` is not runtime-validated and the repo compiles with `strict: false` and no switch-exhaustiveness lint, so a missing case would return `undefined` and silently re-introduce the `?`.
- An optional per-choice `icon?` override is honored when set (a non-empty string wins; `typeof`-guarded so malformed non-string data can't throw during plugin load). There's **no picker UI yet** — see follow-up below.

The resolver lives in `src/utils/choiceUtils.ts` (an App-free core util) and is imported by `main.ts`, keeping command-icon logic out of GUI metadata.

## Verification

- **Unit:** `resolveChoiceIcon` / `defaultIconForChoiceType` — override wins, blank/whitespace falls back, all four type defaults, the `default` arm, and non-string data doesn't throw. Full suite: 2021 passing.
- **Dev-vault e2e (real Obsidian):** after the change, iconless choice commands dropped **26 → 0**; Template→`file-text`, Capture→`pencil`, Macro→`terminal`; a synthetic command-enabled **Multi**→`folder`; an override→its value; a whitespace override→the type default.
- `tsc --noEmit`, `eslint .`, and `build-with-lint` all clean.

## Known limitation (Obsidian-side, documented)

Obsidian's `compileToolbar` caches by the command-id list and only rebuilds when that list changes. For a command **already pinned** to a user's mobile toolbar, the new icon appears after the next app restart (it self-heals, no user action) — consistent with QuickAdd's existing "Requires a reload" pattern for the ribbon toggle. Newly added toolbar entries and the command palette pick up the icon immediately.

## Scope note / follow-up

This is the focused fix for #766: it removes the `?` for everyone with zero config. A per-choice **icon picker** (a context-menu "Set icon…" over the icon list writing the `icon?` override) was designed and adversarially reviewed but intentionally **deferred** — it's a customization feature beyond the report, with extra UI surface and the toolbar-cache caveat. The `icon?` field added here is the seam for it if there's demand.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choices now support custom icon assignments. Assign a custom icon to individual choices, which overrides the default icon for that choice type and displays in registered commands. Template, Capture, Macro, and Multi choice types have default icons automatically assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->