### PR TITLE
feat: add {{FILE:<folder>}} token to pick a file from a folder

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -280,7 +280,7 @@ research-topics:
 - `{{FILE:<folder>|optional}}` — allow skipping the pick (resolves to nothing).
 - `{{FILE:<folder>|custom}}` — also allow typing a value that isn't in the folder.
 - `{{FILE:<folder>|label:Pick a person}}` — set the picker's placeholder text.
-- `{{FILE:<folder>|name:<id>}}` — give the pick a shared **id**. By default every `{{FILE:...}}` token prompts independently (so you can pick two different people from the same folder). Reuse the *same* pick across tokens — for example to insert both the name and a link to one chosen file — by giving them the same `|name:`. Tokens that share an id should target the same folder/filters and agree on `|optional`/`|custom` — the first occurrence's settings drive the shared pick.
+- `{{FILE:<folder>|name:<id>}}` — give the pick a shared **id**. Like `{{VALUE}}` and `{{FIELD}}`, FILE tokens are cached by identity: tokens that differ (by folder, filters, mode, or `|label:`) prompt independently, while *identical* tokens reuse one pick. So to choose **two different** files from the same folder, give them distinct labels — e.g. `{{FILE:People|label:Author}}` and `{{FILE:People|label:Reviewer}}` prompt separately. To reuse the *same* pick across tokens — for example to insert both the name and a link to one chosen file — give them the same `|name:`. Tokens that share an id should target the same folder/filters and agree on `|optional`/`|custom` — the first occurrence's settings drive the shared pick.
 - Filtering reuses the `{{FIELD}}` grammar: `|tag:`, `|exclude-folder:`, `|exclude-tag:`, `|exclude-file:` (each repeatable).
 
 Notes:

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -258,6 +258,38 @@ Examples: `status: {{FIELD:status|default:Draft|default-always:true}}` or `id: {
 
 This is currently in beta, and the syntax can change—leave your thoughts [here](https://github.com/chhoumann/quickadd/issues/337).
 
+## `{{FILE:<folder>}}` {#file}
+
+Prompts you to pick a markdown **file** from `<folder>` and inserts the choice. Unlike `{{FIELD:...}}` (which suggests the *values* of a YAML field), this suggests the files themselves — handy for "metadata folders" such as a `People/` or `Research Topics/` folder where each note is an option. Because the options are real files, the list always reflects what currently exists, which keeps your links consistent.
+
+By default the **basename** (just the file name, no folder or extension) is inserted. Output modes:
+
+- `{{FILE:People}}` — inserts the basename, e.g. `Tom`.
+- `{{FILE:People|link}}` — inserts a resolved wikilink, e.g. `[[Tom]]`, using your link settings (wikilink vs. Markdown, shortest path, etc.). In a capture it resolves relative to the capture target; in a template it resolves like `{{LINKCURRENT}}`. Do **not** wrap this in `[[ ]]` yourself — you'd get `[[[[Tom]]]]`.
+- `{{FILE:People|path}}` — inserts the vault-relative path, e.g. `People/Tom.md`.
+
+Example — add a wikilink to a `research-topics` frontmatter list (quote it so the YAML stays a valid list item):
+
+```
+research-topics:
+  - "{{FILE:Research Topics|link}}"
+```
+
+**Options:**
+
+- `{{FILE:<folder>|optional}}` — allow skipping the pick (resolves to nothing).
+- `{{FILE:<folder>|custom}}` — also allow typing a value that isn't in the folder.
+- `{{FILE:<folder>|label:Pick a person}}` — set the picker's placeholder text.
+- `{{FILE:<folder>|name:<id>}}` — give the pick a shared **id**. By default every `{{FILE:...}}` token prompts independently (so you can pick two different people from the same folder). Reuse the *same* pick across tokens — for example to insert both the name and a link to one chosen file — by giving them the same `|name:`. Tokens that share an id should target the same folder/filters and agree on `|optional`/`|custom` — the first occurrence's settings drive the shared pick.
+- Filtering reuses the `{{FIELD}}` grammar: `|tag:`, `|exclude-folder:`, `|exclude-tag:`, `|exclude-file:` (each repeatable).
+
+Notes:
+
+- The folder is the first part of the token; a `|folder:` option is **not** used here (that's `{{FIELD}}` syntax) and is ignored.
+- The folder is matched **recursively** (its subfolders are included). Point at the leaf folder (e.g. `{{FILE:fields/people}}`) to scope tightly.
+- Markdown files only.
+- `|link` and `|path` insert characters that aren't valid in file names; in the **file name** field, use the default basename mode.
+
 ## `{{selected}}` {#selected}
 
 The selected text in the current editor. Will be empty if no active editor exists.

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -270,7 +270,7 @@ By default the **basename** (just the file name, no folder or extension) is inse
 
 Example — add a wikilink to a `research-topics` frontmatter list (quote it so the YAML stays a valid list item):
 
-```
+```yaml
 research-topics:
   - "{{FILE:Research Topics|link}}"
 ```
@@ -280,7 +280,7 @@ research-topics:
 - `{{FILE:<folder>|optional}}` — allow skipping the pick (resolves to nothing).
 - `{{FILE:<folder>|custom}}` — also allow typing a value that isn't in the folder.
 - `{{FILE:<folder>|label:Pick a person}}` — set the picker's placeholder text.
-- `{{FILE:<folder>|name:<id>}}` — give the pick a shared **id**. Like `{{VALUE}}` and `{{FIELD}}`, FILE tokens are cached by identity: tokens that differ (by folder, filters, mode, or `|label:`) prompt independently, while *identical* tokens reuse one pick. So to choose **two different** files from the same folder, give them distinct labels — e.g. `{{FILE:People|label:Author}}` and `{{FILE:People|label:Reviewer}}` prompt separately. To reuse the *same* pick across tokens — for example to insert both the name and a link to one chosen file — give them the same `|name:`. Tokens that share an id should target the same folder/filters and agree on `|optional`/`|custom` — the first occurrence's settings drive the shared pick.
+- `{{FILE:<folder>|name:<id>}}` — give the pick a shared **id**. Like `{{VALUE}}` and `{{FIELD}}`, FILE tokens are cached by identity: tokens that differ (by folder, filters, mode, or `|label:`) prompt independently, while *identical* tokens reuse one pick. So to choose **two different** files from the same folder, give them distinct labels — e.g. `{{FILE:People|label:Author}}` and `{{FILE:People|label:Reviewer}}` prompt separately. To reuse the *same* pick across tokens — for example to insert both the name and a link to one chosen file — give them the same `|name:`. Tokens that share an id should target the same folder/filters; the shared pick is required if *any* occurrence omits `|optional`.
 - Filtering reuses the `{{FIELD}}` grammar: `|tag:`, `|exclude-folder:`, `|exclude-tag:`, `|exclude-file:` (each repeatable).
 
 Notes:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,9 @@ export const VDATE_OPTIONAL_SYNTAX =
 export const VALUE_CASE_SYNTAX = "{{value|case:kebab}}";
 export const VARIABLE_CASE_SYNTAX = "{{value:<variable name>|case:kebab}}";
 export const FIELD_VAR_SYNTAX = "{{field:<field name>}}";
+export const FILE_SYNTAX = "{{file:<folder>}}";
+export const FILE_LINK_SYNTAX = "{{file:<folder>|link}}";
+export const FILE_PATH_SYNTAX = "{{file:<folder>|path}}";
 export const MATH_VALUE_SYNTAX = "{{mvalue}}";
 export const LINKCURRENT_SYNTAX = "{{linkcurrent}}";
 export const FILENAMECURRENT_SYNTAX = "{{filenamecurrent}}";
@@ -53,6 +56,9 @@ export const FORMAT_SYNTAX: string[] = [
 	"{{field:<fieldname>|tag:<tagname>}}",
 	"{{field:<fieldname>|inline:true}}",
 	"{{field:<fieldname>|inline:true|inline-code-blocks:ad-note}}",
+	FILE_SYNTAX,
+	FILE_LINK_SYNTAX,
+	FILE_PATH_SYNTAX,
 	LINKCURRENT_SYNTAX,
 	FILENAMECURRENT_SYNTAX,
 	FOLDER_SYNTAX,
@@ -83,6 +89,7 @@ export const FILE_NAME_FORMAT_SYNTAX: string[] = [
 	VARIABLE_TEXT_SYNTAX,
 	VARIABLE_NAME_SYNTAX,
 	FIELD_VAR_SYNTAX,
+	FILE_SYNTAX,
 	RANDOM_SYNTAX,
 ];
 // Note: |optional is deliberately absent from FILE_NAME_FORMAT_SYNTAX — an
@@ -114,6 +121,11 @@ export const FIELD_VARIABLE_PREFIX = "FIELD:";
 export const FIELD_VAR_REGEX_WITH_FILTERS = new RegExp(
 	/{{FIELD:([^\n\r}]*)(\|[^\n\r}]*)?}}/i,
 );
+// {{FILE:<folder>|...}} — pick a file from a folder. `{` is excluded from the
+// interior so a malformed nested token (e.g. {{FILE:{{VALUE:x}}}}) cannot
+// mis-consume; nested tokens inside the folder arg are unsupported. The required
+// `:` means this never matches {{FILENAMECURRENT}} (no colon after FILE).
+export const FILE_REGEX = new RegExp(/{{FILE:([^\n\r{}]*)}}/i);
 export const DATE_VARIABLE_REGEX = new RegExp(
 	/{{VDATE:([^\n\r},|]*)(?:,\s*([^\n\r}|]*))?(?:\|([^\n\r}]*))?}}/i,
 );
@@ -172,6 +184,12 @@ export const FILENAMECURRENT_SYNTAX_SUGGEST_REGEX = new RegExp(
 );
 export const FOLDER_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[F]?[O]?[L]?[D]?[E]?[R]?[}]?[}]?$/i,
