### PR TITLE
feat(format): support Obsidian property types in format syntax (#757)

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -127,7 +127,7 @@ Tailors the input to an Obsidian property type. These are single-value prompts (
 
 - `|type:number` shows a numeric input. The value is written unquoted (`rating: 42`), so Obsidian reads it as a **Number**.
 - `|type:checkbox` (alias `|type:boolean`) shows a forced **true / false** picker — useful for a `checkbox` property. The `|label:` becomes the picker's title so you know which property you're setting. Writes `done: true` (a boolean).
-- `|type:text` keeps the value a **string** even when it looks like a number/boolean. Without it, a text property given `0042` would be read by Obsidian as the number `42`; `|type:text` writes `id: "0042"` so the text is preserved.
+- `|type:text` keeps the value a **string**. It writes the value as a quoted YAML scalar (`id: "0042"`), so Obsidian can't retype it — without it, a text property given `0042` is read as the number `42`, `true` as a boolean, and a value like `#todo` or `[a]` is mis-parsed entirely.
 
 ```markdown
 ---
@@ -137,9 +137,7 @@ id: {{VALUE:id|type:text}}
 ---
 ```
 
-**Good to know:** plain number and checkbox values already round-trip correctly without `|type:` — `count: {{VALUE:count}}` typed `42` becomes a Number, and `{{VALUE:true,false}}` becomes a Boolean. The `|type:` options add the right input widget and validation, and `|type:text` closes the one case Obsidian gets "wrong" (a text value that looks like a number/boolean/null). Dates like `2025-12-25` are always kept as text by Obsidian, so they never need `|type:text`.
-
-Type-aware quoting also runs automatically (no `|type:text` needed) when you enable **Settings → QuickAdd → "Format template variables as proper property types"** and the property is explicitly typed **Text** in Obsidian.
+**Good to know:** plain number and checkbox values already round-trip correctly without `|type:` — `count: {{VALUE:count}}` typed `42` becomes a Number, and `{{VALUE:true,false}}` becomes a Boolean. The `|type:` options add the right input widget and validation, and `|type:text` closes the cases Obsidian gets "wrong" (a text value that looks like a number/boolean, or one that starts with a YAML character like `#` or `[`). Dates like `2025-12-25` are always kept as text by Obsidian, so they never need `|type:text`.
 
 ## `{{VALUE|case:<style>}}` / `{{NAME|case:<style>}}` / `{{VALUE:<variable>|case:<style>}}` {#value-case}
 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -35,6 +35,18 @@ You can combine a default with the `optional` flag in any order: `{{VDATE:due,YY
 
 **Note:** Pipe characters (`|`) cannot be used inside VDATE date formats — everything after the first pipe is treated as the default value (and flags). Use a different literal, e.g. wrap text in square brackets: `{{VDATE:due,[Due ]YYYY-MM-DD}}`.
 
+## `{{VDATE:<variable name>, <date format>|time}}` {#vdate-time}
+
+Adds a **time picker** to the date prompt (aliases: `|datetime`, `|type:datetime`), for `Date & time` properties. The calendar gains an `HH:mm` control, and picking a day keeps the time you set (it isn't reset to midnight). If you omit the date format, it defaults to `YYYY-MM-DD HH:mm`.
+
+```markdown
+---
+start: {{VDATE:start,YYYY-MM-DDTHH:mm|time}}
+---
+```
+
+Combines with a default and `optional` in any order: `{{VDATE:meeting,YYYY-MM-DD HH:mm|tomorrow at 3pm|time|optional}}`. Without `|time`, the picker stays date-only and behaves exactly as before.
+
 ## `{{VALUE}}` / `{{NAME}}` {#value}
 
 Interchangeable. Represents the value given in an input prompt. If text is selected in the current editor, it will be used as the value. For Capture choices, selection-as-value can be disabled globally or per-capture. When using the QuickAdd API, this can be passed programmatically using the reserved variable name 'value'.
@@ -109,6 +121,26 @@ Example:
 {{VALUE:summary|type:multiline|label:Summary}}
 ```
 
+## `{{VALUE:<variable>|type:number}}` / `|type:checkbox` / `|type:text` {#value-property-types}
+
+Tailors the input to an Obsidian property type. These are single-value prompts (no comma options / `|custom`):
+
+- `|type:number` shows a numeric input. The value is written unquoted (`rating: 42`), so Obsidian reads it as a **Number**.
+- `|type:checkbox` (alias `|type:boolean`) shows a forced **true / false** picker — useful for a `checkbox` property. The `|label:` becomes the picker's title so you know which property you're setting. Writes `done: true` (a boolean).
+- `|type:text` keeps the value a **string** even when it looks like a number/boolean. Without it, a text property given `0042` would be read by Obsidian as the number `42`; `|type:text` writes `id: "0042"` so the text is preserved.
+
+```markdown
+---
+rating: {{VALUE:rating|type:number}}
+done: {{VALUE:done|type:checkbox|label:Completed?}}
+id: {{VALUE:id|type:text}}
+---
+```
+
+**Good to know:** plain number and checkbox values already round-trip correctly without `|type:` — `count: {{VALUE:count}}` typed `42` becomes a Number, and `{{VALUE:true,false}}` becomes a Boolean. The `|type:` options add the right input widget and validation, and `|type:text` closes the one case Obsidian gets "wrong" (a text value that looks like a number/boolean/null). Dates like `2025-12-25` are always kept as text by Obsidian, so they never need `|type:text`.
+
+Type-aware quoting also runs automatically (no `|type:text` needed) when you enable **Settings → QuickAdd → "Format template variables as proper property types"** and the property is explicitly typed **Text** in Obsidian.
+
 ## `{{VALUE|case:<style>}}` / `{{NAME|case:<style>}}` / `{{VALUE:<variable>|case:<style>}}` {#value-case}
 
 Transforms the resolved value into a casing style. Supported: `kebab`, `snake`, `camel`, `pascal`, `title`, `lower`, `upper`, `slug`.
@@ -118,6 +150,35 @@ Example: `{{DATE:YYYY-MM-DD}}-{{VALUE:title|case:slug}}.md`.
 ## `{{VALUE:<options>|custom}}` {#value-custom}
 
 Allows you to type custom values in addition to selecting from the provided options. Example: `{{VALUE:Red,Green,Blue|custom}}` will suggest Red, Green, and Blue, but also allows you to type any other value like "Purple". This is useful when you have common options but want flexibility for edge cases. **Note:** You cannot combine `|custom` with a shorthand default value - use `|default:` if you need both.
+
+## `{{VALUE:<options>|multi}}` {#value-multi}
+
+Turns an option-list suggester into a **multi-select**: pick several values and they're written as a YAML **List**. Requires an option list (2+ comma-separated values).
+
+```markdown
+---
+tags: {{VALUE:work,home,urgent|multi}}
+---
+```
+
+picks `work` and `urgent` → 
+
+```yaml
+tags:
+  - work
+  - urgent
+```
+
+Variants and combinations:
+
+- `|multi:linklist` wraps each pick as a wikilink, for List properties of links: `{{VALUE:Alice,Bob,Carol|multi:linklist}}` → `- "[[Alice]]"` / `- "[[Bob]]"`.
+- `|multi|custom` lets you add values not in the list (a text box in the picker).
+- Combines with `|name:`, `|label:`, `|text:`, and `|optional`. `|case:` is ignored with `|multi` (a list isn't case-transformed).
+
+Notes:
+
+- Multi-select writes a real List with no settings required. It produces a List **inside front matter**; used in the note body it renders as a comma-separated string.
+- In a **Capture**, multi-select becomes a List only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template). Other capture shapes write a comma-separated string instead.
 
 ## `{{VALUE:<options>|name:<variable name>}}` {#value-name}
 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -177,6 +177,7 @@ Notes:
 
 - Multi-select writes a real List with no settings required. It produces a List **inside front matter**; used in the note body it renders as a comma-separated string.
 - In a **Capture**, multi-select becomes a List only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template). Other capture shapes write a comma-separated string instead.
+- With the **one-page input form** (Settings → QuickAdd), avoid commas inside an individual option (e.g. `|text:"High, urgent"`) on a `|multi` token — the one-page picker can't round-trip a comma that lives inside a single option. The default one-prompt-at-a-time picker handles it correctly.
 
 ## `{{VALUE:<options>|name:<variable name>}}` {#value-name}
 

--- a/docs/docs/TemplatePropertyTypes.md
+++ b/docs/docs/TemplatePropertyTypes.md
@@ -18,6 +18,14 @@ QuickAdd writes proper Obsidian property types for template variables in front m
 
 The goal is to make note creation easier and more intuitive. While the string conversion is in beta, we appreciate your feedback and suggestions.
 
+**Prefer explicit format-syntax options** when you want a specific input or type, with no beta toggle required:
+
+- [`{{VALUE:x|type:number}}` / `|type:checkbox` / `|type:text`](./FormatSyntax#value-property-types) — pick the right input widget; `|type:text` keeps a number-looking value (e.g. `0042`) a string.
+- [`{{VALUE:a,b,c|multi}}`](./FormatSyntax#value-multi) — a multi-select picker that writes a real List (also `|multi:linklist` for link lists).
+- [`{{VDATE:when,fmt|time}}`](./FormatSyntax#vdate-time) — a date **and time** picker for `Date & time` properties.
+
+Plain `{{VALUE}}` already round-trips numbers, booleans, and dates to the correct type without any setting — the beta string conversion below mainly adds comma/bullet-string → List for properties typed as a list.
+
 **Before:**
 ```yaml
 authors: "John Doe, Jane Smith, Bob Wilson"  # Manual string formatting

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -306,6 +306,19 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				!this.choice?.createFileIfItDoesntExist?.createWithTemplate;
 			this.suppressFrontmatterCollection = !captureBecomesOwnFrontmatter;
 
+			// |multi only yields a real YAML list when its array can be collected
+			// into the new note's own front matter. In any other capture shape the
+			// array degrades to a comma-joined string; warn instead of silently
+			// writing the wrong shape.
+			if (
+				this.suppressFrontmatterCollection &&
+				/\{\{VALUE:[^}]*\|[^}]*multi/i.test(this.choice?.format?.format ?? "")
+			) {
+				log.logWarning(
+					"QuickAdd: {{VALUE:…|multi}} in this capture writes a comma-separated string, not a YAML list. Multi-select produces a real list only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template).",
+				);
+			}
+
 			if (fileAlreadyExists) {
 				getFileAndAddContentFn =
 					this.onFileExists.bind(this) as GetFileAndAddContentFn;

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -312,9 +312,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			// writing the wrong shape.
 			if (
 				this.suppressFrontmatterCollection &&
-				// `\|\s*multi` requires the flag directly after a pipe, and
-				// `(?![a-z])` excludes `|type:multiline`.
-				/\{\{VALUE:[^}]*\|\s*multi(?![a-z])/i.test(
+				// Match the `|multi` flag specifically: a pipe, then `multi`
+				// terminated by `:`/`|`/`}` or end — excluding `|type:multiline`,
+				// `|multi1`, `|multi-select`, etc.
+				/\{\{VALUE:[^}]*\|\s*multi(?=[:}|]|$)/i.test(
 					this.choice?.format?.format ?? "",
 				)
 			) {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -312,7 +312,11 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			// writing the wrong shape.
 			if (
 				this.suppressFrontmatterCollection &&
-				/\{\{VALUE:[^}]*\|[^}]*multi/i.test(this.choice?.format?.format ?? "")
+				// `\|\s*multi` requires the flag directly after a pipe, and
+				// `(?![a-z])` excludes `|type:multiline`.
+				/\{\{VALUE:[^}]*\|\s*multi(?![a-z])/i.test(
+					this.choice?.format?.format ?? "",
+				)
 			) {
 				log.logWarning(
 					"QuickAdd: {{VALUE:…|multi}} in this capture writes a comma-separated string, not a YAML list. Multi-select produces a real list only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template).",

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 	genericInputPromptWithContext: vi.fn(),
 	inputSuggesterSuggest: vi.fn(),
 	genericSuggesterSuggest: vi.fn(),
+	multiSuggesterSuggest: vi.fn(),
 	vdatePrompt: vi.fn(),
 	mathPrompt: vi.fn(),
 	fieldParse: vi.fn(),
@@ -104,6 +105,10 @@ vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
 
 vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
 	default: { Suggest: mocks.genericSuggesterSuggest },
+}));
+
+vi.mock("src/gui/MultiSuggester/multiSuggester", () => ({
+	default: { Suggest: mocks.multiSuggesterSuggest },
 }));
 
 vi.mock("src/gui/VDateInputPrompt/VDateInputPrompt", () => ({

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -324,6 +324,30 @@ export class CompleteFormatter extends Formatter {
 					return this.value;
 				}
 			}
+			// Anonymous {{VALUE|type:checkbox}} gets the same forced true/false
+			// picker as the named form (resolved before the InputPrompt factory).
+			if (this.valuePromptContext?.inputTypeOverride === "checkbox") {
+				try {
+					this.value = await GenericSuggester.Suggest(
+						this.app,
+						["true", "false"],
+						["true", "false"],
+						this.valuePromptContext.description ??
+							this.valueHeader ??
+							"Choose value",
+						undefined,
+						this.valuePromptContext.optional
+							? { skippable: true }
+							: undefined,
+					);
+					return this.value;
+				} catch (error) {
+					if (isCancellationError(error)) {
+						throw new UserCancelError("Input cancelled by user");
+					}
+					throw error;
+				}
+			}
 			try {
 				const linkSourcePath = this.getLinkSourcePath();
 				const promptFactory = new InputPrompt().factory(

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -381,6 +381,21 @@ export class CompleteFormatter extends Formatter {
 				);
 			}
 
+			// {{VALUE:x|type:checkbox}} renders a forced true/false picker (no
+			// free text) so the written `x: true` round-trips as a Checkbox. The
+			// |label (carried as description for single-value tokens) becomes the
+			// modal title so the user knows which property they are setting (#202).
+			if (context?.inputTypeOverride === "checkbox") {
+				return await GenericSuggester.Suggest(
+					this.app,
+					["true", "false"],
+					["true", "false"],
+					context.description ?? header ?? context.label ?? "Choose value",
+					undefined,
+					context.optional ? { skippable: true } : undefined,
+				);
+			}
+
 			// Use default prompt for other variables
 			return await new InputPrompt().factory(context?.inputTypeOverride).Prompt(
 				this.app,

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -2,6 +2,7 @@ import type { App, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
 import GenericInputPrompt from "src/gui/GenericInputPrompt/GenericInputPrompt";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
+import MultiSuggester from "src/gui/MultiSuggester/multiSuggester";
 import VDateInputPrompt from "src/gui/VDateInputPrompt/VDateInputPrompt";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { GLOBAL_VAR_REGEX, INLINE_JAVASCRIPT_REGEX } from "../constants";
@@ -460,6 +461,38 @@ export class CompleteFormatter extends Formatter {
 				context?.placeholder,
 				undefined,
 				context?.optional ? { skippable: true } : undefined,
+			);
+		} catch (error) {
+			if (isCancellationError(error)) {
+				throw new UserCancelError("Input cancelled by user");
+			}
+			throw error;
+		}
+	}
+
+	protected async suggestForValueMulti(
+		suggestedValues: string[],
+		allowCustomInput = false,
+		context?: {
+			placeholder?: string;
+			variableKey?: string;
+			displayValues?: string[];
+			optional?: boolean;
+		},
+	): Promise<string[]> {
+		try {
+			const displayValues = context?.displayValues ?? suggestedValues;
+			return await MultiSuggester.Suggest(
+				this.app,
+				displayValues,
+				suggestedValues,
+				{
+					...(context?.placeholder
+						? { placeholder: context.placeholder }
+						: {}),
+					allowCustomValue: allowCustomInput,
+					...(context?.optional ? { skippable: true } : {}),
+				},
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -374,10 +374,13 @@ export class CompleteFormatter extends Formatter {
 				return await VDateInputPrompt.Prompt(
 					this.app,
 					(header as string) ?? context.label ?? "Enter date",
-					"Enter a date (e.g., 'tomorrow', 'next friday', '2025-12-25')",
+					context.withTime
+						? "Enter a date & time (e.g., 'tomorrow at 3pm', '2025-12-25 14:30')"
+						: "Enter a date (e.g., 'tomorrow', 'next friday', '2025-12-25')",
 					context.defaultValue,
 					context.dateFormat ?? "YYYY-MM-DD",
 					context.optional ? { optional: true } : undefined,
+					context.withTime,
 				);
 			}
 

--- a/src/formatters/formatter-linksection.test.ts
+++ b/src/formatters/formatter-linksection.test.ts
@@ -44,6 +44,10 @@ class StubFormatter extends Formatter {
 		return "";
 	}
 
+	protected suggestForFile(): string {
+		return "";
+	}
+
 	protected async suggestForField(): Promise<string> {
 		return "";
 	}

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -738,7 +738,13 @@ export abstract class Formatter {
 				rawValue: rawValueForCollector,
 				fallbackKey: variableName,
 				collectionActive,
-				heuristicEnabled: propertyTypesEnabled && collectionActive,
+				// |type:text forces a string: never run the string->structured
+				// heuristic on it, or a comma/bracket value (`a,b`, `[x]`) would be
+				// collected as a List and bypass the quoting path below.
+				heuristicEnabled:
+					propertyTypesEnabled &&
+					collectionActive &&
+					parsed.inputTypeOverride !== "text",
 			});
 
 			// Keep the interim frontmatter YAML-parseable until post-processing

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -64,6 +64,7 @@ export interface PromptContext {
 	variableKey?: string;
 	inputTypeOverride?: ValueInputType; // Undefined means use global input prompt setting.
 	optional?: boolean; // Token carries |optional: empty submissions are accepted as the answer.
+	withTime?: boolean; // VDATE |time/|datetime: render a date AND time picker.
 }
 
 export interface TemplateInclusionState {
@@ -963,8 +964,11 @@ export abstract class Formatter {
 			if (!match || !match[1]) break;
 
 			const variableName = match[1].trim();
-			const dateFormat = match[2]?.trim() || "YYYY-MM-DD";
-			const { defaultValue, optional } = parseVDateOptions(match[3]);
+			const { defaultValue, optional, withTime } = parseVDateOptions(match[3]);
+			// A |time/|datetime token with no explicit format gets a datetime
+			// default so the rendered value carries the picked time.
+			const dateFormat =
+				match[2]?.trim() || (withTime ? "YYYY-MM-DD HH:mm" : "YYYY-MM-DD");
 
 			// Skip processing if variable name or format is empty
 			// This prevents crashes when typing incomplete patterns like {{VDATE:,
@@ -983,7 +987,7 @@ export abstract class Formatter {
 					// Prompt for date input with VDATE context
 					const dateInput = await this.promptForVariable(
 						variableName,
-						{ type: "VDATE", dateFormat, defaultValue, optional }
+						{ type: "VDATE", dateFormat, defaultValue, optional, withTime }
 					);
 					if (optional && !dateInput?.trim()) {
 						// Optional date left blank or skipped: answered-empty.

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -40,6 +40,7 @@ import { settingsStore } from "../settingsStore";
 import { normalizeDateInput } from "../utils/dateAliases";
 import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
+import { quoteYamlDouble } from "../utils/yamlScalarQuoting";
 import {
 	type ParsedValueToken,
 	parseAnonymousValueOptions,
@@ -706,9 +707,27 @@ export abstract class Formatter {
 			// fallback replacement to a string so non-string variable values (e.g.
 			// arrays from scripts on the non-collected path) don't desync the scanner.
 			const placeholder = getYamlPlaceholder(structuredYamlValue);
-			const replacement =
-				placeholder ??
-				String(transformCase(this.getVariableValue(effectiveKey), caseStyle) ?? "");
+			let replacement: string;
+			if (placeholder !== undefined) {
+				replacement = placeholder;
+			} else {
+				const stringVal = String(
+					transformCase(this.getVariableValue(effectiveKey), caseStyle) ?? "",
+				);
+				// Type-aware quoting (#757): stop Obsidian coercing a text value
+				// like "0042"/"true" into a Number/Boolean. Quotes only a
+				// coercion-prone string at a sole-value frontmatter position when
+				// the token is |type:text or the property is declared Text.
+				const quote = this.propertyCollector.shouldQuoteScalar({
+					input: output,
+					matchStart: match.index,
+					matchEnd: match.index + match[0].length,
+					rawString: stringVal,
+					explicitText: parsed.inputTypeOverride === "text",
+					autoEnabled: propertyTypesEnabled && collectionActive,
+				});
+				replacement = quote ? quoteYamlDouble(stringVal) : stringVal;
+			}
 
 			// Replace in output and adjust regex position
 			output = output.slice(0, match.index) + replacement + output.slice(match.index + match[0].length);

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -40,7 +40,7 @@ import { settingsStore } from "../settingsStore";
 import { normalizeDateInput } from "../utils/dateAliases";
 import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
-import { quoteYamlDouble } from "../utils/yamlScalarQuoting";
+import { quoteYamlDouble, shouldQuoteTextScalar } from "../utils/yamlScalarQuoting";
 import { toWikiLink } from "../utils/linkWrap";
 import {
 	type ParsedValueToken,
@@ -214,13 +214,26 @@ export abstract class Formatter {
 		// Replace all occurrences in a single non-recursive pass.
 		// Important: use a replacer function so `$` in user input is treated literally.
 		const regex = new RegExp(NAME_VALUE_REGEX.source, "gi");
-		output = output.replace(regex, (token) => {
+		output = output.replace(regex, (...args) => {
+			const token = args[0] as string;
+			const offset = args[args.length - 2] as number;
+			const source = args[args.length - 1] as string;
 			const inner = token.slice(2, -2);
 			const optionsIndex = inner.indexOf("|");
 			if (optionsIndex === -1) return this.value;
 			const rawOptions = inner.slice(optionsIndex);
 			const parsed = parseAnonymousValueOptions(rawOptions);
-			return transformCase(this.value, parsed.caseStyle);
+			const transformed = transformCase(this.value, parsed.caseStyle);
+			// |type:text on the anonymous {{VALUE|...}} form quotes the same way
+			// as the named form (see replaceVariableInString).
+			if (
+				parsed.inputTypeOverride === "text" &&
+				transformed !== "" &&
+				shouldQuoteTextScalar(source, offset, offset + token.length)
+			) {
+				return quoteYamlDouble(transformed);
+			}
+			return transformed;
 		});
 
 		return output;
@@ -247,8 +260,8 @@ export abstract class Formatter {
 			if (!context.defaultValue && parsed.defaultValue) {
 				context.defaultValue = parsed.defaultValue;
 			}
-			if (parsed.inputTypeOverride === "multiline") {
-				context.inputTypeOverride = "multiline";
+			if (parsed.inputTypeOverride && !context.inputTypeOverride) {
+				context.inputTypeOverride = parsed.inputTypeOverride;
 			}
 			if (parsed.optional) {
 				context.optional = true;
@@ -512,12 +525,15 @@ export abstract class Formatter {
 		if (!parsed.aliasName || !parsed.hasOptions) return;
 		const nameKey = parsed.variableKey.toLowerCase();
 		// Capture everything that changes the suggester behaviour — the
-		// options, the custom-input flag, and the display mapping — so a
-		// reordered definition that differs in any of these is flagged.
+		// options, the custom-input flag, the display mapping, and the
+		// multi-select shape — so a reordered definition that differs in any of
+		// these is flagged.
 		const signature = JSON.stringify([
 			parsed.suggestedValues,
 			parsed.allowCustomInput,
 			parsed.displayValues ?? null,
+			parsed.multiSelect,
+			parsed.multiEmit,
 		]);
 		const previous = this.namedSuggesterOptionSigs.get(nameKey);
 		if (previous === undefined) {
@@ -742,18 +758,17 @@ export abstract class Formatter {
 				const stringVal = String(
 					transformCase(this.getVariableValue(effectiveKey), caseStyle) ?? "",
 				);
-				// Type-aware quoting (#757): stop Obsidian coercing a text value
-				// like "0042"/"true" into a Number/Boolean. Quotes only a
-				// coercion-prone string at a sole-value frontmatter position when
-				// the token is |type:text or the property is declared Text.
-				const quote = this.propertyCollector.shouldQuoteScalar({
-					input: output,
-					matchStart: match.index,
-					matchEnd: match.index + match[0].length,
-					rawString: stringVal,
-					explicitText: parsed.inputTypeOverride === "text",
-					autoEnabled: propertyTypesEnabled && collectionActive,
-				});
+				// |type:text (#757): write the value as a quoted YAML string at a
+				// sole-value front-matter position so Obsidian can't retype it
+				// (e.g. "0042" -> 42, "true" -> boolean, "#todo" -> a comment).
+				const quote =
+					parsed.inputTypeOverride === "text" &&
+					stringVal !== "" &&
+					shouldQuoteTextScalar(
+						output,
+						match.index,
+						match.index + match[0].length,
+					);
 				replacement = quote ? quoteYamlDouble(stringVal) : stringVal;
 			}
 

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -41,6 +41,7 @@ import { normalizeDateInput } from "../utils/dateAliases";
 import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
 import { quoteYamlDouble } from "../utils/yamlScalarQuoting";
+import { toWikiLink } from "../utils/linkWrap";
 import {
 	type ParsedValueToken,
 	parseAnonymousValueOptions,
@@ -560,9 +561,30 @@ export abstract class Formatter {
 
 		if (resolvedKey) return resolvedKey;
 
-		let variableValue = "";
 		const helperText = !hasOptions && label ? label : undefined;
 		const suggesterPlaceholder = hasOptions && label ? label : undefined;
+
+		// |multi opens a multi-select picker and stores a real ARRAY so the
+		// property collector writes a proper YAML list (no beta flag needed).
+		if (hasOptions && parsed.multiSelect) {
+			const picked = await this.suggestForValueMulti(
+				suggestedValues,
+				allowCustomInput,
+				{
+					placeholder: suggesterPlaceholder,
+					variableKey,
+					displayValues,
+					optional: parsed.optional,
+				},
+			);
+			this.variables.set(
+				variableKey,
+				parsed.multiEmit === "linklist" ? picked.map(toWikiLink) : picked,
+			);
+			return variableKey;
+		}
+
+		let variableValue = "";
 
 		if (!hasOptions) {
 			// For single-value prompts, pass default value to pre-populate the input
@@ -711,6 +733,11 @@ export abstract class Formatter {
 			let replacement: string;
 			if (placeholder !== undefined) {
 				replacement = placeholder;
+			} else if (Array.isArray(rawValue)) {
+				// A |multi (or script) array that was NOT collected (body text, or a
+				// capture flow that suppresses frontmatter collection): join with
+				// commas. Guards against transformCase()/String() on an array.
+				replacement = rawValue.join(",");
 			} else {
 				const stringVal = String(
 					transformCase(this.getVariableValue(effectiveKey), caseStyle) ?? "",
@@ -953,6 +980,26 @@ export abstract class Formatter {
 			optional?: boolean;
 		},
 	): Promise<string> | string;
+
+	/**
+	 * Multi-select variant for {{VALUE:a,b,c|multi}}. Returns the chosen values
+	 * as an array, which the caller stores verbatim so the property collector
+	 * writes a YAML list. Non-abstract with an empty default so preview/preflight
+	 * and test stubs need no change; CompleteFormatter overrides it with the real
+	 * picker.
+	 */
+	protected suggestForValueMulti(
+		_suggestedValues: string[],
+		_allowCustomInput?: boolean,
+		_context?: {
+			placeholder?: string;
+			variableKey?: string;
+			displayValues?: string[];
+			optional?: boolean;
+		},
+	): Promise<string[]> | string[] {
+		return [];
+	}
 
 	protected abstract suggestForField(variableName: string): Promise<string>;
 

--- a/src/gui/InputPrompt.ts
+++ b/src/gui/InputPrompt.ts
@@ -1,5 +1,6 @@
 import GenericWideInputPrompt from "./GenericWideInputPrompt/GenericWideInputPrompt";
 import GenericInputPrompt from "./GenericInputPrompt/GenericInputPrompt";
+import NumberInputPrompt from "./NumberInputPrompt/NumberInputPrompt";
 import { getQuickAddInstance } from "../quickAddInstance";
 import type { ValueInputType } from "../utils/valueSyntax";
 
@@ -8,6 +9,12 @@ export default class InputPrompt {
 		if (inputTypeOverride === "multiline") {
 			return GenericWideInputPrompt;
 		}
+		if (inputTypeOverride === "number") {
+			return NumberInputPrompt;
+		}
+		// "checkbox" is resolved before the factory (a true/false suggester),
+		// and "text" only affects YAML quoting at write time — both fall
+		// through to the standard single-line prompt below.
 		if (getQuickAddInstance().settings.inputPrompt === "multi-line") {
 			return GenericWideInputPrompt;
 		} else {

--- a/src/gui/MultiSuggester/multiSuggester.ts
+++ b/src/gui/MultiSuggester/multiSuggester.ts
@@ -1,0 +1,156 @@
+import type { App } from "obsidian";
+import { Modal, Setting } from "obsidian";
+import { normalizeDisplayItem } from "../suggesters/utils";
+
+export interface MultiSuggesterOptions {
+	/** Modal title / prompt header. */
+	placeholder?: string;
+	/** Allow typing a value that isn't in the option list (|custom). */
+	allowCustomValue?: boolean;
+	/** Optional token: a "Skip" affordance resolves an empty selection. */
+	skippable?: boolean;
+}
+
+/**
+ * A modal multi-select for `{{VALUE:a,b,c|multi}}`. Each option is a toggle;
+ * the resolved value is the ordered list of selected option VALUES (display
+ * labels map back to their values), followed by any custom additions. Resolves
+ * `string[]` on Done, `[]` on Skip, and rejects (cancels the run) on
+ * Cancel/Esc — mirroring GenericSuggester's reject-on-dismiss contract.
+ */
+export default class MultiSuggester extends Modal {
+	public waitForClose: Promise<string[]>;
+	private resolvePromise!: (values: string[]) => void;
+	private rejectPromise!: (reason?: unknown) => void;
+	private didSubmit = false;
+	private skipped = false;
+
+	private readonly items: string[];
+	private readonly displayItems: string[];
+	private readonly opts: MultiSuggesterOptions;
+	private readonly selected = new Set<string>();
+	private readonly customValues: string[] = [];
+
+	public static Suggest(
+		app: App,
+		displayItems: string[],
+		items: string[],
+		options: MultiSuggesterOptions = {},
+	): Promise<string[]> {
+		return new MultiSuggester(app, displayItems, items, options).waitForClose;
+	}
+
+	constructor(
+		app: App,
+		displayItems: string[],
+		items: string[],
+		options: MultiSuggesterOptions = {},
+	) {
+		super(app);
+		this.items = items;
+		this.displayItems =
+			displayItems.length === items.length ? displayItems : items;
+		this.opts = options;
+		this.waitForClose = new Promise<string[]>((resolve, reject) => {
+			this.resolvePromise = resolve;
+			this.rejectPromise = reject;
+		});
+		this.render();
+		this.open();
+	}
+
+	private render() {
+		this.containerEl.addClass("quickAddModal", "qaMultiSuggester");
+		this.titleEl.setText(this.opts.placeholder ?? "Select one or more");
+		const { contentEl } = this;
+		contentEl.empty();
+
+		const list = contentEl.createDiv({ cls: "qa-multi-list" });
+		const rows = [
+			...this.items.map((value, i) => ({
+				value,
+				display: normalizeDisplayItem(this.displayItems[i] ?? value),
+			})),
+			...this.customValues.map((value) => ({ value, display: value })),
+		];
+		for (const { value, display } of rows) {
+			new Setting(list).setName(display).addToggle((toggle) =>
+				toggle.setValue(this.selected.has(value)).onChange((on) => {
+					if (on) this.selected.add(value);
+					else this.selected.delete(value);
+				}),
+			);
+		}
+
+		if (this.opts.allowCustomValue) {
+			let draft = "";
+			new Setting(contentEl)
+				.setName("Add a custom value")
+				.addText((text) =>
+					text
+						.setPlaceholder("Not in the list…")
+						.onChange((v) => (draft = v)),
+				)
+				.addButton((btn) =>
+					btn.setButtonText("Add").onClick(() => {
+						const trimmed = draft.trim();
+						if (!trimmed) return;
+						if (
+							!this.items.includes(trimmed) &&
+							!this.customValues.includes(trimmed)
+						) {
+							this.customValues.push(trimmed);
+						}
+						this.selected.add(trimmed);
+						this.render();
+					}),
+				);
+		}
+
+		const buttons = new Setting(contentEl);
+		buttons.addButton((btn) =>
+			btn.setButtonText("Done").setCta().onClick(() => this.submit()),
+		);
+		buttons.addButton((btn) =>
+			btn.setButtonText("Cancel").onClick(() => this.close()),
+		);
+		if (this.opts.skippable) {
+			buttons.addButton((btn) =>
+				btn
+					.setButtonText("Skip")
+					.setTooltip("Leave empty")
+					.onClick(() => {
+						this.skipped = true;
+						this.didSubmit = true;
+						this.close();
+					}),
+			);
+		}
+	}
+
+	private submit() {
+		this.didSubmit = true;
+		this.close();
+	}
+
+	/** Selected values in option order, then custom additions in add order. */
+	private collectResult(): string[] {
+		const ordered: string[] = [];
+		for (const value of this.items) {
+			if (this.selected.has(value)) ordered.push(value);
+		}
+		for (const value of this.customValues) {
+			if (this.selected.has(value)) ordered.push(value);
+		}
+		return ordered;
+	}
+
+	onClose() {
+		super.onClose();
+		if (this.didSubmit) {
+			this.resolvePromise(this.skipped ? [] : this.collectResult());
+		} else {
+			this.rejectPromise("no input given.");
+		}
+	}
+}

--- a/src/gui/NumberInputPrompt/NumberInputPrompt.ts
+++ b/src/gui/NumberInputPrompt/NumberInputPrompt.ts
@@ -1,0 +1,77 @@
+import type { App } from "obsidian";
+import type { TextComponent } from "obsidian";
+import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
+import type { InputPromptOptions } from "../../types/inputPrompt";
+
+/**
+ * A {@link GenericInputPrompt} that renders an `<input type="number">` for
+ * `{{VALUE:x|type:number}}` tokens. Chromium-based number inputs reject
+ * non-numeric content (the element's `.value` returns "" for invalid input),
+ * so a typed scalar always ends up either a valid number or empty — never the
+ * raw garbage that would land in frontmatter as a string and trip Obsidian's
+ * "Type mismatch". The returned value is still a string ("42") and is written
+ * raw-inline, which Obsidian already infers as a Number.
+ *
+ * Mirrors {@link GenericWideInputPrompt}: each prompt class owns a static
+ * `Prompt`/`PromptWithContext` that constructs ITS OWN type, because the base
+ * `GenericInputPrompt.Prompt` hardcodes `new GenericInputPrompt`.
+ */
+export default class NumberInputPrompt extends GenericInputPrompt {
+	public static Prompt(
+		app: App,
+		header: string,
+		placeholder?: string,
+		value?: string,
+		description?: string,
+		options?: InputPromptOptions,
+	): Promise<string> {
+		const modal = new NumberInputPrompt(
+			app,
+			header,
+			placeholder,
+			value,
+			undefined,
+			description,
+			options,
+		);
+		return modal.waitForClose;
+	}
+
+	public static PromptWithContext(
+		app: App,
+		header: string,
+		placeholder?: string,
+		value?: string,
+		linkSourcePath?: string,
+		description?: string,
+		options?: InputPromptOptions,
+	): Promise<string> {
+		const modal = new NumberInputPrompt(
+			app,
+			header,
+			placeholder,
+			value,
+			linkSourcePath,
+			description,
+			options,
+		);
+		return modal.waitForClose;
+	}
+
+	protected createInputField(
+		container: HTMLElement,
+		placeholder?: string,
+		value?: string,
+	): TextComponent {
+		const textComponent = super.createInputField(
+			container,
+			placeholder,
+			value,
+		);
+		textComponent.inputEl.type = "number";
+		textComponent.inputEl.inputMode = "decimal";
+		// Allow decimals/scientific notation; the browser still rejects letters.
+		textComponent.inputEl.setAttr("step", "any");
+		return textComponent;
+	}
+}

--- a/src/gui/VDateInputPrompt/VDateInputPrompt.ts
+++ b/src/gui/VDateInputPrompt/VDateInputPrompt.ts
@@ -17,6 +17,8 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 	private currentInput: string;
 	private isOpen = true;
 	private defaultValue: string | undefined;
+	private withTime: boolean;
+	private pickerHostEl: HTMLElement;
 	private datePicker?: DatePickerController;
 	private selectedIso?: string;
 	private lastPickerDisplayValue?: string;
@@ -28,7 +30,8 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 		placeholder?: string,
 		defaultValue?: string,
 		dateFormat?: string,
-		options?: InputPromptOptions
+		options?: InputPromptOptions,
+		withTime?: boolean
 	): Promise<string> {
 		const newPromptModal = new VDateInputPrompt(
 			app,
@@ -36,7 +39,8 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 			placeholder,
 			defaultValue,
 			dateFormat,
-			options
+			options,
+			withTime
 		);
 		return newPromptModal.waitForClose;
 	}
@@ -47,15 +51,25 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 		placeholder?: string,
 		defaultValue?: string,
 		dateFormat?: string,
-		options?: InputPromptOptions
+		options?: InputPromptOptions,
+		withTime?: boolean
 	) {
 		// Pass the defaultValue to the parent so the input box is pre-filled
 		super(app, header, placeholder, defaultValue ?? "", undefined, undefined, options);
 
 		this.containerEl.addClass("qaDatePrompt");
-		this.dateFormat = dateFormat || "YYYY-MM-DD";
+		this.withTime = withTime === true;
+		// A |time/|datetime token without an explicit format gets a datetime
+		// default so the rendered value carries the time the user picked.
+		this.dateFormat =
+			dateFormat || (this.withTime ? "YYYY-MM-DD HH:mm" : "YYYY-MM-DD");
 		this.defaultValue = defaultValue;
 		this.currentInput = defaultValue ?? "";
+
+		// Mount the picker here (NOT in createInputField, which runs during the
+		// super() display() call before this.withTime is set), so the time
+		// control reflects the |time/|datetime flag.
+		this.mountDatePicker();
 
 		// Create debounced preview update function (250ms delay, reset on each call)
 		this.updatePreviewDebounced = debounce(
@@ -92,7 +106,12 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 		// Initialize currentInput with the initial value (which should be defaultValue)
 		this.currentInput = value ?? "";
 
-		this.createDatePicker(container);
+		// Only reserve the host element here (runs during super(), before
+		// this.withTime is known); the picker itself is mounted from the
+		// constructor body via mountDatePicker().
+		this.pickerHostEl = container.createDiv({
+			cls: "qa-date-picker-container",
+		});
 
 		// Create preview element
 		this.createPreviewElement(container);
@@ -100,14 +119,11 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 		return textComponent;
 	}
 
-	private createDatePicker(container: HTMLElement) {
-		const pickerContainer = container.createDiv({
-			cls: "qa-date-picker-container",
-		});
-
+	private mountDatePicker() {
 		this.datePicker = createDatePicker({
-			container: pickerContainer,
+			container: this.pickerHostEl,
 			initialIso: this.selectedIso,
+			withTime: this.withTime,
 			onSelect: (iso) => {
 				if (iso) this.applyPickerSelection(iso);
 				else this.clearPickerSelection();

--- a/src/gui/date-picker/datePicker.test.ts
+++ b/src/gui/date-picker/datePicker.test.ts
@@ -36,4 +36,14 @@ describe("extractTimeFromIso", () => {
 		expect(extractTimeFromIso("2025-12-25")).toBeNull();
 		expect(extractTimeFromIso(undefined)).toBeNull();
 	});
+
+	it("rejects out-of-range hours/minutes", () => {
+		expect(extractTimeFromIso("2025-12-25T99:99")).toBeNull();
+		expect(extractTimeFromIso("2025-12-25T24:00")).toBeNull();
+		expect(extractTimeFromIso("2025-12-25T12:60")).toBeNull();
+		expect(extractTimeFromIso("2025-12-25T23:59")).toEqual({
+			hour: 23,
+			minute: 59,
+		});
+	});
 });

--- a/src/gui/date-picker/datePicker.test.ts
+++ b/src/gui/date-picker/datePicker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { extractTimeFromIso, toIsoFromParts } from "./datePicker";
+
+describe("toIsoFromParts", () => {
+	it("emits a bare date key with no time (byte-identical to date-only)", () => {
+		expect(toIsoFromParts(2025, 11, 25)).toBe("2025-12-25");
+		expect(toIsoFromParts(2025, 11, 25, null)).toBe("2025-12-25");
+	});
+
+	it("emits an offset-less local datetime when given a time", () => {
+		expect(toIsoFromParts(2025, 11, 25, { hour: 14, minute: 30 })).toBe(
+			"2025-12-25T14:30:00",
+		);
+		expect(toIsoFromParts(2026, 0, 5, { hour: 9, minute: 5 })).toBe(
+			"2026-01-05T09:05:00",
+		);
+	});
+});
+
+describe("extractTimeFromIso", () => {
+	it("reads HH:mm from a T-separated datetime", () => {
+		expect(extractTimeFromIso("2025-12-25T14:30:00")).toEqual({
+			hour: 14,
+			minute: 30,
+		});
+	});
+
+	it("reads HH:mm from a space-separated datetime", () => {
+		expect(extractTimeFromIso("2025-12-25 09:05")).toEqual({
+			hour: 9,
+			minute: 5,
+		});
+	});
+
+	it("returns null for a date-only string or undefined", () => {
+		expect(extractTimeFromIso("2025-12-25")).toBeNull();
+		expect(extractTimeFromIso(undefined)).toBeNull();
+	});
+});

--- a/src/gui/date-picker/datePicker.ts
+++ b/src/gui/date-picker/datePicker.ts
@@ -13,7 +13,14 @@ export interface DatePickerOptions {
 	container: HTMLElement;
 	initialIso?: string;
 	weekStartsOn?: number;
+	/** When true, render a time control and emit datetime ISOs (issue #757). */
+	withTime?: boolean;
 	onSelect: (iso: string | null, source: DatePickerSelectSource) => void;
+}
+
+interface TimeParts {
+	hour: number;
+	minute: number;
 }
 
 const pad = (value: number) => value.toString().padStart(2, "0");
@@ -73,8 +80,32 @@ const parseIsoToDate = (iso?: string): Date | null => {
 	return parsed;
 };
 
-const toIsoFromParts = (year: number, month: number, day: number): string => {
-	return formatDateKey(year, month, day);
+/**
+ * Builds the ISO emitted on selection. Without time it stays the bare
+ * `YYYY-MM-DD` date key (byte-identical to the date-only picker). With time it
+ * appends an OFFSET-LESS local wall-clock `THH:mm:00` — never `Z`/toISOString,
+ * so the chosen hour round-trips identically across timezones.
+ */
+export const toIsoFromParts = (
+	year: number,
+	month: number,
+	day: number,
+	time?: TimeParts | null,
+): string => {
+	const dateKey = formatDateKey(year, month, day);
+	if (!time) return dateKey;
+	return `${dateKey}T${pad(time.hour)}:${pad(time.minute)}:00`;
+};
+
+/** Reads HH:mm out of a `...THH:mm` or `... HH:mm` ISO; null when absent. */
+export const extractTimeFromIso = (iso?: string): TimeParts | null => {
+	if (!iso) return null;
+	const match = /[T ](\d{2}):(\d{2})/.exec(iso);
+	if (!match) return null;
+	const hour = Number.parseInt(match[1], 10);
+	const minute = Number.parseInt(match[2], 10);
+	if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+	return { hour, minute };
 };
 
 export const createDatePicker = (
@@ -88,6 +119,13 @@ export const createDatePicker = (
 	let viewYear = initialDate.getFullYear();
 	let viewMonth = initialDate.getMonth();
 	let selectedIso = options.initialIso;
+
+	const withTime = options.withTime === true;
+	// The wall-clock time merged into every picked day. Seeded from the initial
+	// ISO (if it carried a time), else midnight.
+	let currentTime: TimeParts | null = withTime
+		? extractTimeFromIso(options.initialIso) ?? { hour: 0, minute: 0 }
+		: null;
 
 	const root = options.container.createDiv({ cls: "qa-date-picker" });
 
@@ -129,6 +167,20 @@ export const createDatePicker = (
 	});
 	clearBtn.type = "button";
 
+	let timeInput: HTMLInputElement | undefined;
+	if (withTime) {
+		const timeRow = root.createDiv({ cls: "qa-date-picker__time" });
+		timeRow.createEl("label", {
+			cls: "qa-date-picker__time-label",
+			text: "Time",
+		});
+		timeInput = timeRow.createEl("input", { cls: "qa-date-picker__time-input" });
+		timeInput.type = "time";
+		if (currentTime) {
+			timeInput.value = `${pad(currentTime.hour)}:${pad(currentTime.minute)}`;
+		}
+	}
+
 	const shiftMonth = (delta: number) => {
 		viewMonth += delta;
 		if (viewMonth > 11) {
@@ -162,6 +214,7 @@ export const createDatePicker = (
 			today.getFullYear(),
 			today.getMonth(),
 			today.getDate(),
+			currentTime,
 		);
 		viewYear = today.getFullYear();
 		viewMonth = today.getMonth();
@@ -169,6 +222,30 @@ export const createDatePicker = (
 	});
 
 	clearBtn.addEventListener("click", () => clearSelection("action"));
+
+	if (timeInput) {
+		timeInput.addEventListener("change", () => {
+			const [h, m] = timeInput.value.split(":").map((p) => Number.parseInt(p, 10));
+			if (Number.isNaN(h) || Number.isNaN(m)) return;
+			currentTime = { hour: h, minute: m };
+			// Re-emit so editing the time after picking a day updates the value
+			// instead of being dropped.
+			if (selectedIso) {
+				const parsed = parseIsoToDate(selectedIso);
+				if (parsed) {
+					selectIso(
+						toIsoFromParts(
+							parsed.getFullYear(),
+							parsed.getMonth(),
+							parsed.getDate(),
+							currentTime,
+						),
+						"picker",
+					);
+				}
+			}
+		});
+	}
 
 	const render = () => {
 		label.textContent = getMonthLabel(viewYear, viewMonth);
@@ -217,6 +294,7 @@ export const createDatePicker = (
 					date.getFullYear(),
 					date.getMonth(),
 					date.getDate(),
+					currentTime,
 				);
 				selectIso(iso, "picker");
 			});
@@ -233,6 +311,17 @@ export const createDatePicker = (
 				if (parsed) {
 					viewYear = parsed.getFullYear();
 					viewMonth = parsed.getMonth();
+				}
+			}
+			// Reflect a time carried by the incoming ISO (e.g. parsed from the
+			// text box) into the time control so the two stay in sync.
+			if (withTime && iso) {
+				const time = extractTimeFromIso(iso);
+				if (time) {
+					currentTime = time;
+					if (timeInput) {
+						timeInput.value = `${pad(time.hour)}:${pad(time.minute)}`;
+					}
 				}
 			}
 			render();

--- a/src/gui/date-picker/datePicker.ts
+++ b/src/gui/date-picker/datePicker.ts
@@ -105,6 +105,7 @@ export const extractTimeFromIso = (iso?: string): TimeParts | null => {
 	const hour = Number.parseInt(match[1], 10);
 	const minute = Number.parseInt(match[2], 10);
 	if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+	if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
 	return { hour, minute };
 };
 

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -145,6 +145,23 @@ export class OnePageInputModal extends Modal {
 					.onChange((v) => setValue(req.id, v));
 				break;
 			}
+			case "number": {
+				// |type:number — a numeric input so the one-page form rejects
+				// non-numeric text like the runtime NumberInputPrompt does.
+				const setting = new Setting(this.contentEl).setName(
+					this.decorateLabel(req),
+				);
+				if (req.description) setting.setDesc(req.description);
+				const input = new TextComponent(setting.controlEl);
+				input.inputEl.type = "number";
+				input.inputEl.inputMode = "decimal";
+				input.inputEl.setAttr("step", "any");
+				input
+					.setPlaceholder(req.placeholder ?? "")
+					.setValue(starting)
+					.onChange((v) => setValue(req.id, v));
+				break;
+			}
 			case "dropdown": {
 				const setting = new Setting(this.contentEl).setName(
 					this.decorateLabel(req),

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -209,6 +209,7 @@ export class OnePageInputModal extends Modal {
 				const datePicker = createDatePicker({
 					container: pickerContainer,
 					initialIso: selectedIso,
+					withTime: req.withTime === true,
 					onSelect: (iso) => {
 						if (iso) applyPickerSelection(iso);
 						else clearPickerSelection();

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -406,3 +406,42 @@ describe("RequirementCollector — optional fields (issue #1259)", () => {
     });
   });
 });
+
+describe("RequirementCollector property types (#757)", () => {
+  const run = async (template: string) => {
+    const rc = new RequirementCollector(makeApp(), makePlugin());
+    await rc.scanString(template);
+    return Object.fromEntries(
+      Array.from(rc.requirements.values()).map((r) => [r.id, r]),
+    );
+  };
+
+  it("maps |type:number to a number field", async () => {
+    const byId = await run("{{VALUE:rating|type:number}}");
+    expect(byId["rating"].type).toBe("number");
+  });
+
+  it("maps |type:checkbox to a true/false dropdown", async () => {
+    const byId = await run("{{VALUE:done|type:checkbox}}");
+    expect(byId["done"].type).toBe("dropdown");
+    expect(byId["done"].options).toEqual(["true", "false"]);
+  });
+
+  it("maps |multi to a multi-select suggester", async () => {
+    const byId = await run("{{VALUE:a,b,c|multi}}");
+    const req = byId["a,b,c"];
+    expect(req.type).toBe("suggester");
+    expect(req.suggesterConfig?.multiSelect).toBe(true);
+    expect(req.multiEmit).toBe("text");
+  });
+
+  it("carries |multi:linklist and |multi|custom config", async () => {
+    const link = await run("{{VALUE:a,b|multi:linklist}}");
+    expect(link["a,b"].multiEmit).toBe("linklist");
+    const custom = await run("{{VALUE:a,b|multi|custom}}");
+    expect(custom["a,b"].suggesterConfig).toMatchObject({
+      multiSelect: true,
+      allowCustomInput: true,
+    });
+  });
+});

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -180,6 +180,10 @@ export class RequirementCollector extends Formatter {
 			const requirementId = variableKey;
 
 			if (!this.requirements.has(requirementId)) {
+				// |type:checkbox renders a forced true/false dropdown so the
+				// one-page form matches the runtime suggester (item #757).
+				const isCheckbox =
+					!hasOptions && parsed.inputTypeOverride === "checkbox";
 				const baseInputType =
 					parsed.inputTypeOverride === "multiline" ||
 					this.plugin.settings.inputPrompt === "multi-line"
@@ -190,11 +194,14 @@ export class RequirementCollector extends Formatter {
 					label: displayLabel,
 					type: hasOptions
 						? this.optionFieldType(parsed)
-						: baseInputType,
+						: isCheckbox
+							? "dropdown"
+							: baseInputType,
 					description,
 					optional: parsed.optional,
 				};
 				if (hasOptions) this.applyOptionFields(req, parsed);
+				else if (isCheckbox) req.options = ["true", "false"];
 				if (defaultValue) req.defaultValue = defaultValue;
 				this.requirements.set(requirementId, req);
 			} else {

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -27,6 +27,7 @@ import {
 
 export type FieldType =
 	| "text"
+	| "number"
 	| "textarea"
 	| "dropdown"
 	| "date"
@@ -182,11 +183,14 @@ export class RequirementCollector extends Formatter {
 			const requirementId = variableKey;
 
 			if (!this.requirements.has(requirementId)) {
-				// |type:checkbox renders a forced true/false dropdown so the
-				// one-page form matches the runtime suggester (item #757).
+				// |type:checkbox renders a forced true/false dropdown and
+				// |type:number a numeric input, so the one-page form matches the
+				// runtime suggester/prompt (item #757).
 				const isCheckbox =
 					!hasOptions && parsed.inputTypeOverride === "checkbox";
-				const baseInputType =
+				const isNumber =
+					!hasOptions && parsed.inputTypeOverride === "number";
+				const baseInputType: FieldType =
 					parsed.inputTypeOverride === "multiline" ||
 					this.plugin.settings.inputPrompt === "multi-line"
 						? "textarea"
@@ -198,7 +202,9 @@ export class RequirementCollector extends Formatter {
 						? this.optionFieldType(parsed)
 						: isCheckbox
 							? "dropdown"
-							: baseInputType,
+							: isNumber
+								? "number"
+								: baseInputType,
 					description,
 					optional: parsed.optional,
 				};

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -45,6 +45,7 @@ export interface FieldRequirement {
 	displayOptions?: string[]; // visible labels for mapped VALUE lists
 	// Additional metadata
 	dateFormat?: string; // for VDATE
+	withTime?: boolean; // VDATE |time/|datetime: render a date AND time picker
 	filters?: string; // serialized filters for FIELD variables
 	source?: "collected" | "script"; // provenance for UX badges
 	/** True only when EVERY scanned occurrence of the variable is |optional. */
@@ -288,8 +289,11 @@ export class RequirementCollector extends Formatter {
 			const variableName = match[1]?.trim();
 			if (!variableName) continue;
 
-			const dateFormat = match[2]?.trim() || "YYYY-MM-DD";
-			const { defaultValue, optional } = parseVDateOptions(match[3]);
+			const { defaultValue, optional, withTime } = parseVDateOptions(
+				match[3],
+			);
+			const dateFormat =
+				match[2]?.trim() || (withTime ? "YYYY-MM-DD HH:mm" : "YYYY-MM-DD");
 
 			const existing = this.requirements.get(variableName);
 			if (!existing) {
@@ -299,6 +303,7 @@ export class RequirementCollector extends Formatter {
 					type: "date",
 					defaultValue,
 					dateFormat,
+					withTime,
 					optional,
 					source: "collected",
 				});

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -46,6 +46,7 @@ export interface FieldRequirement {
 	// Additional metadata
 	dateFormat?: string; // for VDATE
 	withTime?: boolean; // VDATE |time/|datetime: render a date AND time picker
+	multiEmit?: "text" | "linklist"; // |multi:linklist wraps picks as [[name]]
 	filters?: string; // serialized filters for FIELD variables
 	source?: "collected" | "script"; // provenance for UX badges
 	/** True only when EVERY scanned occurrence of the variable is |optional. */
@@ -246,8 +247,12 @@ export class RequirementCollector extends Formatter {
 
 	private optionFieldType(parsed: {
 		allowCustomInput: boolean;
+		multiSelect?: boolean;
 	}): FieldType {
-		return parsed.allowCustomInput ? "suggester" : "dropdown";
+		// Multi-select needs the suggester widget (the dropdown is single-value).
+		return parsed.allowCustomInput || parsed.multiSelect
+			? "suggester"
+			: "dropdown";
 	}
 
 	private hasOptionList(req: FieldRequirement): boolean {
@@ -260,15 +265,22 @@ export class RequirementCollector extends Formatter {
 			suggestedValues: string[];
 			displayValues?: string[];
 			allowCustomInput: boolean;
+			multiSelect?: boolean;
+			multiEmit?: "text" | "linklist";
 		},
 	): void {
 		req.options = parsed.suggestedValues;
 		if (parsed.displayValues) req.displayOptions = parsed.displayValues;
-		if (parsed.allowCustomInput) {
+		if (parsed.multiSelect) req.multiEmit = parsed.multiEmit ?? "text";
+		else delete req.multiEmit;
+		// A suggesterConfig is needed for EITHER a custom-input OR a multi-select
+		// token (the two are independent — |multi without |custom must still
+		// enable multiSelect on the one-page picker).
+		if (parsed.allowCustomInput || parsed.multiSelect) {
 			req.suggesterConfig = {
-				allowCustomInput: true,
+				allowCustomInput: parsed.allowCustomInput,
 				caseSensitive: false,
-				multiSelect: false,
+				multiSelect: parsed.multiSelect ?? false,
 			};
 		} else {
 			delete req.suggesterConfig;

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -335,6 +335,12 @@ export class RequirementCollector extends Formatter {
 				)
 					existing.defaultValue = defaultValue;
 				existing.optional = (existing.optional ?? false) && optional;
+				// If ANY occurrence of the reused date wants a time picker, the
+				// shared control must offer one (and a datetime format).
+				if (existing.type === "date" && withTime && !existing.withTime) {
+					existing.withTime = true;
+					if (!match[2]?.trim()) existing.dateFormat = "YYYY-MM-DD HH:mm";
+				}
 			}
 		}
 	}

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -82,7 +82,11 @@ export async function runOnePagePreflight(
 		// wrapping when requested.
 		const multiInfoByKey = new Map<
 			string,
-			{ emit: "text" | "linklist"; displayToValue: Map<string, string> }
+			{
+				emit: "text" | "linklist";
+				allowCustom: boolean;
+				displayToValue: Map<string, string>;
+			}
 		>();
 		for (const req of unresolved) {
 			if (req.id.startsWith(FILE_VARIABLE_PREFIX)) {
@@ -97,6 +101,7 @@ export async function runOnePagePreflight(
 				});
 				multiInfoByKey.set(req.id, {
 					emit: req.multiEmit ?? "text",
+					allowCustom: req.suggesterConfig.allowCustomInput ?? false,
 					displayToValue,
 				});
 			}
@@ -110,6 +115,12 @@ export async function runOnePagePreflight(
 					.split(",")
 					.map((s) => s.trim())
 					.filter(Boolean)
+					// Drop typed entries that aren't options unless the token opted
+					// into custom input, matching the runtime MultiSuggester.
+					.filter(
+						(label) =>
+							multiInfo.allowCustom || multiInfo.displayToValue.has(label),
+					)
 					// Map the display label back to its value; a typed custom value
 					// (no mapping) passes through unchanged.
 					.map((label) => multiInfo.displayToValue.get(label) ?? label);

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -75,30 +75,47 @@ export async function runOnePagePreflight(
 		// requirement's encoded `@file:` picks is treated as typed custom text (and
 		// can't spoof a pick by typing the internal `@file:` sentinel).
 		const fileOptionsByKey = new Map<string, string[]>();
-		// |multi requirements: the suggester stores a ", "-joined string; split it
-		// back into a real array so the formatter writes a YAML list (matching the
-		// runtime |multi path), applying linklist wrapping when requested.
-		const multiEmitByKey = new Map<string, "text" | "linklist">();
+		// |multi requirements: the suggester stores a ", "-joined string of the
+		// DISPLAY labels; split it, map each label back to its option value (so
+		// |text: mappings round-trip), and store a real array so the formatter
+		// writes a YAML list — matching the runtime |multi path, with linklist
+		// wrapping when requested.
+		const multiInfoByKey = new Map<
+			string,
+			{ emit: "text" | "linklist"; displayToValue: Map<string, string> }
+		>();
 		for (const req of unresolved) {
 			if (req.id.startsWith(FILE_VARIABLE_PREFIX)) {
 				fileOptionsByKey.set(req.id, req.options ?? []);
 			}
 			if (req.suggesterConfig?.multiSelect) {
-				multiEmitByKey.set(req.id, req.multiEmit ?? "text");
+				const options = req.options ?? [];
+				const displayOptions = req.displayOptions ?? options;
+				const displayToValue = new Map<string, string>();
+				options.forEach((value, i) => {
+					displayToValue.set((displayOptions[i] ?? value).trim(), value);
+				});
+				multiInfoByKey.set(req.id, {
+					emit: req.multiEmit ?? "text",
+					displayToValue,
+				});
 			}
 		}
 
 		// Store results into executor variables
 		Object.entries(values).forEach(([k, v]) => {
-			const multiEmit = multiEmitByKey.get(k);
-			if (multiEmit !== undefined) {
+			const multiInfo = multiInfoByKey.get(k);
+			if (multiInfo !== undefined) {
 				const items = String(v)
 					.split(",")
 					.map((s) => s.trim())
-					.filter(Boolean);
+					.filter(Boolean)
+					// Map the display label back to its value; a typed custom value
+					// (no mapping) passes through unchanged.
+					.map((label) => multiInfo.displayToValue.get(label) ?? label);
 				choiceExecutor.variables.set(
 					k,
-					multiEmit === "linklist" ? items.map(toWikiLink) : items,
+					multiInfo.emit === "linklist" ? items.map(toWikiLink) : items,
 				);
 				return;
 			}

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -9,6 +9,7 @@ import {
 	canonicalizeOnePageFileValue,
 	FILE_VARIABLE_PREFIX,
 } from "src/utils/fileSyntax";
+import { toWikiLink } from "src/utils/linkWrap";
 import {
 	collectChoiceRequirements,
 	getUnresolvedRequirements,
@@ -74,14 +75,33 @@ export async function runOnePagePreflight(
 		// requirement's encoded `@file:` picks is treated as typed custom text (and
 		// can't spoof a pick by typing the internal `@file:` sentinel).
 		const fileOptionsByKey = new Map<string, string[]>();
+		// |multi requirements: the suggester stores a ", "-joined string; split it
+		// back into a real array so the formatter writes a YAML list (matching the
+		// runtime |multi path), applying linklist wrapping when requested.
+		const multiEmitByKey = new Map<string, "text" | "linklist">();
 		for (const req of unresolved) {
 			if (req.id.startsWith(FILE_VARIABLE_PREFIX)) {
 				fileOptionsByKey.set(req.id, req.options ?? []);
+			}
+			if (req.suggesterConfig?.multiSelect) {
+				multiEmitByKey.set(req.id, req.multiEmit ?? "text");
 			}
 		}
 
 		// Store results into executor variables
 		Object.entries(values).forEach(([k, v]) => {
+			const multiEmit = multiEmitByKey.get(k);
+			if (multiEmit !== undefined) {
+				const items = String(v)
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean);
+				choiceExecutor.variables.set(
+					k,
+					multiEmit === "linklist" ? items.map(toWikiLink) : items,
+				);
+				return;
+			}
 			const fileOptions = fileOptionsByKey.get(k);
 			const normalized = fileOptions
 				? canonicalizeOnePageFileValue(v, fileOptions)

--- a/src/styles.css
+++ b/src/styles.css
@@ -985,6 +985,17 @@
 	flex: 1;
 }
 
+.qaMultiSuggester .qa-multi-list {
+	max-height: 50vh;
+	overflow-y: auto;
+	margin-bottom: 0.5rem;
+}
+
+.qaMultiSuggester .qa-multi-list .setting-item {
+	padding: 0.4rem 0;
+	border: none;
+}
+
 /* Priority indicators - subtle left border */
 .qa-suggest-exact::before {
   content: '';

--- a/src/styles.css
+++ b/src/styles.css
@@ -967,6 +967,24 @@
 	background: var(--background-modifier-hover);
 }
 
+.qa-date-picker__time {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+	padding-top: 0.5rem;
+	border-top: 1px solid var(--background-modifier-border);
+}
+
+.qa-date-picker__time-label {
+	font-size: 0.75rem;
+	color: var(--text-muted);
+}
+
+.qa-date-picker__time-input {
+	flex: 1;
+}
+
 /* Priority indicators - subtle left border */
 .qa-suggest-exact::before {
   content: '';

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -5,7 +5,6 @@ import {
 	type ParseOptions,
 } from "./templatePropertyStringParser";
 import { isContainerYamlValue, isStructuredYamlValue } from "./yamlValues";
-import { wouldYamlMisCoerce } from "./yamlScalarQuoting";
 
 const PATH_SEPARATOR = "\u0000";
 
@@ -33,7 +32,6 @@ type CollectArgs = {
 export class TemplatePropertyCollector {
   private map = new Map<string, unknown>();
   private propertyTypeCache = new Map<string, string | null>();
-  private expectedTypeCache = new Map<string, string | null>();
 
   constructor(private readonly app?: App) {}
 
@@ -153,99 +151,36 @@ export class TemplatePropertyCollector {
     return path.length > 0 ? path : null;
   }
 
-  private getTypeInfo(propertyKey: string):
-    | {
-        expected?: { type?: string } | null;
-        inferred?: { type?: string } | null;
-      }
-    | undefined {
-    if (!this.app) return undefined;
-    const appAny = this.app as unknown as {
-      metadataTypeManager?: { getTypeInfo?: (key: string) => unknown };
-      metadataCache?: { app?: { metadataTypeManager?: { getTypeInfo?: (key: string) => unknown } } };
-    };
-    const manager =
-      appAny.metadataTypeManager ?? appAny.metadataCache?.app?.metadataTypeManager;
-    if (!manager || typeof manager.getTypeInfo !== "function") return undefined;
-    return manager.getTypeInfo(propertyKey) as
-      | {
-          expected?: { type?: string } | null;
-          inferred?: { type?: string } | null;
-        }
-      | undefined;
-  }
-
-  /** Expected-or-inferred type; used to decide comma/bullet list splitting. */
   private resolvePropertyType(propertyKey: string): string | null {
     if (!this.app) return null;
     if (this.propertyTypeCache.has(propertyKey)) {
       return this.propertyTypeCache.get(propertyKey) ?? null;
     }
-    const info = this.getTypeInfo(propertyKey);
+
+    const appAny = this.app as unknown as {
+      metadataTypeManager?: { getTypeInfo?: (key: string) => unknown };
+      metadataCache?: { app?: { metadataTypeManager?: { getTypeInfo?: (key: string) => unknown } } };
+    };
+
+    const manager =
+      appAny.metadataTypeManager ?? appAny.metadataCache?.app?.metadataTypeManager;
+
+    if (!manager || typeof manager.getTypeInfo !== "function") {
+      this.propertyTypeCache.set(propertyKey, null);
+      return null;
+    }
+
+    const info = manager.getTypeInfo(propertyKey) as
+      | {
+          expected?: { type?: string } | null;
+          inferred?: { type?: string } | null;
+        }
+      | undefined;
+
     const type = info?.expected?.type ?? info?.inferred?.type ?? null;
     const normalized = typeof type === "string" ? type : null;
     this.propertyTypeCache.set(propertyKey, normalized);
     return normalized;
-  }
-
-  /**
-   * EXPECTED (explicitly declared) type only — never the inferred default.
-   * Obsidian reports inferred type "text" for any string-valued property, so
-   * auto-quoting (item #757) keys off the declared type to avoid quoting every
-   * string property under the beta flag.
-   */
-  private resolveExpectedType(propertyKey: string): string | null {
-    if (!this.app) return null;
-    if (this.expectedTypeCache.has(propertyKey)) {
-      return this.expectedTypeCache.get(propertyKey) ?? null;
-    }
-    const info = this.getTypeInfo(propertyKey);
-    const type = info?.expected?.type ?? null;
-    const normalized = typeof type === "string" ? type : null;
-    this.expectedTypeCache.set(propertyKey, normalized);
-    return normalized;
-  }
-
-  /**
-   * Whether a resolved scalar VALUE should be written as a double-quoted YAML
-   * string instead of raw inline, to stop Obsidian coercing a text value into a
-   * Number/Boolean/null (issue #757, the inverse footgun). Returns true only
-   * when:
-   *   - the raw string is one Obsidian would actually coerce (wouldYamlMisCoerce),
-   *   - the token is the SOLE value at a frontmatter key:value or list-item
-   *     position and not already author-quoted, AND
-   *   - the author asked for it via |type:text, OR (under the beta flag, in a
-   *     collection scope) the property is EXPLICITLY declared a Text type.
-   */
-  public shouldQuoteScalar(args: {
-    input: string;
-    matchStart: number;
-    matchEnd: number;
-    rawString: string;
-    explicitText: boolean;
-    autoEnabled: boolean;
-  }): boolean {
-    const { input, matchStart, matchEnd, rawString, explicitText, autoEnabled } =
-      args;
-    if (!explicitText && !autoEnabled) return false;
-    if (!wouldYamlMisCoerce(rawString)) return false;
-
-    const yamlRange = findYamlFrontMatterRange(input);
-    const ctx = getYamlContextForMatch(input, matchStart, matchEnd, yamlRange);
-    if (!ctx.isInYaml || ctx.isQuoted) return false;
-    if (!ctx.isKeyValuePosition && !ctx.isListItemPosition) return false;
-
-    // Explicit |type:text protects a sole-value scalar (key:value or list item).
-    if (explicitText) return true;
-
-    // AUTO: only at a key:value scalar position and only when the property is
-    // EXPLICITLY declared Text in Obsidian.
-    if (!ctx.isKeyValuePosition) return false;
-    const lineContent = input.slice(ctx.lineStart, ctx.lineEnd);
-    const keyMatch = lineContent.match(/^\s*([^:]+):/);
-    const key = keyMatch ? keyMatch[1].trim() : "";
-    if (!key) return false;
-    return this.resolveExpectedType(key) === "text";
   }
 
   public static readonly PATH_SEPARATOR = PATH_SEPARATOR;

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -5,6 +5,7 @@ import {
 	type ParseOptions,
 } from "./templatePropertyStringParser";
 import { isContainerYamlValue, isStructuredYamlValue } from "./yamlValues";
+import { wouldYamlMisCoerce } from "./yamlScalarQuoting";
 
 const PATH_SEPARATOR = "\u0000";
 
@@ -32,6 +33,7 @@ type CollectArgs = {
 export class TemplatePropertyCollector {
   private map = new Map<string, unknown>();
   private propertyTypeCache = new Map<string, string | null>();
+  private expectedTypeCache = new Map<string, string | null>();
 
   constructor(private readonly app?: App) {}
 
@@ -151,36 +153,99 @@ export class TemplatePropertyCollector {
     return path.length > 0 ? path : null;
   }
 
-  private resolvePropertyType(propertyKey: string): string | null {
-    if (!this.app) return null;
-    if (this.propertyTypeCache.has(propertyKey)) {
-      return this.propertyTypeCache.get(propertyKey) ?? null;
-    }
-
+  private getTypeInfo(propertyKey: string):
+    | {
+        expected?: { type?: string } | null;
+        inferred?: { type?: string } | null;
+      }
+    | undefined {
+    if (!this.app) return undefined;
     const appAny = this.app as unknown as {
       metadataTypeManager?: { getTypeInfo?: (key: string) => unknown };
       metadataCache?: { app?: { metadataTypeManager?: { getTypeInfo?: (key: string) => unknown } } };
     };
-
     const manager =
       appAny.metadataTypeManager ?? appAny.metadataCache?.app?.metadataTypeManager;
-
-    if (!manager || typeof manager.getTypeInfo !== "function") {
-      this.propertyTypeCache.set(propertyKey, null);
-      return null;
-    }
-
-    const info = manager.getTypeInfo(propertyKey) as
+    if (!manager || typeof manager.getTypeInfo !== "function") return undefined;
+    return manager.getTypeInfo(propertyKey) as
       | {
           expected?: { type?: string } | null;
           inferred?: { type?: string } | null;
         }
       | undefined;
+  }
 
+  /** Expected-or-inferred type; used to decide comma/bullet list splitting. */
+  private resolvePropertyType(propertyKey: string): string | null {
+    if (!this.app) return null;
+    if (this.propertyTypeCache.has(propertyKey)) {
+      return this.propertyTypeCache.get(propertyKey) ?? null;
+    }
+    const info = this.getTypeInfo(propertyKey);
     const type = info?.expected?.type ?? info?.inferred?.type ?? null;
     const normalized = typeof type === "string" ? type : null;
     this.propertyTypeCache.set(propertyKey, normalized);
     return normalized;
+  }
+
+  /**
+   * EXPECTED (explicitly declared) type only — never the inferred default.
+   * Obsidian reports inferred type "text" for any string-valued property, so
+   * auto-quoting (item #757) keys off the declared type to avoid quoting every
+   * string property under the beta flag.
+   */
+  private resolveExpectedType(propertyKey: string): string | null {
+    if (!this.app) return null;
+    if (this.expectedTypeCache.has(propertyKey)) {
+      return this.expectedTypeCache.get(propertyKey) ?? null;
+    }
+    const info = this.getTypeInfo(propertyKey);
+    const type = info?.expected?.type ?? null;
+    const normalized = typeof type === "string" ? type : null;
+    this.expectedTypeCache.set(propertyKey, normalized);
+    return normalized;
+  }
+
+  /**
+   * Whether a resolved scalar VALUE should be written as a double-quoted YAML
+   * string instead of raw inline, to stop Obsidian coercing a text value into a
+   * Number/Boolean/null (issue #757, the inverse footgun). Returns true only
+   * when:
+   *   - the raw string is one Obsidian would actually coerce (wouldYamlMisCoerce),
+   *   - the token is the SOLE value at a frontmatter key:value or list-item
+   *     position and not already author-quoted, AND
+   *   - the author asked for it via |type:text, OR (under the beta flag, in a
+   *     collection scope) the property is EXPLICITLY declared a Text type.
+   */
+  public shouldQuoteScalar(args: {
+    input: string;
+    matchStart: number;
+    matchEnd: number;
+    rawString: string;
+    explicitText: boolean;
+    autoEnabled: boolean;
+  }): boolean {
+    const { input, matchStart, matchEnd, rawString, explicitText, autoEnabled } =
+      args;
+    if (!explicitText && !autoEnabled) return false;
+    if (!wouldYamlMisCoerce(rawString)) return false;
+
+    const yamlRange = findYamlFrontMatterRange(input);
+    const ctx = getYamlContextForMatch(input, matchStart, matchEnd, yamlRange);
+    if (!ctx.isInYaml || ctx.isQuoted) return false;
+    if (!ctx.isKeyValuePosition && !ctx.isListItemPosition) return false;
+
+    // Explicit |type:text protects a sole-value scalar (key:value or list item).
+    if (explicitText) return true;
+
+    // AUTO: only at a key:value scalar position and only when the property is
+    // EXPLICITLY declared Text in Obsidian.
+    if (!ctx.isKeyValuePosition) return false;
+    const lineContent = input.slice(ctx.lineStart, ctx.lineEnd);
+    const keyMatch = lineContent.match(/^\s*([^:]+):/);
+    const key = keyMatch ? keyMatch[1].trim() : "";
+    if (!key) return false;
+    return this.resolveExpectedType(key) === "text";
   }
 
   public static readonly PATH_SEPARATOR = PATH_SEPARATOR;

--- a/src/utils/linkWrap.ts
+++ b/src/utils/linkWrap.ts
@@ -1,0 +1,6 @@
+/** Wrap a value as an Obsidian wikilink for |multi:linklist, idempotently. */
+export function toWikiLink(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) return trimmed;
+	return /^\[\[.*\]\]$/.test(trimmed) ? trimmed : `[[${trimmed}]]`;
+}

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -148,6 +148,47 @@ describe("parseValueToken", () => {
 		).toBeUndefined();
 		expect(warnSpy).toHaveBeenCalled();
 	});
+
+	it("parses |multi on an option list", () => {
+		const parsed = parseValueToken("work,home,urgent|multi");
+		expect(parsed?.multiSelect).toBe(true);
+		expect(parsed?.multiEmit).toBe("text");
+	});
+
+	it("parses |multi:linklist", () => {
+		const parsed = parseValueToken("Alice,Bob|multi:linklist");
+		expect(parsed?.multiSelect).toBe(true);
+		expect(parsed?.multiEmit).toBe("linklist");
+	});
+
+	it("warns and ignores |multi without an option list", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(parseValueToken("Only|multi")?.multiSelect).toBe(false);
+		expect(parseValueToken("Only|multi:linklist")?.multiSelect).toBe(false);
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it("composes |multi with |custom and |name", () => {
+		const custom = parseValueToken("a,b|multi|custom");
+		expect(custom?.multiSelect).toBe(true);
+		expect(custom?.allowCustomInput).toBe(true);
+		const named = parseValueToken("a,b|multi|name:tags");
+		expect(named?.multiSelect).toBe(true);
+		expect(named?.aliasName).toBe("tags");
+	});
+
+	it("drops |case when combined with |multi (a list is not case-transformed)", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("a,b,c|multi|case:upper");
+		expect(parsed?.multiSelect).toBe(true);
+		expect(parsed?.caseStyle).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	it("leaves multiSelect false for ordinary option lists", () => {
+		expect(parseValueToken("a,b,c")?.multiSelect).toBe(false);
+		expect(parseValueToken("a,b,c|custom")?.multiSelect).toBe(false);
+	});
 });
 
 describe("parseAnonymousValueOptions", () => {

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -112,6 +112,42 @@ describe("parseValueToken", () => {
 		expect(parsed?.inputTypeOverride).toBeUndefined();
 		expect(warnSpy).toHaveBeenCalled();
 	});
+
+	it("parses type:number / checkbox / text without warning", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(parseValueToken("Rating|type:number")?.inputTypeOverride).toBe(
+			"number",
+		);
+		expect(parseValueToken("Done|type:checkbox")?.inputTypeOverride).toBe(
+			"checkbox",
+		);
+		expect(parseValueToken("Note|type:text")?.inputTypeOverride).toBe(
+			"text",
+		);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("treats type:boolean as an alias for checkbox", () => {
+		expect(parseValueToken("Done|type:boolean")?.inputTypeOverride).toBe(
+			"checkbox",
+		);
+	});
+
+	it("still rejects an unknown type and names the new supported set", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(parseValueToken("Body|type:wide")?.inputTypeOverride).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("multiline, number, checkbox, text"),
+		);
+	});
+
+	it("ignores a scalar type on an option-list token", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		expect(
+			parseValueToken("Red,Green|type:number")?.inputTypeOverride,
+		).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalled();
+	});
 });
 
 describe("parseAnonymousValueOptions", () => {

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -28,7 +28,10 @@ const VALUE_OPTION_KEYS = new Set([
 	"case",
 	"text",
 	"optional",
+	"multi",
 ]);
+
+export type MultiEmit = "text" | "linklist";
 
 // `name` is recognized ONLY on the named `{{VALUE:...}}` grammar, never on the
 // anonymous `{{VALUE|...}}` grammar (which shares parseOptions). Gating it here
@@ -53,6 +56,10 @@ export type ParsedValueToken = {
 	hasOptions: boolean;
 	inputTypeOverride?: ValueInputType;
 	optional: boolean;
+	/** |multi: pick several options into a YAML list (option-list tokens only). */
+	multiSelect: boolean;
+	/** |multi:linklist wraps each pick as [[name]]; defaults to plain text. */
+	multiEmit: MultiEmit;
 };
 
 export function buildValueVariableKey(
@@ -120,6 +127,8 @@ type ParsedOptions = {
 	displayValuesRaw?: string;
 	optionalExplicit?: boolean;
 	name?: string;
+	multiSelect?: boolean;
+	multiEmit?: MultiEmit;
 };
 
 /**
@@ -168,7 +177,10 @@ function parseOptions(
 		optionParts.some(
 			(part) => part.trim().toLowerCase() === "custom",
 		);
-	const usesOptions = hasExplicitOption || hasCustomFlag;
+	const hasMultiFlag =
+		hasOptions &&
+		optionParts.some((part) => part.trim().toLowerCase() === "multi");
+	const usesOptions = hasExplicitOption || hasCustomFlag || hasMultiFlag;
 
 	if (!usesOptions) {
 		return {
@@ -186,6 +198,8 @@ function parseOptions(
 	let displayValuesRaw: string | undefined;
 	let optionalExplicit: boolean | undefined;
 	let name: string | undefined;
+	let multiSelect = false;
+	let multiEmit: MultiEmit | undefined;
 
 	for (const part of optionParts) {
 		const trimmed = part.trim();
@@ -193,6 +207,11 @@ function parseOptions(
 
 		if (hasOptions && trimmed.toLowerCase() === "custom") {
 			allowCustomInput = true;
+			continue;
+		}
+
+		if (hasOptions && trimmed.toLowerCase() === "multi") {
+			multiSelect = true;
 			continue;
 		}
 
@@ -223,6 +242,11 @@ function parseOptions(
 			case "optional":
 				optionalExplicit = parseBooleanFlag(value);
 				break;
+			case "multi":
+				multiSelect = true;
+				multiEmit =
+					value.trim().toLowerCase() === "linklist" ? "linklist" : "text";
+				break;
 			case "name":
 				// Gated to the named grammar via optionKeys; empty `|name:` is a
 				// no-op alias and warns so the author notices the typo.
@@ -247,6 +271,8 @@ function parseOptions(
 		inputTypeOverride,
 		displayValuesRaw,
 		optionalExplicit,
+		multiSelect,
+		multiEmit,
 	};
 }
 
@@ -402,6 +428,8 @@ export function parseValueToken(
 		extractBareOptionalFlag(parts);
 	const options = parseOptions(optionParts, hasOptions, true, quiet);
 	let { label, caseStyle, defaultValue, allowCustomInput } = options;
+	let multiSelect = options.multiSelect ?? false;
+	const multiEmit: MultiEmit = options.multiEmit ?? "text";
 	const optional = options.optionalExplicit ?? bareOptional;
 
 	if (!options.usesOptions) {
@@ -478,6 +506,23 @@ export function parseValueToken(
 		);
 	}
 
+	// |multi needs an option list and is incompatible with |case (a list is not
+	// case-transformed, and routing an array through transformCase would throw).
+	if (multiSelect && !hasOptions) {
+		if (!quiet)
+			console.warn(
+				`QuickAdd: |multi needs an option list (2+ comma-separated values) in "${tokenDisplay}"; ignoring.`,
+			);
+		multiSelect = false;
+	}
+	if (multiSelect && caseStyle) {
+		if (!quiet)
+			console.warn(
+				`QuickAdd: |case is ignored with |multi in "${tokenDisplay}" — a list is not case-transformed.`,
+			);
+		caseStyle = undefined;
+	}
+
 	const variableKey = aliasName
 		? aliasName
 		: buildValueVariableKey(variablePart, label, hasOptions);
@@ -496,6 +541,8 @@ export function parseValueToken(
 		hasOptions,
 		inputTypeOverride,
 		optional,
+		multiSelect,
+		multiEmit,
 	};
 }
 

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -9,7 +9,16 @@ import {
 // Internal-only delimiter for scoping labeled VALUE lists. Unlikely to appear in user input.
 export const VALUE_LABEL_KEY_DELIMITER = "\u001F";
 
-export type ValueInputType = "multiline";
+export type ValueInputType = "multiline" | "number" | "checkbox" | "text";
+
+// Types that render a different input widget but are meaningless alongside a
+// comma option-list or |custom (those already pick from a fixed/free set).
+const OPTION_INCOMPATIBLE_TYPES = new Set<ValueInputType>([
+	"multiline",
+	"number",
+	"checkbox",
+	"text",
+]);
 
 const VALUE_OPTION_KEYS = new Set([
 	"label",
@@ -251,22 +260,24 @@ function resolveInputType(
 	quiet = false,
 ): ValueInputType | undefined {
 	if (!rawType) return undefined;
-	const normalized = rawType.trim().toLowerCase();
-	if (normalized !== "multiline") {
+	const raw = rawType.trim().toLowerCase();
+	// `boolean` is a friendly alias for the checkbox true/false picker.
+	const normalized = (raw === "boolean" ? "checkbox" : raw) as ValueInputType;
+	if (!OPTION_INCOMPATIBLE_TYPES.has(normalized)) {
 		if (!quiet)
 			console.warn(
-				`QuickAdd: Unsupported VALUE type "${rawType}" in token "${tokenDisplay}". Supported types: multiline.`,
+				`QuickAdd: Unsupported VALUE type "${rawType}" in token "${tokenDisplay}". Supported types: multiline, number, checkbox, text.`,
 			);
 		return undefined;
 	}
 	if (hasOptions || allowCustomInput) {
 		if (!quiet)
 			console.warn(
-				`QuickAdd: Ignoring type:multiline for option-list VALUE token "${tokenDisplay}".`,
+				`QuickAdd: Ignoring type:${normalized} for option-list VALUE token "${tokenDisplay}".`,
 			);
 		return undefined;
 	}
-	return "multiline";
+	return normalized;
 }
 
 // The "double-quote class" that opens/closes a quoted option: the straight

--- a/src/utils/vdateSyntax.test.ts
+++ b/src/utils/vdateSyntax.test.ts
@@ -3,15 +3,25 @@ import { parseVDateOptions } from "./vdateSyntax";
 
 describe("parseVDateOptions (issue #1259)", () => {
 	it("returns no default and not-optional for empty input", () => {
-		expect(parseVDateOptions(undefined)).toEqual({ optional: false });
-		expect(parseVDateOptions(null)).toEqual({ optional: false });
-		expect(parseVDateOptions("")).toEqual({ optional: false });
+		expect(parseVDateOptions(undefined)).toEqual({
+			optional: false,
+			withTime: false,
+		});
+		expect(parseVDateOptions(null)).toEqual({
+			optional: false,
+			withTime: false,
+		});
+		expect(parseVDateOptions("")).toEqual({
+			optional: false,
+			withTime: false,
+		});
 	});
 
 	it("treats a plain segment as the legacy default", () => {
 		expect(parseVDateOptions("tomorrow")).toEqual({
 			defaultValue: "tomorrow",
 			optional: false,
+			withTime: false,
 		});
 	});
 
@@ -19,6 +29,7 @@ describe("parseVDateOptions (issue #1259)", () => {
 		expect(parseVDateOptions("optional")).toEqual({
 			defaultValue: undefined,
 			optional: true,
+			withTime: false,
 		});
 	});
 
@@ -31,10 +42,12 @@ describe("parseVDateOptions (issue #1259)", () => {
 		expect(parseVDateOptions("tomorrow|optional")).toEqual({
 			defaultValue: "tomorrow",
 			optional: true,
+			withTime: false,
 		});
 		expect(parseVDateOptions("optional|tomorrow")).toEqual({
 			defaultValue: "tomorrow",
 			optional: true,
+			withTime: false,
 		});
 	});
 
@@ -43,6 +56,7 @@ describe("parseVDateOptions (issue #1259)", () => {
 		expect(parseVDateOptions("optional:false|tomorrow")).toEqual({
 			defaultValue: "tomorrow",
 			optional: false,
+			withTime: false,
 		});
 		expect(parseVDateOptions("optional|optional:false").optional).toBe(
 			false,
@@ -53,6 +67,45 @@ describe("parseVDateOptions (issue #1259)", () => {
 		expect(parseVDateOptions("a|optional|b")).toEqual({
 			defaultValue: "a|b",
 			optional: true,
+			withTime: false,
+		});
+	});
+});
+
+describe("parseVDateOptions withTime (issue #757)", () => {
+	it("recognizes the bare |time flag", () => {
+		expect(parseVDateOptions("time").withTime).toBe(true);
+	});
+
+	it("recognizes |datetime and |type:datetime", () => {
+		expect(parseVDateOptions("datetime").withTime).toBe(true);
+		expect(parseVDateOptions("type:datetime").withTime).toBe(true);
+	});
+
+	it("defaults withTime to false and keeps date-only output byte-identical", () => {
+		expect(parseVDateOptions("tomorrow").withTime).toBe(false);
+		expect(parseVDateOptions("type:date").withTime).toBe(false);
+	});
+
+	it("does NOT leak a keyed |type: control flag into the default", () => {
+		expect(parseVDateOptions("tomorrow|type:datetime")).toEqual({
+			defaultValue: "tomorrow",
+			optional: false,
+			withTime: true,
+		});
+		expect(parseVDateOptions("type:date").defaultValue).toBeUndefined();
+	});
+
+	it("is order-insensitive and composes with optional + default", () => {
+		expect(parseVDateOptions("tomorrow at 3pm|time|optional")).toEqual({
+			defaultValue: "tomorrow at 3pm",
+			optional: true,
+			withTime: true,
+		});
+		expect(parseVDateOptions("optional|datetime|next friday")).toEqual({
+			defaultValue: "next friday",
+			optional: true,
+			withTime: true,
 		});
 	});
 });

--- a/src/utils/vdateSyntax.ts
+++ b/src/utils/vdateSyntax.ts
@@ -8,6 +8,8 @@ import {
 export type ParsedVDateOptions = {
 	defaultValue?: string;
 	optional: boolean;
+	/** Token requested a date AND time picker via |time / |datetime / |type:datetime. */
+	withTime: boolean;
 };
 
 /**
@@ -23,14 +25,27 @@ export type ParsedVDateOptions = {
 export function parseVDateOptions(
 	rawOptions: string | undefined | null,
 ): ParsedVDateOptions {
-	if (!rawOptions) return { optional: false };
+	if (!rawOptions) return { optional: false, withTime: false };
 
-	const { remaining, found: bareOptional } = extractBareFlagPart(
+	// Pull the bare control flags out before re-joining the rest as the default,
+	// so a legacy pipe-containing natural-language default still survives. Order
+	// is insensitive (same approach as |optional). A literal default of exactly
+	// "time"/"datetime" needs the |default-style escape — vanishingly rare.
+	const { remaining: afterOptional, found: bareOptional } = extractBareFlagPart(
 		splitPipeParts(rawOptions),
 		"optional",
 	);
+	const { remaining: afterTime, found: bareTime } = extractBareFlagPart(
+		afterOptional,
+		"time",
+	);
+	const { remaining, found: bareDatetime } = extractBareFlagPart(
+		afterTime,
+		"datetime",
+	);
 
 	let explicitOptional: boolean | undefined;
+	let keyedDatetime = false;
 	const rest: string[] = [];
 
 	for (const part of remaining) {
@@ -39,10 +54,20 @@ export function parseVDateOptions(
 			explicitOptional = parseBooleanFlag(keyed.value);
 			continue;
 		}
+		if (keyed?.key === "type") {
+			// |type:datetime enables the time picker; any keyed |type:... is a
+			// control flag, never part of the natural-language default.
+			if (keyed.value.trim().toLowerCase() === "datetime") keyedDatetime = true;
+			continue;
+		}
 
 		rest.push(part);
 	}
 
 	const defaultValue = rest.join("|").trim() || undefined;
-	return { defaultValue, optional: explicitOptional ?? bareOptional };
+	return {
+		defaultValue,
+		optional: explicitOptional ?? bareOptional,
+		withTime: bareTime || bareDatetime || keyedDatetime,
+	};
 }

--- a/src/utils/yamlContext.ts
+++ b/src/utils/yamlContext.ts
@@ -62,10 +62,13 @@ export function getYamlContextForMatch(
 
   const beforeTrimmed = before.replace(/["']$/, "");
   const afterTrimmed = after.replace(/^["']/, "");
-  const isKeyValuePosition = /:\s*$/.test(beforeTrimmed) && afterTrimmed.trim().length === 0;
+  // A trailing YAML comment (` #…`) is not part of the scalar, so a token
+  // followed only by a comment is still the sole value of its key / list item.
+  const afterIsSoleValue =
+    afterTrimmed.replace(/\s+#.*$/, "").trim().length === 0;
+  const isKeyValuePosition = /:\s*$/.test(beforeTrimmed) && afterIsSoleValue;
   // `- {{match}}` (optionally indented / quoted) and nothing else on the line.
-  const isListItemPosition =
-    /^\s*-\s*$/.test(beforeTrimmed) && afterTrimmed.trim().length === 0;
+  const isListItemPosition = /^\s*-\s*$/.test(beforeTrimmed) && afterIsSoleValue;
 
   return {
     isInYaml: true,

--- a/src/utils/yamlContext.ts
+++ b/src/utils/yamlContext.ts
@@ -7,6 +7,13 @@ export interface YamlMatchContext {
   lineEnd: number;
   baseIndent: string;
   isKeyValuePosition: boolean;
+  /**
+   * True when the match is the SOLE value of a YAML list item, i.e. the line is
+   * `- {{match}}` (optionally indented / wrapped in quotes). Mirrors
+   * isKeyValuePosition for the `- value` shape so a consumer can tell a list
+   * item value apart from prose that merely starts with a dash.
+   */
+  isListItemPosition: boolean;
 }
 
 /** Finds the YAML front matter range. Returns [start, end] or null. */
@@ -36,6 +43,7 @@ export function getYamlContextForMatch(
       lineEnd: 0,
       baseIndent: "",
       isKeyValuePosition: false,
+      isListItemPosition: false,
     };
   }
 
@@ -55,6 +63,9 @@ export function getYamlContextForMatch(
   const beforeTrimmed = before.replace(/["']$/, "");
   const afterTrimmed = after.replace(/^["']/, "");
   const isKeyValuePosition = /:\s*$/.test(beforeTrimmed) && afterTrimmed.trim().length === 0;
+  // `- {{match}}` (optionally indented / quoted) and nothing else on the line.
+  const isListItemPosition =
+    /^\s*-\s*$/.test(beforeTrimmed) && afterTrimmed.trim().length === 0;
 
   return {
     isInYaml: true,
@@ -63,5 +74,6 @@ export function getYamlContextForMatch(
     lineEnd,
     baseIndent,
     isKeyValuePosition,
+    isListItemPosition,
   };
 }

--- a/src/utils/yamlScalarQuoting.test.ts
+++ b/src/utils/yamlScalarQuoting.test.ts
@@ -19,6 +19,11 @@ describe("quoteYamlDouble", () => {
 		expect(quoteYamlDouble('he said "hi"')).toBe('"he said \\"hi\\""');
 		expect(quoteYamlDouble("a\\b")).toBe('"a\\\\b"');
 	});
+
+	it("escapes control characters so a seeded value stays valid YAML", () => {
+		expect(quoteYamlDouble("a\nb")).toBe('"a\\nb"');
+		expect(quoteYamlDouble("a\tb")).toBe('"a\\tb"');
+	});
 });
 
 describe("shouldQuoteTextScalar", () => {
@@ -37,6 +42,12 @@ describe("shouldQuoteTextScalar", () => {
 
 	it("does NOT quote an already author-quoted value", () => {
 		expect(check(`---\nid: "${TOKEN}"\n---`)).toBe(false);
+	});
+
+	it("quotes a sole value followed only by a trailing YAML comment", () => {
+		expect(check(`---\nid: ${TOKEN} # keep\n---`)).toBe(true);
+		// but not when real content follows the token
+		expect(check(`---\nid: ${TOKEN} more # c\n---`)).toBe(false);
 	});
 
 	it("does NOT quote in the note body (outside front matter)", () => {

--- a/src/utils/yamlScalarQuoting.test.ts
+++ b/src/utils/yamlScalarQuoting.test.ts
@@ -1,82 +1,46 @@
 import { describe, expect, it } from "vitest";
-import { quoteYamlDouble, wouldYamlMisCoerce } from "./yamlScalarQuoting";
+import { quoteYamlDouble, shouldQuoteTextScalar } from "./yamlScalarQuoting";
 
-describe("wouldYamlMisCoerce", () => {
-	// The exact set Obsidian's YAML parser coerces to a non-string, pinned
-	// empirically against a live metadataCache probe.
-	const COERCES = [
-		"42",
-		"-7",
-		"+5",
-		"0042",
-		"00",
-		"-0",
-		"3.5",
-		".5",
-		"5.",
-		"1e3",
-		"2e10",
-		"0x1F",
-		"0o17",
-		".inf",
-		"-.inf",
-		".Inf",
-		".nan",
-		".NaN",
-		"true",
-		"True",
-		"TRUE",
-		"false",
-		"False",
-		"FALSE",
-		"null",
-		"Null",
-		"NULL",
-		"~",
-	];
+const TOKEN = "{{VALUE:x}}";
 
-	// Obsidian keeps these as STRINGS — quoting them would be needless churn.
-	const STAYS_STRING = [
-		"yes",
-		"no",
-		"on",
-		"off",
-		"YES",
-		"Off",
-		"tRue", // mixed case
-		"1000_000", // underscores
-		"2025-12-25", // date
-		"2025-12-25T15:30:00", // datetime
-		"12:30", // sexagesimal
-		"1:02:03",
-		"0b101", // binary
-		"1.2.3",
-		"0x", // incomplete
-		"1e",
-		"1,000",
-		"hello",
-		"007abc",
-		"", // empty
-		"   ", // whitespace
-	];
-
-	it.each(COERCES)("treats %s as coercion-prone", (value) => {
-		expect(wouldYamlMisCoerce(value)).toBe(true);
-	});
-
-	it.each(STAYS_STRING)("leaves %s as a string", (value) => {
-		expect(wouldYamlMisCoerce(value)).toBe(false);
-	});
-});
+/** Helper: locate the token in `input` and ask whether it should be quoted. */
+function check(input: string): boolean {
+	const start = input.indexOf(TOKEN);
+	return shouldQuoteTextScalar(input, start, start + TOKEN.length);
+}
 
 describe("quoteYamlDouble", () => {
 	it("wraps a plain value in double quotes", () => {
 		expect(quoteYamlDouble("0042")).toBe('"0042"');
-		expect(quoteYamlDouble("true")).toBe('"true"');
+		expect(quoteYamlDouble("#todo")).toBe('"#todo"');
 	});
 
 	it("escapes embedded double quotes and backslashes", () => {
 		expect(quoteYamlDouble('he said "hi"')).toBe('"he said \\"hi\\""');
 		expect(quoteYamlDouble("a\\b")).toBe('"a\\\\b"');
+	});
+});
+
+describe("shouldQuoteTextScalar", () => {
+	it("quotes a sole-value front-matter scalar", () => {
+		expect(check(`---\nid: ${TOKEN}\n---\nbody`)).toBe(true);
+	});
+
+	it("quotes a sole-value list item", () => {
+		expect(check(`---\ntags:\n  - ${TOKEN}\n---\nbody`)).toBe(true);
+	});
+
+	it("does NOT quote when the token is only part of the value", () => {
+		expect(check(`---\nid: prefix-${TOKEN}\n---`)).toBe(false);
+		expect(check(`---\nid: ${TOKEN} suffix\n---`)).toBe(false);
+	});
+
+	it("does NOT quote an already author-quoted value", () => {
+		expect(check(`---\nid: "${TOKEN}"\n---`)).toBe(false);
+	});
+
+	it("does NOT quote in the note body (outside front matter)", () => {
+		expect(check(`---\ntitle: x\n---\nSome ${TOKEN} prose`)).toBe(false);
+		expect(check(`No front matter here ${TOKEN}`)).toBe(false);
 	});
 });

--- a/src/utils/yamlScalarQuoting.test.ts
+++ b/src/utils/yamlScalarQuoting.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { quoteYamlDouble, wouldYamlMisCoerce } from "./yamlScalarQuoting";
+
+describe("wouldYamlMisCoerce", () => {
+	// The exact set Obsidian's YAML parser coerces to a non-string, pinned
+	// empirically against a live metadataCache probe.
+	const COERCES = [
+		"42",
+		"-7",
+		"+5",
+		"0042",
+		"00",
+		"-0",
+		"3.5",
+		".5",
+		"5.",
+		"1e3",
+		"2e10",
+		"0x1F",
+		"0o17",
+		".inf",
+		"-.inf",
+		".Inf",
+		".nan",
+		".NaN",
+		"true",
+		"True",
+		"TRUE",
+		"false",
+		"False",
+		"FALSE",
+		"null",
+		"Null",
+		"NULL",
+		"~",
+	];
+
+	// Obsidian keeps these as STRINGS — quoting them would be needless churn.
+	const STAYS_STRING = [
+		"yes",
+		"no",
+		"on",
+		"off",
+		"YES",
+		"Off",
+		"tRue", // mixed case
+		"1000_000", // underscores
+		"2025-12-25", // date
+		"2025-12-25T15:30:00", // datetime
+		"12:30", // sexagesimal
+		"1:02:03",
+		"0b101", // binary
+		"1.2.3",
+		"0x", // incomplete
+		"1e",
+		"1,000",
+		"hello",
+		"007abc",
+		"", // empty
+		"   ", // whitespace
+	];
+
+	it.each(COERCES)("treats %s as coercion-prone", (value) => {
+		expect(wouldYamlMisCoerce(value)).toBe(true);
+	});
+
+	it.each(STAYS_STRING)("leaves %s as a string", (value) => {
+		expect(wouldYamlMisCoerce(value)).toBe(false);
+	});
+});
+
+describe("quoteYamlDouble", () => {
+	it("wraps a plain value in double quotes", () => {
+		expect(quoteYamlDouble("0042")).toBe('"0042"');
+		expect(quoteYamlDouble("true")).toBe('"true"');
+	});
+
+	it("escapes embedded double quotes and backslashes", () => {
+		expect(quoteYamlDouble('he said "hi"')).toBe('"he said \\"hi\\""');
+		expect(quoteYamlDouble("a\\b")).toBe('"a\\\\b"');
+	});
+});

--- a/src/utils/yamlScalarQuoting.ts
+++ b/src/utils/yamlScalarQuoting.ts
@@ -1,53 +1,14 @@
-/**
- * Pure helpers for issue #757 type-aware YAML quoting.
- *
- * A value typed into a `{{VALUE}}` prompt is written raw-inline into a note's
- * frontmatter; Obsidian's YAML parser then COERCES certain unquoted strings
- * into Number/Boolean/null, silently changing a text value's type — e.g.
- * `id: 0042` becomes the number 42, `flag: true` becomes a boolean. When the
- * target property should stay text, wrapping the value in a double-quoted YAML
- * scalar keeps it a string.
- *
- * The coercion set below was pinned EMPIRICALLY against Obsidian's own parser
- * (a live metadataCache probe), NOT against the YAML 1.1 spec — they differ.
- * Obsidian keeps these as STRINGS (so they are intentionally NOT quoted):
- *   - YAML 1.1 booleans yes / no / on / off (and YES, Off, ...)
- *   - integers with underscores (1_000)
- *   - dates and date-times (2025-12-25, 2025-12-25T15:30, 12:30)
- *   - binary (0b101), mixed-case bool/null (tRue), incomplete forms (0x, 1e)
- * Obsidian coerces these to non-strings (so they ARE quoted when the property
- * is text): true/True/TRUE, false/False/FALSE, null/Null/NULL/~, signed
- * decimals/floats/scientific (incl. leading-zero 0042), hex 0x.., octal 0o..,
- * and .inf/.nan.
- */
-
-// true / True / TRUE / false / False / FALSE — NOT mixed case (tRue stays text).
-const YAML_BOOL = /^(?:true|True|TRUE|false|False|FALSE)$/;
-// null / Null / NULL / ~
-const YAML_NULL = /^(?:null|Null|NULL|~)$/;
-// Signed decimal int + float: 42, -7, +5, 0042, 3.5, .5, 5., 1e3, 2e10.
-// Also matches plain integers (the `[0-9]+` alternative), which is intended.
-const YAML_FLOAT = /^[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)(?:[eE][-+]?[0-9]+)?$/;
-const YAML_HEX = /^[-+]?0x[0-9a-fA-F]+$/;
-const YAML_OCT = /^[-+]?0o[0-7]+$/;
-const YAML_INFNAN = /^[-+]?\.(?:inf|Inf|INF|nan|NaN|NAN)$/;
+import { findYamlFrontMatterRange, getYamlContextForMatch } from "./yamlContext";
 
 /**
- * Whether Obsidian's YAML parser would turn this exact string into a
- * non-string (Number/Boolean/null) when written unquoted as a scalar value.
+ * Pure helpers for issue #757 `|type:text` quoting.
+ *
+ * A value typed into a `{{VALUE:x|type:text}}` prompt is written raw-inline into
+ * front matter, where Obsidian's YAML parser would otherwise retype or break it:
+ * `0042` -> the number 42, `true` -> a boolean, `#todo` -> a comment (null),
+ * `[a]` -> a list, `a: b` -> invalid YAML, and so on. Wrapping the value in a
+ * double-quoted scalar guarantees it stays the exact string the user entered.
  */
-export function wouldYamlMisCoerce(value: string): boolean {
-	const s = value.trim();
-	if (!s) return false;
-	return (
-		YAML_BOOL.test(s) ||
-		YAML_NULL.test(s) ||
-		YAML_FLOAT.test(s) ||
-		YAML_HEX.test(s) ||
-		YAML_OCT.test(s) ||
-		YAML_INFNAN.test(s)
-	);
-}
 
 /**
  * Wrap a value in a YAML double-quoted scalar, escaping `\` and `"`. VALUE
@@ -56,4 +17,30 @@ export function wouldYamlMisCoerce(value: string): boolean {
  */
 export function quoteYamlDouble(value: string): string {
 	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Whether a `|type:text` VALUE at [matchStart, matchEnd) should be written as a
+ * quoted YAML scalar. True only when the token is the SOLE value at a front
+ * matter key:value or list-item position and the author has not already quoted
+ * it — so quoting never corrupts body prose or a partially quoted value.
+ *
+ * We quote unconditionally at that position (not only for coercion-prone values)
+ * because YAML has many indicator characters (`#`, `[`, `{`, `*`, `&`, `!`, …)
+ * that silently retype or break an unquoted string; a single static predicate
+ * for "safe plain scalar" is error-prone, while quoting is always correct.
+ */
+export function shouldQuoteTextScalar(
+	input: string,
+	matchStart: number,
+	matchEnd: number,
+): boolean {
+	const ctx = getYamlContextForMatch(
+		input,
+		matchStart,
+		matchEnd,
+		findYamlFrontMatterRange(input),
+	);
+	if (!ctx.isInYaml || ctx.isQuoted) return false;
+	return ctx.isKeyValuePosition || ctx.isListItemPosition;
 }

--- a/src/utils/yamlScalarQuoting.ts
+++ b/src/utils/yamlScalarQuoting.ts
@@ -11,12 +11,19 @@ import { findYamlFrontMatterRange, getYamlContextForMatch } from "./yamlContext"
  */
 
 /**
- * Wrap a value in a YAML double-quoted scalar, escaping `\` and `"`. VALUE
- * tokens can never contain newlines (the variable regex forbids them), so no
- * other escaping is required.
+ * Wrap a value in a YAML double-quoted scalar, escaping `\`, `"`, and control
+ * characters. VALUE tokens typed in the UI are single-line, but a value can be
+ * seeded programmatically (script/CLI), so newlines/tabs are escaped to keep
+ * the emitted scalar valid YAML.
  */
 export function quoteYamlDouble(value: string): string {
-	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+	const escaped = value
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '\\"')
+		.replace(/\n/g, "\\n")
+		.replace(/\r/g, "\\r")
+		.replace(/\t/g, "\\t");
+	return `"${escaped}"`;
 }
 
 /**

--- a/src/utils/yamlScalarQuoting.ts
+++ b/src/utils/yamlScalarQuoting.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers for issue #757 type-aware YAML quoting.
+ *
+ * A value typed into a `{{VALUE}}` prompt is written raw-inline into a note's
+ * frontmatter; Obsidian's YAML parser then COERCES certain unquoted strings
+ * into Number/Boolean/null, silently changing a text value's type — e.g.
+ * `id: 0042` becomes the number 42, `flag: true` becomes a boolean. When the
+ * target property should stay text, wrapping the value in a double-quoted YAML
+ * scalar keeps it a string.
+ *
+ * The coercion set below was pinned EMPIRICALLY against Obsidian's own parser
+ * (a live metadataCache probe), NOT against the YAML 1.1 spec — they differ.
+ * Obsidian keeps these as STRINGS (so they are intentionally NOT quoted):
+ *   - YAML 1.1 booleans yes / no / on / off (and YES, Off, ...)
+ *   - integers with underscores (1_000)
+ *   - dates and date-times (2025-12-25, 2025-12-25T15:30, 12:30)
+ *   - binary (0b101), mixed-case bool/null (tRue), incomplete forms (0x, 1e)
+ * Obsidian coerces these to non-strings (so they ARE quoted when the property
+ * is text): true/True/TRUE, false/False/FALSE, null/Null/NULL/~, signed
+ * decimals/floats/scientific (incl. leading-zero 0042), hex 0x.., octal 0o..,
+ * and .inf/.nan.
+ */
+
+// true / True / TRUE / false / False / FALSE — NOT mixed case (tRue stays text).
+const YAML_BOOL = /^(?:true|True|TRUE|false|False|FALSE)$/;
+// null / Null / NULL / ~
+const YAML_NULL = /^(?:null|Null|NULL|~)$/;
+// Signed decimal int + float: 42, -7, +5, 0042, 3.5, .5, 5., 1e3, 2e10.
+// Also matches plain integers (the `[0-9]+` alternative), which is intended.
+const YAML_FLOAT = /^[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)(?:[eE][-+]?[0-9]+)?$/;
+const YAML_HEX = /^[-+]?0x[0-9a-fA-F]+$/;
+const YAML_OCT = /^[-+]?0o[0-7]+$/;
+const YAML_INFNAN = /^[-+]?\.(?:inf|Inf|INF|nan|NaN|NAN)$/;
+
+/**
+ * Whether Obsidian's YAML parser would turn this exact string into a
+ * non-string (Number/Boolean/null) when written unquoted as a scalar value.
+ */
+export function wouldYamlMisCoerce(value: string): boolean {
+	const s = value.trim();
+	if (!s) return false;
+	return (
+		YAML_BOOL.test(s) ||
+		YAML_NULL.test(s) ||
+		YAML_FLOAT.test(s) ||
+		YAML_HEX.test(s) ||
+		YAML_OCT.test(s) ||
+		YAML_INFNAN.test(s)
+	);
+}
+
+/**
+ * Wrap a value in a YAML double-quoted scalar, escaping `\` and `"`. VALUE
+ * tokens can never contain newlines (the variable regex forbids them), so no
+ * other escaping is required.
+ */
+export function quoteYamlDouble(value: string): string {
+	return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}


### PR DESCRIPTION
Closes #757.

Full format-syntax support for Obsidian's property types. Everything output stays **raw-inline** (no `processFrontMatter`, so YAML comments are preserved) except multi-select, which reuses the existing always-on array→List pipeline.

## What's new

| Token | Behaviour |
|---|---|
| `{{VALUE:x\|type:number}}` | Numeric input prompt; writes `x: 42` → **Number** |
| `{{VALUE:x\|type:checkbox}}` (alias `\|type:boolean`) | Forced true/false picker (the `\|label:` is its title); writes `x: true` → **Checkbox** |
| `{{VALUE:x\|type:text}}` | Quotes the value (`id: "0042"`) so a number/bool/YAML-indicator-looking string stays **Text** |
| `{{VALUE:a,b,c\|multi}}` | Multi-select picker → a real YAML **List** (no setting required). `\|multi:linklist` wraps picks as `[[name]]`; `\|multi\|custom` adds off-list values |
| `{{VDATE:when,fmt\|time}}` (alias `\|datetime`) | Adds a **time** control to the date picker; a day-click merges the picked day with the set time |

Plain `{{VALUE}}` already round-trips numbers/booleans/dates to the correct type — these options add the right input widget + validation, and `|type:text` closes the inverse footgun (a text value Obsidian would otherwise retype).

Also fixes a pre-existing red `tsc`/`pnpm build` at HEAD (a `{{linksection}}` test stub didn't implement the abstract `suggestForFile` added by the `{{FILE:}}` token).

## How it was verified

Every feature was driven end-to-end in an isolated Obsidian vault (`pnpm run obsidian:e2e`), reading back the created note's frontmatter and parsed types — e.g. `n: 42`→number, `done: true`→boolean, `id: "0042"`→string, `tags: [work, urgent]` (flag OFF), `when: 2026-06-15T14:30`. The "what Obsidian coerces" rules were pinned empirically against Obsidian's own parser.

`pnpm run build-with-lint` green; **2328 unit tests** pass (Vitest).

## Review

Hardened across two adversarial review rounds. Notably: an earlier auto-quoting path was **removed** after verifying `metadataTypeManager.getTypeInfo().expected.type` returns `"text"` even for undeclared keys (it would have quoted every `42`/`true` under the beta flag); `|type:text` now quotes unconditionally at a sole-value front-matter position (covering `#todo`/`[a]`/trailing-comment cases), and only via the explicit token.

### Known limitations (documented)
- An empty `|type:text` input writes an empty/`null` value (consistent with every other token), not `""`.
- The opt-in **one-page input form** can't round-trip a comma *inside a single* `|multi` option; the default one-prompt-at-a-time picker handles it correctly.

## Docs
`docs/docs/FormatSyntax.md` + `docs/docs/TemplatePropertyTypes.md` (Next/unreleased only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-select option lists via `{{VALUE:<options>|multi}}`, including YAML list output and optional wikilink emission using `|multi:linklist`.
  * Date/time picking for `{{VDATE}}` using `|time`/`|datetime` (with updated datetime default formatting).
  * New input type overrides: `|type:number`, `|type:checkbox`/`|type:boolean`, and `|type:text`, plus support for number input prompts and checkbox-style prompts.

* **Documentation**
  * Updated guidance for `|multi` and format/token input-type selection.

* **Bug Fixes**
  * Warning added for capture cases where `|multi` may render as a comma-separated string instead of a YAML list.

* **Tests**
  * Expanded coverage for multi-select, value/type parsing, and date/time picker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->