### PR TITLE
fix(gui): stop DataCloneError when configuring a choice nested in a folder or Macro

### DIFF
--- a/src/gui/ChoiceBuilder/captureChoiceFormProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceFormProps.svelte.ts
@@ -22,11 +22,12 @@ export function createCaptureChoiceFormProps(
 	// the form and snapshotted back out by onClose (getResultChoice). #1130
 	//
 	// Why $state.snapshot and NOT structuredClone:
-	//  - EXISTING choice: can arrive as a live $state proxy (a Macro's nested
-	//    command.choice is reactive — see CommandList.svelte). structuredClone throws
-	//    DataCloneError on a $state proxy under Svelte's dev build; $state.snapshot
-	//    detaches it via Svelte's own deep clone. This is the Plain<T> proxy-detach
-	//    rule from persist.svelte.ts.
+	//  - EXISTING choice: can arrive as a live $state proxy. A choice nested inside a
+	//    folder (Multi) or a Macro is held/rendered through $state (ChoiceList's
+	//    dndzone / CommandList), so it is reactive — only ROOT-level choices stay
+	//    plain. structuredClone throws DataCloneError on a $state proxy under Svelte's
+	//    dev build; $state.snapshot detaches it via Svelte's own deep clone. This is
+	//    the Plain<T> proxy-detach rule from persist.svelte.ts.
 	//  - NEW choice: createChoice() returns a `new CaptureChoice()` class instance,
 	//    which $state() leaves UN-proxied — it must be plain for nested {#if} rows to
 	//    react. snapshot deep-clones it too: a Choice is plain data, so Svelte's clone

--- a/src/gui/ChoiceBuilder/captureChoiceFormProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceFormProps.svelte.ts
@@ -18,12 +18,19 @@ export interface CaptureChoiceFormProps {
 export function createCaptureChoiceFormProps(
 	initial: CaptureChoiceFormProps,
 ): CaptureChoiceFormProps {
-	// Plain-clone the choice so $state deeply proxies it. Svelte's proxy() returns
-	// class instances UNCHANGED (un-proxied) — newly created choices come from
-	// `createChoice()` as `new CaptureChoice()` instances, whose nested mutations
-	// would then NOT be reactive (conditional {#if} rows wouldn't appear in the
-	// add-new flow). structuredClone strips the class prototype to a plain object;
+	// Detach the choice into a plain clone so $state can deeply proxy it. Svelte's
+	// proxy() returns class instances UNCHANGED (un-proxied) — newly created choices
+	// come from `createChoice()` as `new CaptureChoice()` instances, whose nested
+	// mutations would then NOT be reactive (conditional {#if} rows wouldn't appear in
+	// the add-new flow). $state.snapshot strips the class prototype to a plain object;
 	// the form mutates this proxy and onClose snapshots it (getResultChoice). #1130
-	const props = $state({ ...initial, choice: structuredClone(initial.choice) });
+	//
+	// Use $state.snapshot, NOT structuredClone: an EXISTING choice arrives here as a
+	// live $state proxy (ChoiceView holds saved choices, loaded from data.json as
+	// plain objects, in a $state array). structuredClone throws DataCloneError on a
+	// $state proxy; $state.snapshot detaches it (see the Plain<T> rule in
+	// persist.svelte.ts). New choices are class instances (un-proxied) and snapshot
+	// strips their prototype just the same.
+	const props = $state({ ...initial, choice: $state.snapshot(initial.choice) });
 	return props;
 }

--- a/src/gui/ChoiceBuilder/captureChoiceFormProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceFormProps.svelte.ts
@@ -18,19 +18,21 @@ export interface CaptureChoiceFormProps {
 export function createCaptureChoiceFormProps(
 	initial: CaptureChoiceFormProps,
 ): CaptureChoiceFormProps {
-	// Detach the choice into a plain clone so $state can deeply proxy it. Svelte's
-	// proxy() returns class instances UNCHANGED (un-proxied) — newly created choices
-	// come from `createChoice()` as `new CaptureChoice()` instances, whose nested
-	// mutations would then NOT be reactive (conditional {#if} rows wouldn't appear in
-	// the add-new flow). $state.snapshot strips the class prototype to a plain object;
-	// the form mutates this proxy and onClose snapshots it (getResultChoice). #1130
+	// Detach the choice into a plain clone so $state can deeply proxy it, mutated by
+	// the form and snapshotted back out by onClose (getResultChoice). #1130
 	//
-	// Use $state.snapshot, NOT structuredClone: an EXISTING choice arrives here as a
-	// live $state proxy (ChoiceView holds saved choices, loaded from data.json as
-	// plain objects, in a $state array). structuredClone throws DataCloneError on a
-	// $state proxy; $state.snapshot detaches it (see the Plain<T> rule in
-	// persist.svelte.ts). New choices are class instances (un-proxied) and snapshot
-	// strips their prototype just the same.
+	// Why $state.snapshot and NOT structuredClone:
+	//  - EXISTING choice: can arrive as a live $state proxy (a Macro's nested
+	//    command.choice is reactive — see CommandList.svelte). structuredClone throws
+	//    DataCloneError on a $state proxy under Svelte's dev build; $state.snapshot
+	//    detaches it via Svelte's own deep clone. This is the Plain<T> proxy-detach
+	//    rule from persist.svelte.ts.
+	//  - NEW choice: createChoice() returns a `new CaptureChoice()` class instance,
+	//    which $state() leaves UN-proxied — it must be plain for nested {#if} rows to
+	//    react. snapshot deep-clones it too: a Choice is plain data, so Svelte's clone
+	//    delegates the cloneable instance to structuredClone, stripping the prototype
+	//    to Object.prototype. (Verified by the add-new reactivity test in
+	//    CaptureChoiceForm.test.ts and choiceFormProps.proxy.svelte.test.ts.)
 	const props = $state({ ...initial, choice: $state.snapshot(initial.choice) });
 	return props;
 }

--- a/src/gui/ChoiceBuilder/choiceFormProps.proxy.svelte.test.ts
+++ b/src/gui/ChoiceBuilder/choiceFormProps.proxy.svelte.test.ts
@@ -51,16 +51,23 @@ describe("choice form props: existing (proxied plain-object) choices", () => {
 		expect(props.choice).not.toBe(proxied);
 	});
 
-	it("still builds Template props from a freshly created class instance", () => {
-		// The add-new flow: createChoice() returns a class instance. Must remain
-		// reactive (plain-prototype clone) — the original reason the clone exists.
-		const props = createTemplateChoiceFormProps({
-			choice: new TemplateChoice("New"),
-			app,
-			plugin,
-		});
-		expect(Object.getPrototypeOf(props.choice)).toBe(Object.prototype);
+	it("still builds Template props from a freshly created class instance (deep, plain)", () => {
+		// The add-new flow: createChoice() returns a class INSTANCE (prototype is
+		// TemplateChoice.prototype, not Object.prototype). $state.snapshot must still
+		// produce a plain-prototype DEEP clone so $state() deeply proxies it and nested
+		// {#if} rows react (#1130). Svelte's clone delegates the cloneable instance to
+		// structuredClone, which strips the prototype — assert that here, plus deep
+		// independence so the class-instance path is covered as fully as the proxy one.
+		const source = new TemplateChoice("New");
+		source.folder.folders.push("Seed");
+		expect(Object.getPrototypeOf(source)).not.toBe(Object.prototype); // is a class instance
+
+		const props = createTemplateChoiceFormProps({ choice: source, app, plugin });
+		expect(Object.getPrototypeOf(props.choice)).toBe(Object.prototype); // prototype stripped
 		expect(props.choice.name).toBe("New");
+
+		(props.choice.folder.folders as string[]).push("Added");
+		expect(source.folder.folders).toEqual(["Seed"]); // deep clone — original untouched
 	});
 
 	// The clone must be DEEP: the form mutates props.choice freely (incl. nested

--- a/src/gui/ChoiceBuilder/choiceFormProps.proxy.svelte.test.ts
+++ b/src/gui/ChoiceBuilder/choiceFormProps.proxy.svelte.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { App } from "obsidian";
+import type QuickAdd from "../../main";
+import type ITemplateChoice from "../../types/choices/ITemplateChoice";
+import type ICaptureChoice from "../../types/choices/ICaptureChoice";
+import { TemplateChoice } from "../../types/choices/TemplateChoice";
+import { CaptureChoice } from "../../types/choices/CaptureChoice";
+import { createTemplateChoiceFormProps } from "./templateChoiceFormProps.svelte";
+import { createCaptureChoiceFormProps } from "./captureChoiceFormProps.svelte";
+
+// The app/plugin are passed through the factory untouched (only the choice is
+// cloned), so minimal stubs suffice.
+const app = {} as unknown as App;
+const plugin = {} as unknown as QuickAdd;
+
+/**
+ * Regression for the DataCloneError when configuring a choice whose object is a
+ * live Svelte `$state` PROXY. The real trigger is the Macro builder: a nested
+ * command's `choice` is a `$state` proxy (CommandList.svelte), so configuring it
+ * calls the form-props factory with a proxy. Under Svelte's dev build (active when
+ * Obsidian runs with NODE_ENV=development), a proxy's NESTED objects are
+ * non-cloneable, so `structuredClone(choice)` throws
+ * "#<Object> could not be cloned." — the user-reported crash. `$state.snapshot`
+ * detaches the proxy instead and never throws.
+ *
+ * Vitest compiles Svelte in dev mode, so this models that exact condition: the
+ * test throws on the old `structuredClone(initial.choice)` and passes on
+ * `$state.snapshot(initial.choice)`.
+ */
+function asSavedProxy<T>(choice: T): T {
+	const plain = JSON.parse(JSON.stringify(choice)) as T;
+	const holder = $state({ choices: [plain] });
+	return holder.choices[0];
+}
+
+describe("choice form props: existing (proxied plain-object) choices", () => {
+	it("builds Template props from a $state proxy without DataCloneError", () => {
+		const proxied = asSavedProxy<ITemplateChoice>(new TemplateChoice("Saved"));
+		const props = createTemplateChoiceFormProps({ choice: proxied, app, plugin });
+		// props.choice must be a fresh, reactive (plain-prototype) clone.
+		expect(Object.getPrototypeOf(props.choice)).toBe(Object.prototype);
+		expect(props.choice.name).toBe("Saved");
+		expect(props.choice).not.toBe(proxied);
+	});
+
+	it("builds Capture props from a $state proxy without DataCloneError", () => {
+		const proxied = asSavedProxy<ICaptureChoice>(new CaptureChoice("Saved"));
+		const props = createCaptureChoiceFormProps({ choice: proxied, app, plugin });
+		expect(Object.getPrototypeOf(props.choice)).toBe(Object.prototype);
+		expect(props.choice.name).toBe("Saved");
+		expect(props.choice).not.toBe(proxied);
+	});
+
+	it("still builds Template props from a freshly created class instance", () => {
+		// The add-new flow: createChoice() returns a class instance. Must remain
+		// reactive (plain-prototype clone) — the original reason the clone exists.
+		const props = createTemplateChoiceFormProps({
+			choice: new TemplateChoice("New"),
+			app,
+			plugin,
+		});
+		expect(Object.getPrototypeOf(props.choice)).toBe(Object.prototype);
+		expect(props.choice.name).toBe("New");
+	});
+
+	// The clone must be DEEP: the form mutates props.choice freely (incl. nested
+	// arrays/objects), and those edits must NOT leak into the original choice — the
+	// builder only commits on save (onClose snapshots props.choice). A shallow clone
+	// would alias nested branches and silently mutate the source proxy. These lock
+	// that contract so a future shallow-clone regression fails loudly.
+	it("Template: nested mutations on props.choice do not leak into the original", () => {
+		const source = new TemplateChoice("Saved");
+		source.folder = {
+			enabled: true,
+			folders: ["A", "B"],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		};
+		source.appendLink = { type: "all", placement: "afterContent" } as never;
+		source.fileExistsBehavior = { kind: "append" } as never;
+		const proxied = asSavedProxy<ITemplateChoice>(source);
+
+		const props = createTemplateChoiceFormProps({ choice: proxied, app, plugin });
+		(props.choice.folder.folders as string[]).push("C");
+		props.choice.folder.enabled = false;
+		(props.choice.appendLink as { placement: string }).placement = "beforeContent";
+		(props.choice.fileExistsBehavior as { kind: string }).kind = "prompt";
+
+		expect(proxied.folder.folders).toEqual(["A", "B"]);
+		expect(proxied.folder.enabled).toBe(true);
+		expect((proxied.appendLink as { placement: string }).placement).toBe("afterContent");
+		expect((proxied.fileExistsBehavior as { kind: string }).kind).toBe("append");
+	});
+
+	it("Capture: nested mutations on props.choice do not leak into the original", () => {
+		const source = new CaptureChoice("Saved");
+		source.insertAfter = {
+			enabled: true,
+			after: "## Heading",
+			insertAtEnd: false,
+			considerSubsections: false,
+			createIfNotFound: false,
+			createIfNotFoundLocation: "top",
+		} as never;
+		const proxied = asSavedProxy<ICaptureChoice>(source);
+
+		const props = createCaptureChoiceFormProps({ choice: proxied, app, plugin });
+		props.choice.insertAfter.after = "## Changed";
+		props.choice.insertAfter.enabled = false;
+
+		expect(proxied.insertAfter.after).toBe("## Heading");
+		expect(proxied.insertAfter.enabled).toBe(true);
+	});
+});

--- a/src/gui/ChoiceBuilder/choiceFormProps.proxy.svelte.test.ts
+++ b/src/gui/ChoiceBuilder/choiceFormProps.proxy.svelte.test.ts
@@ -15,8 +15,9 @@ const plugin = {} as unknown as QuickAdd;
 
 /**
  * Regression for the DataCloneError when configuring a choice whose object is a
- * live Svelte `$state` PROXY. The real trigger is the Macro builder: a nested
- * command's `choice` is a `$state` proxy (CommandList.svelte), so configuring it
+ * live Svelte `$state` PROXY. This happens for any NESTED choice — one inside a
+ * folder (Multi, rendered through ChoiceList's dndzone) or a Macro (CommandList) —
+ * whose object is held in `$state`; root-level choices stay plain. Configuring it
  * calls the form-props factory with a proxy. Under Svelte's dev build (active when
  * Obsidian runs with NODE_ENV=development), a proxy's NESTED objects are
  * non-cloneable, so `structuredClone(choice)` throws

--- a/src/gui/ChoiceBuilder/templateChoiceFormProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceFormProps.svelte.ts
@@ -18,12 +18,19 @@ export interface TemplateChoiceFormProps {
 export function createTemplateChoiceFormProps(
 	initial: TemplateChoiceFormProps,
 ): TemplateChoiceFormProps {
-	// Plain-clone the choice so $state deeply proxies it. Svelte's proxy() returns
-	// class instances UNCHANGED (un-proxied) — newly created choices come from
-	// `createChoice()` as `new TemplateChoice()` instances, whose nested mutations
-	// would then NOT be reactive (conditional {#if} rows wouldn't appear in the
-	// add-new flow). structuredClone strips the class prototype to a plain object;
+	// Detach the choice into a plain clone so $state can deeply proxy it. Svelte's
+	// proxy() returns class instances UNCHANGED (un-proxied) — newly created choices
+	// come from `createChoice()` as `new TemplateChoice()` instances, whose nested
+	// mutations would then NOT be reactive (conditional {#if} rows wouldn't appear in
+	// the add-new flow). $state.snapshot strips the class prototype to a plain object;
 	// the form mutates this proxy and onClose snapshots it (getResultChoice). #1130
-	const props = $state({ ...initial, choice: structuredClone(initial.choice) });
+	//
+	// Use $state.snapshot, NOT structuredClone: an EXISTING choice arrives here as a
+	// live $state proxy (ChoiceView holds saved choices, loaded from data.json as
+	// plain objects, in a $state array). structuredClone throws DataCloneError on a
+	// $state proxy; $state.snapshot detaches it (see the Plain<T> rule in
+	// persist.svelte.ts). New choices are class instances (un-proxied) and snapshot
+	// strips their prototype just the same.
+	const props = $state({ ...initial, choice: $state.snapshot(initial.choice) });
 	return props;
 }

--- a/src/gui/ChoiceBuilder/templateChoiceFormProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceFormProps.svelte.ts
@@ -18,19 +18,21 @@ export interface TemplateChoiceFormProps {
 export function createTemplateChoiceFormProps(
 	initial: TemplateChoiceFormProps,
 ): TemplateChoiceFormProps {
-	// Detach the choice into a plain clone so $state can deeply proxy it. Svelte's
-	// proxy() returns class instances UNCHANGED (un-proxied) — newly created choices
-	// come from `createChoice()` as `new TemplateChoice()` instances, whose nested
-	// mutations would then NOT be reactive (conditional {#if} rows wouldn't appear in
-	// the add-new flow). $state.snapshot strips the class prototype to a plain object;
-	// the form mutates this proxy and onClose snapshots it (getResultChoice). #1130
+	// Detach the choice into a plain clone so $state can deeply proxy it, mutated by
+	// the form and snapshotted back out by onClose (getResultChoice). #1130
 	//
-	// Use $state.snapshot, NOT structuredClone: an EXISTING choice arrives here as a
-	// live $state proxy (ChoiceView holds saved choices, loaded from data.json as
-	// plain objects, in a $state array). structuredClone throws DataCloneError on a
-	// $state proxy; $state.snapshot detaches it (see the Plain<T> rule in
-	// persist.svelte.ts). New choices are class instances (un-proxied) and snapshot
-	// strips their prototype just the same.
+	// Why $state.snapshot and NOT structuredClone:
+	//  - EXISTING choice: can arrive as a live $state proxy (a Macro's nested
+	//    command.choice is reactive — see CommandList.svelte). structuredClone throws
+	//    DataCloneError on a $state proxy under Svelte's dev build; $state.snapshot
+	//    detaches it via Svelte's own deep clone. This is the Plain<T> proxy-detach
+	//    rule from persist.svelte.ts.
+	//  - NEW choice: createChoice() returns a `new TemplateChoice()` class instance,
+	//    which $state() leaves UN-proxied — it must be plain for nested {#if} rows to
+	//    react. snapshot deep-clones it too: a Choice is plain data, so Svelte's clone
+	//    delegates the cloneable instance to structuredClone, stripping the prototype
+	//    to Object.prototype. (Verified by the add-new reactivity test in
+	//    CaptureChoiceForm.test.ts and choiceFormProps.proxy.svelte.test.ts.)
 	const props = $state({ ...initial, choice: $state.snapshot(initial.choice) });
 	return props;
 }

--- a/src/gui/ChoiceBuilder/templateChoiceFormProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceFormProps.svelte.ts
@@ -22,11 +22,12 @@ export function createTemplateChoiceFormProps(
 	// the form and snapshotted back out by onClose (getResultChoice). #1130
 	//
 	// Why $state.snapshot and NOT structuredClone:
-	//  - EXISTING choice: can arrive as a live $state proxy (a Macro's nested
-	//    command.choice is reactive — see CommandList.svelte). structuredClone throws
-	//    DataCloneError on a $state proxy under Svelte's dev build; $state.snapshot
-	//    detaches it via Svelte's own deep clone. This is the Plain<T> proxy-detach
-	//    rule from persist.svelte.ts.
+	//  - EXISTING choice: can arrive as a live $state proxy. A choice nested inside a
+	//    folder (Multi) or a Macro is held/rendered through $state (ChoiceList's
+	//    dndzone / CommandList), so it is reactive — only ROOT-level choices stay
+	//    plain. structuredClone throws DataCloneError on a $state proxy under Svelte's
+	//    dev build; $state.snapshot detaches it via Svelte's own deep clone. This is
+	//    the Plain<T> proxy-detach rule from persist.svelte.ts.
 	//  - NEW choice: createChoice() returns a `new TemplateChoice()` class instance,
 	//    which $state() leaves UN-proxied — it must be plain for nested {#if} rows to
 	//    react. snapshot deep-clones it too: a Choice is plain data, so Svelte's clone


### PR DESCRIPTION
## Problem

Configuring a **Template or Capture choice nested inside a folder (Multi)** — or inside a Macro — crashed with an uncaught:

```
DataCloneError: Failed to execute 'structuredClone' on 'Window': #<Object> could not be cloned.
    at … (createTemplateChoiceFormProps)
    at … builder.display() → new builder → getChoiceBuilder(Template) → onConfigureChoice
```

It only reproduces when Obsidian runs with `NODE_ENV=development`, which is why it looked intermittent.

## Root cause

The choice handed to the builder must be a **plain, structured-cloneable object**, but a **nested** choice arrives as a live Svelte **`$state` proxy**:
- a choice inside a **folder (Multi)** is rendered through `ChoiceList`'s `dndzone` (`$state`-held items), and
- a choice inside a **Macro** is held in `CommandList`'s `$state`.

Root-level choices stay plain (the top-level `choices` bindable isn't deeply proxied) — so they don't crash, which is the common confusion. Configuring a nested choice constructs the builder, whose form-props factory did `structuredClone(initial.choice)`. Under Svelte's **dev build**, a `$state` proxy's *nested* objects are not structured-cloneable, so the clone throws. (In prod builds proxies clone fine — hence the intermittency.)

## Fix

Replace `structuredClone(initial.choice)` with **`$state.snapshot(initial.choice)`** in both `templateChoiceFormProps.svelte.ts` and `captureChoiceFormProps.svelte.ts` — the codebase's own prescribed proxy-detach (`persist.svelte.ts`). It:
- strips the class prototype (preserving add-new reactivity for `createChoice()` class instances — via Svelte's clone delegating cloneable plain-data instances to `structuredClone`), and
- detaches a live `$state` proxy via Svelte's manual deep clone (`shared/clone.js`) **without throwing**.

The only other production `structuredClone` is in `deepClone.ts`, which already `try/catch`-falls back, so these two form-props factories were the sole throwing sites. The single factory covers **all** open paths — root, folder, and macro.

## Verification (real Obsidian dev vault, `NODE_ENV=development`)

Reproduce → fix → reproduce, on the actual trigger:
- **RED** — unfixed build, configuring a choice **inside a folder** → uncaught `DataCloneError`.
- **GREEN** — fixed build, `DEV_active: true` verified (proxy genuinely non-cloneable): builder mounts, **no errors**. Also verified the nested-Macro path and a regular top-level choice (no regression).

**Tests:** added `choiceFormProps.proxy.svelte.test.ts` — builds the form-props from a `$state` proxy (the condition vitest's dev-mode Svelte reproduces; RED on `structuredClone`, GREEN on `$state.snapshot`), asserts the **deep-detach isolation contract**, and asserts the class-instance path stays a deep, plain-prototype clone. Full suite: 2176 passing; tsc + lint clean.

## Reviewed (adversarial + bots)

- Two opposing-model reviewers (Skeptic → SHIP; Architect → noted a follow-up: the proxy still reaches the builder constructor's `normalizeChoice`, a pre-existing minor source-mutation — out of scope here).
- Devin flagged two 🔴s claiming `$state.snapshot` leaves class instances un-stripped (regressing #1130). Verified against `svelte/internal/shared/clone.js`: a cloneable plain-data `Choice` class is delegated to `structuredClone`, which **does** strip the prototype; the end-to-end add-new reactivity test passes. False positive — replied inline with evidence; its test-coverage point was addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved template and capture choice form initialization to safely handle live reactive choice proxies, avoiding cloning-related runtime errors.
  * The form now operates on a deep-detached, plain-data snapshot of the choice so form edits don’t affect the original data.

* **Tests**
  * Added regression tests covering both template and capture form builders, including live proxy inputs and class-based choice instances, verifying deep clone isolation for nested changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->