+);
+// Requires the full literal "FILE" before offering {{FILE:}}, so it isn't
+// offered prematurely at {{F/{{FI; {{FILENAMECURRENT}} still co-suggests at
+// {{FILE (benign — both are valid completions of that prefix).
+export const FILE_SYNTAX_SUGGEST_REGEX = new RegExp(
+	/{{FILE[:]?$|{{FILE:[^\n\r}]*}}$/i,
 );
 export const TEMPLATE_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[T]?[E]?[M]?[P]?[L]?[A]?[T]?[E]?[:]?$|{{TEMPLATE:[^\n\r}]*[}]?[}]?$/i,

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -15,6 +15,13 @@ import {
 	FieldSuggestionParser,
 	type FieldFilter,
 } from "../utils/FieldSuggestionParser";
+import { EnhancedFieldSuggestionFileFilter } from "../utils/EnhancedFieldSuggestionFileFilter";
+import {
+	buildFileDisplayLabels,
+	FILE_CUSTOM_PREFIX,
+	FILE_PICK_PREFIX,
+	type ParsedFileToken,
+} from "../utils/fileSyntax";
 import {
 	collectFieldValuesProcessedDetailed,
 	collectFieldValuesRaw,
@@ -57,6 +64,7 @@ export class CompleteFormatter extends Formatter {
 		output = await this.replaceDateVariableInString(output);
 		output = await this.replaceVariableInString(output);
 		output = await this.replaceFieldVarInString(output);
+		output = await this.replaceFileInString(output);
 		output = await this.replaceMathValueInString(output);
 		output = this.replaceRandomInString(output);
 
@@ -125,7 +133,7 @@ export class CompleteFormatter extends Formatter {
 	 * Resolves QuickAdd format tokens inside a *template source path*, so a
 	 * choice can point at e.g. "Templates/{{value:type}} Template.md" (issue
 	 * #620). This is deliberately a PATH-SAFE subset of {@link format}: it
-	 * resolves value/date/time/field/global/selected/clipboard/random/math
+	 * resolves value/date/time/field/file/global/selected/clipboard/random/math
 	 * tokens, but never runs macros, inline JavaScript, or {{TEMPLATE:}}
 	 * inclusion — a file-path lookup should not execute code or splice another
 	 * template's body into a path. Note-relative tokens ({{title}}, {{FOLDER}},
@@ -172,6 +180,11 @@ export class CompleteFormatter extends Formatter {
 		output = await this.replaceDateVariableInString(output);
 		output = await this.replaceVariableInString(output);
 		output = await this.replaceFieldVarInString(output);
+		// {{FILE:...}} is path-safe (lists files + a picker, runs no code) and is
+		// collected from the template path by preflight (scanTemplateSource), so it
+		// MUST resolve here too or a `Templates/{{FILE:...|path}}` source path would
+		// prompt up front and then fail to resolve at runtime.
+		output = await this.replaceFileInString(output);
 		output = await this.replaceMathValueInString(output);
 		output = this.replaceRandomInString(output);
 
@@ -198,9 +211,8 @@ export class CompleteFormatter extends Formatter {
 		return output;
 	}
 
-	protected getLinkSourcePath(): string | null {
-		return null;
-	}
+	// getLinkSourcePath() inherits the base Formatter default (null);
+	// CaptureChoiceFormatter overrides it with the capture destination.
 
 	protected getCurrentFileLink(): string | null {
 		const currentFile = this.app.workspace.getActiveFile();
@@ -417,6 +429,75 @@ export class CompleteFormatter extends Formatter {
 
 	private generateCacheKey(filters: FieldFilter): string {
 		return generateFieldCacheKey(filters);
+	}
+
+	protected async suggestForFile(parsed: ParsedFileToken): Promise<string> {
+		try {
+			const files = EnhancedFieldSuggestionFileFilter.filterFiles(
+				this.app.vault.getMarkdownFiles(),
+				parsed.filter,
+				(file) => this.app.metadataCache.getFileCache(file),
+			);
+
+			const placeholder =
+				parsed.label ?? `Select a file from ${parsed.folderPath}`;
+
+			// Empty folder (or no match): fall back to free-text so a capture never
+			// dead-ends, mirroring suggestForField. A typed value is stored as custom
+			// (never resolved to a real file); an empty/skip stays "".
+			if (files.length === 0) {
+				const typed = await GenericInputPrompt.Prompt(
+					this.app,
+					placeholder,
+					`No markdown files found in "${parsed.folderPath}". Type a value or leave empty.`,
+					undefined,
+					undefined,
+					parsed.optional ? { optional: true } : undefined,
+				);
+				return typed ? `${FILE_CUSTOM_PREFIX}${typed}` : "";
+			}
+
+			const displayItems = buildFileDisplayLabels(files);
+			const items = files.map((file) => `${FILE_PICK_PREFIX}${file.path}`);
+
+			if (parsed.allowCustomInput) {
+				const basenames = new Set(
+					files.map((file) => file.basename.toLowerCase()),
+				);
+				const result = await InputSuggester.Suggest(
+					this.app,
+					displayItems,
+					items,
+					{
+						placeholder,
+						// Typing a real basename (e.g. "Tom", or "tom") should pick that
+						// file, not add a separate, indistinguishable custom row.
+						valueExists: (typed) => basenames.has(typed.toLowerCase()),
+						...(parsed.optional ? { skippable: true } : {}),
+					},
+				);
+				if (!result) return ""; // skipped
+				// A chosen row returns the encoded item; anything else is a type-in.
+				return items.includes(result)
+					? result
+					: `${FILE_CUSTOM_PREFIX}${result}`;
+			}
+
+			const result = await GenericSuggester.Suggest(
+				this.app,
+				displayItems,
+				items,
+				placeholder,
+				undefined,
+				parsed.optional ? { skippable: true } : undefined,
+			);
+			return result ?? "";
+		} catch (error) {
+			if (isCancellationError(error)) {
+				throw new UserCancelError("Input cancelled by user");
+			}
+			throw error;
+		}
 	}
 
 	protected async getMacroValue(

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -13,6 +13,8 @@ import {
 	DateFormatPreviewGenerator
 } from "./helpers/previewHelpers";
 import { getValueVariableBaseName } from "../utils/valueSyntax";
+import { EnhancedFieldSuggestionFileFilter } from "../utils/EnhancedFieldSuggestionFileFilter";
+import { FILE_CUSTOM_PREFIX, FILE_PICK_PREFIX, type ParsedFileToken } from "../utils/fileSyntax";
 
 import type QuickAdd from "../main";
 
@@ -41,6 +43,7 @@ export class FileNameDisplayFormatter extends Formatter {
 			output = await this.replaceDateVariableInString(output);
 			output = await this.replaceVariableInString(output);
 			output = await this.replaceFieldVarInString(output);
+			output = await this.replaceFileInString(output);
 			output = await this.replaceCurrentFileNameInString(output);
 			output = this.replaceTargetFolderInString(output);
 			output = this.replaceRandomInString(output);
@@ -131,6 +134,19 @@ export class FileNameDisplayFormatter extends Formatter {
 
 	protected async suggestForField(variableName: string): Promise<string> {
 		return `${variableName}_field_value`;
+	}
+
+	protected suggestForFile(parsed: ParsedFileToken): string {
+		// Preview: show a representative real file, else a placeholder. Never prompt.
+		const files = this.app
+			? EnhancedFieldSuggestionFileFilter.filterFiles(
+					this.app.vault.getMarkdownFiles(),
+					parsed.filter,
+					(file) => this.app!.metadataCache.getFileCache(file),
+				)
+			: [];
+		if (files.length > 0) return `${FILE_PICK_PREFIX}${files[0].path}`;
+		return `${FILE_CUSTOM_PREFIX}${parsed.folderPath || "file"}`;
 	}
 
 	protected async replaceDateVariableInString(input: string): Promise<string> {

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -16,6 +16,8 @@ import {
 } from "./helpers/previewHelpers";
 import { getValueVariableBaseName } from "../utils/valueSyntax";
 import { parseVDateOptions } from "../utils/vdateSyntax";
+import { EnhancedFieldSuggestionFileFilter } from "../utils/EnhancedFieldSuggestionFileFilter";
+import { FILE_CUSTOM_PREFIX, FILE_PICK_PREFIX, type ParsedFileToken } from "../utils/fileSyntax";
 
 export class FormatDisplayFormatter extends Formatter {
 	constructor(
@@ -50,6 +52,7 @@ export class FormatDisplayFormatter extends Formatter {
 			output = await this.replaceMacrosInString(output);
 			output = await this.replaceTemplateInString(output);
 			output = await this.replaceFieldVarInString(output);
+			output = await this.replaceFileInString(output);
 			output = this.replaceRandomInString(output);
 		} catch {
 			// Return the input as-is if formatting fails during preview
@@ -155,6 +158,19 @@ export class FormatDisplayFormatter extends Formatter {
 
 	protected async suggestForField(variableName: string) {
 		return Promise.resolve(`${variableName}_field_value`);
+	}
+
+	protected suggestForFile(parsed: ParsedFileToken): string {
+		// Preview: show a representative real file, else a placeholder. Never prompt.
+		const files = this.app
+			? EnhancedFieldSuggestionFileFilter.filterFiles(
+					this.app.vault.getMarkdownFiles(),
+					parsed.filter,
+					(file) => this.app!.metadataCache.getFileCache(file),
+				)
+			: [];
+		if (files.length > 0) return `${FILE_PICK_PREFIX}${files[0].path}`;
+		return `${FILE_CUSTOM_PREFIX}${parsed.folderPath || "file"}`;
 	}
 
 	protected async replaceDateVariableInString(input: string): Promise<string> {

--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -194,6 +194,10 @@ class DocsExampleFormatter extends Formatter {
 		return suggestedValues[0] ?? "";
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected async suggestForField(variableName: string): Promise<string> {
 		return `[field:${variableName}]`;
 	}

--- a/src/formatters/formatter-case.test.ts
+++ b/src/formatters/formatter-case.test.ts
@@ -48,6 +48,10 @@ class CaseTestFormatter extends Formatter {
 		return "";
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected suggestForField(_variableName: string): Promise<string> {
 		return Promise.resolve("");
 	}

--- a/src/formatters/formatter-field-title-regression.test.ts
+++ b/src/formatters/formatter-field-title-regression.test.ts
@@ -28,6 +28,10 @@ class FieldTitleFormatter extends Formatter {
 		return await this.format(input);
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected async suggestForField(specifier: string): Promise<string> {
 		this.fieldCalls.push(specifier);
 		const value = this.fieldResponses.get(specifier);

--- a/src/formatters/formatter-file.test.ts
+++ b/src/formatters/formatter-file.test.ts
@@ -1,0 +1,244 @@
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+import { describe, expect, it, vi } from "vitest";
+import { Formatter } from "./formatter";
+import {
+	FILE_CUSTOM_PREFIX,
+	FILE_PICK_PREFIX,
+	type ParsedFileToken,
+} from "../utils/fileSyntax";
+
+function makeFile(path: string): TFile {
+	const segment = path.split("/").pop() ?? path;
+	const basename = segment.replace(/\.md$/, "");
+	const parentPath = path.includes("/")
+		? path.slice(0, path.lastIndexOf("/"))
+		: "/";
+	return Object.assign(new TFile(), {
+		path,
+		name: segment,
+		basename,
+		parent: { path: parentPath },
+	});
+}
+
+// A stub app where given paths resolve to real TFiles and links render in a
+// recognizable shape so link mode is observable.
+function makeApp(paths: string[]) {
+	const files = new Map(paths.map((p) => [p, makeFile(p)]));
+	return {
+		vault: {
+			getAbstractFileByPath: (p: string) => files.get(p) ?? null,
+		},
+		fileManager: {
+			generateMarkdownLink: vi.fn(
+				(file: TFile, source: string) => `[[${file.basename}@${source}]]`,
+			),
+		},
+	};
+}
+
+class FileTestFormatter extends Formatter {
+	public calls = 0;
+	private linkSource: string | null;
+
+	constructor(
+		app: unknown,
+		private responder: (parsed: ParsedFileToken) => string,
+		linkSource: string | null = null,
+	) {
+		super(app as App);
+		this.linkSource = linkSource;
+	}
+
+	protected getLinkSourcePath(): string | null {
+		return this.linkSource;
+	}
+
+	protected suggestForFile(parsed: ParsedFileToken): string {
+		this.calls += 1;
+		return this.responder(parsed);
+	}
+
+	public run(input: string): Promise<string> {
+		return this.replaceFileInString(input);
+	}
+
+	/** Test seam: pre-seed a stored FILE value to exercise rendering directly. */
+	public seed(key: string, value: string): void {
+		this.variables.set(key, value);
+	}
+
+	// --- inert abstract impls ---
+	protected async format(input: string): Promise<string> {
+		return input;
+	}
+	protected getCurrentFileLink(): string | null {
+		return null;
+	}
+	protected getCurrentFileName(): string | null {
+		return null;
+	}
+	protected async promptForValue(): Promise<string> {
+		return "";
+	}
+	protected async promptForMathValue(): Promise<string> {
+		return "";
+	}
+	protected getVariableValue(): string {
+		return "";
+	}
+	protected async suggestForValue(): Promise<string> {
+		return "";
+	}
+	protected async suggestForField(): Promise<string> {
+		return "";
+	}
+	protected async getMacroValue(): Promise<string> {
+		return "";
+	}
+	protected async promptForVariable(): Promise<string> {
+		return "";
+	}
+	protected async getTemplateContent(): Promise<string> {
+		return "";
+	}
+	protected async getSelectedText(): Promise<string> {
+		return "";
+	}
+	protected async getClipboardContent(): Promise<string> {
+		return "";
+	}
+	protected isTemplatePropertyTypesEnabled(): boolean {
+		return false;
+	}
+}
+
+describe("Formatter {{FILE:...}} token", () => {
+	it("renders the basename by default", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+		);
+		expect(await f.run("Hi {{FILE:People}}")).toBe("Hi Tom");
+	});
+
+	it("renders a resolved wikilink in link mode (with source path)", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+			"Notes/Inbox.md",
+		);
+		expect(await f.run("{{FILE:People|link}}")).toBe("[[Tom@Notes/Inbox.md]]");
+	});
+
+	it("renders the vault path in path mode", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+		);
+		expect(await f.run("{{FILE:People|path}}")).toBe("People/Tom.md");
+	});
+
+	it("prompts once for identical tokens (cached by identity)", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+		);
+		await f.run("{{FILE:People}} and {{FILE:People}}");
+		expect(f.calls).toBe(1);
+	});
+
+	it("prompts independently for different modes by default", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+		);
+		await f.run("{{FILE:People}} {{FILE:People|link}}");
+		expect(f.calls).toBe(2);
+	});
+
+	it("shares one pick across tokens with the same |name:", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+		);
+		const out = await f.run(
+			"{{FILE:People|name:r}} as {{FILE:People|link|name:r}}",
+		);
+		expect(f.calls).toBe(1);
+		expect(out).toBe("Tom as [[Tom@]]");
+	});
+
+	it("treats an optional skip as empty in every mode (never [[]])", async () => {
+		const name = new FileTestFormatter(makeApp([]), () => "");
+		expect(await name.run("[{{FILE:People|optional}}]")).toBe("[]");
+		const link = new FileTestFormatter(makeApp([]), () => "");
+		expect(await link.run("[{{FILE:People|link|optional}}]")).toBe("[]");
+	});
+
+	it("renders a |custom typed value by name and never resolves it to a file", async () => {
+		// Even though "People/Tom.md" exists, a custom-typed value is not resolved.
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_CUSTOM_PREFIX}Alice`,
+		);
+		expect(await f.run("{{FILE:People|custom}}")).toBe("Alice");
+		const link = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_CUSTOM_PREFIX}Alice`,
+		);
+		expect(await link.run("{{FILE:People|custom|link}}")).toBe("[[Alice]]");
+	});
+
+	it("falls back to [[basename]] when a stored path no longer resolves", async () => {
+		const f = new FileTestFormatter(
+			makeApp([]), // path does not resolve
+			() => `${FILE_PICK_PREFIX}People/Ghost.md`,
+		);
+		expect(await f.run("{{FILE:People|link}}")).toBe("[[Ghost]]");
+	});
+
+	it("prompts independently for tokens that differ only by label", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+		);
+		await f.run(
+			"{{FILE:People|label:Author}} / {{FILE:People|label:Reviewer}}",
+		);
+		expect(f.calls).toBe(2);
+	});
+
+	it("treats an untagged (raw) stored value as literal text — never resolved", async () => {
+		// Simulates a one-page-typed custom value or a script-seeded plain string:
+		// it must NOT resolve to the real (possibly filtered-out) file.
+		const linkF = new FileTestFormatter(makeApp(["People/Tom.md"]), () => "");
+		linkF.seed("FILE:folder=People|mode=link", "People/Tom.md");
+		// Raw → linked by name, never via generateMarkdownLink on the real file.
+		expect(await linkF.run("{{FILE:People|link}}")).toBe("[[People/Tom.md]]");
+
+		const nameF = new FileTestFormatter(makeApp(["People/Tom.md"]), () => "");
+		nameF.seed("FILE:folder=People|mode=name", "Archive/Tom.md");
+		expect(await nameF.run("{{FILE:People}}")).toBe("Archive/Tom.md");
+	});
+
+	it("leaves {{FILENAMECURRENT}} untouched (no FILE_REGEX collision)", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md"]),
+			() => `${FILE_PICK_PREFIX}People/Tom.md`,
+		);
+		expect(await f.run("{{FILENAMECURRENT}} {{FILE:People}}")).toBe(
+			"{{FILENAMECURRENT}} Tom",
+		);
+		expect(f.calls).toBe(1);
+	});
+
+	it("leaves an empty {{FILE:}} token literal and never prompts", async () => {
+		const f = new FileTestFormatter(makeApp([]), () => {
+			throw new Error("should not prompt");
+		});
+		expect(await f.run("a {{FILE:}} b")).toBe("a {{FILE:}} b");
+		expect(f.calls).toBe(0);
+	});
+});

--- a/src/formatters/formatter-filenamecurrent.test.ts
+++ b/src/formatters/formatter-filenamecurrent.test.ts
@@ -42,6 +42,10 @@ class StubFormatter extends Formatter {
     return "";
   }
 
+  protected suggestForFile(): string {
+  	return "";
+  }
+
   protected async suggestForField(_variableName: string): Promise<string> {
     return "";
   }

--- a/src/formatters/formatter-folder.test.ts
+++ b/src/formatters/formatter-folder.test.ts
@@ -34,6 +34,10 @@ class StubFormatter extends Formatter {
     return "";
   }
 
+  protected suggestForFile(): string {
+  	return "";
+  }
+
   protected async suggestForField(): Promise<string> {
     return "";
   }

--- a/src/formatters/formatter-issue920.test.ts
+++ b/src/formatters/formatter-issue920.test.ts
@@ -51,6 +51,10 @@ class Issue920TestFormatter extends Formatter {
 		return "";
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected suggestForField(_variableName: string): Promise<string> {
 		return Promise.resolve("");
 	}

--- a/src/formatters/formatter-issue929-integration.test.ts
+++ b/src/formatters/formatter-issue929-integration.test.ts
@@ -47,6 +47,10 @@ class CaptureFormatterTest extends Formatter {
         return "";
     }
 
+    protected suggestForFile(): string {
+    	return "";
+    }
+
     protected suggestForField(_variableName: string): Promise<string> {
         return Promise.resolve("");
     }

--- a/src/formatters/formatter-issue929.test.ts
+++ b/src/formatters/formatter-issue929.test.ts
@@ -38,6 +38,10 @@ class Issue929TestFormatter extends Formatter {
         return "";
     }
 
+    protected suggestForFile(): string {
+    	return "";
+    }
+
     protected suggestForField(_variableName: string): Promise<string> {
         return Promise.resolve("");
     }

--- a/src/formatters/formatter-linkcurrent.test.ts
+++ b/src/formatters/formatter-linkcurrent.test.ts
@@ -42,6 +42,10 @@ class StubFormatter extends Formatter {
     return "";
   }
 
+  protected suggestForFile(): string {
+  	return "";
+  }
+
   protected async suggestForField(_variableName: string): Promise<string> {
     return "";
   }

--- a/src/formatters/formatter-named-suggester.test.ts
+++ b/src/formatters/formatter-named-suggester.test.ts
@@ -58,6 +58,10 @@ class TestFormatter extends Formatter {
 		);
 		return this.suggestReturns.get(key) ?? suggestedValues[0];
 	}
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected async suggestForField(): Promise<string> {
 		return "";
 	}

--- a/src/formatters/formatter-optional.test.ts
+++ b/src/formatters/formatter-optional.test.ts
@@ -102,6 +102,10 @@ class OptionalTestFormatter extends Formatter {
 	protected getCurrentFileName(): string | null {
 		return null;
 	}
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected async suggestForField(): Promise<string> {
 		return "";
 	}

--- a/src/formatters/formatter-template-property-types.test.ts
+++ b/src/formatters/formatter-template-property-types.test.ts
@@ -37,6 +37,10 @@ class TemplatePropertyTypesTestFormatter extends Formatter {
 		return '';
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected suggestForField(_variableName: string): Promise<string> {
 		return Promise.resolve('');
 	}

--- a/src/formatters/formatter-text-mapping.test.ts
+++ b/src/formatters/formatter-text-mapping.test.ts
@@ -93,6 +93,10 @@ class TextMappingFormatter extends Formatter {
 		return suggestedValues[0] ?? "";
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected suggestForField(_variableName: string): Promise<string> {
 		return Promise.resolve("");
 	}

--- a/src/formatters/formatter-title.test.ts
+++ b/src/formatters/formatter-title.test.ts
@@ -37,6 +37,10 @@ class TestFormatter extends Formatter {
         return "";
     }
 
+    protected suggestForFile(): string {
+    	return "";
+    }
+
     protected suggestForField(_variableName: string): Promise<string> {
         return Promise.resolve("");
     }

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -1,3 +1,4 @@
+import { TFile } from "obsidian";
 import type { App } from "obsidian";
 import {
 	DATE_REGEX,
@@ -5,6 +6,7 @@ import {
 	DATE_VARIABLE_REGEX,
 	LINK_TO_CURRENT_FILE_REGEX,
 	FILE_NAME_OF_CURRENT_FILE_REGEX,
+	FILE_REGEX,
 	TARGET_FOLDER_REGEX,
 	MACRO_REGEX,
 	MATH_VALUE_REGEX,
@@ -22,6 +24,13 @@ import {
 	TITLE_REGEX,
 	RANDOM_REGEX,
 } from "../constants";
+import {
+	decodeFileValue,
+	fileBasenameFromPath,
+	type FileMode,
+	type ParsedFileToken,
+	parseFileToken,
+} from "../utils/fileSyntax";
 import { getDate } from "../utilityObsidian";
 import type { IDateParser } from "../parsers/IDateParser";
 import { log } from "../logger/logManager";
@@ -656,6 +665,111 @@ export abstract class Formatter {
 	private getFieldVariableKey(fieldSpecifier: string): string {
 		return `${FIELD_VARIABLE_PREFIX}${fieldSpecifier}`;
 	}
+
+	/**
+	 * Resolve {{FILE:<folder>|...}} tokens: prompt once per identity (full token,
+	 * or the shared `|name:` key), cache the chosen file, and render each
+	 * occurrence by mode (basename / wikilink / path). Uses the non-mutating
+	 * accumulator scan of replaceFieldVarInString — not the in-place splice — so an
+	 * unresolved/empty token can be emitted literally without re-scan loops.
+	 */
+	protected async replaceFileInString(input: string): Promise<string> {
+		const regex = new RegExp(FILE_REGEX.source, "gi");
+		let output = "";
+		let lastIndex = 0;
+		let match: RegExpExecArray | null;
+
+		while ((match = regex.exec(input)) !== null) {
+			output += input.slice(lastIndex, match.index);
+
+			const parsed = parseFileToken(match[1] ?? "");
+			if (!parsed) {
+				// Empty folder / malformed: leave the token literal and move on.
+				output += match[0];
+				lastIndex = regex.lastIndex;
+				continue;
+			}
+
+			const key = parsed.variableKey;
+			if (!this.hasConcreteVariable(key)) {
+				this.variables.set(key, await this.suggestForFile(parsed));
+			}
+
+			output += this.renderFileValue(this.variables.get(key), parsed.mode);
+			lastIndex = regex.lastIndex;
+		}
+
+		return output + input.slice(lastIndex);
+	}
+
+	private renderFileValue(stored: unknown, mode: FileMode): string {
+		if (mode === "link") return this.getFileLinkForStoredValue(stored);
+
+		const decoded = decodeFileValue(stored);
+		switch (decoded.kind) {
+			case "empty":
+				return "";
+			case "file":
+				return mode === "path"
+					? decoded.path
+					: fileBasenameFromPath(decoded.path);
+			case "custom":
+			case "raw":
+				// Literal, user-provided text (a |custom type-in, a one-page typed
+				// value, or a script-seeded string). It is NEVER resolved to a real
+				// file — only a `@file:` pick from the filtered list is.
+				return decoded.kind === "custom" ? decoded.text : decoded.value;
+		}
+	}
+
+	/**
+	 * Render a stored FILE value as a wikilink. Only a real pick from the filtered
+	 * list (`@file:`) is resolved through generateMarkdownLink (so the user's link
+	 * settings and source path apply); a literal/custom value links by name and is
+	 * never resolved (so a typed string can't reach a filtered-out file). Empty
+	 * resolves to "" (not `[[]]`).
+	 */
+	protected getFileLinkForStoredValue(stored: unknown): string {
+		const decoded = decodeFileValue(stored);
+		if (decoded.kind === "empty") return "";
+		if (decoded.kind !== "file") {
+			const text = decoded.kind === "custom" ? decoded.text : decoded.value;
+			return text ? `[[${text}]]` : "";
+		}
+
+		const path = decoded.path;
+		if (!path) return "";
+
+		const file = this.app?.vault.getAbstractFileByPath(path);
+		if (file instanceof TFile) {
+			return (
+				this.app?.fileManager.generateMarkdownLink(
+					file,
+					this.getLinkSourcePath() ?? "",
+				) ?? `[[${fileBasenameFromPath(path)}]]`
+			);
+		}
+		return `[[${fileBasenameFromPath(path)}]]`;
+	}
+
+	/**
+	 * Source path used to resolve {{FILE:...|link}} (and other) wikilinks.
+	 * Defaults to none (resolve from the vault root); CaptureChoiceFormatter
+	 * overrides this with the capture destination so relative links are correct.
+	 */
+	protected getLinkSourcePath(): string | null {
+		return null;
+	}
+
+	/**
+	 * Prompts the user to pick a file matching the parsed FILE token and returns
+	 * the encoded stored value (`@file:<path>` for a pick, `@filecustom:<text>`
+	 * for a |custom type-in, or "" when skipped). Display/preview formatters
+	 * return a representative value without prompting.
+	 */
+	protected abstract suggestForFile(
+		parsed: ParsedFileToken,
+	): Promise<string> | string;
 
 	protected abstract promptForMathValue(): Promise<string>;
 

--- a/src/formatters/vdate-default.test.ts
+++ b/src/formatters/vdate-default.test.ts
@@ -74,6 +74,10 @@ class TestFormatter extends Formatter {
         return suggestedValues[0] || "";
     }
 
+    protected suggestForFile(): string {
+    	return "";
+    }
+
     protected async suggestForField(_variableName: string): Promise<string> {
         return "";
     }

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -9,6 +9,7 @@ import {
 	LINKCURRENT_SYNTAX_SUGGEST_REGEX,
 	FILENAMECURRENT_SYNTAX,
 	FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
+	FILE_SYNTAX_SUGGEST_REGEX,
 	FOLDER_SYNTAX_SUGGEST_REGEX,
 	MACRO_SYNTAX_SUGGEST_REGEX,
 	MATH_VALUE_SYNTAX,
@@ -41,6 +42,7 @@ enum FormatSyntaxToken {
 	Value,
 	Name,
 	Variable,
+	File,
 	LinkCurrent,
 	FilenameCurrent,
 	FolderTarget,
@@ -134,6 +136,12 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 			regex: VARIABLE_DATE_SYNTAX_SUGGEST_REGEX,
 			token: FormatSyntaxToken.VariableDate,
 			suggestion: "{{VDATE:}}",
+			cursorOffset: 2
+		},
+		{
+			regex: FILE_SYNTAX_SUGGEST_REGEX,
+			token: FormatSyntaxToken.File,
+			suggestion: "{{FILE:}}",
 			cursorOffset: 2
 		},
 	];
@@ -310,6 +318,21 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 					"{{VALUE:option1,option2|label:Pick one}}",
 					"{{VALUE:title|label:Snake case|default:My_Title}}",
 					"{{VALUE:title|optional}}"
+				);
+			} else if (tokenDef.token === FormatSyntaxToken.File) {
+				// Pick a file from a folder; default inserts the basename.
+				suggestions.push("{{FILE:<folder>}}");
+				// |link / |path insert characters invalid in a file name, so only
+				// offer them outside the file-name field.
+				if (!this.suggestForFileNames) {
+					suggestions.push(
+						"{{FILE:<folder>|link}}",
+						"{{FILE:<folder>|path}}",
+					);
+				}
+				suggestions.push(
+					"{{FILE:<folder>|optional}}",
+					"{{FILE:<folder>|custom}}",
 				);
 			}
 		}

--- a/src/preflight/RequirementCollector.file.test.ts
+++ b/src/preflight/RequirementCollector.file.test.ts
@@ -87,6 +87,28 @@ describe("RequirementCollector — {{FILE:...}}", () => {
 		expect(rc.requirements.has(key)).toBe(true);
 	});
 
+	it("merges |optional across shared-id occurrences (required if any is required)", async () => {
+		const app = makeApp(["People/Tom.md"]);
+		const rc = new RequirementCollector(app, makePlugin());
+		// optional first, required second — the shared requirement must be required.
+		await rc.scanString(
+			"{{FILE:People|optional|name:ref}} then {{FILE:People|link|name:ref}}",
+		);
+		const key = parseFileToken("People|name:ref")!.variableKey;
+		expect(rc.requirements.size).toBe(1);
+		expect(rc.requirements.get(key)?.optional).toBe(false);
+	});
+
+	it("keeps a shared-id requirement optional only when every occurrence is optional", async () => {
+		const app = makeApp(["People/Tom.md"]);
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString(
+			"{{FILE:People|optional|name:ref}} then {{FILE:People|link|optional|name:ref}}",
+		);
+		const key = parseFileToken("People|name:ref")!.variableKey;
+		expect(rc.requirements.get(key)?.optional).toBe(true);
+	});
+
 	it("does not confuse {{FILENAMECURRENT}} with a FILE requirement", async () => {
 		const app = makeApp(["People/Tom.md"]);
 		const rc = new RequirementCollector(app, makePlugin());

--- a/src/preflight/RequirementCollector.file.test.ts
+++ b/src/preflight/RequirementCollector.file.test.ts
@@ -109,6 +109,19 @@ describe("RequirementCollector — {{FILE:...}}", () => {
 		expect(rc.requirements.get(key)?.optional).toBe(true);
 	});
 
+	it("upgrades a shared-id requirement to a custom suggester order-independently", async () => {
+		const app = makeApp(["People/Tom.md"]);
+		const rc = new RequirementCollector(app, makePlugin());
+		// non-custom first (would be a forced dropdown), |custom second.
+		await rc.scanString(
+			"{{FILE:People|name:ref}} then {{FILE:People|custom|name:ref}}",
+		);
+		const key = parseFileToken("People|name:ref")!.variableKey;
+		const req = rc.requirements.get(key);
+		expect(req?.type).toBe("suggester");
+		expect(req?.suggesterConfig?.allowCustomInput).toBe(true);
+	});
+
 	it("does not confuse {{FILENAMECURRENT}} with a FILE requirement", async () => {
 		const app = makeApp(["People/Tom.md"]);
 		const rc = new RequirementCollector(app, makePlugin());

--- a/src/preflight/RequirementCollector.file.test.ts
+++ b/src/preflight/RequirementCollector.file.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { RequirementCollector } from "./RequirementCollector";
+import {
+	FILE_PICK_PREFIX,
+	parseFileToken,
+} from "src/utils/fileSyntax";
+
+function makeFile(path: string) {
+	const segment = path.split("/").pop() ?? path;
+	const basename = segment.replace(/\.md$/, "");
+	const parentPath = path.includes("/")
+		? path.slice(0, path.lastIndexOf("/"))
+		: "/";
+	return { path, name: segment, basename, parent: { path: parentPath } };
+}
+
+const makeApp = (paths: string[]) =>
+	({
+		workspace: { getActiveFile: () => null },
+		vault: {
+			getAbstractFileByPath: () => null,
+			cachedRead: async () => "",
+			getMarkdownFiles: () => paths.map(makeFile),
+		},
+		metadataCache: { getFileCache: () => null },
+	}) as never;
+
+const makePlugin = () =>
+	({
+		settings: { inputPrompt: "single-line", globalVariables: {} },
+	}) as never;
+
+describe("RequirementCollector — {{FILE:...}}", () => {
+	it("records a forced DROPDOWN (non-custom) whose options round-trip as encoded paths", async () => {
+		const app = makeApp([
+			"Research Topics/Alpha.md",
+			"Research Topics/Beta.md",
+			"People/Tom.md", // outside the scope; must be excluded
+		]);
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString("- \"{{FILE:Research Topics|link}}\"");
+
+		const key = parseFileToken("Research Topics|link")!.variableKey;
+		const req = rc.requirements.get(key);
+		expect(req).toBeDefined();
+		// Non-custom FILE is a forced dropdown so a one-page user cannot type a raw
+		// value that bypasses the option list.
+		expect(req?.type).toBe("dropdown");
+		expect(req?.options).toEqual([
+			`${FILE_PICK_PREFIX}Research Topics/Alpha.md`,
+			`${FILE_PICK_PREFIX}Research Topics/Beta.md`,
+		]);
+		expect(req?.displayOptions).toEqual(["Alpha", "Beta"]);
+	});
+
+	it("records a suggester (free text) only when |custom, with the flags set", async () => {
+		const app = makeApp(["People/Tom.md"]);
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString("{{FILE:People|optional|custom}}");
+
+		const key = parseFileToken("People|optional|custom")!.variableKey;
+		const req = rc.requirements.get(key);
+		expect(req?.type).toBe("suggester");
+		expect(req?.optional).toBe(true);
+		expect(req?.suggesterConfig?.allowCustomInput).toBe(true);
+	});
+
+	it("falls back to a suggester when the folder has no markdown files", async () => {
+		const app = makeApp(["People/Tom.md"]); // nothing under Empty/
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString("{{FILE:Empty}}");
+
+		const key = parseFileToken("Empty")!.variableKey;
+		const req = rc.requirements.get(key);
+		expect(req?.type).toBe("suggester");
+		expect(req?.options).toEqual([]);
+	});
+
+	it("records ONE requirement for two |name:-shared tokens across modes", async () => {
+		const app = makeApp(["People/Tom.md"]);
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString(
+			"{{FILE:People|name:ref}} as {{FILE:People|link|name:ref}}",
+		);
+		expect(rc.requirements.size).toBe(1);
+		const key = parseFileToken("People|name:ref")!.variableKey;
+		expect(rc.requirements.has(key)).toBe(true);
+	});
+
+	it("does not confuse {{FILENAMECURRENT}} with a FILE requirement", async () => {
+		const app = makeApp(["People/Tom.md"]);
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString("{{FILENAMECURRENT}} — {{FILE:People}}");
+
+		const key = parseFileToken("People")!.variableKey;
+		const fileReq = rc.requirements.get(key);
+		expect(fileReq?.type).toBe("dropdown");
+		expect(fileReq?.label).toBe("File from People");
+		// Only the FILE token created a requirement.
+		expect(rc.requirements.size).toBe(1);
+	});
+});

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -432,6 +432,17 @@ export class RequirementCollector extends Formatter {
 			// AND rule as VALUE/VDATE: optional only if EVERY occurrence is
 			// optional, so a later required use still prompts.
 			existing.optional = (existing.optional ?? false) && parsed.optional;
+			// Merge custom-input capability order-independently: if ANY occurrence
+			// allows custom input, the shared field must expose the free-text
+			// suggester (most-permissive wins, mirroring VALUE's option upgrade).
+			if (parsed.allowCustomInput) {
+				existing.type = "suggester";
+				existing.suggesterConfig = {
+					allowCustomInput: true,
+					caseSensitive: false,
+					multiSelect: false,
+				};
+			}
 			return;
 		}
 

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -2,6 +2,7 @@ import type { App } from "obsidian";
 import {
 	DATE_VARIABLE_REGEX,
 	FIELD_VARIABLE_PREFIX,
+	FILE_REGEX,
 	GLOBAL_VAR_REGEX,
 	TEMPLATE_REGEX,
 	VARIABLE_REGEX,
@@ -21,6 +22,7 @@ import {
 	buildFileDisplayLabels,
 	FILE_PICK_PREFIX,
 	type ParsedFileToken,
+	parseFileToken,
 } from "src/utils/fileSyntax";
 
 export type FieldType =
@@ -86,6 +88,7 @@ export class RequirementCollector extends Formatter {
 		// Run a safe formatting pass that collects variables but avoids side-effects
 		this.scanVariableTokens(expanded);
 		this.scanDateTokens(expanded);
+		this.scanFileTokens(expanded);
 		await this.format(expanded);
 	}
 
@@ -403,54 +406,82 @@ export class RequirementCollector extends Formatter {
 		return "";
 	}
 
-	protected suggestForFile(parsed: ParsedFileToken): string {
-		// Record a one-page requirement so {{FILE:...}} is visible up front (and
-		// the non-interactive CLI rejects it when unprovided) instead of ambushing
-		// with a runtime picker. Options are the folder's files encoded as
-		// `@file:<path>` (display = basenames) so the chosen value round-trips to
-		// the runtime formatter, which decodes it back to the file.
-		const key = parsed.variableKey;
-		if (!this.requirements.has(key)) {
-			const files = EnhancedFieldSuggestionFileFilter.filterFiles(
-				this.app.vault.getMarkdownFiles(),
-				parsed.filter,
-				(file) => this.app.metadataCache.getFileCache(file),
-			);
-			const options = files.map((file) => `${FILE_PICK_PREFIX}${file.path}`);
-			const displayOptions = buildFileDisplayLabels(files);
-			// A non-custom FILE is a FORCED choice: render it as a dropdown so the
-			// one-page form can't store a raw typed value (a free-text suggester
-			// would let "type name + Enter" bypass the option list, mirroring the
-			// runtime GenericSuggester vs InputSuggester split). Fall back to a
-			// suggester (free text) when |custom, or when the folder is empty so the
-			// field isn't a dead, disabled dropdown.
-			const useSuggester = parsed.allowCustomInput || options.length === 0;
-			// Disambiguate same-scope tokens that differ only by mode (e.g. a
-			// basename and a link to the same folder) when no explicit |label.
-			const autoLabel =
-				parsed.mode === "name"
-					? `File from ${parsed.folderPath}`
-					: `File from ${parsed.folderPath} (${parsed.mode})`;
-			this.requirements.set(key, {
-				id: key,
-				label: parsed.label ?? autoLabel,
-				type: useSuggester ? "suggester" : "dropdown",
-				source: "collected",
-				options,
-				displayOptions,
-				optional: parsed.optional,
-				...(useSuggester
-					? {
-							suggesterConfig: {
-								allowCustomInput: parsed.allowCustomInput,
-								caseSensitive: false,
-								multiSelect: false,
-							},
-						}
-					: {}),
-			});
+	/**
+	 * Records {{FILE:...}} requirements so they're visible up front (one-page form
+	 * + non-interactive CLI) instead of ambushing with a runtime picker. Like
+	 * scanVariableTokens/scanDateTokens, this scans EVERY occurrence — the
+	 * inherited replaceFileInString prompt hook fires at most once per key (it
+	 * caches the first inert answer), so per-occurrence flags such as |optional
+	 * would otherwise never be merged.
+	 */
+	private scanFileTokens(input: string) {
+		const re = new RegExp(FILE_REGEX.source, "gi");
+		let match: RegExpExecArray | null;
+		while ((match = re.exec(input)) !== null) {
+			const parsed = parseFileToken(match[1] ?? "");
+			if (!parsed) continue;
+			this.recordFileRequirement(parsed);
 		}
-		return ""; // inert: keep scanning
+	}
+
+	private recordFileRequirement(parsed: ParsedFileToken): void {
+		const key = parsed.variableKey;
+		const existing = this.requirements.get(key);
+		if (existing) {
+			// A repeated key (same identity, or a shared |name:). Apply the same
+			// AND rule as VALUE/VDATE: optional only if EVERY occurrence is
+			// optional, so a later required use still prompts.
+			existing.optional = (existing.optional ?? false) && parsed.optional;
+			return;
+		}
+
+		// Options are the folder's files encoded as `@file:<path>` (display =
+		// basenames) so the chosen value round-trips to the runtime formatter,
+		// which decodes it back to the file.
+		const files = EnhancedFieldSuggestionFileFilter.filterFiles(
+			this.app.vault.getMarkdownFiles(),
+			parsed.filter,
+			(file) => this.app.metadataCache.getFileCache(file),
+		);
+		const options = files.map((file) => `${FILE_PICK_PREFIX}${file.path}`);
+		const displayOptions = buildFileDisplayLabels(files);
+		// A non-custom FILE is a FORCED choice: render it as a dropdown so the
+		// one-page form can't store a raw typed value (a free-text suggester would
+		// let "type name + Enter" bypass the option list, mirroring the runtime
+		// GenericSuggester vs InputSuggester split). Fall back to a suggester (free
+		// text) when |custom, or when the folder is empty so the field isn't a
+		// dead, disabled dropdown.
+		const useSuggester = parsed.allowCustomInput || options.length === 0;
+		// Disambiguate same-scope tokens that differ only by mode (e.g. a basename
+		// and a link to the same folder) when no explicit |label.
+		const autoLabel =
+			parsed.mode === "name"
+				? `File from ${parsed.folderPath}`
+				: `File from ${parsed.folderPath} (${parsed.mode})`;
+		this.requirements.set(key, {
+			id: key,
+			label: parsed.label ?? autoLabel,
+			type: useSuggester ? "suggester" : "dropdown",
+			source: "collected",
+			options,
+			displayOptions,
+			optional: parsed.optional,
+			...(useSuggester
+				? {
+						suggesterConfig: {
+							allowCustomInput: parsed.allowCustomInput,
+							caseSensitive: false,
+							multiSelect: false,
+						},
+					}
+				: {}),
+		});
+	}
+
+	protected suggestForFile(_parsed: ParsedFileToken): string {
+		// Requirements are recorded by scanFileTokens (which sees every
+		// occurrence). This hook fires at most once per key, so it stays inert.
+		return "";
 	}
 
 	protected async suggestForValue(

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -16,6 +16,12 @@ import {
 	unwrapQuotedValue,
 } from "src/utils/valueSyntax";
 import { parseVDateOptions } from "src/utils/vdateSyntax";
+import { EnhancedFieldSuggestionFileFilter } from "src/utils/EnhancedFieldSuggestionFileFilter";
+import {
+	buildFileDisplayLabels,
+	FILE_PICK_PREFIX,
+	type ParsedFileToken,
+} from "src/utils/fileSyntax";
 
 export type FieldType =
 	| "text"
@@ -107,6 +113,7 @@ export class RequirementCollector extends Formatter {
 		output = await this.replaceDateVariableInString(output);
 		output = await this.replaceVariableInString(output);
 		output = await this.replaceFieldVarInString(output);
+		output = await this.replaceFileInString(output);
 
 		// Math value
 		output = await this.replaceMathValueInString(output);
@@ -394,6 +401,56 @@ export class RequirementCollector extends Formatter {
 			});
 		}
 		return "";
+	}
+
+	protected suggestForFile(parsed: ParsedFileToken): string {
+		// Record a one-page requirement so {{FILE:...}} is visible up front (and
+		// the non-interactive CLI rejects it when unprovided) instead of ambushing
+		// with a runtime picker. Options are the folder's files encoded as
+		// `@file:<path>` (display = basenames) so the chosen value round-trips to
+		// the runtime formatter, which decodes it back to the file.
+		const key = parsed.variableKey;
+		if (!this.requirements.has(key)) {
+			const files = EnhancedFieldSuggestionFileFilter.filterFiles(
+				this.app.vault.getMarkdownFiles(),
+				parsed.filter,
+				(file) => this.app.metadataCache.getFileCache(file),
+			);
+			const options = files.map((file) => `${FILE_PICK_PREFIX}${file.path}`);
+			const displayOptions = buildFileDisplayLabels(files);
+			// A non-custom FILE is a FORCED choice: render it as a dropdown so the
+			// one-page form can't store a raw typed value (a free-text suggester
+			// would let "type name + Enter" bypass the option list, mirroring the
+			// runtime GenericSuggester vs InputSuggester split). Fall back to a
+			// suggester (free text) when |custom, or when the folder is empty so the
+			// field isn't a dead, disabled dropdown.
+			const useSuggester = parsed.allowCustomInput || options.length === 0;
+			// Disambiguate same-scope tokens that differ only by mode (e.g. a
+			// basename and a link to the same folder) when no explicit |label.
+			const autoLabel =
+				parsed.mode === "name"
+					? `File from ${parsed.folderPath}`
+					: `File from ${parsed.folderPath} (${parsed.mode})`;
+			this.requirements.set(key, {
+				id: key,
+				label: parsed.label ?? autoLabel,
+				type: useSuggester ? "suggester" : "dropdown",
+				source: "collected",
+				options,
+				displayOptions,
+				optional: parsed.optional,
+				...(useSuggester
+					? {
+							suggesterConfig: {
+								allowCustomInput: parsed.allowCustomInput,
+								caseSensitive: false,
+								multiSelect: false,
+							},
+						}
+					: {}),
+			});
+		}
+		return ""; // inert: keep scanning
 	}
 
 	protected async suggestForValue(

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -6,6 +6,10 @@ import type IChoice from "src/types/choices/IChoice";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { OnePageInputModal } from "./OnePageInputModal";
 import {
+	canonicalizeOnePageFileValue,
+	FILE_VARIABLE_PREFIX,
+} from "src/utils/fileSyntax";
+import {
 	collectChoiceRequirements,
 	getUnresolvedRequirements,
 } from "./collectChoiceRequirements";
@@ -65,12 +69,25 @@ export async function runOnePagePreflight(
 		);
 		const values = await modal.waitForClose;
 
-		// No additional normalization needed: date inputs already store @date:ISO
+		// Date inputs already store @date:ISO. FILE inputs need canonicalizing: the
+		// generic suggester stores raw typed text, so a value that isn't one of the
+		// requirement's encoded `@file:` picks is treated as typed custom text (and
+		// can't spoof a pick by typing the internal `@file:` sentinel).
+		const fileOptionsByKey = new Map<string, string[]>();
+		for (const req of unresolved) {
+			if (req.id.startsWith(FILE_VARIABLE_PREFIX)) {
+				fileOptionsByKey.set(req.id, req.options ?? []);
+			}
+		}
 
 		// Store results into executor variables
-		Object.entries(values).forEach(([k, v]) =>
-			choiceExecutor.variables.set(k, v),
-		);
+		Object.entries(values).forEach(([k, v]) => {
+			const fileOptions = fileOptionsByKey.get(k);
+			const normalized = fileOptions
+				? canonicalizeOnePageFileValue(v, fileOptions)
+				: v;
+			choiceExecutor.variables.set(k, normalized);
+		});
 
 		return true;
 	} catch (error) {

--- a/src/utils/fileSyntax.test.ts
+++ b/src/utils/fileSyntax.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildFileDisplayLabels,
+	canonicalizeOnePageFileValue,
+	decodeFileValue,
+	fileBasenameFromPath,
+	FILE_CUSTOM_PREFIX,
+	FILE_PICK_PREFIX,
+	FILE_VARIABLE_PREFIX,
+	parseFileToken,
+} from "./fileSyntax";
+
+describe("parseFileToken", () => {
+	it("returns null for an empty folder", () => {
+		expect(parseFileToken("")).toBeNull();
+		expect(parseFileToken("|link")).toBeNull();
+		expect(parseFileToken("  ")).toBeNull();
+	});
+
+	it("parses a bare folder with the default name mode", () => {
+		const parsed = parseFileToken("People");
+		expect(parsed?.folderPath).toBe("People");
+		expect(parsed?.mode).toBe("name");
+		expect(parsed?.optional).toBe(false);
+		expect(parsed?.allowCustomInput).toBe(false);
+		expect(parsed?.filter.folder).toBe("People");
+	});
+
+	it("parses the mode flags (last one wins)", () => {
+		expect(parseFileToken("People|link")?.mode).toBe("link");
+		expect(parseFileToken("People|path")?.mode).toBe("path");
+		expect(parseFileToken("People|name")?.mode).toBe("name");
+		expect(parseFileToken("People|link|path")?.mode).toBe("path");
+	});
+
+	it("parses optional and custom bare flags", () => {
+		const parsed = parseFileToken("People|optional|custom");
+		expect(parsed?.optional).toBe(true);
+		expect(parsed?.allowCustomInput).toBe(true);
+	});
+
+	it("parses label and the |name: alias", () => {
+		const parsed = parseFileToken("People|link|label:Pick a person|name:reviewer");
+		expect(parsed?.label).toBe("Pick a person");
+		expect(parsed?.aliasName).toBe("reviewer");
+		// The alias drives the variable key (shared identity), scoped to the folder.
+		expect(parsed?.variableKey).toBe(
+			`${FILE_VARIABLE_PREFIX}name=reviewer|folder=People`,
+		);
+	});
+
+	it("reuses the FIELD filter grammar (folder/tag/exclude-*)", () => {
+		const parsed = parseFileToken(
+			"fields/people|tag:topic|exclude-folder:Archive|exclude-tag:wip|exclude-file:tmp.md",
+		);
+		expect(parsed?.filter.folder).toBe("fields/people");
+		expect(parsed?.filter.tags).toEqual(["topic"]);
+		expect(parsed?.filter.excludeFolders).toEqual(["Archive"]);
+		expect(parsed?.filter.excludeTags).toEqual(["wip"]);
+		expect(parsed?.filter.excludeFiles).toEqual(["tmp.md"]);
+	});
+
+	describe("variableKey identity", () => {
+		it("differs by mode (independent prompts by default)", () => {
+			const name = parseFileToken("People")!.variableKey;
+			const link = parseFileToken("People|link")!.variableKey;
+			expect(name).not.toBe(link);
+		});
+
+		it("collapses slash variants of the same folder", () => {
+			const a = parseFileToken("People")!.variableKey;
+			const b = parseFileToken("/People")!.variableKey;
+			const c = parseFileToken("People/")!.variableKey;
+			expect(a).toBe(b);
+			expect(b).toBe(c);
+		});
+
+		it("is order-insensitive across filters", () => {
+			const a = parseFileToken("People|tag:a|tag:b")!.variableKey;
+			const b = parseFileToken("People|tag:b|tag:a")!.variableKey;
+			expect(a).toBe(b);
+		});
+
+		it("differs by optional/custom flags", () => {
+			const base = parseFileToken("People")!.variableKey;
+			expect(parseFileToken("People|optional")!.variableKey).not.toBe(base);
+			expect(parseFileToken("People|custom")!.variableKey).not.toBe(base);
+		});
+
+		it("differs by label (distinct prompts, e.g. Author vs Reviewer)", () => {
+			const author = parseFileToken("People|label:Author")!.variableKey;
+			const reviewer = parseFileToken("People|label:Reviewer")!.variableKey;
+			expect(author).not.toBe(reviewer);
+		});
+
+		it("shares the key across tokens with the same |name: and folder", () => {
+			const a = parseFileToken("People|link|name:r")!.variableKey;
+			const b = parseFileToken("People|name:r")!.variableKey;
+			expect(a).toBe(b);
+		});
+
+		it("does NOT share |name: across different folders", () => {
+			const people = parseFileToken("People|name:ref")!.variableKey;
+			const projects = parseFileToken("Projects|name:ref")!.variableKey;
+			expect(people).not.toBe(projects);
+		});
+
+		it("does NOT share |name: across different filters (different file lists)", () => {
+			const pub = parseFileToken("People|tag:public|name:ref")!.variableKey;
+			const priv = parseFileToken("People|tag:private|name:ref")!.variableKey;
+			expect(pub).not.toBe(priv);
+		});
+
+		it("DOES share |name: across modes within the same scope", () => {
+			const name = parseFileToken("People|tag:x|name:ref")!.variableKey;
+			const link = parseFileToken("People|tag:x|link|name:ref")!.variableKey;
+			const path = parseFileToken("People|tag:x|path|name:ref")!.variableKey;
+			expect(name).toBe(link);
+			expect(link).toBe(path);
+		});
+	});
+});
+
+describe("decodeFileValue", () => {
+	it("classifies empty, file, custom, and raw", () => {
+		expect(decodeFileValue("")).toEqual({ kind: "empty" });
+		expect(decodeFileValue(undefined)).toEqual({ kind: "empty" });
+		expect(decodeFileValue(`${FILE_PICK_PREFIX}People/Tom.md`)).toEqual({
+			kind: "file",
+			path: "People/Tom.md",
+		});
+		expect(decodeFileValue(`${FILE_CUSTOM_PREFIX}Alice`)).toEqual({
+			kind: "custom",
+			text: "Alice",
+		});
+		expect(decodeFileValue("People/Tom.md")).toEqual({
+			kind: "raw",
+			value: "People/Tom.md",
+		});
+	});
+});
+
+describe("canonicalizeOnePageFileValue", () => {
+	const picks = [
+		`${FILE_PICK_PREFIX}People/Tom.md`,
+		`${FILE_PICK_PREFIX}People/Jack.md`,
+	];
+
+	it("keeps an exact encoded pick as-is", () => {
+		expect(
+			canonicalizeOnePageFileValue(`${FILE_PICK_PREFIX}People/Tom.md`, picks),
+		).toBe(`${FILE_PICK_PREFIX}People/Tom.md`);
+	});
+
+	it("wraps typed text as custom", () => {
+		expect(canonicalizeOnePageFileValue("Alice", picks)).toBe(
+			`${FILE_CUSTOM_PREFIX}Alice`,
+		);
+	});
+
+	it("does NOT let a typed @file: sentinel spoof a pick", () => {
+		// User types the internal sentinel verbatim into a |custom field.
+		const spoof = `${FILE_PICK_PREFIX}Archive/Secret.md`;
+		const out = canonicalizeOnePageFileValue(spoof, picks);
+		// It is treated as literal custom text, not a real pick.
+		expect(out).toBe(`${FILE_CUSTOM_PREFIX}${spoof}`);
+		expect(decodeFileValue(out)).toEqual({ kind: "custom", text: spoof });
+	});
+
+	it("leaves empty (skip) untouched", () => {
+		expect(canonicalizeOnePageFileValue("", picks)).toBe("");
+	});
+});
+
+describe("fileBasenameFromPath", () => {
+	it("drops folders and a trailing markdown-family extension", () => {
+		expect(fileBasenameFromPath("People/Tom.md")).toBe("Tom");
+		expect(fileBasenameFromPath("a/b/My.Notes.md")).toBe("My.Notes");
+		expect(fileBasenameFromPath("Diagrams/x.canvas")).toBe("x");
+		expect(fileBasenameFromPath("Alice")).toBe("Alice");
+	});
+});
+
+describe("buildFileDisplayLabels", () => {
+	const makeFile = (path: string) => {
+		const segment = path.split("/").pop() ?? path;
+		const basename = segment.replace(/\.md$/, "");
+		const parentPath = path.includes("/")
+			? path.slice(0, path.lastIndexOf("/"))
+			: "/";
+		return { basename, parent: { path: parentPath } } as never;
+	};
+
+	it("uses bare basenames when unambiguous", () => {
+		const labels = buildFileDisplayLabels([
+			makeFile("People/Tom.md"),
+			makeFile("People/Jack.md"),
+		]);
+		expect(labels).toEqual(["Tom", "Jack"]);
+	});
+
+	it("disambiguates duplicate basenames with the parent folder", () => {
+		const labels = buildFileDisplayLabels([
+			makeFile("Companies/Apple.md"),
+			makeFile("Fruits/Apple.md"),
+		]);
+		expect(labels).toEqual(["Apple (Companies)", "Apple (Fruits)"]);
+	});
+});

--- a/src/utils/fileSyntax.ts
+++ b/src/utils/fileSyntax.ts
@@ -1,0 +1,250 @@
+import type { TFile } from "obsidian";
+import {
+	FieldSuggestionParser,
+	type FieldFilter,
+} from "./FieldSuggestionParser";
+import {
+	extractBareFlagPart,
+	parsePipeKeyValue,
+	splitPipeParts,
+} from "./pipeSyntax";
+
+// Namespaces FILE variable values in the variables map, separate from plain
+// VALUE/FIELD variables (parallel to FIELD_VARIABLE_PREFIX in constants.ts).
+export const FILE_VARIABLE_PREFIX = "FILE:";
+
+// Internal encoding for a resolved FILE variable value. A value chosen from the
+// folder list is stored as `@file:<vaultPath>`; a value typed via |custom is
+// stored as `@filecustom:<text>` so rendering NEVER resolves a typed string back
+// to a real file (which would let |custom bypass exclude-folder etc.). Mirrors
+// VDATE's `@date:` sentinel. An empty string means "answered, intentionally empty"
+// (optional skip). A value with neither prefix is treated as a raw path/name
+// (script-seeded or one-page legacy) and resolved best-effort.
+export const FILE_PICK_PREFIX = "@file:";
+export const FILE_CUSTOM_PREFIX = "@filecustom:";
+
+export type FileMode = "name" | "link" | "path";
+
+export type ParsedFileToken = {
+	raw: string;
+	folderPath: string;
+	mode: FileMode;
+	label?: string;
+	/** Explicit shared key from `|name:`; undefined when not provided. */
+	aliasName?: string;
+	optional: boolean;
+	allowCustomInput: boolean;
+	/** Reuses the FIELD file filter so folder/tag/exclude-* behave identically. */
+	filter: FieldFilter;
+	/** Variables-map key. Full token identity by default; `|name:` shares it. */
+	variableKey: string;
+};
+
+const MODE_FLAGS = new Set<FileMode>(["name", "link", "path"]);
+
+/** Strip leading/trailing slashes, matching EnhancedFieldSuggestionFileFilter. */
+function normalizeFolder(path: string): string {
+	return path.replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * The slash- and order-insensitive part of the cache key that determines WHICH
+ * files the picker lists (folder + tag/exclude-* filters). Two tokens that share
+ * this list can meaningfully share a pick; two that don't, can't.
+ */
+function buildFileScopeSignature(folderPath: string, filter: FieldFilter): string {
+	const parts = [`folder=${normalizeFolder(folderPath)}`];
+	if (filter.tags?.length)
+		parts.push(`tags=${[...filter.tags].sort().join(",")}`);
+	if (filter.excludeFolders?.length)
+		parts.push(
+			`xfolder=${[...filter.excludeFolders]
+				.map(normalizeFolder)
+				.sort()
+				.join(",")}`,
+		);
+	if (filter.excludeTags?.length)
+		parts.push(`xtag=${[...filter.excludeTags].sort().join(",")}`);
+	if (filter.excludeFiles?.length)
+		parts.push(`xfile=${[...filter.excludeFiles].sort().join(",")}`);
+	return parts.join("|");
+}
+
+/**
+ * Full identity signature for an un-named token. Builds on the scope signature
+ * and adds `mode`, `label`, `optional`, and `custom` so two prompts that differ
+ * only by mode/label/flags are distinct identities — sharing one pick is the
+ * explicit job of `|name:`.
+ */
+function buildFileSignature(parsed: {
+	folderPath: string;
+	mode: FileMode;
+	label?: string;
+	optional: boolean;
+	allowCustomInput: boolean;
+	filter: FieldFilter;
+}): string {
+	const { folderPath, mode, label, optional, allowCustomInput, filter } =
+		parsed;
+	const parts = [
+		buildFileScopeSignature(folderPath, filter),
+		`mode=${mode}`,
+	];
+	if (label) parts.push(`label=${label}`);
+	if (optional) parts.push("optional");
+	if (allowCustomInput) parts.push("custom");
+	return parts.join("|");
+}
+
+/**
+ * Parse the interior of a `{{FILE:<folder>|...}}` token.
+ *
+ * The first pipe-part is the (required) folder path. FILE-specific options are
+ * peeled off here — the bare mode flags `name`/`link`/`path`, `optional`,
+ * `custom`, and the key:value `label:` / `name:` — then the remainder is handed
+ * to {@link FieldSuggestionParser.parse} so the folder/tag/exclude-* filter
+ * grammar can never diverge from {{FIELD}}. The folder (first segment) is the
+ * picker SCOPE, so it is applied as `filter.folder` regardless of any `|folder:`.
+ *
+ * Returns `null` for an empty folder (the token is left literal by the caller).
+ */
+export function parseFileToken(raw: string): ParsedFileToken | null {
+	if (!raw) return null;
+
+	const allParts = splitPipeParts(raw);
+	const folderPath = (allParts.shift() ?? "").trim();
+	if (!folderPath) return null;
+
+	// Peel bare flags first.
+	let remaining = allParts;
+	const optionalResult = extractBareFlagPart(remaining, "optional");
+	remaining = optionalResult.remaining;
+	const optional = optionalResult.found;
+
+	const customResult = extractBareFlagPart(remaining, "custom");
+	remaining = customResult.remaining;
+	const allowCustomInput = customResult.found;
+
+	let mode: FileMode = "name";
+	const afterMode: string[] = [];
+	for (const part of remaining) {
+		const trimmed = part.trim().toLowerCase();
+		if (MODE_FLAGS.has(trimmed as FileMode)) {
+			mode = trimmed as FileMode; // last one wins
+			continue;
+		}
+		afterMode.push(part);
+	}
+
+	// Peel key:value options that are FILE-specific (label/name); everything else
+	// (tag/exclude-*) is parsed by FieldSuggestionParser below.
+	let label: string | undefined;
+	let aliasName: string | undefined;
+	for (const part of afterMode) {
+		const parsed = parsePipeKeyValue(part);
+		if (!parsed) continue;
+		if (parsed.key === "label" && parsed.value) label = parsed.value;
+		else if (parsed.key === "name" && parsed.value) aliasName = parsed.value;
+	}
+
+	// Delegate filter parsing to the shared FIELD parser (it skips unknown keys
+	// like label/name and bare flags), then force the scope folder. The first
+	// segment is the folder, so any `|folder:` sub-option the parser picks up is
+	// intentionally discarded below (the positional folder always wins).
+	const fieldParsed = FieldSuggestionParser.parse(raw);
+	const filter: FieldFilter = {
+		folder: folderPath,
+		tags: fieldParsed.filters.tags,
+		excludeFolders: fieldParsed.filters.excludeFolders,
+		excludeTags: fieldParsed.filters.excludeTags,
+		excludeFiles: fieldParsed.filters.excludeFiles,
+	};
+
+	// Sharing (`|name:`) is scoped to the picker's SCOPE (folder + filters): a pick
+	// comes from one specific file list, so `{{FILE:People|name:ref}}` and
+	// `{{FILE:Projects|name:ref}}` — or the same folder with different filters —
+	// must not silently reuse each other's pick. Mode/label/optional/custom are
+	// intentionally NOT in the alias key, so one pick renders across modes.
+	const variableKey = aliasName
+		? `${FILE_VARIABLE_PREFIX}name=${aliasName}|${buildFileScopeSignature(folderPath, filter)}`
+		: `${FILE_VARIABLE_PREFIX}${buildFileSignature({
+				folderPath,
+				mode,
+				label,
+				optional,
+				allowCustomInput,
+				filter,
+			})}`;
+
+	return {
+		raw,
+		folderPath,
+		mode,
+		label,
+		aliasName,
+		optional,
+		allowCustomInput,
+		filter,
+		variableKey,
+	};
+}
+
+export type DecodedFileValue =
+	| { kind: "empty" }
+	| { kind: "file"; path: string }
+	| { kind: "custom"; text: string }
+	| { kind: "raw"; value: string };
+
+/**
+ * Canonicalize a FILE value submitted through the one-page input form, where the
+ * suggester/dropdown stores either an encoded `@file:<path>` option (a real pick)
+ * or raw typed text. Only a value that exactly matches one of the requirement's
+ * encoded picks is trusted as a pick; anything else is treated as typed text and
+ * wrapped as `@filecustom:<text>` verbatim. This stops a user from spoofing a
+ * pick by typing the internal `@file:` sentinel into a |custom field. Empty
+ * stays empty (an intentional skip).
+ */
+export function canonicalizeOnePageFileValue(
+	value: string,
+	validPicks: Iterable<string>,
+): string {
+	if (!value) return value;
+	for (const pick of validPicks) {
+		if (value === pick) return value;
+	}
+	return `${FILE_CUSTOM_PREFIX}${value}`;
+}
+
+/** Decode a stored FILE variable value into its representation kind. */
+export function decodeFileValue(stored: unknown): DecodedFileValue {
+	if (typeof stored !== "string" || stored === "") return { kind: "empty" };
+	if (stored.startsWith(FILE_CUSTOM_PREFIX))
+		return { kind: "custom", text: stored.slice(FILE_CUSTOM_PREFIX.length) };
+	if (stored.startsWith(FILE_PICK_PREFIX))
+		return { kind: "file", path: stored.slice(FILE_PICK_PREFIX.length) };
+	return { kind: "raw", value: stored };
+}
+
+/** Basename of a vault path (drop folders + a trailing known extension). */
+export function fileBasenameFromPath(value: string): string {
+	const segment = value.split("/").pop() ?? value;
+	return segment.replace(/\.(md|canvas|base)$/i, "");
+}
+
+/**
+ * Display labels for a folder's files: basenames, with the parent folder
+ * appended when a basename is ambiguous within the list so duplicate-named files
+ * are still distinguishable in the picker.
+ */
+export function buildFileDisplayLabels(files: TFile[]): string[] {
+	const counts = new Map<string, number>();
+	for (const file of files) {
+		counts.set(file.basename, (counts.get(file.basename) ?? 0) + 1);
+	}
+	return files.map((file) => {
+		if ((counts.get(file.basename) ?? 0) <= 1) return file.basename;
+		const parent = file.parent?.path;
+		const where = parent && parent !== "/" ? parent : "vault root";
+		return `${file.basename} (${where})`;
+	});
+}


### PR DESCRIPTION
## Summary

Adds a new format-syntax token, **`{{FILE:<folder>}}`**, that prompts the user to pick a markdown file from a specified folder and inserts the choice. This covers the two long-standing requests for choosing from the files in a "metadata folder" (e.g. `People/`, `Research Topics/`) instead of retyping names — keeping links consistent.

Closes #933
Closes #1159

## Syntax

```
{{FILE:People}}                      → Tom              (basename, default)
{{FILE:People|link}}                 → [[Tom]]          (resolved wikilink)
{{FILE:People|path}}                 → People/Tom.md    (vault-relative path)
{{FILE:People|optional}}             → skippable (resolves to nothing)
{{FILE:People|custom}}               → also allow typing a value not in the folder
{{FILE:People|label:Pick a person}}  → suggester placeholder
{{FILE:People|name:reviewer}}        → share this pick across tokens (opt-in)
{{FILE:fields/people|tag:t|exclude-folder:p|exclude-file:f}}  → FIELD-style filters
```

- Default inserts the **basename**; `|link` inserts a resolved wikilink (respecting your link settings — relative to the capture target in captures, like `{{LINKCURRENT}}` in templates); `|path` inserts the vault path.
- Folder is matched **recursively**; markdown files only.
- Each token prompts independently by default; reuse one pick across tokens/modes with the same `|name:`.

## Design notes

- **Dedicated token** (not an overload of `{{VALUE}}`/`{{FIELD}}`), storing the *chosen file* and rendering per-mode — so one pick can render as both a name and a link.
- **Discriminated storage**: `@file:<path>` for a real pick (resolves via `generateMarkdownLink`) vs `@filecustom:<text>` for typed input (literal, never resolved) — so `|custom` input can't reach a filtered-out note.
- **Preflight aware**: flows through `RequirementCollector` so the one-page input form and the non-interactive CLI surface it up front (forced dropdown for a non-custom pick; free suggester for `|custom`) instead of ambushing at runtime.
- Filtering reuses the existing `{{FIELD}}` grammar (`FieldSuggestionParser` + `EnhancedFieldSuggestionFileFilter`).

## Surfaces touched

Parser (`src/utils/fileSyntax.ts`), base + complete + both preview formatters, `RequirementCollector` / `runOnePagePreflight`, the format-syntax autocomplete, `constants.ts`, and docs (`docs/docs/FormatSyntax.md`, Next).

## Testing

- **+41 unit tests** (parser, rendering, identity/caching, preflight requirement shape, one-page value canonicalization); full suite **2233 passing**, lint clean, `tsc` clean.
- **Verified end-to-end in a real Obsidian vault**: the interactive picker lists exactly the folder's files and resolves the choice; all three modes render correctly (real `generateMarkdownLink`); optional-skip yields empty (not `[[]]`); no runtime errors.
- Reviewed across multiple rounds (design + diff) by independent adversarial reviewers; all blocker/major findings (preflight integration, link-source/identity, one-page forced selection, sentinel-spoofing) addressed.

> Note: docs are added under `docs/docs/` (Next) only — this token is unreleased.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `{{FILE:<folder>}}` token to insert markdown files from a folder, with output modes for basename (default), `|link`, and `|path`.
  * Added options like `|optional`, `|custom`, `|label:<text>`, and `|name:<id>`, including shared selection reuse, plus improved inline previews and autocomplete.

* **Bug Fixes**
  * Improved parsing and resolution rules to prevent token misinterpretation and provide safer fallback behavior when files aren’t available.

* **Documentation**
  * Documented the complete `{{FILE:<folder>}}` syntax and filtering behavior.

* **Tests**
  * Added comprehensive tests covering formatting, caching, and preflight requirement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->