### PR TITLE
test: add isolated Obsidian e2e vault workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ src/**/*.js
 
 # e2e test failure artifacts
 .obsidian-e2e-artifacts
+.obsidian-e2e-vaults
+.obsidian-e2e-instances
 # Test coverage output
 coverage/
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,46 @@ QuickAdd uses `pnpm` for local development tasks:
 - `pnpm run test:e2e` runs Obsidian-backed end-to-end tests.
 
 The E2E suite is local-only today. It depends on a locally installed Obsidian
-app, the `obsidian` CLI being available on `PATH`, and the `dev` vault being
-open and reachable. Failed E2E runs may write artifacts to
-`.obsidian-e2e-artifacts/`.
+app and the `obsidian` CLI being available on `PATH`. By default it targets the
+`dev` vault, but the target is configurable:
+
+```bash
+pnpm run provision:e2e-vault -- --vault quickadd-my-worktree --register-via dev --print-env
+export QUICKADD_E2E_VAULT='quickadd-my-worktree'
+export QUICKADD_E2E_VAULT_PATH='/absolute/path/from/printed/output'
+pnpm run test:e2e
+```
+
+`provision:e2e-vault` creates an isolated Obsidian vault under
+`.obsidian-e2e-vaults/` and symlinks QuickAdd's `manifest.json`, `main.js`, and
+`styles.css` from the selected worktree. Pass `--worktree /path/to/worktree` to
+provision a vault for another checkout. `--register-via dev` asks the running
+Obsidian app to register the new vault through the already-addressable `dev`
+vault, disables Restricted Mode for the provisioned vault, and waits until
+`quickadd:list` works. Omit it if you only want to prepare the vault directory.
+When `QUICKADD_E2E_VAULT_PATH` is set, the tests verify that the Obsidian CLI
+resolved `QUICKADD_E2E_VAULT` to that exact directory before they mutate the
+vault.
+
+For worktree-local Obsidian runtime isolation, use:
+
+```bash
+pnpm run start:e2e-obsidian -- --vault quickadd-my-worktree --print-env
+export QUICKADD_E2E_VAULT='quickadd-my-worktree'
+export QUICKADD_E2E_VAULT_PATH='/absolute/path/from/printed/output'
+export QUICKADD_E2E_OBSIDIAN_HOME='/absolute/path/from/printed/output'
+pnpm run test:e2e
+```
+
+`start:e2e-obsidian` creates a private Obsidian `HOME` under
+`/tmp/quickadd-obsidian-e2e/`, launches a separate Obsidian app instance with
+that `HOME` and its own Electron `--user-data-dir`, waits until the CLI resolves
+the provisioned vault through that instance's socket, disables Restricted Mode,
+and waits until `quickadd:list` succeeds. Set the printed
+`QUICKADD_E2E_OBSIDIAN_HOME` when running tests so `obsidian-e2e` talks to that
+worktree's Obsidian instance instead of the shared desktop instance.
+
+Failed E2E runs may write artifacts to `.obsidian-e2e-artifacts/`.
 
 ## Support
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "build-with-lint": "tsc -noEmit -skipLibCheck && pnpm lint && node esbuild.config.mjs production",
     "check": "svelte-check --threshold error",
+    "provision:e2e-vault": "node scripts/provision-obsidian-e2e-vault.mjs",
+    "start:e2e-obsidian": "node scripts/start-obsidian-e2e-instance.mjs",
     "test": "vitest run --config vitest.config.mts --passWithNoTests",
     "test:coverage": "vitest run --config vitest.config.mts --coverage",
     "test:e2e": "vitest run --config vitest.e2e.config.mts"

