### PR TITLE
feat(mobile): add choices to the mobile share menu (#632)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage/
 # Claude Code session/runtime state (ephemeral, machine-local)
 .claude/scheduled_tasks.lock
 .claude/scheduled_tasks.json
+
+# Local design/spike notes (never committed — maintainer policy)
+plans/

--- a/docs/docs/Advanced/MobileShareMenu.md
+++ b/docs/docs/Advanced/MobileShareMenu.md
@@ -1,0 +1,34 @@
+---
+title: Mobile Share Menu
+---
+
+On mobile, when you share text or a link to Obsidian from another app, Obsidian shows an in-app menu (for example *Insert text* and *Add to daily note*). QuickAdd can add your choices to that menu, so shared content can be routed straight through a Capture, Template, Macro, or Multi choice.
+
+This lets you do "share a URL to my reading inbox" or "send selected text to a capture" without any external automation.
+
+## Enable a choice in the share menu
+
+1. Open **Settings → QuickAdd**.
+2. Right-click a choice (or open its **⋯ More options** menu).
+3. Choose **Show in mobile share menu**.
+
+Repeat for any choices you want available when sharing. To remove one, open the same menu and choose **Hide from mobile share menu**.
+
+The toggle is configured on any device but only has an effect on mobile — the underlying share event never fires on desktop.
+
+## How the shared text is passed to your choice
+
+The shared text is bound to QuickAdd's reserved `value`, the same one `{{VALUE}}` uses:
+
+- **Capture / Template** choices: a bare `{{VALUE}}` in your capture format, template body, or file-name format resolves to the shared text **without prompting**.
+- **Macro** choices: your user scripts read it from `params.variables.value`.
+- A format that does not reference `{{VALUE}}` simply ignores the shared text.
+
+For example, a Capture choice with the format `- [ ] Read: {{VALUE}}` files the shared link as a task with no extra input.
+
+## Good to know
+
+- **It runs exactly like the command palette.** Only the bare `{{VALUE}}` prompt is skipped. Any other input your choice needs — date prompts, `{{VALUE:option1,option2}}` dropdowns, a target-file picker, a Macro suggester, or a Multi choice's sub-menu — still appears. Design share-targeted choices to run with as little extra input as possible.
+- **Template file names.** If a Template choice has no file-name format set, the new note is named after the shared text — so a long URL or paragraph would become the file name. Give share-targeted Template choices an explicit **file-name format** (for example a date-based name like `Inbox/{{DATE}}`) and put `{{VALUE}}` in the template body instead.
+- **Choices that need an active note.** Choices that write to the *currently open* note (a Capture set to "capture to the active file", or a Macro that runs an editor command) need a note open in Obsidian. When you arrive from a share there may not be one, so prefer choices that create or target a specific file.
+- **Files and other share types** are not supported yet — only shared text and links.

--- a/docs/docs/Choices/Packages.md
+++ b/docs/docs/Choices/Packages.md
@@ -63,6 +63,8 @@ much it can affect your vault:
 - **Runs on startup** — a macro set to run automatically every time Obsidian
   launches, with no interaction.
 - **Adds commands** — choices that register a command in the palette / hotkeys.
+- **Adds mobile share-menu entries** — choices that appear in Obsidian's mobile
+  "share to" menu (see [Mobile Share Menu](../Advanced/MobileShareMenu)).
 - **Overwrites existing choices or files**, **sends content to an AI provider**,
   **triggers other Obsidian commands**, and similar.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -65,3 +65,8 @@ when you need exact method details.
 
 Use [Obsidian URI](./Advanced/ObsidianUri) for URI-triggered workflows, or the
 [QuickAdd CLI](./Advanced/CLI) for shell scripts and external automation.
+
+### I want to run a choice from the mobile share menu
+
+Add a choice to Obsidian's mobile "share to" menu so shared text and links route
+straight through it. See the [Mobile Share Menu](./Advanced/MobileShareMenu) guide.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -194,6 +194,11 @@ const sidebars = {
 					id: "Advanced/ObsidianUri",
 					label: "Obsidian URI",
 				},
+				{
+					type: "doc",
+					id: "Advanced/MobileShareMenu",
+					label: "Mobile Share Menu",
+				},
 			],
 		},
 		{

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,23 @@
 import type { Plugin as ObsidianPlugin } from "obsidian";
 
 declare module "obsidian" {
+	interface Workspace {
+		/**
+		 * Undocumented mobile event (#632): fired when text is shared into Obsidian,
+		 * letting plugins add items to the in-app "share to" menu before it is shown.
+		 * Absent from the public obsidian.d.ts — the public `Events.on(name: string, …)`
+		 * catch-all already typechecks the call, so this overload is a DX nicety that
+		 * types the `(menu, text)` arguments. Verified emitted by the current Obsidian
+		 * bundle (`workspace.trigger("receive-text-menu", menu, text)`) and used in
+		 * production by ReadItLater.
+		 */
+		on(
+			name: "receive-text-menu",
+			callback: (menu: Menu, text: string) => unknown,
+			ctx?: unknown,
+		): EventRef;
+	}
+
 	interface App {
 		plugins: {
 			plugins: {

--- a/src/gui/choiceList/ChoiceList.a11y.test.ts
+++ b/src/gui/choiceList/ChoiceList.a11y.test.ts
@@ -32,6 +32,7 @@ function actionsSpy(): ChoiceListActions {
 		onDeleteChoice: vi.fn(),
 		onConfigureChoice: vi.fn(),
 		onToggleCommand: vi.fn(),
+		onToggleShareMenu: vi.fn(),
 		onDuplicateChoice: vi.fn(),
 		onRenameChoice: vi.fn(),
 		onMoveChoice: vi.fn(),

--- a/src/gui/choiceList/ChoiceList.callbacks.test.ts
+++ b/src/gui/choiceList/ChoiceList.callbacks.test.ts
@@ -26,6 +26,7 @@ function actionsSpy(): ChoiceListActions {
 		onDeleteChoice: vi.fn(),
 		onConfigureChoice: vi.fn(),
 		onToggleCommand: vi.fn(),
+		onToggleShareMenu: vi.fn(),
 		onDuplicateChoice: vi.fn(),
 		onRenameChoice: vi.fn(),
 		onMoveChoice: vi.fn(),

--- a/src/gui/choiceList/ChoiceList.crosszone.test.ts
+++ b/src/gui/choiceList/ChoiceList.crosszone.test.ts
@@ -30,6 +30,7 @@ function actionsSpy(): ChoiceListActions {
 		onDeleteChoice: vi.fn(),
 		onConfigureChoice: vi.fn(),
 		onToggleCommand: vi.fn(),
+		onToggleShareMenu: vi.fn(),
 		onDuplicateChoice: vi.fn(),
 		onRenameChoice: vi.fn(),
 		onMoveChoice: vi.fn(),

--- a/src/gui/choiceList/ChoiceListItem.svelte
+++ b/src/gui/choiceList/ChoiceListItem.svelte
@@ -47,6 +47,7 @@
 	const menuActions = () => ({
 		onRename: () => actions.onRenameChoice(choice),
 		onToggle: () => actions.onToggleCommand(choice),
+		onToggleShareMenu: () => actions.onToggleShareMenu(choice),
 		onConfigure: () => actions.onConfigureChoice(choice),
 		onDuplicate: () => actions.onDuplicateChoice(choice),
 		onDelete: () => actions.onDeleteChoice(choice),

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -10,6 +10,7 @@
 		configureChoice,
 		createChoice,
 		createToggleCommandChoice,
+		createToggleShareMenuChoice,
 		deleteChoiceWithConfirmation,
 		duplicateChoice,
 		addChoiceToTree,
@@ -226,6 +227,16 @@
 		save();
 	}
 
+	// No registry side effect: the share menu is rebuilt live from settings each time
+	// the `receive-text-menu` event fires, so persisting the flag is enough (see
+	// QuickAdd.registerShareMenu). Reassign immutably so the toggle is reactive.
+	function toggleShareMenuForChoice(oldChoice: IChoice) {
+		const updatedChoice = createToggleShareMenuChoice(oldChoice);
+
+		choices = choices.map((choice) => updateChoiceHelper(choice, updatedChoice));
+		save();
+	}
+
 	function handleDuplicateChoice(sourceChoice: IChoice) {
 		const newChoice = duplicateChoice(sourceChoice);
 		choices = [...choices, newChoice];
@@ -268,6 +279,7 @@
 		onDeleteChoice: deleteChoice,
 		onConfigureChoice: handleConfigureChoice,
 		onToggleCommand: toggleCommandForChoice,
+		onToggleShareMenu: toggleShareMenuForChoice,
 		onDuplicateChoice: handleDuplicateChoice,
 		onRenameChoice: handleRenameChoice,
 		onMoveChoice: handleMoveChoice,

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -10,7 +10,7 @@
 		configureChoice,
 		createChoice,
 		createToggleCommandChoice,
-		createToggleShareMenuChoice,
+		toggleShareMenuById,
 		deleteChoiceWithConfirmation,
 		duplicateChoice,
 		addChoiceToTree,
@@ -227,13 +227,14 @@
 		save();
 	}
 
-	// No registry side effect: the share menu is rebuilt live from settings each time
-	// the `receive-text-menu` event fires, so persisting the flag is enough (see
-	// QuickAdd.registerShareMenu). Reassign immutably so the toggle is reactive.
+	// Flip ONLY the flag, resolved by id against the live tree — never merge the
+	// passed row, which may be a filtered-view clone of a Multi with truncated
+	// children (merging it would drop the folder's non-matching children on save).
+	// No registry side effect: the share menu is rebuilt live from settings on each
+	// `receive-text-menu` event (QuickAdd.registerShareMenu). Reassign immutably so
+	// the toggle is reactive.
 	function toggleShareMenuForChoice(oldChoice: IChoice) {
-		const updatedChoice = createToggleShareMenuChoice(oldChoice);
-
-		choices = choices.map((choice) => updateChoiceHelper(choice, updatedChoice));
+		choices = toggleShareMenuById(choices, oldChoice.id);
 		save();
 	}
 

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -11,6 +11,7 @@
 		createChoice,
 		createToggleCommandChoice,
 		toggleShareMenuById,
+		findChoiceById,
 		deleteChoiceWithConfirmation,
 		duplicateChoice,
 		addChoiceToTree,
@@ -168,8 +169,17 @@
 		}
 	}
 
+	// The row passed from the list can be a filtered-view CLONE of a Multi holding
+	// only the children that matched the filter (see filterChoices). Resolve the
+	// AUTHORITATIVE live choice by id before any edit/duplicate/delete-count, so a
+	// folder's hidden children are never dropped or miscounted on save.
+	function liveChoice(choice: IChoice): IChoice {
+		return findChoiceById(choices, choice.id) ?? choice;
+	}
+
 	async function deleteChoice(choice: IChoice) {
-		const userConfirmed = await deleteChoiceWithConfirmation(choice, app);
+		const target = liveChoice(choice);
+		const userConfirmed = await deleteChoiceWithConfirmation(target, app);
 		if (!userConfirmed) return;
 
 		// Immutable removal at any depth — so the delete is reactive on the runes
@@ -181,11 +191,12 @@
 	}
 
 	async function handleConfigureChoice(oldChoice: IChoice) {
-		const updatedChoice = await configureChoice(oldChoice, app, plugin);
+		const live = liveChoice(oldChoice);
+		const updatedChoice = await configureChoice(live, app, plugin);
 		if (!updatedChoice) return;
 
 		choices = choices.map((choice) => updateChoiceHelper(choice, updatedChoice));
-		commandRegistry.updateCommand(oldChoice, updatedChoice);
+		commandRegistry.updateCommand(live, updatedChoice);
 		save();
 	}
 
@@ -211,14 +222,15 @@
 		const newName = await promptRenameChoice(app, choice.name);
 		if (!newName) return;
 
-		const updatedChoice = { ...choice, name: newName };
+		const live = liveChoice(choice);
+		const updatedChoice = { ...live, name: newName };
 		choices = choices.map((entry) => updateChoiceHelper(entry, updatedChoice));
-		commandRegistry.updateCommand(choice, updatedChoice);
+		commandRegistry.updateCommand(live, updatedChoice);
 		save();
 	}
 
 	function toggleCommandForChoice(oldChoice: IChoice) {
-		const updatedChoice = createToggleCommandChoice(oldChoice);
+		const updatedChoice = createToggleCommandChoice(liveChoice(oldChoice));
 
 		choices = choices.map((choice) => updateChoiceHelper(choice, updatedChoice));
 		updatedChoice.command
@@ -239,7 +251,7 @@
 	}
 
 	function handleDuplicateChoice(sourceChoice: IChoice) {
-		const newChoice = duplicateChoice(sourceChoice);
+		const newChoice = duplicateChoice(liveChoice(sourceChoice));
 		choices = [...choices, newChoice];
 		save();
 	}

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -60,6 +60,7 @@
     const menuActions = () => ({
         onRename: () => actions.onRenameChoice(choice),
         onToggle: () => actions.onToggleCommand(choice),
+        onToggleShareMenu: () => actions.onToggleShareMenu(choice),
         onConfigure: () => actions.onConfigureChoice(choice),
         onDuplicate: () => actions.onDuplicateChoice(choice),
         onDelete: () => actions.onDeleteChoice(choice),

--- a/src/gui/choiceList/choiceListActions.ts
+++ b/src/gui/choiceList/choiceListActions.ts
@@ -15,6 +15,14 @@ export interface ChoiceListActions {
 	onDeleteChoice: (choice: IChoice) => void;
 	onConfigureChoice: (choice: IChoice) => void;
 	onToggleCommand: (choice: IChoice) => void;
+	/**
+	 * Toggle whether a choice appears in Obsidian's mobile "share to" in-app menu.
+	 * Routed to the top-level ChoiceView handler, which reassigns the root tree
+	 * immutably (by id, any depth) and persists — an in-place mutation isn't reactive
+	 * until the array is proxied by a reassignment. No command-registry side effect:
+	 * the share menu is rebuilt live from settings on each `receive-text-menu` event.
+	 */
+	onToggleShareMenu: (choice: IChoice) => void;
 	onDuplicateChoice: (choice: IChoice) => void;
 	onRenameChoice: (choice: IChoice) => void;
 	onMoveChoice: (choice: IChoice, targetId: string) => void;

--- a/src/gui/choiceList/cmpLifecycle.test.ts
+++ b/src/gui/choiceList/cmpLifecycle.test.ts
@@ -15,6 +15,7 @@ const actions = (): ChoiceListActions => ({
 	onDeleteChoice: vi.fn(),
 	onConfigureChoice: vi.fn(),
 	onToggleCommand: vi.fn(),
+	onToggleShareMenu: vi.fn(),
 	onDuplicateChoice: vi.fn(),
 	onRenameChoice: vi.fn(),
 	onMoveChoice: vi.fn(),

--- a/src/gui/choiceList/contextMenu.ts
+++ b/src/gui/choiceList/contextMenu.ts
@@ -51,6 +51,7 @@ function isInvalidTarget(moving: IChoice, target: IChoice): boolean {
 type MenuActions = {
   onRename: () => void;
   onToggle: () => void;
+  onToggleShareMenu: () => void;
   onConfigure: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
@@ -77,6 +78,16 @@ function buildChoiceMenu(
         )
         .setIcon("zap")
         .onClick(actions.onToggle),
+    )
+    .addItem((item) =>
+      item
+        .setTitle(
+          choice.showInShareMenu
+            ? "Hide from mobile share menu"
+            : "Show in mobile share menu",
+        )
+        .setIcon("share")
+        .onClick(actions.onToggleShareMenu),
     )
     .addItem((item) => item.setTitle("Rename").setIcon("pencil").onClick(actions.onRename))
     .addItem((item) => item.setTitle("Configure").setIcon("settings").onClick(actions.onConfigure))

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 /** biome-ignore-all assist/source/organizeImports: Import order is critical to prevent circular dependencies - ChoiceExecutor must load before dependent classes */
-import type { Debouncer } from "obsidian";
+import type { Debouncer, Menu } from "obsidian";
 import { Plugin, TFile, debounce } from "obsidian";
 import { QuickAddSettingsTab } from "./quickAddSettingsTab";
 import { DEFAULT_SETTINGS } from "./settings";
@@ -28,7 +28,7 @@ import { CommandType } from "./types/macros/CommandType";
 import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { isMajorUpdate } from "./utils/semver";
-import { resolveChoiceIcon } from "./utils/choiceUtils";
+import { flattenChoicesWithPath, resolveChoiceIcon } from "./utils/choiceUtils";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
 import { setQuickAddInstance } from "./quickAddInstance";
@@ -299,6 +299,8 @@ export default class QuickAdd extends Plugin {
 
 		this.addCommandsForChoices(this.settings.choices);
 
+		this.registerShareMenu();
+
 		await migrate(this);
 
 		const registerCli = () => {
@@ -444,6 +446,64 @@ export default class QuickAdd extends Plugin {
 		for (const choice of choices) {
 			this.addCommandForChoice(choice);
 		}
+	}
+
+	/**
+	 * Add opted-in choices to Obsidian's mobile "share to" in-app menu (#632).
+	 *
+	 * `receive-text-menu` is an undocumented but live Workspace event: when text is
+	 * shared into Obsidian on mobile, the app builds a menu, fires this event so
+	 * plugins can add items, then shows it. (Absent from the public obsidian.d.ts —
+	 * see the augmentation in global.d.ts. Verified emitted by the current bundle and
+	 * used in production by ReadItLater.) The event never fires on desktop, so this
+	 * listener is a harmless no-op there.
+	 *
+	 * The menu is rebuilt from settings on every event, so choices read here are
+	 * always current — no need to re-register when the user toggles the flag. The
+	 * shared text is bound to the reserved `value` variable: a bare `{{VALUE}}`
+	 * resolves to it without a prompt (Template/Capture); Macro scripts read it via
+	 * `params.variables.value`. Every other prompt (one-page preflight, VDATE,
+	 * `{{VALUE:a,b}}` selects, target-file pickers, macro suggesters, the Multi
+	 * sub-picker) still fires — a shared choice runs exactly as from the command
+	 * palette. Unlike the URI x-callback (Template/Capture only, because it needs a
+	 * reportable outcome), share uses plain void `execute()` and is safe for all types.
+	 */
+	private registerShareMenu(): void {
+		this.registerEvent(
+			this.app.workspace.on("receive-text-menu", (menu: Menu, shareText: string) => {
+				const shared = flattenChoicesWithPath(this.settings.choices).filter(
+					(entry) => entry.choice.showInShareMenu,
+				);
+
+				for (const { choice, path } of shared) {
+					menu.addItem((item) =>
+						item
+							// Same section Obsidian uses for its own share actions.
+							.setSection("options")
+							// Path-prefixed so two same-named choices in different folders
+							// stay distinguishable (mirrors the CLI's flattened paths).
+							.setTitle(path.join(" / "))
+							.setIcon(resolveChoiceIcon(choice))
+							.onClick(async () => {
+								try {
+									const choiceExecutor = new ChoiceExecutor(this.app, this);
+									choiceExecutor.variables.set("value", shareText);
+									// Read live by id so an edit between registration and click
+									// can't run a stale copy (matches addCommandForChoice).
+									await choiceExecutor.execute(
+										this.getChoiceById(choice.id),
+									);
+								} catch (err) {
+									reportError(
+										err,
+										`Error running shared choice ${choice.id}`,
+									);
+								}
+							}),
+					);
+				}
+			}),
+		);
 	}
 
 	public addCommandForChoice(choice: IChoice) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,11 @@ import { CommandType } from "./types/macros/CommandType";
 import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { isMajorUpdate } from "./utils/semver";
-import { flattenChoicesWithPath, resolveChoiceIcon } from "./utils/choiceUtils";
+import { resolveChoiceIcon } from "./utils/choiceUtils";
+import {
+	collectShareMenuItems,
+	runChoiceWithSharedText,
+} from "./sharemenu/shareMenuItems";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
 import { setQuickAddInstance } from "./quickAddInstance";
@@ -471,33 +475,26 @@ export default class QuickAdd extends Plugin {
 	private registerShareMenu(): void {
 		this.registerEvent(
 			this.app.workspace.on("receive-text-menu", (menu: Menu, shareText: string) => {
-				const shared = flattenChoicesWithPath(this.settings.choices).filter(
-					(entry) => entry.choice.showInShareMenu,
-				);
-
-				for (const { choice, path } of shared) {
+				for (const { id, title, icon } of collectShareMenuItems(
+					this.settings.choices,
+				)) {
 					menu.addItem((item) =>
+						// "options" is the section Obsidian uses for its own share actions.
 						item
-							// Same section Obsidian uses for its own share actions.
 							.setSection("options")
-							// Path-prefixed so two same-named choices in different folders
-							// stay distinguishable (mirrors the CLI's flattened paths).
-							.setTitle(path.join(" / "))
-							.setIcon(resolveChoiceIcon(choice))
+							.setTitle(title)
+							.setIcon(icon)
 							.onClick(async () => {
 								try {
-									const choiceExecutor = new ChoiceExecutor(this.app, this);
-									choiceExecutor.variables.set("value", shareText);
-									// Read live by id so an edit between registration and click
-									// can't run a stale copy (matches addCommandForChoice).
-									await choiceExecutor.execute(
-										this.getChoiceById(choice.id),
+									// Read the choice live by id so an edit between registration
+									// and click can't run a stale copy (matches addCommandForChoice).
+									await runChoiceWithSharedText(
+										new ChoiceExecutor(this.app, this),
+										this.getChoiceById(id),
+										shareText,
 									);
 								} catch (err) {
-									reportError(
-										err,
-										`Error running shared choice ${choice.id}`,
-									);
+									reportError(err, `Error running shared choice ${id}`);
 								}
 							}),
 					);

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -104,7 +104,7 @@ const {
 	deleteChoiceWithConfirmation,
 	configureChoice,
 	createToggleCommandChoice,
-	createToggleShareMenuChoice,
+	toggleShareMenuById,
 	CommandRegistry,
 	moveChoice,
 } = await import("./choiceService");
@@ -430,31 +430,53 @@ describe("choiceService", () => {
 		});
 	});
 
-	describe("createToggleShareMenuChoice", () => {
-		it("flips undefined -> true without mutating the original", () => {
-			const choice = createChoice("Macro", "M");
-			expect(choice.showInShareMenu).toBeUndefined();
-			const toggled = createToggleShareMenuChoice(choice);
-			expect(toggled.showInShareMenu).toBe(true);
-			expect(choice.showInShareMenu).toBeUndefined();
-			expect(toggled).not.toBe(choice);
+	describe("toggleShareMenuById", () => {
+		it("flips undefined -> true on the matching top-level choice, immutably", () => {
+			const a = createChoice("Macro", "A");
+			const b = createChoice("Capture", "B");
+			const result = toggleShareMenuById([a, b], a.id);
+			expect(result[0].showInShareMenu).toBe(true);
+			expect(result[1].showInShareMenu).toBeUndefined();
+			expect(a.showInShareMenu).toBeUndefined(); // original untouched
+			expect(result[0]).not.toBe(a);
 		});
 
-		it("flips true -> false", () => {
-			const choice = createChoice("Capture", "C");
-			choice.showInShareMenu = true;
-			const toggled = createToggleShareMenuChoice(choice);
-			expect(toggled.showInShareMenu).toBe(false);
+		it("flips true -> false and leaves siblings alone", () => {
+			const a = createChoice("Template", "A");
+			a.showInShareMenu = true;
+			const b = createChoice("Template", "B");
+			const [na, nb] = toggleShareMenuById([a, b], a.id);
+			expect(na.showInShareMenu).toBe(false);
+			expect(nb.showInShareMenu).toBeUndefined();
 		});
 
-		it("preserves all other properties, including command", () => {
-			const choice = createChoice("Template", "T");
-			choice.command = true;
-			const toggled = createToggleShareMenuChoice(choice);
-			expect(toggled.id).toBe(choice.id);
-			expect(toggled.name).toBe(choice.name);
-			expect(toggled.type).toBe(choice.type);
-			expect(toggled.command).toBe(true);
+		it("flips a nested choice inside a Multi", () => {
+			const nested = createChoice("Capture", "Nested");
+			const folder = createChoice("Multi", "Folder") as IMultiChoice;
+			folder.choices = [nested];
+			const result = toggleShareMenuById([folder], nested.id) as IMultiChoice[];
+			expect(result[0].choices[0].showInShareMenu).toBe(true);
+		});
+
+		// Regression guard for the filtered-view clone data-loss bug: toggling a
+		// Multi must NEVER drop its children, even if the passed tree node looks
+		// like a folder. We flip the flag by id and keep every child intact.
+		it("preserves a folder's children when toggling the folder itself", () => {
+			const child1 = createChoice("Capture", "Keep 1");
+			const child2 = createChoice("Capture", "Keep 2");
+			const folder = createChoice("Multi", "Folder") as IMultiChoice;
+			folder.choices = [child1, child2];
+
+			const [updated] = toggleShareMenuById([folder], folder.id) as IMultiChoice[];
+
+			expect(updated.showInShareMenu).toBe(true);
+			expect(updated.choices.map((c) => c.id)).toEqual([child1.id, child2.id]);
+		});
+
+		it("returns choices unchanged when the id is not found", () => {
+			const a = createChoice("Template", "A");
+			const result = toggleShareMenuById([a], "does-not-exist");
+			expect(result[0].showInShareMenu).toBeUndefined();
 		});
 	});
 

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -104,6 +104,7 @@ const {
 	deleteChoiceWithConfirmation,
 	configureChoice,
 	createToggleCommandChoice,
+	createToggleShareMenuChoice,
 	CommandRegistry,
 	moveChoice,
 } = await import("./choiceService");
@@ -426,6 +427,34 @@ describe("choiceService", () => {
 			expect(toggled.id).toBe(choice.id);
 			expect(toggled.name).toBe(choice.name);
 			expect(toggled.type).toBe(choice.type);
+		});
+	});
+
+	describe("createToggleShareMenuChoice", () => {
+		it("flips undefined -> true without mutating the original", () => {
+			const choice = createChoice("Macro", "M");
+			expect(choice.showInShareMenu).toBeUndefined();
+			const toggled = createToggleShareMenuChoice(choice);
+			expect(toggled.showInShareMenu).toBe(true);
+			expect(choice.showInShareMenu).toBeUndefined();
+			expect(toggled).not.toBe(choice);
+		});
+
+		it("flips true -> false", () => {
+			const choice = createChoice("Capture", "C");
+			choice.showInShareMenu = true;
+			const toggled = createToggleShareMenuChoice(choice);
+			expect(toggled.showInShareMenu).toBe(false);
+		});
+
+		it("preserves all other properties, including command", () => {
+			const choice = createChoice("Template", "T");
+			choice.command = true;
+			const toggled = createToggleShareMenuChoice(choice);
+			expect(toggled.id).toBe(choice.id);
+			expect(toggled.name).toBe(choice.name);
+			expect(toggled.type).toBe(choice.type);
+			expect(toggled.command).toBe(true);
 		});
 	});
 

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -159,15 +159,30 @@ export function createToggleCommandChoice(choice: IChoice): IChoice {
 }
 
 /**
- * Toggle whether a choice appears in Obsidian's mobile "share to" in-app menu.
- * Returns a new choice (immutable) so the edit is reactive when reassigned into
- * the choices `$state` — an in-place `choice.showInShareMenu = …` isn't tracked
- * (see choice-prop mutation reactivity). Unlike the command toggle there is no
- * registry side effect: the share menu is rebuilt live from settings each time the
- * `receive-text-menu` event fires (see QuickAdd.registerShareMenu).
+ * Immutably flip a choice's `showInShareMenu` flag by id, anywhere in the tree,
+ * touching ONLY that flag. It deliberately does NOT spread a whole choice object:
+ * the choice-list row passed to the context menu can be a filtered-view CLONE of a
+ * Multi with truncated children (see ChoiceView.filterChoices), so merging the
+ * clone back would drop the folder's non-matching descendants on save. Resolving
+ * by id against the live tree and changing only the flag avoids that data loss.
+ * Reassigning the result into the choices `$state` makes the edit reactive (see
+ * choice-prop mutation reactivity). No registry side effect — the share menu is
+ * rebuilt live from settings on each `receive-text-menu` event (registerShareMenu).
  */
-export function createToggleShareMenuChoice(choice: IChoice): IChoice {
-	return { ...choice, showInShareMenu: !choice.showInShareMenu };
+export function toggleShareMenuById(choices: IChoice[], id: string): IChoice[] {
+	return choices.map((choice) => {
+		if (choice.id === id) {
+			return { ...choice, showInShareMenu: !choice.showInShareMenu };
+		}
+		if (choice.type === "Multi") {
+			const multi = choice as IMultiChoice;
+			return {
+				...multi,
+				choices: toggleShareMenuById(multi.choices, id),
+			} as IChoice;
+		}
+		return choice;
+	});
 }
 
 /**

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -239,7 +239,14 @@ export function moveChoice(
 	return inserted ?? rootChoices;
 }
 
-function findChoiceById(choices: IChoice[], id: string): IChoice | undefined {
+/**
+ * Find a choice by id anywhere in the tree (recurses into Multi folders), or
+ * undefined. Used to resolve the AUTHORITATIVE live choice before an edit: the
+ * row passed from a filtered choice list can be a clone of a Multi holding only
+ * the children that matched the filter (see ChoiceView.filterChoices), so editing
+ * that clone would drop the folder's non-matching children on save.
+ */
+export function findChoiceById(choices: IChoice[], id: string): IChoice | undefined {
 	for (const c of choices) {
 		if (c.id === id) return c;
 		if (c.type === "Multi") {

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -159,6 +159,18 @@ export function createToggleCommandChoice(choice: IChoice): IChoice {
 }
 
 /**
+ * Toggle whether a choice appears in Obsidian's mobile "share to" in-app menu.
+ * Returns a new choice (immutable) so the edit is reactive when reassigned into
+ * the choices `$state` — an in-place `choice.showInShareMenu = …` isn't tracked
+ * (see choice-prop mutation reactivity). Unlike the command toggle there is no
+ * registry side effect: the share menu is rebuilt live from settings each time the
+ * `receive-text-menu` event fires (see QuickAdd.registerShareMenu).
+ */
+export function createToggleShareMenuChoice(choice: IChoice): IChoice {
+	return { ...choice, showInShareMenu: !choice.showInShareMenu };
+}
+
+/**
  * Command registry adapter to decouple plugin interactions
  */
 export class CommandRegistry {

--- a/src/services/packagePreview.test.ts
+++ b/src/services/packagePreview.test.ts
@@ -261,6 +261,27 @@ describe("buildPackagePreview - choice flags & dedupe", () => {
 		expect(preview.summary.registersCommandCount).toBe(1);
 	});
 
+	it("discloses showInShareMenu as an info-level capability", () => {
+		const shared = macro("s1", "Shared", []);
+		shared.showInShareMenu = true;
+		const plain = macro("p1", "Plain", []);
+		const pkg = makePackage([
+			pkgChoice(shared, ["Shared"]),
+			pkgChoice(plain, ["Plain"]),
+		]);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+		expect(
+			preview.choices.find((c) => c.choiceId === "s1")?.flags,
+		).toContain("share-menu");
+		expect(
+			preview.choices.find((c) => c.choiceId === "p1")?.flags,
+		).not.toContain("share-menu");
+		const row = preview.capabilityRows.find((r) => r.flag === "share-menu");
+		expect(row?.severity).toBe("info");
+		expect(row?.detail).toBe("1 choice");
+	});
+
 	it("attributes an inline-only Multi child's capabilities to its parent (no hiding)", () => {
 		// A crafted package puts a dangerous macro inline in a Multi.choices array
 		// WITHOUT listing it as its own pkg.choices entry.

--- a/src/services/packagePreview.ts
+++ b/src/services/packagePreview.ts
@@ -42,6 +42,7 @@ export type PreviewFlag =
 	| "run-on-startup"
 	| "mislabeled-executable"
 	| "registers-command"
+	| "share-menu"
 	| "obsidian-command"
 	| "ai"
 	| "capture-writes"
@@ -93,6 +94,11 @@ const FLAG_META: Record<PreviewFlag, FlagMeta> = {
 		severity: "warning",
 		label: "COMMAND",
 		description: "Adds a command to the command palette.",
+	},
+	"share-menu": {
+		severity: "info",
+		label: "SHARE",
+		description: "Adds an entry to Obsidian's mobile share menu that runs this choice.",
 	},
 	"obsidian-command": {
 		severity: "warning",
@@ -410,6 +416,10 @@ function collectChoice(
 	if (choice.command) {
 		walk.registersCommand = true;
 		walk.flags.add("registers-command");
+	}
+
+	if (choice.showInShareMenu) {
+		walk.flags.add("share-menu");
 	}
 
 	if (isMacroChoice(choice)) {
@@ -805,6 +815,18 @@ export function buildPackagePreview(
 			detail: `${registersCommandCount} choice${
 				registersCommandCount === 1 ? "" : "s"
 			}`,
+		});
+	}
+
+	const shareMenuCount = choices.filter((c) =>
+		c.flags.includes("share-menu"),
+	).length;
+	if (shareMenuCount > 0) {
+		capabilityRows.push({
+			flag: "share-menu",
+			severity: "info",
+			title: "Adds entries to Obsidian's mobile share menu",
+			detail: `${shareMenuCount} choice${shareMenuCount === 1 ? "" : "s"}`,
 		});
 	}
 

--- a/src/sharemenu/shareMenuItems.test.ts
+++ b/src/sharemenu/shareMenuItems.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import type IChoice from "../types/choices/IChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import {
+	collectShareMenuItems,
+	runChoiceWithSharedText,
+	type SharedTextExecutor,
+} from "./shareMenuItems";
+
+let idCounter = 0;
+function choice(
+	name: string,
+	type: IChoice["type"] = "Template",
+	extra: Partial<IChoice> = {},
+): IChoice {
+	return { name, id: `choice-${idCounter++}`, type, command: false, ...extra };
+}
+function multi(name: string, children: IChoice[], extra: Partial<IMultiChoice> = {}): IMultiChoice {
+	return {
+		name,
+		id: `multi-${idCounter++}`,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: children,
+		...extra,
+	} as IMultiChoice;
+}
+
+describe("collectShareMenuItems", () => {
+	it("selects only choices flagged showInShareMenu, including nested ones", () => {
+		const shared = choice("Shared", "Macro", { showInShareMenu: true });
+		const plain = choice("Plain", "Capture");
+		const nested = choice("Nested", "Capture", { showInShareMenu: true });
+		const folder = multi("Inbox", [nested, plain]);
+
+		const items = collectShareMenuItems([shared, plain, folder]);
+
+		expect(items.map((i) => i.title)).toEqual(["Shared", "Inbox / Nested"]);
+		expect(items.map((i) => i.id)).toEqual([shared.id, nested.id]);
+	});
+
+	it("titles items by their full name path so duplicate names stay distinct", () => {
+		const a = choice("Inbox", "Capture", { showInShareMenu: true });
+		const b = choice("Inbox", "Capture", { showInShareMenu: true });
+		const items = collectShareMenuItems([multi("Work", [a]), multi("Personal", [b])]);
+		expect(items.map((i) => i.title)).toEqual(["Work / Inbox", "Personal / Inbox"]);
+	});
+
+	it("resolves the per-type default icon (or a per-choice override)", () => {
+		const cap = choice("Cap", "Capture", { showInShareMenu: true });
+		const mac = choice("Mac", "Macro", { showInShareMenu: true, icon: "rocket" });
+		const items = collectShareMenuItems([cap, mac]);
+		expect(items[0].icon).toBe("pencil"); // Capture default
+		expect(items[1].icon).toBe("rocket"); // per-choice override wins
+	});
+
+	it("returns nothing when no choice opts in", () => {
+		expect(collectShareMenuItems([choice("a"), multi("F", [choice("b")])])).toEqual([]);
+	});
+});
+
+describe("runChoiceWithSharedText", () => {
+	it("binds the shared text to the reserved `value` variable, then runs the choice", async () => {
+		const order: string[] = [];
+		const variables = new Map<string, unknown>();
+		const target = choice("Target", "Capture");
+		const executor: SharedTextExecutor = {
+			variables,
+			execute: vi.fn(async (c: IChoice) => {
+				// value must be seeded BEFORE execute runs (so {{VALUE}} resolves without a prompt)
+				order.push(`exec:${c.id}:${variables.get("value")}`);
+			}),
+		};
+
+		await runChoiceWithSharedText(executor, target, "shared payload");
+
+		expect(variables.get("value")).toBe("shared payload");
+		expect(executor.execute).toHaveBeenCalledWith(target);
+		expect(order).toEqual([`exec:${target.id}:shared payload`]);
+	});
+});

--- a/src/sharemenu/shareMenuItems.ts
+++ b/src/sharemenu/shareMenuItems.ts
@@ -1,0 +1,50 @@
+import type IChoice from "../types/choices/IChoice";
+import { flattenChoicesWithPath, resolveChoiceIcon } from "../utils/choiceUtils";
+
+/** One entry to add to Obsidian's mobile "share to" in-app menu (#632). */
+export interface ShareMenuItem {
+	/** Live choice id — resolve the choice fresh at click time, never close over a copy. */
+	id: string;
+	/** Menu title — the choice's name path, so duplicate names in different folders stay distinct. */
+	title: string;
+	/** Lucide/Obsidian icon id (per-choice override or per-type default). */
+	icon: string;
+}
+
+/**
+ * Select the choices opted into the share menu and shape each into a menu item.
+ * Pure (no Obsidian/App): flatten the tree (so nested choices are reachable),
+ * keep only `showInShareMenu`, and title by the name path. This is the exact
+ * selection QuickAdd.registerShareMenu renders, so testing it pins the contract.
+ */
+export function collectShareMenuItems(choices: IChoice[]): ShareMenuItem[] {
+	return flattenChoicesWithPath(choices)
+		.filter((entry) => entry.choice.showInShareMenu)
+		.map((entry) => ({
+			id: entry.choice.id,
+			title: entry.path.join(" / "),
+			icon: resolveChoiceIcon(entry.choice),
+		}));
+}
+
+/** The slice of ChoiceExecutor the share path needs — kept structural so this stays testable. */
+export interface SharedTextExecutor {
+	variables: Map<string, unknown>;
+	execute(choice: IChoice): Promise<void>;
+}
+
+/**
+ * Bind the shared text to the reserved `value` variable, then run the choice.
+ * Seeding `value` is what makes a bare `{{VALUE}}` resolve to the shared text
+ * WITHOUT a prompt (formatter reads a concrete `value` first); Macro user scripts
+ * read the same via `params.variables.value`. Extracted so the value-seed contract
+ * is unit-tested rather than living only in the event-handler closure.
+ */
+export async function runChoiceWithSharedText(
+	executor: SharedTextExecutor,
+	choice: IChoice,
+	sharedText: string,
+): Promise<void> {
+	executor.variables.set("value", sharedText);
+	await executor.execute(choice);
+}

--- a/src/types/choices/Choice.ts
+++ b/src/types/choices/Choice.ts
@@ -9,6 +9,7 @@ export abstract class Choice implements IChoice {
 	command: boolean;
 	onePageInput?: "always" | "never" | undefined;
 	icon?: string;
+	showInShareMenu?: boolean;
 
 	protected constructor(name: string, type: ChoiceType) {
 		this.id = uuidv4();

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -13,4 +13,12 @@ export default interface IChoice {
 	 * per-type default (see resolveChoiceIcon). Never persisted as a default.
 	 */
 	icon?: string;
+	/**
+	 * When true, this choice is added to Obsidian's mobile "share to" in-app menu
+	 * (the menu shown after sharing content into Obsidian). The shared text is bound
+	 * to the reserved `value` variable, so a bare `{{VALUE}}` resolves to it without
+	 * a prompt. Mobile-only effect — the underlying `receive-text-menu` event never
+	 * fires on desktop. undefined/false = not shown. See QuickAdd.registerShareMenu.
+	 */
+	showInShareMenu?: boolean;
 }

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -86,49 +86,6 @@ describe("flattenChoicesWithPath", () => {
 	});
 });
 
-// Documents the selection contract QuickAdd.registerShareMenu (#632) relies on:
-// flatten the (possibly nested) tree, keep only choices flagged showInShareMenu,
-// and title each item by its name path so duplicates in different folders stay
-// distinguishable in Obsidian's mobile share menu.
-describe("share-menu selection (flattenChoicesWithPath + showInShareMenu)", () => {
-	const selectForShareMenu = (choices: IChoice[]) =>
-		flattenChoicesWithPath(choices)
-			.filter((entry) => entry.choice.showInShareMenu)
-			.map((entry) => entry.path.join(" / "));
-
-	it("selects only flagged choices, including deeply nested ones", () => {
-		const shared = choice("Shared note");
-		shared.showInShareMenu = true;
-		const unshared = choice("Plain note");
-		const nestedShared = choice("Nested macro");
-		nestedShared.showInShareMenu = true;
-		const folder = multi("Inbox", [nestedShared, unshared]);
-
-		const titles = selectForShareMenu([shared, unshared, folder]);
-
-		expect(titles).toEqual(["Shared note", "Inbox / Nested macro"]);
-	});
-
-	it("disambiguates same-named choices in different folders by path", () => {
-		const a = choice("Inbox");
-		a.showInShareMenu = true;
-		const b = choice("Inbox");
-		b.showInShareMenu = true;
-		const work = multi("Work", [a]);
-		const personal = multi("Personal", [b]);
-
-		const titles = selectForShareMenu([work, personal]);
-
-		expect(titles).toEqual(["Work / Inbox", "Personal / Inbox"]);
-	});
-
-	it("returns nothing when no choice opts in", () => {
-		expect(selectForShareMenu([choice("a"), multi("F", [choice("b")])])).toEqual(
-			[],
-		);
-	});
-});
-
 describe("defaultIconForChoiceType", () => {
 	it("maps each choice type to a meaningful lucide id", () => {
 		expect(defaultIconForChoiceType("Template")).toBe("file-text");

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -86,6 +86,49 @@ describe("flattenChoicesWithPath", () => {
 	});
 });
 
+// Documents the selection contract QuickAdd.registerShareMenu (#632) relies on:
+// flatten the (possibly nested) tree, keep only choices flagged showInShareMenu,
+// and title each item by its name path so duplicates in different folders stay
+// distinguishable in Obsidian's mobile share menu.
+describe("share-menu selection (flattenChoicesWithPath + showInShareMenu)", () => {
+	const selectForShareMenu = (choices: IChoice[]) =>
+		flattenChoicesWithPath(choices)
+			.filter((entry) => entry.choice.showInShareMenu)
+			.map((entry) => entry.path.join(" / "));
+
+	it("selects only flagged choices, including deeply nested ones", () => {
+		const shared = choice("Shared note");
+		shared.showInShareMenu = true;
+		const unshared = choice("Plain note");
+		const nestedShared = choice("Nested macro");
+		nestedShared.showInShareMenu = true;
+		const folder = multi("Inbox", [nestedShared, unshared]);
+
+		const titles = selectForShareMenu([shared, unshared, folder]);
+
+		expect(titles).toEqual(["Shared note", "Inbox / Nested macro"]);
+	});
+
+	it("disambiguates same-named choices in different folders by path", () => {
+		const a = choice("Inbox");
+		a.showInShareMenu = true;
+		const b = choice("Inbox");
+		b.showInShareMenu = true;
+		const work = multi("Work", [a]);
+		const personal = multi("Personal", [b]);
+
+		const titles = selectForShareMenu([work, personal]);
+
+		expect(titles).toEqual(["Work / Inbox", "Personal / Inbox"]);
+	});
+
+	it("returns nothing when no choice opts in", () => {
+		expect(selectForShareMenu([choice("a"), multi("F", [choice("b")])])).toEqual(
+			[],
+		);
+	});
+});
+
 describe("defaultIconForChoiceType", () => {
 	it("maps each choice type to a meaningful lucide id", () => {
 		expect(defaultIconForChoiceType("Template")).toBe("file-text");


### PR DESCRIPTION
Closes #632.

## What
Lets a choice opt into Obsidian's mobile **"share to" in-app menu** (the menu Obsidian shows after you share text/a link into it). Each opted-in choice appears as a tap-target; tapping runs it with the shared text bound to the reserved `value` variable, so a bare `{{VALUE}}` resolves to it **without a prompt** (Macro scripts read `params.variables.value`).

This is the same mechanism Memo / ReadItLater use, and solves the long-standing "quick-add a note from the mobile share sheet" request without external automation.

## How
- New optional per-choice flag `showInShareMenu` (`IChoice`/`Choice`) — optional ⇒ migration-free.
- Toggled from the **choice context menu** ("Show/Hide in mobile share menu") — the same surface as the command-palette toggle, so it reaches **all** choice types (incl. Macro/Multi, which use modals rather than Svelte builders). Persisted immutably via `createToggleShareMenuChoice` → `updateChoiceHelper` → `save()`.
- `QuickAdd.registerShareMenu()` (in `onload`) listens for the **`receive-text-menu`** workspace event, rebuilds the menu live from settings via the existing `flattenChoicesWithPath` (path-prefixed titles disambiguate duplicate names), and runs the clicked choice **by id** through a fresh `ChoiceExecutor`. No-op on desktop (the event only fires on mobile share).
- `receive-text-menu` is undocumented (absent from `obsidian.d.ts`) but live in the current bundle and used in production by ReadItLater; typed via the existing `src/global.d.ts` augmentation.
- Docs: **Advanced → Mobile Share Menu** (Next only — unreleased). Unit tests for the toggle and the share-menu selection/path logic.

## Caveats (documented)
- Runs a choice exactly like the command palette — only the bare `{{VALUE}}` prompt is skipped; other prompts (VDATE, `{{VALUE:a,b}}`, target pickers, macro suggesters, Multi sub-picker) still fire.
- Template choices with no file-name format would name the note after the shared text — docs steer share-targeted Templates to set an explicit file-name format and put `{{VALUE}}` in the body.
- Choices that need the active editor (capture-to-active-file, editor-command macros) degrade gracefully (Notice) when there's no open note.

## Testing
- `tsc`, `svelte-check` (0 errors), `eslint`, **2133 unit tests**, and the docs build all pass.
- **Real dev-vault e2e:** firing `receive-text-menu` invoked the handler → added a correct item (title / `pencil` icon / `options` section / click) → clicking ran a Capture choice that created a note whose body was exactly the shared text (proves value-seeding, no prompt). No runtime errors.
- Reviewed by an ultracode multi-agent pass (SHIP) + 2 adversarial reviewers (PASS) — only minor/prose findings, addressed.

> Note: the real OS share-intent path (Capacitor cold-start ordering, mobile menu lifecycle) is only fully exercisable on a physical device; the desktop e2e exercises the event → menu → execution wiring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile share menu integration: enable specific choices to appear in Obsidian's mobile share menu with shared content passed via the `value` variable
  * Package preview now displays mobile share menu capability status

* **Documentation**
  * New guide for configuring and using the mobile share menu feature
<!-- end of auto-generated comment: release notes by coderabbit.ai -->