### PR TITLE
feat(template): replace folder-location toggles with a single dropdown (#1131)

### DIFF
--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -20,15 +20,13 @@ If you want a new markdown note to include a live embedded Base dashboard, see
 Basically, this allows you to have dynamic file names. If you wrote `£ {{DATE}} {{NAME}}`, it would translate to a file name like `£ 2021-06-12 Manually-Written-File-Name`, where `Manually-Written-File-Name` is a value you enter when invoking the template.
 If you disable **File Name Format**, QuickAdd uses `{{VALUE}}` as the file name format. This keeps the default behavior of prompting for a file name when you run the choice, with the same `{{VALUE}}` / `{{NAME}}` behavior described in the format syntax docs.
 
-**Create in folder**. In which folder should the file be created in.
-You can specify as many folders as you want. If you don't, it'll just create the file in the root directory. If you specify one folder, it'll automatically create the file in there.
-If you specify multiple folders, you'll get a suggester asking which of the folders you wish to create the file in.
-Folder paths also support QuickAdd [format syntax](/FormatSyntax.md), including `{{VALUE}}`, named values such as `{{VALUE:client}}`, dates, and global variables. For example, `Projects/{{VALUE:client}}/{{DATE:YYYY}}` prompts for a client and creates the file under that client's folder for the current year.
+**New note location**. A dropdown that controls where the note is created. Pick one of four modes:
+- **Obsidian default** – use Obsidian's "Default location for new notes" setting.
+- **In a specific folder** – create the note in the folder(s) you configure below. If you specify one folder, the note is created there; if you specify multiple, you'll get a suggester asking which folder to use. An **Include subfolders** toggle (shown only in this mode) lets the suggester offer the selected folders *and* their subfolders. Folder paths support QuickAdd [format syntax](/FormatSyntax.md), including `{{VALUE}}`, named values such as `{{VALUE:client}}`, dates, and global variables — for example, `Projects/{{VALUE:client}}/{{DATE:YYYY}}` prompts for a client and creates the file under that client's folder for the current year.
+- **Same folder as current file** – create the note next to the currently active file (falls back to the vault root if no file is open).
+- **Ask for folder each time** – prompt you to pick any folder in the vault each time the choice runs.
 
-When **Create in folder** is enabled, a few sub-toggles appear:
-- **Choose folder when creating a new note** – instead of using the folders configured here, prompt you to pick a destination folder each time the choice runs.
-- **Include subfolders** – when prompted, choose from both the selected folders and their subfolders when creating the note.
-- **Create in same folder as active file** – creates the file in the same folder as the currently active file. Will not create the file if there is no active file.
+Switching modes hides the fields that don't apply, but your configured folder list is kept — switching back restores it.
 
 **Link to created file**. Choose how QuickAdd should insert a link to the created file in the current note. Pick one of three modes:
 - **Enabled (requires active file)** – throw an error if no note is focused (legacy behavior)

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -316,6 +316,10 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		return folderPaths;
 	}
 
