### PR TITLE
fix(capture): stop adding a blank line after a task-formatted insert-after capture

### DIFF
--- a/src/formatters/captureChoiceFormatter-312-task-blankline.test.ts
+++ b/src/formatters/captureChoiceFormatter-312-task-blankline.test.ts
@@ -266,6 +266,33 @@ describe("issue #312 — no blank line after a task-formatted capture (insert af
 		expect(result).toBe("===== Task ======\r\n- [ ] buy milk\r\nold one\r\n");
 	});
 
+	it("recognises a real blank last line when the body has no trailing newline", async () => {
+		// "anchor\n   " — the final split slot is genuine whitespace content, not the
+		// trailing-newline artifact, so the injected task newline must still collapse.
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("buy milk"),
+			createChoice(),
+			"===== Task ======\n   ",
+			createFile(),
+		);
+
+		expect(result).not.toMatch(/- \[ \] buy milk\n[ \t]*\n/);
+		expect(result.startsWith("===== Task ======\n- [ ] buy milk")).toBe(true);
+	});
+
+	it("keeps the EOF trailing-newline slot intact (does not collapse it as a blank line)", async () => {
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("buy milk"),
+			createChoice(),
+			"===== Task ======\n",
+			createFile(),
+		);
+
+		// Target is the last real line with only the trailing-newline artifact below:
+		// the task keeps its own terminating newline, no content is glued or dropped.
+		expect(result).toBe("===== Task ======\n- [ ] buy milk\n");
+	});
+
 	it("leaves a user-typed trailing newline in the format string untouched (gate is off for task: false)", async () => {
 		// Guard/scope test: this passes with OR without the fix because the gate is
 		// gated on choice.task. It pins the gate scope so a non-task capture whose

--- a/src/formatters/captureChoiceFormatter-312-task-blankline.test.ts
+++ b/src/formatters/captureChoiceFormatter-312-task-blankline.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+
+// Mocks mirror captureChoiceFormatter-linebreak.test.ts so the formatter can run
+// under jsdom without real Obsidian/Templater.
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory() {
+			return {
+				Prompt: vi.fn().mockResolvedValue(""),
+				PromptWithContext: vi.fn().mockResolvedValue(""),
+			} as any;
+		}
+	},
+}));
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: class {
+		constructor() {}
+	},
+}));
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../utils/errorUtils", () => ({
+	__esModule: true,
+	reportError: vi.fn(),
+	isCancellationError: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+	},
+}));
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+vi.mock("../main", () => ({
+	__esModule: true,
+	default: class QuickAdd {
+		static instance = {
+			settings: { inputPrompt: "single-line" },
+			app: {
+				workspace: { getActiveViewOfType: vi.fn().mockReturnValue(null) },
+			},
+		};
+		settings = QuickAdd.instance.settings;
+		app = QuickAdd.instance.app;
+	},
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+const insertAfter = (after: string, insertAtEnd = false) => ({
+	enabled: true,
+	after,
+	insertAtEnd,
+	considerSubsections: false,
+	createIfNotFound: false,
+	createIfNotFoundLocation: "",
+	inline: false,
+	replaceExisting: false,
+	blankLineAfterMatchMode: "auto" as const,
+});
+
+const createChoice = (
+	overrides: Partial<ICaptureChoice> = {},
+): ICaptureChoice =>
+	({
+		id: "test",
+		name: "Test Choice",
+		type: "Capture",
+		command: false,
+		captureTo: "Target.md",
+		captureToActiveFile: false,
+		captureToCanvasNodeId: "",
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: false,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: true, format: "{{VALUE}}" },
+		prepend: false,
+		appendLink: false,
+		task: true,
+		insertAfter: insertAfter("===== Task ======"),
+		newLineCapture: { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: true,
+		},
+		...overrides,
+	}) as ICaptureChoice;
+
+const createMockApp = (): App =>
+	({
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(null),
+		},
+		metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		fileManager: {
+			generateMarkdownLink: vi.fn().mockReturnValue(""),
+			processFrontMatter: vi.fn(),
+		},
+		vault: { adapter: { exists: vi.fn() }, cachedRead: vi.fn() },
+	}) as unknown as App;
+
+const createFile = (path = "Target.md"): TFile =>
+	({
+		path,
+		name: path.split("/").pop() ?? path,
+		basename: (path.split("/").pop() ?? path).replace(/\.(md|canvas)$/i, ""),
+		extension: "md",
+	}) as unknown as TFile;
+
+const createFormatter = () =>
+	new CaptureChoiceFormatter(createMockApp(), {
+		settings: {
+			inputPrompt: "single-line",
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any);
+
+beforeEach(() => {
+	(global as any).navigator = {
+		clipboard: { readText: vi.fn().mockResolvedValue("") },
+	};
+});
+
+/**
+ * Mirrors CaptureChoiceEngine.getCaptureContent(): "Format value as task" wraps
+ * the format string and appends a trailing newline so a bare task is a complete
+ * line. The blank-line bug (#312) lives in how that injected newline is joined,
+ * so the test must feed the same task-shaped input the engine produces.
+ */
+const taskInput = (value: string) => `- [ ] ${value}\n`;
+
+describe("issue #312 — no blank line after a task-formatted capture (insert after)", () => {
+	it("does not add a blank line when the target has a blank line directly below it", async () => {
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("buy milk"),
+			createChoice(),
+			"===== Task ======\n\nold one\n",
+			createFile(),
+		);
+
+		expect(result).toBe("===== Task ======\n- [ ] buy milk\nold one\n");
+		expect(result).not.toMatch(/- \[ \] buy milk\n\n/);
+	});
+
+	it("does not add a trailing blank when the target is followed only by a blank line at EOF", async () => {
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("buy milk"),
+			createChoice(),
+			"===== Task ======\n\n",
+			createFile(),
+		);
+
+		expect(result).toBe("===== Task ======\n- [ ] buy milk\n");
+	});
+
+	it("keeps the task on its own line (no glue) when content sits directly below the target", async () => {
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("buy milk"),
+			createChoice(),
+			"===== Task ======\nold one\n",
+			createFile(),
+		);
+
+		expect(result).toBe("===== Task ======\n- [ ] buy milk\nold one\n");
+	});
+
+	it("stacks repeated task captures tightly with no accumulating blank lines", async () => {
+		let body = "===== Task ======\n\n";
+		for (const value of ["A", "B", "C"]) {
+			body = await createFormatter().formatContentWithFile(
+				taskInput(value),
+				createChoice(),
+				body,
+				createFile(),
+			);
+		}
+
+		expect(body).toBe("===== Task ======\n- [ ] C\n- [ ] B\n- [ ] A\n");
+		expect(body).not.toMatch(/\n[ \t]*\n/);
+	});
+
+	it("collapses the injected newline on the insert-at-end-of-section path too", async () => {
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("new task"),
+			createChoice({ insertAfter: insertAfter("## Task", true) }),
+			"## Task\n- old\n\n## Other\nx\n",
+			createFile(),
+		);
+
+		expect(result).toBe("## Task\n- old\n- [ ] new task\n## Other\nx\n");
+		expect(result).not.toMatch(/- \[ \] new task\n\n/);
+	});
+
+	it("recognises a whitespace-only blank line directly below the target", async () => {
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("buy milk"),
+			createChoice(),
+			"===== Task ======\n   \nold one\n",
+			createFile(),
+		);
+
+		expect(result).not.toMatch(/- \[ \] buy milk\n[ \t]*\n/);
+	});
+
+	it("recognises a CRLF blank line directly below the target (#312 on Windows notes)", async () => {
+		const result = await createFormatter().formatContentWithFile(
+			taskInput("buy milk"),
+			createChoice(),
+			"===== Task ======\r\n\r\nold one\r\n",
+			createFile(),
+		);
+
+		// No blank line after the task, and the CRLF following content is preserved.
+		expect(result).toBe("===== Task ======\r\n- [ ] buy milk\r\nold one\r\n");
+	});
+
+	it("leaves a user-typed trailing newline in the format string untouched (gate is off for task: false)", async () => {
+		// Guard/scope test: this passes with OR without the fix because the gate is
+		// gated on choice.task. It pins the gate scope so a non-task capture whose
+		// format intentionally ends in a newline keeps that explicit newline.
+		const result = await createFormatter().formatContentWithFile(
+			"buy milk\n",
+			createChoice({ task: false }),
+			"===== Task ======\n\nold one\n",
+			createFile(),
+		);
+
+		expect(result).toBe("===== Task ======\nbuy milk\n\nold one\n");
+	});
+});

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -874,11 +874,17 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		//
 		// Detect the blank line via the split index, not `post.startsWith("\n")`, so
 		// whitespace-only and CRLF blanks (where the line is "\r" or "   ", not "")
