### PR TITLE
fix(choice-list): preserve folder children when editing from a filtered view

### DIFF
--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -10,6 +10,7 @@
 		configureChoice,
 		createChoice,
 		createToggleCommandChoice,
+		findChoiceById,
 		deleteChoiceWithConfirmation,
 		duplicateChoice,
 		addChoiceToTree,
@@ -167,8 +168,17 @@
 		}
 	}
 
+	// The row passed from the list can be a filtered-view CLONE of a Multi holding
+	// only the children that matched the filter (see filterChoices). Resolve the
+	// AUTHORITATIVE live choice by id before any edit/duplicate/delete-count, so a
+	// folder's hidden children are never dropped or miscounted on save.
+	function liveChoice(choice: IChoice): IChoice {
+		return findChoiceById(choices, choice.id) ?? choice;
+	}
+
 	async function deleteChoice(choice: IChoice) {
-		const userConfirmed = await deleteChoiceWithConfirmation(choice, app);
+		const target = liveChoice(choice);
+		const userConfirmed = await deleteChoiceWithConfirmation(target, app);
 		if (!userConfirmed) return;
 
 		// Immutable removal at any depth — so the delete is reactive on the runes
@@ -180,11 +190,12 @@
 	}
 
 	async function handleConfigureChoice(oldChoice: IChoice) {
-		const updatedChoice = await configureChoice(oldChoice, app, plugin);
+		const live = liveChoice(oldChoice);
+		const updatedChoice = await configureChoice(live, app, plugin);
 		if (!updatedChoice) return;
 
 		choices = choices.map((choice) => updateChoiceHelper(choice, updatedChoice));
-		commandRegistry.updateCommand(oldChoice, updatedChoice);
+		commandRegistry.updateCommand(live, updatedChoice);
 		save();
 	}
 
@@ -210,14 +221,15 @@
 		const newName = await promptRenameChoice(app, choice.name);
 		if (!newName) return;
 
-		const updatedChoice = { ...choice, name: newName };
+		const live = liveChoice(choice);
+		const updatedChoice = { ...live, name: newName };
 		choices = choices.map((entry) => updateChoiceHelper(entry, updatedChoice));
-		commandRegistry.updateCommand(choice, updatedChoice);
+		commandRegistry.updateCommand(live, updatedChoice);
 		save();
 	}
 
 	function toggleCommandForChoice(oldChoice: IChoice) {
-		const updatedChoice = createToggleCommandChoice(oldChoice);
+		const updatedChoice = createToggleCommandChoice(liveChoice(oldChoice));
 
 		choices = choices.map((choice) => updateChoiceHelper(choice, updatedChoice));
 		updatedChoice.command
@@ -227,7 +239,7 @@
 	}
 
 	function handleDuplicateChoice(sourceChoice: IChoice) {
-		const newChoice = duplicateChoice(sourceChoice);
+		const newChoice = duplicateChoice(liveChoice(sourceChoice));
 		choices = [...choices, newChoice];
 		save();
 	}

--- a/src/gui/choiceList/ChoiceView.test.ts
+++ b/src/gui/choiceList/ChoiceView.test.ts
@@ -183,6 +183,57 @@ describe("ChoiceView", () => {
 		expect(saveChoices).not.toHaveBeenCalled();
 	});
 