+	// The branch precedence below is mirrored by the choice builder's folder-mode
+	// dropdown (gui/ChoiceBuilder/folderMode.ts → deriveFolderMode). If you change
+	// the order or conditions here, update that helper (and its 16-combo test) so
+	// the dropdown keeps showing the mode that actually runs.
 	private async getFolderPath() {
 		const folders: string[] = await this.formatFolderPaths([
 			...this.choice.folder.folders,

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -19,6 +19,13 @@ import { sortFolderPathsByTree } from "../../utils/folder-sorting";
 import { ExclusiveSuggester } from "../suggesters/exclusiveSuggester";
 import { FormatSyntaxSuggester } from "../suggesters/formatSyntaxSuggester";
 import FolderList from "./FolderList.svelte";
+import {
+	applyFolderMode,
+	deriveFolderMode,
+	FOLDER_MODE_DESCRIPTIONS,
+	FOLDER_MODE_OPTIONS,
+	type FolderMode,
+} from "./folderMode";
 import SettingItem from "../components/SettingItem.svelte";
 import Toggle from "../components/Toggle.svelte";
 import Dropdown from "../components/Dropdown.svelte";
@@ -68,6 +75,21 @@ const fileNameSuggesters = [
 ];
 
 // --- Folder selector -----------------------------------------------------
+// The four persisted folder booleans encode mutually-exclusive destination
+// modes; the dropdown is a derived view over them (no schema change). The mode
+// mirrors TemplateChoiceEngine.getFolderPath() precedence — see folderMode.ts.
+const folderMode = $derived(deriveFolderMode(choice.folder));
+const folderModeDesc = $derived(FOLDER_MODE_DESCRIPTIONS[folderMode]);
+const needsFolderList = $derived(
+	folderMode === "specified" && choice.folder.folders.length === 0,
+);
+
+function onFolderModeChange(value: string) {
+	// Immutable reassignment so the nested change is reactive (in-place
+	// choice.folder.x = ... would not retrigger the {#if} blocks).
+	choice.folder = applyFolderMode(choice.folder, value as FolderMode);
+}
+
 let folderInputValue = $state("");
 let folderSuggester: ExclusiveSuggester | undefined;
 
@@ -82,7 +104,9 @@ function attachFolderSuggester(el: HTMLInputElement | HTMLTextAreaElement) {
 }
 
 // Keep the exclusion set in sync with the current folder list (replaces the
-// imperative updateCurrentItems() calls).
+// imperative updateCurrentItems() calls). Tolerates a destroyed suggester after
+// the input unmounts on a mode switch — updateCurrentItems is field-only and the
+// input is recreated (with a fresh suggester) when "specified" mode returns.
 $effect(() => {
 	folderSuggester?.updateCurrentItems(choice.folder.folders);
 });
@@ -171,63 +195,51 @@ function onModeChange(value: string) {
 
 <SettingItem name="Location" heading />
 
-<SettingItem
-	name="Create in folder"
-	desc="Create the file in the specified folder. If multiple folders are specified, you will be prompted for which folder to create the file in."
->
+<SettingItem name="New note location" desc={folderModeDesc}>
 	{#snippet control()}
-		<Toggle bind:checked={choice.folder.enabled} />
+		<Dropdown
+			value={folderMode}
+			options={FOLDER_MODE_OPTIONS}
+			ariaLabel="New note location"
+			onchange={onFolderModeChange}
+		/>
 	{/snippet}
 </SettingItem>
 
-{#if choice.folder.enabled}
-	{#if !choice.folder.createInSameFolderAsActiveFile}
-		<SettingItem name="Choose folder when creating a new note">
-			{#snippet control()}
-				<Toggle bind:checked={choice.folder.chooseWhenCreatingNote} />
-			{/snippet}
-		</SettingItem>
+{#if folderMode === "specified"}
+	<div class="folderSelectionContainer">
+		<div class="folderList">
+			<FolderList folders={choice.folder.folders} {deleteFolder} />
+		</div>
+		<div class="folderInputContainer">
+			<input
+				type="text"
+				class="qa-folder-path-input"
+				placeholder="Folder path"
+				aria-label="Folder path"
+				bind:value={folderInputValue}
+				onkeypress={onFolderInputKeypress}
+				use:suggester={attachFolderSuggester}
+			/>
+			<button type="button" class="mod-cta" onclick={addFolder}>Add</button>
+		</div>
+	</div>
 
-		{#if !choice.folder.chooseWhenCreatingNote}
-			<div class="folderSelectionContainer">
-				<div class="folderList">
-					<FolderList folders={choice.folder.folders} {deleteFolder} />
-				</div>
-				<div class="folderInputContainer">
-					<input
-						type="text"
-						class="qa-folder-path-input"
-						placeholder="Folder path"
-						aria-label="Folder path"
-						bind:value={folderInputValue}
-						onkeypress={onFolderInputKeypress}
-						use:suggester={attachFolderSuggester}
-					/>
-					<button type="button" class="mod-cta" onclick={addFolder}>Add</button>
-				</div>
-			</div>
-		{/if}
-
-		<SettingItem
-			name="Include subfolders"
-			desc="Get prompted to choose from both the selected folders and their subfolders when creating the note."
-		>
-			{#snippet control()}
-				<Toggle bind:checked={choice.folder.chooseFromSubfolders} />
-			{/snippet}
-		</SettingItem>
+	{#if needsFolderList}
+		<div class="qa-folder-mode-warning">
+			Add at least one folder, or the note will be created in the active file's
+			folder instead of a specific one.
+		</div>
 	{/if}
 
-	{#if !choice.folder.chooseWhenCreatingNote}
-		<SettingItem
-			name="Create in same folder as active file"
-			desc="Creates the file in the same folder as the currently active file. Will not create the file if there is no active file."
-		>
-			{#snippet control()}
-				<Toggle bind:checked={choice.folder.createInSameFolderAsActiveFile} />
-			{/snippet}
-		</SettingItem>
-	{/if}
+	<SettingItem
+		name="Include subfolders"
+		desc="Get prompted to choose from both the selected folders and their subfolders when creating the note."
+	>
+		{#snippet control()}
+			<Toggle bind:checked={choice.folder.chooseFromSubfolders} />
+		{/snippet}
+	</SettingItem>
 {/if}
 
 <SettingItem name="Linking" heading />

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -22,8 +22,8 @@ import FolderList from "./FolderList.svelte";
 import {
 	applyFolderMode,
 	deriveFolderMode,
-	FOLDER_MODE_DESCRIPTIONS,
-	FOLDER_MODE_OPTIONS,
+	folderModeDescriptions,
+	folderModeOptions,
 	type FolderMode,
 } from "./folderMode";
 import SettingItem from "../components/SettingItem.svelte";
@@ -79,7 +79,7 @@ const fileNameSuggesters = [
 // modes; the dropdown is a derived view over them (no schema change). The mode
 // mirrors TemplateChoiceEngine.getFolderPath() precedence — see folderMode.ts.
 const folderMode = $derived(deriveFolderMode(choice.folder));
-const folderModeDesc = $derived(FOLDER_MODE_DESCRIPTIONS[folderMode]);
+const folderModeDesc = $derived(folderModeDescriptions[folderMode]);
 const needsFolderList = $derived(
 	folderMode === "specified" && choice.folder.folders.length === 0,
 );
@@ -199,7 +199,7 @@ function onModeChange(value: string) {
 	{#snippet control()}
 		<Dropdown
 			value={folderMode}
-			options={FOLDER_MODE_OPTIONS}
+			options={folderModeOptions}
 			ariaLabel="New note location"
 			onchange={onFolderModeChange}
 		/>
@@ -227,8 +227,8 @@ function onModeChange(value: string) {
 
 	{#if needsFolderList}
 		<div class="qa-folder-mode-warning">
-			Add at least one folder, or the note will be created in the active file's
-			folder instead of a specific one.
+			Add at least one folder. With none, the note falls back to the active
+			file's folder (or you'll be prompted to pick one if no file is open).
 		</div>
 	{/if}
 

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -159,9 +159,9 @@ describe("TemplateChoiceForm", () => {
 			enabled: true,
 			createInSameFolderAsActiveFile: true,
 			chooseWhenCreatingNote: false,
-			// reset outside "specified" so the InsertEngine move-offer stays available
-			chooseFromSubfolders: false,
-			// the costly list is preserved across the switch
+			// preserved across the switch (matches the old form; restored on return
+			// to "specified") — only the mode-discriminant flags change
+			chooseFromSubfolders: true,
 			folders: ["Notes"],
 		});
 		expect(container.querySelector(".qa-folder-path-input")).toBeNull();

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
 
 import { App } from "obsidian";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import { flushSync } from "svelte";
 import type QuickAdd from "../../main";
 import type ITemplateChoice from "../../types/choices/ITemplateChoice";
@@ -45,6 +45,14 @@ function settingNames(container: HTMLElement): string[] {
 	);
 }
 
+function locationDropdown(container: HTMLElement): HTMLSelectElement {
+	const el = container.querySelector<HTMLSelectElement>(
+		'select.dropdown[aria-label="New note location"]',
+	);
+	if (!el) throw new Error("Location dropdown not found");
+	return el;
+}
+
 const plugin = {
 	getTemplateFiles: () => [],
 	settings: { choices: [] },
@@ -63,29 +71,113 @@ function mountForm() {
 }
 
 describe("TemplateChoiceForm", () => {
-	it("reveals folder sub-settings reactively without remounting (the #1130 fix)", () => {
+	it("reveals the specific-folder controls reactively without remounting (the #1130 fix)", () => {
 		const { container, props } = mountForm();
 		const headerBefore = container.querySelector(".choiceNameHeaderButton");
 
-		expect(settingNames(container)).not.toContain(
-			"Choose folder when creating a new note",
-		);
+		// Default (obsidian-default) mode: no folder list / subfolder control.
+		expect(settingNames(container)).not.toContain("Include subfolders");
+		expect(container.querySelector(".qa-folder-path-input")).toBeNull();
 
-		// Toggling the controlling field updates the {#if} in place — the former
-		// reload() would have torn down and rebuilt the whole modal here.
+		// Flipping the controlling field updates the {#if} in place — the former
+		// reload() would have torn down and rebuilt the whole modal here. A bare
+		// `enabled` with no other flag derives to "specified" mode.
 		props.choice.folder.enabled = true;
 		flushSync();
 
-		expect(settingNames(container)).toContain(
-			"Choose folder when creating a new note",
-		);
-		expect(settingNames(container)).toContain(
-			"Create in same folder as active file",
-		);
+		expect(settingNames(container)).toContain("Include subfolders");
+		expect(container.querySelector(".qa-folder-path-input")).not.toBeNull();
 		// Same header node => no full remount (scroll/caret would survive in-app).
 		expect(container.querySelector(".choiceNameHeaderButton")).toBe(
 			headerBefore,
 		);
+	});
+
+	it("consolidates the location modes into one dropdown with four options", () => {
+		const { container } = mountForm();
+		expect(settingNames(container)).toContain("New note location");
+		const options = Array.from(locationDropdown(container).options).map(
+			(o) => o.value,
+		);
+		expect(options).toEqual([
+			"obsidian-default",
+			"specified",
+			"active-file",
+			"prompt",
+		]);
+	});
+
+	it("opens a legacy choice on its derived mode", () => {
+		const props = createTemplateChoiceFormProps({
+			choice: {
+				...templateChoice(),
+				folder: {
+					enabled: true,
+					folders: [],
+					chooseWhenCreatingNote: true,
+					createInSameFolderAsActiveFile: false,
+					chooseFromSubfolders: false,
+				},
+			},
+			app: new App(),
+			plugin,
+		});
+		const { container } = render(TemplateChoiceForm, {
+			props: { choice: props.choice, app: props.app, plugin: props.plugin },
+		});
+		expect(locationDropdown(container).value).toBe("prompt");
+		// "prompt" mode hides the specific-folder list.
+		expect(container.querySelector(".qa-folder-path-input")).toBeNull();
+	});
+
+	it("writes the canonical booleans when a mode is selected", async () => {
+		const props = createTemplateChoiceFormProps({
+			choice: {
+				...templateChoice(),
+				folder: {
+					enabled: true,
+					folders: ["Notes"],
+					chooseWhenCreatingNote: false,
+					createInSameFolderAsActiveFile: false,
+					chooseFromSubfolders: true,
+				},
+			},
+			app: new App(),
+			plugin,
+		});
+		const { container } = render(TemplateChoiceForm, {
+			props: { choice: props.choice, app: props.app, plugin: props.plugin },
+		});
+		expect(locationDropdown(container).value).toBe("specified");
+
+		await fireEvent.change(locationDropdown(container), {
+			target: { value: "active-file" },
+		});
+		flushSync();
+
+		expect(props.choice.folder).toMatchObject({
+			enabled: true,
+			createInSameFolderAsActiveFile: true,
+			chooseWhenCreatingNote: false,
+			// reset outside "specified" so the InsertEngine move-offer stays available
+			chooseFromSubfolders: false,
+			// the costly list is preserved across the switch
+			folders: ["Notes"],
+		});
+		expect(container.querySelector(".qa-folder-path-input")).toBeNull();
+	});
+
+	it("warns when 'specific folder' mode has no folders configured", () => {
+		const { container, props } = mountForm();
+		props.choice.folder.enabled = true; // -> specified mode, empty list
+		flushSync();
+		expect(
+			container.querySelector(".qa-folder-mode-warning"),
+		).not.toBeNull();
+
+		props.choice.folder.folders = ["Notes"];
+		flushSync();
+		expect(container.querySelector(".qa-folder-mode-warning")).toBeNull();
 	});
 
 	it("reveals the file-opening settings only when openFile is enabled", () => {

--- a/src/gui/ChoiceBuilder/folderMode.test.ts
+++ b/src/gui/ChoiceBuilder/folderMode.test.ts
@@ -3,7 +3,7 @@ import type { TemplateFolderConfig } from "../../types/choices/ITemplateChoice";
 import {
 	applyFolderMode,
 	deriveFolderMode,
-	FOLDER_MODE_OPTIONS,
+	folderModeOptions,
 	type FolderMode,
 } from "./folderMode";
 
@@ -119,17 +119,21 @@ describe("applyFolderMode", () => {
 		}
 	});
 
-	it("keeps chooseFromSubfolders only in 'specified' mode (inert elsewhere)", () => {
+	it("preserves chooseFromSubfolders across every mode switch (matches the old form)", () => {
 		const withSubfolders = config({
 			enabled: true,
 			chooseFromSubfolders: true,
 			folders: ["Notes"],
 		});
-		expect(applyFolderMode(withSubfolders, "specified").chooseFromSubfolders).toBe(
-			true,
-		);
-		for (const mode of ["obsidian-default", "active-file", "prompt"] as const) {
+		for (const mode of MODES) {
 			expect(applyFolderMode(withSubfolders, mode).chooseFromSubfolders).toBe(
+				true,
+			);
+		}
+		// And a false value stays false everywhere.
+		const noSubfolders = config({ enabled: true, folders: ["Notes"] });
+		for (const mode of MODES) {
+			expect(applyFolderMode(noSubfolders, mode).chooseFromSubfolders).toBe(
 				false,
 			);
 		}
@@ -143,7 +147,7 @@ describe("applyFolderMode", () => {
 	});
 
 	it("exposes a dropdown option for every mode", () => {
-		expect(FOLDER_MODE_OPTIONS.map((o) => o.value).sort()).toEqual(
+		expect(folderModeOptions.map((o) => o.value).sort()).toEqual(
 			[...MODES].sort(),
 		);
 	});

--- a/src/gui/ChoiceBuilder/folderMode.test.ts
+++ b/src/gui/ChoiceBuilder/folderMode.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { TemplateFolderConfig } from "../../types/choices/ITemplateChoice";
+import {
+	applyFolderMode,
+	deriveFolderMode,
+	FOLDER_MODE_OPTIONS,
+	type FolderMode,
+} from "./folderMode";
+
+const MODES: FolderMode[] = [
+	"obsidian-default",
+	"specified",
+	"active-file",
+	"prompt",
+];
+
+function config(
+	overrides: Partial<TemplateFolderConfig> = {},
+): TemplateFolderConfig {
+	return {
+		enabled: false,
+		folders: [],
+		chooseWhenCreatingNote: false,
+		createInSameFolderAsActiveFile: false,
+		chooseFromSubfolders: false,
+		...overrides,
+	};
+}
+
+/**
+ * Independent oracle: which mode TemplateChoiceEngine.getFolderPath() resolves a
+ * config to, modelled directly from its branch precedence (TemplateChoiceEngine.ts
+ * run() else-branch + getFolderPath branches 1-4). If deriveFolderMode ever drifts
+ * from the engine, this disagrees.
+ */
+function engineMode(f: TemplateFolderConfig): FolderMode {
+	if (!f.enabled) return "obsidian-default"; // run(): folder.enabled === false
+	// branch 1: chooseFromSubfolders gated by !(cwn || cisf) -> specified family
+	if (
+		f.chooseFromSubfolders &&
+		!(f.chooseWhenCreatingNote || f.createInSameFolderAsActiveFile)
+	)
+		return "specified";
+	if (f.chooseWhenCreatingNote) return "prompt"; // branch 2
+	if (f.createInSameFolderAsActiveFile) return "active-file"; // branch 3
+	return "specified"; // branch 4 (folders list)
+}
+
+// All 16 combinations of the four booleans.
+const ALL_COMBOS: TemplateFolderConfig[] = [];
+for (const enabled of [false, true])
+	for (const chooseWhenCreatingNote of [false, true])
+		for (const createInSameFolderAsActiveFile of [false, true])
+			for (const chooseFromSubfolders of [false, true])
+				ALL_COMBOS.push(
+					config({
+						enabled,
+						chooseWhenCreatingNote,
+						createInSameFolderAsActiveFile,
+						chooseFromSubfolders,
+						folders: ["Notes"],
+					}),
+				);
+
+describe("deriveFolderMode", () => {
+	it("matches the engine's resolved mode for all 16 boolean combinations", () => {
+		for (const f of ALL_COMBOS) {
+			expect(deriveFolderMode(f)).toBe(engineMode(f));
+		}
+	});
+
+	it("folds the legacy 'both prompt and active' combo to 'prompt' (engine branch 2)", () => {
+		const legacy = config({
+			enabled: true,
+			chooseWhenCreatingNote: true,
+			createInSameFolderAsActiveFile: true,
+		});
+		expect(deriveFolderMode(legacy)).toBe("prompt");
+		expect(engineMode(legacy)).toBe("prompt");
+	});
+
+	it("treats the subfolder-prompt combo as the 'specified' family", () => {
+		const subfolders = config({
+			enabled: true,
+			chooseFromSubfolders: true,
+			folders: ["Notes"],
+		});
+		expect(deriveFolderMode(subfolders)).toBe("specified");
+	});
+});
+
+describe("applyFolderMode", () => {
+	it("round-trips: deriveFolderMode(applyFolderMode(f, m)) === m", () => {
+		for (const f of ALL_COMBOS) {
+			for (const mode of MODES) {
+				expect(deriveFolderMode(applyFolderMode(f, mode))).toBe(mode);
+			}
+		}
+	});
+
+	it("produces flags the engine resolves back to the chosen mode", () => {
+		for (const f of ALL_COMBOS) {
+			for (const mode of MODES) {
+				expect(engineMode(applyFolderMode(f, mode))).toBe(mode);
+			}
+		}
+	});
+
+	it("preserves the folders[] list across every mode switch", () => {
+		const withFolders = config({
+			enabled: true,
+			folders: ["Notes", "Journal/2026"],
+		});
+		for (const mode of MODES) {
+			expect(applyFolderMode(withFolders, mode).folders).toEqual([
+				"Notes",
+				"Journal/2026",
+			]);
+		}
+	});
+
+	it("keeps chooseFromSubfolders only in 'specified' mode (inert elsewhere)", () => {
+		const withSubfolders = config({
+			enabled: true,
+			chooseFromSubfolders: true,
+			folders: ["Notes"],
+		});
+		expect(applyFolderMode(withSubfolders, "specified").chooseFromSubfolders).toBe(
+			true,
+		);
+		for (const mode of ["obsidian-default", "active-file", "prompt"] as const) {
+			expect(applyFolderMode(withSubfolders, mode).chooseFromSubfolders).toBe(
+				false,
+			);
+		}
+	});
+
+	it("does not mutate the input config", () => {
+		const original = config({ enabled: true, folders: ["Notes"] });
+		const snapshot = JSON.parse(JSON.stringify(original));
+		applyFolderMode(original, "prompt");
+		expect(original).toEqual(snapshot);
+	});
+
+	it("exposes a dropdown option for every mode", () => {
+		expect(FOLDER_MODE_OPTIONS.map((o) => o.value).sort()).toEqual(
+			[...MODES].sort(),
+		);
+	});
+});

--- a/src/gui/ChoiceBuilder/folderMode.ts
+++ b/src/gui/ChoiceBuilder/folderMode.ts
@@ -1,0 +1,102 @@
+import type { TemplateFolderConfig } from "../../types/choices/ITemplateChoice";
+
+/**
+ * The mutually-exclusive destination modes a Template choice can use, surfaced as
+ * a single dropdown in the choice builder (#1131). Each mode maps to a canonical
+ * combination of the four persisted `folder` booleans; nothing about the stored
+ * shape changes, so this is purely a GUI consolidation.
+ */
+export type FolderMode =
+	| "obsidian-default"
+	| "specified"
+	| "active-file"
+	| "prompt";
+
+/**
+ * Derive the mode a stored `folder` config resolves to.
+ *
+ * This MUST mirror `TemplateChoiceEngine.getFolderPath()`'s branch precedence
+ * exactly, so the dropdown always shows the mode that will actually run:
+ *   - !enabled                          -> Obsidian "Default location for new notes"
+ *   - chooseWhenCreatingNote            -> engine branch 2 (prompt across all folders)
+ *   - createInSameFolderAsActiveFile    -> engine branch 3 (active file's folder)
+ *   - else                              -> engine branches 1 & 4 (folders list, optionally + subfolders)
+ *
+ * The order below matches the engine: branch 1 (subfolders) is gated by
+ * `!(chooseWhenCreatingNote || createInSameFolderAsActiveFile)`, so a legacy
+ * choice with several flags set folds to the same mode the engine would run.
+ */
+export function deriveFolderMode(folder: TemplateFolderConfig): FolderMode {
+	if (!folder.enabled) return "obsidian-default";
+	if (folder.chooseWhenCreatingNote) return "prompt";
+	if (folder.createInSameFolderAsActiveFile) return "active-file";
+	return "specified";
+}
+
+/**
+ * Return a NEW folder config with the canonical flags for `mode`.
+ *
+ * - `folders[]` (the expensive, user-entered list) is preserved across every
+ *   switch, so hiding a mode never deletes the configured folders (#1131: the
+ *   reporter's "my config disappeared" anxiety).
+ * - `chooseFromSubfolders` is owned by "specified" mode and reset to `false`
+ *   everywhere else. It is NOT fully inert outside "specified":
+ *   `TemplateInsertEngine.computeChoiceTargetPath` reads it UNGATED, so a leftover
+ *   `true` would make the apply-to-note move-offer silently unavailable for an
+ *   otherwise-resolvable active-file choice. Resetting keeps every mode canonical.
+ */
+export function applyFolderMode(
+	folder: TemplateFolderConfig,
+	mode: FolderMode,
+): TemplateFolderConfig {
+	switch (mode) {
+		case "obsidian-default":
+			return {
+				...folder,
+				enabled: false,
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			};
+		case "specified":
+			return {
+				...folder,
+				enabled: true,
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+			};
+		case "active-file":
+			return {
+				...folder,
+				enabled: true,
+				createInSameFolderAsActiveFile: true,
+				chooseWhenCreatingNote: false,
+				chooseFromSubfolders: false,
+			};
+		case "prompt":
+			return {
+				...folder,
+				enabled: true,
+				chooseWhenCreatingNote: true,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			};
+	}
+}
+
+export const FOLDER_MODE_OPTIONS: { value: FolderMode; label: string }[] = [
+	{ value: "obsidian-default", label: "Obsidian default" },
+	{ value: "specified", label: "In a specific folder" },
+	{ value: "active-file", label: "Same folder as current file" },
+	{ value: "prompt", label: "Ask for folder each time" },
+];
+
+export const FOLDER_MODE_DESCRIPTIONS: Record<FolderMode, string> = {
+	"obsidian-default":
+		"Use Obsidian's “Default location for new notes” setting.",
+	specified:
+		"Create the note in the folder(s) below. With multiple folders, you'll be asked which one when the note is created.",
+	"active-file":
+		"Create the note next to the currently active file (falls back to the vault root if no file is open).",
+	prompt: "Choose any folder in the vault when the note is created.",
+};

--- a/src/gui/ChoiceBuilder/folderMode.ts
+++ b/src/gui/ChoiceBuilder/folderMode.ts
@@ -36,14 +36,17 @@ export function deriveFolderMode(folder: TemplateFolderConfig): FolderMode {
 /**
  * Return a NEW folder config with the canonical flags for `mode`.
  *
- * - `folders[]` (the expensive, user-entered list) is preserved across every
- *   switch, so hiding a mode never deletes the configured folders (#1131: the
- *   reporter's "my config disappeared" anxiety).
- * - `chooseFromSubfolders` is owned by "specified" mode and reset to `false`
- *   everywhere else. It is NOT fully inert outside "specified":
- *   `TemplateInsertEngine.computeChoiceTargetPath` reads it UNGATED, so a leftover
- *   `true` would make the apply-to-note move-offer silently unavailable for an
- *   otherwise-resolvable active-file choice. Resetting keeps every mode canonical.
+ * Only the mode-discriminant flags (`enabled`, `chooseWhenCreatingNote`,
+ * `createInSameFolderAsActiveFile`) are set; `folders[]` and `chooseFromSubfolders`
+ * are PRESERVED across every switch. This matches the previous toggle form, which
+ * hid but never cleared those values — so switching mode and back never loses the
+ * user's folder list or their "Include subfolders" preference.
+ *
+ * `chooseFromSubfolders` only affects the engine in "specified" mode (its branch 1
+ * is gated by `!(chooseWhenCreatingNote || createInSameFolderAsActiveFile)`), so a
+ * preserved value is inert in the other modes here. (Note:
+ * `TemplateInsertEngine.computeChoiceTargetPath` reads it ungated — a pre-existing
+ * quirk, unchanged by this UI work.)
  */
 export function applyFolderMode(
 	folder: TemplateFolderConfig,
@@ -56,7 +59,6 @@ export function applyFolderMode(
 				enabled: false,
 				chooseWhenCreatingNote: false,
 				createInSameFolderAsActiveFile: false,
-				chooseFromSubfolders: false,
 			};
 		case "specified":
 			return {
@@ -71,7 +73,6 @@ export function applyFolderMode(
 				enabled: true,
 				createInSameFolderAsActiveFile: true,
 				chooseWhenCreatingNote: false,
-				chooseFromSubfolders: false,
 			};
 		case "prompt":
 			return {
@@ -79,19 +80,18 @@ export function applyFolderMode(
 				enabled: true,
 				chooseWhenCreatingNote: true,
 				createInSameFolderAsActiveFile: false,
-				chooseFromSubfolders: false,
 			};
 	}
 }
 
-export const FOLDER_MODE_OPTIONS: { value: FolderMode; label: string }[] = [
+export const folderModeOptions: { value: FolderMode; label: string }[] = [
 	{ value: "obsidian-default", label: "Obsidian default" },
 	{ value: "specified", label: "In a specific folder" },
 	{ value: "active-file", label: "Same folder as current file" },
 	{ value: "prompt", label: "Ask for folder each time" },
 ];
 
-export const FOLDER_MODE_DESCRIPTIONS: Record<FolderMode, string> = {
+export const folderModeDescriptions: Record<FolderMode, string> = {
 	"obsidian-default":
 		"Use Obsidian's “Default location for new notes” setting.",
 	specified:

--- a/src/styles.css
+++ b/src/styles.css
@@ -190,6 +190,13 @@
 	width: 100%;
 }
 
+.quickAddModal .qa-folder-mode-warning {
+	color: var(--text-warning);
+	font-size: var(--font-ui-smaller);
+	margin: 0 auto 12px;
+	max-width: 50%;
+}
+
 .quickAddModal .qa-template-format-input {
 	margin-bottom: 8px;
 }

--- a/src/types/choices/ITemplateChoice.ts
+++ b/src/types/choices/ITemplateChoice.ts
@@ -3,15 +3,23 @@ import type { AppendLinkOptions } from "../linkPlacement";
 import type { OpenLocation, FileViewMode2 } from "../fileOpening";
 import type { TemplateFileExistsBehavior } from "../../template/fileExistsPolicy";
 
+/**
+ * Destination configuration for a Template choice. These four booleans encode a
+ * set of mutually-exclusive destination modes at runtime (see
+ * TemplateChoiceEngine.getFolderPath); the choice builder surfaces them through a
+ * single derived dropdown (see gui/ChoiceBuilder/folderMode.ts).
+ */
+export type TemplateFolderConfig = {
+	enabled: boolean;
+	folders: string[];
+	chooseWhenCreatingNote: boolean;
+	createInSameFolderAsActiveFile: boolean;
+	chooseFromSubfolders: boolean;
+};
+
 export default interface ITemplateChoice extends IChoice {
 	templatePath: string;
-	folder: {
-		enabled: boolean;
-		folders: string[];
-		chooseWhenCreatingNote: boolean;
-		createInSameFolderAsActiveFile: boolean;
-		chooseFromSubfolders: boolean;
-	};
+	folder: TemplateFolderConfig;
 	fileNameFormat: { enabled: boolean; format: string };
 	/** 
 	 * Configure link appending behavior. 

--- a/src/types/choices/TemplateChoice.ts
+++ b/src/types/choices/TemplateChoice.ts
@@ -1,4 +1,5 @@
 import type ITemplateChoice from "./ITemplateChoice";
+import type { TemplateFolderConfig } from "./ITemplateChoice";
 import { Choice } from "./Choice";
 import type { OpenLocation, FileViewMode2 } from "../fileOpening";
 import type { AppendLinkOptions } from "../linkPlacement";
@@ -8,13 +9,7 @@ import type { TemplateFileExistsBehavior } from "../../template/fileExistsPolicy
 export class TemplateChoice extends Choice implements ITemplateChoice {
 	appendLink: boolean | AppendLinkOptions;
 	fileNameFormat: { enabled: boolean; format: string };
-	folder: {
-		enabled: boolean;
-		folders: string[];
-		chooseWhenCreatingNote: boolean;
-		createInSameFolderAsActiveFile: boolean;
-		chooseFromSubfolders: boolean;
-	};
+	folder: TemplateFolderConfig;
 	openFile: boolean;
 	fileOpening: {
 		location: OpenLocation;


### PR DESCRIPTION
Closes #1131.

## Problem
The Template choice builder's **Location** section used **4 interdependent toggles** (*Create in folder* · *Choose folder when creating a new note* · *Include subfolders* · *Create in same folder as active file*) whose visibility depended on each other. New users found this confusing — and turning on the last toggle made the folder config *above* it vanish. Confirmed live in the dev vault (toggling *Create in same folder as active file* ON removes the folder input **and** two other toggles).

## Solution
One **"New note location"** dropdown with four mutually-exclusive modes:

| Mode | Behaviour |
|---|---|
| Obsidian default | Use Obsidian's "Default location for new notes" |
| In a specific folder | Folder list (+ *Include subfolders* sub-checkbox) |
| Same folder as current file | Create next to the active file |
| Ask for folder each time | Prompt for any vault folder on create |

It matches the form's existing pattern (the "If the target file already exists" row is already a dropdown) and is **obsidian-native** (`<select>`).

## How it works — no schema change
The dropdown is a **derived view** over the existing four persisted booleans (`folder.{enabled, folders, chooseWhenCreatingNote, createInSameFolderAsActiveFile, chooseFromSubfolders}`):

- A pure helper (`src/gui/ChoiceBuilder/folderMode.ts`) maps booleans → mode (`deriveFolderMode`) and mode → canonical booleans (`applyFolderMode`).
- `deriveFolderMode` **mirrors `TemplateChoiceEngine.getFolderPath()` precedence exactly** — pinned by a 16-combination oracle test, so the dropdown always shows the mode that will actually run (legacy choices with multiple flags set open on their true mode).
- Switching modes **hides but never deletes** the configured folder list (directly fixes the "my config disappeared" anxiety).
- `Include subfolders` is scoped to the one mode where the engine honours it; `chooseFromSubfolders` is reset outside that mode so it stays inert in `TemplateInsertEngine`'s move-offer.

**Zero migration · forward/backward compatible · engines untouched · package export/import unaffected.** Existing `data.json` works as-is; an older QuickAdd build still reads the booleans.

## Empty-folder guard
"In a specific folder" with an empty list previously fell through to the active file's folder silently. A required inline warning now flags this.

## Scope (maintainer-confirmed)
- **"Vault root" mode** (the issue's 5th option) — **deferred**: there is no persisted representation independent of Obsidian's global setting, and adding one would break the zero-migration premise. Reachable today via "Obsidian default" when the global setting points at root.
- **Capture** — **out of scope**: it has no folder object (`captureTo` string + `captureToActiveFile`) and does not have this bug.

## Verification
- Full vitest suite green (incl. a new `folderMode.test.ts`: 16-combo precedence oracle, round-trip, residue-reset; rewritten `TemplateChoiceForm.test.ts` keeps the #1130 no-remount guard).
- `tsc` + ESLint clean; production build OK.
- Live dev-vault e2e: dropdown renders, all 4 modes show/hide the right fields, and **end-to-end persistence** writes the canonical booleans to `data.json` (`active-file → prompt` resets `createInSameFolderAsActiveFile`; `prompt → specified` + folder + subfolders persists).

## Migration / release impact
None. User-facing UI only; `feat` → minor release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Template note location is now managed via a single dropdown (Obsidian default, specific folder(s), active file location, or prompt), with the relevant controls shown/hidden per selection.
  * “Include subfolders” is available for specific folder(s), and incomplete folder selections now show a warning.
  * Improved styling for the folder-mode guidance and warning display.
* **Documentation**
  * Updated TemplateChoice documentation to reflect the new “New note location” dropdown and modes.
* **Tests**
  * Expanded automated coverage for folder mode selection and configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->