### PR TITLE
test: fix master build break (linksection stub missing suggestForFile)

### DIFF
--- a/src/formatters/formatter-linksection.test.ts
+++ b/src/formatters/formatter-linksection.test.ts
@@ -48,6 +48,10 @@ class StubFormatter extends Formatter {
 		return "";
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected async getMacroValue(): Promise<string> {
 		return "";
 	}


### PR DESCRIPTION
## Problem

`master` is currently failing CI (`build-with-lint` -> `tsc -noEmit`). Two PRs that were each green in isolation collide:

- #1357 (`{{FILE:}}` token) added the abstract method `Formatter.suggestForFile`.
- #387 (`{{linksection}}` token) added a `StubFormatter` in `formatter-linksection.test.ts` that predates that method.

Together, `tsc -noEmit` fails:

```
src/formatters/formatter-linksection.test.ts(8,7): error TS2515: Non-abstract class 'StubFormatter' does not implement inherited abstract member suggestForFile from class 'Formatter'.
```

This breaks `pnpm run build` and `pnpm run build-with-lint` (and the CI Build+Lint job) on master.

## Fix

Implement the missing stub method, mirroring the sibling `formatter-linkcurrent.test.ts` stub:

```ts
protected suggestForFile(): string {
    return "";
}
```

Test-only change; no runtime/user-facing impact (and `test:` so it does not trigger a release).

## Verification

- `pnpm exec tsc -noEmit -skipLibCheck` -> exit 0
- `pnpm run build` -> tsc + esbuild succeed, `main.js`/`styles.css` produced
- `pnpm exec vitest run src/formatters/formatter-linksection.test.ts` -> 5/5 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to ensure proper code quality assurance and compatibility with base requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->