-		// are recognised too. The final split slot when `body` ends in a newline is
-		// the EOF artifact, not a real blank line, so it must not trigger the drop.
+		// are recognised too. When `body` ends in a newline, split() appends a
+		// trailing empty slot that is the EOF artifact, not a real blank line, so it
+		// must not trigger the drop; a body WITHOUT a trailing newline has no such
+		// artifact, so its final slot is a genuine (possibly blank) last line.
 		const lineBelow = splitContent[pos + 1];
+		const isTrailingNewlineArtifact =
+			body.endsWith("\n") && pos + 1 === splitContent.length - 1;
 		const blankLineDirectlyBelow =
-			pos + 1 < splitContent.length - 1 && (lineBelow ?? "").trim() === "";
+			pos + 1 < splitContent.length &&
+			!isTrailingNewlineArtifact &&
+			(lineBelow ?? "").trim() === "";
 		const text =
 			this.choice.task && rawText.endsWith("\n") && blankLineDirectlyBelow
 				? rawText.slice(0, -1)

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -849,15 +849,40 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	private insertTextAfterPositionInBody(
-		text: string,
+		rawText: string,
 		body: string,
 		pos: number,
 	): string {
 		// Line-matched insertAfter callers always pass a real line index (>= 0); the
 		// frontmatter-aware "top" insertion lives in insertAtNoteBodyStart instead.
+		// Shared by every "after" path: the line-matched handler, insert-at-end-of-
+		// section, and the create-if-not-found cursor paths.
 		const splitContent = body.split("\n");
 		const pre = splitContent.slice(0, pos + 1).join("\n");
 		const post = splitContent.slice(pos + 1).join("\n");
+
+		// "Format as task" injects a trailing newline onto the capture content
+		// (getCaptureContent in CaptureChoiceEngine) so a bare task is always a
+		// complete line. When the line directly below the insertion point is already
+		// blank, that injected newline stacks on top of the existing blank line and
+		// renders a spurious blank line AFTER the task (issue #312) — an asymmetry
+		// the user does not see without the task option. Drop the redundant injected
+		// newline in that case; the existing blank line still separates the task from
+		// the following content. A user-typed trailing newline in the format string
+		// is intentional content and is left untouched (gated on choice.task, this
+		// only collapses QuickAdd's own injected task newline).
+		//
+		// Detect the blank line via the split index, not `post.startsWith("\n")`, so
+		// whitespace-only and CRLF blanks (where the line is "\r" or "   ", not "")
+		// are recognised too. The final split slot when `body` ends in a newline is
+		// the EOF artifact, not a real blank line, so it must not trigger the drop.
+		const lineBelow = splitContent[pos + 1];
+		const blankLineDirectlyBelow =
+			pos + 1 < splitContent.length - 1 && (lineBelow ?? "").trim() === "";
+		const text =
+			this.choice.task && rawText.endsWith("\n") && blankLineDirectlyBelow
+				? rawText.slice(0, -1)
+				: rawText;
 
 		return `${pre}\n${text}${post}`;
 	}


