### PR TITLE
feat(value): allow commas inside quoted multi-select options (#239)

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -49,6 +49,20 @@ Example: `- [ ] {{VALUE|label:Task}}`.
 
 You can now use variable names in values. They'll get saved and inserted just like values, but the difference is that you can have as many of them as you want. Use comma separation to get a suggester rather than a prompt.
 
+**Commas inside an option:** wrap an option in double quotes to include a literal comma in it. The quotes are stripped from the inserted value.
+
+```markdown
+{{VALUE:"This is a single choice, with a comma",Second choice}}
+```
+
+This shows two options: `This is a single choice, with a comma` and `Second choice`. Notes:
+
+- Both straight (`"`) and curly (`“ ”`) double quotes work, so pasting from a rich-text editor is fine.
+- To include a literal double quote inside a quoted option, double it: `"say ""hi"""` inserts `say "hi"`.
+- Single quotes/apostrophes are never special, so `Bob's,Alice's` keeps working unchanged.
+- The same quoting applies to `|text:` display labels and to `|default:` (e.g. `|default:"a, b"`).
+- Pipes (`|`) inside an option are still not supported; whitespace inside quotes is trimmed.
+
 If the same variable name appears in multiple macro steps, QuickAdd prompts once and reuses the value.
 
 Example:
@@ -68,7 +82,7 @@ Example: `{{VALUE:project|label:Client or project name}}`.
 
 ## `{{VALUE:<items>|text:<display items>}}` {#value-text}
 
-For option lists, decouples what is shown in the suggester from what is inserted. `items` and `text` must have the same number of comma-separated entries, and each `text` entry must be unique. If you also use `|custom`, typed custom text is inserted as-is.
+For option lists, decouples what is shown in the suggester from what is inserted. `items` and `text` must have the same number of comma-separated entries, and each `text` entry must be unique. To put a comma inside one `items` or `text` entry, wrap that entry in double quotes (e.g. `text:"High, urgent",Low`). If you also use `|custom`, typed custom text is inserted as-is.
 
 Example: `priority: {{VALUE:🔽,🔼,⏫|text:Low,Normal,High}}`.
 
@@ -268,7 +282,7 @@ The final rendered filename (without extension) of the note being created or cap
 
 Example: `# {{TITLE}}`.
 
-`|text:` limitations (current): commas and pipes inside individual `items`/`text` entries are not supported.
+`|text:` limitations (current): a comma inside an `items`/`text` entry needs double quotes (e.g. `"a, b"`); pipes (`|`) inside an entry are not supported.
 
 ### Mixed-mode example
 

--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -16,6 +16,8 @@ const CURRENT_AND_2120_EXAMPLES = [
 	"---\ntitle: {{VALUE:title}}\n---\n# {{VALUE:title}}",
 	"{{VALUE:project|label:Client or project name}}",
 	"priority: {{VALUE:🔽,🔼,⏫|text:Low,Normal,High}}",
+	'{{VALUE:"This is a single choice, with a comma",Second choice}}',
+	'priority: {{VALUE:high,"a, b"|text:"High, urgent","A or B"}}',
 	"status: {{VALUE:status|Draft}}",
 	"{{VALUE:title|label:Note title|default:Untitled}}",
 	"## Summary\n{{VALUE:summary|type:multiline|label:Summary}}",

--- a/src/formatters/formatter-text-mapping.test.ts
+++ b/src/formatters/formatter-text-mapping.test.ts
@@ -159,6 +159,34 @@ describe("Formatter VALUE text mapping", () => {
 		expect(result).toBe("⏫");
 	});
 
+	// #239: a comma inside a quoted item/label round-trips end-to-end — selecting
+	// the comma-bearing display label inserts the comma-bearing item value.
+	it("maps a quoted-comma display label to its quoted-comma item value", async () => {
+		formatter.setSelectedDisplayValue("High, urgent");
+		const result = await formatter.testFormat(
+			'{{VALUE:high,"a, b"|text:"High, urgent","A or B"}}',
+		);
+
+		expect(result).toBe("high");
+		expect(formatter.lastSuggestCall?.suggestedValues).toEqual([
+			"high",
+			"a, b",
+		]);
+		expect(formatter.lastSuggestCall?.displayValues).toEqual([
+			"High, urgent",
+			"A or B",
+		]);
+
+		// Fresh formatter: the first instance has already cached its selection.
+		const second = new TextMappingFormatter();
+		second.setSelectedDisplayValue("A or B");
+		expect(
+			await second.testFormat(
+				'{{VALUE:high,"a, b"|text:"High, urgent","A or B"}}',
+			),
+		).toBe("a, b");
+	});
+
 	it("keeps custom typed values when custom input is enabled", async () => {
 		formatter.setNextSuggestionResult("urgent!");
 		const result = await formatter.testFormat(

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -361,4 +361,48 @@ describe("RequirementCollector — optional fields (issue #1259)", () => {
       optional: true,
     });
   });
+
+  // #239: commas inside a quoted option must survive the preflight (one-page) path.
+  it("collects a quoted-comma option as a single dropdown entry", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    await rc.scanString('{{VALUE:"a, b",c}}');
+
+    const dropdown = Array.from(rc.requirements.values()).find(
+      (r) => r.type === "dropdown",
+    );
+    expect(dropdown?.options).toEqual(["a, b", "c"]);
+  });
+
+  it("collects quoted-comma text labels aligned with their items", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    await rc.scanString('{{VALUE:high,"a, b"|text:"High, urgent","A or B"}}');
+
+    const dropdown = Array.from(rc.requirements.values()).find(
+      (r) => r.type === "dropdown",
+    );
+    expect(dropdown?.options).toEqual(["high", "a, b"]);
+    expect(dropdown?.displayOptions).toEqual(["High, urgent", "A or B"]);
+  });
+
+  it("a single quoted option records a text field, not a dropdown (preflight == runtime)", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    await rc.scanString('{{VALUE:"a, b"}}');
+
+    expect(rc.requirements.get('"a, b"')?.type).toBe("text");
+  });
+
+  it("preserves a quoted-comma default when a reuse precedes the option-list definition", async () => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    // Option-less reuse recorded first, then the named definition upgrades it to
+    // a dropdown — the quoted default must unwrap to match an unquoted option.
+    await rc.scanString(
+      '{{VALUE:category|default:"a, b"}} {{VALUE:c,"a, b"|name:category}}',
+    );
+
+    expect(rc.requirements.get("category")).toMatchObject({
+      type: "dropdown",
+      options: ["c", "a, b"],
+      defaultValue: "a, b",
+    });
+  });
 });

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -10,7 +10,11 @@ import { Formatter, type PromptContext } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import type QuickAdd from "src/main";
 import { NLDParser } from "src/parsers/NLDParser";