+	// Regression: editing a folder from the FILTERED view must not drop the folder's
+	// hidden (non-matching) children. The filtered render is a truncated clone, so the
+	// edit handlers resolve the live choice by id (liveChoice) before merging — the real
+	// folder keeps every child on save. Command-toggle is the representative destructive
+	// path; rename and configure(Multi) share the same updateChoiceHelper merge.
+	it("keeps a folder's hidden children when editing it from the filtered view", async () => {
+		const saveChoices = vi.fn<(next: Plain<IChoice[]>) => void>();
+		const folderChoice = {
+			id: "f1",
+			name: "Inbox",
+			type: "Multi",
+			collapsed: false,
+			command: false,
+			choices: [
+				{ id: "c1", name: "Findme", type: "Template", command: false },
+				{ id: "c2", name: "Hidden", type: "Template", command: false },
+			],
+		} as unknown as IChoice;
+
+		const { getByLabelText, getByPlaceholderText } = render(ChoiceView, {
+			props: {
+				app: new App() as never,
+				// Command toggle is the only path that touches the plugin; stub the two
+				// registry methods it calls so the toggle doesn't throw.
+				plugin: {
+					addCommandForChoice: vi.fn(),
+					removeCommandForChoice: vi.fn(),
+				} as unknown as QuickAdd,
+				choices: [folderChoice],
+				saveChoices,
+			},
+		});
+
+		// Filter so only "Findme" matches -> the folder renders as a clone WITHOUT "Hidden".
+		await fireEvent.input(getByPlaceholderText("Filter choices (fuzzy)"), {
+			target: { value: "Findme" },
+		});
+
+		// Toggle the folder's command from that truncated-clone row.
+		await fireEvent.click(getByLabelText("Command palette: Inbox"));
+
+		await vi.waitFor(() => expect(saveChoices).toHaveBeenCalled());
+		const saved = saveChoices.mock.calls.at(-1)![0];
+		const folder = saved.find((c) => c.id === "f1") as
+			| { command: boolean; choices: Array<{ name: string }> }
+			| undefined;
+		expect(folder?.command).toBe(true); // the edit took effect...
+		// ...and BOTH children survived, not just the filter-matching one.
+		expect(folder?.choices.map((c) => c.name)).toEqual(["Findme", "Hidden"]);
+	});
+
 	// Covers the redesign's novel add-into-folder path end-to-end through the
 	// real component DOM (the per-folder "New folder" affordance), which the
 	// Obsidian Menu / builder modal can't be synthetically driven to exercise.

--- a/src/gui/choiceList/ChoiceView.test.ts
+++ b/src/gui/choiceList/ChoiceView.test.ts
@@ -234,6 +234,53 @@ describe("ChoiceView", () => {
 		expect(folder?.choices.map((c) => c.name)).toEqual(["Findme", "Hidden"]);
 	});
 
+	// Same data-loss class via a SEPARATE handler: duplicating a folder from the
+	// filtered view must copy the whole folder, not the truncated clone. Guards
+	// handleDuplicateChoice independently of the command-toggle/merge path above.
+	it("duplicates the whole folder (not the filtered clone) from the filtered view", async () => {
+		const saveChoices = vi.fn<(next: Plain<IChoice[]>) => void>();
+		const folderChoice = {
+			id: "f1",
+			name: "Inbox",
+			type: "Multi",
+			collapsed: false,
+			command: false,
+			choices: [
+				{ id: "c1", name: "Findme", type: "Template", command: false },
+				{ id: "c2", name: "Hidden", type: "Template", command: false },
+			],
+		} as unknown as IChoice;
+
+		const { getByLabelText, getByPlaceholderText } = render(ChoiceView, {
+			props: {
+				app: new App() as never,
+				plugin: {} as unknown as QuickAdd,
+				choices: [folderChoice],
+				saveChoices,
+			},
+		});
+
+		await fireEvent.input(getByPlaceholderText("Filter choices (fuzzy)"), {
+			target: { value: "Findme" },
+		});
+
+		// Duplicate from the truncated-clone row (a one-click row button).
+		await fireEvent.click(getByLabelText("Duplicate Inbox"));
+
+		await vi.waitFor(() => expect(saveChoices).toHaveBeenCalled());
+		const saved = saveChoices.mock.calls.at(-1)![0];
+		const copy = saved.find((c) => c.name === "Inbox (copy)") as
+			| { choices: Array<{ name: string }> }
+			| undefined;
+		expect(copy).toBeDefined();
+		// The copy has BOTH children (duplicateChoice appends "(copy)" to each) — the original
+		// folder was duplicated, not the filtered clone (which would yield only "Findme (copy)").
+		expect(copy?.choices.map((c) => c.name)).toEqual([
+			"Findme (copy)",
+			"Hidden (copy)",
+		]);
+	});
+
 	// Covers the redesign's novel add-into-folder path end-to-end through the
 	// real component DOM (the per-folder "New folder" affordance), which the
 	// Obsidian Menu / builder modal can't be synthetically driven to exercise.

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -106,6 +106,7 @@ const {
 	createToggleCommandChoice,
 	CommandRegistry,
 	moveChoice,
+	findChoiceById,
 } = await import("./choiceService");
 
 const { TemplateChoice } = await import("../types/choices/TemplateChoice");
