### PR TITLE
docs: cover 5 shipped-but-undocumented features (#1013)

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -44,6 +44,16 @@ folders. The picker also accepts custom input, so you can type a new file name
 or path and let QuickAdd create it when **Create file if it doesn't exist** is
 enabled. The picker still needs at least one matching Markdown file to open.
 
+The list is ordered like Obsidian's Quick Switcher: notes you opened most
+recently appear first (this session first, then your recent-files history), then
+everything else alphabetically. Ordering deliberately ignores modification time,
+so a sync or import that touches old notes does not push them to the top. Files
+in Obsidian's **Excluded files** list sink to the bottom but stay selectable.
+When **Create file if it doesn't exist** is enabled, a **Create new note:
+&lt;name&gt;** row lets you create a note from what you typed; it is hidden when
+the typed name already matches a note in scope, so typing an existing name
+selects that note instead of offering a duplicate.
+
 ### Capturing to folders
 
 You can also type a **folder name** into the _Capture To_ field, and QuickAdd will ask you which file in the folder you'd like to capture to.

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -109,6 +109,8 @@ Example:
 {{VALUE:summary|type:multiline|label:Summary}}
 ```
 
+**Keyboard:** In the multi-line prompt, pressing **Tab** inserts a tab character at the cursor (handy for nested Markdown lists) instead of moving focus; with text selected, Tab indents every line the selection touches. **Shift+Tab** is left unbound, so it still moves focus out of the field.
+
 ## `{{VALUE|case:<style>}}` / `{{NAME|case:<style>}}` / `{{VALUE:<variable>|case:<style>}}` {#value-case}
 
 Transforms the resolved value into a casing style. Supported: `kebab`, `snake`, `camel`, `pascal`, `title`, `lower`, `upper`, `slug`.
@@ -139,6 +141,8 @@ Notes:
 - `|name` combines with the other options, e.g. `{{VALUE:🔽,🔼,⏫|name:priority|text:Low,Normal,High|label:Pick a priority}}`.
 - Within a single field the order is free — the definition and its `{{VALUE:category}}` reuses can appear in any order, because the named suggester is resolved before the field's other prompts. Across fields in the default one-prompt-at-a-time flow, define the named suggester in the field that is resolved first (the file name is resolved before the body); a reuse in an earlier field than its definition falls back to a text prompt. The one-page input form (Settings → QuickAdd) removes this caveat entirely.
 - `value` and `title` are reserved and can't be used as a name.
+- Names match **case-insensitively**: `{{VALUE:Category}}` reuses a value picked at `{{VALUE:...|name:category}}`.
+- **First definition wins.** If you reuse the same `|name` with a different definition (different options, or a different `|custom` / `|text:` setting) in one run, the first definition's chosen value is reused for the rest — the later definition is not shown (a warning is logged to the developer console). Use distinct names if you want separate prompts.
 
 ## Optional fields: `|optional` {#optional-fields}
 
@@ -231,7 +235,7 @@ Example: `{{TEMPLATE:Templates/Meeting.md}}`.
 
 ## `{{GLOBAL_VAR:<name>}}` {#global-var}
 
-Inserts the value of a globally defined snippet from QuickAdd settings. Snippet values can include other QuickAdd tokens (e.g., `{{VALUE:...}}`, `{{VDATE:...}}`) and are processed by the usual formatter passes. Names match case‑insensitively in the token.
+Inserts the value of a globally defined snippet from QuickAdd settings. Snippet values can include other QuickAdd tokens (e.g., `{{VALUE:...}}`, `{{VDATE:...}}`) and are processed by the usual formatter passes. The `GLOBAL_VAR` keyword itself is case‑insensitive, but the snippet name must match the name you defined (it is case‑sensitive).
 
 Example: `{{GLOBAL_VAR:Meeting Header}}`.
 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -155,6 +155,8 @@ Opens a wider prompt for longer text input (multi-line).
 
 **Returns:** Promise resolving to the entered string. Cancelling rejects with `MacroAbortError` (same as `inputPrompt`).
 
+**Keyboard:** Pressing **Tab** inserts a tab character at the cursor (handy for nested Markdown lists) instead of moving focus; with text selected, Tab indents every line the selection touches. **Shift+Tab** still moves focus out of the field. See [multi-line input](./FormatSyntax.md#value-multiline).
+
 **Example:**
 ```javascript
 const description = await quickAddApi.wideInputPrompt(

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -48,5 +48,5 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 ## Command icons
 
-- **Automatic command icons** — When you turn a choice into a command (the ⚡ icon next to it), QuickAdd gives that command an icon based on the choice type — Template a document, Capture a pencil, Macro a terminal, Multi a folder — so the command palette and the mobile editing toolbar show a meaningful glyph instead of a generic `?`. The icons are automatic; there is no setting for them.
+- **Automatic command icons** — When you turn a choice into a command (the ⚡ icon next to it), QuickAdd gives that command an icon based on the choice type — `file-text` for Template, `pencil` for Capture, `terminal` for Macro, and `folder` for Multi — so the command palette and the mobile editing toolbar show a meaningful glyph instead of a generic `?`. The icons are automatic; there is no setting for them.
 - **Override a choice's icon** — Add an `icon` field with any [Lucide](https://lucide.dev) icon id (for example `"icon": "star"`) to that choice in `data.json`, then reload Obsidian so the command re-registers with the new icon. There is currently no in-app control for this; edit `data.json` while the plugin is disabled, since QuickAdd rewrites the file when settings change.

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -24,7 +24,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 ## Templates & Properties
 
-- **Template Folder Path** — Path to the folder where templates are stored. Used to suggest template files when configuring QuickAdd.
+- **Template folder paths** — Folders where templates are stored, used to suggest template files when configuring QuickAdd. Add as many folders as you like: type a folder (with autocomplete) and press **Add** or Enter, then remove one with its row's trash button. Leave the list empty to suggest every template file in the vault. Note that an empty list also disables the **New note from template** launcher row and command, which need at least one configured folder.
 - **Convert string front matter variables to typed properties (Beta)** — List/object values from scripts are **always** written as proper Obsidian properties (a list value becomes a List property), so templates produce valid front matter out of the box. This toggle **additionally** converts string values into typed properties: a comma or bullet-list string becomes a List, `"42"` becomes a Number, `"true"` becomes a Checkbox, etc. Disabled by default; the string conversion is a beta heuristic that may have edge cases. See [Template Property Types (Beta)](./TemplatePropertyTypes).
 
 ## Notifications
@@ -40,7 +40,13 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 ## AI & Online
 
 - **Disable AI & Online features** — This prevents the plugin from making requests to external providers like OpenAI. You can still use User Scripts to execute arbitrary code, including contacting external providers. However, this setting disables plugin features like the AI Assistant from doing so. You need to disable this setting to use the AI Assistant. See [AI Assistant](./AIAssistant).
+- **Allow URI x-callback-url** — Off by default, because the callback URL is set by whoever creates the `obsidian://` link and a successful callback can carry the affected note's vault path. When on, an `obsidian://quickadd` URI may open a callback URL (`x-success` / `x-error` / `x-cancel`) after a Template or Capture choice finishes, sending the outcome (and, on success, the note's vault path and URL) to that callback. Only `shortcuts:` and `obsidian:` callback URLs are permitted. See [Obsidian URI](./Advanced/ObsidianUri).
 
 ## Appearance
 
 - **Show icon in sidebar** — Add QuickAdd icon to the sidebar ribbon. Requires a reload.
+
+## Command icons
+
+- **Automatic command icons** — When you turn a choice into a command (the ⚡ icon next to it), QuickAdd gives that command an icon based on the choice type — Template a document, Capture a pencil, Macro a terminal, Multi a folder — so the command palette and the mobile editing toolbar show a meaningful glyph instead of a generic `?`. The icons are automatic; there is no setting for them.
+- **Override a choice's icon** — Add an `icon` field with any [Lucide](https://lucide.dev) icon id (for example `"icon": "star"`) to that choice in `data.json`, then reload Obsidian so the command re-registers with the new icon. There is currently no in-app control for this; edit `data.json` while the plugin is disabled, since QuickAdd rewrites the file when settings change.


### PR DESCRIPTION
## What

Coverage follow-up to the #1013 docs UI-drift audit (PR #1329, merged). An ultracode 29-feature sweep cross-checked `docs/docs` against every recently shipped feature: **24/29 were already covered** (FormatSyntax.md in particular is excellent), and an adversarial verify pass confirmed **5 real gaps**. This PR fills them. Every gap shipped *after* the 2.13.1 release, so the edits are in `docs/docs` (Next) **only** — the frozen `version-2.13.1` snapshot is correctly untouched.

## Gaps closed

| Feature | PR | Doc fix |
| --- | --- | --- |
| Multiple template folder paths | #1325 | `Settings.md`: stale singular **"Template Folder Path"** → the **"Template folder paths"** list (add/remove, empty-list behaviour + its effect on the launcher) |
| Tab in multi-line prompt | #764 | `FormatSyntax.md` (`#value-multiline`) + `QuickAddAPI.md` (`wideInputPrompt`): Tab inserts/indents, Shift+Tab moves focus |
| Command icons | #766/#1342 | `Settings.md` new **Command icons** section: per-type defaults + the `data.json` `icon` override |
| Named suggester edge cases | #148/#1336 | `FormatSyntax.md`: name reuse is case-insensitive and first-write-wins |
| Note-picker recency ordering | #745/#539/#1335 | `CaptureChoice.md`: Quick-Switcher ordering, Excluded-files sink, "Create new note" row |

Plus two opportunistic accuracy fixes while in the files:
- `Settings.md`: documented the **"Allow URI x-callback-url"** toggle (a real AI & Online control the page was missing), with its off-by-default security rationale.
- `FormatSyntax.md`: corrected a **pre-existing** `{{GLOBAL_VAR}}` note — the *keyword* is case-insensitive but the snippet *name* is case-sensitive (`completeFormatter.ts` does a plain object lookup).

## Verification

- Every claim was grounded in source and then checked by an adversarial verification workflow (accuracy-vs-source, completeness, style, links, version targeting). All findings from that pass are folded in — including dropping a wrong "same rule as `{{GLOBAL_VAR}}`" cross-reference and broadening the named-suggester conflict trigger.
- `cd docs && pnpm build` succeeds with no broken-link errors.
- Version targeting confirmed: all six feature commits post-date the 2.13.1 tag; no `versioned_docs` files touched.

Refs #1013. Does not close it on its own, but clears the audit's remaining "document new settings/options" tail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated capture choice documentation with Quick Switcher-like ordering details and “create new note” row behavior.
  * Enhanced format syntax guide with multiline input keyboard behavior, case-insensitive named suggester matching, and global variable casing rules.
  * Added keyboard behavior notes for text input prompts.
  * Expanded settings documentation with support for multiple template folders, URI callback configuration guidance, and command icon customization (including override via `data.json`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->