-import { parseValueToken } from "src/utils/valueSyntax";
+import {
+	parseValueToken,
+	splitQuotedCommaList,
+	unwrapQuotedValue,
+} from "src/utils/valueSyntax";
 import { parseVDateOptions } from "src/utils/vdateSyntax";
 
 export type FieldType =
@@ -199,12 +203,16 @@ export class RequirementCollector extends Formatter {
 					// that isn't one (incl. a display label) would be normalized to
 					// the first option anyway — clear it for an honest empty start.
 					// The suggester/custom path accepts free text, so keep it.
-					if (
-						existing.defaultValue !== undefined &&
-						!parsed.allowCustomInput &&
-						!parsed.suggestedValues.includes(existing.defaultValue)
-					) {
-						existing.defaultValue = undefined;
+					// The original default was recorded option-less, so unwrap any
+					// quotes now (the option list is unquoted) before matching, so a
+					// quoted comma default like |default:"a, b" still pre-selects.
+					if (existing.defaultValue !== undefined && !parsed.allowCustomInput) {
+						const unwrapped = unwrapQuotedValue(existing.defaultValue);
+						existing.defaultValue = parsed.suggestedValues.includes(
+							unwrapped,
+						)
+							? unwrapped
+							: undefined;
 					}
 				}
 				if (defaultValue && existing.defaultValue === undefined)
@@ -329,8 +337,14 @@ export class RequirementCollector extends Formatter {
 
 		// Generic named variables
 		if (!this.requirements.has(key)) {
-			// Detect simple comma-separated option lists
-			const hasOptions = variableName.includes(",");
+			// Detect comma-separated option lists, honoring quoted commas the same
+			// way parseValueToken does so this fallback can never disagree with the
+			// runtime split (e.g. a single quoted option stays one value, not a
+			// bogus dropdown).
+			const optionValues = splitQuotedCommaList(variableName)
+				.map((s) => s.trim())
+				.filter(Boolean);
+			const hasOptions = optionValues.length > 1;
 			const baseInputType =
 				context?.inputTypeOverride === "multiline" ||
 				this.plugin.settings.inputPrompt === "multi-line"
@@ -344,10 +358,7 @@ export class RequirementCollector extends Formatter {
 				source: "collected",
 			};
 			if (hasOptions) {
-				req.options = variableName
-					.split(",")
-					.map((s) => s.trim())
-					.filter(Boolean);
+				req.options = optionValues;
 			}
 			if (context?.defaultValue) req.defaultValue = context.defaultValue;
 			this.requirements.set(key, req);

--- a/src/utils/valueSyntax.quoted-commas.239.test.ts
+++ b/src/utils/valueSyntax.quoted-commas.239.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+	parseValueToken,
+	splitQuotedCommaList,
+	unwrapQuotedValue,
+} from "./valueSyntax";
+
+// #239: allow a comma inside a single {{VALUE:a,b}} option by quoting it.
+// The headline invariant: any list WITHOUT a balanced double-quoted field
+// parses byte-identically to the pre-#239 naive comma split.
+
+describe("splitQuotedCommaList — the fix", () => {
+	it("keeps a comma inside a double-quoted option (issue example)", () => {
+		expect(
+			splitQuotedCommaList(
+				'"This is a single choice, with a comma",Second Choice',
+			),
+		).toEqual(["This is a single choice, with a comma", "Second Choice"]);
+	});
+
+	it("honors the reporter's verbatim paste with a CURLY close-quote", () => {
+		// The #239 body pastes a straight open-quote and a curly U+201D close.
+		expect(
+			splitQuotedCommaList(
+				'"This is a single choice, with a comma”,Second Choice',
+			),
+		).toEqual(["This is a single choice, with a comma", "Second Choice"]);
+	});
+
+	it("supports fully curly-quoted fields", () => {
+		expect(splitQuotedCommaList("“a, b”,c")).toEqual(["a, b", "c"]);
+	});
+
+	it("treats `\"\"` inside a quoted field as one literal quote", () => {
+		expect(splitQuotedCommaList('"a""b",c')).toEqual(['a"b', "c"]);
+	});
+
+	it("allows a leading space before an opening quote (later fields)", () => {
+		expect(splitQuotedCommaList('a, "b, c"')).toEqual(["a", "b, c"]);
+	});
+
+	it("strips quotes from every quoted field", () => {
+		expect(splitQuotedCommaList('"A",B,"C"')).toEqual(["A", "B", "C"]);
+	});
+
+	it("supports a quoted comma-only field", () => {
+		expect(splitQuotedCommaList('","')).toEqual([","]);
+	});
+});
+
+describe("splitQuotedCommaList — strict close reverts to legacy", () => {
+	it("a quote closed by other text is not real quoting", () => {
+		// next char after the close is text, not a comma/EOF -> legacy split.
+		expect(splitQuotedCommaList('"a"b,c')).toEqual(['"a"b', "c"]);
+		expect(splitQuotedCommaList('"Hello" he said,next')).toEqual([
+			'"Hello" he said',
+			"next",
+		]);
+	});
+
+	it("an unterminated quote falls back to a plain split", () => {
+		expect(splitQuotedCommaList('"oops,more')).toEqual(['"oops', "more"]);
+	});
+
+	it("honors non-breaking / unicode space between a close quote and comma", () => {
+		// NBSP (U+00A0) can arrive from rich-text paste; it must not break
+		// the close. Plain space and tab are covered too.
+		expect(splitQuotedCommaList('"a"\u00a0,b')).toEqual(["a", "b"]);
+		expect(splitQuotedCommaList('"a, b" ,c')).toEqual(["a, b", "c"]);
+		expect(splitQuotedCommaList('"a"\t,c')).toEqual(["a", "c"]);
+	});
+
+	it("interleaved quotes mid-field stay literal", () => {
+		expect(splitQuotedCommaList('say "hi" yo,next')).toEqual([
+			'say "hi" yo',
+			"next",
+		]);
+	});
+
+	it("a double-quote in an UNquoted field never opens a span", () => {
+		// buf is non-empty when the quote appears, so `a""b` stays literal.
+		expect(splitQuotedCommaList("a\"\"b,c")).toEqual(['a""b', "c"]);
+	});
+});
+
+describe("splitQuotedCommaList — backward-compat property (no double quotes)", () => {
+	it("is byte-identical to input.split(',') for every double-quote-free input", () => {
+		const alphabet = ["a", "b", ",", " ", "'", "|"];
+		let checked = 0;
+		let mismatches = 0;
+		const enumerate = (prefix: string, depth: number) => {
+			if (depth === 0) return;
+			for (const ch of alphabet) {
+				const s = prefix + ch;
+				checked++;
+				const got = splitQuotedCommaList(s);
+				const want = s.split(",");
+				if (JSON.stringify(got) !== JSON.stringify(want)) mismatches++;
+				enumerate(s, depth - 1);
+			}
+		};
+		enumerate("", 4);
+		expect(checked).toBeGreaterThan(1500);
+		expect(mismatches).toBe(0);
+	});
+
+	it("unbalanced fallback re-enters the same trim/filter post-processing", () => {
+		for (const s of [' "a , , b ', '"x, ,y', '  ,  ,  ', '"only open']) {
+			const got = splitQuotedCommaList(s).map((v) => v.trim()).filter(Boolean);
+			const legacy = s
+				.split(",")
+				.map((v) => v.trim())
+				.filter(Boolean);
+			expect(got).toEqual(legacy);
+		}
+	});
+});
+
+describe("parseValueToken — option values", () => {
+	it("reproduces the fix end-to-end (issue example -> two clean options)", () => {
+		const parsed = parseValueToken(
+			'"This is a single choice, with a comma",Second Choice',
+		);
+		expect(parsed?.suggestedValues).toEqual([
+			"This is a single choice, with a comma",
+			"Second Choice",
+		]);
+		expect(parsed?.hasOptions).toBe(true);
+	});
+
+	it("apostrophes are untouched (single quote is not special)", () => {
+		expect(parseValueToken("Bob's,Alice's")?.suggestedValues).toEqual([
+			"Bob's",
+			"Alice's",
+		]);
+		expect(parseValueToken("'tis,'twas")?.suggestedValues).toEqual([
+			"'tis",
+			"'twas",
+		]);
+	});
+
+	it("a single quoted field collapses to one option (suggester -> prompt)", () => {
+		// Documented control-type flip: one option => hasOptions=false.
+		const parsed = parseValueToken('"a, b"');
+		expect(parsed?.suggestedValues).toEqual(["a, b"]);
+		expect(parsed?.hasOptions).toBe(false);
+	});
+
+	it("drops an empty quoted option", () => {
+		expect(parseValueToken('"",a')?.suggestedValues).toEqual(["a"]);
+	});
+});
+
+describe("parseValueToken — text: labels", () => {
+	it("honors quoted commas in display labels and aligns the count", () => {
+		const parsed = parseValueToken('a,b|text:"X, Y",Z');
+		expect(parsed?.suggestedValues).toEqual(["a", "b"]);
+		expect(parsed?.displayValues).toEqual(["X, Y", "Z"]);
+	});
+
+	it("a quoted-comma label that desyncs the count throws with a quoting hint", () => {
+		// Was incidentally valid pre-#239 (naive 3==3); now items=3, labels=2.
+		expect(() => parseValueToken('x,y,z|text:"a,b",c')).toThrow(
+			/double quotes/i,
+		);
+	});
+});
+
+describe("parseValueToken — default: unwrap on option lists", () => {
+	it("unwraps a quoted comma default so it matches its option", () => {
+		const parsed = parseValueToken('c,"a, b"|default:"a, b"');
+		expect(parsed?.suggestedValues).toEqual(["c", "a, b"]);
+		expect(parsed?.defaultValue).toBe("a, b");
+		expect(parsed?.suggestedValues).toContain(parsed?.defaultValue);
+	});
+
+	it("unwraps a curly-quoted default", () => {
+		const parsed = parseValueToken('c,"a, b"|default:“a, b”');
+		expect(parsed?.defaultValue).toBe("a, b");
+	});
+
+	it("leaves an unquoted default untouched", () => {
+		expect(parseValueToken("a,b|default:b")?.defaultValue).toBe("b");
+	});
+
+	it("does not unwrap a single-value (non-option) default", () => {
+		// hasOptions=false, so a quoted default stays literal.
+		expect(parseValueToken('title|default:"x"')?.defaultValue).toBe('"x"');
+	});
+});
+
+describe("unwrapQuotedValue", () => {
+	it("strips a surrounding straight or curly pair and unescapes ``\"\"``", () => {
+		expect(unwrapQuotedValue('"a, b"')).toBe("a, b");
+		expect(unwrapQuotedValue("“a, b”")).toBe("a, b");
+		expect(unwrapQuotedValue('"a""b"')).toBe('a"b');
+	});
+
+	it("passes unquoted values through unchanged", () => {
+		expect(unwrapQuotedValue("a, b")).toBe("a, b");
+		expect(unwrapQuotedValue("plain")).toBe("plain");
+		expect(unwrapQuotedValue('"unbalanced')).toBe('"unbalanced');
+	});
+
+	it("is strict like the splitter: leaves malformed/multi-field values literal", () => {
+		// Same grammar as splitQuotedCommaList — not a naive first/last strip.
+		expect(unwrapQuotedValue('"a","b"')).toBe('"a","b"');
+		expect(unwrapQuotedValue('"a"b"')).toBe('"a"b"');
+		expect(unwrapQuotedValue('"a""')).toBe('"a""');
+	});
+});
+
+describe("strict-close fallback via the parseValueToken entry point", () => {
+	it("keeps literal quotes when a quote is closed by other text", () => {
+		expect(parseValueToken('"a"b,c')?.suggestedValues).toEqual([
+			'"a"b',
+			"c",
+		]);
+	});
+});

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -269,6 +269,108 @@ function resolveInputType(
 	return "multiline";
 }
 
+// The "double-quote class" that opens/closes a quoted option: the straight
+// double quote plus the curly pair editors (and Obsidian) auto-substitute. The
+// reporter's own example in #239 pastes a curly close-quote (U+201D), so curly
+// quotes must work, not just `"`. Single quotes/apostrophes are intentionally
+// NOT special — they are ubiquitous in option text (Bob's, 'tis).
+const DOUBLE_QUOTE_CHARS = new Set(['"', "“", "”"]);
+
+function isDoubleQuote(ch: string | undefined): boolean {
+	return ch !== undefined && DOUBLE_QUOTE_CHARS.has(ch);
+}
+
+// Horizontal whitespace only (space, tab, NBSP, other Unicode spaces) — NOT
+// line breaks. VALUE tokens never contain newlines (constants.ts VARIABLE_REGEX
+// excludes them), but excluding them here keeps the helper safe if reused.
+const HORIZONTAL_WS = /[^\S\r\n]/;
+
+/**
+ * Split a comma-separated VALUE option list while honoring double-quoted fields,
+ * so a comma inside `"..."` stays literal (#239). CSV-style rules:
+ *   - A field is quoted only when it STARTS with a double-quote (after optional
+ *     leading whitespace); a quote anywhere else is literal.
+ *   - Inside a quoted field, `""` is one literal quote and a comma is literal.
+ *   - A closing quote is only honored when the next non-space char is a comma or
+ *     end-of-input (STRICT close).
+ *
+ * Any input that is not cleanly quote-balanced — an unterminated quote, or a
+ * quote "closed" by other text (e.g. `"a"b`) — falls back to a plain comma
+ * split. That guarantees every token WITHOUT a balanced double-quoted field
+ * parses byte-identically to the pre-#239 behavior.
+ *
+ * Returns raw fields with the surrounding quotes stripped; callers apply the
+ * usual `.map(trim).filter(Boolean)`. Whitespace inside quotes is therefore not
+ * preserved — quoting protects commas, which survive the trim.
+ */
+export function splitQuotedCommaList(input: string): string[] {
+	const fields: string[] = [];
+	let buf = "";
+	let inQuotes = false;
+
+	for (let i = 0; i < input.length; i++) {
+		const ch = input[i];
+
+		if (inQuotes) {
+			if (isDoubleQuote(ch)) {
+				if (isDoubleQuote(input[i + 1])) {
+					// Doubled quote -> one literal straight quote.
+					buf += '"';
+					i++;
+					continue;
+				}
+				// Candidate close: valid only if followed by ws* then `,`/EOF.
+				let j = i + 1;
+				while (j < input.length && HORIZONTAL_WS.test(input[j])) j++;
+				if (j >= input.length || input[j] === ",") {
+					inQuotes = false;
+					i = j - 1; // skip the trailing whitespace up to the delimiter
+					continue;
+				}
+				// Quote closed by other text -> not real quoting; keep legacy.
+				return input.split(",");
+			}
+			buf += ch; // commas (and everything else) are literal inside quotes
+			continue;
+		}
+
+		if (ch === ",") {
+			fields.push(buf);
+			buf = "";
+			continue;
+		}
+		if (isDoubleQuote(ch) && buf.trim() === "") {
+			// Opening quote: drop any leading whitespace already buffered.
+			inQuotes = true;
+			buf = "";
+			continue;
+		}
+		buf += ch;
+	}
+
+	if (inQuotes) return input.split(","); // unterminated quote -> legacy
+	fields.push(buf);
+	return fields;
+}
+
+/**
+ * Strip a single surrounding double-quote pair from one value, applying the same
+ * `""` -> `"` unescape as {@link splitQuotedCommaList}. Used to unwrap a
+ * `|default:"a, b"` on an option-list token so the default matches its
+ * now-unquoted option (in both the preflight form and the runtime fallback).
+ * Unquoted values pass through unchanged.
+ */
+export function unwrapQuotedValue(value: string): string {
+	const trimmed = value.trim();
+	if (!isDoubleQuote(trimmed[0])) return value;
+	// Reuse the list grammar so unwrapping matches splitting exactly (strict
+	// close, doubled-quote escape). Only a single, fully balanced quoted field is
+	// unwrapped; anything that falls back to a literal split is left untouched.
+	const fields = splitQuotedCommaList(trimmed);
+	if (fields.length === 1 && fields[0] !== trimmed) return fields[0].trim();
+	return value;
+}
+
 export function parseValueToken(
 	raw: string,
 	opts?: { quiet?: boolean },
@@ -280,8 +382,7 @@ export function parseValueToken(
 	const variablePart = (parts.shift() ?? "").trim();
 	if (!variablePart) return null;
 
-	const suggestedValues = variablePart
-		.split(",")
+	const suggestedValues = splitQuotedCommaList(variablePart)
 		.map((value) => value.trim())
 		.filter(Boolean);
 	const hasOptions = suggestedValues.length > 1;
@@ -296,6 +397,13 @@ export function parseValueToken(
 		const legacyDefault = defaultValue;
 		allowCustomInput = hasOptions && legacyDefault.toLowerCase() === "custom";
 		defaultValue = allowCustomInput ? "" : legacyDefault;
+	}
+
+	// Option-list defaults may contain a comma, which is only expressible as a
+	// quoted value (|default:"a, b"); unwrap it so it matches its now-unquoted
+	// option in both the preflight form and the runtime empty-submission fallback.
+	if (hasOptions && defaultValue) {
+		defaultValue = unwrapQuotedValue(defaultValue);
 	}
 
 	const tokenDisplay = `{{VALUE:${raw}}}`;
@@ -317,14 +425,13 @@ export function parseValueToken(
 			);
 		}
 
-		displayValues = options.displayValuesRaw
-			.split(",")
+		displayValues = splitQuotedCommaList(options.displayValuesRaw)
 			.map((value) => value.trim())
 			.filter(Boolean);
 
 		if (displayValues.length !== suggestedValues.length) {
 			throw new Error(
-				`QuickAdd: VALUE token "${tokenDisplay}" must define the same number of text entries and item entries.`,
+				`QuickAdd: VALUE token "${tokenDisplay}" must define the same number of text entries and item entries. To include a comma inside one entry, wrap it in double quotes, e.g. "a, b".`,
 			);
 		}
 


### PR DESCRIPTION
Closes #239.

## What

Multi-select `{{VALUE:a,b,c}}` tokens split options on **every** comma, so an option could never contain a comma. Now you can wrap an option in double quotes to include a literal comma:

```
{{VALUE:"This is a single choice, with a comma",Second choice}}
```

→ two options: `This is a single choice, with a comma` and `Second choice` (quotes stripped).

## How

A new pure `splitQuotedCommaList()` in `src/utils/valueSyntax.ts` — a single-pass, CSV-style splitter:

- **Straight (`"`) and curly (`“ ”`) double quotes** both work. The issue's pasted example uses a curly close-quote, and editors/Obsidian auto-substitute straight→curly, so this is the common paste.
- **`""`** inside a quoted field is a literal `"` (CSV escape).
- **Strict close**: a closing quote is only honored when followed by horizontal whitespace (incl. NBSP) then a comma or end-of-input. Otherwise the whole input reverts to a plain comma split — so `"a"b,c` and `"Hello" he said,x` keep their literal quotes.
- **Backward-compat invariant**: any input with no double-quote character parses byte-identically to the old `split(",")`. Locked by a property test (and reviewers' fuzz over 200k+ inputs found zero mismatches).

Centralized in `parseValueToken`, so the runtime suggester, live preview, preflight one-page form, and `api.format` all inherit it. The same splitter is applied to `|text:` display labels, and `|default:` is unwrapped via the same grammar so a quoted-comma default still pre-selects its (now-unquoted) option — including the reuse-before-definition upgrade path in the preflight collector.

## Scope / limitations (documented)

- Single quotes / apostrophes stay literal (so `Bob's,Alice's` is unchanged) — apostrophes are too common to make special.
- Pipes (`|`) inside an option remain unsupported (pipe-splitting runs first).
- Whitespace inside quotes is trimmed (quoting protects commas).
- Rare, documented behavior change for tokens that already contain a balanced double-quote pair (e.g. `a,"b",c` → `a,b,c`; a single quoted field like `"a, b"` becomes one option → a text prompt instead of a 2-way split).

## Tests & verification

- New `valueSyntax.quoted-commas.239.test.ts`: the fix, curly quotes, `""` escape, strict-close reverts, NBSP close, apostrophes, the single-field flip, `default:` unwrap, and the no-double-quote **backward-compat property check**.
- `RequirementCollector.test.ts`: preflight collects quoted-comma options/labels as single dropdown entries, and preserves a quoted-comma default across reuse-before-definition.
- `formatter-text-mapping.test.ts`: end-to-end — selecting a comma-bearing display label inserts the comma-bearing item value.
- Full suite green (2160 passed); `tsc` + ESLint clean.
- **Dev-vault e2e** (real Obsidian suggester): the issue example (straight + verbatim curly paste) shows exactly 2 clean options; `a,b,c` still 3; apostrophes untouched; a selected quoted option persists to the note **without** quotes.

## Review

Design and implementation each went through an ultracode multi-lens review plus 2 opposite-model (Codex) adversarial reviewers. Implementation verdicts: tokenizer **ship (no defects)**, backcompat **ship**, integration **ship**, plus SHIP-WITH-FIXES items (strict-close NBSP whitespace, `unwrapQuotedValue` grammar consistency, preflight default unwrap, added preflight/e2e tests) — all addressed in this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VALUE tokens now support literal commas in quoted options. Options containing commas can be specified by wrapping them in double quotes; quotes are stripped from the inserted value.

* **Documentation**
  * Updated format syntax guide to document comma handling in VALUE tokens, including quoting rules and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->