@@ -587,6 +588,33 @@ describe("choiceService", () => {
 			const newInner = newOuter.choices[0] as IMultiChoice;
 			expect(newInner.choices).toHaveLength(1);
 			expect(newInner.choices[0].id).toBe(moving.id);
+		});
+	});
+
+	// The fix for filtered-view data loss resolves the live choice by id before an
+	// edit. findChoiceById is that resolver: given an id, it must return the
+	// AUTHORITATIVE node from the live tree — the one with the full children — not a
+	// truncated clone that happens to share the id.
+	describe("findChoiceById", () => {
+		it("finds a top-level choice by id", () => {
+			const a = createChoice("Template", "A");
+			const b = createChoice("Capture", "B");
+			expect(findChoiceById([a, b], b.id)).toBe(b);
+		});
+
+		it("finds a choice nested inside a Multi (and returns the live node with its children)", () => {
+			const child = createChoice("Capture", "Child");
+			const folder = createChoice("Multi", "Folder") as IMultiChoice;
+			folder.choices = [child, createChoice("Capture", "Sibling")];
+
+			const found = findChoiceById([folder], folder.id) as IMultiChoice;
+			expect(found).toBe(folder);
+			expect(found.choices).toHaveLength(2); // full children, not truncated
+			expect(findChoiceById([folder], child.id)).toBe(child);
+		});
+
+		it("returns undefined when the id is not present", () => {
+			expect(findChoiceById([createChoice("Template", "A")], "nope")).toBeUndefined();
 		});
 	});
 });

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -212,7 +212,14 @@ export function moveChoice(
 	return inserted ?? rootChoices;
 }
 
-function findChoiceById(choices: IChoice[], id: string): IChoice | undefined {
+/**
+ * Find a choice by id anywhere in the tree (recurses into Multi folders), or
+ * undefined. Used to resolve the AUTHORITATIVE live choice before an edit: the
+ * row passed from a filtered choice list can be a clone of a Multi holding only
+ * the children that matched the filter (see ChoiceView.filterChoices), so editing
+ * that clone would drop the folder's non-matching children on save.
+ */
+export function findChoiceById(choices: IChoice[], id: string): IChoice | undefined {
 	for (const c of choices) {
 		if (c.id === id) return c;
 		if (c.type === "Multi") {


### PR DESCRIPTION
## The bug

When the choice list is filtered, each matching Multi (folder) row is rendered as a **clone that only holds the children that matched the filter** (`ChoiceView.filterChoices`). The edit handlers then operated on that truncated clone and merged it back via `updateChoiceHelper`, so on save the folder's non-matching (hidden) children were **silently dropped**.

This is a pre-existing data-loss bug. It came in with the Svelte 5 choice-list migration (#1248) and affects the released version too — it's not specific to any one feature.

Affected operations: command-toggle, rename, configure (Multi), the delete-confirmation **count**, and duplicate. `Move` was already safe because it resolves by id.

**Repro:** create a folder with two choices, e.g. `Keep` and `Findme`. Filter the list to `Findme` (the folder shows, but now contains only `Findme`). Toggle the folder's command (or rename / configure / duplicate it). Clear the filter — `Keep` is gone. (Duplicate isn't destructive to the original, but it copies an incomplete folder; delete under-counts the confirmation, e.g. "delete 1 child" then removes all.)

## The fix

Resolve the authoritative **live** choice by id before each edit:

- Export `findChoiceById` from `choiceService`.
- Add a `liveChoice(choice)` helper in `ChoiceView` that returns `findChoiceById(choices, choice.id) ?? choice`.
- Call it at the start of the 5 affected handlers: `deleteChoice`, `handleConfigureChoice`, `handleRenameChoice`, `toggleCommandForChoice`, `handleDuplicateChoice`.

So edits always act on the full live node, never the filtered clone.

## Diff

4 files, +106/-8:

- `src/gui/choiceList/ChoiceView.svelte`
- `src/services/choiceService.ts`
- `src/gui/choiceList/ChoiceView.test.ts`
- `src/services/choiceService.test.ts`

## Tests

- A `ChoiceView` component regression: filter → command-toggle a folder → assert the hidden child survives on save. **Verified to fail without the fix.**
- `findChoiceById` unit tests (incl. nested lookup).

All gates pass: `tsc`, `svelte-check` (0), `eslint`, full suite 2180 passing.

---

Branch is off `master` and is independent of the (now-closed) mobile share-menu work in #1346 — this was a real, separate bug surfaced during that PR's review and extracted so the fix isn't lost.

Closes #1352

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue in filtered choice views where editing, renaming, toggling commands, or duplicating a folder could unintentionally change hidden (non-matching) child items upon save.

* **Tests**
  * Added regression tests covering filtered-view folder interactions for toggle and duplicate actions.
  * Expanded test coverage for choice lookup to ensure the correct live item is found by id.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->