### PR TITLE
fix(format): resolve current-file/note tokens in one pass to stop rescan loops (#1358)

### DIFF
--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -509,6 +509,61 @@ describe("CompleteFormatter - getCurrentFileLink / getCurrentFileName", () => {
 	});
 });
 
+// End-to-end guards for #1358 driven through the REAL entry points (not the
+// combined helper directly), so a future revert to sequential token passes —
+// where a later pass re-scans an earlier pass's generated output — is caught
+// here. The combined-resolver unit semantics live in
+// formatter-token-named-file.test.ts.
+describe("CompleteFormatter - #1358 token-named active file (production wiring)", () => {
+	it("formatFileContent keeps a generated link intact when the active file is named {{folder}}", async () => {
+		// Real-app repro: file '{{folder}}.md' + body {{LINKCURRENT}} used to
+		// produce [[]] because the folder pass re-scanned the generated link.
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "{{folder}}" }, generatedLink: "[[{{folder}}]]" },
+		);
+		await expect(f.formatFileContent("{{LINKCURRENT}}")).resolves.toBe(
+			"[[{{folder}}]]",
+		);
+	});
+
+	it("formatFileContent keeps a generated link intact when the active file is named {{title}}", async () => {
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "{{title}}" }, generatedLink: "[[{{title}}]]" },
+		);
+		f.setTitle("Brand New Title");
+		await expect(f.formatFileContent("{{LINKCURRENT}}")).resolves.toBe(
+			"[[{{title}}]]",
+		);
+	});
+
+	it("formatFileContent does not hang when the active file is literally named {{filenamecurrent}}", async () => {
+		// Would infinite-loop on the old while-loop replacer; the test completing
+		// IS the assertion that the loop is gone.
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "{{filenamecurrent}}" } },
+		);
+		await expect(f.formatFileContent("{{FILENAMECURRENT}}")).resolves.toBe(
+			"{{filenamecurrent}}",
+		);
+	});
+
+	it("formatFileName does not let the folder pass rewrite a {{folder}}-named basename", async () => {
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "{{folder}}" } },
+		);
+		f.setTargetFolderPath("Projects");
+		// {{FILENAMECURRENT}} -> '{{folder}}' (the basename); the folder pass must
+		// NOT then rewrite that to 'Projects'.
+		await expect(f.formatFileName("{{FILENAMECURRENT}}", "header")).resolves.toBe(
+			"{{folder}}",
+		);
+	});
+});
+
 describe("CompleteFormatter - title handling", () => {
 	it("replaces {{title}} in file content with the set title", async () => {
 		const f = defaultFormatter();

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -103,8 +103,13 @@ export class CompleteFormatter extends Formatter {
 
 		this.valueHeader = valueHeader;
 		let output = await this.format(input);
-		output = await this.replaceCurrentFileNameInString(output);
-		output = this.replaceTargetFolderInString(output);
+		// {{filenamecurrent}} + {{folder}} in one pass (links stay literal in a
+		// file name; {{title}} threw above). One pass so no token re-scans
+		// another's output (#1358).
+		output = this.replaceCurrentFileTokensInString(output, {
+			fileName: true,
+			folder: true,
+		});
 		return output;
 	}
 
@@ -112,12 +117,16 @@ export class CompleteFormatter extends Formatter {
 		let output: string = input;
 
 		output = await this.format(output);
-		// Resolve {{linkcurrent}} + {{linksection}} in one pass so neither
-		// re-scans the other's generated link (both embed the basename).
-		output = this.replaceCurrentFileLinksInString(output);
-		output = await this.replaceCurrentFileNameInString(output);
-		output = this.replaceTargetFolderInString(output);
-		output = this.replaceTitleInString(output);
+		// Resolve ALL note-derived tokens ({{linkcurrent}}, {{linksection}},
+		// {{filenamecurrent}}, {{folder}}, {{title}}) in ONE pass so no token
+		// re-scans another's generated output — fixing both the cross-pass
+		// corruption and the infinite loop a token-named file/title caused (#1358).
+		output = this.replaceCurrentFileTokensInString(output, {
+			links: true,
+			fileName: true,
+			folder: true,
+			title: true,
+		});
 
 		return output;
 	}
@@ -133,7 +142,9 @@ export class CompleteFormatter extends Formatter {
 		// {{FOLDER}} in a folder definition is self-referential: the target
 		// folder isn't known while folders are being resolved, so it collapses
 		// to an empty string rather than leaking the literal token into a path.
-		return this.replaceTargetFolderInString(await this.format(folderName));
+		return this.replaceCurrentFileTokensInString(await this.format(folderName), {
+			folder: true,
+		});
 	}
 
 	/**
@@ -210,12 +221,16 @@ export class CompleteFormatter extends Formatter {
 	 */
 	protected async formatLocationString(input: string): Promise<string> {
 		let output = await this.format(input);
-		output = this.replaceCurrentFileLinksInString(output);
-		output = await this.replaceCurrentFileNameInString(output);
-		// Note: {{FOLDER}} is deliberately NOT resolved in location selectors
-		// (insert-after/before targets) — an empty resolution would match the
-		// first line, and folder reflection isn't meaningful for a line target.
-		output = this.replaceTitleInString(output);
+		// Links + {{filenamecurrent}} + {{title}} in one pass so no token re-scans
+		// another's output (#1358). {{FOLDER}} is deliberately left literal in
+		// location selectors (insert-after/before targets) — an empty resolution
+		// would match the first line, and folder reflection isn't meaningful for a
+		// line target.
+		output = this.replaceCurrentFileTokensInString(output, {
+			links: true,
+			fileName: true,
+			title: true,
+		});
 		return output;
 	}
 

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -44,8 +44,12 @@ export class FileNameDisplayFormatter extends Formatter {
 			output = await this.replaceVariableInString(output);
 			output = await this.replaceFieldVarInString(output);
 			output = await this.replaceFileInString(output);
-			output = await this.replaceCurrentFileNameInString(output);
-			output = this.replaceTargetFolderInString(output);
+			// {{filenamecurrent}} + {{folder}} in one pass so neither re-scans the
+			// other's output (#1358).
+			output = this.replaceCurrentFileTokensInString(output, {
+				fileName: true,
+				folder: true,
+			});
 			output = this.replaceRandomInString(output);
 		} catch {
 			// Return the input as-is if formatting fails during preview

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -47,9 +47,14 @@ export class FormatDisplayFormatter extends Formatter {
 			output = await this.replaceClipboardInString(output);
 			output = await this.replaceDateVariableInString(output);
 			output = await this.replaceVariableInString(output);
-			output = this.replaceCurrentFileLinksInString(output);
-			output = await this.replaceCurrentFileNameInString(output);
-			output = this.replaceTargetFolderInString(output);
+			// Links + {{filenamecurrent}} + {{folder}} in one pass so no token
+			// re-scans another's output (#1358). ({{title}} has never been resolved
+			// in this preview formatter — preserved by omitting it.)
+			output = this.replaceCurrentFileTokensInString(output, {
+				links: true,
+				fileName: true,
+				folder: true,
+			});
 			output = await this.replaceMacrosInString(output);
 			output = await this.replaceTemplateInString(output);
 			output = await this.replaceFieldVarInString(output);

--- a/src/formatters/formatter-token-named-file.test.ts
+++ b/src/formatters/formatter-token-named-file.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import { Formatter } from "./formatter";
+
+type Behavior = Parameters<Formatter["setLinkToCurrentFileBehavior"]>[0];
+
+/**
+ * Regression coverage for #1358: note-derived contextual tokens
+ * ({{linkcurrent}}, {{linksection}}, {{filenamecurrent}}, {{folder}}/{{folder|name}},
+ * {{title}}) used to resolve as separate sequential passes, so a later pass would
+ * re-scan an earlier pass's generated output — corrupting a link, or looping forever
+ * when the active file/title was literally named like a token.
+ *
+ * Every production entry point delegates to replaceCurrentFileTokensInString with a
+ * token subset, so these tests drive that combined resolver directly with the exact
+ * opts each entry point uses:
+ *   formatFileContent     -> { links, fileName, folder, title }
+ *   formatFileName        -> { fileName, folder }
+ *   formatFolderPath      -> { folder }
+ *   formatLocationString  -> { links, fileName, title }
+ *   FileNameDisplay       -> { fileName, folder }
+ *   FormatDisplay         -> { links, fileName, folder }
+ */
+class StubFormatter extends Formatter {
+	private link: string | null = null;
+	private section: string | null = null;
+	private filename: string | null = null;
+	private titleValue = "";
+
+	constructor() {
+		super();
+	}
+
+	protected async format(input: string): Promise<string> {
+		return input;
+	}
+	protected getCurrentFileLink(): string | null {
+		return this.link;
+	}
+	protected getCurrentFileLinkToSection(): string | null {
+		return this.section;
+	}
+	protected getCurrentFileName(): string | null {
+		return this.filename;
+	}
+	protected getVariableValue(name: string): string {
+		return name === "title" ? this.titleValue : "";
+	}
+	protected async promptForValue(): Promise<string> {
+		return "";
+	}
+	protected async promptForMathValue(): Promise<string> {
+		return "";
+	}
+	protected async suggestForValue(): Promise<string> {
+		return "";
+	}
+	protected suggestForFile(): string {
+		return "";
+	}
+	protected async suggestForField(): Promise<string> {
+		return "";
+	}
+	protected async getMacroValue(): Promise<string> {
+		return "";
+	}
+	protected async promptForVariable(): Promise<string> {
+		return "";
+	}
+	protected async getTemplateContent(): Promise<string> {
+		return "";
+	}
+	protected async getSelectedText(): Promise<string> {
+		return "";
+	}
+	protected async getClipboardContent(): Promise<string> {
+		return "";
+	}
+	protected isTemplatePropertyTypesEnabled(): boolean {
+		return false;
+	}
+
+	setLink(v: string | null) {
+		this.link = v;
+	}
+	setSection(v: string | null) {
+		this.section = v;
+	}
+	setFilename(v: string | null) {
+		this.filename = v;
+	}
+	setTitleValue(v: string) {
+		this.titleValue = v;
+	}
+	setFolder(v: string | null) {
+		this.setTargetFolderPath(v);
+	}
+	setBehavior(b: Behavior) {
+		this.setLinkToCurrentFileBehavior(b);
+	}
+
+	// Expose the protected methods under test.
+	combined(
+		input: string,
+		opts: { links?: boolean; fileName?: boolean; folder?: boolean; title?: boolean },
+	) {
+		return this.replaceCurrentFileTokensInString(input, opts);
+	}
+	linkCurrentStandalone(input: string) {
+		return this.replaceLinkToCurrentFileInString(input);
+	}
+}
+
+const ALL = { links: true, fileName: true, folder: true, title: true } as const;
+
+describe("#1358 note-derived token rescan", () => {
+	describe("no infinite loop when a file/title is literally named like a token", () => {
+		it("{{filenamecurrent}} body, file basename literally {{filenamecurrent}}", () => {
+			const f = new StubFormatter();
+			f.setFilename("{{filenamecurrent}}");
+			expect(f.combined("{{FILENAMECURRENT}}", ALL)).toBe("{{filenamecurrent}}");
+		});
+
+		it("{{linkcurrent}} body, file basename literally {{filenamecurrent}} keeps the link intact", () => {
+			const f = new StubFormatter();
+			f.setFilename("{{filenamecurrent}}");
+			f.setLink("[[{{filenamecurrent}}]]");
+			expect(f.combined("{{LINKCURRENT}}", ALL)).toBe("[[{{filenamecurrent}}]]");
+		});
+
+		it("{{title}} body, title value literally {{title}}", () => {
+			const f = new StubFormatter();
+			f.setTitleValue("{{title}}");
+			expect(f.combined("{{TITLE}}", ALL)).toBe("{{title}}");
+		});
+
+		it("standalone replaceLinkToCurrentFileInString no longer loops on a {{linkcurrent}}-named file", async () => {
+			const f = new StubFormatter();
+			f.setBehavior("optional");
+			f.setLink("[[{{linkcurrent}}]]");
+			await expect(f.linkCurrentStandalone("{{LINKCURRENT}}")).resolves.toBe(
+				"[[{{linkcurrent}}]]",
+			);
+		});
+	});
+
+	describe("no cross-pass corruption (a later token rewriting a generated link)", () => {
+		it("a {{folder}} inside a generated link is NOT rewritten by the folder pass", () => {
+			const f = new StubFormatter();
+			f.setLink("[[{{folder}}]]");
+			f.setFolder("Projects");
+			expect(f.combined("{{LINKCURRENT}}", ALL)).toBe("[[{{folder}}]]");
+		});
+
+		it("a {{title}} inside a generated link is NOT rewritten by the title pass", () => {
+			const f = new StubFormatter();
+			f.setLink("[[{{title}}]]");
+			f.setTitleValue("Brand New Title");
+			expect(f.combined("{{LINKCURRENT}}", ALL)).toBe("[[{{title}}]]");
+		});
+
+		it("a {{filenamecurrent}} inside a generated section link is NOT rewritten by the filename pass", () => {
+			const f = new StubFormatter();
+			f.setSection("[[{{filenamecurrent}}#Heading]]");
+			f.setFilename("real-basename");
+			expect(f.combined("{{LINKSECTION}}", ALL)).toBe(
+				"[[{{filenamecurrent}}#Heading]]",
+			);
+		});
+	});
+
+	describe("inactive token categories are left literal (per entry point)", () => {
+		it("formatFileName opts leave {{linkcurrent}} and {{title}} literal", () => {
+			const f = new StubFormatter();
+			f.setFilename("Note");
+			f.setLink("[[Note]]");
+			f.setTitleValue("T");
+			f.setFolder("Inbox");
+			expect(
+				f.combined("{{LINKCURRENT}} {{FILENAMECURRENT}} {{FOLDER}} {{TITLE}}", {
+					fileName: true,
+					folder: true,
+				}),
+			).toBe("{{LINKCURRENT}} Note Inbox {{TITLE}}");
+		});
+
+		it("formatLocationString opts leave {{folder}} literal", () => {
+			const f = new StubFormatter();
+			f.setLink("[[Note]]");
+			f.setFilename("Note");
+			f.setTitleValue("T");
+			expect(
+				f.combined("{{LINKCURRENT}} {{FOLDER}} {{TITLE}}", {
+					links: true,
+					fileName: true,
+					title: true,
+				}),
+			).toBe("[[Note]] {{FOLDER}} T");
+		});
+
+		it("a links-disabled entry point does not throw on a literal {{linkcurrent}} (required, no active file)", () => {
+			const f = new StubFormatter();
+			f.setBehavior("required");
+			f.setLink(null);
+			f.setFilename("Note");
+			// formatFileName-style opts: links inactive -> token stays literal, no throw.
+			expect(
+				f.combined("{{LINKCURRENT}}-{{FILENAMECURRENT}}", {
+					fileName: true,
+					folder: true,
+				}),
+			).toBe("{{LINKCURRENT}}-Note");
+		});
+	});
+
+	describe("required/optional + throw precedence preserved", () => {
+		it("required + no active file throws the LINK message when a link token is active", () => {
+			const f = new StubFormatter();
+			f.setBehavior("required");
+			f.setLink(null);
+			f.setFilename(null);
+			expect(() => f.combined("{{FILENAMECURRENT}} {{LINKCURRENT}}", ALL)).toThrow(
+				"Unable to get current file path",
+			);
+		});
+
+		it("required + no active file throws the FILENAME message when only a filename token is active", () => {
+			const f = new StubFormatter();
+			f.setBehavior("required");
+			f.setFilename(null);
+			expect(() => f.combined("{{FILENAMECURRENT}}", ALL)).toThrow(
+				"Unable to get current file name",
+			);
+		});
+
+		it("link message wins regardless of token order in the string", () => {
+			const f = new StubFormatter();
+			f.setBehavior("required");
+			f.setLink(null);
+			f.setFilename(null);
+			// Filename token appears first, but the link message must still win.
+			expect(() =>
+				f.combined("{{FILENAMECURRENT}} then {{LINKCURRENT}}", ALL),
+			).toThrow("Unable to get current file path");
+		});
+
+		it("optional + no active file strips active link/filename tokens", () => {
+			const f = new StubFormatter();
+			f.setBehavior("optional");
+			f.setLink(null);
+			f.setFilename(null);
+			expect(f.combined("a{{LINKCURRENT}}b{{FILENAMECURRENT}}c", ALL)).toBe("abc");
+		});
+	});
+
+	describe("folder + multi-occurrence + $-literal preserved", () => {
+		it("{{FOLDER}} full path and {{FOLDER|name}} leaf, case-insensitive, $ literal", () => {
+			const f = new StubFormatter();
+			f.setFolder("A/B/Cash$Money");
+			expect(f.combined("{{FOLDER}} | {{FOLDER|NAME}}", { folder: true })).toBe(
+				"A/B/Cash$Money | Cash$Money",
+			);
+		});
+
+		it("replaces multiple occurrences in one pass", () => {
+			const f = new StubFormatter();
+			f.setFilename("Doc");
+			expect(
+				f.combined("{{FILENAMECURRENT}}-{{FILENAMECURRENT}}", { fileName: true }),
+			).toBe("Doc-Doc");
+		});
+
+		it("{{TITLE|name}} is not a valid token and stays literal", () => {
+			const f = new StubFormatter();
+			f.setTitleValue("T");
+			expect(f.combined("{{TITLE|name}}", ALL)).toBe("{{TITLE|name}}");
+		});
+	});
+});

--- a/src/formatters/formatter-token-named-file.test.ts
+++ b/src/formatters/formatter-token-named-file.test.ts
@@ -110,27 +110,27 @@ class StubFormatter extends Formatter {
 	}
 }
 
-const ALL = { links: true, fileName: true, folder: true, title: true } as const;
+const allTokens = { links: true, fileName: true, folder: true, title: true } as const;
 
 describe("#1358 note-derived token rescan", () => {
 	describe("no infinite loop when a file/title is literally named like a token", () => {
 		it("{{filenamecurrent}} body, file basename literally {{filenamecurrent}}", () => {
 			const f = new StubFormatter();
 			f.setFilename("{{filenamecurrent}}");
-			expect(f.combined("{{FILENAMECURRENT}}", ALL)).toBe("{{filenamecurrent}}");
+			expect(f.combined("{{FILENAMECURRENT}}", allTokens)).toBe("{{filenamecurrent}}");
 		});
 
 		it("{{linkcurrent}} body, file basename literally {{filenamecurrent}} keeps the link intact", () => {
 			const f = new StubFormatter();
 			f.setFilename("{{filenamecurrent}}");
 			f.setLink("[[{{filenamecurrent}}]]");
-			expect(f.combined("{{LINKCURRENT}}", ALL)).toBe("[[{{filenamecurrent}}]]");
+			expect(f.combined("{{LINKCURRENT}}", allTokens)).toBe("[[{{filenamecurrent}}]]");
 		});
 
 		it("{{title}} body, title value literally {{title}}", () => {
 			const f = new StubFormatter();
 			f.setTitleValue("{{title}}");
-			expect(f.combined("{{TITLE}}", ALL)).toBe("{{title}}");
+			expect(f.combined("{{TITLE}}", allTokens)).toBe("{{title}}");
 		});
 
 		it("standalone replaceLinkToCurrentFileInString no longer loops on a {{linkcurrent}}-named file", async () => {
@@ -148,21 +148,21 @@ describe("#1358 note-derived token rescan", () => {
 			const f = new StubFormatter();
 			f.setLink("[[{{folder}}]]");
 			f.setFolder("Projects");
-			expect(f.combined("{{LINKCURRENT}}", ALL)).toBe("[[{{folder}}]]");
+			expect(f.combined("{{LINKCURRENT}}", allTokens)).toBe("[[{{folder}}]]");
 		});
 
 		it("a {{title}} inside a generated link is NOT rewritten by the title pass", () => {
 			const f = new StubFormatter();
 			f.setLink("[[{{title}}]]");
 			f.setTitleValue("Brand New Title");
-			expect(f.combined("{{LINKCURRENT}}", ALL)).toBe("[[{{title}}]]");
+			expect(f.combined("{{LINKCURRENT}}", allTokens)).toBe("[[{{title}}]]");
 		});
 
 		it("a {{filenamecurrent}} inside a generated section link is NOT rewritten by the filename pass", () => {
 			const f = new StubFormatter();
 			f.setSection("[[{{filenamecurrent}}#Heading]]");
 			f.setFilename("real-basename");
-			expect(f.combined("{{LINKSECTION}}", ALL)).toBe(
+			expect(f.combined("{{LINKSECTION}}", allTokens)).toBe(
 				"[[{{filenamecurrent}}#Heading]]",
 			);
 		});
@@ -218,7 +218,7 @@ describe("#1358 note-derived token rescan", () => {
 			f.setBehavior("required");
 			f.setLink(null);
 			f.setFilename(null);
-			expect(() => f.combined("{{FILENAMECURRENT}} {{LINKCURRENT}}", ALL)).toThrow(
+			expect(() => f.combined("{{FILENAMECURRENT}} {{LINKCURRENT}}", allTokens)).toThrow(
 				"Unable to get current file path",
 			);
 		});
@@ -227,7 +227,7 @@ describe("#1358 note-derived token rescan", () => {
 			const f = new StubFormatter();
 			f.setBehavior("required");
 			f.setFilename(null);
-			expect(() => f.combined("{{FILENAMECURRENT}}", ALL)).toThrow(
+			expect(() => f.combined("{{FILENAMECURRENT}}", allTokens)).toThrow(
 				"Unable to get current file name",
 			);
 		});
@@ -239,7 +239,7 @@ describe("#1358 note-derived token rescan", () => {
 			f.setFilename(null);
 			// Filename token appears first, but the link message must still win.
 			expect(() =>
-				f.combined("{{FILENAMECURRENT}} then {{LINKCURRENT}}", ALL),
+				f.combined("{{FILENAMECURRENT}} then {{LINKCURRENT}}", allTokens),
 			).toThrow("Unable to get current file path");
 		});
 
@@ -248,7 +248,7 @@ describe("#1358 note-derived token rescan", () => {
 			f.setBehavior("optional");
 			f.setLink(null);
 			f.setFilename(null);
-			expect(f.combined("a{{LINKCURRENT}}b{{FILENAMECURRENT}}c", ALL)).toBe("abc");
+			expect(f.combined("a{{LINKCURRENT}}b{{FILENAMECURRENT}}c", allTokens)).toBe("abc");
 		});
 	});
 
@@ -272,7 +272,7 @@ describe("#1358 note-derived token rescan", () => {
 		it("{{TITLE|name}} is not a valid token and stays literal", () => {
 			const f = new StubFormatter();
 			f.setTitleValue("T");
-			expect(f.combined("{{TITLE|name}}", ALL)).toBe("{{TITLE|name}}");
+			expect(f.combined("{{TITLE|name}}", allTokens)).toBe("{{TITLE|name}}");
 		});
 	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -6,9 +6,7 @@ import {
 	DATE_VARIABLE_REGEX,
 	LINK_TO_CURRENT_FILE_REGEX,
 	LINK_TO_CURRENT_SECTION_REGEX,
-	FILE_NAME_OF_CURRENT_FILE_REGEX,
 	FILE_REGEX,
-	TARGET_FOLDER_REGEX,
 	MACRO_REGEX,
 	MATH_VALUE_REGEX,
 	NAME_VALUE_REGEX,
@@ -22,7 +20,6 @@ import {
 	CLIPBOARD_REGEX,
 	TIME_REGEX,
 	TIME_REGEX_FORMATTED,
-	TITLE_REGEX,
 	RANDOM_REGEX,
 } from "../constants";
 import {
@@ -296,31 +293,28 @@ export abstract class Formatter {
 	}
 
 
+	/**
+	 * Resolves ONLY {{linkcurrent}} (single-token; production resolves all
+	 * note-derived tokens together via {@link replaceCurrentFileTokensInString}).
+	 * Kept for direct/legacy callers and unit tests. A single function-replacer
+	 * pass — never a while loop — so a file literally named "{{linkcurrent}}"
+	 * (whose generated link re-contains the token) can't loop forever (#1358).
+	 */
 	protected async replaceLinkToCurrentFileInString(
 		input: string,
 	): Promise<string> {
-		const currentFilePathLink = this.getCurrentFileLink();
-		let output = input;
+		if (!LINK_TO_CURRENT_FILE_REGEX.test(input)) return input;
 
-		if (!currentFilePathLink && LINK_TO_CURRENT_FILE_REGEX.test(output)) {
+		const currentFilePathLink = this.getCurrentFileLink();
+		if (!currentFilePathLink) {
 			if (this.linkToCurrentFileBehavior === "required") {
 				throw new Error("Unable to get current file path. Make sure you have a file open in the editor.");
 			}
 			log.logMessage("Skipping {{LINKCURRENT}} replacement because no active file is available.");
-			while (LINK_TO_CURRENT_FILE_REGEX.test(output)) {
-				output = this.replacer(output, LINK_TO_CURRENT_FILE_REGEX, "");
-			}
-			return output;
-		} else if (!currentFilePathLink) return output; // No need to throw, there's no {{LINKCURRENT}} + we can skip while loop.
+		}
 
-		while (LINK_TO_CURRENT_FILE_REGEX.test(output))
-			output = this.replacer(
-				output,
-				LINK_TO_CURRENT_FILE_REGEX,
-				currentFilePathLink,
-			);
-
-		return output;
+		const regex = new RegExp(LINK_TO_CURRENT_FILE_REGEX.source, "gi");
+		return input.replace(regex, () => currentFilePathLink ?? "");
 	}
 
 	/**
@@ -371,33 +365,130 @@ export abstract class Formatter {
 	 * formatter); the individual replacers remain for direct/legacy callers.
 	 */
 	protected replaceCurrentFileLinksInString(input: string): string {
-		if (!/{{(LINKCURRENT|LINKSECTION)}}/i.test(input)) return input;
+		return this.replaceCurrentFileTokensInString(input, { links: true });
+	}
 
+	/**
+	 * Resolves the note-derived contextual tokens — {{linkcurrent}},
+	 * {{linksection}}, {{filenamecurrent}}, {{folder}}/{{folder|name}} and
+	 * {{title}} — in a SINGLE function-replacer pass. Each token's replacement
+	 * embeds user-controlled text (the active file's basename, the target folder's
+	 * name, the note title), so resolving them as separate sequential passes lets
+	 * one pass re-scan and rewrite another's generated output — corrupting it
+	 * (e.g. {{linkcurrent}} → `[[{{folder}}]]`, then the folder pass rewrites the
+	 * basename → `[[]]`), or, when the active file/title is literally named like
+	 * the token, looping forever (the value re-matches the regex every iteration
+	 * → #1358). A single left-to-right pass inserts each resolved value literally
+	 * and never re-scans it, fixing both. Generalises
+	 * {@link replaceCurrentFileLinksInString}, which already does this for the two
+	 * link tokens.
+	 *
+	 * `opts` selects which token categories are active in this context; an inactive
+	 * category's token is returned verbatim (left literal), preserving each entry
+	 * point's existing behaviour (file names leave links/title literal; location
+	 * selectors leave {{folder}} literal; the format-preview formatter resolves no
+	 * {{title}}). The required/optional contract mirrors the individual replacers:
+	 * an ACTIVE link or file-name token that cannot resolve (no active file) throws
+	 * when behaviour is "required" and is stripped when "optional";
+	 * {{folder}}/{{title}} never throw. The link message takes precedence over the
+	 * file-name message, matching the legacy "links resolved before file name"
+	 * order.
+	 */
+	protected replaceCurrentFileTokensInString(
+		input: string,
+		opts: {
+			links?: boolean;
+			fileName?: boolean;
+			folder?: boolean;
+			title?: boolean;
+		},
+	): string {
+		// One alternation over every note-derived token. The |name modifier is
+		// scoped to FOLDER (capture group 3) so the other tokens match EXACTLY as
+		// their individual regexes do (e.g. {{TITLE|name}} stays literal). Built
+		// fresh per call so the global lastIndex is never shared across invocations.
+		const regex =
+			/{{(?:(LINKCURRENT|LINKSECTION|FILENAMECURRENT|TITLE)|(FOLDER)(\|name)?)}}/gi;
+
+		// Each category is resolved lazily, at most once. `undefined` means "not
+		// yet resolved"; the resolvers may legitimately return null/"" (a missing
+		// file, an unset title), so a resolved-but-empty value is distinct from
+		// "uncomputed".
 		let fileLink: string | null | undefined;
 		let sectionLink: string | null | undefined;
-		let missing = false;
+		let fileName: string | null | undefined;
+		let folderFull: string | undefined;
+		let folderLeaf: string | undefined;
+		let title: string | undefined;
+		let missingLink = false;
+		let missingFileName = false;
 
 		const output = input.replace(
-			/{{(LINKCURRENT|LINKSECTION)}}/gi,
-			(_match, token: string) => {
-				if (token.toUpperCase() === "LINKSECTION") {
-					if (sectionLink === undefined)
-						sectionLink = this.getCurrentFileLinkToSection() ?? null;
-					if (!sectionLink) missing = true;
-					return sectionLink ?? "";
+			regex,
+			(
+				match: string,
+				simpleToken: string | undefined,
+				folderToken: string | undefined,
+				folderModifier: string | undefined,
+			) => {
+				// FOLDER (optional |name). Never throws; "" when no target folder.
+				if (folderToken !== undefined) {
+					if (!opts.folder) return match;
+					if (folderFull === undefined) {
+						folderFull = this.targetFolderPath ?? "";
+						const slash = folderFull.lastIndexOf("/");
+						folderLeaf =
+							slash === -1 ? folderFull : folderFull.slice(slash + 1);
+					}
+					return folderModifier ? (folderLeaf as string) : folderFull;
 				}
-				if (fileLink === undefined)
-					fileLink = this.getCurrentFileLink() ?? null;
-				if (!fileLink) missing = true;
-				return fileLink ?? "";
+
+				switch ((simpleToken ?? "").toUpperCase()) {
+					case "LINKCURRENT": {
+						if (!opts.links) return match;
+						if (fileLink === undefined)
+							fileLink = this.getCurrentFileLink() ?? null;
+						if (!fileLink) missingLink = true;
+						return fileLink ?? "";
+					}
+					case "LINKSECTION": {
+						if (!opts.links) return match;
+						if (sectionLink === undefined)
+							sectionLink = this.getCurrentFileLinkToSection() ?? null;
+						if (!sectionLink) missingLink = true;
+						return sectionLink ?? "";
+					}
+					case "FILENAMECURRENT": {
+						if (!opts.fileName) return match;
+						if (fileName === undefined)
+							fileName = this.getCurrentFileName() ?? null;
+						if (!fileName) missingFileName = true;
+						return fileName ?? "";
+					}
+					case "TITLE": {
+						if (!opts.title) return match;
+						if (title === undefined) title = this.getVariableValue("title");
+						return title;
+					}
+				}
+				return match; // unreachable: the regex only matches the cases above
 			},
 		);
 
-		if (missing) {
+		// Required/optional handling mirrors the individual replacers. A missing
+		// link takes precedence over a missing file name (legacy "links first"
+		// order); the messages are kept byte-identical to those replacers.
+		if (missingLink || missingFileName) {
 			if (this.linkToCurrentFileBehavior === "required") {
-				throw new Error("Unable to get current file path. Make sure you have a file open in the editor.");
+				throw new Error(
+					missingLink
+						? "Unable to get current file path. Make sure you have a file open in the editor."
+						: "Unable to get current file name. Make sure you have a file open in the editor.",
+				);
 			}
-			log.logMessage("Skipping {{LINKCURRENT}}/{{LINKSECTION}} replacement because no active file is available.");
+			log.logMessage(
+				"Skipping current-file token replacement because no active file is available.",
+			);
 		}
 
 		return output;
@@ -406,28 +497,11 @@ export abstract class Formatter {
 	protected async replaceCurrentFileNameInString(
 		input: string,
 	): Promise<string> {
-		const currentFileName = this.getCurrentFileName();
-		let output = input;
-
-		if (!currentFileName && FILE_NAME_OF_CURRENT_FILE_REGEX.test(output)) {
-			if (this.linkToCurrentFileBehavior === "required") {
-				throw new Error("Unable to get current file name. Make sure you have a file open in the editor.");
-			}
-			log.logMessage("Skipping {{FILENAMECURRENT}} replacement because no active file is available.");
-			while (FILE_NAME_OF_CURRENT_FILE_REGEX.test(output)) {
-				output = this.replacer(output, FILE_NAME_OF_CURRENT_FILE_REGEX, "");
-			}
-			return output;
-		} else if (!currentFileName) return output;
-
-		while (FILE_NAME_OF_CURRENT_FILE_REGEX.test(output))
-			output = this.replacer(
-				output,
-				FILE_NAME_OF_CURRENT_FILE_REGEX,
-				currentFileName,
-			);
-
-		return output;
+		// Routed through the combined single-pass resolver so a file literally
+		// named "{{filenamecurrent}}" can't loop (#1358). Kept for direct/legacy
+		// callers and unit tests; production resolves all tokens at once via the
+		// entry points in CompleteFormatter / the display formatters.
+		return this.replaceCurrentFileTokensInString(input, { fileName: true });
 	}
 
 	public setLinkToCurrentFileBehavior(behavior: LinkToCurrentFileBehavior) {
@@ -460,14 +534,9 @@ export abstract class Formatter {
 	 * capture "Capture to" field, the API, and macro paths).
 	 */
 	protected replaceTargetFolderInString(input: string): string {
-		const fullPath = this.targetFolderPath ?? "";
-		const slashIndex = fullPath.lastIndexOf("/");
-		const leafName =
-			slashIndex === -1 ? fullPath : fullPath.slice(slashIndex + 1);
-		const regex = new RegExp(TARGET_FOLDER_REGEX.source, "gi");
-		return input.replace(regex, (_match, modifier) =>
-			modifier ? leafName : fullPath,
-		);
+		// Routed through the combined single-pass resolver (kept for direct/legacy
+		// callers and unit tests). See {@link replaceCurrentFileTokensInString}.
+		return this.replaceCurrentFileTokensInString(input, { folder: true });
 	}
 
 	/**
@@ -1312,13 +1381,9 @@ export abstract class Formatter {
 	}
 
 	protected replaceTitleInString(input: string): string {
-		let output = input;
-		const title = this.getVariableValue("title");
-
-		while (TITLE_REGEX.test(output)) {
-			output = this.replacer(output, TITLE_REGEX, title);
-		}
-
-		return output;
+		// Routed through the combined single-pass resolver so a title literally
+		// equal to "{{title}}" can't loop (#1358). Kept for direct/legacy callers
+		// and unit tests. See {@link replaceCurrentFileTokensInString}.
+		return this.replaceCurrentFileTokensInString(input, { title: true });
 	}
 }


### PR DESCRIPTION
## Summary
Closes #1358.

Note-derived format tokens — `{{linkcurrent}}`, `{{linksection}}`, `{{filenamecurrent}}`, `{{folder}}`/`{{folder|name}}`, `{{title}}` — resolved as **separate sequential regex passes** after `format()`. Each replacement embeds user-controlled text (the active file's basename, the target folder's name, the note title), so a **later pass re-scanned an earlier pass's generated output**. Two defects when a note/folder/title was literally named like a token:

- **Corruption** — a note `{{folder}}.md` with a `{{linkcurrent}}` body: the link pass makes `[[{{folder}}]]`, then the folder pass rewrites `{{folder}}` → `[[]]` (link destroyed). Same for `{{title}}.md`.
- **Hang** — `replaceCurrentFileNameInString` and `replaceTitleInString` used `while (REGEX.test(output)) output = replacer(output, REGEX, value)`. When the value itself matches the regex (a note `{{filenamecurrent}}.md`, or a title literally `{{title}}`), the loop never terminates and **freezes the formatter** (and Obsidian).

`{{linkcurrent}}`/`{{linksection}}` were already hardened against re-scanning **each other** in #1356; this PR extends that single-pass guarantee to **all** note-derived tokens so none can re-scan another's output.

## Fix
Resolve every note-derived token in **one function-replacer pass** — `Formatter.replaceCurrentFileTokensInString(input, opts)`. A single left-to-right `String.replace` inserts each resolved value literally and never re-scans it, fixing both the corruption and the hang.

- The six entry points each call it with their token subset; an **inactive** token category is left literal, preserving per-entry-point behaviour:
  | entry point | tokens resolved |
  |---|---|
  | `CompleteFormatter.formatFileContent` | links + filename + folder + title |
  | `CompleteFormatter.formatFileName` | filename + folder (links literal; `{{title}}` throws earlier) |
  | `CompleteFormatter.formatFolderPath` | folder |
  | `CompleteFormatter.formatLocationString` | links + filename + title (folder deliberately literal) |
  | `FileNameDisplayFormatter.format` | filename + folder |
  | `FormatDisplayFormatter.format` | links + filename + folder (no title, as before) |
- The individual replacers now **delegate** to the combined method (centralising the logic and fixing their standalone self-loops); `replaceLinkToCurrentFileInString` is converted from a `while` loop to a single pass.

`CaptureChoiceFormatter` inherits the fix via `super.formatFileContent`/`formatLocationString`. Preflight (`RequirementCollector`) and the syntax suggester never resolve these tokens, so they need no change.

## Behaviour preserved
Required/optional throw semantics + **byte-identical messages** + link-over-filename precedence; `{{folder}}`/`{{title}}` never throw; multi-occurrence replacement; `$` treated literally; case-insensitive `{{FOLDER|NAME}}`; the inactive-token-literal contract per entry point. The only intended change is that a token appearing **inside a generated value** is no longer re-resolved — exactly the bug class being fixed.

## Verification
- **Reproduced first** in the isolated E2E Obsidian vault via `api.format`: `{{folder}}.md`+`{{linkcurrent}}` → `[[]]`; `{{title}}.md`+`{{linkcurrent}}` → `[[]]`; the `{{filenamecurrent}}` cases **hung**.
- **After the fix** (real app): `[[{{folder}}]]`, `[[{{title}}]]`, `{{filenamecurrent}}`, `[[{{filenamecurrent}}]]` — the previously-hanging cases now **return**. Happy path unchanged (`Normal Note` → `[[Normal Note]]`).
- Full suite green (2449 passed), `tsc`, `eslint`, and `build` clean.
- New regression tests: `formatter-token-named-file.test.ts` (combined-resolver unit semantics: no-loop, no-corruption, inactive-literal, throw precedence, `$`/case/multi-occurrence) **and** production-level guards in `completeFormatter.test.ts` driving the real `formatFileContent`/`formatFileName` so a future revert to sequential passes is caught.

## Review
Design reviewed by an ultracode completeness pass + 2 adversarial reviewers (all "sound"); implementation diff reviewed by 3 adversarial reviewers (Codex).

## Known, pre-existing limitations (out of scope, not regressions)
- **Nested-template boundary**: a parent that `{{TEMPLATE:}}`-includes a child whose output contains a resolved value literally equal to a token (only possible with a degenerately-named note) is still re-scanned by the parent's pass (`[[]]`). The old code produced the same result via the child's own pass; fixing it cleanly needs sentinel-protection across the template-composition boundary.
- **Preview formatters**: contextual tokens resolve before the macro/template/field/random passes, so a file/folder literally named `{{macro:…}}`/`{{random:n}}` is mutated in the **preview only** (no disk writes; pre-existing position, unchanged here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue `#1358`: prevented re-scanning/re-writing of generated file links when active file basenames include formatting tokens.
  * Resolved hanging behavior when the active file is literally named `{{filenamecurrent}}`.
  * Fixed token corruption by switching current-file token resolution to a safer single-pass flow across formatter entry points (including folder/location handling).
* **Tests**
  * Added an end-to-end regression suite covering tokenized basenames and link preservation for the formatter entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->