### PR TITLE
refactor(capture): fold the heading picker into "After line…" as a toggle

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -74,8 +74,7 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
     -   **Top of file (after frontmatter)** (active file only)
     -   **New line above cursor** (active file only)
     -   **New line below cursor** (active file only)
-    -   **After line…**
-    -   **Under heading…** - pick a heading from the target note at capture time (a dropdown of the note's headings appears when you run the capture), and the text is inserted under the one you choose. See [Under heading](#under-heading).
+    -   **After line…** — insert after a target line. You can either type the target now, or enable **Choose heading when capturing** to pick a heading from the note at run time. See [Insert after](#insert-after).
     -   **Before line…**
     -   **Bottom of file**
 -   _Link to captured file_ is a dropdown that controls whether QuickAdd inserts a link to the captured file in the current note. You can choose between three modes:
@@ -223,11 +222,17 @@ I use this in my daily journal capture, where I insert after the heading line `#
 It's also possible to use `Create line if not found`, which will create the line if it doesn't exist. This is useful if you want to insert after a line that might not exist in the file you're capturing to.
 This setting can place the line at the start or end of the file, or at your current cursor position.
 
-## Under heading
+### Choose heading when capturing
 
-Choose **Under heading…** as the _Write position_ when you want to pick the target heading **at capture time** instead of typing it in advance. When you run the capture, QuickAdd reads the target note and shows a dropdown of its headings — pick one, and the text is inserted under it. This is the same idea as the note-selection dropdown that appears when no file name is specified, but for headings within a single note.
+Insert After normally uses a target line you type when you build the choice. Enable
+**Choose heading when capturing** to instead pick the heading **at run time**: when you
+run the capture, QuickAdd reads the target note and shows a dropdown of its headings — pick
+one, and the text is inserted under it. This is the same idea as the note-selection dropdown
+that appears when no file name is specified, but for headings within a single note. It's
+useful when the heading varies between runs, or when you'd rather not remember and type it.
 
-This is a flavor of [Insert after](#insert-after) (the picked heading becomes the insert-after target), so all of its placement controls still apply:
+The picked heading simply becomes the insert-after target, so every placement control still
+applies:
 
 -   By default the text is inserted directly under the chosen heading line. Enable `Insert at end of section` to append it to the end of that heading's section instead.
 -   `Consider subsections`, `Blank lines after match`, and `Create line if not found` work exactly as for Insert after.

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -79,7 +79,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	// suppressed in that case so collected containers aren't stranded as "[]"
 	// placeholders (and written to the wrong note's front matter). See run().
 	private suppressFrontmatterCollection = false;
-	// Set when the "Under heading…" runtime picker resolves a heading. Holds the heading
+	// Set when the "Choose heading when capturing" picker resolves a heading. Holds the heading
 	// TEXT (without '#' markers) for the success notice; the verbatim line goes to the
 	// formatter override. Null when not in heading mode.
 	private resolvedInsertAfterHeading: string | null = null;
@@ -278,7 +278,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			let getFileAndAddContentFn: GetFileAndAddContentFn;
 			const fileAlreadyExists = await this.fileExists(filePath);
 
-			// "Under heading…" write position: prompt for a heading from the resolved
+			// "Choose heading when capturing" (After line…): prompt for a heading from the resolved
 			// target note and feed the picked line to the formatter as an insert-after
 			// override. Runs after the target file is known and before any formatting/write.
 			// Canvas TEXT cards are handled earlier in handleCanvasTextCapture (which resolves
@@ -446,7 +446,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const captureTemplate = this.getCaptureContent();
 		const existingText = getCanvasTextCaptureContent(target);
 
-		// "Under heading…" write position on a canvas text card: resolve the heading from
+		// "Choose heading when capturing" on a canvas text card: resolve the heading from
 		// the card's own text so the insert-after override targets a real line in the card
 		// (otherwise heading mode leaves the static `after` empty and the formatter aborts).
 		if (this.isInsertAfterHeadingMode()) {
@@ -520,7 +520,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	}
 
 	/**
-	 * For the "Under heading…" write position: prompt the user with a dropdown of the
+	 * For "Choose heading when capturing": prompt the user with a dropdown of the
 	 * destination's headings and set the picked line as the formatter's insert-after
 	 * override. The items are byte-exact heading LINES from `content` (so the formatter's
 	 * literal search and create-if-not-found round-trip exactly, the #742 invariant),
@@ -578,7 +578,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	}
 
 	/**
-	 * Whether the choice is in "Under heading…" mode (insert-after + runtime heading picker).
+	 * Whether the choice is in heading-picker mode (After line… + "Choose heading when capturing").
 	 */
 	private isInsertAfterHeadingMode(): boolean {
 		return (

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -40,7 +40,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		*/
 	private templaterProcessed = false;
 	/**
-		* When set (by the engine's "Under heading…" runtime picker), this verbatim
+		* When set (by the engine's "Choose heading when capturing" picker), this verbatim
 		* file line replaces the static `insertAfter.after` target for this run. It is a
 		* concrete line copied from the destination file (`lines[heading.line]`), so it is
 		* matched LITERALLY — `formatLocationString`/escape-expansion are deliberately
@@ -79,7 +79,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 	/**
 		* Sets (or clears with `null`) the runtime-resolved insert-after target used by the
-		* "Under heading…" write position. The value is a verbatim line from the
+		* heading-picker option. The value is a verbatim line from the
 		* destination file and is matched literally — see `insertAfterTargetOverride`.
 		*/
 	public setInsertAfterTargetOverride(target: string | null): void {
@@ -469,7 +469,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 		// Inline targets are single-line by definition and use a separate
 		// indexOf-based path; keep their selector unexpanded (out of scope #742).
-		// The "Under heading…" override always wants the block (section) path, never
+		// The heading-picker override always wants the block (section) path, never
 		// the same-line inline path, so the override short-circuits inline here too.
 		if (this.choice.insertAfter?.inline && override === null) {
 			const inlineTarget: string = await this.formatLocationString(

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -70,13 +70,35 @@ function onConsiderSubsectionsToggle(value: boolean) {
 		);
 	}
 }
+
+function onPromptHeadingToggle(value: boolean) {
+	// Heading mode always inserts on its own line under the picked heading (the block
+	// path), so clear the inline same-line flags when it's switched on.
+	if (value) {
+		insertAfter.inline = false;
+		insertAfter.replaceExisting = false;
+	}
+}
 </script>
 
+<SettingItem
+	name="Choose heading when capturing"
+	desc="Instead of typing a target line now, show a dropdown of the target note's headings when you run this capture and insert under the one you pick."
+>
+	{#snippet control()}
+		<Toggle
+			bind:checked={insertAfter.promptHeading}
+			onchange={onPromptHeadingToggle}
+		/>
+	{/snippet}
+</SettingItem>
+
 {#if insertAfter.promptHeading}
-	<SettingItem
-		name="Under heading"
-		desc="You'll pick a heading from the target note when you run this capture, and the text is inserted under it. Use the toggles below to control placement within that section."
-	/>
+	<div class="setting-item-description">
+		You'll pick a heading from the target note when you run this capture, and the
+		text is inserted under it. Use the toggles below to control placement within that
+		section.
+	</div>
 {:else}
 	<SettingItem
 		name="Insert after"

--- a/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
@@ -28,8 +28,7 @@ let {
 const isActiveFile = $derived(!!choice.captureToActiveFile);
 
 const current = $derived.by(() => {
-	if (choice.insertAfter?.enabled)
-		return choice.insertAfter.promptHeading ? "underHeading" : "after";
+	if (choice.insertAfter?.enabled) return "after";
 	if (choice.insertBefore?.enabled) return "before";
 	if (choice.newLineCapture?.enabled)
 		return choice.newLineCapture.direction === "above"
@@ -54,7 +53,6 @@ const options = $derived([
 			]
 		: []),
 	{ value: "after", label: "After line…" },
-	{ value: "underHeading", label: "Under heading…" },
 	{ value: "before", label: "Before line…" },
 	{ value: "bottom", label: "Bottom of file" },
 ]);
@@ -64,13 +62,12 @@ function onWritePositionChange(value: string) {
 	// (verbatim order from the imperative builder, captureChoiceBuilder.ts:941-999).
 	choice.prepend = false;
 	choice.insertAfter.enabled = false;
-	// Heading mode is a distinct insert-after flavor; clear it on every change so
-	// the two insert-after variants ("After line…" / "Under heading…") stay mutually
-	// exclusive. Also clear inline/replaceExisting so the persisted config stays clean
-	// and unambiguous when switching modes. (The formatter independently guards the
-	// inline path with `inline && override === null`, so a stale inline flag can't
-	// bypass a picked heading at runtime; this reset is the matching builder-side
-	// hygiene, not the sole safeguard.)
+	// Leaving insert-after mode clears its sub-flags so the persisted config stays
+	// clean. promptHeading (the "Choose heading when capturing" toggle) and
+	// inline/replaceExisting are properties of "After line…"; re-selecting it starts
+	// from the plain typed-target default and the user opts back into heading mode via
+	// the toggle. Existing heading-mode choices load as "After line…" with the toggle on
+	// (this handler only runs on an explicit dropdown change, not on load).
 	choice.insertAfter.promptHeading = false;
 	choice.insertAfter.inline = false;
 	choice.insertAfter.replaceExisting = false;
@@ -112,11 +109,6 @@ function onWritePositionChange(value: string) {
 	}
 	if (value === "before") {
 		choice.insertBefore.enabled = true;
-		return;
-	}
-	if (value === "underHeading") {
-		choice.insertAfter.enabled = true;
-		choice.insertAfter.promptHeading = true;
 		return;
 	}
 	choice.insertAfter.enabled = true;

--- a/src/types/choices/ICaptureChoice.ts
+++ b/src/types/choices/ICaptureChoice.ts
@@ -40,10 +40,11 @@ export default interface ICaptureChoice extends IChoice {
 		replaceExisting?: boolean;
 		blankLineAfterMatchMode?: BlankLineAfterMatchMode;
 		/**
-			* When true, the insert-after target is chosen at capture time from a dropdown
-			* of the target note's headings (the "Under heading…" write position) instead of
-			* the static `after` text. Resolved fresh each run and applied via a formatter
-			* override; never persisted back into `after`. Undefined ⇒ false (no migration).
+			* When true (the "Choose heading when capturing" option of "After line…"), the
+			* insert-after target is chosen at capture time from a dropdown of the target
+			* note's headings instead of the static `after` text. Resolved fresh each run and
+			* applied via a formatter override; never persisted back into `after`. Undefined ⇒
+			* false (no migration).
 			*/
 		promptHeading?: boolean;
 	};


### PR DESCRIPTION
## What

Follow-up to #1348 (which closed #738). The runtime heading picker shipped as a separate **"Under heading…"** Write-position entry. This refolds it into **"After line…"** as a **"Choose heading when capturing"** toggle.

## Why

"Under heading…" and "After line…" aren't two different *write positions* — they're the same one (insert after a line). What differs is **how you choose the target line**: type it now, or pick a heading at capture time. Presenting that target-selection mode as a peer destination made it read as a confusing, lesser twin of "After line…" (it runs through the same insert-after engine; the only thing it adds is the runtime picker).

After this change there's **one** write position with two clearly-related ways to resolve the target.

| Before | After |
|---|---|
| Write position: `After line…` / **`Under heading…`** (two entries) | Write position: `After line…` → toggle **"Choose heading when capturing"** |

## How

- Removed the `underHeading` option, its `current` derivation, and its `onChange` branch from `WritePositionSetting.svelte`.
- Added the **Choose heading when capturing** toggle (bound to `insertAfter.promptHeading`) inside `InsertAfterFields.svelte`; ON hides the typed-target field + inline toggle and shows the hint, OFF is the classic typed target.
- Docs + internal comments updated.

**UI-only.** The runtime behavior, the `insertAfter.promptHeading` flag, and the formatter/engine are unchanged.

## Migration

None. `promptHeading` is unchanged; an existing choice saved as "Under heading…" loads as **"After line…" with the toggle on** — verified in the dev vault (the demo choice round-tripped correctly), along with toggle reactivity both ways.

## Verification

- Full vitest suite green (2171 passed); tsc + full eslint + svelte-check clean.
- Dev-vault e2e: dropdown no longer lists "Under heading…"; existing `promptHeading` choice loads as After line… + toggle on; toggling reveals/hides the typed field and the hint reactively.

Refs #738
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated capture choice documentation to reflect revised heading selection workflow.

* **Bug Fixes**
  * Improved heading target resolution to occur at capture runtime via dropdown selection rather than static configuration.

* **UI/UX**
  * Replaced static "Under heading" option with "Choose heading when capturing" toggle, enabling users to select destination headings dynamically during capture execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->