--- a/scripts/provision-obsidian-e2e-vault.mjs
+++ b/scripts/provision-obsidian-e2e-vault.mjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const REQUIRED_PLUGIN_FILES = ["manifest.json", "main.js", "styles.css"];
+const DEFAULT_ROOT = ".obsidian-e2e-vaults";
+const DEFAULT_VAULT_PREFIX = "quickadd";
+const DEFAULT_QUICKADD_DATA = { choices: [], migrations: {} };
+const execFileAsync = promisify(execFile);
+const QUICKADD_VERIFY_TIMEOUT_MS = 15_000;
+const QUICKADD_VERIFY_INTERVAL_MS = 500;
+
+function slugify(value) {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 80) || "worktree";
+}
+
+function printUsage() {
+	console.log(`Usage: node scripts/provision-obsidian-e2e-vault.mjs [options]
+
+Options:
+  --vault <name>        Vault name to provision. Defaults to quickadd-<worktree>.
+  --root <path>         Directory that contains provisioned vaults. Defaults to .obsidian-e2e-vaults.
+  --worktree <path>     QuickAdd worktree to link plugin files from. Defaults to cwd.
+  --data <path>         Optional QuickAdd data.json seed to copy on first provision.
+  --register-via <name> Register the provisioned vault through an open CLI-addressable vault.
+  --force               Recreate plugin symlinks if they already exist.
+  --print-env           Print QUICKADD_E2E_VAULT exports after provisioning.
+  --json                Print a machine-readable summary after provisioning.
+  --help                Show this help.
+`);
+}
+
+export function parseArgs(argv) {
+	const options = {
+		force: false,
+		json: false,
+		printEnv: false,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--":
+				break;
+			case "--force":
+				options.force = true;
+				break;
+			case "--json":
+				options.json = true;
+				break;
+			case "--print-env":
+				options.printEnv = true;
+				break;
+			case "--help":
+				options.help = true;
+				break;
+			case "--vault":
+			case "--root":
+			case "--worktree":
+			case "--data":
+			case "--register-via": {
+				const value = argv[index + 1];
+				if (!value || value.startsWith("--")) {
+					throw new Error(`${arg} requires a value.`);
+				}
+				options[toOptionKey(arg)] = value;
+				index += 1;
+				break;
+			}
+			default:
+				throw new Error(`Unknown option: ${arg}`);
+		}
+	}
+
+	return options;
+}
+
+function toOptionKey(arg) {
+	if (arg === "--register-via") return "registerVia";
+	return arg.slice(2);
+}
+
+export function resolveProvisionOptions(rawOptions, cwd = process.cwd()) {
+	const worktreePath = path.resolve(cwd, rawOptions.worktree ?? ".");
+	const vaultName = rawOptions.vault ?? `${DEFAULT_VAULT_PREFIX}-${slugify(path.basename(worktreePath))}`;
+	const rootPath = path.resolve(cwd, rawOptions.root ?? DEFAULT_ROOT);
+	const vaultPath = path.resolve(rootPath, vaultName);
+	const dataPath = rawOptions.data
+		? path.resolve(cwd, rawOptions.data)
+		: undefined;
+
+	return {
+		dataPath,
+		force: rawOptions.force ?? false,
+		json: rawOptions.json ?? false,
+		printEnv: rawOptions.printEnv ?? false,
+		registerVia: rawOptions.registerVia,
+		rootPath,
+		vaultName,
+		vaultPath,
+		worktreePath,
+	};
+}
+
+async function pathExists(filePath) {
+	try {
+		await fs.lstat(filePath);
+		return true;
+	} catch (error) {
+		if (error?.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+async function assertRequiredPluginFiles(worktreePath) {
+	const missing = [];
+	for (const fileName of REQUIRED_PLUGIN_FILES) {
+		const filePath = path.join(worktreePath, fileName);
+		if (!(await pathExists(filePath))) missing.push(fileName);
+	}
+
+	if (missing.length > 0) {
+		throw new Error(
+			[
+				`Cannot provision QuickAdd in ${worktreePath}; missing ${missing.join(", ")}.`,
+				"Run pnpm run build in that worktree before provisioning.",
+			].join(" "),
+		);
+	}
+}
+
+async function writeJson(filePath, value) {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(`${filePath}.tmp`, `${JSON.stringify(value, null, "\t")}\n`);
+	await fs.rename(`${filePath}.tmp`, filePath);
+}
+
+async function writeJsonIfMissing(filePath, value) {
+	if (await pathExists(filePath)) return;
+	await writeJson(filePath, value);
+}
+
+async function linkPluginFile(sourcePath, destinationPath, force) {
+	const existing = await pathExists(destinationPath);
+	if (existing && force) {
+		await fs.unlink(destinationPath);
+	} else if (existing) {
+		const stat = await fs.lstat(destinationPath);
+		if (!stat.isSymbolicLink()) {
+			throw new Error(`${destinationPath} exists and is not a symlink. Use --force after reviewing it.`);
+		}
+
+		const currentTarget = await fs.readlink(destinationPath);
+		if (path.resolve(path.dirname(destinationPath), currentTarget) === sourcePath) {
+			return;
+		}
+
+		throw new Error(`${destinationPath} points at ${currentTarget}. Use --force to relink it.`);
+	}
+
+	await fs.symlink(sourcePath, destinationPath);
+}
+
+export async function provisionVault(options) {
+	await assertRequiredPluginFiles(options.worktreePath);
+
+	const obsidianPath = path.join(options.vaultPath, ".obsidian");
+	const pluginPath = path.join(obsidianPath, "plugins", "quickadd");
+
+	await fs.mkdir(pluginPath, { recursive: true });
+	await writeJsonIfMissing(path.join(obsidianPath, "app.json"), {});
+	await writeJsonIfMissing(path.join(obsidianPath, "appearance.json"), {});
+	await writeJsonIfMissing(path.join(obsidianPath, "core-plugins.json"), []);
+	await writeJson(path.join(obsidianPath, "community-plugins.json"), ["quickadd"]);
+	await writeJsonIfMissing(path.join(obsidianPath, "workspace.json"), {
+		main: { id: "quickadd-e2e", type: "split", children: [] },
+		left: { id: "quickadd-e2e-left", type: "split", children: [] },
+		right: { id: "quickadd-e2e-right", type: "split", children: [] },
+	});
+
+	for (const fileName of REQUIRED_PLUGIN_FILES) {
+		await linkPluginFile(
+			path.join(options.worktreePath, fileName),
+			path.join(pluginPath, fileName),
+			options.force,
+		);
+	}
+
+	const pluginDataPath = path.join(pluginPath, "data.json");
+	if (options.dataPath && !(await pathExists(pluginDataPath))) {
+		await fs.copyFile(options.dataPath, pluginDataPath);
+	} else {
+		await writeJsonIfMissing(pluginDataPath, DEFAULT_QUICKADD_DATA);
+	}
+
+	return {
+		pluginPath,
+		registered: false,
+		trusted: false,
+		verifiedQuickAdd: false,
+		vaultName: options.vaultName,
+		vaultPath: options.vaultPath,
+		worktreePath: options.worktreePath,
+	};
+}
+
+export async function registerVault(options) {
+	if (!options.registerVia) return false;
+
+	const code = [
+		"(() => {",
+		"const { ipcRenderer } = require('electron');",
+		`return ipcRenderer.sendSync('vault-open', ${JSON.stringify(options.vaultPath)}, false);`,
+		"})()",
+	].join(" ");
+	const { stdout } = await execFileAsync("obsidian", [
+		`vault=${options.registerVia}`,
+		"eval",
+		`code=${code}`,
+	]);
+
+	if (!stdout.includes("=> true")) {
+		throw new Error(
+			`Obsidian did not confirm vault registration through ${options.registerVia}: ${stdout.trim()}`,
+		);
+	}
+
+	return true;
+}
+
+export async function trustVaultAndVerifyQuickAdd(options) {
+	if (!options.registerVia) return {
+		trusted: false,
+		verifiedQuickAdd: false,
+	};
+
+	await execFileAsync("obsidian", [
+		`vault=${options.vaultName}`,
+		"plugins:restrict",
+		"off",
+	]);
+
+	const deadline = Date.now() + QUICKADD_VERIFY_TIMEOUT_MS;
+	let lastError = "";
+	while (Date.now() < deadline) {
+		try {
+			const { stdout } = await execFileAsync("obsidian", [
+				`vault=${options.vaultName}`,
+				"quickadd:list",
+			]);
+			if (stdout.includes("\"ok\":true")) {
+				return {
+					trusted: true,
+					verifiedQuickAdd: true,
+				};
+			}
+			lastError = stdout.trim();
+		} catch (error) {
+			lastError = error?.stderr?.trim() || error?.stdout?.trim() || error?.message || String(error);
+		}
+		await new Promise((resolve) => setTimeout(resolve, QUICKADD_VERIFY_INTERVAL_MS));
+	}
+
+	throw new Error(
+		`QuickAdd commands did not become available in ${options.vaultName} after disabling restricted mode. Last error: ${lastError}`,
+	);
+}
+
+export function toShellExports(result) {
+	return [
+		`export QUICKADD_E2E_VAULT=${shellQuote(result.vaultName)}`,
+		`export QUICKADD_E2E_VAULT_PATH=${shellQuote(result.vaultPath)}`,
+	].join("\n");
+}
+
+function shellQuote(value) {
+	return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+async function main() {
+	const rawOptions = parseArgs(process.argv.slice(2));
+	if (rawOptions.help) {
+		printUsage();
+		return;
+	}
+
+	const options = resolveProvisionOptions(rawOptions);
+	const result = await provisionVault(options);
+	result.registered = await registerVault(options);
+	const trustResult = await trustVaultAndVerifyQuickAdd(options);
+	result.trusted = trustResult.trusted;
+	result.verifiedQuickAdd = trustResult.verifiedQuickAdd;
+
+	if (options.json) {
+		console.log(JSON.stringify(result, null, 2));
+	} else {
+		console.log(`Provisioned Obsidian E2E vault ${result.vaultName}`);
+		console.log(`Vault path: ${result.vaultPath}`);
+		console.log(`QuickAdd plugin: ${result.pluginPath}`);
+		if (result.registered) {
+			console.log(`Registered via vault: ${options.registerVia}`);
+		}
+		if (result.trusted) {
+			console.log("Restricted mode: off");
+		}
+		if (result.verifiedQuickAdd) {
+			console.log("QuickAdd command check: ok");
+		}
+	}
+
+	if (options.printEnv) {
+		console.log(toShellExports(result));
+	}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : error);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import {
+	provisionVault,
+	resolveProvisionOptions,
+	toShellExports,
+} from "./provision-obsidian-e2e-vault.mjs";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_PROFILE_ROOT = "/tmp/quickadd-obsidian-e2e";
+const DEFAULT_OBSIDIAN_APP = "Obsidian";
+const DEFAULT_OBSIDIAN_BIN = "obsidian";
+const READY_TIMEOUT_MS = 30_000;
+const READY_INTERVAL_MS = 500;
+
+function printUsage() {
+	console.log(`Usage: node scripts/start-obsidian-e2e-instance.mjs [options]
+
+Options:
+  --vault <name>        Vault/profile name. Defaults to quickadd-<worktree>.
+  --root <path>         Directory that contains provisioned vaults. Defaults to .obsidian-e2e-vaults.
+  --worktree <path>     QuickAdd worktree to link plugin files from. Defaults to cwd.
+  --data <path>         Optional QuickAdd data.json seed to copy on first provision.
+  --profile-root <path> Directory for per-vault Obsidian HOME profiles. Defaults to /tmp/quickadd-obsidian-e2e.
+  --obsidian-app <name> Obsidian app name for macOS open. Defaults to Obsidian.
+  --obsidian-bin <path> Obsidian CLI executable. Defaults to obsidian.
+  --force               Recreate plugin symlinks if they already exist.
+  --no-launch           Prepare the profile and vault without launching Obsidian.
+  --print-env           Print exports for running e2e tests against this instance.
+  --json                Print a machine-readable summary.
+  --help                Show this help.
+`);
+}
+
+export function parseArgs(argv) {
+	const options = {
+		force: false,
+		json: false,
+		launch: true,
+		printEnv: false,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--":
+				break;
+			case "--force":
+				options.force = true;
+				break;
+			case "--json":
+				options.json = true;
+				break;
+			case "--no-launch":
+				options.launch = false;
+				break;
+			case "--print-env":
+				options.printEnv = true;
+				break;
+			case "--help":
+				options.help = true;
+				break;
+			case "--vault":
+			case "--root":
+			case "--worktree":
+			case "--data":
+			case "--profile-root":
+			case "--obsidian-app":
+			case "--obsidian-bin": {
+				const value = argv[index + 1];
+				if (!value || value.startsWith("--")) {
+					throw new Error(`${arg} requires a value.`);
+				}
+				options[toOptionKey(arg)] = value;
+				index += 1;
+				break;
+			}
+			default:
+				throw new Error(`Unknown option: ${arg}`);
+		}
+	}
+
+	return options;
+}
+
+function toOptionKey(arg) {
+	if (arg === "--profile-root") return "profileRoot";
+	if (arg === "--obsidian-app") return "obsidianApp";
+	if (arg === "--obsidian-bin") return "obsidianBin";
+	return arg.slice(2);
+}
+
+export function resolveInstanceOptions(rawOptions, cwd = process.cwd()) {
+	const provisionOptions = resolveProvisionOptions(rawOptions, cwd);
+	const profileRoot = path.resolve(cwd, rawOptions.profileRoot ?? DEFAULT_PROFILE_ROOT);
+	const instanceId = stableInstanceId(provisionOptions.worktreePath, provisionOptions.vaultName);
+	const instancePath = path.join(profileRoot, instanceId);
+	const obsidianHome = path.join(instancePath, "home");
+
+	return {
+		...provisionOptions,
+		instanceId,
+		instancePath,
+		launch: rawOptions.launch ?? true,
+		obsidianApp: rawOptions.obsidianApp ?? DEFAULT_OBSIDIAN_APP,
+		obsidianBin: rawOptions.obsidianBin ?? DEFAULT_OBSIDIAN_BIN,
+		obsidianHome,
+		profileRoot,
+	};
+}
+
+function stableInstanceId(worktreePath, vaultName) {
+	const hash = crypto
+		.createHash("sha256")
+		.update(`${path.resolve(worktreePath)}\0${vaultName}`)
+		.digest("hex")
+		.slice(0, 12);
+	return `${safeName(vaultName).slice(0, 32)}-${hash}`;
+}
+
+function safeName(value) {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "") || "vault";
+}
+
+export async function prepareObsidianProfile(options) {
+	const userDataPath = path.join(options.obsidianHome, "Library", "Application Support", "obsidian");
+	await fs.mkdir(userDataPath, { recursive: true });
+	await fs.mkdir(path.join(options.obsidianHome, "Library", "Logs"), { recursive: true });
+	await linkHostKeychains(options);
+
+	const vaultId = stableVaultId(options.vaultPath);
+	const obsidianJsonPath = path.join(userDataPath, "obsidian.json");
+	await writeJson(obsidianJsonPath, {
+		cli: true,
+		updateDisabled: true,
+		vaults: {
+			[vaultId]: {
+				open: true,
+				path: options.vaultPath,
+				ts: Date.now(),
+			},
+		},
+	});
+
+	return {
+		obsidianJsonPath,
+		userDataPath,
+		vaultId,
+	};
+}
+
+async function linkHostKeychains(options) {
+	const realHome = process.env.HOME;
+	if (!realHome) return;
+
+	const source = path.join(realHome, "Library", "Keychains");
+	const destination = path.join(options.obsidianHome, "Library", "Keychains");
+	try {
+		await fs.lstat(source);
+	} catch (error) {
+		if (error?.code === "ENOENT") return;
+		throw error;
+	}
+
+	try {
+		const stat = await fs.lstat(destination);
+		if (!stat.isSymbolicLink()) return;
+		const target = await fs.readlink(destination);
+		if (path.resolve(path.dirname(destination), target) === source) return;
+		await fs.unlink(destination);
+	} catch (error) {
+		if (error?.code !== "ENOENT") throw error;
+	}
+
+	await fs.mkdir(path.dirname(destination), { recursive: true });
+	await fs.symlink(source, destination);
+}
+
+function stableVaultId(vaultPath) {
+	return crypto
+		.createHash("sha256")
+		.update(path.resolve(vaultPath))
+		.digest("hex")
+		.slice(0, 16);
+}
+
+async function writeJson(filePath, value) {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(`${filePath}.tmp`, `${JSON.stringify(value, null, "\t")}\n`);
+	await fs.rename(`${filePath}.tmp`, filePath);
+}
+
+export async function launchObsidianInstance(options) {
+	await fs.mkdir(options.instancePath, { recursive: true });
+	await execFileAsync("/usr/bin/open", [
+		"-n",
+		"-g",
+		"-a",
+		options.obsidianApp,
+		"--env",
+		`HOME=${options.obsidianHome}`,
+		"--args",
+		`--user-data-dir=${options.userDataPath}`,
+		"--password-store=basic",
+	], {
+		env: obsidianEnv(options),
+	});
+
+	return {
+		pid: null,
+		pidPath: null,
+	};
+}
+
+function obsidianEnv(options) {
+	return {
+		...process.env,
+		HOME: options.obsidianHome,
+	};
+}
+
+async function execObsidian(options, args, execOptions = {}) {
+	return execFileAsync(options.obsidianBin, args, {
+		env: obsidianEnv(options),
+		...execOptions,
+	});
+}
+
+export async function waitForInstanceReady(options) {
+	const expectedPath = path.resolve(options.vaultPath);
+	const deadline = Date.now() + READY_TIMEOUT_MS;
+	let lastError = "";
+
+	while (Date.now() < deadline) {
+		try {
+			const { stdout } = await execObsidian(options, [
+				`vault=${options.vaultName}`,
+				"vault",
+				"info=path",
+			]);
+			const actualPath = path.resolve(stdout.trim());
+			if (actualPath === expectedPath) return actualPath;
+			lastError = `resolved ${actualPath}, expected ${expectedPath}`;
+		} catch (error) {
+			lastError = error?.stderr?.trim() || error?.stdout?.trim() || error?.message || String(error);
+		}
+		await sleep(READY_INTERVAL_MS);
+	}
+
+	throw new Error(`Obsidian instance did not become ready for ${options.vaultName}. Last error: ${lastError}`);
+}
+
+export async function trustVaultAndVerifyQuickAdd(options) {
+	await execObsidian(options, [
+		`vault=${options.vaultName}`,
+		"plugins:restrict",
+		"off",
+	]);
+
+	const deadline = Date.now() + READY_TIMEOUT_MS;
+	let lastError = "";
+	while (Date.now() < deadline) {
+		try {
+			const { stdout } = await execObsidian(options, [
+				`vault=${options.vaultName}`,
+				"quickadd:list",
+			]);
+			if (stdout.includes("\"ok\":true")) return true;
+			lastError = stdout.trim();
+		} catch (error) {
+			lastError = error?.stderr?.trim() || error?.stdout?.trim() || error?.message || String(error);
+		}
+		await sleep(READY_INTERVAL_MS);
+	}
+
+	throw new Error(`QuickAdd did not become available in ${options.vaultName}. Last error: ${lastError}`);
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function toInstanceShellExports(result) {
+	return [
+		toShellExports(result),
+		`export QUICKADD_E2E_OBSIDIAN_HOME=${shellQuote(result.obsidianHome)}`,
+	].join("\n");
+}
+
+function shellQuote(value) {
+	return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+async function main() {
+	const rawOptions = parseArgs(process.argv.slice(2));
+	if (rawOptions.help) {
+		printUsage();
+		return;
+	}
+
+	const options = resolveInstanceOptions(rawOptions);
+	const provisionResult = await provisionVault(options);
+	const profileResult = await prepareObsidianProfile(options);
+	options.userDataPath = profileResult.userDataPath;
+	const launchResult = options.launch
+		? await launchObsidianInstance(options)
+		: { pid: null, pidPath: null };
+	const resolvedVaultPath = options.launch
+		? await waitForInstanceReady(options)
+		: null;
+	const verifiedQuickAdd = options.launch
+		? await trustVaultAndVerifyQuickAdd(options)
+		: false;
+	const result = {
+		...provisionResult,
+		...profileResult,
+		...launchResult,
+		obsidianHome: options.obsidianHome,
+		resolvedVaultPath,
+		verifiedQuickAdd,
+	};
+
+	if (rawOptions.json) {
+		console.log(JSON.stringify(result, null, 2));
+	} else {
+		console.log(`Prepared Obsidian E2E instance ${result.vaultName}`);
+		console.log(`Vault path: ${result.vaultPath}`);
+		console.log(`Obsidian HOME: ${result.obsidianHome}`);
+		if (result.pid) console.log(`Obsidian PID: ${result.pid}`);
+		if (result.verifiedQuickAdd) console.log("QuickAdd command check: ok");
+	}
+
+	if (rawOptions.printEnv) {
+		console.log(toInstanceShellExports(result));
+	}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : error);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -132,8 +132,8 @@ function safeName(value) {
 
 export async function prepareObsidianProfile(options) {
 	const userDataPath = path.join(options.obsidianHome, "Library", "Application Support", "obsidian");
-	await fs.mkdir(userDataPath, { recursive: true });
-	await fs.mkdir(path.join(options.obsidianHome, "Library", "Logs"), { recursive: true });
+	await fs.mkdir(userDataPath, { recursive: true, mode: 0o700 });
+	await fs.mkdir(path.join(options.obsidianHome, "Library", "Logs"), { recursive: true, mode: 0o700 });
 	await linkHostKeychains(options);
 
 	const vaultId = stableVaultId(options.vaultPath);
@@ -193,9 +193,18 @@ function stableVaultId(vaultPath) {
 }
 
 async function writeJson(filePath, value) {
-	await fs.mkdir(path.dirname(filePath), { recursive: true });
-	await fs.writeFile(`${filePath}.tmp`, `${JSON.stringify(value, null, "\t")}\n`);
-	await fs.rename(`${filePath}.tmp`, filePath);
+	await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+	try {
+		const stat = await fs.lstat(filePath);
+		if (stat.isSymbolicLink() || !stat.isFile()) {
+			throw new Error(`${filePath} exists but is not a regular file.`);
+		}
+	} catch (error) {
+		if (error?.code !== "ENOENT") throw error;
+	}
+	await fs.writeFile(filePath, `${JSON.stringify(value, null, "\t")}\n`, {
+		mode: 0o600,
+	});
 }
 
 export async function launchObsidianInstance(options) {

--- a/tests/e2e/apply-template-to-active-note.test.ts
+++ b/tests/e2e/apply-template-to-active-note.test.ts
@@ -1,9 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
-	acquireVaultRunLock,
 	captureFailureArtifacts,
 	clearVaultRunLockMarker,
-	createObsidianClient,
 	createSandboxApi,
 } from "obsidian-e2e";
 import type {
@@ -12,12 +10,15 @@ import type {
 	SandboxApi,
 	VaultRunLock,
 } from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
 
 // ---------------------------------------------------------------------------
 // Constants & types
 // ---------------------------------------------------------------------------
 
-const VAULT = "dev";
 const PLUGIN_ID = "quickadd";
 const TPL_CONTENT = "APPLIED_TEMPLATE_CONTENT";
 const TPL_FM = "---\nstatus: draft\npriority: high\n---\nTPL_BODY";
@@ -105,13 +106,8 @@ function expectOrderedSubstrings(
 // ---------------------------------------------------------------------------
 
 beforeAll(async () => {
-	obsidian = createObsidianClient({ vault: VAULT });
-	await obsidian.verify();
-
-	lock = await acquireVaultRunLock({
-		vaultName: VAULT,
-		vaultPath: await obsidian.vaultPath(),
-	});
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
 
 	qa = obsidian.plugin(PLUGIN_ID);

--- a/tests/e2e/conditional-branch-persistence.test.ts
+++ b/tests/e2e/conditional-branch-persistence.test.ts
@@ -1,12 +1,13 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
-	acquireVaultRunLock,
 	clearVaultRunLockMarker,
-	createObsidianClient,
 } from "obsidian-e2e";
 import type { ObsidianClient, PluginHandle, VaultRunLock } from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
 
-const VAULT = "dev";
 const PLUGIN_ID = "quickadd";
 const CHOICE_ID = "qa-e2e-cond-branch";
 const COND_ID = "qa-e2e-cond";
@@ -36,12 +37,8 @@ async function closeAllModals() {
 }
 
 beforeAll(async () => {
-	obsidian = createObsidianClient({ vault: VAULT });
-	await obsidian.verify();
-	lock = await acquireVaultRunLock({
-		vaultName: VAULT,
-		vaultPath: await obsidian.vaultPath(),
-	});
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
 	qa = obsidian.plugin(PLUGIN_ID);
 	await qa.reload({ waitUntilReady: true });

--- a/tests/e2e/e2eVault.ts
+++ b/tests/e2e/e2eVault.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+import {
+	acquireVaultRunLock,
+	createObsidianClient,
+} from "obsidian-e2e";
+import type {
+	ObsidianClient,
+	VaultRunLock,
+} from "obsidian-e2e";
+
+export const E2E_VAULT = process.env.QUICKADD_E2E_VAULT ?? "dev";
+export const E2E_VAULT_EXPECTED_PATH = process.env.QUICKADD_E2E_VAULT_PATH;
+export const E2E_OBSIDIAN_HOME = process.env.QUICKADD_E2E_OBSIDIAN_HOME;
+
+export function createQuickAddObsidianClient(): ObsidianClient {
+	return createObsidianClient({
+		vault: E2E_VAULT,
+		...(E2E_OBSIDIAN_HOME && {
+			defaultExecOptions: {
+				env: {
+					...process.env,
+					HOME: E2E_OBSIDIAN_HOME,
+				},
+			},
+		}),
+	});
+}
+
+export async function verifyE2EVault(obsidian: ObsidianClient): Promise<string> {
+	await obsidian.verify();
+
+	const vaultPath = path.resolve(await obsidian.vaultPath());
+	if (E2E_VAULT_EXPECTED_PATH) {
+		const expectedPath = path.resolve(E2E_VAULT_EXPECTED_PATH);
+		if (vaultPath !== expectedPath) {
+			throw new Error(
+				[
+					`Obsidian CLI resolved QUICKADD_E2E_VAULT=${E2E_VAULT} to ${vaultPath}.`,
+					`Expected ${expectedPath}.`,
+					"Refusing to run E2E tests against the wrong vault.",
+				].join(" "),
+			);
+		}
+	}
+
+	return vaultPath;
+}
+
+export async function acquireQuickAddVaultRunLock(
+	obsidian: ObsidianClient,
+): Promise<VaultRunLock> {
+	const vaultPath = await verifyE2EVault(obsidian);
+	return acquireVaultRunLock({
+		vaultName: E2E_VAULT,
+		vaultPath,
+	});
+}

--- a/tests/e2e/file-exists-behavior.test.ts
+++ b/tests/e2e/file-exists-behavior.test.ts
@@ -1,18 +1,19 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
-	acquireVaultRunLock,
 	captureFailureArtifacts,
 	clearVaultRunLockMarker,
-	createObsidianClient,
 	createSandboxApi,
 } from "obsidian-e2e";
 import type { ObsidianClient, SandboxApi, PluginHandle, VaultRunLock } from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
 
 // ---------------------------------------------------------------------------
 // Constants & types
 // ---------------------------------------------------------------------------
 
-const VAULT = "dev";
 const PLUGIN_ID = "quickadd";
 const TPL_CONTENT = "QA_TEMPLATE_CONTENT";
 const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
@@ -124,13 +125,8 @@ function findChoice(data: QuickAddData, id: string) {
 // ---------------------------------------------------------------------------
 
 beforeAll(async () => {
-	obsidian = createObsidianClient({ vault: VAULT });
-	await obsidian.verify();
-
-	lock = await acquireVaultRunLock({
-		vaultName: VAULT,
-		vaultPath: await obsidian.vaultPath(),
-	});
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
 
 	qa = obsidian.plugin(PLUGIN_ID);

--- a/tests/e2e/locked-leaf-file-opening.test.ts
+++ b/tests/e2e/locked-leaf-file-opening.test.ts
@@ -1,9 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
-	acquireVaultRunLock,
 	captureFailureArtifacts,
 	clearVaultRunLockMarker,
-	createObsidianClient,
 	createSandboxApi,
 } from "obsidian-e2e";
 import type {
@@ -12,8 +10,11 @@ import type {
 	SandboxApi,
 	VaultRunLock,
 } from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
 
-const VAULT = "dev";
 const PLUGIN_ID = "quickadd";
 const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
 const TEST_PREFIX = "__qa-test-1165-";
@@ -287,13 +288,8 @@ async function runTeardownStep(
 }
 
 beforeAll(async () => {
-	obsidian = createObsidianClient({ vault: VAULT });
-	await obsidian.verify();
-
-	lock = await acquireVaultRunLock({
-		vaultName: VAULT,
-		vaultPath: await obsidian.vaultPath(),
-	});
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
 
 	qa = obsidian.plugin(PLUGIN_ID);

--- a/tests/e2e/macro-member-access.test.ts
+++ b/tests/e2e/macro-member-access.test.ts
@@ -1,9 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
-	acquireVaultRunLock,
 	captureFailureArtifacts,
 	clearVaultRunLockMarker,
-	createObsidianClient,
 	createSandboxApi,
 } from "obsidian-e2e";
 import type {
@@ -12,8 +10,11 @@ import type {
 	SandboxApi,
 	VaultRunLock,
 } from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
 
-const VAULT = "dev";
 const PLUGIN_ID = "quickadd";
 const waitTimeoutMs = Number(process.env.E2E_TIMEOUT_MS) || 15_000;
 const WAIT_OPTS = { timeoutMs: waitTimeoutMs, intervalMs: 200 };
@@ -131,13 +132,8 @@ async function runTeardownStep(
 }
 
 beforeAll(async () => {
-	obsidian = createObsidianClient({ vault: VAULT });
-	await obsidian.verify();
-
-	lock = await acquireVaultRunLock({
-		vaultName: VAULT,
-		vaultPath: await obsidian.vaultPath(),
-	});
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
 
 	qa = obsidian.plugin(PLUGIN_ID);

--- a/tests/e2e/scorecard-composed-flows.test.ts
+++ b/tests/e2e/scorecard-composed-flows.test.ts
@@ -1,9 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
-	acquireVaultRunLock,
 	captureFailureArtifacts,
 	clearVaultRunLockMarker,
-	createObsidianClient,
 	createSandboxApi,
 } from "obsidian-e2e";
 import type {
@@ -12,8 +10,11 @@ import type {
 	SandboxApi,
 	VaultRunLock,
 } from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
 
-const VAULT = "dev";
 const PLUGIN_ID = "quickadd";
 const TEST_PREFIX = "__qa-scorecard-";
 const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
@@ -148,13 +149,8 @@ async function runTeardownStep(
 }
 
 beforeAll(async () => {
-	obsidian = createObsidianClient({ vault: VAULT });
-	await obsidian.verify();
-
-	lock = await acquireVaultRunLock({
-		vaultName: VAULT,
-		vaultPath: await obsidian.vaultPath(),
-	});
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
 
 	qa = obsidian.plugin(PLUGIN_ID);

--- a/tests/e2e/template-property-links.test.ts
+++ b/tests/e2e/template-property-links.test.ts
@@ -1,9 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
-	acquireVaultRunLock,
 	captureFailureArtifacts,
 	clearVaultRunLockMarker,
-	createObsidianClient,
 	createSandboxApi,
 } from "obsidian-e2e";
 import type {
@@ -12,8 +10,11 @@ import type {
 	SandboxApi,
 	VaultRunLock,
 } from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
 
-const VAULT = "dev";
 const PLUGIN_ID = "quickadd";
 const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
 
@@ -113,13 +114,8 @@ async function runTeardownStep(
 }
 
 beforeAll(async () => {
-	obsidian = createObsidianClient({ vault: VAULT });
-	await obsidian.verify();
-
-	lock = await acquireVaultRunLock({
-		vaultName: VAULT,
-		vaultPath: await obsidian.vaultPath(),
-	});
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
 
 	qa = obsidian.plugin(PLUGIN_ID);

--- a/tests/provision-obsidian-e2e-vault.test.ts
+++ b/tests/provision-obsidian-e2e-vault.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	parseArgs,
+	provisionVault,
+	resolveProvisionOptions,
+	toShellExports,
+} from "../scripts/provision-obsidian-e2e-vault.mjs";
+
+const tempRoots: string[] = [];
+
+async function makeTempDir(name: string) {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), `${name}-`));
+	tempRoots.push(dir);
+	return dir;
+}
+
+async function seedWorktree(dir: string, label: string) {
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(path.join(dir, "manifest.json"), JSON.stringify({ id: "quickadd" }));
+	await fs.writeFile(path.join(dir, "main.js"), `console.log(${JSON.stringify(label)});\n`);
+	await fs.writeFile(path.join(dir, "styles.css"), `.quickadd-${label} {}\n`);
+}
+
+async function readLinkedTarget(filePath: string) {
+	return path.resolve(path.dirname(filePath), await fs.readlink(filePath));
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempRoots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("provision-obsidian-e2e-vault", () => {
+	it("parses registration options", () => {
+		const options = resolveProvisionOptions(
+			parseArgs(["--vault", "quickadd-a", "--register-via", "dev"]),
+			"/tmp/quickadd-repo",
+		);
+
+		expect(options.registerVia).toBe("dev");
+		expect(options.vaultName).toBe("quickadd-a");
+		expect(options.vaultPath).toBe("/tmp/quickadd-repo/.obsidian-e2e-vaults/quickadd-a");
+	});
+
+	it("creates an Obsidian vault with QuickAdd symlinked from a worktree", async () => {
+		const root = await makeTempDir("quickadd-e2e-root");
+		const worktree = await makeTempDir("quickadd-worktree-a");
+		await seedWorktree(worktree, "a");
+
+		const options = resolveProvisionOptions({
+			root,
+			vault: "quickadd-a",
+			worktree,
+		});
+
+		const result = await provisionVault(options);
+		const pluginPath = path.join(result.vaultPath, ".obsidian", "plugins", "quickadd");
+
+		await expect(fs.readFile(path.join(result.vaultPath, ".obsidian", "community-plugins.json"), "utf8"))
+			.resolves.toBe("[\n\t\"quickadd\"\n]\n");
+		await expect(readLinkedTarget(path.join(pluginPath, "main.js")))
+			.resolves.toBe(path.join(worktree, "main.js"));
+		await expect(readLinkedTarget(path.join(pluginPath, "manifest.json")))
+			.resolves.toBe(path.join(worktree, "manifest.json"));
+		await expect(readLinkedTarget(path.join(pluginPath, "styles.css")))
+			.resolves.toBe(path.join(worktree, "styles.css"));
+		await expect(fs.readFile(path.join(pluginPath, "data.json"), "utf8"))
+			.resolves.toBe("{\n\t\"choices\": [],\n\t\"migrations\": {}\n}\n");
+		expect(result.registered).toBe(false);
+		expect(result.trusted).toBe(false);
+		expect(result.verifiedQuickAdd).toBe(false);
+		expect(toShellExports(result)).toContain("QUICKADD_E2E_VAULT='quickadd-a'");
+		expect(toShellExports(result)).toContain(`QUICKADD_E2E_VAULT_PATH='${result.vaultPath}'`);
+	});
+
+	it("keeps separately provisioned worktrees isolated", async () => {
+		const root = await makeTempDir("quickadd-e2e-root");
+		const worktreeA = await makeTempDir("quickadd-worktree-a");
+		const worktreeB = await makeTempDir("quickadd-worktree-b");
+		await seedWorktree(worktreeA, "a");
+		await seedWorktree(worktreeB, "b");
+
+		const resultA = await provisionVault(resolveProvisionOptions({
+			root,
+			vault: "quickadd-a",
+			worktree: worktreeA,
+		}));
+		const resultB = await provisionVault(resolveProvisionOptions({
+			root,
+			vault: "quickadd-b",
+			worktree: worktreeB,
+		}));
+
+		const mainA = path.join(resultA.vaultPath, ".obsidian", "plugins", "quickadd", "main.js");
+		const mainB = path.join(resultB.vaultPath, ".obsidian", "plugins", "quickadd", "main.js");
+
+		await expect(readLinkedTarget(mainA)).resolves.toBe(path.join(worktreeA, "main.js"));
+		await expect(readLinkedTarget(mainB)).resolves.toBe(path.join(worktreeB, "main.js"));
+		expect(resultA.vaultPath).not.toBe(resultB.vaultPath);
+	});
+
+	it("does not overwrite existing plugin data", async () => {
+		const root = await makeTempDir("quickadd-e2e-root");
+		const worktree = await makeTempDir("quickadd-worktree");
+		const seedData = path.join(await makeTempDir("quickadd-seed"), "data.json");
+		await seedWorktree(worktree, "a");
+		await fs.writeFile(seedData, "{\"choices\":[{\"name\":\"seed\"}]}\n");
+
+		const options = resolveProvisionOptions({
+			data: seedData,
+			root,
+			vault: "quickadd-data",
+			worktree,
+		});
+
+		const result = await provisionVault(options);
+		const dataPath = path.join(result.pluginPath, "data.json");
+		await fs.writeFile(dataPath, "{\"choices\":[{\"name\":\"kept\"}]}\n");
+		await provisionVault(options);
+
+		await expect(fs.readFile(dataPath, "utf8"))
+			.resolves.toBe("{\"choices\":[{\"name\":\"kept\"}]}\n");
+	});
+});

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	parseArgs,
+	prepareObsidianProfile,
+	resolveInstanceOptions,
+	toInstanceShellExports,
+} from "../scripts/start-obsidian-e2e-instance.mjs";
+
+const tempRoots: string[] = [];
+
+async function makeTempDir(name: string) {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), `${name}-`));
+	tempRoots.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempRoots.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("start-obsidian-e2e-instance", () => {
+	it("creates a private Obsidian profile registered to the provisioned vault", async () => {
+		const cwd = await makeTempDir("quickadd-instance");
+		const options = resolveInstanceOptions(
+			parseArgs([
+				"--vault",
+				"quickadd-worktree-a",
+				"--root",
+				"vaults",
+				"--profile-root",
+				"profiles",
+				"--no-launch",
+			]),
+			cwd,
+		);
+
+		const profile = await prepareObsidianProfile(options);
+		const registry = JSON.parse(await fs.readFile(profile.obsidianJsonPath, "utf8"));
+		const vaults = Object.values(registry.vaults) as Array<{ path: string; open: boolean }>;
+
+		expect(registry.cli).toBe(true);
+		expect(registry.updateDisabled).toBe(true);
+		await expect(fs.readlink(path.join(options.obsidianHome, "Library", "Keychains")))
+			.resolves.toBe(path.join(process.env.HOME ?? "", "Library", "Keychains"));
+		expect(options.obsidianHome.startsWith(path.join(cwd, "profiles", "quickadd-worktree-a-"))).toBe(true);
+		expect(options.obsidianHome.endsWith("/home")).toBe(true);
+		expect(vaults).toEqual([
+			{
+				open: true,
+				path: path.join(cwd, "vaults", "quickadd-worktree-a"),
+				ts: expect.any(Number),
+			},
+		]);
+		expect(toInstanceShellExports({
+			obsidianHome: options.obsidianHome,
+			vaultName: options.vaultName,
+			vaultPath: options.vaultPath,
+		})).toContain("QUICKADD_E2E_OBSIDIAN_HOME=");
+	});
+});

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -45,8 +45,13 @@ describe("start-obsidian-e2e-instance", () => {
 
 		expect(registry.cli).toBe(true);
 		expect(registry.updateDisabled).toBe(true);
-		await expect(fs.readlink(path.join(options.obsidianHome, "Library", "Keychains")))
-			.resolves.toBe(path.join(process.env.HOME ?? "", "Library", "Keychains"));
+		const hostKeychains = path.join(process.env.HOME ?? "", "Library", "Keychains");
+		const privateKeychains = path.join(options.obsidianHome, "Library", "Keychains");
+		if (await exists(hostKeychains)) {
+			await expect(fs.readlink(privateKeychains)).resolves.toBe(hostKeychains);
+		} else {
+			await expect(fs.lstat(privateKeychains)).rejects.toMatchObject({ code: "ENOENT" });
+		}
 		expect(options.obsidianHome.startsWith(path.join(cwd, "profiles", "quickadd-worktree-a-"))).toBe(true);
 		expect(options.obsidianHome.endsWith("/home")).toBe(true);
 		expect(vaults).toEqual([
@@ -63,3 +68,13 @@ describe("start-obsidian-e2e-instance", () => {
 		})).toContain("QUICKADD_E2E_OBSIDIAN_HOME=");
 	});
 });
+
+async function exists(filePath: string) {
+	try {
+		await fs.lstat(filePath);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -23,7 +23,8 @@ export default defineConfig({
 	test: {
 		include: [
 			"src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
-			"tests/*.test.ts",
+			"tests/*.{test,spec}.{ts,tsx}",
+			"tests/!(e2e|packages)/**/*.{test,spec}.{ts,tsx}",
 		],
 		globals: true,
 		environment: "jsdom",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -21,7 +21,10 @@ export default defineConfig({
 		},
 	},
 	test: {
-		include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+		include: [
+			"src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+			"tests/*.test.ts",
+		],
 		globals: true,
 		environment: "jsdom",
 		setupFiles: ["./tests/vitest-setup.ts"],


### PR DESCRIPTION
Add tooling for running QuickAdd Obsidian-backed e2e tests against isolated vaults and worktree-local Obsidian instances instead of the shared dev vault.

The new provisioner creates a vault per worktree/unit of work, symlinks the built QuickAdd artifacts, seeds plugin data, enables QuickAdd, disables Restricted Mode, and waits for \`quickadd:list\` to work. The e2e tests now resolve their target vault through shared environment-driven helpers and refuse to run if the CLI resolves the vault name to a different path.

For stronger isolation, \`start:e2e-obsidian\` creates a short private Obsidian HOME under \`/tmp/quickadd-obsidian-e2e\`, launches a separate Electron profile with its own \`--user-data-dir\`, links the host Keychains directory to avoid macOS keychain prompts, enables Obsidian CLI in the generated profile, and exports the environment needed for \`obsidian-e2e\` to target that instance.

Reviewer context: the scripts intentionally use local macOS/Obsidian behavior and are meant for local maintainer verification, not CI. The private instance flow keeps the CLI socket/profile/vault isolated while reusing the host keychain to avoid first-launch automation prompts.

Validated locally with \`pnpm run build-with-lint\`, unit coverage for both scripts, and a focused live e2e smoke against a worktree-local Obsidian instance using \`QUICKADD_E2E_OBSIDIAN_HOME\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added E2E command helpers to provision an Obsidian test vault and start an Obsidian test instance.
* **Documentation**
  * Expanded the E2E “Development” section with full setup steps, required environment variables, and command examples.
* **Tests**
  * Added E2E coverage for vault provisioning and instance/profile setup.
  * Updated E2E tests to use QuickAdd-focused harness utilities.
* **Chores**
  * Updated ignore rules for additional E2E artifact directories.
* **Refactor**
  * Improved test discovery configuration for Vitest E2E coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->