### PR TITLE
feat(capture): ordered create-if-not-found location for reverse-chrono logs (#481)

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -268,7 +268,75 @@ You can see an explanation of these below.
 I use this in my daily journal capture, where I insert after the heading line `## What did I do today?`.
 
 It's also possible to use `Create line if not found`, which will create the line if it doesn't exist. This is useful if you want to insert after a line that might not exist in the file you're capturing to.
-This setting can place the line at the start or end of the file, or at your current cursor position.
+This setting can place the created line at the **Top** or **Bottom** of the file, at your **Cursor** position, or **Ordered** — at its sorted position among same-level headings. See [Ordered section placement](#ordered-section-placement) for reverse-chronological daily logs, changelogs, and other sorted sections.
+
+### Ordered section placement
+
+When `Create line if not found` is enabled and its location dropdown is set to **Ordered** (the full label is `Ordered (place new section among siblings)`), a missing "Insert after" heading is created at its **sorted position among same-level sibling headings** instead of at the top or bottom of the note. This is the building block for a reverse-chronological log: a new dated section is added above older ones, while a fixed title/intro stays pinned at the top.
+
+This is the recipe for the classic "daily log, newest first" note (issue [#481](https://github.com/chhoumann/quickadd/issues/481)):
+
+-   **Capture to**: your log note (enable `Create file if it doesn't exist` if you want it auto-created).
+-   **Format**: the entry, ending with a newline, e.g. `- {{TIME:HH:mm}} {{VALUE}}\n`. The trailing newline (or enabling `Capture as task`) is what keeps multiple entries on the same day on separate lines — without it, repeated same-day captures run together on one line.
+-   **Insert after**: the day heading, `## {{DATE:YYYY-MM-DD}}`.
+-   **Insert at end of section**: off, so each new entry lands directly under the day heading (newest entry on top within the day).
+-   **Create line if not found**: on, with the location set to **Ordered**, **Sort sections by** = `Date`, and **Section order** = `Newest / highest first`.
+
+Running it on consecutive days (and twice on the same day) produces:
+
+```markdown
+# My Daily Log
+
+A short intro that always stays at the top.
+
+## 2026-06-16
+- 09:40 reviewed the code
+- 09:13 started the design
+
+## 2026-06-14
+- 09:00 older entry
+```
+
+The first capture of a day creates `## 2026-06-16` directly below the intro and above `## 2026-06-14`; later captures that day find the existing heading and add their entry on top. The `# My Daily Log` title stays put because it is a different heading level (only `##` headings are sorted against each other), and any YAML frontmatter is skipped entirely — it is never treated as a heading, even if it contains `#` lines.
+
+#### Sort options
+
+Once `Create line if not found` is on and its location is **Ordered**, these controls appear (the last two only for the sort keys noted):
+
+-   **Sort sections by** — how the sort key is read from each heading's text:
+    -   `Insertion order (no sorting)` — newest-first simply prepends the new section above the others; oldest-first appends it below. No parsing.
+    -   `Text (A→Z)` — case-insensitive text compare.
+    -   `Number` — the leading number in the heading (e.g. `## 12 Project X`).
+    -   `Date` — parsed with a **Date format** (shown only for this key; auto-detected from the `{{DATE:…}}` token in your "Insert after" text, and editable). Trailing decoration like `## 2026-06-14 (Friday)` is ignored.
+    -   `Version (semver)` — `major.minor.patch`, so `1.10.0` correctly sorts above `1.9.0`. A leading `v` and the Keep a Changelog `## [1.10.0] - 2026-06-16` bracket form are both understood.
+-   **Section order** — `Newest / highest first` (descending) or `Oldest / lowest first` (ascending).
+-   **Existing unparseable headings** — shown for the `Date`, `Number`, and `Version (semver)` keys: where to rank existing headings whose text can't be parsed for the chosen key (e.g. an `## Unreleased` heading in a versioned changelog) — `Sort existing unparseable headings to bottom` (default) or `…to top`. A new heading that can't be parsed is always appended at the end.
+
+Use **Insert at end of section** (above) to control the order *within* each section: off = newest entry on top (good for date logs), on = entries appended at the section end (good for changelogs).
+
+#### More examples
+
+A changelog, newest version on top — **Insert after** `## {{VALUE:version}}`, **Format** `- {{VALUE:change}}\n`, **Insert at end of section** on (new changes append below earlier ones in the same version), **Create line if not found** on → **Ordered**, **Sort by** `Version (semver)`, **Order** `Newest / highest first`:
+
+```markdown
+# Changelog
+
+## 1.10.0
+- new feature
+- another fix in 1.10.0
+
+## 1.9.0
+- old fix
+```
+
+A "books read" note grouped by year — **Insert after** `## {{DATE:YYYY}}`, **Format** `- {{VALUE}}\n`, **Create line if not found** on → **Ordered**, **Sort by** `Date` with **Date format** `YYYY`, **Order** `Newest / highest first`.
+
+#### Notes and limits
+
+-   The heading is created **once** and reused: every later capture finds it, so the section is never duplicated. This relies on the heading resolving to the **same text** each time, so use a stable token (`{{DATE:…}}`, a `{{VALUE:…}}` you supply) — not a random or constantly-changing one.
+-   Sorting is over **all same-level headings in the note**; it is not scoped to one parent section. For the layouts above (a single group of dated/versioned `##` sections under one title) this is exactly what you want. Keep the fixed title/intro at a different heading level (e.g. an `#` title above `##` sections) so it is never treated as a sortable sibling.
+-   Ordered placement only positions the **new** section; it does not re-sort sections you already have.
+-   **Ordered** is for headings and can't be combined with **Inline insertion**.
 
 ### Choose heading when capturing
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -104,6 +104,9 @@ export const NUMBER_REGEX = new RegExp(/^-?[0-9]*$/);
 export const CREATE_IF_NOT_FOUND_TOP = "top";
 export const CREATE_IF_NOT_FOUND_BOTTOM = "bottom";
 export const CREATE_IF_NOT_FOUND_CURSOR = "cursor";
+// "ordered": create a missing insert-after heading at its sorted position among
+// same-level sibling headings (issue #481). Joins TOP/BOTTOM/CURSOR.
+export const CREATE_IF_NOT_FOUND_ORDERED = "ordered";
 
 // == Format Syntax == //
 export const DATE_REGEX = new RegExp(/{{DATE(\+-?[0-9]+)?}}/i);

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -15,6 +15,7 @@ import type { IChoiceExecutor } from "../IChoiceExecutor";
 import {
 	BASE_FILE_EXTENSION_REGEX,
 	CANVAS_FILE_EXTENSION_REGEX,
+	CREATE_IF_NOT_FOUND_ORDERED,
 	MARKDOWN_FILE_EXTENSION_REGEX,
 	QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
 	VALUE_SYNTAX,
@@ -98,6 +99,24 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		this.choice = choice;
 		this.plugin = plugin;
 		this.formatter = new CaptureChoiceFormatter(app, plugin, choiceExecutor);
+	}
+
+	/**
+	 * For ordered captures (the "ordered" create-if-not-found location), copy the
+	 * formatter's resolved insert-after heading (e.g. `## 2026-06-16`) so the
+	 * success notice names the real heading instead of the raw `{{DATE:…}}` token.
+	 * Called after the format pass; a no-op for every other capture (so existing
+	 * insert-after notice behaviour is unchanged).
+	 */
+	private captureResolvedOrderedHeading(): void {
+		if (
+			this.choice.insertAfter?.enabled &&
+			this.choice.insertAfter.createIfNotFoundLocation ===
+				CREATE_IF_NOT_FOUND_ORDERED
+		) {
+			const resolved = this.formatter.getResolvedInsertAfterHeading();
+			if (resolved) this.resolvedInsertAfterHeading = resolved;
+		}
 	}
 
 	private showSuccessNotice(
@@ -325,6 +344,8 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			const { file, newFileContent, captureContent } =
 				await getFileAndAddContentFn(filePath, content);
 
+			this.captureResolvedOrderedHeading();
+
 			// Handle capture to active file with special actions
 			if (isEditorInsertionAction) {
 				// Parse Templater syntax in the capture content.
@@ -462,6 +483,8 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			existingText,
 			file,
 		);
+
+		this.captureResolvedOrderedHeading();
 
 		await setCanvasTextCaptureContent(this.app, target, nextText);
 

--- a/src/formatters/captureChoiceFormatter-481-ordered.test.ts
+++ b/src/formatters/captureChoiceFormatter-481-ordered.test.ts
@@ -1,0 +1,487 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import type { SectionOrdering } from "../types/choices/ICaptureChoice";
+
+// Mocks mirror captureChoiceFormatter-742-multiline-insert.test.ts so the
+// formatter can run under jsdom without real Obsidian/Templater.
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory() {
+			return {
+				Prompt: vi.fn().mockResolvedValue(""),
+				PromptWithContext: vi.fn().mockResolvedValue(""),
+			} as any;
+		}
+	},
+}));
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: class {
+		constructor() {}
+	},
+}));
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../utils/errorUtils", () => ({
+	__esModule: true,
+	reportError: vi.fn(),
+	isCancellationError: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+	},
+}));
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+vi.mock("../main", () => ({
+	__esModule: true,
+	default: class QuickAdd {
+		static instance = {
+			settings: { inputPrompt: "single-line" },
+			app: {
+				workspace: { getActiveViewOfType: vi.fn().mockReturnValue(null) },
+			},
+		};
+		settings = QuickAdd.instance.settings;
+		app = QuickAdd.instance.app;
+	},
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+/**
+ * A real-enough lenient date parser injected as window.moment so the date sort is
+ * exercised end-to-end through the formatter (the obsidian-stub moment is a no-op
+ * with no valueOf). Supports the formats used below; leniently matches the leading
+ * date and ignores trailing decoration.
+ */
+function installFakeMoment() {
+	const fake = (input: string, format?: string) => {
+		let value = Number.NaN;
+		if (format === "YYYY-MM-DD") {
+			const m = input.match(/^(\d{4})-(\d{2})-(\d{2})/);
+			if (m) value = Date.UTC(+m[1], +m[2] - 1, +m[3]);
+		} else {
+			const m = input.match(/^(\d{4})-(\d{2})-(\d{2})/);
+			if (m) value = Date.UTC(+m[1], +m[2] - 1, +m[3]);
+		}
+		return { isValid: () => !Number.isNaN(value), valueOf: () => value };
+	};
+	(global as any).window = { ...(global as any).window, moment: fake };
+}
+
+const baseInsertAfter = {
+	enabled: true,
+	after: "## Section",
+	insertAtEnd: false,
+	considerSubsections: false,
+	createIfNotFound: true,
+	createIfNotFoundLocation: "ordered",
+	inline: false,
+	replaceExisting: false,
+	blankLineAfterMatchMode: "auto" as const,
+	orderBy: {
+		by: "insertion",
+		direction: "desc",
+		unparseable: "bottom",
+	} as SectionOrdering,
+};
+
+const createChoice = (
+	insertAfterOverrides: Partial<typeof baseInsertAfter> = {},
+	overrides: Partial<ICaptureChoice> = {},
+): ICaptureChoice =>
+	({
+		id: "test",
+		name: "Test Choice",
+		type: "Capture",
+		command: false,
+		captureTo: "Target.md",
+		captureToActiveFile: false,
+		captureToCanvasNodeId: "",
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: false,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: false, format: "" },
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: {
+			...baseInsertAfter,
+			...insertAfterOverrides,
+			orderBy: {
+				...baseInsertAfter.orderBy,
+				...(insertAfterOverrides.orderBy ?? {}),
+			},
+		},
+		insertBefore: {
+			enabled: false,
+			before: "",
+			createIfNotFound: false,
+			createIfNotFoundLocation: "top",
+		},
+		newLineCapture: { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: true,
+		},
+		...overrides,
+	}) as ICaptureChoice;
+
+const createMockApp = (): App =>
+	({
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(null),
+		},
+		metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		fileManager: {
+			generateMarkdownLink: vi.fn().mockReturnValue(""),
+			processFrontMatter: vi.fn(),
+		},
+		vault: { adapter: { exists: vi.fn() }, cachedRead: vi.fn() },
+	}) as unknown as App;
+
+const createFile = (path = "Target.md"): TFile =>
+	({
+		path,
+		name: path.split("/").pop() ?? path,
+		basename: (path.split("/").pop() ?? path).replace(/\.(md|canvas)$/i, ""),
+		extension: "md",
+	}) as unknown as TFile;
+
+const createFormatter = () =>
+	new CaptureChoiceFormatter(createMockApp(), {
+		settings: {
+			inputPrompt: "single-line",
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any);
+
+async function runOnce(
+	choice: ICaptureChoice,
+	content: string,
+	capture: string,
+): Promise<string> {
+	const formatter = createFormatter();
+	return formatter.formatContentWithFile(capture, choice, content, createFile());
+}
+
+/** Feed each run's output back as the next run's content (real repeat-capture). */
+async function runCaptures(
+	choice: ICaptureChoice,
+	seed: string,
+	captures: string[],
+): Promise<string> {
+	let content = seed;
+	for (const capture of captures) {
+		content = await runOnce(choice, content, capture);
+	}
+	return content;
+}
+
+const count = (haystack: string, needle: string) =>
+	haystack.split(needle).length - 1;
+
+beforeEach(() => {
+	(global as any).navigator = {
+		clipboard: { readText: vi.fn().mockResolvedValue("") },
+	};
+	installFakeMoment();
+});
+
+describe("#481 — ordered create-if-not-found placement", () => {
+	it("pins an H1 + blurb preamble above a newly created section (desc)", async () => {
+		const choice = createChoice({
+			after: "## NEW",
+			orderBy: { by: "insertion", direction: "desc", unparseable: "bottom" },
+		});
+		const seed = "# My Daily Log\n\nA running journal.\n\n## OLD\n- old\n";
+		const out = await runOnce(choice, seed, "- new entry\n");
+		expect(out).toBe(
+			"# My Daily Log\n\nA running journal.\n\n## NEW\n- new entry\n\n## OLD\n- old\n",
+		);
+	});
+
+	it("creates the first-ever section after the preamble, blurb stays above", async () => {
+		const choice = createChoice({
+			after: "## TODAY",
+			orderBy: { by: "insertion", direction: "desc", unparseable: "bottom" },
+		});
+		const seed = "# My Daily Log\n\nA running journal.\n";
+		const out = await runOnce(choice, seed, "- first entry\n");
+		expect(out).toBe(
+			"# My Daily Log\n\nA running journal.\n\n## TODAY\n- first entry\n",
+		);
+	});
+
+	it("is idempotent and newest-on-top within a section across repeated captures", async () => {
+		const choice = createChoice({
+			after: "## Log",
+			insertAtEnd: false,
+			orderBy: { by: "insertion", direction: "desc", unparseable: "bottom" },
+		});
+		const seed = "# Title\n\nblurb\n";
+		const out = await runCaptures(choice, seed, [
+			"- first\n",
+			"- second\n",
+			"- third\n",
+		]);
+		// Header created exactly once; entries newest-first directly under it.
+		expect(count(out, "## Log")).toBe(1);
+		expect(out).toBe(
+			"# Title\n\nblurb\n\n## Log\n- third\n- second\n- first\n",
+		);
+	});
+
+	it("date desc places a newer ISO day above an existing older day (real {{DATE}} path uses window.moment)", async () => {
+		// Use literal date headings (the stub resolves {{DATE}} to a constant, so we
+		// drive distinct dates literally; window.moment does the real comparison).
+		const choice = createChoice({
+			after: "## 2026-06-16",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed =
+			"# My Daily Log\n\nblurb\n\n## 2026-06-14\n- older entry\n";
+		const out = await runOnce(choice, seed, "- new entry\n");
+		expect(out).toBe(
+			"# My Daily Log\n\nblurb\n\n## 2026-06-16\n- new entry\n\n## 2026-06-14\n- older entry\n",
+		);
+	});
+
+	it("date desc inserts a middle day in its chronological slot", async () => {
+		const choice = createChoice({
+			after: "## 2026-06-12",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed =
+			"# Log\n\n## 2026-06-16\n- a\n\n## 2026-06-10\n- b\n";
+		const out = await runOnce(choice, seed, "- mid\n");
+		expect(out).toBe(
+			"# Log\n\n## 2026-06-16\n- a\n\n## 2026-06-12\n- mid\n\n## 2026-06-10\n- b\n",
+		);
+	});
+
+	it("preserves CRLF and finds CRLF siblings", async () => {
+		const choice = createChoice({
+			after: "## 2026-06-16",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed =
+			"# Log\r\n\r\n## 2026-06-14\r\n- older\r\n";
+		const out = await runOnce(choice, seed, "- new\n");
+		// New section placed above the older one; existing CRLF bytes preserved.
+		expect(out).toBe(
+			"# Log\r\n\r\n## 2026-06-16\r\n- new\r\n\r\n## 2026-06-14\r\n- older\r\n",
+		);
+		expect(out).not.toContain("## 2026-06-16\n"); // not a lone LF among CRLF
+	});
+
+	it("asc appends a new section after the band (oldest/lowest first)", async () => {
+		const choice = createChoice({
+			after: "## C",
+			insertAtEnd: true,
+			orderBy: { by: "lexical", direction: "asc", unparseable: "bottom" },
+		});
+		const seed = "# Items\n\n## A\n- a\n\n## B\n- b\n";
+		const out = await runOnce(choice, seed, "- c\n");
+		expect(out).toBe("# Items\n\n## A\n- a\n\n## B\n- b\n\n## C\n- c\n");
+	});
+
+	it("never splices into YAML frontmatter (H1 ordered choice with a '#' comment in frontmatter)", async () => {
+		const choice = createChoice({
+			after: "# 2026",
+			orderBy: { by: "insertion", direction: "desc", unparseable: "bottom" },
+		});
+		// A frontmatter line "# my yaml comment" matches the ATX heading regex.
+		const seed = "---\n# my yaml comment\ntags: x\n---\n# Title\nblurb\n";
+		const out = await runOnce(choice, seed, "- entry\n");
+		// Frontmatter block stays intact; the new H1 lands in the body (above "# Title").
+		expect(out).toContain("---\n# my yaml comment\ntags: x\n---\n");
+		expect(out).toBe(
+			"---\n# my yaml comment\ntags: x\n---\n\n# 2026\n- entry\n\n# Title\nblurb\n",
+		);
+	});
+
+	it("places the first dated section after frontmatter, not above it", async () => {
+		const choice = createChoice({
+			after: "## 2026-06-16",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed = "---\ntype: log\n---\n# My Daily Log\n\nblurb\n";
+		const out = await runOnce(choice, seed, "- entry\n");
+		expect(out).toBe(
+			"---\ntype: log\n---\n# My Daily Log\n\nblurb\n\n## 2026-06-16\n- entry\n",
+		);
+	});
+
+	it("does not normalize a mixed-EOL file's existing line endings", async () => {
+		const choice = createChoice({
+			after: "## 2026-06-16",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		// One CRLF line ("## 2026-06-14\r\n") amid otherwise-LF content.
+		const seed = "# Log\n\n## 2026-06-14\r\n- old\n";
+		const out = await runOnce(choice, seed, "- new\n");
+		// Existing LF lines stay LF; the existing CRLF line stays CRLF; only the
+		// inserted lines adopt the dominant (CRLF) ending.
+		expect(out).toBe(
+			"# Log\n\n## 2026-06-16\r\n- new\r\n\r\n## 2026-06-14\r\n- old\n",
+		);
+		expect(out).toContain("# Log\n\n"); // not flipped to CRLF
+		expect(out).toContain("- old\n"); // trailing LF line preserved
+	});
+
+	it("does not duplicate a heading when a multi-line anchor's tail is missing (idempotency)", async () => {
+		// Multi-line anchor: heading + a "**Tasks**" sub-line. The note already has a
+		// bare "## 2026-06-16" (e.g. from another source) WITHOUT the **Tasks** line,
+		// so the full-block search reports "not found". Ordered create must NOT add a
+		// second "## 2026-06-16"; it inserts the entry under the existing heading.
+		const choice = createChoice({
+			after: "## 2026-06-16\\n**Tasks**",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed = "# Log\n\n## 2026-06-16\n- existing\n";
+		const out = await runOnce(choice, seed, "- new\n");
+		expect(count(out, "## 2026-06-16")).toBe(1);
+		expect(out).toBe("# Log\n\n## 2026-06-16\n- new\n- existing\n");
+	});
+
+	it("does not treat a fenced '## …' as the existing heading (dedup guard is fence-aware)", async () => {
+		// Multi-line anchor; the only "## 2026-06-16" in the note is inside a code
+		// fence. The dedup guard must NOT match it (which would insert into the code
+		// block) — it should create a real sorted section instead.
+		const choice = createChoice({
+			after: "## 2026-06-16\\n**Tasks**",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed =
+			"# Log\n\n```md\n## 2026-06-16\n```\n\n## 2026-06-14\n- old\n";
+		const out = await runOnce(choice, seed, "- new\n");
+		// The fenced block is untouched; a real section is created before 06-14.
+		expect(out).toContain("```md\n## 2026-06-16\n```");
+		expect(count(out, "**Tasks**")).toBe(1);
+		expect(out).toBe(
+			"# Log\n\n```md\n## 2026-06-16\n```\n\n## 2026-06-16\n**Tasks**\n- new\n\n## 2026-06-14\n- old\n",
+		);
+	});
+
+	it("appends at EOF of a CRLF file with no trailing newline without a dangling CR", async () => {
+		const choice = createChoice({
+			after: "## 1.9.0",
+			insertAtEnd: true,
+			orderBy: { by: "semver", direction: "desc", unparseable: "bottom" },
+		});
+		// CRLF file, NO trailing newline, append an older version at EOF.
+		const seed = "# Changelog\r\n\r\n## 2.0.0\r\n- big";
+		const out = await runOnce(choice, seed, "- old\n");
+		expect(out).toBe(
+			"# Changelog\r\n\r\n## 2.0.0\r\n- big\r\n\r\n## 1.9.0\r\n- old",
+		);
+		expect(out).not.toMatch(/\r(?!\n)/); // no bare CR not followed by LF
+	});
+
+	it("does not duplicate the header on the second same-day run (found-path)", async () => {
+		const choice = createChoice({
+			after: "## 2026-06-16",
+			insertAtEnd: false,
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed = "# Log\n\n## 2026-06-14\n- old\n";
+		const out = await runCaptures(choice, seed, ["- first\n", "- second\n"]);
+		expect(count(out, "## 2026-06-16")).toBe(1);
+		expect(out).toBe(
+			"# Log\n\n## 2026-06-16\n- second\n- first\n\n## 2026-06-14\n- old\n",
+		);
+	});
+});

--- a/src/formatters/captureChoiceFormatter-481-ordered.test.ts
+++ b/src/formatters/captureChoiceFormatter-481-ordered.test.ts
@@ -451,6 +451,49 @@ describe("#481 — ordered create-if-not-found placement", () => {
 		);
 	});
 
+	it("ignores a single-line target that only exists inside a code fence (creates the real section)", async () => {
+		// The note's only "## 2026-06-16" is inside a fenced example. A single-line
+		// ordered target must NOT match it (which would insert into the code block);
+		// it should create a real sorted section above ## 2026-06-14.
+		const choice = createChoice({
+			after: "## 2026-06-16",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		const seed =
+			"# Log\n\n```markdown\n## 2026-06-16\n- example\n```\n\n## 2026-06-14\n- old\n";
+		const out = await runOnce(choice, seed, "- new\n");
+		expect(out).toContain("```markdown\n## 2026-06-16\n- example\n```");
+		expect(out).toBe(
+			"# Log\n\n```markdown\n## 2026-06-16\n- example\n```\n\n## 2026-06-16\n- new\n\n## 2026-06-14\n- old\n",
+		);
+	});
+
+	it("ignores a single-line target that only exists in frontmatter (creates the real section)", async () => {
+		const choice = createChoice({
+			after: "## 2026-06-16",
+			orderBy: {
+				by: "date",
+				direction: "desc",
+				dateFormat: "YYYY-MM-DD",
+				unparseable: "bottom",
+			},
+		});
+		// A frontmatter value literally equal to the target heading line.
+		const seed =
+			"---\nheading: '## 2026-06-16'\n---\n# Log\n\n## 2026-06-14\n- old\n";
+		const out = await runOnce(choice, seed, "- new\n");
+		// Frontmatter untouched; real section created in the body.
+		expect(out).toContain("---\nheading: '## 2026-06-16'\n---\n");
+		expect(out).toBe(
+			"---\nheading: '## 2026-06-16'\n---\n# Log\n\n## 2026-06-16\n- new\n\n## 2026-06-14\n- old\n",
+		);
+	});
+
 	it("appends at EOF of a CRLF file with no trailing newline without a dangling CR", async () => {
 		const choice = createChoice({
 			after: "## 1.9.0",

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -538,10 +538,17 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		}
 
 		const fileContentLines: string[] = getLinesInString(this.fileContent);
-		const { start, end } = this.findInsertAfterRange(
-			fileContentLines,
-			targetLines,
-		);
+		// For ordered placement, the target search must ignore headings inside YAML
+		// frontmatter or fenced code blocks. Otherwise a sample/comment heading that
+		// happens to match (e.g. a `## 2026-06-16` in a ```markdown example) would be
+		// treated as "found" and the capture inserted there, bypassing the
+		// fence/frontmatter-aware ordered create path. Masking preserves line indices,
+		// so the found-path position math below stays valid. Non-ordered captures keep
+		// their existing (unmasked) search behaviour.
+		const searchLines = this.isOrderedCreate()
+			? this.maskNonBodyHeadingsForSearch(fileContentLines)
+			: fileContentLines;
+		const { start, end } = this.findInsertAfterRange(searchLines, targetLines);
 		const targetNotFound = start === -1;
 		if (targetNotFound) {
 			if (this.choice.insertAfter?.createIfNotFound) {
@@ -787,6 +794,42 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	 * A non-heading anchor has no sibling band, so it degrades gracefully to the
 	 * existing TOP behavior (parity with considerSubsectionsForAnchor).
 	 */
+	/** True when this capture uses the ordered create-if-not-found location. */
+	private isOrderedCreate(): boolean {
+		return (
+			!!this.choice.insertAfter?.createIfNotFound &&
+			this.choice.insertAfter?.createIfNotFoundLocation ===
+				CREATE_IF_NOT_FOUND_ORDERED
+		);
+	}
+
+	/**
+	 * Index of the first body line after any YAML frontmatter (0 when none).
+	 * Mirrors insertAtNoteBodyStart's frontmatter detection (getBodyStartOffset).
+	 */
+	private getBodyStartLine(): number {
+		const bodyStartOffset = getBodyStartOffset(this.fileContent);
+		return bodyStartOffset > 0
+			? this.fileContent.slice(0, bodyStartOffset).split("\n").length - 1
+			: 0;
+	}
+
+	/**
+	 * Returns CRLF-stripped lines with frontmatter lines blanked and fenced-code
+	 * headings neutralized, so the ordered target search never matches a heading
+	 * that isn't a real body section. Line indices are preserved.
+	 */
+	private maskNonBodyHeadingsForSearch(lines: string[]): string[] {
+		const bodyStartLine = this.getBodyStartLine();
+		const masked = maskFencedHeadings(lines).map((line) =>
+			line.replace(/\r$/, ""),
+		);
+		for (let i = 0; i < bodyStartLine && i < masked.length; i++) {
+			masked[i] = "";
+		}
+		return masked;
+	}
+
 	private createInsertAfterOrdered(
 		formatted: string,
 		targetString: string,
@@ -817,11 +860,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		// Exclude any YAML frontmatter so a `#`-prefixed YAML line is never treated
 		// as a sibling/ancestor and the new section can never be spliced into the
 		// frontmatter block (frontmatter detection mirrors insertAtNoteBodyStart).
-		const bodyStartOffset = getBodyStartOffset(this.fileContent);
-		const bodyStartLine =
-			bodyStartOffset > 0
-				? this.fileContent.slice(0, bodyStartOffset).split("\n").length - 1
-				: 0;
+		const bodyStartLine = this.getBodyStartLine();
 
 		// Idempotency guard for multi-line anchors: the block search (findInsertAfterRange)
 		// matches the WHOLE multi-line target, so a target like "## 2026-06-16\n**Tasks**"

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -3,6 +3,7 @@ import { getLinesInString } from "src/utility";
 import {
 	CREATE_IF_NOT_FOUND_BOTTOM,
 	CREATE_IF_NOT_FOUND_CURSOR,
+	CREATE_IF_NOT_FOUND_ORDERED,
 	CREATE_IF_NOT_FOUND_TOP,
 } from "../constants";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
@@ -12,7 +13,16 @@ import { reportError } from "../utils/errorUtils";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { CompleteFormatter } from "./completeFormatter";
 import getEndOfSection, { getMarkdownHeadings } from "./helpers/getEndOfSection";
-import { insertAtNoteBodyStart } from "../utils/noteContentInsertion";
+import {
+	computeOrderedSectionInsertIndex,
+	maskFencedHeadings,
+	type MomentLike,
+	type OrderedSlot,
+} from "./helpers/orderedSectionPlacement";
+import {
+	getBodyStartOffset,
+	insertAtNoteBodyStart,
+} from "../utils/noteContentInsertion";
 import { parentFolderPath } from "../utils/pathUtils";
 
 /**
@@ -50,6 +60,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		*/
 	private insertAfterTargetOverride: string | null = null;
 	/**
+	 * The resolved first-line heading of the insert-after target for this run
+	 * (e.g. `## 2026-06-16`, leading `#`s kept), captured once the token-driven
+	 * `after` string is resolved. The engine reads it (via
+	 * getResolvedInsertAfterHeading) to show `Captured to X under '## 2026-06-16'`
+	 * instead of the raw `{{DATE:…}}` token in the success notice for ordered
+	 * captures. Null until the non-inline/non-override block path resolves a
+	 * heading target.
+	 */
+	private lastResolvedInsertAfterHeading: string | null = null;
+	/**
 		* Tracks whether `\n` escapes in the capture format string have been expanded.
 		* Expansion must happen on the raw format template BEFORE token substitution,
 		* and only once per capture run: multi-stage flows pass already-substituted
@@ -84,6 +104,17 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		*/
 	public setInsertAfterTargetOverride(target: string | null): void {
 		this.insertAfterTargetOverride = target;
+	}
+
+	/**
+	 * The resolved insert-after heading line for this run, leading `#`s KEPT (e.g.
+	 * `## 2026-06-16`), or null if the target was not a resolved heading. Used by
+	 * the engine's success notice for ordered captures (see
+	 * lastResolvedInsertAfterHeading). The `#` form matches the notice's raw-token
+	 * fallback; do not strip it here without aligning the promptHeading path.
+	 */
+	public getResolvedInsertAfterHeading(): string | null {
+		return this.lastResolvedInsertAfterHeading;
 	}
 
 	protected shouldUseSelectionForValue(): boolean {
@@ -489,6 +520,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 				await this.expandFormatTemplateEscapes(this.choice.insertAfter.after),
 			));
 
+		// Record the resolved heading for the success notice (ordered captures show
+		// '## 2026-06-16' instead of the raw token). Token-driven path only; the
+		// promptHeading override sets its own notice text in the engine.
+		if (override === null) {
+			const firstLine = targetString.split("\n", 1)[0];
+			this.lastResolvedInsertAfterHeading = /^#+\s+\S/.test(firstLine)
+				? firstLine.trim()
+				: null;
+		}
+
 		const targetLines = this.toTargetLines(targetString);
 		if (this.isBlankTarget(targetLines)) {
 			throw new ChoiceAbortError(
@@ -726,9 +767,185 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			}
 		}
 
+		if (
+			this.choice.insertAfter?.createIfNotFoundLocation ===
+			CREATE_IF_NOT_FOUND_ORDERED
+		) {
+			return this.createInsertAfterOrdered(formatted, insertAfterLine);
+		}
+
 		throw new ChoiceAbortError(
 			`Unknown createIfNotFoundLocation: ${this.choice.insertAfter?.createIfNotFoundLocation}`,
 		);
+	}
+
+	/**
+	 * Create a missing insert-after heading at its sorted position among same-level
+	 * siblings (the "ordered" create-if-not-found location, issue #481). The
+	 * heading level and sort key come from the FIRST line of a (possibly multi-line
+	 * #742) anchor; CRLF is stripped for the line model, then re-applied on splice.
+	 * A non-heading anchor has no sibling band, so it degrades gracefully to the
+	 * existing TOP behavior (parity with considerSubsectionsForAnchor).
+	 */
+	private createInsertAfterOrdered(
+		formatted: string,
+		targetString: string,
+	): string {
+		const orderBy = this.choice.insertAfter?.orderBy ?? {
+			by: "insertion" as const,
+			direction: "desc" as const,
+			unparseable: "bottom" as const,
+		};
+
+		const firstLine = targetString.split(/\r?\n/, 1)[0];
+		const level = getMarkdownHeadings([firstLine])[0]?.level ?? 0;
+
+		// Reused verbatim so the created block is byte-identical to next-run's search
+		// target (the #742 round-trip invariant that keeps creation idempotent).
+		const payload = `${targetString}\n${formatted}`;
+
+		// Non-heading anchor: ordered placement is meaningless → graceful TOP degrade.
+		if (level === 0) {
+			return insertAtNoteBodyStart(this.fileContent, payload);
+		}
+
+		// CRLF-safe line model: the helper detects headings on \r-stripped lines;
+		// the splice happens on the original lines to preserve EOL bytes.
+		const rawLines = getLinesInString(this.fileContent);
+		const lines = rawLines.map((line) => line.replace(/\r$/, ""));
+
+		// Exclude any YAML frontmatter so a `#`-prefixed YAML line is never treated
+		// as a sibling/ancestor and the new section can never be spliced into the
+		// frontmatter block (frontmatter detection mirrors insertAtNoteBodyStart).
+		const bodyStartOffset = getBodyStartOffset(this.fileContent);
+		const bodyStartLine =
+			bodyStartOffset > 0
+				? this.fileContent.slice(0, bodyStartOffset).split("\n").length - 1
+				: 0;
+
+		// Idempotency guard for multi-line anchors: the block search (findInsertAfterRange)
+		// matches the WHOLE multi-line target, so a target like "## 2026-06-16\n**Tasks**"
+		// is "not found" when the note already has a bare "## 2026-06-16" without the
+		// **Tasks** line — which would otherwise create a DUPLICATE heading here. When the
+		// heading line itself already exists in the body, insert the content under it
+		// instead (top of section, or section end when insertAtEnd), never duplicating.
+		// Match against fence-masked lines so a `## …` inside a code block is not
+		// mistaken for a real heading (consistent with computeOrderedSectionInsertIndex).
+		const maskedLines = maskFencedHeadings(lines);
+		const headingNeedle = firstLine.replace(/\r$/, "").trimEnd();
+		const existingHeadingLine = maskedLines.findIndex(
+			(line, i) => i >= bodyStartLine && line.trimEnd() === headingNeedle,
+		);
+		if (existingHeadingLine !== -1) {
+			const position = this.choice.insertAfter?.insertAtEnd
+				? this.findInsertAfterPositionAtSectionEnd(
+						maskedLines,
+						getEndOfSection(
+							maskedLines,
+							existingHeadingLine,
+							this.considerSubsectionsForAnchor(
+								maskedLines,
+								existingHeadingLine,
+							),
+						) ?? maskedLines.length - 1,
+						this.fileContent,
+						formatted,
+					)
+				: this.findInsertAfterPositionWithBlankLines(
+						maskedLines,
+						existingHeadingLine,
+						this.fileContent,
+						this.choice.insertAfter?.blankLineAfterMatchMode ?? "auto",
+					);
+			return this.insertTextAfterPositionInBody(
+				formatted,
+				this.fileContent,
+				position,
+			);
+		}
+
+		const moment =
+			typeof window !== "undefined"
+				? (window.moment as unknown as MomentLike | undefined)
+				: undefined;
+		const slot = computeOrderedSectionInsertIndex(
+			lines,
+			firstLine,
+			level,
+			orderBy,
+			moment,
+			bodyStartLine,
+		);
+
+		if (slot.mode === "bodyStart") {
+			return insertAtNoteBodyStart(this.fileContent, payload);
+		}
+
+		return this.spliceOrderedSection(rawLines, slot, payload);
+	}
+
+	/**
+	 * Splice a created section at the resolved slot, padding it with a single blank
+	 * line above the heading (when the preceding line is non-blank) and below the
+	 * block (when the following line is non-blank) so the heading is never glued to
+	 * neighbouring content (the helpers QuickAdd ships do not pad headings —
+	 * verified — so this is the dedicated separation path for ordered creation).
+	 *
+	 * Byte-preserving: the original `fileContent` is sliced at the insertion offset
+	 * and the existing text on both sides is kept VERBATIM (so a mixed-EOL note is
+	 * never wholesale-normalized — an ordered capture produces a minimal diff). Only
+	 * the inserted block and its two seams use the file's dominant EOL. The offset
+	 * is derived from `rawLines` (which `getLinesInString` produced by splitting on
+	 * "\n", so each prior line consumed its own length + 1 for the "\n"). `\r` is
+	 * stripped only for the blank-line trim checks.
+	 */
+	private spliceOrderedSection(
+		rawLines: string[],
+		slot: Exclude<OrderedSlot, { mode: "bodyStart" }>,
+		payload: string,
+	): string {
+		const content = this.fileContent;
+		const eol = content.includes("\r\n") ? "\r\n" : "\n";
+		const insertIdx = slot.mode === "before" ? slot.line : slot.line + 1;
+
+		// Character offset of the start of line `insertIdx` in the original content.
+		let offset = 0;
+		for (let i = 0; i < insertIdx && i < rawLines.length; i++) {
+			offset += rawLines[i].length + 1; // +1 for the consumed "\n"
+		}
+		if (offset > content.length) offset = content.length;
+		const before = content.slice(0, offset);
+		const after = content.slice(offset);
+
+		const prev =
+			insertIdx > 0 ? (rawLines[insertIdx - 1] ?? "").replace(/\r$/, "") : "";
+		const next =
+			insertIdx < rawLines.length
+				? (rawLines[insertIdx] ?? "").replace(/\r$/, "")
+				: "";
+
+		const payloadLines = payload.split("\n").map((line) => line.replace(/\r$/, ""));
+		// Drop a single trailing empty line that a format ending in "\n" produces, so
+		// separation is controlled solely by the padding below.
+		if (payloadLines.length > 1 && payloadLines[payloadLines.length - 1] === "") {
+			payloadLines.pop();
+		}
+
+		const blockLines: string[] = [];
+		if (insertIdx > 0 && prev.trim() !== "") blockLines.push(""); // blank above heading
+		blockLines.push(...payloadLines);
+		if (insertIdx < rawLines.length && next.trim() !== "") blockLines.push(""); // blank below block
+
+		const blockText = blockLines.join(eol);
+		// Terminate the preceding line when `before` doesn't already end with a
+		// newline (the EOF-without-trailing-newline case), and terminate the block
+		// when content follows it OR when the file already ended with a newline (so
+		// appending at EOF preserves the file's trailing newline). Existing bytes in
+		// before/after stay verbatim.
+		const lead = before.length > 0 && !/\n$/.test(before) ? eol : "";
+		const trail =
+			after.length > 0 || /\n$/.test(content) ? eol : "";
+		return `${before}${lead}${blockText}${trail}${after}`;
 	}
 
 	private async createInsertBeforeIfNotFound(

--- a/src/formatters/helpers/orderedSectionPlacement.test.ts
+++ b/src/formatters/helpers/orderedSectionPlacement.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from "vitest";
+import {
+	computeOrderedSectionInsertIndex,
+	type MomentLike,
+} from "./orderedSectionPlacement";
+import type { SectionOrdering } from "../../types/choices/ICaptureChoice";
+
+/**
+ * A real-enough, lenient date parser injected so the date comparator is exercised
+ * for real (the obsidian-stub `moment` is a no-op). Deliberately supports
+ * "DD-MM-YYYY" — whose lexical order disagrees with chronological order — so a
+ * test can prove the date path is not secretly falling back to lexical. Leniency:
+ * the leading date prefix is matched and trailing decoration ignored.
+ */
+function makeFakeMoment(): MomentLike {
+	return (input: string, format?: string) => {
+		let value = Number.NaN;
+		if (format === "DD-MM-YYYY") {
+			const m = input.match(/^(\d{2})-(\d{2})-(\d{4})/);
+			if (m) value = Date.UTC(+m[3], +m[2] - 1, +m[1]);
+		} else if (format === "YYYY") {
+			const m = input.match(/^(\d{4})/);
+			if (m) value = Date.UTC(+m[1], 0, 1);
+		} else {
+			// default / "YYYY-MM-DD"
+			const m = input.match(/^(\d{4})-(\d{2})-(\d{2})/);
+			if (m) value = Date.UTC(+m[1], +m[2] - 1, +m[3]);
+		}
+		return { isValid: () => !Number.isNaN(value), valueOf: () => value };
+	};
+}
+
+const ob = (over: Partial<SectionOrdering>): SectionOrdering => ({
+	by: "insertion",
+	direction: "desc",
+	unparseable: "bottom",
+	...over,
+});
+
+describe("computeOrderedSectionInsertIndex", () => {
+	describe("zero siblings", () => {
+		it("nests after the ancestor's whole section (preamble pinned) — R1", () => {
+			const lines = [
+				"# My Daily Log",
+				"A running journal.",
+				"",
+			];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2026-06-16",
+				2,
+				ob({ by: "date", dateFormat: "YYYY-MM-DD" }),
+				makeFakeMoment(),
+			);
+			// after the last non-empty preamble line ("A running journal." = index 1)
+			expect(slot).toEqual({ mode: "after", line: 1 });
+		});
+
+		it("falls back to bodyStart when there is no ancestor heading", () => {
+			const lines = ["", "- loose note", ""];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2026",
+				2,
+				ob({}),
+			);
+			expect(slot).toEqual({ mode: "bodyStart" });
+		});
+	});
+
+	describe("insertion order", () => {
+		const lines = ["# Log", "", "## B", "- x", "", "## A", "- y"];
+		it("desc prepends before the first sibling", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## C",
+				2,
+				ob({ by: "insertion", direction: "desc" }),
+			);
+			expect(slot).toEqual({ mode: "before", line: 2 }); // before "## B"
+		});
+		it("asc appends after the last sibling's section end", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## C",
+				2,
+				ob({ by: "insertion", direction: "asc" }),
+			);
+			expect(slot).toEqual({ mode: "after", line: 6 }); // after "- y"
+		});
+	});
+
+	describe("lexical", () => {
+		const lines = ["# Meetings", "", "## Globex", "- standup"];
+		it("asc places Acme before Globex", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## Acme",
+				2,
+				ob({ by: "lexical", direction: "asc" }),
+			);
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+		it("is case-insensitive", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## acme",
+				2,
+				ob({ by: "lexical", direction: "asc" }),
+			);
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+	});
+
+	describe("numeric", () => {
+		const lines = ["# Items", "", "## 2. Two", "- a", "", "## 1. One", "- b"];
+		it("desc places higher number on top, tolerating decoration", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 3. Three",
+				2,
+				ob({ by: "numeric", direction: "desc" }),
+			);
+			expect(slot).toEqual({ mode: "before", line: 2 }); // before "## 2. Two"
+		});
+	});
+
+	describe("date (injected moment, non-lexical format)", () => {
+		// Lexical order of these DD-MM-YYYY strings DISAGREES with chronology, so a
+		// correct result proves the date comparator is used, not lexical.
+		const lines = [
+			"# Log",
+			"",
+			"## 31-12-2025 (Wed)",
+			"- old",
+			"",
+			"## 01-06-2025",
+			"- older",
+		];
+		it("desc places the newer date on top despite lexical order", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 01-01-2026 (Thu)",
+				2,
+				ob({ by: "date", dateFormat: "DD-MM-YYYY", direction: "desc" }),
+				makeFakeMoment(),
+			);
+			// 2026-01-01 is newest → before the first sibling (31-12-2025)
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+		it("places a middle date in its chronological slot", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 15-09-2025",
+				2,
+				ob({ by: "date", dateFormat: "DD-MM-YYYY", direction: "desc" }),
+				makeFakeMoment(),
+			);
+			// 2025-09-15 is between 2025-12-31 and 2025-06-01 → before the 01-06-2025 sibling
+			expect(slot).toEqual({ mode: "before", line: 5 });
+		});
+		it("without an injected moment, a date key is unparseable → appended", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 01-01-2026",
+				2,
+				ob({ by: "date", dateFormat: "DD-MM-YYYY", direction: "desc" }),
+				// no moment
+			);
+			expect(slot).toEqual({ mode: "after", line: 6 });
+		});
+	});
+
+	describe("semver", () => {
+		const lines = ["# Changelog", "", "## 1.9.0", "- old fix"];
+		it("places 1.10.0 above 1.9.0 (not lexical)", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 1.10.0",
+				2,
+				ob({ by: "semver", direction: "desc" }),
+			);
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+		it("does not alias across segments (clamp)", () => {
+			const big = ["# C", "", "## 2.0.0", "- x"];
+			const slot = computeOrderedSectionInsertIndex(
+				big,
+				"## 1.999999.0",
+				2,
+				ob({ by: "semver", direction: "desc" }),
+			);
+			// 1.999999.0 < 2.0.0 → should NOT precede → appended after band
+			expect(slot).toEqual({ mode: "after", line: 3 });
+		});
+		it("tolerates a 'v' prefix and trailing codename", () => {
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## v2.0.0 — codename",
+				2,
+				ob({ by: "semver", direction: "desc" }),
+			);
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+
+		it("parses the Keep a Changelog bracketed format '## [x.y.z] - date'", () => {
+			const kac = ["# Changelog", "", "## [1.9.0] - 2026-01-01", "- old fix"];
+			const slot = computeOrderedSectionInsertIndex(
+				kac,
+				"## [1.10.0] - 2026-06-16",
+				2,
+				ob({ by: "semver", direction: "desc" }),
+			);
+			// [1.10.0] > [1.9.0] → placed above, not appended below as unparseable.
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+	});
+
+	describe("unparseable keys", () => {
+		it("an unparseable NEW key is appended at band end (desc)", () => {
+			const lines = ["# C", "", "## 2.0.0", "- a", "", "## 1.0.0", "- b"];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## Unreleased",
+				2,
+				ob({ by: "semver", direction: "desc" }),
+			);
+			expect(slot).toEqual({ mode: "after", line: 6 });
+		});
+		it("an unparseable NEW key is appended at band end (asc too)", () => {
+			const lines = ["# C", "", "## 1.0.0", "- a"];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## Unreleased",
+				2,
+				ob({ by: "semver", direction: "asc" }),
+			);
+			expect(slot).toEqual({ mode: "after", line: 3 });
+		});
+		it("existing unparseable sibling sinks to bottom (new parsed key precedes it)", () => {
+			const lines = ["# C", "", "## Draft", "- a", "", "## 1.0.0", "- b"];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2.0.0",
+				2,
+				ob({ by: "semver", direction: "desc", unparseable: "bottom" }),
+			);
+			// "Draft" sinks → new parsed key should precede it
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+		it("existing unparseable sibling pinned to top (new parsed key does not precede it)", () => {
+			const lines = ["# C", "", "## Draft", "- a", "", "## 1.0.0", "- b"];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2.0.0",
+				2,
+				ob({ by: "semver", direction: "desc", unparseable: "top" }),
+			);
+			// "Draft" pinned top → new key does NOT precede it; precedes 1.0.0 instead
+			expect(slot).toEqual({ mode: "before", line: 5 });
+		});
+	});
+
+	describe("ties", () => {
+		it("a distinct-but-equal key appends adjacent (stable)", () => {
+			const lines = ["# C", "", "## 1.2.0", "- a"];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 1.2.0-rc1",
+				2,
+				ob({ by: "semver", direction: "desc" }),
+			);
+			// compares equal → not precede → appended after band
+			expect(slot).toEqual({ mode: "after", line: 3 });
+		});
+	});
+
+	describe("level scoping & structure", () => {
+		it("ignores headings of other levels (## never sorts against ### / #)", () => {
+			const lines = [
+				"# Log",
+				"",
+				"## 2026-06-14",
+				"### sub of the 14th",
+				"- nested",
+				"",
+				"## 2026-06-10",
+				"- older",
+			];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2026-06-16",
+				2,
+				ob({ by: "date", dateFormat: "YYYY-MM-DD", direction: "desc" }),
+				makeFakeMoment(),
+			);
+			expect(slot).toEqual({ mode: "before", line: 2 }); // before "## 2026-06-14"
+		});
+
+		it("band-end append clears a last sibling's ### subsection", () => {
+			const lines = [
+				"# Log",
+				"",
+				"## 2026-06-14",
+				"- entry",
+				"### detail",
+				"- nested",
+			];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2026-06-10",
+				2,
+				ob({ by: "date", dateFormat: "YYYY-MM-DD", direction: "desc" }),
+				makeFakeMoment(),
+			);
+			// older date appends AFTER the whole 06-14 section (incl. its ### subsection)
+			expect(slot).toEqual({ mode: "after", line: 5 });
+		});
+	});
+
+	describe("frontmatter exclusion (bodyStartLine)", () => {
+		// "---\n# fm comment\ntags: x\n---\n# Title\nblurb\n" → body starts at line 4.
+		const lines = [
+			"---",
+			"# fm comment",
+			"tags: x",
+			"---",
+			"# Title",
+			"blurb",
+		];
+
+		it("ignores a frontmatter '#' line as an H1 ancestor", () => {
+			// H2 section, no body siblings, real ancestor is "# Title" (line 4) — NOT
+			// the frontmatter "# fm comment" (line 1).
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2026",
+				2,
+				ob({ by: "insertion", direction: "desc" }),
+				undefined,
+				4,
+			);
+			expect(slot).toEqual({ mode: "after", line: 5 }); // after "blurb"
+		});
+
+		it("never selects a frontmatter '#' line as an H1 sibling", () => {
+			// H1 section: the only body H1 is "# Title" (line 4); the frontmatter
+			// "# fm comment" must not be a sibling, else we'd splice into the YAML.
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"# 2026",
+				1,
+				ob({ by: "insertion", direction: "desc" }),
+				undefined,
+				4,
+			);
+			expect(slot).toEqual({ mode: "before", line: 4 }); // before "# Title", below the frontmatter
+		});
+	});
+
+	describe("fenced code blocks", () => {
+		it("does not treat a ## inside a code fence as a sibling", () => {
+			const lines = [
+				"# Log",
+				"",
+				"## 2026-06-14",
+				"```md",
+				"## 2026-12-31 (this is example text, not a heading)",
+				"```",
+				"- entry",
+			];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2026-06-16",
+				2,
+				ob({ by: "date", dateFormat: "YYYY-MM-DD", direction: "desc" }),
+				makeFakeMoment(),
+			);
+			// Only "## 2026-06-14" is a real sibling; newest goes before it.
+			expect(slot).toEqual({ mode: "before", line: 2 });
+		});
+
+		it("appends after a last section whose body contains a fenced ## (not split)", () => {
+			const lines = [
+				"# Log",
+				"",
+				"## 2026-06-14",
+				"- entry",
+				"```md",
+				"## not a heading",
+				"```",
+			];
+			const slot = computeOrderedSectionInsertIndex(
+				lines,
+				"## 2026-06-10",
+				2,
+				ob({ by: "date", dateFormat: "YYYY-MM-DD", direction: "desc" }),
+				makeFakeMoment(),
+			);
+			// older date appends after the whole 06-14 section incl. the code block
+			expect(slot).toEqual({ mode: "after", line: 6 });
+		});
+	});
+});

--- a/src/formatters/helpers/orderedSectionPlacement.ts
+++ b/src/formatters/helpers/orderedSectionPlacement.ts
@@ -1,0 +1,209 @@
+import getEndOfSection, { getMarkdownHeadings } from "./getEndOfSection";
+import type { SectionOrdering } from "../../types/choices/ICaptureChoice";
+
+/**
+ * Pure placement logic for the "ordered" create-if-not-found location (issue #481).
+ *
+ * Given a note's body lines and a new section heading that is known to be ABSENT,
+ * compute WHERE the new heading should be created so that same-level sibling
+ * sections stay sorted. It positions only the new section and assumes existing
+ * siblings are already in order; it never re-sorts what is already there.
+ *
+ * The caller passes CRLF-stripped lines and a single first-line header, so this
+ * module never sees `\r` or embedded newlines. Returned line indices are valid
+ * against the SAME array that was passed in (fence masking preserves indices).
+ */
+export type OrderedSlot =
+	| { mode: "bodyStart" }
+	| { mode: "before"; line: number }
+	| { mode: "after"; line: number };
+
+/** A moment-like factory; injected so the helper stays App-free and testable. */
+export type MomentLike = (
+	input: string,
+	format?: string,
+	strict?: boolean,
+) => { isValid(): boolean; valueOf(): number };
+
+type ParsedKey = { value: number | string; parsed: boolean };
+
+/**
+ * Neutralize heading-like lines INSIDE fenced code blocks (``` / ~~~) so a `## x`
+ * in a code sample is never mistaken for a sibling heading, while preserving line
+ * indices AND non-blankness. Only the leading `#` run of a fenced heading-like
+ * line is replaced (with a zero-width sentinel that `String.trim()` does not
+ * strip), so the line stays non-blank: `getEndOfSection`'s blank-trimming still
+ * spans a code block at a section's tail instead of cutting the section short.
+ * Mirrors CommonMark loosely: an opening fence may carry an info string; a closing
+ * fence is the same marker char, at least as long, with nothing after it. An
+ * unclosed fence runs to EOF. Non-heading lines (incl. the fence markers) are kept
+ * verbatim — they are already non-blank and non-heading.
+ */
+const FENCED_HEADING_SENTINEL = "​"; // zero-width space: non-blank to trim(), never a heading
+
+export function maskFencedHeadings(lines: string[]): string[] {
+	const out = lines.slice();
+	let inFence = false;
+	let fenceChar = "";
+	let fenceLen = 0;
+
+	for (let i = 0; i < lines.length; i++) {
+		const match = lines[i].match(/^(\s*)(`{3,}|~{3,})/);
+		if (!inFence) {
+			if (match) {
+				inFence = true;
+				fenceChar = match[2][0];
+				fenceLen = match[2].length;
+			}
+			continue;
+		}
+
+		// Inside a fence: neutralize only heading-like lines.
+		out[i] = lines[i].replace(/^(\s*)#+(\s)/, `$1${FENCED_HEADING_SENTINEL}$2`);
+
+		if (match && match[2][0] === fenceChar && match[2].length >= fenceLen) {
+			const afterMarker = lines[i].slice(match[1].length + match[2].length);
+			if (afterMarker.trim() === "") {
+				inFence = false;
+				fenceChar = "";
+				fenceLen = 0;
+			}
+		}
+	}
+
+	return out;
+}
+
+function headingKeyText(line: string): string {
+	return (line.match(/^#+\s+(.*)$/)?.[1] ?? "").trim();
+}
+
+function parseSemver(text: string): ParsedKey {
+	// Tolerate a leading "[" (Keep a Changelog "## [1.10.0] - 2026-06-16") and a
+	// "v" prefix; the leading-prefix match ignores any trailing " - date"/codename.
+	const match =
+		text.match(/^\[?v?(\d+)\.(\d+)\.(\d+)(?:[-+\]].*)?$/i) ??
+		text.match(/^\[?v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/i);
+	if (!match) return { value: 0, parsed: false };
+	// Clamp each segment so packing into one comparable number can't alias
+	// (e.g. minor 1_000_000 colliding with the next major).
+	const seg = (s?: string) => Math.min(Number(s ?? "0"), 999_999);
+	return {
+		value: seg(match[1]) * 1e12 + seg(match[2]) * 1e6 + seg(match[3]),
+		parsed: true,
+	};
+}
+
+function parseKey(
+	text: string,
+	ob: SectionOrdering,
+	moment?: MomentLike,
+): ParsedKey {
+	switch (ob.by) {
+		case "lexical":
+			return { value: text.toLocaleLowerCase(), parsed: true };
+		case "numeric": {
+			// Leading-number prefix, decoration-tolerant: "2. Roadmap" → 2.
+			const match = text.match(/^-?\d+(?:\.\d+)?/);
+			return match
+				? { value: Number(match[0]), parsed: true }
+				: { value: 0, parsed: false };
+		}
+		case "date": {
+			// Lenient parse of the LEADING date, ignoring trailing decoration
+			// ("2026-06-14 (Friday)"). Without an injected moment the date sort
+			// degrades to unparseable (loud → append) rather than a silent lexical
+			// fallback that would mask the real production path.
+			const parsed = moment
+				? moment(text, ob.dateFormat || undefined, false)
+				: null;
+			return parsed && parsed.isValid()
+				? { value: parsed.valueOf(), parsed: true }
+				: { value: 0, parsed: false };
+		}
+		case "semver":
+			return parseSemver(text);
+		default:
+			return { value: 0, parsed: true }; // insertion
+	}
+}
+
+function compareValues(a: ParsedKey, b: ParsedKey): number {
+	if (typeof a.value === "string" && typeof b.value === "string") {
+		return a.value < b.value ? -1 : a.value > b.value ? 1 : 0;
+	}
+	const an = a.value as number;
+	const bn = b.value as number;
+	return an < bn ? -1 : an > bn ? 1 : 0;
+}
+
+/**
+ * Compute the slot for a new, absent section heading among its same-level
+ * siblings. `level` and `newHeaderFirstLine` come from the resolved target
+ * heading; `lines` is the CRLF-stripped body.
+ *
+ * `bodyStartLine` is the index of the first line AFTER any YAML frontmatter (0
+ * when there is none). Headings before it are excluded so a `#`-prefixed YAML
+ * line (e.g. a comment) is never treated as a sibling/ancestor and the new
+ * section can never be spliced into the frontmatter block (issue #481).
+ */
+export function computeOrderedSectionInsertIndex(
+	lines: string[],
+	newHeaderFirstLine: string,
+	level: number,
+	ob: SectionOrdering,
+	moment?: MomentLike,
+	bodyStartLine = 0,
+): OrderedSlot {
+	const masked = maskFencedHeadings(lines);
+	const headings = getMarkdownHeadings(masked).filter(
+		(heading) => heading.line >= bodyStartLine,
+	);
+	const siblings = headings.filter((heading) => heading.level === level);
+	const newKey = parseKey(headingKeyText(newHeaderFirstLine), ob, moment);
+
+	// R1 (preamble pinned): with zero same-level siblings, nest the new section
+	// after the nearest higher-level ancestor's WHOLE section (so an H1 title and
+	// its blurb stay above), else at the body start.
+	if (siblings.length === 0) {
+		const ancestor = headings.filter((heading) => heading.level < level).pop();
+		if (ancestor) {
+			const end = getEndOfSection(masked, ancestor.line, true);
+			return { mode: "after", line: end };
+		}
+		return { mode: "bodyStart" };
+	}
+
+	const appendAfterBand = (): OrderedSlot => {
+		const last = siblings[siblings.length - 1];
+		return { mode: "after", line: getEndOfSection(masked, last.line, true) };
+	};
+
+	// Insertion order: no parsing — prepend (desc) or append (asc) the band.
+	if (ob.by === "insertion") {
+		return ob.direction === "desc"
+			? { mode: "before", line: siblings[0].line }
+			: appendAfterBand();
+	}
+
+	// An unparseable NEW key is always appended at the band end (predictable),
+	// independent of how EXISTING unparseable siblings are ranked.
+	if (!newKey.parsed) return appendAfterBand();
+
+	const sink = ob.unparseable ?? "bottom"; // governs EXISTING unparseable siblings
+	for (const sibling of siblings) {
+		const sibKey = parseKey(headingKeyText(masked[sibling.line]), ob, moment);
+		let shouldPrecede: boolean;
+		if (!sibKey.parsed) {
+			// New key parsed, sibling not: place new ABOVE the sibling iff
+			// unparseables sink to the bottom.
+			shouldPrecede = sink === "bottom";
+		} else {
+			const c = compareValues(newKey, sibKey);
+			shouldPrecede = ob.direction === "desc" ? c > 0 : c < 0;
+		}
+		if (shouldPrecede) return { mode: "before", line: sibling.line };
+	}
+
+	return appendAfterBand();
+}

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -3,9 +3,11 @@ import type { App } from "obsidian";
 import { Notice } from "obsidian";
 import type QuickAdd from "../../../main";
 import type ICaptureChoice from "../../../types/choices/ICaptureChoice";
+import type { SectionOrdering } from "../../../types/choices/ICaptureChoice";
 import {
 	CREATE_IF_NOT_FOUND_BOTTOM,
 	CREATE_IF_NOT_FOUND_CURSOR,
+	CREATE_IF_NOT_FOUND_ORDERED,
 	CREATE_IF_NOT_FOUND_TOP,
 } from "../../../constants";
 import { FormatSyntaxSuggester } from "../../suggesters/formatSyntaxSuggester";
@@ -52,11 +54,140 @@ const blankLineOptions = [
 	{ value: "none", label: "Never skip" },
 ];
 
-const createLocationOptions = [
-	{ value: CREATE_IF_NOT_FOUND_TOP, label: "Top" },
-	{ value: CREATE_IF_NOT_FOUND_BOTTOM, label: "Bottom" },
-	{ value: CREATE_IF_NOT_FOUND_CURSOR, label: "Cursor" },
+// Inline same-line insertion and ordered section placement are mutually
+// exclusive (ordered always creates a heading on its own line). Omit "Ordered"
+// while inline is on so it can never be selected into a crashing combination.
+const createLocationOptions = $derived(
+	insertAfter.inline
+		? [
+				{ value: CREATE_IF_NOT_FOUND_TOP, label: "Top" },
+				{ value: CREATE_IF_NOT_FOUND_BOTTOM, label: "Bottom" },
+				{ value: CREATE_IF_NOT_FOUND_CURSOR, label: "Cursor" },
+			]
+		: [
+				{ value: CREATE_IF_NOT_FOUND_TOP, label: "Top" },
+				{ value: CREATE_IF_NOT_FOUND_BOTTOM, label: "Bottom" },
+				{ value: CREATE_IF_NOT_FOUND_CURSOR, label: "Cursor" },
+				{
+					value: CREATE_IF_NOT_FOUND_ORDERED,
+					label: "Ordered (place new section among siblings)",
+				},
+			],
+);
+
+const orderByOptions = [
+	{ value: "insertion", label: "Insertion order (no sorting)" },
+	{ value: "lexical", label: "Text (A→Z)" },
+	{ value: "numeric", label: "Number" },
+	{ value: "date", label: "Date" },
+	{ value: "semver", label: "Version (semver)" },
 ];
+const orderDirectionOptions = [
+	{ value: "desc", label: "Newest / highest first" },
+	{ value: "asc", label: "Oldest / lowest first" },
+];
+const unparseableOptions = [
+	{ value: "bottom", label: "Sort existing unparseable headings to bottom" },
+	{ value: "top", label: "Sort existing unparseable headings to top" },
+];
+
+// Tracks whether the ordering descriptor is "pinned" — either the user explicitly
+// chose a sort key / date format, or the choice arrived already carrying an
+// orderBy (a saved/imported ordered choice). When pinned, the reactive seed never
+// auto-rewrites `by`/`dateFormat` from the `after` text, so opening or editing an
+// existing choice can't silently clobber its saved sort config.
+let userPickedBy = $state(!!insertAfter.orderBy);
+
+// Ordered placement is selected (regardless of whether "Create line if not found"
+// is currently on). Used to gate the mutually-exclusive Inline toggle so the
+// invalid inline+ordered combo can't be assembled via a toggle sequence.
+const orderedSelected = $derived(
+	insertAfter.createIfNotFoundLocation === CREATE_IF_NOT_FOUND_ORDERED,
+);
+// Ordered placement is ACTIVE (will run): location is ordered AND creation is on.
+// Drives the ordered sub-panel + warnings.
+const isOrdered = $derived(
+	insertAfter.createIfNotFound && orderedSelected,
+);
+
+// Non-optional read view for the ordered sub-panel: the panel only renders when
+// `insertAfter.orderBy` is present, but its `{#snippet}` closures lose the
+// truthiness narrowing, so reads go through this guaranteed-present derived.
+// Writes still target `insertAfter.orderBy` through guarded handlers.
+const ordering = $derived<SectionOrdering>(
+	insertAfter.orderBy ?? { by: "insertion", direction: "desc", unparseable: "bottom" },
+);
+
+/**
+ * Extract a moment date format from a `{{DATE:fmt}}` / `{{VDATE:name,fmt}}` token
+ * so an ordered date log auto-detects its sort format. Returns undefined for a
+ * bare `{{DATE}}`, a literal-`+` format, or a multi-token heading — those can't be
+ * reliably round-tripped, so the UI falls back to insertion + a warning.
+ */
+function detectDateFormatFromAfter(after: string): string | undefined {
+	const date = after.match(/\{\{DATE:([^}\n\r+]*)(?:\+-?\d+)?\}\}/i);
+	if (date?.[1]?.trim()) return date[1].trim();
+	// VDATE is {{VDATE:name,format}} or {{VDATE:name,format|default}} — drop the
+	// "|default" segment so it doesn't leak into the moment parse format.
+	const vdate = after.match(/\{\{VDATE:[^,}]+,([^}\n\r]*)\}\}/i);
+	const vdateFormat = vdate?.[1]?.split("|")[0]?.trim();
+	if (vdateFormat) return vdateFormat;
+	return undefined;
+}
+
+const afterHasDateToken = $derived(/\{\{V?DATE\b/i.test(insertAfter.after ?? ""));
+const showInsertionFallbackWarning = $derived(
+	isOrdered &&
+		insertAfter.orderBy?.by === "insertion" &&
+		afterHasDateToken &&
+		!detectDateFormatFromAfter(insertAfter.after ?? ""),
+);
+
+// Single seeder (builder-owned): seed orderBy when "ordered" is first selected,
+// and while the user hasn't pinned a key, keep the date/insertion choice in sync
+// with the `after` text. Resolves the Load-vs-builder two-seeder divergence.
+$effect(() => {
+	// Only seed when ordered placement is actually active (location ordered AND
+	// creation on), so a merely-selected-but-inert ordered location never persists
+	// dead orderBy config.
+	if (!isOrdered) return;
+	const fmt = detectDateFormatFromAfter(insertAfter.after ?? "");
+	if (!insertAfter.orderBy) {
+		insertAfter.orderBy = {
+			by: fmt ? "date" : "insertion",
+			direction: "desc",
+			dateFormat: fmt,
+			unparseable: "bottom",
+		};
+		return;
+	}
+	if (
+		!userPickedBy &&
+		(insertAfter.orderBy.by === "insertion" || insertAfter.orderBy.by === "date")
+	) {
+		insertAfter.orderBy.by = fmt ? "date" : "insertion";
+		insertAfter.orderBy.dateFormat = fmt;
+	}
+});
+
+function onCreateLocationChange(value: string) {
+	insertAfter.createIfNotFoundLocation = value;
+	if (value === CREATE_IF_NOT_FOUND_ORDERED) {
+		// Ordered always creates a heading on its own line.
+		insertAfter.inline = false;
+	} else {
+		// Leaving ordered: drop the now-irrelevant descriptor so stale config
+		// never persists on a non-ordered choice.
+		insertAfter.orderBy = undefined;
+		userPickedBy = false;
+	}
+}
+
+function onOrderByChange(value: string) {
+	userPickedBy = true;
+	if (!insertAfter.orderBy) return;
+	insertAfter.orderBy.by = value as SectionOrdering["by"];
+}
 
 function onConsiderSubsectionsToggle(value: boolean) {
 	// In heading mode the runtime target is always a heading, so the
@@ -116,10 +247,12 @@ function onPromptHeadingToggle(value: boolean) {
 
 	<SettingItem
 		name="Inline insertion"
-		desc="Insert captured content on the same line, immediately after the matched text (no newline added)."
+		desc={orderedSelected
+			? "Inline insertion can't be combined with ordered placement."
+			: "Insert captured content on the same line, immediately after the matched text (no newline added)."}
 	>
 		{#snippet control()}
-			<Toggle bind:checked={insertAfter.inline} />
+			<Toggle bind:checked={insertAfter.inline} disabled={orderedSelected} />
 		{/snippet}
 	</SettingItem>
 {/if}
@@ -187,7 +320,95 @@ function onPromptHeadingToggle(value: boolean) {
 		<Dropdown
 			value={insertAfter.createIfNotFoundLocation || CREATE_IF_NOT_FOUND_TOP}
 			options={createLocationOptions}
-			onchange={(value) => (insertAfter.createIfNotFoundLocation = value)}
+			onchange={onCreateLocationChange}
 		/>
 	{/snippet}
 </SettingItem>
+
+{#if isOrdered && insertAfter.orderBy}
+	<div class="setting-item-description">
+		The "Insert after" heading is created at its sorted position among ALL
+		same-level headings in the note (it is not scoped to one parent section). It
+		does NOT re-sort headings you already have; only the new one is placed. Use
+		"Insert at end of section" above for newest-on-top vs. appended entries within
+		each section.
+	</div>
+
+	<SettingItem name="Sort sections by">
+		{#snippet control()}
+			<Dropdown
+				value={ordering.by}
+				options={orderByOptions}
+				onchange={onOrderByChange}
+			/>
+		{/snippet}
+	</SettingItem>
+
+	<SettingItem name="Section order">
+		{#snippet control()}
+			<Dropdown
+				value={ordering.direction}
+				options={orderDirectionOptions}
+				onchange={(value) => {
+					if (insertAfter.orderBy)
+						insertAfter.orderBy.direction =
+							value as SectionOrdering["direction"];
+				}}
+			/>
+		{/snippet}
+	</SettingItem>
+
+	{#if ordering.by === "date"}
+		<SettingItem
+			name="Date format"
+			desc="Moment format used to parse existing heading dates for sorting (e.g. YYYY-MM-DD)."
+		>
+			{#snippet control()}
+				<ValidatedInput
+					value={ordering.dateFormat ?? ""}
+					placeholder="YYYY-MM-DD"
+					ariaLabel="Date format"
+					onChange={(value) => {
+						// A deliberate format edit pins the descriptor so the after-keyed
+						// seeder stops re-deriving dateFormat from the token.
+						userPickedBy = true;
+						if (insertAfter.orderBy) insertAfter.orderBy.dateFormat = value;
+					}}
+				/>
+			{/snippet}
+		</SettingItem>
+	{/if}
+
+	{#if ordering.by === "date" || ordering.by === "numeric" || ordering.by === "semver"}
+		<SettingItem
+			name="Existing unparseable headings"
+			desc="Where to rank EXISTING headings whose text can't be parsed for this sort. (A new heading that can't be parsed is appended at the end.)"
+		>
+			{#snippet control()}
+				<Dropdown
+					value={ordering.unparseable ?? "bottom"}
+					options={unparseableOptions}
+					onchange={(value) => {
+						if (insertAfter.orderBy)
+							insertAfter.orderBy.unparseable =
+								value as NonNullable<SectionOrdering["unparseable"]>;
+					}}
+				/>
+			{/snippet}
+		</SettingItem>
+	{/if}
+
+	{#if ordering.by === "insertion"}
+		<div class="setting-item-description">
+			No sorting: newest-first prepends the new section above existing ones;
+			oldest-first appends it below.
+		</div>
+	{/if}
+
+	{#if showInsertionFallbackWarning}
+		<div class="setting-item-description">
+			This heading uses a date token QuickAdd can't auto-read for sorting. Pick
+			"Date" and enter the format, or sections stay in insertion order.
+		</div>
+	{/if}
+{/if}

--- a/src/types/choices/CaptureChoice.test.ts
+++ b/src/types/choices/CaptureChoice.test.ts
@@ -64,4 +64,70 @@ describe("CaptureChoice.Load", () => {
 			createIfNotFoundLocation: "top",
 		});
 	});
+
+	it("backfills a safe ordering descriptor for an ordered choice missing orderBy", () => {
+		const choice = new CaptureChoice("Ordered") as any;
+		choice.insertAfter.enabled = true;
+		choice.insertAfter.createIfNotFound = true;
+		choice.insertAfter.createIfNotFoundLocation = "ordered";
+		delete choice.insertAfter.orderBy;
+
+		const loaded = CaptureChoice.Load(choice);
+
+		expect(loaded.insertAfter.orderBy).toEqual({
+			by: "insertion",
+			direction: "desc",
+			unparseable: "bottom",
+		});
+	});
+
+	it("preserves an existing orderBy descriptor on an ordered choice", () => {
+		const choice = new CaptureChoice("OrderedDate") as any;
+		choice.insertAfter.enabled = true;
+		choice.insertAfter.createIfNotFound = true;
+		choice.insertAfter.createIfNotFoundLocation = "ordered";
+		choice.insertAfter.orderBy = {
+			by: "date",
+			direction: "desc",
+			dateFormat: "YYYY-MM-DD",
+			unparseable: "top",
+		};
+
+		const loaded = CaptureChoice.Load(choice);
+
+		expect(loaded.insertAfter.orderBy).toEqual({
+			by: "date",
+			direction: "desc",
+			dateFormat: "YYYY-MM-DD",
+			unparseable: "top",
+		});
+	});
+
+	it("clears inline on an ordered choice (enforces the UI invariant at load)", () => {
+		const choice = new CaptureChoice("InlineOrdered") as any;
+		choice.insertAfter.enabled = true;
+		choice.insertAfter.inline = true;
+		choice.insertAfter.createIfNotFound = true;
+		choice.insertAfter.createIfNotFoundLocation = "ordered";
+
+		const loaded = CaptureChoice.Load(choice);
+
+		expect(loaded.insertAfter.inline).toBe(false);
+		expect(loaded.insertAfter.orderBy).toEqual({
+			by: "insertion",
+			direction: "desc",
+			unparseable: "bottom",
+		});
+	});
+
+	it("does not add orderBy to non-ordered choices", () => {
+		const choice = new CaptureChoice("Top") as any;
+		choice.insertAfter.enabled = true;
+		choice.insertAfter.createIfNotFound = true;
+		choice.insertAfter.createIfNotFoundLocation = "top";
+
+		const loaded = CaptureChoice.Load(choice);
+
+		expect(loaded.insertAfter.orderBy).toBeUndefined();
+	});
 });

--- a/src/types/choices/CaptureChoice.ts
+++ b/src/types/choices/CaptureChoice.ts
@@ -1,6 +1,10 @@
 import { Choice } from "./Choice";
 import type ICaptureChoice from "./ICaptureChoice";
-import type { BlankLineAfterMatchMode } from "./ICaptureChoice";
+import type {
+	BlankLineAfterMatchMode,
+	SectionOrdering,
+} from "./ICaptureChoice";
+import { CREATE_IF_NOT_FOUND_ORDERED } from "../../constants";
 import type { OpenLocation, FileViewMode2 } from "../fileOpening";
 import type { AppendLinkOptions } from "../linkPlacement";
 import { normalizeFileOpening } from "../../utils/fileOpeningDefaults";
@@ -28,6 +32,7 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 		inline?: boolean;
 		replaceExisting?: boolean;
 		blankLineAfterMatchMode?: BlankLineAfterMatchMode;
+		orderBy?: SectionOrdering;
 		promptHeading?: boolean;
 	};
 	insertBefore: {
@@ -146,6 +151,27 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 		}
 		if (loaded.insertAfter && loaded.insertAfter.promptHeading === undefined) {
 			loaded.insertAfter.promptHeading = false;
+		}
+		// Ordered create-location needs an ordering descriptor; backfill a safe
+		// insertion default so the formatter never dereferences undefined for a
+		// hand-edited or imported "ordered" choice (issue #481). The builder owns
+		// date auto-detection, so imported configs stay on the parser-free default.
+		if (
+			loaded.insertAfter?.createIfNotFoundLocation ===
+			CREATE_IF_NOT_FOUND_ORDERED
+		) {
+			if (!loaded.insertAfter.orderBy) {
+				loaded.insertAfter.orderBy = {
+					by: "insertion",
+					direction: "desc",
+					unparseable: "bottom",
+				};
+			}
+			// Ordered always creates a heading on its own line; inline same-line
+			// insertion is mutually exclusive (the inline create path can't honor
+			// "ordered" and would abort). Enforce the UI invariant here too so a
+			// hand-edited/imported inline+ordered choice can't reach that abort.
+			loaded.insertAfter.inline = false;
 		}
 		return loaded;
 	}

--- a/src/types/choices/CaptureChoice.ts
+++ b/src/types/choices/CaptureChoice.ts
@@ -160,7 +160,10 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 			loaded.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_ORDERED
 		) {
-			if (!loaded.insertAfter.orderBy) {
+			// Only backfill orderBy when ordered placement is actually active, so an
+			// inert config (ordered location selected but create-if-not-found off) is
+			// not mutated on load (avoids needless persisted-diff churn).
+			if (loaded.insertAfter.createIfNotFound && !loaded.insertAfter.orderBy) {
 				loaded.insertAfter.orderBy = {
 					by: "insertion",
 					direction: "desc",

--- a/src/types/choices/ICaptureChoice.ts
+++ b/src/types/choices/ICaptureChoice.ts
@@ -4,6 +4,29 @@ import type { OpenLocation, FileViewMode2 } from "../fileOpening";
 
 export type BlankLineAfterMatchMode = "auto" | "skip" | "none";
 
+/** How to derive a sort key from a section heading's text (issue #481). */
+export type SectionOrderBy =
+	| "insertion"
+	| "lexical"
+	| "date"
+	| "numeric"
+	| "semver";
+export type SectionOrderDirection = "asc" | "desc";
+/** Where to rank EXISTING sibling headings whose text can't be parsed. */
+export type UnparseableKeyPolicy = "bottom" | "top";
+
+/**
+ * Ordering descriptor for the "ordered" create-if-not-found location. A missing
+ * insert-after heading is created at its sorted position among same-level
+ * siblings. Read ONLY when `insertAfter.createIfNotFoundLocation === "ordered"`.
+ */
+export interface SectionOrdering {
+	by: SectionOrderBy; // default "insertion"
+	direction: SectionOrderDirection; // default "desc" (newest/highest on top)
+	dateFormat?: string; // moment parse format, only when by === "date"
+	unparseable?: UnparseableKeyPolicy; // default "bottom"; ranks EXISTING unparseable siblings
+}
+
 export default interface ICaptureChoice extends IChoice {
 	captureTo: string;
 	captureToActiveFile: boolean;
@@ -39,6 +62,12 @@ export default interface ICaptureChoice extends IChoice {
 		inline?: boolean;
 		replaceExisting?: boolean;
 		blankLineAfterMatchMode?: BlankLineAfterMatchMode;
+		/**
+			* Sort descriptor for the "ordered" create-if-not-found location. Read ONLY
+			* when `createIfNotFoundLocation === "ordered"`. Absent for every other
+			* location, so existing choices round-trip byte-identically (issue #481).
+			*/
+		orderBy?: SectionOrdering;
 		/**
 			* When true (the "Choose heading when capturing" option of "After line…"), the
 			* insert-after target is chosen at capture time from a dropdown of the target


### PR DESCRIPTION
## Summary

Adds a fourth **"Create line if not found"** location to Capture's *Insert after* — **Ordered** — that creates a missing target heading at its **sorted position among same-level sibling headings**, instead of only at the top/bottom/cursor.

This is the generic primitive behind the long-standing request in #481 ("combining multiple insert-afters"): a reverse-chronological daily log where a fixed title/intro stays pinned, each new day's `## YYYY-MM-DD` heading is auto-created **below the intro and above older days**, and the newest entry sits at the top of each day. The same one mechanism also covers semver changelogs, year-grouped lists, alphabetical/numeric section logs, etc. via configuration.

Closes #481.

## How it works

When the insert-after heading (e.g. `## {{DATE:YYYY-MM-DD}}`) is missing, the new `Ordered` location sorts it into place among its same-level siblings:

- **`SectionOrdering`** (`by`: insertion / lexical / numeric / date / semver, `direction`: asc/desc, `dateFormat`, `unparseable`) — read **only** when `createIfNotFoundLocation === "ordered"`. Fully additive: no migration, no version bump; existing choices are byte-identical.
- A pure, **frontmatter- and fence-aware** placement helper (`orderedSectionPlacement.ts`).
- A **byte-preserving** splice (existing line endings untouched → minimal diff).
- **Idempotent**: the heading is created once; later captures find it and use the normal found-path. Within-day ordering uses the existing `Insert at end of section` toggle.
- Builder UI: a 4th create-location option + an *ordered* sub-panel; `Ordered` is mutually exclusive with `Inline insertion`.

Requirement structure falls out of the design: the title/intro stays pinned because it's a different heading level (and frontmatter is excluded entirely); the day heading is the ordered create; within-day order is the existing `insertAtEnd`.

## Example (#481)

```markdown
# My Daily Log

A short intro that always stays at the top.

## 2026-06-16
- 09:40 reviewed the code
- 09:13 started the design

## 2026-06-14
- 09:00 older entry
```

## Testing

- **51 new tests** (pure-helper placement matrix, full-handler integration, Load migration) — full suite green (**2368 passing**); `tsc`, `svelte-check`, and `eslint` clean; docs site builds.
- **End-to-end verified in a real Obsidian vault** (isolated worktree instance): the #481 daily log (incl. rendered screenshot), a semver changelog, the Keep-a-Changelog `[1.10.0]` bracket form, frontmatter-preserving captures, mixed/CRLF EOL preservation, and idempotent repeat captures.

## Review

Iterated through multiple review rounds (multi-lens + cross-model adversarial). Fixes that came out of review include: frontmatter-aware placement (prevented a YAML-corruption path), byte-preserving mixed-EOL/EOF splice, multi-line-anchor de-duplication (idempotency), fence-aware heading detection, builder reactivity that never clobbers a saved sort config, and the documented requirement that the capture format end in a newline.

## Deferred (documented limitations)

- Sorting is over **all** same-level headings in the note (not scoped per parent section) — correct for the single-group layouts above; `scopeToParent` is a future extension.
- Full SemVer pre-release precedence (build/pre-release metadata is dropped from the comparable core).
- "Re-sort an existing note's sections" is a separate future command (this only places the new section).

## Docs

New **"Ordered section placement"** subsection in `docs/docs/Choices/CaptureChoice.md` (Next/unreleased) with the daily-log recipe, sort options, changelog & books-by-year examples, and the limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **ordered placement** mode for “insert after” captures to create missing headings at the correct sorted position using configurable sort strategies (insertion order, text, number, date, and semver).
  * Updated the UI and capture-choice loading to support ordered options and enforce ordered vs inline compatibility.
  * Ordered inserts now display success messages referencing the resolved target heading.
* **Documentation**
  * Expanded capture documentation with detailed ordered placement rules, constraints, and examples.
* **Tests**
  * Added comprehensive coverage for ordered section placement logic, edge cases, and document formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->