### PR TITLE
feat(capture): "Under heading…" write position with a runtime heading dropdown

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -75,6 +75,7 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
     -   **New line above cursor** (active file only)
     -   **New line below cursor** (active file only)
     -   **After line…**
+    -   **Under heading…** - pick a heading from the target note at capture time (a dropdown of the note's headings appears when you run the capture), and the text is inserted under the one you choose. See [Under heading](#under-heading).
     -   **Before line…**
     -   **Bottom of file**
 -   _Link to captured file_ is a dropdown that controls whether QuickAdd inserts a link to the captured file in the current note. You can choose between three modes:
@@ -221,6 +222,21 @@ I use this in my daily journal capture, where I insert after the heading line `#
 
 It's also possible to use `Create line if not found`, which will create the line if it doesn't exist. This is useful if you want to insert after a line that might not exist in the file you're capturing to.
 This setting can place the line at the start or end of the file, or at your current cursor position.
+
+## Under heading
+
+Choose **Under heading…** as the _Write position_ when you want to pick the target heading **at capture time** instead of typing it in advance. When you run the capture, QuickAdd reads the target note and shows a dropdown of its headings — pick one, and the text is inserted under it. This is the same idea as the note-selection dropdown that appears when no file name is specified, but for headings within a single note.
+
+This is a flavor of [Insert after](#insert-after) (the picked heading becomes the insert-after target), so all of its placement controls still apply:
+
+-   By default the text is inserted directly under the chosen heading line. Enable `Insert at end of section` to append it to the end of that heading's section instead.
+-   `Consider subsections`, `Blank lines after match`, and `Create line if not found` work exactly as for Insert after.
+
+Notes:
+
+-   You can also **type a heading** that doesn't exist yet. To have QuickAdd create it, enable `Create line if not found` (type the heading with its `#` markers, e.g. `## Tasks`).
+-   The dropdown lists ATX headings (lines starting with `#`). For a brand-new note created from a template, the picker can't list the template's headings yet (the note doesn't exist at pick time) — type the heading and use `Create line if not found`.
+-   If you use the one-page input form, the heading dropdown still appears as a separate step after the form.
 
 ### Consider subsections -option
 

--- a/src/engine/CaptureChoiceEngine.heading-picker.test.ts
+++ b/src/engine/CaptureChoiceEngine.heading-picker.test.ts
@@ -135,7 +135,7 @@ describe("CaptureChoiceEngine 'Under heading…' runtime picker (#738)", () => {
 		(InputSuggester as any).Suggest = suggestSpy;
 		const engine = buildEngine(createChoice());
 
-		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+		await (engine as any).maybeResolveInsertAfterHeading(HEADING_NOTE);
 
 		const [, displayItems, items] = suggestSpy.mock.calls[0] as unknown[];
 		// items are the literal file lines (the insert-after search target).
@@ -148,7 +148,7 @@ describe("CaptureChoiceEngine 'Under heading…' runtime picker (#738)", () => {
 		(InputSuggester as any).Suggest = vi.fn(async () => "## Tasks");
 		const engine = buildEngine(createChoice());
 
-		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+		await (engine as any).maybeResolveInsertAfterHeading(HEADING_NOTE);
 
 		expect(setInsertAfterTargetOverrideMock).toHaveBeenCalledWith("## Tasks");
 		// Notice copy uses the heading TEXT (no '#').
@@ -175,31 +175,35 @@ describe("CaptureChoiceEngine 'Under heading…' runtime picker (#738)", () => {
 			}),
 		);
 
-		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+		await (engine as any).maybeResolveInsertAfterHeading(HEADING_NOTE);
 
 		expect(suggestSpy).not.toHaveBeenCalled();
 		expect(setInsertAfterTargetOverrideMock).not.toHaveBeenCalled();
 	});
 
-	it("skips canvas targets (static field still applies there)", async () => {
-		const suggestSpy = vi.fn(async () => "## Tasks");
-		(InputSuggester as any).Suggest = suggestSpy;
-		const engine = buildEngine(createChoice({ captureTo: "Board.canvas" }));
+	it("resolves headings from arbitrary content (e.g. a Canvas text card body)", async () => {
+		// The helper is content-based, so the same picker serves note bodies and canvas
+		// text cards. handleCanvasTextCapture passes the card's text here.
+		(InputSuggester as any).Suggest = vi.fn(async () => "## Card Heading");
+		const engine = buildEngine(createChoice());
 
-		await (engine as any).maybeResolveInsertAfterHeading("Board.canvas", true);
+		await (engine as any).maybeResolveInsertAfterHeading(
+			"# Card\n\n## Card Heading\n- note\n",
+		);
 
-		expect(suggestSpy).not.toHaveBeenCalled();
+		expect(setInsertAfterTargetOverrideMock).toHaveBeenCalledWith("## Card Heading");
+		expect((engine as any).resolvedInsertAfterHeading).toBe("Card Heading");
 	});
 
-	it("lets the user type a heading on a note with no headings (custom value)", async () => {
+	it("lets the user type a heading when the content has no headings (custom value)", async () => {
 		(InputSuggester as any).Suggest = vi.fn(async (_app, display, items) => {
 			expect(display).toEqual([]);
 			expect(items).toEqual([]);
 			return "## New Heading";
 		});
-		const engine = buildEngine(createChoice(), createApp("just body text\nmore"));
+		const engine = buildEngine(createChoice());
 
-		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+		await (engine as any).maybeResolveInsertAfterHeading("just body text\nmore");
 
 		expect(setInsertAfterTargetOverrideMock).toHaveBeenCalledWith("## New Heading");
 		// Custom value isn't a known heading line → notice falls back to the raw value.
@@ -213,7 +217,7 @@ describe("CaptureChoiceEngine 'Under heading…' runtime picker (#738)", () => {
 		const engine = buildEngine(createChoice());
 
 		await expect(
-			(engine as any).maybeResolveInsertAfterHeading("Inbox.md", true),
+			(engine as any).maybeResolveInsertAfterHeading(HEADING_NOTE),
 		).rejects.toBeInstanceOf(UserCancelError);
 		expect(setInsertAfterTargetOverrideMock).not.toHaveBeenCalled();
 	});

--- a/src/engine/CaptureChoiceEngine.heading-picker.test.ts
+++ b/src/engine/CaptureChoiceEngine.heading-picker.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TFile, type App } from "obsidian";
+import InputSuggester from "src/gui/InputSuggester/inputSuggester";
+import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { UserCancelError } from "../errors/UserCancelError";
+
+// Capture the override the engine pushes into the formatter for the "Under heading…" path.
+const { setInsertAfterTargetOverrideMock } = vi.hoisted(() => ({
+	setInsertAfterTargetOverrideMock: vi.fn(),
+}));
+
+vi.mock("../formatters/captureChoiceFormatter", () => ({
+	CaptureChoiceFormatter: class {
+		setLinkToCurrentFileBehavior() {}
+		setUseSelectionAsCaptureValue() {}
+		setInsertAfterTargetOverride(target: string | null) {
+			setInsertAfterTargetOverrideMock(target);
+		}
+	},
+}));
+
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
+	default: class {},
+}));
+
+vi.mock("../utilityObsidian", () => ({
+	appendToCurrentLine: vi.fn(() => true),
+	getMarkdownFilesInFolder: vi.fn(() => []),
+	getMarkdownFilesWithTag: vi.fn(() => []),
+	insertFileLinkToActiveView: vi.fn(),
+	insertOnNewLineAbove: vi.fn(() => true),
+	insertOnNewLineBelow: vi.fn(() => true),
+	isFolder: vi.fn(() => false),
+	isTemplaterTriggerOnCreateEnabled: vi.fn(() => false),
+	jumpToNextTemplaterCursorIfPossible: vi.fn(),
+	openExistingFileTab: vi.fn(() => null),
+	openFile: vi.fn(),
+	overwriteTemplaterOnce: vi.fn(),
+	templaterParseTemplate: vi.fn(async (_app: unknown, content: string) => content),
+	waitForTemplaterTriggerOnCreateToComplete: vi.fn(),
+}));
+
+vi.mock("three-way-merge", () => ({ default: vi.fn(() => ({})), __esModule: true }));
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+vi.mock("../main", () => ({ default: class QuickAddMock {} }));
+vi.mock("./SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		setLinkToCurrentFileBehavior() {}
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+	},
+}));
+
+const HEADING_NOTE = "# Title\n\nintro\n\n## Tasks\n- a\n\n### Subtask\n- b\n\n## Notes\ntext";
+
+const createApp = (content = HEADING_NOTE) =>
+	({
+		vault: {
+			adapter: { exists: vi.fn(async () => true) },
+			getAbstractFileByPath: vi.fn((path: string) =>
+				Object.assign(new TFile(), {
+					path,
+					name: path,
+					basename: path.replace(/\.md$/, ""),
+					extension: "md",
+				}),
+			),
+			read: vi.fn(async () => content),
+			modify: vi.fn(async () => {}),
+		},
+		workspace: {
+			getActiveFile: vi.fn(() => null),
+			getActiveViewOfType: vi.fn(() => null),
+		},
+		fileManager: { getNewFileParent: vi.fn(() => ({ path: "" })) },
+	}) as unknown as App;
+
+const createChoice = (overrides: Partial<ICaptureChoice> = {}): ICaptureChoice => ({
+	id: "capture-choice-id",
+	name: "Capture Choice",
+	type: "Capture",
+	command: false,
+	captureTo: "Inbox.md",
+	captureToActiveFile: false,
+	createFileIfItDoesntExist: { enabled: false, createWithTemplate: false, template: "" },
+	format: { enabled: false, format: "" },
+	prepend: false,
+	appendLink: false,
+	task: false,
+	insertAfter: {
+		enabled: true,
+		after: "",
+		insertAtEnd: false,
+		considerSubsections: false,
+		createIfNotFound: false,
+		createIfNotFoundLocation: "top",
+		inline: false,
+		replaceExisting: false,
+		blankLineAfterMatchMode: "auto",
+		promptHeading: true,
+	},
+	newLineCapture: { enabled: false, direction: "below" },
+	openFile: false,
+	fileOpening: { location: "tab", direction: "vertical", mode: "default", focus: true },
+	...overrides,
+});
+
+const createExecutor = (): IChoiceExecutor => ({
+	execute: vi.fn(),
+	variables: new Map<string, unknown>(),
+});
+
+const buildEngine = (choice: ICaptureChoice, app = createApp()) =>
+	new CaptureChoiceEngine(
+		app,
+		{ settings: { useSelectionAsCaptureValue: false } } as any,
+		choice,
+		createExecutor(),
+	);
+
+describe("CaptureChoiceEngine 'Under heading…' runtime picker (#738)", () => {
+	beforeEach(() => {
+		setInsertAfterTargetOverrideMock.mockClear();
+		delete (InputSuggester as any).Suggest;
+	});
+
+	it("offers byte-exact heading lines as items and indents the display by level", async () => {
+		const suggestSpy = vi.fn(async () => "## Tasks");
+		(InputSuggester as any).Suggest = suggestSpy;
+		const engine = buildEngine(createChoice());
+
+		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+
+		const [, displayItems, items] = suggestSpy.mock.calls[0] as unknown[];
+		// items are the literal file lines (the insert-after search target).
+		expect(items).toEqual(["# Title", "## Tasks", "### Subtask", "## Notes"]);
+		// display is indented by heading level (level 1 → no indent).
+		expect(displayItems).toEqual(["Title", "  Tasks", "    Subtask", "  Notes"]);
+	});
+
+	it("pushes the picked heading line to the formatter as a verbatim override", async () => {
+		(InputSuggester as any).Suggest = vi.fn(async () => "## Tasks");
+		const engine = buildEngine(createChoice());
+
+		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+
+		expect(setInsertAfterTargetOverrideMock).toHaveBeenCalledWith("## Tasks");
+		// Notice copy uses the heading TEXT (no '#').
+		expect((engine as any).resolvedInsertAfterHeading).toBe("Tasks");
+	});
+
+	it("does nothing when promptHeading is off (plain 'After line…')", async () => {
+		const suggestSpy = vi.fn(async () => "## Tasks");
+		(InputSuggester as any).Suggest = suggestSpy;
+		const engine = buildEngine(
+			createChoice({
+				insertAfter: {
+					enabled: true,
+					after: "## Tasks",
+					insertAtEnd: false,
+					considerSubsections: false,
+					createIfNotFound: false,
+					createIfNotFoundLocation: "top",
+					inline: false,
+					replaceExisting: false,
+					blankLineAfterMatchMode: "auto",
+					promptHeading: false,
+				},
+			}),
+		);
+
+		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+
+		expect(suggestSpy).not.toHaveBeenCalled();
+		expect(setInsertAfterTargetOverrideMock).not.toHaveBeenCalled();
+	});
+
+	it("skips canvas targets (static field still applies there)", async () => {
+		const suggestSpy = vi.fn(async () => "## Tasks");
+		(InputSuggester as any).Suggest = suggestSpy;
+		const engine = buildEngine(createChoice({ captureTo: "Board.canvas" }));
+
+		await (engine as any).maybeResolveInsertAfterHeading("Board.canvas", true);
+
+		expect(suggestSpy).not.toHaveBeenCalled();
+	});
+
+	it("lets the user type a heading on a note with no headings (custom value)", async () => {
+		(InputSuggester as any).Suggest = vi.fn(async (_app, display, items) => {
+			expect(display).toEqual([]);
+			expect(items).toEqual([]);
+			return "## New Heading";
+		});
+		const engine = buildEngine(createChoice(), createApp("just body text\nmore"));
+
+		await (engine as any).maybeResolveInsertAfterHeading("Inbox.md", true);
+
+		expect(setInsertAfterTargetOverrideMock).toHaveBeenCalledWith("## New Heading");
+		// Custom value isn't a known heading line → notice falls back to the raw value.
+		expect((engine as any).resolvedInsertAfterHeading).toBe("## New Heading");
+	});
+
+	it("aborts cleanly (UserCancelError) when the picker is dismissed", async () => {
+		(InputSuggester as any).Suggest = vi.fn(async () => {
+			throw "no input given.";
+		});
+		const engine = buildEngine(createChoice());
+
+		await expect(
+			(engine as any).maybeResolveInsertAfterHeading("Inbox.md", true),
+		).rejects.toBeInstanceOf(UserCancelError);
+		expect(setInsertAfterTargetOverrideMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -277,7 +277,17 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			// "Under heading…" write position: prompt for a heading from the resolved
 			// target note and feed the picked line to the formatter as an insert-after
 			// override. Runs after the target file is known and before any formatting/write.
-			await this.maybeResolveInsertAfterHeading(filePath, fileAlreadyExists);
+			// Canvas TEXT cards are handled earlier in handleCanvasTextCapture (which resolves
+			// the heading from the card text); a bare .canvas file path here would be a file
+			// card whose underlying note is markdown, so the extension guard is defensive.
+			if (
+				this.isInsertAfterHeadingMode() &&
+				!CANVAS_FILE_EXTENSION_REGEX.test(filePath)
+			) {
+				await this.maybeResolveInsertAfterHeading(
+					await this.readNoteBodyForHeadingPicker(filePath, fileAlreadyExists),
+				);
+			}
 
 			// Collect front matter property types only when the capture content
 			// becomes the file's OWN front matter — i.e. a brand-new file created
@@ -431,6 +441,14 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 		const captureTemplate = this.getCaptureContent();
 		const existingText = getCanvasTextCaptureContent(target);
+
+		// "Under heading…" write position on a canvas text card: resolve the heading from
+		// the card's own text so the insert-after override targets a real line in the card
+		// (otherwise heading mode leaves the static `after` empty and the formatter aborts).
+		if (this.isInsertAfterHeadingMode()) {
+			await this.maybeResolveInsertAfterHeading(existingText);
+		}
+
 		const nextText = await this.formatter.formatContentWithFile(
 			captureTemplate,
 			this.choice,
@@ -499,40 +517,27 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 	/**
 	 * For the "Under heading…" write position: prompt the user with a dropdown of the
-	 * target note's headings and set the picked line as the formatter's insert-after
-	 * override. The items are byte-exact heading LINES from freshly-read content (so the
-	 * formatter's literal search and create-if-not-found round-trip exactly, the #742
-	 * invariant), parsed with the same `getMarkdownHeadings` the inserter uses (so what is
-	 * offered can never desync from what is matched). `allowCustomValue` lets the user type
-	 * a heading on a new / heading-less note (created via "Create line if not found").
-	 * Scoped to markdown notes; canvas text cards keep the static field. Cancelling the
-	 * picker aborts the capture cleanly (UserCancelError), before any write.
+	 * destination's headings and set the picked line as the formatter's insert-after
+	 * override. The items are byte-exact heading LINES from `content` (so the formatter's
+	 * literal search and create-if-not-found round-trip exactly, the #742 invariant),
+	 * parsed with the same `getMarkdownHeadings` the inserter uses (so what is offered can
+	 * never desync from what is matched). `allowCustomValue` lets the user type a heading on
+	 * a new / heading-less target (created via "Create line if not found"). `content` is the
+	 * destination's current text — a note body, or a Canvas text card's text. A no-op unless
+	 * the choice is in heading mode. Cancelling aborts the capture cleanly (UserCancelError),
+	 * before any write.
 	 */
-	private async maybeResolveInsertAfterHeading(
-		filePath: string,
-		fileAlreadyExists: boolean,
-	): Promise<void> {
+	private async maybeResolveInsertAfterHeading(content: string): Promise<void> {
 		const insertAfter = this.choice.insertAfter;
 		if (!insertAfter?.enabled || !insertAfter.promptHeading) return;
-		if (CANVAS_FILE_EXTENSION_REGEX.test(filePath)) return;
 
-		let headingLines: string[] = [];
-		let headingDisplay: string[] = [];
-		let headingTexts: string[] = [];
-
-		if (fileAlreadyExists) {
-			const file = this.app.vault.getAbstractFileByPath(filePath);
-			if (file instanceof TFile) {
-				const content = await this.app.vault.read(file);
-				const lines = getLinesInString(content);
-				const headings = getMarkdownHeadings(lines);
-				headingLines = headings.map((h) => lines[h.line]);
-				headingDisplay = headings.map(
-					(h) => `${"  ".repeat(Math.max(0, h.level - 1))}${h.text}`,
-				);
-				headingTexts = headings.map((h) => h.text);
-			}
-		}
+		const lines = getLinesInString(content);
+		const headings = getMarkdownHeadings(lines);
+		const headingLines = headings.map((h) => lines[h.line]);
+		const headingDisplay = headings.map(
+			(h) => `${"  ".repeat(Math.max(0, h.level - 1))}${h.text}`,
+		);
+		const headingTexts = headings.map((h) => h.text);
 
 		let chosen: string;
 		try {
@@ -566,6 +571,26 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const pickedIndex = headingLines.indexOf(chosen);
 		this.resolvedInsertAfterHeading =
 			pickedIndex >= 0 ? headingTexts[pickedIndex] : chosen;
+	}
+
+	/**
+	 * Whether the choice is in "Under heading…" mode (insert-after + runtime heading picker).
+	 */
+	private isInsertAfterHeadingMode(): boolean {
+		return (
+			!!this.choice.insertAfter?.enabled &&
+			!!this.choice.insertAfter.promptHeading
+		);
+	}
+
+	/** Reads the destination note body for the heading picker (empty when the file is new). */
+	private async readNoteBodyForHeadingPicker(
+		filePath: string,
+		fileAlreadyExists: boolean,
+	): Promise<string> {
+		if (!fileAlreadyExists) return "";
+		const file = this.app.vault.getAbstractFileByPath(filePath);
+		return file instanceof TFile ? await this.app.vault.read(file) : "";
 	}
 
 	private getCaptureContent(): string {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -1,8 +1,8 @@
 import {
 	MarkdownView,
 	Notice,
+	TFile,
 	type App,
-	type TFile,
 	type WorkspaceLeaf,
 } from "obsidian";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
@@ -20,6 +20,8 @@ import {
 	VALUE_SYNTAX,
 } from "../constants";
 import { CaptureChoiceFormatter } from "../formatters/captureChoiceFormatter";
+import { getMarkdownHeadings } from "../formatters/helpers/getEndOfSection";
+import { getLinesInString } from "../utility";
 import { log } from "../logger/logManager";
 import type QuickAdd from "../main";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
@@ -73,6 +75,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	// suppressed in that case so collected containers aren't stranded as "[]"
 	// placeholders (and written to the wrong note's front matter). See run().
 	private suppressFrontmatterCollection = false;
+	// Set when the "Under heading…" runtime picker resolves a heading. Holds the heading
+	// TEXT (without '#' markers) for the success notice; the verbatim line goes to the
+	// formatter override. Null when not in heading mode.
+	private resolvedInsertAfterHeading: string | null = null;
 
 	constructor(
 		app: App,
@@ -127,7 +133,8 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					: `Captured to top of ${fileName}`;
 				break;
 			case "insertAfter": {
-				const heading = this.choice.insertAfter.after;
+				const heading =
+					this.resolvedInsertAfterHeading ?? this.choice.insertAfter.after;
 				msg = heading
 					? `Captured to ${fileName} under '${heading}'`
 					: `Captured to ${fileName}`;
@@ -266,6 +273,11 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			) => Promise<{ file: TFile; newFileContent: string; captureContent: string }>;
 			let getFileAndAddContentFn: GetFileAndAddContentFn;
 			const fileAlreadyExists = await this.fileExists(filePath);
+
+			// "Under heading…" write position: prompt for a heading from the resolved
+			// target note and feed the picked line to the formatter as an insert-after
+			// override. Runs after the target file is known and before any formatting/write.
+			await this.maybeResolveInsertAfterHeading(filePath, fileAlreadyExists);
 
 			// Collect front matter property types only when the capture content
 			// becomes the file's OWN front matter — i.e. a brand-new file created
@@ -483,6 +495,77 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			nodeId,
 			action,
 		);
+	}
+
+	/**
+	 * For the "Under heading…" write position: prompt the user with a dropdown of the
+	 * target note's headings and set the picked line as the formatter's insert-after
+	 * override. The items are byte-exact heading LINES from freshly-read content (so the
+	 * formatter's literal search and create-if-not-found round-trip exactly, the #742
+	 * invariant), parsed with the same `getMarkdownHeadings` the inserter uses (so what is
+	 * offered can never desync from what is matched). `allowCustomValue` lets the user type
+	 * a heading on a new / heading-less note (created via "Create line if not found").
+	 * Scoped to markdown notes; canvas text cards keep the static field. Cancelling the
+	 * picker aborts the capture cleanly (UserCancelError), before any write.
+	 */
+	private async maybeResolveInsertAfterHeading(
+		filePath: string,
+		fileAlreadyExists: boolean,
+	): Promise<void> {
+		const insertAfter = this.choice.insertAfter;
+		if (!insertAfter?.enabled || !insertAfter.promptHeading) return;
+		if (CANVAS_FILE_EXTENSION_REGEX.test(filePath)) return;
+
+		let headingLines: string[] = [];
+		let headingDisplay: string[] = [];
+		let headingTexts: string[] = [];
+
+		if (fileAlreadyExists) {
+			const file = this.app.vault.getAbstractFileByPath(filePath);
+			if (file instanceof TFile) {
+				const content = await this.app.vault.read(file);
+				const lines = getLinesInString(content);
+				const headings = getMarkdownHeadings(lines);
+				headingLines = headings.map((h) => lines[h.line]);
+				headingDisplay = headings.map(
+					(h) => `${"  ".repeat(Math.max(0, h.level - 1))}${h.text}`,
+				);
+				headingTexts = headings.map((h) => h.text);
+			}
+		}
+
+		let chosen: string;
+		try {
+			chosen = await InputSuggester.Suggest(
+				this.app,
+				headingDisplay,
+				headingLines,
+				{
+					allowCustomValue: true,
+					placeholder: "Choose a heading to insert under",
+					emptyStateText: "No headings found — type a heading to create",
+					customValueLabel: (value) => `Insert after new line: ${value}`,
+				},
+			);
+		} catch (error) {
+			if (isCancellationError(error)) {
+				throw new UserCancelError("Input cancelled by user");
+			}
+			throw error;
+		}
+
+		invariant(
+			!!chosen && chosen.length > 0,
+			"No heading selected for capture.",
+		);
+
+		this.formatter.setInsertAfterTargetOverride(chosen);
+
+		// Notice copy: show the heading TEXT (no '#') for a picked heading; fall back to
+		// the raw typed value for a custom entry.
+		const pickedIndex = headingLines.indexOf(chosen);
+		this.resolvedInsertAfterHeading =
+			pickedIndex >= 0 ? headingTexts[pickedIndex] : chosen;
 	}
 
 	private getCaptureContent(): string {

--- a/src/formatters/captureChoiceFormatter-write-position.test.ts
+++ b/src/formatters/captureChoiceFormatter-write-position.test.ts
@@ -533,4 +533,209 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 
 		expect(result).toBe("- [ ] CAPTURE\n## Missing\nBody");
 	});
+
+	it("inserts under the runtime-picked heading override instead of the static after text (#738)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		// "Under heading…" sets a verbatim line override; the static `after` is ignored.
+		formatter.setInsertAfterTargetOverride("## Foo");
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE\n",
+			createChoice({
+				insertAfter: {
+					enabled: true,
+					after: "## NeverUsed",
+					insertAtEnd: false,
+					considerSubsections: false,
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+					inline: false,
+					replaceExisting: false,
+					blankLineAfterMatchMode: "auto",
+					promptHeading: true,
+				},
+			}),
+			"# Title\n## Foo\nexisting\n## Bar",
+			createFile(),
+		);
+
+		expect(result).toBe("# Title\n## Foo\nCAPTURE\nexisting\n## Bar");
+	});
+
+	it("matches the heading override literally, never resolving token-like heading text (#738)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		// A real heading whose text contains format-token syntax. If the override were run
+		// through the format pipeline, "{{DATE}}" would resolve and desync from the real
+		// line (target not found → throw, since createIfNotFound is false). Landing the
+		// capture proves the override is matched verbatim.
+		formatter.setInsertAfterTargetOverride("## {{DATE}}");
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE\n",
+			createChoice({
+				insertAfter: {
+					enabled: true,
+					after: "",
+					insertAtEnd: false,
+					considerSubsections: false,
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+					inline: false,
+					replaceExisting: false,
+					blankLineAfterMatchMode: "auto",
+					promptHeading: true,
+				},
+			}),
+			"## {{DATE}}\nbody",
+			createFile(),
+		);
+
+		expect(result).toBe("## {{DATE}}\nCAPTURE\nbody");
+	});
+
+	it("takes the block (section) path for a heading override even if a stale inline flag is set (#738 blocker)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		formatter.setInsertAfterTargetOverride("## Foo");
+
+		// inline:true is a stale flag from a prior "After line…" inline config. The override
+		// must short-circuit the same-line inline path and insert on its own line under the
+		// heading (belt-and-suspenders with the builder's onChange reset).
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE\n",
+			createChoice({
+				insertAfter: {
+					enabled: true,
+					after: "## NeverUsed",
+					insertAtEnd: false,
+					considerSubsections: false,
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+					inline: true,
+					replaceExisting: true,
+					blankLineAfterMatchMode: "auto",
+					promptHeading: true,
+				},
+			}),
+			"## Foo\nexisting",
+			createFile(),
+		);
+
+		expect(result).toBe("## Foo\nCAPTURE\nexisting");
+	});
+
+	it("creates a typed heading override via create-if-not-found, byte-symmetric with search (#738/#742)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		// User typed a heading that doesn't exist yet; "Create line if not found" creates it.
+		// The created block must be byte-identical to what the next run's search will match.
+		formatter.setInsertAfterTargetOverride("## Tasks");
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE\n",
+			createChoice({
+				insertAfter: {
+					enabled: true,
+					after: "",
+					insertAtEnd: false,
+					considerSubsections: false,
+					createIfNotFound: true,
+					createIfNotFoundLocation: "bottom",
+					inline: false,
+					replaceExisting: false,
+					blankLineAfterMatchMode: "auto",
+					promptHeading: true,
+				},
+			}),
+			"# Title\nbody",
+			createFile(),
+		);
+
+		expect(result).toBe("# Title\nbody\n## Tasks\nCAPTURE\n");
+	});
+
+	it("inserts under the FIRST occurrence when the note has duplicate heading text (#738)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		// Two identical heading lines: the picker's items collapse to one and the search
+		// resolves the first match (parity with the static "After line…" field). Locked so a
+		// future override refactor can't silently change which section is targeted.
+		formatter.setInsertAfterTargetOverride("## Tasks");
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE\n",
+			createChoice({
+				insertAfter: {
+					enabled: true,
+					after: "",
+					insertAtEnd: false,
+					considerSubsections: false,
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+					inline: false,
+					replaceExisting: false,
+					blankLineAfterMatchMode: "auto",
+					promptHeading: true,
+				},
+			}),
+			"## Tasks\nfirst\n\n## Other\nx\n\n## Tasks\nsecond",
+			createFile(),
+		);
+
+		expect(result).toBe(
+			"## Tasks\nCAPTURE\nfirst\n\n## Other\nx\n\n## Tasks\nsecond",
+		);
+	});
 });

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -40,6 +40,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		*/
 	private templaterProcessed = false;
 	/**
+		* When set (by the engine's "Under heading…" runtime picker), this verbatim
+		* file line replaces the static `insertAfter.after` target for this run. It is a
+		* concrete line copied from the destination file (`lines[heading.line]`), so it is
+		* matched LITERALLY — `formatLocationString`/escape-expansion are deliberately
+		* skipped so a heading whose text contains token-like syntax (e.g. `## {{date}}`)
+		* is not resolved and desynced from the real line. The engine + its single
+		* formatter are constructed fresh per run, so this never leaks across captures.
+		*/
+	private insertAfterTargetOverride: string | null = null;
+	/**
 		* Tracks whether `\n` escapes in the capture format string have been expanded.
 		* Expansion must happen on the raw format template BEFORE token substitution,
 		* and only once per capture run: multi-stage flows pass already-substituted
@@ -65,6 +75,15 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 	public setUseSelectionAsCaptureValue(value: boolean): void {
 		this.useSelectionAsCaptureValue = value;
+	}
+
+	/**
+		* Sets (or clears with `null`) the runtime-resolved insert-after target used by the
+		* "Under heading…" write position. The value is a verbatim line from the
+		* destination file and is matched literally — see `insertAfterTargetOverride`.
+		*/
+	public setInsertAfterTargetOverride(target: string | null): void {
+		this.insertAfterTargetOverride = target;
 	}
 
 	protected shouldUseSelectionForValue(): boolean {
@@ -446,21 +465,29 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	private async insertAfterHandler(formatted: string) {
+		const override = this.insertAfterTargetOverride;
+
 		// Inline targets are single-line by definition and use a separate
 		// indexOf-based path; keep their selector unexpanded (out of scope #742).
-		if (this.choice.insertAfter?.inline) {
+		// The "Under heading…" override always wants the block (section) path, never
+		// the same-line inline path, so the override short-circuits inline here too.
+		if (this.choice.insertAfter?.inline && override === null) {
 			const inlineTarget: string = await this.formatLocationString(
 				this.choice.insertAfter.after,
 			);
 			return await this.insertAfterInlineHandler(formatted, inlineTarget);
 		}
 
-		// Expand `\n` escapes BEFORE searching so the search target is identical
-		// to what createInsertAfterIfNotFound writes to disk. Computed once and
-		// reused for the create path so the two can never diverge (issue #742).
-		const targetString: string = await this.formatLocationString(
-			await this.expandFormatTemplateEscapes(this.choice.insertAfter.after),
-		);
+		// Override (runtime-picked heading) is a verbatim file line: match it literally,
+		// skipping formatLocationString/escape-expansion (see insertAfterTargetOverride).
+		// Otherwise expand `\n` escapes BEFORE searching so the search target is identical
+		// to what createInsertAfterIfNotFound writes to disk. Computed once and reused for
+		// the create path so the two can never diverge (issue #742).
+		const targetString: string =
+			override ??
+			(await this.formatLocationString(
+				await this.expandFormatTemplateEscapes(this.choice.insertAfter.after),
+			));
 
 		const targetLines = this.toTargetLines(targetString);
 		if (this.isBlankTarget(targetLines)) {

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -34,6 +34,7 @@ let {
 if (insertAfter.inline === undefined) insertAfter.inline = false;
 if (insertAfter.replaceExisting === undefined)
 	insertAfter.replaceExisting = false;
+if (insertAfter.promptHeading === undefined) insertAfter.promptHeading = false;
 if (!insertAfter.blankLineAfterMatchMode)
 	insertAfter.blankLineAfterMatchMode = "auto";
 if (!insertAfter.createIfNotFound) insertAfter.createIfNotFound = false;
@@ -58,6 +59,9 @@ const createLocationOptions = [
 ];
 
 function onConsiderSubsectionsToggle(value: boolean) {
+	// In heading mode the runtime target is always a heading, so the
+	// "starts with #" guard would misfire against the empty/hidden `after` text.
+	if (insertAfter.promptHeading) return;
 	if (value && !insertAfter.after.startsWith("#")) {
 		// Two-way bind syncs the toggle back to off when the target isn't a heading.
 		insertAfter.considerSubsections = false;
@@ -68,28 +72,35 @@ function onConsiderSubsectionsToggle(value: boolean) {
 }
 </script>
 
-<SettingItem
-	name="Insert after"
-	desc="Insert capture after specified text. Accepts format syntax. Tip: use a heading (starts with #) to target a section. Blank line handling is configurable below."
-/>
-<FormatPreviewField value={insertAfter.after} {app} {plugin} />
-<ValidatedInput
-	bind:value={insertAfter.after}
-	placeholder="Insert after"
-	required
-	requiredMessage="Insert after text is required"
-	makeSuggesters={suggesters}
-	ariaLabel="Insert after"
-/>
+{#if insertAfter.promptHeading}
+	<SettingItem
+		name="Under heading"
+		desc="You'll pick a heading from the target note when you run this capture, and the text is inserted under it. Use the toggles below to control placement within that section."
+	/>
+{:else}
+	<SettingItem
+		name="Insert after"
+		desc="Insert capture after specified text. Accepts format syntax. Tip: use a heading (starts with #) to target a section. Blank line handling is configurable below."
+	/>
+	<FormatPreviewField value={insertAfter.after} {app} {plugin} />
+	<ValidatedInput
+		bind:value={insertAfter.after}
+		placeholder="Insert after"
+		required
+		requiredMessage="Insert after text is required"
+		makeSuggesters={suggesters}
+		ariaLabel="Insert after"
+	/>
 
-<SettingItem
-	name="Inline insertion"
-	desc="Insert captured content on the same line, immediately after the matched text (no newline added)."
->
-	{#snippet control()}
-		<Toggle bind:checked={insertAfter.inline} />
-	{/snippet}
-</SettingItem>
+	<SettingItem
+		name="Inline insertion"
+		desc="Insert captured content on the same line, immediately after the matched text (no newline added)."
+	>
+		{#snippet control()}
+			<Toggle bind:checked={insertAfter.inline} />
+		{/snippet}
+	</SettingItem>
+{/if}
 
 {#if insertAfter.inline}
 	<SettingItem
@@ -132,7 +143,9 @@ function onConsiderSubsectionsToggle(value: boolean) {
 
 	<SettingItem
 		name="Consider subsections"
-		desc="Also include the section’s subsections (requires target to be a heading starting with #). Subsections are headings inside the section."
+		desc={insertAfter.promptHeading
+			? "Also include the chosen heading’s subsections (nested headings inside its section)."
+			: "Also include the section’s subsections (requires target to be a heading starting with #). Subsections are headings inside the section."}
 	>
 		{#snippet control()}
 			<Toggle

--- a/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
@@ -66,10 +66,11 @@ function onWritePositionChange(value: string) {
 	choice.insertAfter.enabled = false;
 	// Heading mode is a distinct insert-after flavor; clear it on every change so
 	// the two insert-after variants ("After line…" / "Under heading…") stay mutually
-	// exclusive. Also clear inline/replaceExisting: insertAfterHandler branches on
-	// `inline` BEFORE the heading override, so a stale inline=true (from a prior
-	// "After line…" inline config) would otherwise take the same-line path and ignore
-	// the picked heading entirely.
+	// exclusive. Also clear inline/replaceExisting so the persisted config stays clean
+	// and unambiguous when switching modes. (The formatter independently guards the
+	// inline path with `inline && override === null`, so a stale inline flag can't
+	// bypass a picked heading at runtime; this reset is the matching builder-side
+	// hygiene, not the sole safeguard.)
 	choice.insertAfter.promptHeading = false;
 	choice.insertAfter.inline = false;
 	choice.insertAfter.replaceExisting = false;

--- a/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
@@ -28,7 +28,8 @@ let {
 const isActiveFile = $derived(!!choice.captureToActiveFile);
 
 const current = $derived.by(() => {
-	if (choice.insertAfter?.enabled) return "after";
+	if (choice.insertAfter?.enabled)
+		return choice.insertAfter.promptHeading ? "underHeading" : "after";
 	if (choice.insertBefore?.enabled) return "before";
 	if (choice.newLineCapture?.enabled)
 		return choice.newLineCapture.direction === "above"
@@ -53,6 +54,7 @@ const options = $derived([
 			]
 		: []),
 	{ value: "after", label: "After line…" },
+	{ value: "underHeading", label: "Under heading…" },
 	{ value: "before", label: "Before line…" },
 	{ value: "bottom", label: "Bottom of file" },
 ]);
@@ -62,6 +64,15 @@ function onWritePositionChange(value: string) {
 	// (verbatim order from the imperative builder, captureChoiceBuilder.ts:941-999).
 	choice.prepend = false;
 	choice.insertAfter.enabled = false;
+	// Heading mode is a distinct insert-after flavor; clear it on every change so
+	// the two insert-after variants ("After line…" / "Under heading…") stay mutually
+	// exclusive. Also clear inline/replaceExisting: insertAfterHandler branches on
+	// `inline` BEFORE the heading override, so a stale inline=true (from a prior
+	// "After line…" inline config) would otherwise take the same-line path and ignore
+	// the picked heading entirely.
+	choice.insertAfter.promptHeading = false;
+	choice.insertAfter.inline = false;
+	choice.insertAfter.replaceExisting = false;
 	if (!choice.insertBefore)
 		choice.insertBefore = {
 			enabled: false,
@@ -100,6 +111,11 @@ function onWritePositionChange(value: string) {
 	}
 	if (value === "before") {
 		choice.insertBefore.enabled = true;
+		return;
+	}
+	if (value === "underHeading") {
+		choice.insertAfter.enabled = true;
+		choice.insertAfter.promptHeading = true;
 		return;
 	}
 	choice.insertAfter.enabled = true;

--- a/src/types/choices/CaptureChoice.ts
+++ b/src/types/choices/CaptureChoice.ts
@@ -28,6 +28,7 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 		inline?: boolean;
 		replaceExisting?: boolean;
 		blankLineAfterMatchMode?: BlankLineAfterMatchMode;
+		promptHeading?: boolean;
 	};
 	insertBefore: {
 		enabled: boolean;
@@ -76,6 +77,7 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 			inline: false,
 			replaceExisting: false,
 			blankLineAfterMatchMode: "auto",
+			promptHeading: false,
 		};
 		this.insertBefore = {
 			enabled: false,
@@ -141,6 +143,9 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 		}
 		if (loaded.insertAfter && loaded.insertAfter.replaceExisting === undefined) {
 			loaded.insertAfter.replaceExisting = false;
+		}
+		if (loaded.insertAfter && loaded.insertAfter.promptHeading === undefined) {
+			loaded.insertAfter.promptHeading = false;
 		}
 		return loaded;
 	}

--- a/src/types/choices/ICaptureChoice.ts
+++ b/src/types/choices/ICaptureChoice.ts
@@ -39,6 +39,13 @@ export default interface ICaptureChoice extends IChoice {
 		inline?: boolean;
 		replaceExisting?: boolean;
 		blankLineAfterMatchMode?: BlankLineAfterMatchMode;
+		/**
+			* When true, the insert-after target is chosen at capture time from a dropdown
+			* of the target note's headings (the "Under heading…" write position) instead of
+			* the static `after` text. Resolved fresh each run and applied via a formatter
+			* override; never persisted back into `after`. Undefined ⇒ false (no migration).
+			*/
+		promptHeading?: boolean;
 	};
 	insertBefore?: {
 		enabled: boolean;


### PR DESCRIPTION
## What

Adds a new Capture **Write position** option — **"Under heading…"** — that shows a dropdown of the **target note's headings at capture time** and inserts the captured text under the one you pick. This is the heading equivalent of the file picker that already appears when no file name is specified (issue #738).

![it's a runtime dropdown, like the file picker, but for headings]

## Why

The existing "Insert after" field is static config-time text: you must know and type the exact heading when *building* the choice. There was no way to choose the heading **at capture time** from the note's actual headings. This delivers exactly the requested UX with zero new format grammar.

## How

Implemented entirely on top of the existing insert-after machinery via one optional flag (`insertAfter.promptHeading`) and a verbatim formatter override:

- **Runtime picker** (`CaptureChoiceEngine.maybeResolveInsertAfterHeading`): offers **byte-exact heading lines** parsed with the same `getMarkdownHeadings` the inserter uses, so search/create round-trip exactly (the #742 invariant). Display is indented by heading level; `allowCustomValue` lets you type a heading for a new / heading-less note (pair with *Create line if not found*).
- **Verbatim override** (`captureChoiceFormatter`): the picked line is matched **literally** (skips `formatLocationString`/escape-expansion), so a heading whose text contains token-like syntax (e.g. `## {{date}}`) is never resolved and desynced from the real line. Reused verbatim in the create-if-not-found path so search and create stay byte-identical.
- **Builder** (`WritePositionSetting` / `InsertAfterFields`): "Under heading…" hides the static text field + inline toggle and shows a hint. `onWritePositionChange` resets `inline`/`replaceExisting` so a stale inline flag can't bypass the picked heading; the formatter's inline branch is additionally gated on the override (belt-and-suspenders).
- **Cancel** the picker → clean abort (`UserCancelError`) before any write. Notice names the picked heading.

**No migration** — `promptHeading` is optional (`undefined ⇒ false`); old choices behave exactly as before.

## Scope / known limitations (documented)

- Insert-after only (the issue's ask). Insert-before / canvas text cards keep the static field.
- With one-page mode on, the heading dropdown is a separate step after the consolidated form (the file picker is the only preflighted requirement).
- New-from-template notes can't *list* the template's headings yet (the note doesn't exist at pick time) — type the heading + *Create line if not found* (works if it matches the template).

## Verification

- **Unit:** full vitest suite green, **11 new tests** (formatter override incl. literal-match, inline-gate, create-path byte-symmetry, duplicate-heading first-match; engine picker wiring incl. byte-exact items, indented display, gating, canvas skip, custom value, cancel). tsc + full eslint + svelte-check clean.
- **Dev-vault e2e (real Obsidian):** picker opens with level-indented headings → picking inserts under the heading → capture succeeds; cancel → clean abort; builder shows "Under heading…", hides the static field, and toggles modes reactively.
- **Reviewed** with an adversarial multi-lens pass (design + implementation): verdict **ship**, no blocker/major.

Fixes #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Under heading”** capture write-position option with a capture-time heading dropdown (or custom entry to create it), inserting the captured text beneath the selected heading.
  * Updated the success notice and insertion behavior to use the resolved heading target.
  * Refreshed the write-position UI so heading mode swaps in the “Under heading…” controls and disables irrelevant settings.
* **Documentation**
  * Documented **“Under heading”** behavior, including subsections, blank lines, and create-if-not-found nuances.
* **Tests**
  * Added coverage for heading picking, cancellation, and exact formatter insertion/creation under heading overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->