### PR TITLE
feat(template): run a template from the configured folder without a per-file choice (#1023)

### DIFF
--- a/docs/docs/Advanced/CLI.md
+++ b/docs/docs/Advanced/CLI.md
@@ -39,6 +39,29 @@ Check which inputs are still missing before a non-interactive run.
 obsidian vault=dev quickadd:check choice="Daily log"
 ```
 
+### `quickadd:run-template`
+
+Create a new note from a template file — no dedicated Template choice required.
+This is the scriptable form of the **New note from template** command.
+
+```bash
+obsidian vault=dev quickadd:run-template \
+  path="Templates/Meeting.md" \
+  value-value="2026-06-14 Standup"
+```
+
+- `path=` is the template file (vault-relative). A leading slash is allowed and a
+  missing `.md` extension is added, matching how Template choices resolve paths.
+  If no file resolves there, the command returns `{"ok":false}` up front.
+- The new note's name comes from `{{value}}` — pass it as `value-value=...`. A
+  non-interactive run with an empty or missing name returns `missingFlags`
+  instead of creating an unnamed note. The note is created in Obsidian's
+  "Default location for new notes".
+- The picker (interactive command) only lists templates inside your configured
+  template folder(s); `path=` here is explicit, so any vault file resolves.
+- Like `quickadd:run`, name collisions on the target note still prompt
+  interactively (the file-exists choice is not a pre-collected input).
+
 ## Passing variables
 
 QuickAdd CLI supports three variable patterns:

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -4,6 +4,10 @@ title: Template
 
 The template choice type is not meant to be a replacement for [Templater](https://github.com/SilentVoid13/Templater/) plugin or core `Templates`. It's meant to augment them, to add more possibilities. You can use both QuickAdd format syntax in a Templater template - and both will work.
 
+:::tip Run a template without making a choice
+If you just want to spin up a note from a template in your [template folder](/Settings.md#templates--properties) without maintaining a Template choice per file, use the **New note from template** command. It lists the templates in your configured folder, prompts for the new note's name, and creates it in Obsidian's default location. When a template folder is configured, the same entry also appears in **Run QuickAdd** — at the bottom by default, or move it to the top / hide it under [Settings → Choice Picker](/Settings.md#choice-picker) — and it's scriptable via [`quickadd:run-template`](/Advanced/CLI.md#quickaddrun-template). Make a Template choice (below) when you need a fixed location, file-name format, linking, or a hotkey.
+:::
+
 The Template choice builder groups its settings into four sections: **Template** (template path and file name format), **Location** (where the file is created), **Linking** (whether and how to link to the created file), and **Behavior** (what happens when the file already exists, and how the file is opened).
 
 ![The QuickAdd Template builder, showing the Template, Location, Linking, and Behavior sections](/img/choices/template-builder.png)

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -12,6 +12,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 ## Choice Picker
 
 - **Search nested choices** — When searching in the choice picker, also match choices nested inside Multi choices and show their path. Note that nested matches can outrank same-level ones. Disable to search only the open level.
+- **"New note from template" in the launcher** — Where the row that lists templates from your configured template folder appears in Run QuickAdd, so you can create a note from a template without a dedicated Template choice. *Show at the bottom* (default) keeps your most-used choice in the first slot; *Show at the top* makes it the first item; *Hide* removes it. Only appears when a [template folder](#templates--properties) is configured; the **New note from template** command works regardless.
 
 ## Input
 

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -1,9 +1,22 @@
 import type IChoice from "./types/choices/IChoice";
+import type ITemplateChoice from "./types/choices/ITemplateChoice";
+import type ICaptureChoice from "./types/choices/ICaptureChoice";
 import type { MacroAbortError } from "./errors/MacroAbortError";
 import type { ChoiceOutcome } from "./types/ChoiceOutcome";
 
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
+	/**
+	 * Executes a Template/Capture choice and returns its structured outcome
+	 * (success with the affected file, error, or cancelled) instead of the void
+	 * {@link execute}. Callers that must report real success/failure — the URI
+	 * x-callback handler and the `quickadd:run-template` CLI — use this so a
+	 * swallowed engine failure can't masquerade as success. Optional so existing
+	 * stubs remain valid.
+	 */
+	executeWithOutcome?(
+		choice: ITemplateChoice | ICaptureChoice,
+	): Promise<ChoiceOutcome>;
 	variables: Map<string, unknown>;
 	/**
 	 * Records the structured outcome of the current execution so an orchestrator

--- a/src/cli/registerQuickAddCliHandlers.test.ts
+++ b/src/cli/registerQuickAddCliHandlers.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliData, CliFlags } from "obsidian";
+import { TFile } from "obsidian";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import type QuickAdd from "../main";
 import { registerQuickAddCliHandlers } from "./registerQuickAddCliHandlers";
@@ -136,6 +137,10 @@ describe("registerQuickAddCliHandlers", () => {
 		ChoiceExecutorMock.mockImplementation(function ChoiceExecutorMock() {
 			const executor: IChoiceExecutor = {
 				execute: vi.fn().mockResolvedValue(undefined),
+				executeWithOutcome: vi.fn().mockResolvedValue({
+					status: "success",
+					file: { path: "Created Note.md" },
+				}),
 				variables: new Map<string, unknown>(),
 				consumeAbortSignal: vi.fn().mockReturnValue(null),
 			};
@@ -160,6 +165,7 @@ describe("registerQuickAddCliHandlers", () => {
 		expect(handlers.map((handler) => handler.command)).toEqual([
 			"quickadd",
 			"quickadd:run",
+			"quickadd:run-template",
 			"quickadd:list",
 			"quickadd:check",
 			"quickadd:package-preview",
@@ -230,6 +236,229 @@ describe("registerQuickAddCliHandlers", () => {
 		expect(payload.missingInputCount).toBeUndefined();
 		expect(payload.missingFlags).toContain("value-title=<value>");
 		expect(executors[0].execute).not.toHaveBeenCalled();
+	});
+
+	function withTemplateFile(plugin: QuickAdd, existingPath: string) {
+		(plugin as unknown as { app: unknown }).app = {
+			vault: {
+				getAbstractFileByPath: vi.fn((path: string) => {
+					if (path !== existingPath) return null;
+					const file = new TFile();
+					file.path = path;
+					return file;
+				}),
+			},
+		};
+	}
+
+	it("returns an error when run-template is given no path", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+		const payload = JSON.parse(String(await run!.handler({})));
+		expect(payload.ok).toBe(false);
+		expect(payload.command).toBe("quickadd:run-template");
+		expect(executors).toHaveLength(0);
+	});
+
+	it("returns an error when the template path does not resolve to a file", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+		const payload = JSON.parse(
+			String(await run!.handler({ path: "Templates/Missing.md" })),
+		);
+		expect(payload.ok).toBe(false);
+		expect(executors).toHaveLength(0);
+	});
+
+	// The note name is validated up front (before any executor): an absent OR
+	// blank {{value}} can't name the note. The requirement collector consumes a
+	// provided-but-empty value (so it can't flag it) and the engine then swallows
+	// the resulting "File name is empty" throw — so run-template must reject blanks
+	// itself to avoid a false ok:true with no note created.
+	it.each([
+		["absent", {}],
+		["empty string", { "value-value": "" }],
+		["whitespace", { "value-value": "   " }],
+		["null via vars", { vars: JSON.stringify({ value: null }) }],
+	])(
+		"rejects a %s note name on a non-interactive run-template (honest envelope)",
+		async (_label, extra) => {
+			const { plugin, handlers } = createPlugin([]);
+			withTemplateFile(plugin, "Templates/Daily.md");
+			registerQuickAddCliHandlers(plugin);
+			const run = handlers.find((h) => h.command === "quickadd:run-template");
+
+			const payload = JSON.parse(
+				String(await run!.handler({ path: "Templates/Daily.md", ...extra })),
+			);
+			expect(payload.ok).toBe(false);
+			expect(payload.missingFlags).toContain("value-value=<value>");
+			// Rejected before an executor is even constructed.
+			expect(executors).toHaveLength(0);
+		},
+	);
+
+	it("reports a swallowed engine failure (e.g. blank name) as ok:false, not false success", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+
+		const payload = JSON.parse(
+			String(
+				await run!.handler({ path: "Templates/Daily.md", "value-value": "Note" }),
+			),
+		);
+		// Default mock outcome is success → ok:true with the created file path.
+		expect(payload.ok).toBe(true);
+		expect(payload.file).toBe("Created Note.md");
+		expect(executors[0].executeWithOutcome).toHaveBeenCalledTimes(1);
+		expect(executors[0].execute).not.toHaveBeenCalled();
+	});
+
+	it("maps an error outcome to ok:false even when execute() would have resolved", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+		// Simulate the engine swallowing a failure (no file created) — incl. the
+		// ui=true + blank-name path that the up-front guard intentionally skips.
+		ChoiceExecutorMock.mockImplementationOnce(function () {
+			const executor: IChoiceExecutor = {
+				execute: vi.fn().mockResolvedValue(undefined),
+				executeWithOutcome: vi.fn().mockResolvedValue({ status: "error" }),
+				variables: new Map<string, unknown>(),
+				consumeAbortSignal: vi.fn().mockReturnValue(null),
+			};
+			executors.push(executor);
+			return executor;
+		});
+
+		const payload = JSON.parse(
+			String(
+				await run!.handler({
+					path: "Templates/Daily.md",
+					"value-value": "",
+					ui: "true",
+				}),
+			),
+		);
+		expect(payload.ok).toBe(false);
+		expect(String(payload.error)).toMatch(/no file/i);
+	});
+
+	it("maps a cancelled outcome to ok:false (aborted)", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+		ChoiceExecutorMock.mockImplementationOnce(function () {
+			const executor: IChoiceExecutor = {
+				execute: vi.fn().mockResolvedValue(undefined),
+				executeWithOutcome: vi
+					.fn()
+					.mockResolvedValue({ status: "cancelled", cancelKind: "user" }),
+				variables: new Map<string, unknown>(),
+				consumeAbortSignal: vi.fn().mockReturnValue(null),
+			};
+			executors.push(executor);
+			return executor;
+		});
+
+		const payload = JSON.parse(
+			String(
+				await run!.handler({ path: "Templates/Daily.md", "value-value": "X" }),
+			),
+		);
+		expect(payload.ok).toBe(false);
+		expect(payload.aborted).toBe(true);
+	});
+
+	it("returns a JSON error envelope for malformed vars (not an unhandled rejection)", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+
+		// The up-front name check parses vars=; malformed JSON must surface as the
+		// standard envelope, like quickadd:run, rather than rejecting the handler.
+		const payload = JSON.parse(
+			String(await run!.handler({ path: "Templates/Daily.md", vars: "{not json" })),
+		);
+		expect(payload.ok).toBe(false);
+		expect(payload.command).toBe("quickadd:run-template");
+		expect(String(payload.error)).toMatch(/vars/i);
+		expect(executors).toHaveLength(0);
+	});
+
+	it("ui mode skips the up-front blank-name guard and delegates to execution", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+
+		const payload = JSON.parse(
+			String(
+				await run!.handler({
+					path: "Templates/Daily.md",
+					"value-value": "",
+					ui: "true",
+				}),
+			),
+		);
+		// Not pre-rejected with missingFlags; routed through executeWithOutcome
+		// (which would prompt at runtime). Default mock outcome is success.
+		expect(payload.missingFlags).toBeUndefined();
+		expect(executors[0].executeWithOutcome).toHaveBeenCalledTimes(1);
+		expect(executors[0].execute).not.toHaveBeenCalled();
+	});
+
+	it("accepts extensionless template paths the engine would resolve", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		// Engine resolver appends .md; the CLI must accept "Templates/Daily" too.
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+
+		const payload = JSON.parse(
+			String(
+				await run!.handler({ path: "Templates/Daily", "value-value": "Note" }),
+			),
+		);
+		expect(payload.ok).toBe(true);
+		const executed = (
+			executors[0].executeWithOutcome as ReturnType<typeof vi.fn>
+		).mock.calls[0][0];
+		expect(executed.templatePath).toBe("Templates/Daily.md");
+	});
+
+	it("runs an ephemeral template choice and does not leak path= as a variable", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		withTemplateFile(plugin, "Templates/Daily.md");
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find((h) => h.command === "quickadd:run-template");
+
+		const payload = JSON.parse(
+			String(
+				await run!.handler({
+					path: "Templates/Daily.md",
+					"value-value": "My New Note",
+				}),
+			),
+		);
+
+		expect(payload.ok).toBe(true);
+		expect(executors).toHaveLength(1);
+		const executedChoice = (
+			executors[0].executeWithOutcome as ReturnType<typeof vi.fn>
+		).mock.calls[0][0];
+		expect(executedChoice.type).toBe("Template");
+		expect(executedChoice.templatePath).toBe("Templates/Daily.md");
+		expect(executors[0].variables.get("value")).toBe("My New Note");
+		expect(executors[0].variables.has("path")).toBe(false);
 	});
 
 	it("lists flattened choices and supports command filter", async () => {

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -1,5 +1,7 @@
 import type { CliData, CliFlags } from "obsidian";
 import { ChoiceExecutor } from "../choiceExecutor";
+import { createFolderTemplateChoice } from "../engine/runTemplateFromFolder";
+import { getTemplateFile } from "../utilityObsidian";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
 import type QuickAdd from "../main";
@@ -9,6 +11,8 @@ import {
 } from "../preflight/collectChoiceRequirements";
 import type IChoice from "../types/choices/IChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import {
 	analysePackagePreview,
 	readQuickAddPackage,
@@ -78,6 +82,20 @@ const LIST_FLAGS: CliFlags = {
 	},
 };
 
+const RUN_TEMPLATE_FLAGS: CliFlags = {
+	path: {
+		value: "<vault-path>",
+		description: "Path to a template file in the vault",
+	},
+	vars: {
+		value: "<json>",
+		description: "Variables object as JSON",
+	},
+	ui: {
+		description: "Allow interactive prompts",
+	},
+};
+
 const CHECK_FLAGS: CliFlags = {
 	choice: {
 		value: "<name>",
@@ -104,11 +122,13 @@ const PREVIEW_FLAGS: CliFlags = {
 };
 
 const RESERVED_RUN_PARAMS = new Set<string>(["choice", "id", "vars", "ui"]);
+const RESERVED_RUN_TEMPLATE_PARAMS = new Set<string>(["path", "vars", "ui"]);
 const RESERVED_CHECK_PARAMS = new Set<string>(["choice", "id", "vars"]);
 
 const CLI_COMMANDS = {
 	runDefault: "quickadd",
 	run: "quickadd:run",
+	runTemplate: "quickadd:run-template",
 	list: "quickadd:list",
 	check: "quickadd:check",
 	preview: "quickadd:package-preview",
@@ -253,15 +273,29 @@ function describeChoice(choice: IChoice) {
 	};
 }
 
-async function runChoiceHandler(
+/**
+ * Shared execution tail for any already-resolved choice (persisted via
+ * `quickadd:run` or built ad-hoc via `quickadd:run-template`): variable wiring,
+ * the non-interactive missing-input guard, execution, and the JSON envelope.
+ */
+async function runResolvedChoice(
 	plugin: QuickAdd,
 	params: CliData,
 	command: string,
+	choice: IChoice,
+	reservedParams: Set<string>,
+	/**
+	 * Report the real execution outcome via executeWithOutcome (Template/Capture
+	 * only) instead of trusting that the void execute() resolving means success.
+	 * The Template/Capture engines swallow runtime failures (missing/empty file
+	 * name, failing inline script, write error) — without this the CLI would
+	 * report ok:true with no file created. quickadd:run keeps the legacy path.
+	 */
+	useOutcome = false,
 ): Promise<string> {
 	const startedAt = Date.now();
 
 	try {
-		const choice = resolveChoiceFromParams(plugin, params);
 		if (choice.type === "Multi") {
 			return serialize({
 				ok: false,
@@ -271,7 +305,7 @@ async function runChoiceHandler(
 			});
 		}
 
-		const variables = extractVariables(params, RESERVED_RUN_PARAMS);
+		const variables = extractVariables(params, reservedParams);
 		const choiceExecutor = new ChoiceExecutor(
 			plugin.app,
 			plugin,
@@ -304,6 +338,47 @@ async function runChoiceHandler(
 			}
 		}
 
+		if (
+			useOutcome &&
+			(choice.type === "Template" || choice.type === "Capture") &&
+			typeof choiceExecutor.executeWithOutcome === "function"
+		) {
+			const outcome = await choiceExecutor.executeWithOutcome(
+				choice as ITemplateChoice | ICaptureChoice,
+			);
+			const durationMs = Date.now() - startedAt;
+
+			if (outcome.status === "success") {
+				return serialize({
+					ok: true,
+					command,
+					choice: describeChoice(choice),
+					file: outcome.file?.path,
+					durationMs,
+				});
+			}
+			if (outcome.status === "cancelled") {
+				return serialize({
+					ok: false,
+					command,
+					error:
+						outcome.cancelKind === "user"
+							? "Execution cancelled by user"
+							: "Execution aborted",
+					aborted: true,
+					choice: describeChoice(choice),
+					durationMs,
+				});
+			}
+			return serialize({
+				ok: false,
+				command,
+				error: "Choice execution failed; no file was created.",
+				choice: describeChoice(choice),
+				durationMs,
+			});
+		}
+
 		await choiceExecutor.execute(choice);
 		const aborted = choiceExecutor.consumeAbortSignal?.();
 		const durationMs = Date.now() - startedAt;
@@ -325,6 +400,114 @@ async function runChoiceHandler(
 			choice: describeChoice(choice),
 			durationMs,
 		});
+	} catch (error) {
+		return serialize({
+			ok: false,
+			command,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+async function runChoiceHandler(
+	plugin: QuickAdd,
+	params: CliData,
+	command: string,
+): Promise<string> {
+	let choice: IChoice;
+	try {
+		choice = resolveChoiceFromParams(plugin, params);
+	} catch (error) {
+		return serialize({
+			ok: false,
+			command,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	return runResolvedChoice(
+		plugin,
+		params,
+		command,
+		choice,
+		RESERVED_RUN_PARAMS,
+	);
+}
+
+async function runTemplateHandler(
+	plugin: QuickAdd,
+	params: CliData,
+): Promise<string> {
+	const command = CLI_COMMANDS.runTemplate;
+
+	// Wrapped so malformed input (e.g. invalid vars= JSON parsed by the up-front
+	// name check) returns the standard {ok:false,error} envelope instead of
+	// rejecting the handler — matching quickadd:run and run-template's ui path.
+	try {
+		const path = typeof params.path === "string" ? params.path.trim() : "";
+		if (!path) {
+			return serialize({
+				ok: false,
+				command,
+				error: "Missing template path. Provide path=<vault-path>.",
+			});
+		}
+
+		// Honest envelope: confirm the template file exists up front rather than
+		// letting the engine swallow a missing-file error and report ok:true. Use
+		// the engine's own resolver (getTemplateFile) so the CLI accepts exactly the
+		// paths the engine does — leading slash stripped, ".md" appended — instead of
+		// a stricter raw lookup that rejects "Templates/Daily" or "/Templates/Daily.md".
+		const file = getTemplateFile(plugin.app, path);
+		if (!file) {
+			return serialize({
+				ok: false,
+				command,
+				error: `No template file found at '${path}'.`,
+			});
+		}
+
+		// Build from the resolved path so the note-name prompt header (basename) and
+		// the content read agree with what the engine will open.
+		const choice = createFolderTemplateChoice(file.path);
+
+		// Honest envelope for the note name. The name is {{value}}; when it's provided
+		// but blank, the requirement collector consumes it (so the standard guard sees
+		// nothing missing) and the engine then throws "File name is empty" and swallows
+		// it — reporting a false ok:true with no note created. Reject a blank name up
+		// front for non-interactive runs (ui mode can still prompt). Headless runs have
+		// no editor selection, so {{value}} comes solely from this variable.
+		if (!isTruthy(params.ui)) {
+			const variables = extractVariables(params, RESERVED_RUN_TEMPLATE_PARAMS);
+			const name = variables.value;
+			if (name == null || String(name).trim().length === 0) {
+				return serialize({
+					ok: false,
+					command,
+					error: "Missing required inputs for non-interactive CLI run.",
+					choice: describeChoice(choice),
+					missing: [
+						{
+							id: "value",
+							label: "New note name",
+							type: "text",
+							source: "collected",
+							optionCount: 0,
+						},
+					],
+					missingFlags: ["value-value=<value>"],
+				});
+			}
+		}
+
+		return await runResolvedChoice(
+			plugin,
+			params,
+			command,
+			choice,
+			RESERVED_RUN_TEMPLATE_PARAMS,
+			/* useOutcome */ true,
+		);
 	} catch (error) {
 		return serialize({
 			ok: false,
@@ -496,6 +679,12 @@ export function registerQuickAddCliHandlers(plugin: QuickAdd): boolean {
 		"Run a QuickAdd choice",
 		RUN_FLAGS,
 		(params: CliData) => runChoiceHandler(plugin, params, CLI_COMMANDS.run),
+	);
+	register(
+		CLI_COMMANDS.runTemplate,
+		"Create a new note from a template file (no Template choice required)",
+		RUN_TEMPLATE_FLAGS,
+		(params: CliData) => runTemplateHandler(plugin, params),
 	);
 	register(
 		CLI_COMMANDS.list,

--- a/src/commandLabels.ts
+++ b/src/commandLabels.ts
@@ -1,5 +1,6 @@
 export const QUICK_ADD_COMMAND_LABELS = {
 	run: "Run",
+	runTemplateFromFolder: "New note from template",
 	applyTemplate: "Apply template to active note",
 	reloadDev: "Reload (dev)",
 	testDev: "Test (dev)",

--- a/src/engine/runTemplateFromFolder.test.ts
+++ b/src/engine/runTemplateFromFolder.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import type QuickAdd from "../main";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import { VALUE_SYNTAX } from "../constants";
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: { Suggest: vi.fn() },
+}));
+
+import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
+import {
+	collectChoiceRequirements,
+	getUnresolvedRequirements,
+} from "../preflight/collectChoiceRequirements";
+import {
+	createFolderTemplateChoice,
+	hasConfiguredTemplateFolders,
+	runTemplateFromFolder,
+} from "./runTemplateFromFolder";
+
+const suggestMock = vi.mocked(GenericSuggester.Suggest);
+
+function tfile(path: string): TFile {
+	const segments = path.split("/");
+	const name = segments[segments.length - 1];
+	return {
+		path,
+		name,
+		basename: name.replace(/\.[^.]+$/, ""),
+		extension: name.includes(".") ? name.split(".").pop()! : "",
+	} as TFile;
+}
+
+function createExecutor(): IChoiceExecutor {
+	return {
+		execute: vi.fn().mockResolvedValue(undefined),
+		variables: new Map<string, unknown>(),
+		consumeAbortSignal: vi.fn().mockReturnValue(null),
+	} as unknown as IChoiceExecutor;
+}
+
+function createPlugin(overrides: {
+	templateFolderPaths?: string[];
+	templateFiles?: TFile[];
+}): QuickAdd {
+	return {
+		settings: {
+			templateFolderPaths: overrides.templateFolderPaths ?? [],
+		},
+		getTemplateFiles: vi.fn(() => overrides.templateFiles ?? []),
+		manifest: { id: "quickadd" },
+	} as unknown as QuickAdd;
+}
+
+const app = {} as App;
+
+describe("createFolderTemplateChoice", () => {
+	it("builds an openable Template choice named after the file basename", () => {
+		const choice = createFolderTemplateChoice("Templates/Daily Note.md");
+
+		expect(choice.type).toBe("Template");
+		expect(choice.name).toBe("Daily Note");
+		expect(choice.templatePath).toBe("Templates/Daily Note.md");
+		expect(choice.openFile).toBe(true);
+	});
+
+	it("enables fileNameFormat with VALUE_SYNTAX so the name prompt is visible to preflight", () => {
+		// Load-bearing: collectChoiceRequirements only scans the format when enabled.
+		const choice = createFolderTemplateChoice("Templates/Daily.md");
+		expect(choice.fileNameFormat.enabled).toBe(true);
+		expect(choice.fileNameFormat.format).toBe(VALUE_SYNTAX);
+		// Default location for new notes — no folder prompt.
+		expect(choice.folder.enabled).toBe(false);
+	});
+
+	it("handles extensionless and nested paths for the display name", () => {
+		expect(createFolderTemplateChoice("note").name).toBe("note");
+		expect(createFolderTemplateChoice("a/b/c/My Template.md").name).toBe(
+			"My Template",
+		);
+		expect(createFolderTemplateChoice("Canvas Tpl.canvas").name).toBe(
+			"Canvas Tpl",
+		);
+	});
+
+	it("returns a fresh uuid id each call (never persisted, no deterministic collision)", () => {
+		const a = createFolderTemplateChoice("Templates/X.md");
+		const b = createFolderTemplateChoice("Templates/X.md");
+		expect(a.id).not.toBe(b.id);
+	});
+});
+
+describe("hasConfiguredTemplateFolders", () => {
+	it("is false for an empty/blank folder list", () => {
+		expect(hasConfiguredTemplateFolders(createPlugin({}))).toBe(false);
+		expect(
+			hasConfiguredTemplateFolders(
+				createPlugin({ templateFolderPaths: ["  ", "/"] }),
+			),
+		).toBe(false);
+	});
+
+	it("is true when at least one folder is configured", () => {
+		expect(
+			hasConfiguredTemplateFolders(
+				createPlugin({ templateFolderPaths: ["Templates"] }),
+			),
+		).toBe(true);
+	});
+});
+
+describe("runTemplateFromFolder", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("runs a given template path directly without a picker or config gate", async () => {
+		const executor = createExecutor();
+		// No template folders configured, but an explicit path must still run.
+		await runTemplateFromFolder(app, createPlugin({}), {
+			templatePath: "Templates/Daily.md",
+			choiceExecutor: executor,
+		});
+
+		expect(executor.execute).toHaveBeenCalledTimes(1);
+		const choice = (executor.execute as ReturnType<typeof vi.fn>).mock
+			.calls[0][0] as ITemplateChoice;
+		expect(choice.templatePath).toBe("Templates/Daily.md");
+		expect(choice.fileNameFormat.enabled).toBe(true);
+	});
+
+	it("does not execute when interactive and no template folder is configured", async () => {
+		const executor = createExecutor();
+		await runTemplateFromFolder(app, createPlugin({}), {
+			choiceExecutor: executor,
+		});
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("does not execute when the configured folder has no template files", async () => {
+		const executor = createExecutor();
+		await runTemplateFromFolder(
+			app,
+			createPlugin({ templateFolderPaths: ["Templates"], templateFiles: [] }),
+			{ choiceExecutor: executor },
+		);
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("runs the picked template when the user selects one", async () => {
+		const executor = createExecutor();
+		suggestMock.mockResolvedValueOnce("Templates/Daily.md");
+		await runTemplateFromFolder(
+			app,
+			createPlugin({
+				templateFolderPaths: ["Templates"],
+				templateFiles: [tfile("Templates/Daily.md")],
+			}),
+			{ choiceExecutor: executor },
+		);
+		expect(executor.execute).toHaveBeenCalledTimes(1);
+		const choice = (executor.execute as ReturnType<typeof vi.fn>).mock
+			.calls[0][0] as ITemplateChoice;
+		expect(choice.templatePath).toBe("Templates/Daily.md");
+	});
+
+	it("does not execute when the picker is cancelled", async () => {
+		const executor = createExecutor();
+		// GenericSuggester rejects with this exact reason on dismissal.
+		suggestMock.mockRejectedValueOnce("no input given.");
+		await runTemplateFromFolder(
+			app,
+			createPlugin({
+				templateFolderPaths: ["Templates"],
+				templateFiles: [tfile("Templates/Daily.md")],
+			}),
+			{ choiceExecutor: executor },
+		);
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+});
+
+describe("createFolderTemplateChoice + real preflight collector", () => {
+	const collectorApp = {
+		workspace: { getActiveFile: () => null },
+		vault: { getAbstractFileByPath: () => null, cachedRead: async () => "" },
+	} as unknown as App;
+	const collectorPlugin = {
+		settings: { inputPrompt: "single-line", globalVariables: {} },
+	} as unknown as QuickAdd;
+
+	it("surfaces the note-name as a required input (load-bearing fileNameFormat.enabled)", async () => {
+		const executor = createExecutor();
+		const choice = createFolderTemplateChoice("Templates/Daily.md");
+		const reqs = await collectChoiceRequirements(
+			collectorApp,
+			collectorPlugin,
+			executor,
+			choice,
+		);
+		const unresolved = getUnresolvedRequirements(reqs, executor.variables);
+		expect(reqs.some((r) => r.id === "value")).toBe(true);
+		expect(unresolved.some((r) => r.id === "value")).toBe(true);
+	});
+
+	it("negative control: disabling fileNameFormat hides the note-name requirement", async () => {
+		const executor = createExecutor();
+		const choice = createFolderTemplateChoice("Templates/Daily.md");
+		choice.fileNameFormat = { enabled: false, format: VALUE_SYNTAX };
+		const reqs = await collectChoiceRequirements(
+			collectorApp,
+			collectorPlugin,
+			executor,
+			choice,
+		);
+		expect(reqs.some((r) => r.id === "value")).toBe(false);
+	});
+});

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -1,0 +1,146 @@
+import type { App, TFile } from "obsidian";
+import { Notice } from "obsidian";
+import { VALUE_SYNTAX } from "../constants";
+import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import type QuickAdd from "../main";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import { TemplateChoice } from "../types/choices/TemplateChoice";
+import { normalizeTemplateFolderPaths } from "../utilityObsidian";
+import { isCancellationError, reportError } from "../utils/errorUtils";
+
+export interface RunTemplateFromFolderParams {
+	/** When set, skips the picker and runs this template directly (CLI / scripted). */
+	templatePath?: string;
+	choiceExecutor: IChoiceExecutor;
+}
+
+/** Basename without its extension, used as the ephemeral choice name + prompt header. */
+function templateDisplayName(path: string): string {
+	const file = path.split("/").pop() ?? path;
+	const dot = file.lastIndexOf(".");
+	return dot > 0 ? file.slice(0, dot) : file;
+}
+
+/**
+ * Builds the throwaway TemplateChoice that powers "New note from template".
+ * Not persisted and never added to settings.choices — it exists only for the
+ * duration of one ChoiceExecutor.execute() call.
+ *
+ * `fileNameFormat.enabled` MUST be true. Runtime is identical to `enabled:false`
+ * (TemplateChoiceEngine resolves both to VALUE_SYNTAX), but collectChoiceRequirements
+ * only scans the file-name format when it is enabled — so with `enabled:false` the
+ * implicit {{value}} note-name prompt is invisible to the non-interactive CLI guard
+ * (it would pass with zero unresolved inputs and then hang on an interactive prompt)
+ * and to the one-page input form (which would omit the name field).
+ */
+export function createFolderTemplateChoice(templatePath: string): ITemplateChoice {
+	const choice = new TemplateChoice(templateDisplayName(templatePath));
+	choice.templatePath = templatePath;
+	// Creating a brand-new note from a template — land in it, like the user expects.
+	choice.openFile = true;
+	choice.fileNameFormat = { enabled: true, format: VALUE_SYNTAX };
+	return choice;
+}
+
+/** Whether at least one template folder is configured (empty = whole vault, which we refuse). */
+export function hasConfiguredTemplateFolders(plugin: QuickAdd): boolean {
+	return (
+		normalizeTemplateFolderPaths(plugin.settings.templateFolderPaths).length > 0
+	);
+}
+
+/** Best-effort: open QuickAdd's settings tab so the user can configure a template folder. */
+function openQuickAddSettings(app: App, pluginId: string): void {
+	const setting = (
+		app as unknown as {
+			setting?: { open?: () => void; openTabById?: (id: string) => void };
+		}
+	).setting;
+	try {
+		setting?.open?.();
+		setting?.openTabById?.(pluginId);
+	} catch {
+		// best-effort only; the Notice already tells the user where to go.
+	}
+}
+
+function renderTemplateRow(path: string, el: HTMLElement): void {
+	const lastSlash = path.lastIndexOf("/");
+	const folder = lastSlash === -1 ? "" : path.slice(0, lastSlash);
+	const content = el.createDiv({ cls: "suggestion-content" });
+	content.createDiv({ cls: "suggestion-title", text: templateDisplayName(path) });
+	if (folder) {
+		el.classList.add("mod-complex");
+		content.createDiv({ cls: "suggestion-note", text: folder });
+	}
+}
+
+async function pickTemplateFile(
+	app: App,
+	files: TFile[],
+): Promise<string | null> {
+	// Stable, path-sorted list; full path is the searchable text so a query can
+	// match folder + name, while the custom row shows basename + folder.
+	const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path));
+	const paths = sorted.map((file) => file.path);
+
+	try {
+		return await GenericSuggester.Suggest(
+			app,
+			paths,
+			paths,
+			"New note from template",
+			(path, el) => renderTemplateRow(path, el),
+		);
+	} catch (error) {
+		if (isCancellationError(error)) return null;
+		throw error;
+	}
+}
+
+/**
+ * Runs a template straight from the configured template folder, prompting for
+ * the new note name — without a dedicated Template choice (issue #1023).
+ *
+ * Interactive (no templatePath): require a configured template folder, list its
+ * templates, then run the picked one. Non-interactive (templatePath given, e.g.
+ * the CLI): skip the picker and the config gate and run it directly.
+ */
+export async function runTemplateFromFolder(
+	app: App,
+	plugin: QuickAdd,
+	params: RunTemplateFromFolderParams,
+): Promise<void> {
+	try {
+		let templatePath = params.templatePath?.trim() || undefined;
+
+		if (!templatePath) {
+			if (!hasConfiguredTemplateFolders(plugin)) {
+				new Notice(
+					"QuickAdd: Set a template folder in Settings → QuickAdd → Templates & Properties to use “New note from template”.",
+					8000,
+				);
+				openQuickAddSettings(app, plugin.manifest.id);
+				return;
+			}
+
+			const files = plugin.getTemplateFiles();
+			if (files.length === 0) {
+				new Notice(
+					"QuickAdd: No template files found in your configured template folder(s).",
+				);
+				return;
+			}
+
+			const picked = await pickTemplateFile(app, files);
+			if (!picked) return;
+			templatePath = picked;
+		}
+
+		await params.choiceExecutor.execute(createFolderTemplateChoice(templatePath));
+	} catch (error) {
+		if (isCancellationError(error)) return;
+		reportError(error, "Error running template from folder");
+	}
+}

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -5,14 +5,25 @@ vi.mock("obsidian-dataview", () => ({
 	getAPI: vi.fn(),
 }));
 
+// Spy on the engine entry while keeping hasConfiguredTemplateFolders real (the
+// constructor's injection gate depends on it).
+vi.mock("../../engine/runTemplateFromFolder", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof RunTemplateFromFolderModule>();
+	return { ...actual, runTemplateFromFolder: vi.fn().mockResolvedValue(undefined) };
+});
+
 import type QuickAdd from "../../main";
 import type IChoice from "../../types/choices/IChoice";
 import type IMultiChoice from "../../types/choices/IMultiChoice";
 import type { IChoiceExecutor } from "../../IChoiceExecutor";
 import { MultiChoice } from "../../types/choices/MultiChoice";
 import { settingsStore } from "../../settingsStore";
+import { runTemplateFromFolder } from "../../engine/runTemplateFromFolder";
+import type * as RunTemplateFromFolderModule from "../../engine/runTemplateFromFolder";
 import ChoiceSuggester, {
 	BACK_CHOICE_ID,
+	RUN_TEMPLATE_FROM_FOLDER_ID,
 	stripInlineMarkdown,
 } from "./choiceSuggester";
 
@@ -113,6 +124,134 @@ describe("ChoiceSuggester", () => {
 	function makeSuggester(choices: IChoice[]): ChoiceSuggester {
 		return new ChoiceSuggester(plugin, choices, { choiceExecutor: executor });
 	}
+
+	describe("template folder launcher row", () => {
+		function pluginWith(settings: {
+			templateFolderPaths?: string[];
+			templateFolderLauncherRow?: "off" | "top" | "bottom" | undefined;
+		}): QuickAdd {
+			return {
+				app,
+				settings: {
+					templateFolderPaths: settings.templateFolderPaths ?? [],
+					// Mirror DEFAULT_SETTINGS: undefined means "bottom".
+					templateFolderLauncherRow:
+						"templateFolderLauncherRow" in settings
+							? settings.templateFolderLauncherRow
+							: "bottom",
+				},
+			} as unknown as QuickAdd;
+		}
+
+		function open(p: QuickAdd, includeRow: boolean): ChoiceSuggester {
+			return new ChoiceSuggester(p, rootChoices, {
+				choiceExecutor: executor,
+				includeTemplateFolderRow: includeRow,
+			});
+		}
+
+		it("appends the row at the bottom by default (keeps the first choice first)", () => {
+			const s = open(pluginWith({ templateFolderPaths: ["Templates"] }), true);
+			const ids = s.getSuggestions("").map((x) => x.item.id);
+			expect(ids[0]).toBe(rootChoices[0].id);
+			expect(ids[ids.length - 1]).toBe(RUN_TEMPLATE_FROM_FOLDER_ID);
+			expect(ids.slice(0, -1)).toEqual(rootChoices.map((c) => c.id));
+		});
+
+		it("prepends the row when position is 'top'", () => {
+			const s = open(
+				pluginWith({
+					templateFolderPaths: ["Templates"],
+					templateFolderLauncherRow: "top",
+				}),
+				true,
+			);
+			const ids = s.getSuggestions("").map((x) => x.item.id);
+			expect(ids[0]).toBe(RUN_TEMPLATE_FROM_FOLDER_ID);
+			expect(ids.slice(1)).toEqual(rootChoices.map((c) => c.id));
+		});
+
+		it("falls back to bottom when the position is unset (legacy data.json)", () => {
+			const s = open(
+				pluginWith({
+					templateFolderPaths: ["Templates"],
+					templateFolderLauncherRow: undefined,
+				}),
+				true,
+			);
+			const ids = s.getSuggestions("").map((x) => x.item.id);
+			expect(ids[ids.length - 1]).toBe(RUN_TEMPLATE_FROM_FOLDER_ID);
+		});
+
+		it("omits the row when position is 'off'", () => {
+			const s = open(
+				pluginWith({
+					templateFolderPaths: ["Templates"],
+					templateFolderLauncherRow: "off",
+				}),
+				true,
+			);
+			expect(
+				s.getSuggestions("").map((x) => x.item.id),
+			).not.toContain(RUN_TEMPLATE_FROM_FOLDER_ID);
+		});
+
+		it("omits the row when no template folder is configured (any position)", () => {
+			for (const pos of ["top", "bottom"] as const) {
+				const s = open(
+					pluginWith({ templateFolderPaths: [], templateFolderLauncherRow: pos }),
+					true,
+				);
+				expect(
+					s.getSuggestions("").map((x) => x.item.id),
+				).not.toContain(RUN_TEMPLATE_FROM_FOLDER_ID);
+			}
+		});
+
+		it("never injects the row for nested levels (includeTemplateFolderRow unset)", () => {
+			const s = new ChoiceSuggester(
+				pluginWith({ templateFolderPaths: ["Templates"] }),
+				rootChoices,
+				{ choiceExecutor: executor },
+			);
+			expect(
+				s.getSuggestions("").map((x) => x.item.id),
+			).not.toContain(RUN_TEMPLATE_FROM_FOLDER_ID);
+		});
+
+		it("excludes the row from nested search results (top or bottom)", () => {
+			for (const pos of ["top", "bottom"] as const) {
+				const s = open(
+					pluginWith({
+						templateFolderPaths: ["Templates"],
+						templateFolderLauncherRow: pos,
+					}),
+					true,
+				);
+				// Typed query goes through the nested-candidate path, which drops the row.
+				expect(
+					s.getSuggestions("template").map((x) => x.item.id),
+				).not.toContain(RUN_TEMPLATE_FROM_FOLDER_ID);
+			}
+		});
+
+		it("dispatches the sentinel row to runTemplateFromFolder, not the executor", () => {
+			const p = pluginWith({ templateFolderPaths: ["Templates"] });
+			const s = open(p, true);
+			const row = s
+				.getSuggestions("")
+				.map((x) => x.item)
+				.find((c) => c.id === RUN_TEMPLATE_FROM_FOLDER_ID)!;
+
+			s.onChooseItem(row, new MouseEvent("click"));
+
+			expect(vi.mocked(runTemplateFromFolder)).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(runTemplateFromFolder).mock.calls[0][2]).toEqual({
+				choiceExecutor: executor,
+			});
+			expect(executed).toEqual([]);
+		});
+	});
 
 	describe("getSuggestions", () => {
 		it("shows only the current level for an empty query", () => {

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -14,8 +14,21 @@ import type { IChoiceExecutor } from "../../IChoiceExecutor";
 import { log } from "../../logger/logManager";
 import { settingsStore } from "../../settingsStore";
 import { flattenChoicesWithPath } from "../../utils/choiceUtils";
+import {
+	hasConfiguredTemplateFolders,
+	runTemplateFromFolder,
+} from "../../engine/runTemplateFromFolder";
 
 const backLabel = "← Back";
+
+/**
+ * Sentinel id for the synthetic "New note from template" launcher row (#1023).
+ * Like {@link BACK_CHOICE_ID}, it is navigation/action — never a real choice —
+ * so it is dispatched explicitly and excluded from nested search. The constant
+ * prefix cannot collide with a real uuid-keyed choice.
+ */
+export const RUN_TEMPLATE_FROM_FOLDER_ID = "quickadd:run-template-from-folder";
+const runTemplateFromFolderLabel = "New note from template…";
 
 /**
  * Sentinel id for the synthetic back item. Back items are created fresh per
@@ -65,7 +78,22 @@ type ChoiceSuggesterOptions = {
 	choiceExecutor?: IChoiceExecutor;
 	placeholder?: string;
 	placeholderStack?: Array<string | undefined>;
+	/**
+	 * Inject the synthetic "New note from template" row at the top of this
+	 * level. Set only by the top-level launcher (Run QuickAdd / ribbon); never
+	 * by nested Multi navigation, so the row stays top-level only.
+	 */
+	includeTemplateFolderRow?: boolean;
 };
+
+function createTemplateFolderRow(): IChoice {
+	return {
+		id: RUN_TEMPLATE_FROM_FOLDER_ID,
+		name: runTemplateFromFolderLabel,
+		type: "Template",
+		command: false,
+	};
+}
 export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 	private choiceExecutor: IChoiceExecutor;
 	private placeholderStack: Array<string | undefined> = [];
@@ -102,6 +130,25 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		this.currentPlaceholder = options?.placeholder?.trim() || undefined;
 		if (this.currentPlaceholder) this.setPlaceholder(this.currentPlaceholder);
 		this.markdownComponent.load();
+
+		// Insert the synthetic "New note from template" row only at the top level
+		// (includeTemplateFolderRow), and only when a template folder is actually
+		// configured (otherwise the action would just send the user to settings).
+		// Position is user-controlled: "bottom" (default) keeps it out of the
+		// first-Enter slot, "top" makes it first, "off" hides it. Settings are read
+		// inside this guard so nested-level opens (no settings on the test plugin)
+		// never touch them.
+		if (options?.includeTemplateFolderRow) {
+			const rowPosition =
+				this.plugin.settings.templateFolderLauncherRow ?? "bottom";
+			if (rowPosition !== "off" && hasConfiguredTemplateFolders(this.plugin)) {
+				const row = createTemplateFolderRow();
+				this.choices =
+					rowPosition === "top"
+						? [row, ...this.choices]
+						: [...this.choices, row];
+			}
+		}
 	}
 
 	onClose(): void {
@@ -136,10 +183,13 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 	private getNestedSearchCandidates(): NestedSearchCandidate[] {
 		if (!this.nestedSearchCandidates) {
 			// The back item wraps the entire previous level; flattening through
-			// it would leak every ancestor into the results. It is dropped as a
-			// candidate altogether — it is navigation, not content.
+			// it would leak every ancestor into the results. It and the synthetic
+			// template-folder row are dropped as candidates — they are
+			// navigation/action, not content.
 			const searchable = this.choices.filter(
-				(choice) => choice.id !== BACK_CHOICE_ID
+				(choice) =>
+					choice.id !== BACK_CHOICE_ID &&
+					choice.id !== RUN_TEMPLATE_FROM_FOLDER_ID
 			);
 			this.nestedSearchCandidates = flattenChoicesWithPath(searchable).map(
 				({ choice, path }) => {
@@ -181,6 +231,8 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		el.classList.add("quickadd-choice-suggestion");
 		if (item.item.id === BACK_CHOICE_ID)
 			el.classList.add("quickadd-choice-suggestion-back");
+		if (item.item.id === RUN_TEMPLATE_FROM_FOLDER_ID)
+			el.classList.add("quickadd-choice-suggestion-run-template");
 	}
 
 	getItemText(item: IChoice): string {
@@ -195,6 +247,17 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		item: IChoice,
 		evt: MouseEvent | KeyboardEvent
 	): void {
+		// Sentinel action row — must be handled before the type dispatch, since it
+		// carries no templatePath and would fail the Template engine's invariant.
+		if (item.id === RUN_TEMPLATE_FROM_FOLDER_ID) {
+			void runTemplateFromFolder(this.app, this.plugin, {
+				choiceExecutor: this.choiceExecutor,
+			}).catch((error) => {
+				log.logError(`Failed to run template from folder: ${error}`);
+			});
+			return;
+		}
+
 		if (item.type === "Multi")
 			this.onChooseMultiType(<IMultiChoice>item);
 		else {

--- a/src/main.commandLabels.test.ts
+++ b/src/main.commandLabels.test.ts
@@ -5,6 +5,7 @@ describe("QuickAdd command labels", () => {
 	it("keeps built-in command labels free of the plugin name", () => {
 		expect(QUICK_ADD_COMMAND_LABELS).toEqual({
 			run: "Run",
+			runTemplateFromFolder: "New note from template",
 			applyTemplate: "Apply template to active note",
 			reloadDev: "Reload (dev)",
 			testDev: "Test (dev)",

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ import {
 	parseCallbackTargets,
 	type CallbackTargets,
 } from "./uri/uriCallback";
+import { runTemplateFromFolder } from "./engine/runTemplateFromFolder";
 
 // Parameters prefixed with `value-` get used as named values for the executed choice
 type CaptureValueParameters = { [key in `value-${string}`]?: string };
@@ -102,7 +103,19 @@ export default class QuickAdd extends Plugin {
 			id: "runQuickAdd",
 			name: QUICK_ADD_COMMAND_LABELS.run,
 			callback: () => {
-				ChoiceSuggester.Open(this, this.settings.choices);
+				ChoiceSuggester.Open(this, this.settings.choices, {
+					includeTemplateFolderRow: true,
+				});
+			},
+		});
+
+		this.addCommand({
+			id: "runTemplateFromFolder",
+			name: QUICK_ADD_COMMAND_LABELS.runTemplateFromFolder,
+			callback: () => {
+				void runTemplateFromFolder(this.app, this, {
+					choiceExecutor: new ChoiceExecutor(this.app, this),
+				});
 			},
 		});
 
@@ -276,7 +289,9 @@ export default class QuickAdd extends Plugin {
 
 		if (this.settings.enableRibbonIcon) {
 			this.addRibbonIcon("file-plus", "QuickAdd", () => {
-				ChoiceSuggester.Open(this, this.settings.choices);
+				ChoiceSuggester.Open(this, this.settings.choices, {
+					includeTemplateFolderRow: true,
+				});
 			});
 		}
 

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -183,6 +183,19 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 		expect(tab.getControlValue("showCaptureNotification")).toBe(true);
 	});
 
+	it("the launcher-row dropdown round-trips its enum value through the store", () => {
+		const tab = makeTab();
+
+		// Default surfaced from DEFAULT_SETTINGS.
+		expect(tab.getControlValue("templateFolderLauncherRow")).toBe("bottom");
+
+		for (const position of ["top", "off", "bottom"] as const) {
+			tab.setControlValue("templateFolderLauncherRow", position);
+			expect(settingsStore.getState().templateFolderLauncherRow).toBe(position);
+			expect(tab.getControlValue("templateFolderLauncherRow")).toBe(position);
+		}
+	});
+
 	it("maps the inputPrompt toggle to and from its enum value", () => {
 		const tab = makeTab();
 
@@ -274,6 +287,7 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 		expect(choicePickerGroup.heading).toBe("Choice Picker");
 		expect(choicePickerGroup.items?.map((item) => item.name)).toEqual([
 			"Search nested choices",
+			"“New note from template” in the launcher",
 		]);
 	});
 });

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -162,6 +162,20 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					desc: "When searching in the choice picker, also match choices nested inside Multi choices and show their path. Note that nested matches can outrank same-level ones. Disable to search only the open level.",
 					control: { type: "toggle", key: "searchNestedChoices" },
 				},
+				{
+					name: "“New note from template” in the launcher",
+					desc: "Add a row to Run QuickAdd that lists templates from your configured template folder, so you can create a note from a template without a dedicated Template choice. Only appears when a template folder is configured; the command palette entry works regardless.",
+					control: {
+						type: "dropdown",
+						key: "templateFolderLauncherRow",
+						defaultValue: "bottom",
+						options: {
+							bottom: "Show at the bottom (keeps your top choice first)",
+							top: "Show at the top",
+							off: "Hide",
+						},
+					},
+				},
 			],
 		};
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,9 @@ import { DefaultProviders, type AIProvider } from "./ai/Provider";
 import type IChoice from "./types/choices/IChoice";
 import { DEFAULT_DATE_ALIASES } from "./utils/dateAliases";
 
+/** Position of the "New note from template" row in the Run QuickAdd launcher. */
+export type TemplateFolderLauncherRowPosition = "off" | "top" | "bottom";
+
 export interface QuickAddSettings {
 	choices: IChoice[];
 	inputPrompt: "multi-line" | "single-line";
@@ -16,6 +19,13 @@ export interface QuickAddSettings {
 		* inside Multi choices and shows matches with their folder path.
 		*/
 	searchNestedChoices: boolean;
+	/**
+		* Where the "New note from template" row appears in Run QuickAdd (when at
+		* least one template folder is configured). `"bottom"` keeps it out of the
+		* first-Enter slot; `"top"` makes it the first item; `"off"` hides it (the
+		* command palette entry always works regardless).
+		*/
+	templateFolderLauncherRow: TemplateFolderLauncherRowPosition;
 	devMode: boolean;
 	/**
 		* Folders whose files are offered as template suggestions when configuring
@@ -85,6 +95,7 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 	persistInputPromptDrafts: true,
 	useSelectionAsCaptureValue: true,
 	searchNestedChoices: true,
+	templateFolderLauncherRow: "bottom",
 	devMode: false,
 	templateFolderPaths: [],
 	announceUpdates: "major",


### PR DESCRIPTION
Closes #1023.

## What
Adds **New note from template** — run a template straight from your configured template folder, prompting for the new note's name, **without maintaining a Template choice per file**.

Three entry points, all backed by one reusable core (`runTemplateFromFolder`) that builds a throwaway, non-persisted `TemplateChoice` and runs it through the existing `ChoiceExecutor` → `TemplateChoiceEngine`:

1. **Command** `New note from template` (palette / hotkey / ribbon).
2. **Run QuickAdd launcher row** — a single `📄 New note from template…` row at the top of the picker, gated on a configured template folder + the new **Show "New note from template" in the launcher** toggle (Settings → Choice Picker).
3. **CLI** `quickadd:run-template path=<vault-path> value-value=<name>` — the scriptable form.

No new persisted choice type (rejected as too much surface); no migration.

## Why this shape
- Reuses `getTemplateFiles()` (the listing seam) + `TemplateChoiceEngine` (the run seam) — the only thing missing was the thin join.
- The ephemeral choice uses `fileNameFormat = { enabled: true, format: {{value}} }` **on purpose**: runtime is identical to `enabled:false`, but `collectChoiceRequirements` only scans the file-name format when enabled, so this makes the note-name visible to the non-interactive CLI guard and the one-page form (otherwise the CLI would hang / report a false success).
- When no template folder is configured, the interactive flow shows a notice and opens settings instead of flooding a whole-vault picker.

## Review
Designed and reviewed before coding (ultracode multi-lens + 2 opposite-model adversarial reviewers), then the implementation was reviewed the same way. Findings fixed:
- **Blocker** — a blank/empty note name no longer reports a false `ok:true` with no note created (the collector consumes a provided-but-empty value, so `run-template` rejects a blank name up front for non-interactive runs).
- CLI path now resolves via `getTemplateFile` (accepts `Templates/Daily` and `/Templates/Daily.md` like the engine); `path=` is reserved so it can't leak as a template variable; up-front file-existence check.

### Known, documented limitations (inherited from the Template engine, shared with `quickadd:run`)
- A name collision on the target note still prompts interactively (file-exists isn't a pre-collected input).
- With an active editor selection, `{{value}}` uses the selection as the name (intrinsic `{{VALUE}}` behavior).
- Canvas/base templates: choosing an "append" mode on an existing canvas/base target can corrupt its JSON.

## Verified
- `pnpm build` + `pnpm lint` clean; **2042 tests pass** (new unit coverage: ephemeral-choice defaults, real-collector integration + negative control, picker resolve/cancel, launcher-row injection/gating/dispatch/exclusion, CLI envelopes incl. blank-name + extensionless paths).
- Dev-vault e2e (obsidian CLI): happy path creates the note with `{{value}}` resolved; blank/empty/omitted name → `ok:false` + `missingFlags`; launcher row appears/dispatches; require-config notice + opens settings; extensionless & leading-slash paths resolve.

## Release impact
`feat` → minor bump. New setting `showTemplateFolderInLauncher` (default true; only surfaces the row when a template folder is configured). `main.js`/`styles.css` are gitignored and regenerated by CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “New note from template” to create notes from configured template files, with an optional launcher row (top/bottom/off) in the Run QuickAdd picker.
  * Added `quickadd:run-template` CLI to create a note from a specified vault-relative template path, supporting `vars` JSON and interactive/non-interactive modes.
* **Settings**
  * Added “Choice Picker” control: show “New note from template” in the launcher, with placement options.
* **Documentation**
  * Updated Advanced CLI docs with `quickadd:run-template` arguments and JSON response behavior for failures/cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->