### PR DESCRIPTION
Closes #312.

## Problem
A Capture with **Insert after line** + **Format value as task** ON adds an unwanted **blank line after the inserted task** — but only when the target line has a blank line directly below it (a very common layout). Disabling "Format value as task" avoids it. Reporter's format: `{{VALUE}} {{DATE:YYYY-MM-DD HH:mm}}`.

Reproduced in a real Obsidian vault:

| Start file | task ON (before) | task OFF |
|---|---|---|
| `===== Task ======`␤`␤old one` | `…␤- [ ] buy milk`**␤**`␤old one` ← blank | `…␤buy milk␤old one` |

## Root cause
- `getCaptureContent()` (`CaptureChoiceEngine.ts:606`) injects a trailing `\n` **only** for tasks (`` `- [ ] ${content}\n` ``) so a bare task is a complete line — the sole task-ON/OFF difference.
- `insertTextAfterPositionInBody` joins `` `${pre}\n${text}${post}` ``. When the line below the anchor is blank, `post` already begins with that blank's newline; the task's injected `\n` stacks on it → `\n\n` → a blank line after the task. Non-task content has no trailing `\n`, so no collision.

## Fix
Drop QuickAdd's *injected* task newline in the join when the line directly below the insertion point is blank — the existing blank still separates the task from following content. Gated on `choice.task`, so a **user-typed** trailing newline in the format string is preserved. Blank detection is split-index/`trim()`-based, so **CRLF (`\r\n`) and whitespace-only** blanks are handled too, without collapsing the EOF trailing-newline slot.

16-line change in one method; the gate also covers the create-if-not-found cursor callers of the same helper.

## Verification
- New `captureChoiceFormatter-312-task-blankline.test.ts` (8 cases) — RED without the fix (4 fail), GREEN with it.
- Full suite **2200 passed / 31 skipped**; eslint + tsc clean.
- Real isolated Obsidian vault: LF-blank, blank+EOF, content-no-blank, **CRLF**, whitespace-blank, `insertAtEnd`, and repeated-stacking layouts all produce **no blank line after the task**; task-OFF unchanged.

## Notes / trade-offs
- The fix consumes one pre-existing blank line directly below the anchor for task captures (this matches what task-OFF already does and is exactly what #312 asks for). On the `insertAtEnd`-before-another-heading layout it therefore also consumes the inter-section blank separator (`## Task␤- old␤␤## Other` → separator gone). The alternative — *preserve* the blank — would re-introduce the reported bug.
- A separate, pre-existing **non-task** insert-after gluing bug (value glued onto immediately-following content when there's no blank) is intentionally **out of scope** here — no regression, no change.

Reviewed via an ultracode multi-lens design review plus two opposite-model (Codex) adversarial reviewers; the only consensus finding (CRLF/whitespace blank detection) is incorporated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where task-formatted captures using insert-after could add unintended extra blank lines, including edge cases with whitespace-only lines, CRLF line endings, end-of-file handling, and repeated insertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->