### PR TITLE
feat: add isolated Obsidian CLI wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ Keep docs in sync: update `docs/docs/` when adding features, and snapshot when r
 Automation or scripted work should surface disruptive operations in the PR description and rerun `pnpm run build-with-lint` to keep `main.js`, `manifest.json`, and `versions.json` synchronized. Treat unexpected diffs in those artifacts as blockers until a maintainer approves.
 
 ## Dev workflow
-Always use the `obsidian` cli to test changes in the dev vault.
+Always use the `obsidian` CLI to test changes. Use the shared `dev` vault in
+the main checkout, and use the isolated worktree wrapper in Codex worktrees.
 
 Obsidian CLI is a command line interface that lets you control Obsidian from your terminal for scripting, automation, and integration with external tools.
 
@@ -74,6 +75,21 @@ Anything you can do in Obsidian can be done from the command line. Obsidian CLI 
 - In this setup, the vault plugin `main.js` is symlinked to
   `/Users/christian/Developer/quickadd/main.js`, so rebuilding updates
   the active plugin code directly.
+
+## Obsidian Worktree Vault Workflow
+- In Codex worktrees, prefer the isolated worktree vault wrapper instead of the
+  shared `dev` vault:
+  `pnpm run obsidian:e2e -- <command> ...`.
+- The wrapper provisions the worktree-local vault, starts or reuses an isolated
+  Obsidian instance, disables Restricted Mode for that vault, waits until
+  QuickAdd is available, and then runs the requested command with the correct
+  private `HOME` and `vault=<worktree vault>` already applied.
+- Examples:
+  - `pnpm run obsidian:e2e -- quickadd:list`
+  - `pnpm run obsidian:e2e -- dev:errors`
+  - `pnpm run obsidian:e2e -- eval code='app.vault.getName()'`
+- Use `pnpm run start:e2e-obsidian -- --print-env` only when you specifically
+  need to export `QUICKADD_E2E_*` variables for a separate E2E test process.
 
 ## Obsidian DevTools Workflow
 - Developer commands are available through `obsidian`:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ vault.
 For worktree-local Obsidian runtime isolation, use:
 
 ```bash
+pnpm run obsidian:e2e -- quickadd:list
+pnpm run obsidian:e2e -- dev:errors
+pnpm run obsidian:e2e -- eval code='app.vault.getName()'
+```
+
+`obsidian:e2e` prepares the worktree-local vault, starts or reuses an isolated
+Obsidian app instance, disables Restricted Mode for that vault, waits until
+`quickadd:list` succeeds, and then forwards the requested command to the
+`obsidian` CLI with the isolated `HOME` and `vault=<worktree vault>` already
+set. Use this wrapper for ad hoc Obsidian CLI work in Codex worktrees instead of
+hand-exporting `QUICKADD_E2E_*` variables for every command.
+
+To run the lower-level setup manually:
+
+```bash
 pnpm run start:e2e-obsidian -- --vault quickadd-my-worktree --print-env
 export QUICKADD_E2E_VAULT='quickadd-my-worktree'
 export QUICKADD_E2E_VAULT_PATH='/absolute/path/from/printed/output'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "build-with-lint": "tsc -noEmit -skipLibCheck && pnpm lint && node esbuild.config.mjs production",
     "check": "svelte-check --threshold error",
+    "obsidian:e2e": "node scripts/obsidian-e2e-cli.mjs",
     "provision:e2e-vault": "node scripts/provision-obsidian-e2e-vault.mjs",
     "start:e2e-obsidian": "node scripts/start-obsidian-e2e-instance.mjs",
     "test": "vitest run --config vitest.config.mts --passWithNoTests",

--- a/scripts/obsidian-e2e-cli.mjs
+++ b/scripts/obsidian-e2e-cli.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+import { execFile, spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import { provisionVault } from "./provision-obsidian-e2e-vault.mjs";
+import {
+	launchObsidianInstance,
+	parseArgs as parseInstanceArgs,
+	prepareObsidianProfile,
+	resolveInstanceOptions,
+	trustVaultAndVerifyQuickAdd,
+	waitForInstanceReady,
+} from "./start-obsidian-e2e-instance.mjs";
+
+const execFileAsync = promisify(execFile);
+const VALUE_OPTIONS = new Set([
+	"--vault",
+	"--root",
+	"--worktree",
+	"--data",
+	"--profile-root",
+	"--obsidian-app",
+	"--obsidian-bin",
+]);
+const BOOLEAN_OPTIONS = new Set(["--force"]);
+
+function printUsage() {
+	console.log(`Usage: node scripts/obsidian-e2e-cli.mjs [instance options] [--] <obsidian command...>
+
+Examples:
+  pnpm run obsidian:e2e -- quickadd:list
+  pnpm run obsidian:e2e -- dev:errors
+  pnpm run obsidian:e2e -- --vault quickadd-my-worktree eval code='app.vault.getName()'
+
+Instance options:
+  --vault <name>        Vault/profile name. Defaults to quickadd-<worktree>.
+  --root <path>         Directory that contains provisioned vaults. Defaults to .obsidian-e2e-vaults.
+  --worktree <path>     QuickAdd worktree to link plugin files from. Defaults to cwd.
+  --data <path>         Optional QuickAdd data.json seed to copy on first provision.
+  --profile-root <path> Directory for per-vault Obsidian HOME profiles. Defaults to /tmp/quickadd-obsidian-e2e.
+  --obsidian-app <name> Obsidian app name for macOS open. Defaults to Obsidian.
+  --obsidian-bin <path> Obsidian CLI executable. Defaults to obsidian.
+  --force               Recreate plugin symlinks if they already exist.
+  --help                Show this help.
+`);
+}
+
+export function parseArgs(argv) {
+	const instanceArgs = [];
+	const commandArgs = [];
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--") {
+			const next = argv[index + 1];
+			if (
+				index === 0 &&
+				(next === "--help" || BOOLEAN_OPTIONS.has(next) || VALUE_OPTIONS.has(next))
+			) {
+				continue;
+			}
+			commandArgs.push(...argv.slice(index + 1));
+			break;
+		}
+		if (arg === "--help") {
+			return { help: true, instanceArgs, commandArgs };
+		}
+		if (BOOLEAN_OPTIONS.has(arg)) {
+			instanceArgs.push(arg);
+			continue;
+		}
+		if (VALUE_OPTIONS.has(arg)) {
+			const value = argv[index + 1];
+			if (!value || value.startsWith("--")) {
+				throw new Error(`${arg} requires a value.`);
+			}
+			instanceArgs.push(arg, value);
+			index += 1;
+			continue;
+		}
+
+		commandArgs.push(...argv.slice(index));
+		break;
+	}
+
+	return {
+		help: false,
+		instanceArgs,
+		commandArgs: commandArgs.length > 0 ? commandArgs : ["quickadd:list"],
+	};
+}
+
+export function obsidianEnv(options) {
+	return {
+		...process.env,
+		HOME: options.obsidianHome,
+	};
+}
+
+export function obsidianCommandArgs(options, commandArgs) {
+	return [`vault=${options.vaultName}`, ...commandArgs];
+}
+
+async function isInstanceReady(options) {
+	try {
+		const { stdout } = await execFileAsync(
+			options.obsidianBin,
+			obsidianCommandArgs(options, ["vault", "info=path"]),
+			{
+				env: obsidianEnv(options),
+				timeout: 5_000,
+			},
+		);
+		return path.resolve(stdout.trim()) === path.resolve(options.vaultPath);
+	} catch {
+		return false;
+	}
+}
+
+export async function ensureObsidianInstance(options) {
+	const provisionResult = await provisionVault(options);
+	const profileResult = await prepareObsidianProfile(options);
+	options.userDataPath = profileResult.userDataPath;
+
+	if (!(await isInstanceReady(options))) {
+		await launchObsidianInstance(options);
+		await waitForInstanceReady(options);
+	}
+
+	await trustVaultAndVerifyQuickAdd(options);
+
+	return {
+		...provisionResult,
+		...profileResult,
+		obsidianHome: options.obsidianHome,
+	};
+}
+
+function spawnObsidian(options, commandArgs) {
+	return new Promise((resolve) => {
+		const child = spawn(
+			options.obsidianBin,
+			obsidianCommandArgs(options, commandArgs),
+			{
+				env: obsidianEnv(options),
+				stdio: "inherit",
+			},
+		);
+		child.on("close", (code, signal) => {
+			if (signal) {
+				process.kill(process.pid, signal);
+				return;
+			}
+			resolve(code ?? 1);
+		});
+		child.on("error", (error) => {
+			console.error(error instanceof Error ? error.message : error);
+			resolve(1);
+		});
+	});
+}
+
+async function main() {
+	const parsed = parseArgs(process.argv.slice(2));
+	if (parsed.help) {
+		printUsage();
+		return;
+	}
+
+	const options = resolveInstanceOptions(parseInstanceArgs(parsed.instanceArgs));
+	await ensureObsidianInstance(options);
+	process.exitCode = await spawnObsidian(options, parsed.commandArgs);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : error);
+		process.exitCode = 1;
+	});
+}

--- a/tests/obsidian-e2e-cli.test.ts
+++ b/tests/obsidian-e2e-cli.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+	obsidianCommandArgs,
+	obsidianEnv,
+	parseArgs,
+} from "../scripts/obsidian-e2e-cli.mjs";
+
+describe("obsidian-e2e-cli", () => {
+	it("defaults to quickadd:list when no Obsidian command is provided", () => {
+		const parsed = parseArgs([]);
+
+		expect(parsed.instanceArgs).toEqual([]);
+		expect(parsed.commandArgs).toEqual(["quickadd:list"]);
+	});
+
+	it("splits instance options from the Obsidian command", () => {
+		const parsed = parseArgs([
+			"--vault",
+			"quickadd-worktree-a",
+			"--profile-root",
+			"profiles",
+			"dev:errors",
+		]);
+
+		expect(parsed.instanceArgs).toEqual([
+			"--vault",
+			"quickadd-worktree-a",
+			"--profile-root",
+			"profiles",
+		]);
+		expect(parsed.commandArgs).toEqual(["dev:errors"]);
+	});
+
+	it("uses -- to pass option-like Obsidian command arguments", () => {
+		const parsed = parseArgs([
+			"--vault",
+			"quickadd-worktree-a",
+			"--",
+			"eval",
+			"--some-obsidian-flag",
+		]);
+
+		expect(parsed.instanceArgs).toEqual(["--vault", "quickadd-worktree-a"]);
+		expect(parsed.commandArgs).toEqual(["eval", "--some-obsidian-flag"]);
+	});
+
+	it("accepts the leading separator produced by pnpm run before wrapper options", () => {
+		const parsed = parseArgs([
+			"--",
+			"--vault",
+			"quickadd-worktree-a",
+			"quickadd:list",
+		]);
+
+		expect(parsed.instanceArgs).toEqual(["--vault", "quickadd-worktree-a"]);
+		expect(parsed.commandArgs).toEqual(["quickadd:list"]);
+	});
+
+	it("prefixes commands with the resolved isolated vault", () => {
+		expect(obsidianCommandArgs(
+			{ vaultName: "quickadd-worktree-a" },
+			["quickadd:list"],
+		)).toEqual(["vault=quickadd-worktree-a", "quickadd:list"]);
+	});
+
+	it("runs Obsidian CLI commands with the isolated HOME", () => {
+		expect(obsidianEnv({ obsidianHome: "/tmp/quickadd/home" })).toMatchObject({
+			HOME: "/tmp/quickadd/home",
+		});
+	});
+});


### PR DESCRIPTION
Add a worktree-bound Obsidian CLI wrapper so Codex workers can run ordinary Obsidian commands against their isolated QuickAdd vault without manually exporting `QUICKADD_E2E_*` values.

The new `pnpm run obsidian:e2e -- <command>` script provisions the worktree-local vault, starts or reuses the isolated Obsidian instance, disables Restricted Mode, waits until QuickAdd is available, and forwards the requested command with the private `HOME` and `vault=<worktree vault>` already applied.

This also updates `AGENTS.md` and `README.md` so future worktree workers default to the wrapper for ad hoc Obsidian CLI verification while keeping `start:e2e-obsidian -- --print-env` as the lower-level path for separate E2E test processes.

Verification:
- `pnpm run test`
- `pnpm run build-with-lint`
- `pnpm run obsidian:e2e -- --vault quickadd-cli-wrapper quickadd:list`
- `pnpm run obsidian:e2e -- --vault quickadd-cli-wrapper dev:errors`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow documentation with guidance on running isolated Obsidian instances for end-to-end testing.

* **New Features**
  * Added `pnpm run obsidian:e2e` command to provision and execute commands against isolated Obsidian instances.

* **Tests**
  * Added test coverage for the new end-to-end testing command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->