### PR TITLE
feat(user-scripts): store secret settings in SecretStorage

### DIFF
--- a/docs/docs/Advanced/scriptsWithSettings.md
+++ b/docs/docs/Advanced/scriptsWithSettings.md
@@ -46,6 +46,11 @@ module.exports = {
                 placeholder: "Placeholder",
                 description: "Description here.",
             },
+            "API Key": {
+                type: "secret",
+                placeholder: "Paste API key",
+                description: "Stored securely with Obsidian SecretStorage.",
+            },
             "Checkbox": {
                 type: "checkbox",
                 defaultValue: false,
@@ -71,6 +76,7 @@ module.exports = {
 
 ## Setting types
 - `text` and `input`: A text field.
+- `secret`: A password-style input stored with Obsidian SecretStorage. QuickAdd stores only a reference in `data.json`; package exports omit secret values and local secret references. The older `text` / `input` plus `secret: true` form is still treated as a secret setting.
 - `textarea`: A multi-line text area.
 - `checkbox` and `toggle`: A checkbox.
 - `dropdown` and `select`: A dropdown.

--- a/docs/docs/UserScripts.md
+++ b/docs/docs/UserScripts.md
@@ -213,19 +213,35 @@ User scripts can define configurable options that users can set through the Quic
 ### Option Types
 
 #### Text Input
-For string values, API keys, paths, etc.
+For regular string values, paths, names, etc.
+
+```javascript
+options: {
+    "Project": {
+        type: "text",              // or "input"
+        defaultValue: "",
+        placeholder: "Project name",
+        description: "Default project" // Optional: help text
+    }
+}
+```
+
+#### Secret Input
+For API keys, access tokens, and other sensitive values. Secrets are stored in Obsidian's SecretStorage and QuickAdd stores only a reference in `data.json`.
 
 ```javascript
 options: {
     "API Key": {
-        type: "text",              // or "input"
-        defaultValue: "",
-        placeholder: "Enter API key",
-        secret: true,              // Optional: masks input for sensitive data
-        description: "Your API key" // Optional: help text
+        type: "secret",
+        placeholder: "Paste API key",
+        description: "Your API key"
     }
 }
 ```
+
+`type: "text"` / `type: "input"` with `secret: true` is still supported for older scripts and is treated as a secret setting.
+
+Secret values are local to the Obsidian app profile. They are not included in QuickAdd package exports and are not synced through the plugin's `data.json`; users must enter them on each device where the script runs.
 
 #### Toggle/Checkbox
 For boolean on/off settings.
@@ -280,10 +296,8 @@ module.exports = {
         author: "Your Name",
         options: {
             "API Key": {
-                type: "text",
-                defaultValue: "",
+                type: "secret",
                 placeholder: "sk-...",
-                secret: true,
                 description: "OpenAI API key"
             },
             "Model": {

--- a/src/engine/MacroChoiceEngine.entry.test.ts
+++ b/src/engine/MacroChoiceEngine.entry.test.ts
@@ -227,6 +227,57 @@ describe("MacroChoiceEngine user script entry handling", () => {
 		);
 	});
 
+	it("migrates legacy plaintext secret settings before invoking the entry export", async () => {
+		const entryFn = vi.fn().mockResolvedValue("entry-result");
+		const secretStore = new Map<string, string>();
+		const secretApp = {
+			secretStorage: {
+				getSecret: vi.fn((name: string) => secretStore.get(name) ?? null),
+				setSecret: vi.fn((name: string, value: string) => {
+					secretStore.set(name, value);
+				}),
+			},
+		} as unknown as App;
+		const saveSettings = vi.fn().mockResolvedValue(undefined);
+		const pluginWithSave = { saveSettings } as unknown as QuickAdd;
+		userScriptCommand.settings = {
+			"API Key": "legacy-secret",
+		};
+
+		mockGetUserScript.mockResolvedValue({
+			entry: entryFn,
+			settings: {
+				options: {
+					"API Key": {
+						type: "secret",
+					},
+				},
+			},
+		});
+
+		const engine = new MacroChoiceEngine(
+			secretApp,
+			pluginWithSave,
+			macroChoice,
+			choiceExecutor,
+			variables,
+		);
+
+		await engine["executeUserScript"](userScriptCommand);
+
+		expect(secretStore.get("quickadd-user-script-user-script-api-key")).toBe(
+			"legacy-secret",
+		);
+		expect(JSON.stringify(userScriptCommand.settings)).not.toContain(
+			"legacy-secret",
+		);
+		expect(entryFn).toHaveBeenCalledWith(
+			expect.objectContaining({ variables: expect.any(Object) }),
+			{ "API Key": "legacy-secret" },
+		);
+		expect(saveSettings).toHaveBeenCalledTimes(1);
+	});
+
 	it("ignores malformed primitive settings exports at the user-script boundary", async () => {
 		const entryFn = vi.fn().mockResolvedValue("entry-result");
 

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -351,15 +351,6 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		if (userScriptSettings) {
 			// Initialize default values for settings before executing the script
 			initializeUserScriptSettings(command.settings, userScriptSettings);
-			if (
-				await migrateUserScriptSecretSettings(
-					this.app,
-					command,
-					userScriptSettings,
-				)
-			) {
-				await this.plugin.saveSettings?.();
-			}
 		}
 		this.userScriptCommand = command;
 		this.userScriptSettingsDefinition = userScriptSettings;
@@ -377,6 +368,24 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 			this.userScriptCommand = null;
 			this.userScriptSettingsDefinition = undefined;
 		}
+	}
+
+	private async getResolvedUserScriptSettings(command: IUserScript) {
+		if (
+			await migrateUserScriptSecretSettings(
+				this.app,
+				command,
+				this.userScriptSettingsDefinition,
+			)
+		) {
+			await this.plugin.saveSettings?.();
+		}
+
+		return resolveUserScriptSettings(
+			this.app,
+			command,
+			this.userScriptSettingsDefinition,
+		);
 	}
 
 	private async runScriptWithSettings(
@@ -400,22 +409,14 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		) {
 			return await this.onExportIsFunction(
 				userScript.entry,
-				await resolveUserScriptSettings(
-					this.app,
-					command,
-					this.userScriptSettingsDefinition,
-				),
+				await this.getResolvedUserScriptSettings(command),
 			);
 		}
 
 		if (typeof userScript === "function") {
 			return await this.onExportIsFunction(
 				userScript,
-				await resolveUserScriptSettings(
-					this.app,
-					command,
-					this.userScriptSettingsDefinition,
-				),
+				await this.getResolvedUserScriptSettings(command),
 			);
 		}
 	}

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -49,6 +49,10 @@ import { TFile } from "obsidian";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { UserCancelError } from "../errors/UserCancelError";
 import { initializeUserScriptSettings } from "../utils/userScriptSettings";
+import {
+	resolveUserScriptSettings,
+	type UserScriptSettingsDefinition,
+} from "../utils/userScriptSecrets";
 import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
 import type { ScriptCondition } from "../types/macros/Conditional/types";
 import { evaluateCondition } from "./helpers/conditionalEvaluator";
@@ -162,6 +166,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 	protected choiceExecutor: IChoiceExecutor;
 	protected readonly plugin: QuickAdd;
 	private userScriptCommand: IUserScript | null;
+	private userScriptSettingsDefinition: UserScriptSettingsDefinition | undefined;
 	private conditionalScriptCache = new Map<string, ConditionalScriptRunner>();
 	private readonly preloadedUserScripts: Map<string, unknown>;
 	private readonly promptLabel?: string;
@@ -248,6 +253,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		this.choiceExecutor = choiceExecutor;
 		this.preloadedUserScripts = preloadedUserScripts ?? new Map();
 		this.promptLabel = promptLabel;
+		this.userScriptSettingsDefinition = undefined;
 		const sharedVariables = this.initSharedVariables(
 			choiceExecutor,
 			variables
@@ -340,13 +346,13 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 			command.settings = {};
 		}
 
-		this.userScriptCommand = command;
-
 		const userScriptSettings = getUserScriptSettings(userScript);
 		if (userScriptSettings) {
 			// Initialize default values for settings before executing the script
 			initializeUserScriptSettings(command.settings, userScriptSettings);
 		}
+		this.userScriptCommand = command;
+		this.userScriptSettingsDefinition = userScriptSettings;
 
 		try {
 			await this.userScriptDelegator(userScript);
@@ -359,6 +365,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 			throw err;
 		} finally {
 			this.userScriptCommand = null;
+			this.userScriptSettingsDefinition = undefined;
 		}
 	}
 
@@ -383,12 +390,23 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		) {
 			return await this.onExportIsFunction(
 				userScript.entry,
-				command.settings
+				await resolveUserScriptSettings(
+					this.app,
+					command,
+					this.userScriptSettingsDefinition,
+				),
 			);
 		}
 
 		if (typeof userScript === "function") {
-			return await this.onExportIsFunction(userScript, command.settings);
+			return await this.onExportIsFunction(
+				userScript,
+				await resolveUserScriptSettings(
+					this.app,
+					command,
+					this.userScriptSettingsDefinition,
+				),
+			);
 		}
 	}
 

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -50,6 +50,7 @@ import { MacroAbortError } from "../errors/MacroAbortError";
 import { UserCancelError } from "../errors/UserCancelError";
 import { initializeUserScriptSettings } from "../utils/userScriptSettings";
 import {
+	migrateUserScriptSecretSettings,
 	resolveUserScriptSettings,
 	type UserScriptSettingsDefinition,
 } from "../utils/userScriptSecrets";
@@ -350,6 +351,15 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		if (userScriptSettings) {
 			// Initialize default values for settings before executing the script
 			initializeUserScriptSettings(command.settings, userScriptSettings);
+			if (
+				await migrateUserScriptSecretSettings(
+					this.app,
+					command,
+					userScriptSettings,
+				)
+			) {
+				await this.plugin.saveSettings?.();
+			}
 		}
 		this.userScriptCommand = command;
 		this.userScriptSettingsDefinition = userScriptSettings;

--- a/src/engine/SingleMacroEngine.member-access.test.ts
+++ b/src/engine/SingleMacroEngine.member-access.test.ts
@@ -252,6 +252,55 @@ describe("SingleMacroEngine member access", () => {
 		expect(saveSettings).toHaveBeenCalledTimes(1);
 	});
 
+	it("does not resolve or migrate settings for non-callable member access", async () => {
+		const getSecret = vi.fn(() => {
+			throw new Error("should not read secrets for metadata access");
+		});
+		const setSecret = vi.fn();
+		const secretApp = {
+			secretStorage: {
+				getSecret,
+				setSecret,
+			},
+		} as unknown as App;
+		const saveSettings = vi.fn().mockResolvedValue(undefined);
+		const pluginWithSave = { saveSettings } as unknown as QuickAdd;
+		const userScript = createUserScript("user-script", "script.js");
+		userScript.settings = {
+			"API Key": {
+				__quickaddSecret: true,
+				secretRef: "missing-secret",
+			},
+		};
+		const macroChoice = baseMacroChoice([userScript]);
+		const choices: IChoice[] = [macroChoice];
+		const exportedSettings = {
+			options: {
+				"API Key": {
+					type: "secret",
+				},
+			},
+		};
+
+		mockGetUserScript.mockResolvedValue({
+			settings: exportedSettings,
+		});
+
+		const engine = new SingleMacroEngine(
+			secretApp,
+			pluginWithSave,
+			choices,
+			choiceExecutor,
+		);
+
+		const result = await engine.runAndGetOutput("My Macro::settings");
+
+		expect(result).toBe(JSON.stringify(exportedSettings));
+		expect(getSecret).not.toHaveBeenCalled();
+		expect(setSecret).not.toHaveBeenCalled();
+		expect(saveSettings).not.toHaveBeenCalled();
+	});
+
 	it("reaches a unique member on a later script while preserving pre and post execution", async () => {
 		const preCommand = {
 			id: "wait-1",

--- a/src/engine/SingleMacroEngine.member-access.test.ts
+++ b/src/engine/SingleMacroEngine.member-access.test.ts
@@ -199,6 +199,59 @@ describe("SingleMacroEngine member access", () => {
 		expect(choiceExecutor.variables.get("newValue")).toBe("hello");
 	});
 
+	it("migrates legacy plaintext secret settings before member-access execution", async () => {
+		const secretStore = new Map<string, string>();
+		const secretApp = {
+			secretStorage: {
+				getSecret: vi.fn((name: string) => secretStore.get(name) ?? null),
+				setSecret: vi.fn((name: string, value: string) => {
+					secretStore.set(name, value);
+				}),
+			},
+		} as unknown as App;
+		const saveSettings = vi.fn().mockResolvedValue(undefined);
+		const pluginWithSave = { saveSettings } as unknown as QuickAdd;
+		const userScript = createUserScript("user-script", "script.js");
+		userScript.settings = {
+			"API Key": "legacy-secret",
+		};
+		const macroChoice = baseMacroChoice([userScript]);
+		const choices: IChoice[] = [macroChoice];
+
+		const engineInstance = macroEngineFactory();
+		macroEngineFactory = () => engineInstance;
+		const exportFn = vi.fn().mockReturnValue("secret-result");
+
+		mockGetUserScript.mockResolvedValue({
+			settings: {
+				options: {
+					"API Key": {
+						type: "secret",
+					},
+				},
+			},
+			f: exportFn,
+		});
+
+		const engine = new SingleMacroEngine(
+			secretApp,
+			pluginWithSave,
+			choices,
+			choiceExecutor,
+		);
+
+		await engine.runAndGetOutput("My Macro::f");
+
+		expect(secretStore.get("quickadd-user-script-user-script-api-key")).toBe(
+			"legacy-secret",
+		);
+		expect(JSON.stringify(userScript.settings)).not.toContain("legacy-secret");
+		expect(exportFn).toHaveBeenCalledWith(engineInstance.params, {
+			"API Key": "legacy-secret",
+		});
+		expect(saveSettings).toHaveBeenCalledTimes(1);
+	});
+
 	it("reaches a unique member on a later script while preserving pre and post execution", async () => {
 		const preCommand = {
 			id: "wait-1",

--- a/src/engine/SingleMacroEngine.ts
+++ b/src/engine/SingleMacroEngine.ts
@@ -9,7 +9,10 @@ import { CommandType } from "../types/macros/CommandType";
 import { getUserScript, getUserScriptMemberAccess } from "../utilityObsidian";
 import { flattenChoices } from "../utils/choiceUtils";
 import { initializeUserScriptSettings } from "../utils/userScriptSettings";
-import { resolveUserScriptSettings } from "../utils/userScriptSecrets";
+import {
+	migrateUserScriptSecretSettings,
+	resolveUserScriptSettings,
+} from "../utils/userScriptSecrets";
 import { MacroChoiceEngine } from "./MacroChoiceEngine";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { MacroAbortError } from "../errors/MacroAbortError";
@@ -285,6 +288,15 @@ export class SingleMacroEngine {
 					userScriptCommand.settings,
 					settingsExport as Record<string, unknown>,
 				);
+				if (
+					await migrateUserScriptSecretSettings(
+						this.app,
+						userScriptCommand,
+						settingsExport as Record<string, unknown>,
+					)
+				) {
+					await this.plugin.saveSettings?.();
+				}
 			}
 
 			const resolvedMember =

--- a/src/engine/SingleMacroEngine.ts
+++ b/src/engine/SingleMacroEngine.ts
@@ -288,15 +288,6 @@ export class SingleMacroEngine {
 					userScriptCommand.settings,
 					settingsExport as Record<string, unknown>,
 				);
-				if (
-					await migrateUserScriptSecretSettings(
-						this.app,
-						userScriptCommand,
-						settingsExport as Record<string, unknown>,
-					)
-				) {
-					await this.plugin.saveSettings?.();
-				}
 			}
 
 			const resolvedMember =
@@ -312,18 +303,32 @@ export class SingleMacroEngine {
 			}
 
 			const postCommands = updatedCommands.slice(refreshedIndex + 1);
-			const resolvedSettings = await resolveUserScriptSettings(
-				this.app,
-				userScriptCommand,
-				settingsExport && typeof settingsExport === "object"
-					? (settingsExport as Record<string, unknown>)
-					: undefined,
-			);
+			let memberSettings = userScriptCommand.settings;
+			if (typeof resolvedMember.value === "function") {
+				if (
+					await migrateUserScriptSecretSettings(
+						this.app,
+						userScriptCommand,
+						settingsExport && typeof settingsExport === "object"
+							? (settingsExport as Record<string, unknown>)
+							: undefined,
+					)
+				) {
+					await this.plugin.saveSettings?.();
+				}
+				memberSettings = await resolveUserScriptSettings(
+					this.app,
+					userScriptCommand,
+					settingsExport && typeof settingsExport === "object"
+						? (settingsExport as Record<string, unknown>)
+						: undefined,
+				);
+			}
 
 			const result = await this.executeResolvedMember(
 				resolvedMember.value,
 				engine,
-				resolvedSettings,
+				memberSettings,
 			);
 			this.ensureNotAborted();
 

--- a/src/engine/SingleMacroEngine.ts
+++ b/src/engine/SingleMacroEngine.ts
@@ -9,6 +9,7 @@ import { CommandType } from "../types/macros/CommandType";
 import { getUserScript, getUserScriptMemberAccess } from "../utilityObsidian";
 import { flattenChoices } from "../utils/choiceUtils";
 import { initializeUserScriptSettings } from "../utils/userScriptSettings";
+import { resolveUserScriptSettings } from "../utils/userScriptSecrets";
 import { MacroChoiceEngine } from "./MacroChoiceEngine";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { MacroAbortError } from "../errors/MacroAbortError";
@@ -299,11 +300,18 @@ export class SingleMacroEngine {
 			}
 
 			const postCommands = updatedCommands.slice(refreshedIndex + 1);
+			const resolvedSettings = await resolveUserScriptSettings(
+				this.app,
+				userScriptCommand,
+				settingsExport && typeof settingsExport === "object"
+					? (settingsExport as Record<string, unknown>)
+					: undefined,
+			);
 
 			const result = await this.executeResolvedMember(
 				resolvedMember.value,
 				engine,
-				userScriptCommand.settings,
+				resolvedSettings,
 			);
 			this.ensureNotAborted();
 

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -52,6 +52,7 @@ import { OpenFileCommand } from "../../types/macros/QuickCommands/OpenFileComman
 import type { IConditionalCommand } from "../../types/macros/Conditional/IConditionalCommand";
 import { getUserScriptMemberAccess } from "../../utilityObsidian";
 import { ConditionalCommand } from "../../types/macros/Conditional/ConditionalCommand";
+import { clearUserScriptSecretsFromCommand } from "../../utils/userScriptSecrets";
 
 type ConditionalHandler = (command: IConditionalCommand) => Promise<boolean>;
 
@@ -153,6 +154,7 @@ export class CommandSequenceEditor {
 				);
 				if (!promptAnswer) return;
 
+				await clearUserScriptSecretsFromCommand(this.app, command);
 				this.commandsRef = this.commandsRef.filter((c) => c.id !== commandId);
 				this.emitCommandsChanged();
 			},

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -154,7 +154,17 @@ export class CommandSequenceEditor {
 				);
 				if (!promptAnswer) return;
 
-				await clearUserScriptSecretsFromCommand(this.app, command);
+				const secretsCleared = await clearUserScriptSecretsFromCommand(
+					this.app,
+					command
+				);
+				if (!secretsCleared) {
+					new Notice(
+						"Could not clear user script secrets. Command was not deleted."
+					);
+					return;
+				}
+
 				this.commandsRef = this.commandsRef.filter((c) => c.id !== commandId);
 				this.emitCommandsChanged();
 			},

--- a/src/gui/MacroGUIs/UserScriptSettingsModal.test.ts
+++ b/src/gui/MacroGUIs/UserScriptSettingsModal.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { CommandType } from "../../types/macros/CommandType";
+import type { IUserScript } from "../../types/macros/IUserScript";
+import { createUserScriptSecretRef } from "../../utils/userScriptSecrets";
+import { UserScriptSettingsModal } from "./UserScriptSettingsModal";
+
+vi.mock("../../quickAddInstance", () => ({
+	getQuickAddInstance: vi.fn(() => ({})),
+}));
+
+vi.mock("../../formatters/formatDisplayFormatter", () => ({
+	FormatDisplayFormatter: class {
+		format(value: string): Promise<string> {
+			return Promise.resolve(value);
+		}
+	},
+}));
+
+vi.mock("../suggesters/formatSyntaxSuggester", () => ({
+	FormatSyntaxSuggester: class {},
+}));
+
+function createCommand(settings: Record<string, unknown> = {}): IUserScript {
+	return {
+		id: "command-1",
+		name: "Script",
+		type: CommandType.UserScript,
+		path: "scripts/script.js",
+		settings,
+	};
+}
+
+function createSettings() {
+	return {
+		name: "Script Settings",
+		options: {
+			"API Key": {
+				type: "secret" as const,
+				defaultValue: "must-not-persist",
+				placeholder: "Paste API key",
+				description: "API key",
+			},
+		},
+	};
+}
+
+function flushPromises(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function inputValue(input: HTMLInputElement, value: string) {
+	input.value = value;
+	input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("UserScriptSettingsModal secret settings", () => {
+	afterEach(() => {
+		document.body.innerHTML = "";
+	});
+
+	it("does not write typed secret text into command settings until Save", async () => {
+		const app = new App();
+		const command = createCommand();
+		const onCommandChange = vi.fn();
+		const modal = new UserScriptSettingsModal(
+			app,
+			command,
+			createSettings(),
+			onCommandChange,
+		);
+		await flushPromises();
+
+		const input = modal.contentEl.querySelector("input") as HTMLInputElement;
+		inputValue(input, "secret-value");
+
+		expect(command.settings["API Key"]).toBeUndefined();
+		expect(JSON.stringify(command.settings)).not.toContain("secret-value");
+		expect(onCommandChange).not.toHaveBeenCalled();
+
+		const save = modal.contentEl.querySelector(
+			'button[aria-label="Save API Key"]',
+		) as HTMLButtonElement;
+		save.click();
+		await flushPromises();
+
+		expect(app.secretStorage.getSecret("quickadd-user-script-command-1-api-key"))
+			.toBe("secret-value");
+		expect(command.settings["API Key"]).toEqual(
+			createUserScriptSecretRef("quickadd-user-script-command-1-api-key"),
+		);
+		expect(JSON.stringify(command.settings)).not.toContain("secret-value");
+		expect(onCommandChange).toHaveBeenCalledTimes(1);
+		expect(input.value).toBe("");
+	});
+
+	it("migrates existing plaintext secret settings after opening", async () => {
+		const app = new App();
+		const command = createCommand({
+			"API Key": "legacy-secret",
+		});
+		const onCommandChange = vi.fn();
+
+		new UserScriptSettingsModal(app, command, createSettings(), onCommandChange);
+		await flushPromises();
+
+		expect(app.secretStorage.getSecret("quickadd-user-script-command-1-api-key"))
+			.toBe("legacy-secret");
+		expect(command.settings["API Key"]).toEqual(
+			createUserScriptSecretRef("quickadd-user-script-command-1-api-key"),
+		);
+		expect(JSON.stringify(command.settings)).not.toContain("legacy-secret");
+		expect(onCommandChange).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears the marker and stored secret", async () => {
+		const app = new App();
+		app.secretStorage.setSecret(
+			"quickadd-user-script-command-1-api-key",
+			"secret-value",
+		);
+		const command = createCommand({
+			"API Key": createUserScriptSecretRef(
+				"quickadd-user-script-command-1-api-key",
+			),
+		});
+		const onCommandChange = vi.fn();
+		const modal = new UserScriptSettingsModal(
+			app,
+			command,
+			createSettings(),
+			onCommandChange,
+		);
+		await flushPromises();
+
+		const clear = modal.contentEl.querySelector(
+			'button[aria-label="Clear API Key"]',
+		) as HTMLButtonElement;
+		clear.click();
+		await flushPromises();
+
+		expect(app.secretStorage.getSecret("quickadd-user-script-command-1-api-key"))
+			.toBeNull();
+		expect(command.settings["API Key"]).toBeUndefined();
+		expect(onCommandChange).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/gui/MacroGUIs/UserScriptSettingsModal.ts
+++ b/src/gui/MacroGUIs/UserScriptSettingsModal.ts
@@ -1,11 +1,19 @@
 import type { App } from "obsidian";
-import { Modal, Setting, TextAreaComponent } from "obsidian";
+import { Modal, Notice, Setting, TextAreaComponent } from "obsidian";
 import type { IUserScript } from "../../types/macros/IUserScript";
 import { getQuickAddInstance } from "../../quickAddInstance";
 import { FormatDisplayFormatter } from "../../formatters/formatDisplayFormatter";
 import { FormatSyntaxSuggester } from "../suggesters/formatSyntaxSuggester";
 import { setPasswordOnBlur } from "../../utils/setPasswordOnBlur";
 import { initializeUserScriptSettings } from "../../utils/userScriptSettings";
+import {
+	clearUserScriptSecret,
+	createUserScriptSecretRef,
+	getSecretRefFromCommandSetting,
+	isSecretUserScriptOption,
+	migrateUserScriptSecretSettings,
+	storeUserScriptSecret,
+} from "../../utils/userScriptSecrets";
 
 type Option = { description?: string } & (
 	| {
@@ -20,6 +28,12 @@ type Option = { description?: string } & (
 			value: string;
 			placeholder?: string;
 			defaultValue: string;
+	  }
+	| {
+			type: "secret";
+			value?: string;
+			placeholder?: string;
+			defaultValue?: string;
 	  }
 	| {
 			type: "checkbox" | "toggle";
@@ -65,11 +79,12 @@ export class UserScriptSettingsModal extends Modal {
 	) {
 		super(app);
 
-		this.display();
 		if (!this.command.settings) this.command.settings = {};
 
 		// Initialize default values for settings
 		initializeUserScriptSettings(this.command.settings, this.settings);
+		this.display();
+		void this.migrateSecretSettings();
 	}
 
 	protected display() {
@@ -89,6 +104,16 @@ export class UserScriptSettingsModal extends Modal {
 		for (const option in options) {
 			if (!Object.prototype.hasOwnProperty.call(options, option)) continue;
 			const entry = options[option];
+			if (isSecretUserScriptOption(entry)) {
+				const setting = this.addSecretInput(
+					option,
+					"placeholder" in entry ? entry.placeholder : undefined,
+				);
+				if (entry.description) {
+					setting.setDesc(entry.description);
+				}
+				continue;
+			}
 
 			let value = entry.defaultValue;
 
@@ -152,6 +177,92 @@ export class UserScriptSettingsModal extends Modal {
 				setPasswordOnBlur(input.inputEl);
 			}
 		});
+	}
+
+	private addSecretInput(name: string, placeholder?: string) {
+		const setting = new Setting(this.contentEl).setName(name);
+		let pendingValue = "";
+		let inputEl: HTMLInputElement | undefined;
+
+		const hasSecret = () => {
+			const value = this.command.settings?.[name];
+			return (
+				getSecretRefFromCommandSetting(this.command, name) !== undefined ||
+				(typeof value === "string" && value.length > 0)
+			);
+		};
+		const updatePlaceholder = () => {
+			if (!inputEl) return;
+			inputEl.placeholder = hasSecret()
+				? "Secret saved"
+				: (placeholder ?? "Paste secret");
+		};
+
+		setting.addText((input) => {
+			input
+				.setValue("")
+				.onChange((value) => {
+					pendingValue = value;
+				});
+			input.inputEl.type = "password";
+			input.inputEl.addClass("qa-user-script-secret-input");
+			input.inputEl.setAttribute("aria-label", name);
+			inputEl = input.inputEl;
+			updatePlaceholder();
+		});
+
+		setting.addButton((button) => {
+			button.buttonEl.setAttribute("aria-label", `Save ${name}`);
+			button.setIcon("save").setTooltip("Save secret").onClick(async () => {
+				if (pendingValue.length === 0) {
+					new Notice("Paste a secret before saving.");
+					return;
+				}
+
+				const secretRef = await storeUserScriptSecret(
+					this.app,
+					this.command,
+					name,
+					pendingValue,
+					getSecretRefFromCommandSetting(this.command, name),
+				);
+
+				if (!secretRef) {
+					new Notice("SecretStorage is unavailable. Secret was not saved.");
+					return;
+				}
+
+				this.command.settings[name] = createUserScriptSecretRef(secretRef);
+				pendingValue = "";
+				if (inputEl) inputEl.value = "";
+				updatePlaceholder();
+				this.onCommandChange?.();
+				new Notice("Secret saved.");
+			});
+		});
+
+		setting.addButton((button) => {
+			button.buttonEl.setAttribute("aria-label", `Clear ${name}`);
+			button.setIcon("trash-2").setTooltip("Clear secret").onClick(async () => {
+				const secretRef = getSecretRefFromCommandSetting(this.command, name);
+				if (secretRef) {
+					const cleared = await clearUserScriptSecret(this.app, secretRef);
+					if (!cleared) {
+						new Notice("SecretStorage is unavailable. Secret was not cleared.");
+						return;
+					}
+				}
+
+				delete this.command.settings[name];
+				pendingValue = "";
+				if (inputEl) inputEl.value = "";
+				updatePlaceholder();
+				this.onCommandChange?.();
+				new Notice("Secret cleared.");
+			});
+		});
+
+		return setting;
 	}
 
 	private addTextArea(
@@ -224,5 +335,18 @@ export class UserScriptSettingsModal extends Modal {
 			(formatDisplay.innerText = await displayFormatter.format(value)))();
 
 		return setting;
+	}
+
+	private async migrateSecretSettings() {
+		if (
+			await migrateUserScriptSecretSettings(
+				this.app,
+				this.command,
+				this.settings,
+			)
+		) {
+			this.onCommandChange?.();
+			this.display();
+		}
 	}
 }

--- a/src/gui/MacroGUIs/UserScriptSettingsModal.ts
+++ b/src/gui/MacroGUIs/UserScriptSettingsModal.ts
@@ -212,7 +212,6 @@ export class UserScriptSettingsModal extends Modal {
 		});
 
 		setting.addButton((button) => {
-			button.buttonEl.setAttribute("aria-label", `Save ${name}`);
 			button.setIcon("save").setTooltip("Save secret").onClick(async () => {
 				if (pendingValue.length === 0) {
 					new Notice("Paste a secret before saving.");
@@ -239,10 +238,10 @@ export class UserScriptSettingsModal extends Modal {
 				this.onCommandChange?.();
 				new Notice("Secret saved.");
 			});
+			button.buttonEl.setAttribute("aria-label", `Save ${name}`);
 		});
 
 		setting.addButton((button) => {
-			button.buttonEl.setAttribute("aria-label", `Clear ${name}`);
 			button.setIcon("trash-2").setTooltip("Clear secret").onClick(async () => {
 				const secretRef = getSecretRefFromCommandSetting(this.command, name);
 				if (secretRef) {
@@ -260,6 +259,7 @@ export class UserScriptSettingsModal extends Modal {
 				this.onCommandChange?.();
 				new Notice("Secret cleared.");
 			});
+			button.buttonEl.setAttribute("aria-label", `Clear ${name}`);
 		});
 
 		return setting;

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -12,7 +12,7 @@
 		createToggleCommandChoice,
 		findChoiceById,
 		deleteChoiceWithConfirmation,
-		duplicateChoice,
+		duplicateChoiceWithUserScriptSecretSanitization,
 		addChoiceToTree,
 		moveChoice as moveChoiceService,
 		removeChoiceById,
@@ -238,8 +238,11 @@
 		save();
 	}
 
-	function handleDuplicateChoice(sourceChoice: IChoice) {
-		const newChoice = duplicateChoice(liveChoice(sourceChoice));
+	async function handleDuplicateChoice(sourceChoice: IChoice) {
+		const newChoice = await duplicateChoiceWithUserScriptSecretSanitization(
+			liveChoice(sourceChoice),
+			app,
+		);
 		choices = [...choices, newChoice];
 		save();
 	}

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 import type QuickAdd from "../main";
 import type IChoice from "../types/choices/IChoice";
 import type IMacroChoice from "../types/choices/IMacroChoice";
@@ -105,6 +105,7 @@ const {
 	configureChoice,
 	createToggleCommandChoice,
 	CommandRegistry,
+	duplicateChoiceWithUserScriptSecretSanitization,
 	moveChoice,
 	findChoiceById,
 } = await import("./choiceService");
@@ -126,6 +127,7 @@ describe("choiceService", () => {
 		mocks.multiModal.mockReset();
 		mocks.yesNoPrompt.mockReset();
 		mocks.storeChoices = [];
+		(Notice as unknown as { instances: unknown[] }).instances.length = 0;
 	});
 
 	describe("createChoice", () => {
@@ -234,7 +236,7 @@ describe("choiceService", () => {
 			expect(original.macro.commands[0].name).toBe("Cmd");
 		});
 
-		it("strips user-script SecretStorage refs when duplicating macros", () => {
+		it("strips user-script secrets when duplicating macros", async () => {
 			const original = createChoice("Macro", "Mac") as IMacroChoice;
 			original.macro.commands.push({
 				id: "cmd-1",
@@ -242,17 +244,44 @@ describe("choiceService", () => {
 				type: "UserScript",
 				path: "Scripts/script.js",
 				settings: {
-					"API Key": createUserScriptSecretRef("local-secret-ref"),
+					"API Key": "legacy-secret",
+					Token: createUserScriptSecretRef("local-secret-ref"),
 					Model: "gpt-4",
+					Enabled: true,
 				},
 			} as unknown as IMacroChoice["macro"]["commands"][number]);
+			const app = {
+				vault: {
+					adapter: {
+						exists: vi.fn().mockResolvedValue(true),
+						read: vi.fn().mockResolvedValue(`
+							module.exports = {
+								settings: {
+									options: {
+										"API Key": { "type": "secret" },
+										Token: { type: "text", secret: true },
+										Model: { type: "text" },
+									},
+								},
+							};
+						`),
+					},
+				},
+			} as unknown as App;
 
-			const copy = duplicateChoice(original) as IMacroChoice;
+			const copy = await duplicateChoiceWithUserScriptSecretSanitization(
+				original,
+				app,
+			) as IMacroChoice;
 			const copiedCommand = copy.macro.commands[0] as unknown as {
 				settings: Record<string, unknown>;
 			};
 
-			expect(copiedCommand.settings).toEqual({ Model: "gpt-4" });
+			expect(copiedCommand.settings).toEqual({
+				Model: "gpt-4",
+				Enabled: true,
+			});
+			expect(JSON.stringify(copy)).not.toContain("legacy-secret");
 			expect(JSON.stringify(copy)).not.toContain("local-secret-ref");
 			expect(JSON.stringify(copy)).not.toContain("__quickaddSecret");
 		});
@@ -400,6 +429,35 @@ describe("choiceService", () => {
 			await deleteChoiceWithConfirmation(macro, app);
 
 			expect(deleteSecret).toHaveBeenCalledWith("local-secret-ref");
+		});
+
+		it("keeps a Macro choice when clearing nested secrets fails", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const app = {
+				secretStorage: {
+					delete: vi.fn().mockRejectedValue(new Error("delete failed")),
+				},
+			} as unknown as App;
+			const macro = createChoice("Macro", "MyMacro") as IMacroChoice;
+			macro.macro.commands.push({
+				id: "cmd",
+				name: "Run script",
+				type: "UserScript",
+				path: "Scripts/script.js",
+				settings: {
+					"API Key": createUserScriptSecretRef("local-secret-ref"),
+				},
+			} as unknown as IMacroChoice["macro"]["commands"][number]);
+
+			const result = await deleteChoiceWithConfirmation(macro, app);
+
+			expect(result).toBe(false);
+			expect((Notice as unknown as { instances: { message: string }[] }).instances)
+				.toContainEqual({
+					message: "Could not clear user script secrets. Choice was not deleted.",
+					timeout: undefined,
+					messageEl: expect.any(HTMLElement),
+				});
 		});
 
 		it("does not include Multi/Macro warnings for a plain Template choice", async () => {

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -113,6 +113,7 @@ const { TemplateChoice } = await import("../types/choices/TemplateChoice");
 const { CaptureChoice } = await import("../types/choices/CaptureChoice");
 const { MacroChoice } = await import("../types/choices/MacroChoice");
 const { MultiChoice } = await import("../types/choices/MultiChoice");
+const { createUserScriptSecretRef } = await import("../utils/userScriptSecrets");
 
 // Minimal fakes — App/QuickAdd are only used as opaque references here.
 const fakeApp = { name: "fake-app" } as unknown as App;
@@ -231,6 +232,29 @@ describe("choiceService", () => {
 			// Mutating the copy does not affect the original.
 			copy.macro.commands[0].name = "Changed";
 			expect(original.macro.commands[0].name).toBe("Cmd");
+		});
+
+		it("strips user-script SecretStorage refs when duplicating macros", () => {
+			const original = createChoice("Macro", "Mac") as IMacroChoice;
+			original.macro.commands.push({
+				id: "cmd-1",
+				name: "Run script",
+				type: "UserScript",
+				path: "Scripts/script.js",
+				settings: {
+					"API Key": createUserScriptSecretRef("local-secret-ref"),
+					Model: "gpt-4",
+				},
+			} as unknown as IMacroChoice["macro"]["commands"][number]);
+
+			const copy = duplicateChoice(original) as IMacroChoice;
+			const copiedCommand = copy.macro.commands[0] as unknown as {
+				settings: Record<string, unknown>;
+			};
+
+			expect(copiedCommand.settings).toEqual({ Model: "gpt-4" });
+			expect(JSON.stringify(copy)).not.toContain("local-secret-ref");
+			expect(JSON.stringify(copy)).not.toContain("__quickaddSecret");
 		});
 
 		it("recursively duplicates nested Multi choices and preserves placeholder/collapsed", () => {
@@ -352,6 +376,30 @@ describe("choiceService", () => {
 			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
 			expect(message).toContain("MyMacro");
 			expect(message).toContain("macro commands");
+		});
+
+		it("clears nested user-script secrets when deleting a Macro choice", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const deleteSecret = vi.fn();
+			const app = {
+				secretStorage: {
+					delete: deleteSecret,
+				},
+			} as unknown as App;
+			const macro = createChoice("Macro", "MyMacro") as IMacroChoice;
+			macro.macro.commands.push({
+				id: "cmd",
+				name: "Run script",
+				type: "UserScript",
+				path: "Scripts/script.js",
+				settings: {
+					"API Key": createUserScriptSecretRef("local-secret-ref"),
+				},
+			} as unknown as IMacroChoice["macro"]["commands"][number]);
+
+			await deleteChoiceWithConfirmation(macro, app);
+
+			expect(deleteSecret).toHaveBeenCalledWith("local-secret-ref");
 		});
 
 		it("does not include Multi/Macro warnings for a plain Template choice", async () => {

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -242,7 +242,7 @@ describe("choiceService", () => {
 				id: "cmd-1",
 				name: "Run script",
 				type: "UserScript",
-				path: "Scripts/script.js",
+				path: "Scripts/script.md",
 				settings: {
 					"API Key": "legacy-secret",
 					Token: createUserScriptSecretRef("local-secret-ref"),
@@ -254,17 +254,23 @@ describe("choiceService", () => {
 				vault: {
 					adapter: {
 						exists: vi.fn().mockResolvedValue(true),
-						read: vi.fn().mockResolvedValue(`
-							module.exports = {
-								settings: {
-									options: {
-										"API Key": { "type": "secret" },
-										Token: { type: "text", secret: true },
-										Model: { type: "text" },
-									},
-								},
-							};
-						`),
+						read: vi.fn().mockResolvedValue(
+							[
+								"# Script note",
+								"",
+								"```js",
+								"module.exports = {",
+								"  settings: {",
+								"    options: {",
+								"      \"API Key\": { \"type\": \"secret\" },",
+								"      Token: { type: \"text\", secret: true },",
+								"      Model: { type: \"text\" },",
+								"    },",
+								"  },",
+								"};",
+								"```",
+							].join("\n"),
+						),
 					},
 				},
 			} as unknown as App;

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -152,6 +152,7 @@ async function buildSecretOptionNamesByPath(
 
 			const detection = detectUserScriptSecretOptions(
 				await app.vault.adapter.read(path),
+				path,
 			);
 			secretOptionNamesByPath.set(
 				path,

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -234,16 +234,7 @@ export async function deleteChoiceWithConfirmation(
 
 	if (!userConfirmed) return false;
 
-	if (isMacro) {
-		const cleared = await clearUserScriptSecretsFromCommand(app, {
-			type: "NestedChoice",
-			choice,
-		});
-		if (!cleared) {
-			new Notice("Could not clear user script secrets. Choice was not deleted.");
-			return false;
-		}
-	} else if (isMulti) {
+	if (isMacro || isMulti) {
 		const cleared = await clearUserScriptSecretsFromCommand(app, {
 			type: "NestedChoice",
 			choice,

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -1,4 +1,4 @@
-import type { App } from "obsidian";
+import { Notice, type App } from "obsidian";
 import type { ChoiceType } from "src/types/choices/choiceType";
 import { CaptureChoiceBuilder } from "../gui/ChoiceBuilder/captureChoiceBuilder";
 import { TemplateChoiceBuilder } from "../gui/ChoiceBuilder/templateChoiceBuilder";
@@ -21,8 +21,11 @@ import { excludeKeys } from "../utils/excludeKeys";
 import { deepClone } from "../utils/deepClone";
 import {
 	clearUserScriptSecretsFromCommand,
+	detectUserScriptSecretOptions,
 	stripUserScriptSecretRefsFromChoice,
 } from "../utils/userScriptSecrets";
+import type { UserScriptSecretSanitizerOptions } from "../utils/userScriptSecrets";
+import { log } from "../logger/logManager";
 
 const choiceConstructors: Record<ChoiceType, new (name: string) => IChoice> = {
 	Template: TemplateChoice,
@@ -40,7 +43,10 @@ export function createChoice(type: ChoiceType, name: string): IChoice {
 /**
  * Recursively duplicates a choice, ensuring unique ids and deep-cloning macros.
  */
-export function duplicateChoice(choice: IChoice): IChoice {
+export function duplicateChoice(
+	choice: IChoice,
+	secretSanitizerOptions?: UserScriptSecretSanitizerOptions,
+): IChoice {
 	const newChoice = createChoice(choice.type, `${choice.name} (copy)`);
 
 	if (choice.type === "Multi") {
@@ -50,7 +56,9 @@ export function duplicateChoice(choice: IChoice): IChoice {
 		// the other choice types). `choices` is excluded here and set via the
 		// recursive map below so children get fresh ids, not the source's.
 		Object.assign(newMulti, excludeKeys(sourceMulti, ["id", "name", "choices"]));
-		newMulti.choices = sourceMulti.choices.map(duplicateChoice);
+		newMulti.choices = sourceMulti.choices.map((child) =>
+			duplicateChoice(child, secretSanitizerOptions)
+		);
 		return newMulti;
 	}
 
@@ -60,10 +68,107 @@ export function duplicateChoice(choice: IChoice): IChoice {
 	if (choice.type === "Macro") {
 		(newChoice as IMacroChoice).macro = deepClone((choice as IMacroChoice).macro);
 		regenerateIds((newChoice as IMacroChoice).macro);
-		stripUserScriptSecretRefsFromChoice(newChoice);
+		stripUserScriptSecretRefsFromChoice(newChoice, secretSanitizerOptions);
 	}
 
 	return newChoice;
+}
+
+export async function duplicateChoiceWithUserScriptSecretSanitization(
+	choice: IChoice,
+	app: App,
+): Promise<IChoice> {
+	const secretOptionNamesByPath = await buildSecretOptionNamesByPath(app, choice);
+
+	return duplicateChoice(choice, {
+		secretOptionNamesByPath,
+		stripUnknownStringSettings: true,
+	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function collectUserScriptPathsFromCommand(
+	command: unknown,
+	paths: Set<string>,
+): void {
+	if (!isRecord(command)) return;
+
+	if (command.type === "UserScript" && typeof command.path === "string") {
+		paths.add(command.path);
+	}
+
+	if (Array.isArray(command.thenCommands)) {
+		for (const child of command.thenCommands) {
+			collectUserScriptPathsFromCommand(child, paths);
+		}
+	}
+
+	if (Array.isArray(command.elseCommands)) {
+		for (const child of command.elseCommands) {
+			collectUserScriptPathsFromCommand(child, paths);
+		}
+	}
+
+	collectUserScriptPathsFromChoice(command.choice, paths);
+}
+
+function collectUserScriptPathsFromChoice(
+	choice: unknown,
+	paths: Set<string>,
+): void {
+	if (!isRecord(choice)) return;
+
+	if (choice.type === "Macro" && isRecord(choice.macro)) {
+		const commands = choice.macro.commands;
+		if (Array.isArray(commands)) {
+			for (const command of commands) {
+				collectUserScriptPathsFromCommand(command, paths);
+			}
+		}
+	}
+
+	if (choice.type === "Multi" && Array.isArray(choice.choices)) {
+		for (const child of choice.choices) {
+			collectUserScriptPathsFromChoice(child, paths);
+		}
+	}
+}
+
+async function buildSecretOptionNamesByPath(
+	app: App,
+	choice: IChoice,
+): Promise<Map<string, ReadonlySet<string> | null>> {
+	const paths = new Set<string>();
+	collectUserScriptPathsFromChoice(choice, paths);
+	const secretOptionNamesByPath = new Map<string, ReadonlySet<string> | null>();
+
+	for (const path of paths) {
+		try {
+			const exists = await app.vault.adapter.exists(path);
+			if (!exists) continue;
+
+			const detection = detectUserScriptSecretOptions(
+				await app.vault.adapter.read(path),
+			);
+			secretOptionNamesByPath.set(
+				path,
+				detection.foundSecretOptions && detection.names.size === 0
+					? null
+					: detection.names,
+			);
+		} catch (error) {
+			log.logWarning(
+				`QuickAdd could not inspect user-script settings '${path}' while duplicating choice: ${
+					(error as Error)?.message ?? error
+				}`,
+			);
+		}
+	}
+
+	return secretOptionNamesByPath;
 }
 
 /**
@@ -129,15 +234,23 @@ export async function deleteChoiceWithConfirmation(
 	if (!userConfirmed) return false;
 
 	if (isMacro) {
-		await clearUserScriptSecretsFromCommand(app, {
+		const cleared = await clearUserScriptSecretsFromCommand(app, {
 			type: "NestedChoice",
 			choice,
 		});
+		if (!cleared) {
+			new Notice("Could not clear user script secrets. Choice was not deleted.");
+			return false;
+		}
 	} else if (isMulti) {
-		await clearUserScriptSecretsFromCommand(app, {
+		const cleared = await clearUserScriptSecretsFromCommand(app, {
 			type: "NestedChoice",
 			choice,
 		});
+		if (!cleared) {
+			new Notice("Could not clear user script secrets. Choice was not deleted.");
+			return false;
+		}
 	}
 
 	return true;

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -19,6 +19,10 @@ import { TemplateChoice } from "../types/choices/TemplateChoice";
 import { regenerateIds } from "../utils/macroUtils";
 import { excludeKeys } from "../utils/excludeKeys";
 import { deepClone } from "../utils/deepClone";
+import {
+	clearUserScriptSecretsFromCommand,
+	stripUserScriptSecretRefsFromChoice,
+} from "../utils/userScriptSecrets";
 
 const choiceConstructors: Record<ChoiceType, new (name: string) => IChoice> = {
 	Template: TemplateChoice,
@@ -56,6 +60,7 @@ export function duplicateChoice(choice: IChoice): IChoice {
 	if (choice.type === "Macro") {
 		(newChoice as IMacroChoice).macro = deepClone((choice as IMacroChoice).macro);
 		regenerateIds((newChoice as IMacroChoice).macro);
+		stripUserScriptSecretRefsFromChoice(newChoice);
 	}
 
 	return newChoice;
@@ -121,7 +126,21 @@ export async function deleteChoiceWithConfirmation(
             `,
 	);
 
-	return userConfirmed;
+	if (!userConfirmed) return false;
+
+	if (isMacro) {
+		await clearUserScriptSecretsFromCommand(app, {
+			type: "NestedChoice",
+			choice,
+		});
+	} else if (isMulti) {
+		await clearUserScriptSecretsFromCommand(app, {
+			type: "NestedChoice",
+			choice,
+		});
+	}
+
+	return true;
 }
 
 /**

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -443,7 +443,7 @@ describe("buildPackage", () => {
 				id: "cmd-us",
 				name: "Run script",
 				type: CommandType.UserScript,
-				path: "Scripts/userScript.js",
+				path: "Scripts/userScript.md",
 				settings: {
 					"API Key": "legacy-secret",
 					Token: createUserScriptSecretRef("local-secret-ref"),
@@ -453,18 +453,22 @@ describe("buildPackage", () => {
 		]);
 		const { app } = makeFakeApp({
 			files: {
-				"Scripts/userScript.js": `
-					module.exports = {
-						settings: {
-							options: {
-								"API Key": { "type": "secret" },
-								Token: { type: "text", secret: true },
-								Model: { type: "text" },
-							},
-						},
-						entry: () => {},
-					};
-				`,
+				"Scripts/userScript.md": [
+					"# Script note",
+					"",
+					"```js",
+					"module.exports = {",
+					"  settings: {",
+					"    options: {",
+					"      \"API Key\": { \"type\": \"secret\" },",
+					"      Token: { type: \"text\", secret: true },",
+					"      Model: { type: \"text\" },",
+					"    },",
+					"  },",
+					"  entry: () => {},",
+					"};",
+					"```",
+				].join("\n"),
 			},
 		});
 

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -437,7 +437,7 @@ describe("buildPackage", () => {
 		expect(result.missingAssets).toEqual([]);
 	});
 
-	it("strips user-script SecretStorage refs from exported package choices", async () => {
+	it("strips user-script secrets from exported package choices", async () => {
 		const macro = makeMacroChoice("macro1", "Macro", [
 			{
 				id: "cmd-us",
@@ -445,14 +445,26 @@ describe("buildPackage", () => {
 				type: CommandType.UserScript,
 				path: "Scripts/userScript.js",
 				settings: {
-					"API Key": createUserScriptSecretRef("local-secret-ref"),
+					"API Key": "legacy-secret",
+					Token: createUserScriptSecretRef("local-secret-ref"),
 					Model: "gpt-4",
 				},
 			} as never,
 		]);
 		const { app } = makeFakeApp({
 			files: {
-				"Scripts/userScript.js": "module.exports = () => {};",
+				"Scripts/userScript.js": `
+					module.exports = {
+						settings: {
+							options: {
+								"API Key": { "type": "secret" },
+								Token: { type: "text", secret: true },
+								Model: { type: "text" },
+							},
+						},
+						entry: () => {},
+					};
+				`,
 			},
 		});
 
@@ -466,6 +478,7 @@ describe("buildPackage", () => {
 		};
 
 		expect(exportedCommand.settings).toEqual({ Model: "gpt-4" });
+		expect(JSON.stringify(result.pkg)).not.toContain("legacy-secret");
 		expect(JSON.stringify(result.pkg)).not.toContain("local-secret-ref");
 		expect(JSON.stringify(result.pkg)).not.toContain("__quickaddSecret");
 	});

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -14,6 +14,7 @@ import type IMultiChoice from "../types/choices/IMultiChoice";
 import type IMacroChoice from "../types/choices/IMacroChoice";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import { createUserScriptSecretRef } from "../utils/userScriptSecrets";
 
 // --- Choice factory helpers (minimal but type-shaped) -----------------------
 
@@ -434,6 +435,39 @@ describe("buildPackage", () => {
 		expect(byPath.get("Scripts/userScript.js")).toBe("user-script");
 		expect(byPath.get("Scripts/condition.js")).toBe("conditional-script");
 		expect(result.missingAssets).toEqual([]);
+	});
+
+	it("strips user-script SecretStorage refs from exported package choices", async () => {
+		const macro = makeMacroChoice("macro1", "Macro", [
+			{
+				id: "cmd-us",
+				name: "Run script",
+				type: CommandType.UserScript,
+				path: "Scripts/userScript.js",
+				settings: {
+					"API Key": createUserScriptSecretRef("local-secret-ref"),
+					Model: "gpt-4",
+				},
+			} as never,
+		]);
+		const { app } = makeFakeApp({
+			files: {
+				"Scripts/userScript.js": "module.exports = () => {};",
+			},
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [macro], rootChoiceIds: ["macro1"] }),
+		);
+		const exported = result.pkg.choices[0].choice as IMacroChoice;
+		const exportedCommand = exported.macro.commands[0] as unknown as {
+			settings: Record<string, unknown>;
+		};
+
+		expect(exportedCommand.settings).toEqual({ Model: "gpt-4" });
+		expect(JSON.stringify(result.pkg)).not.toContain("local-secret-ref");
+		expect(JSON.stringify(result.pkg)).not.toContain("__quickaddSecret");
 	});
 
 	it("collects capture-template assets from a Capture choice", async () => {

--- a/src/services/packageExportService.ts
+++ b/src/services/packageExportService.ts
@@ -3,10 +3,10 @@ import { normalizePath } from "obsidian";
 import type IChoice from "../types/choices/IChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
 import type {
- QuickAddPackage,
- QuickAddPackageAsset,
- QuickAddPackageChoice,
- QuickAddPackageAssetKind,
+	QuickAddPackage,
+	QuickAddPackageAsset,
+	QuickAddPackageChoice,
+	QuickAddPackageAssetKind,
 } from "../types/packages/QuickAddPackage";
 import { QUICKADD_PACKAGE_SCHEMA_VERSION } from "../types/packages/QuickAddPackage";
 import {
@@ -15,10 +15,13 @@ import {
 	collectFileDependencies,
 } from "../utils/packageTraversal";
 import { log } from "../logger/logManager";
-import { encodeToBase64 } from "../utils/base64";
+import { decodeFromBase64, encodeToBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
 import { ensureParentFolders } from "../utils/ensureParentFolders";
-import { stripUserScriptSecretRefsFromChoice } from "../utils/userScriptSecrets";
+import {
+	detectUserScriptSecretOptions,
+	stripUserScriptSecretRefsFromChoice,
+} from "../utils/userScriptSecrets";
 
 export interface BuildPackageOptions {
 	choices: IChoice[];
@@ -62,6 +65,9 @@ export async function buildPackage(
 	const assetDescriptors = collectAssetDescriptors(scripts, files);
 
 	const assets = await encodeAssets(app, assetDescriptors);
+	const secretOptionNamesByPath = buildSecretOptionNamesByPath(
+		assets.encodedAssets,
+	);
 
 	const packageChoices: QuickAddPackageChoice[] = closure.choiceIds.map(
 			(choiceId) => {
@@ -69,7 +75,10 @@ export async function buildPackage(
 				if (!entry) throw new Error(`Choice '${choiceId}' missing from catalog.`);
 				const clonedChoice = deepClone(entry.choice);
 				pruneChoiceTree(clonedChoice, includedChoiceIds);
-				stripUserScriptSecretRefsFromChoice(clonedChoice);
+				stripUserScriptSecretRefsFromChoice(clonedChoice, {
+					secretOptionNamesByPath,
+					stripUnknownStringSettings: true,
+				});
 				return {
 					choice: clonedChoice,
 					pathHint: [...entry.path],
@@ -143,37 +152,67 @@ async function encodeAssets(
 	app: App,
 	descriptors: AssetDescriptor[],
 ): Promise<EncodedAssets> {
-   const encodedAssets: QuickAddPackageAsset[] = [];
-   const missingAssets: MissingAsset[] = [];
+	const encodedAssets: QuickAddPackageAsset[] = [];
+	const missingAssets: MissingAsset[] = [];
 
-   for (const { path, kind } of descriptors) {
-      try {
-        const exists = await app.vault.adapter.exists(path);
-        if (!exists) {
-          missingAssets.push({ path, kind });
-          log.logWarning(`QuickAdd export skipped missing ${kind}: ${path}`);
-          continue;
-        }
+	for (const { path, kind } of descriptors) {
+		try {
+			const exists = await app.vault.adapter.exists(path);
+			if (!exists) {
+				missingAssets.push({ path, kind });
+				log.logWarning(`QuickAdd export skipped missing ${kind}: ${path}`);
+				continue;
+			}
 
-        const content = await app.vault.adapter.read(path);
+			const content = await app.vault.adapter.read(path);
 
-        encodedAssets.push({
-          kind,
-          originalPath: path,
-          contentEncoding: "base64",
-          content: encodeToBase64(content),
-        });
-      } catch (error) {
-        missingAssets.push({ path, kind });
-        log.logWarning(
-          `QuickAdd export failed to read ${kind} '${path}': ${
-            (error as Error)?.message ?? error
-          }`,
-        );
-      }
-    }
+			encodedAssets.push({
+				kind,
+				originalPath: path,
+				contentEncoding: "base64",
+				content: encodeToBase64(content),
+			});
+		} catch (error) {
+			missingAssets.push({ path, kind });
+			log.logWarning(
+				`QuickAdd export failed to read ${kind} '${path}': ${
+					(error as Error)?.message ?? error
+				}`,
+			);
+		}
+	}
 
 	return { encodedAssets, missingAssets };
+}
+
+function buildSecretOptionNamesByPath(
+	assets: QuickAddPackageAsset[],
+): Map<string, ReadonlySet<string> | null> {
+	const secretOptionNamesByPath = new Map<string, ReadonlySet<string> | null>();
+
+	for (const asset of assets) {
+		if (asset.kind !== "user-script") continue;
+
+		try {
+			const detection = detectUserScriptSecretOptions(
+				decodeFromBase64(asset.content),
+			);
+			secretOptionNamesByPath.set(
+				asset.originalPath,
+				detection.foundSecretOptions && detection.names.size === 0
+					? null
+					: detection.names,
+			);
+		} catch (error) {
+			log.logWarning(
+				`QuickAdd export could not inspect user-script settings '${asset.originalPath}': ${
+					(error as Error)?.message ?? error
+				}`,
+			);
+		}
+	}
+
+	return secretOptionNamesByPath;
 }
 
 function pruneChoiceTree(

--- a/src/services/packageExportService.ts
+++ b/src/services/packageExportService.ts
@@ -196,6 +196,7 @@ function buildSecretOptionNamesByPath(
 		try {
 			const detection = detectUserScriptSecretOptions(
 				decodeFromBase64(asset.content),
+				asset.originalPath,
 			);
 			secretOptionNamesByPath.set(
 				asset.originalPath,

--- a/src/services/packageExportService.ts
+++ b/src/services/packageExportService.ts
@@ -18,6 +18,7 @@ import { log } from "../logger/logManager";
 import { encodeToBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
 import { ensureParentFolders } from "../utils/ensureParentFolders";
+import { stripUserScriptSecretRefsFromChoice } from "../utils/userScriptSecrets";
 
 export interface BuildPackageOptions {
 	choices: IChoice[];
@@ -68,6 +69,7 @@ export async function buildPackage(
 				if (!entry) throw new Error(`Choice '${choiceId}' missing from catalog.`);
 				const clonedChoice = deepClone(entry.choice);
 				pruneChoiceTree(clonedChoice, includedChoiceIds);
+				stripUserScriptSecretRefsFromChoice(clonedChoice);
 				return {
 					choice: clonedChoice,
 					pathHint: [...entry.path],

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -34,6 +34,7 @@ import type {
 	ChoiceImportDecision,
 	AssetImportDecision,
 } from "./packageImportService";
+const { createUserScriptSecretRef } = await import("../utils/userScriptSecrets");
 
 // --- Fake app / vault -------------------------------------------------------
 
@@ -568,6 +569,48 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 		expect(result.addedChoiceIds).toEqual(["uuid-1"]);
 		expect(result.updatedChoices[0].id).toBe("uuid-1");
 		expect(result.updatedChoices[0].name).toBe("Orig");
+	});
+
+	it("strips user-script SecretStorage refs from imported package choices", async () => {
+		const { app } = createFakeApp();
+		const macro = {
+			...makeChoice("macro", "Macro", "Macro"),
+			macro: {
+				id: "macro-id",
+				name: "M",
+				commands: [
+					{
+						id: "cmd",
+						name: "Run script",
+						type: CommandType.UserScript,
+						path: "Scripts/script.js",
+						settings: {
+							"API Key": createUserScriptSecretRef("local-secret-ref"),
+							Model: "gpt-4",
+						},
+					} as IUserScript,
+				],
+			},
+			runOnStartup: false,
+		} as IMacroChoice;
+		const pkg = makePackage({
+			choices: [makePackageChoice(macro)],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: decisions([["macro", "import"]]),
+			assetDecisions: [],
+		});
+
+		const inserted = result.updatedChoices[0] as IMacroChoice;
+		const command = inserted.macro.commands[0] as IUserScript;
+
+		expect(command.settings).toEqual({ Model: "gpt-4" });
+		expect(JSON.stringify(inserted)).not.toContain("local-secret-ref");
+		expect(JSON.stringify(inserted)).not.toContain("__quickaddSecret");
 	});
 
 	it("propagates duplication to descendants and regenerates macro/command ids", async () => {

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -571,7 +571,7 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 		expect(result.updatedChoices[0].name).toBe("Orig");
 	});
 
-	it("strips user-script SecretStorage refs from imported package choices", async () => {
+	it("strips user-script secrets from imported package choices", async () => {
 		const { app } = createFakeApp();
 		const macro = {
 			...makeChoice("macro", "Macro", "Macro"),
@@ -585,7 +585,8 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 						type: CommandType.UserScript,
 						path: "Scripts/script.js",
 						settings: {
-							"API Key": createUserScriptSecretRef("local-secret-ref"),
+							"API Key": "legacy-secret",
+							Token: createUserScriptSecretRef("local-secret-ref"),
 							Model: "gpt-4",
 						},
 					} as IUserScript,
@@ -595,6 +596,25 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 		} as IMacroChoice;
 		const pkg = makePackage({
 			choices: [makePackageChoice(macro)],
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "Scripts/script.js",
+					contentEncoding: "base64",
+					content: encodeToBase64(`
+						module.exports = {
+							settings: {
+								options: {
+									"API Key": { "type": "secret" },
+									Token: { type: "text", secret: true },
+									Model: { type: "text" },
+								},
+							},
+							entry: () => {},
+						};
+					`),
+				},
+			],
 		});
 
 		const result = await applyPackageImport({
@@ -609,6 +629,7 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 		const command = inserted.macro.commands[0] as IUserScript;
 
 		expect(command.settings).toEqual({ Model: "gpt-4" });
+		expect(JSON.stringify(inserted)).not.toContain("legacy-secret");
 		expect(JSON.stringify(inserted)).not.toContain("local-secret-ref");
 		expect(JSON.stringify(inserted)).not.toContain("__quickaddSecret");
 	});

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -583,7 +583,7 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 						id: "cmd",
 						name: "Run script",
 						type: CommandType.UserScript,
-						path: "Scripts/script.js",
+						path: "Scripts/script.md",
 						settings: {
 							"API Key": "legacy-secret",
 							Token: createUserScriptSecretRef("local-secret-ref"),
@@ -599,20 +599,26 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 			assets: [
 				{
 					kind: "user-script",
-					originalPath: "Scripts/script.js",
+					originalPath: "Scripts/script.md",
 					contentEncoding: "base64",
-					content: encodeToBase64(`
-						module.exports = {
-							settings: {
-								options: {
-									"API Key": { "type": "secret" },
-									Token: { type: "text", secret: true },
-									Model: { type: "text" },
-								},
-							},
-							entry: () => {},
-						};
-					`),
+					content: encodeToBase64(
+						[
+							"# Script note",
+							"",
+							"```js",
+							"module.exports = {",
+							"  settings: {",
+							"    options: {",
+							"      \"API Key\": { \"type\": \"secret\" },",
+							"      Token: { type: \"text\", secret: true },",
+							"      Model: { type: \"text\" },",
+							"    },",
+							"  },",
+							"  entry: () => {},",
+							"};",
+							"```",
+						].join("\n"),
+					),
 				},
 			],
 		});

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -22,6 +22,7 @@ import { log } from "../logger/logManager";
 import { decodeFromBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
 import { ensureParentFolders } from "../utils/ensureParentFolders";
+import { stripUserScriptSecretRefsFromCommand } from "../utils/userScriptSecrets";
 import {
 	buildPackagePreview,
 	collectReferencedAssetPaths,
@@ -543,6 +544,7 @@ function remapCommands(
 ): void {
 	for (const command of commands) {
 		if (!command) continue;
+		stripUserScriptSecretRefsFromCommand(command);
 
 		if (shouldRegenerateIds) {
 			command.id = uuidv4();

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -522,6 +522,7 @@ function buildSecretOptionNamesByPath(
 		try {
 			const detection = detectUserScriptSecretOptions(
 				decodeFromBase64(asset.content),
+				asset.originalPath,
 			);
 			secretOptionNamesByPath.set(
 				asset.originalPath,

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -22,7 +22,11 @@ import { log } from "../logger/logManager";
 import { decodeFromBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
 import { ensureParentFolders } from "../utils/ensureParentFolders";
-import { stripUserScriptSecretRefsFromCommand } from "../utils/userScriptSecrets";
+import {
+	detectUserScriptSecretOptions,
+	stripUserScriptSecretRefsFromCommand,
+} from "../utils/userScriptSecrets";
+import type { UserScriptSecretSanitizerOptions } from "../utils/userScriptSecrets";
 import {
 	buildPackagePreview,
 	collectReferencedAssetPaths,
@@ -253,6 +257,7 @@ export async function applyPackageImport(
 	);
 
 	const catalog = new Map(pkg.choices.map((entry) => [entry.choice.id, entry]));
+	const secretOptionNamesByPath = buildSecretOptionNamesByPath(pkg);
 	const importableChoiceIds = new Set<string>();
 	const importableCache = new Map<string, boolean>();
 	const importableVisiting = new Set<string>();
@@ -376,7 +381,15 @@ export async function applyPackageImport(
 		}
 
 			const clone = deepClone(entry.choice);
-			const remapped = remapChoiceTree(clone, idMap, importableChoiceIds);
+			const remapped = remapChoiceTree(
+				clone,
+				idMap,
+				importableChoiceIds,
+				{
+					secretOptionNamesByPath,
+					stripUnknownStringSettings: true,
+				},
+			);
 			preparedChoices.set(entry.choice.id, remapped);
 		}
 
@@ -498,6 +511,36 @@ export async function applyPackageImport(
 	};
 }
 
+function buildSecretOptionNamesByPath(
+	pkg: QuickAddPackage,
+): Map<string, ReadonlySet<string> | null> {
+	const secretOptionNamesByPath = new Map<string, ReadonlySet<string> | null>();
+
+	for (const asset of pkg.assets) {
+		if (asset.kind !== "user-script") continue;
+
+		try {
+			const detection = detectUserScriptSecretOptions(
+				decodeFromBase64(asset.content),
+			);
+			secretOptionNamesByPath.set(
+				asset.originalPath,
+				detection.foundSecretOptions && detection.names.size === 0
+					? null
+					: detection.names,
+			);
+		} catch (error) {
+			log.logWarning(
+				`QuickAdd import could not inspect user-script settings '${asset.originalPath}': ${
+					(error as Error)?.message ?? error
+				}`,
+			);
+		}
+	}
+
+	return secretOptionNamesByPath;
+}
+
 async function assetExists(app: App, path: string): Promise<boolean> {
 	try {
 		return await app.vault.adapter.exists(path);
@@ -510,6 +553,7 @@ function remapChoiceTree(
 	choice: IChoice,
 	idMap: Map<string, string>,
 	importableChoiceIds: Set<string>,
+	secretSanitizerOptions: UserScriptSecretSanitizerOptions,
 ): IChoice {
 	const originalId = choice.id;
 	const finalId = idMap.get(originalId) ?? originalId;
@@ -521,7 +565,13 @@ function remapChoiceTree(
 		if (isDuplicated) {
 			macroChoice.macro.id = uuidv4();
 		}
-		remapCommands(macroChoice.macro.commands, idMap, importableChoiceIds, isDuplicated);
+		remapCommands(
+			macroChoice.macro.commands,
+			idMap,
+			importableChoiceIds,
+			isDuplicated,
+			secretSanitizerOptions,
+		);
 	}
 
 	if (choice.type === "Multi") {
@@ -529,7 +579,14 @@ function remapChoiceTree(
 		if (Array.isArray(multi.choices)) {
 			multi.choices = multi.choices
 				.filter((child) => importableChoiceIds.has(child.id))
-				.map((child) => remapChoiceTree(child, idMap, importableChoiceIds));
+				.map((child) =>
+					remapChoiceTree(
+						child,
+						idMap,
+						importableChoiceIds,
+						secretSanitizerOptions,
+					),
+				);
 		}
 	}
 
@@ -541,10 +598,11 @@ function remapCommands(
 	idMap: Map<string, string>,
 	importableChoiceIds: Set<string>,
 	shouldRegenerateIds: boolean,
+	secretSanitizerOptions: UserScriptSecretSanitizerOptions,
 ): void {
 	for (const command of commands) {
 		if (!command) continue;
-		stripUserScriptSecretRefsFromCommand(command);
+		stripUserScriptSecretRefsFromCommand(command, secretSanitizerOptions);
 
 		if (shouldRegenerateIds) {
 			command.id = uuidv4();
@@ -564,12 +622,14 @@ function remapCommands(
 					idMap,
 					importableChoiceIds,
 					shouldRegenerateIds,
+					secretSanitizerOptions,
 				);
 				remapCommands(
 					conditional.elseCommands,
 					idMap,
 					importableChoiceIds,
 					shouldRegenerateIds,
+					secretSanitizerOptions,
 				);
 				break;
 			}
@@ -580,6 +640,7 @@ function remapCommands(
 					nested.choice,
 					idMap,
 					importableChoiceIds,
+					secretSanitizerOptions,
 				);
 			}
 			break;

--- a/src/utils/userScriptSecrets.test.ts
+++ b/src/utils/userScriptSecrets.test.ts
@@ -17,6 +17,7 @@ vi.mock("../logger/logManager", () => ({
 const {
 	buildUserScriptSecretId,
 	clearUserScriptSecret,
+	clearUserScriptSecretsFromCommand,
 	createUserScriptSecretRef,
 	isSecretUserScriptOption,
 	isUserScriptSecretRef,
@@ -152,6 +153,18 @@ describe("userScriptSecrets", () => {
 		expect(command.settings["API Key"]).toBe("legacy-secret");
 	});
 
+	it("preserves absence for unset secret settings at runtime", async () => {
+		const command = createCommand();
+
+		const resolved = await resolveUserScriptSettings(undefined, command, {
+			options: {
+				"API Key": { type: "secret" },
+			},
+		});
+
+		expect("API Key" in resolved).toBe(false);
+	});
+
 	it("throws a clear error when a marker cannot resolve on this device", async () => {
 		const command = createCommand({
 			"API Key": createUserScriptSecretRef(
@@ -271,5 +284,38 @@ describe("userScriptSecrets", () => {
 
 		expect(changed).toBe(false);
 		expect(setSecret).not.toHaveBeenCalled();
+	});
+
+	it("clears secret refs recursively from deleted command trees", async () => {
+		const deleteSecret = vi.fn().mockResolvedValue(undefined);
+		const app = createApp({ delete: deleteSecret });
+		const commandTree = {
+			type: "Conditional",
+			thenCommands: [
+				createCommand({
+					"API Key": createUserScriptSecretRef("then-secret"),
+				}),
+			],
+			elseCommands: [
+				{
+					type: "NestedChoice",
+					choice: {
+						type: "Macro",
+						macro: {
+							commands: [
+								createCommand({
+									"API Key": createUserScriptSecretRef("nested-secret"),
+								}),
+							],
+						},
+					},
+				},
+			],
+		};
+
+		await clearUserScriptSecretsFromCommand(app, commandTree);
+
+		expect(deleteSecret).toHaveBeenCalledWith("then-secret");
+		expect(deleteSecret).toHaveBeenCalledWith("nested-secret");
 	});
 });

--- a/src/utils/userScriptSecrets.test.ts
+++ b/src/utils/userScriptSecrets.test.ts
@@ -20,6 +20,7 @@ const {
 	createUserScriptSecretRef,
 	isSecretUserScriptOption,
 	isUserScriptSecretRef,
+	migrateUserScriptSecretSettings,
 	resolveUserScriptSettings,
 	storeUserScriptSecret,
 } = await import("./userScriptSecrets");
@@ -179,5 +180,96 @@ describe("userScriptSecrets", () => {
 
 		await expect(clearUserScriptSecret(app, "secret-ref")).resolves.toBe(true);
 		expect(setSecret).toHaveBeenCalledWith("secret-ref", "");
+	});
+
+	it("migrates legacy plaintext secret settings into SecretStorage", async () => {
+		const command = createCommand({
+			"API Key": "legacy-secret",
+			Model: "gpt-4",
+		});
+		const setSecret = vi.fn().mockResolvedValue(undefined);
+		const app = createApp({
+			getSecret: vi.fn().mockResolvedValue(null),
+			setSecret,
+		});
+
+		const changed = await migrateUserScriptSecretSettings(app, command, {
+			options: {
+				"API Key": { type: "secret" },
+				Model: { type: "text" },
+			},
+		});
+
+		expect(changed).toBe(true);
+		expect(setSecret).toHaveBeenCalledWith(
+			"quickadd-user-script-command-1-api-key",
+			"legacy-secret",
+		);
+		expect(command.settings["API Key"]).toEqual(
+			createUserScriptSecretRef("quickadd-user-script-command-1-api-key"),
+		);
+		expect(JSON.stringify(command.settings)).not.toContain("legacy-secret");
+	});
+
+	it("does not migrate or clear legacy plaintext when SecretStorage is unavailable", async () => {
+		const command = createCommand({
+			"API Key": "legacy-secret",
+		});
+
+		const changed = await migrateUserScriptSecretSettings(undefined, command, {
+			options: {
+				"API Key": { type: "secret" },
+			},
+		});
+
+		expect(changed).toBe(false);
+		expect(command.settings["API Key"]).toBe("legacy-secret");
+		expect(logWarningMock).toHaveBeenCalledWith(
+			expect.stringContaining("SecretStorage unavailable"),
+		);
+	});
+
+	it("leaves plaintext untouched when SecretStorage write fails", async () => {
+		const command = createCommand({
+			"API Key": "legacy-secret",
+		});
+		const app = createApp({
+			getSecret: vi.fn().mockResolvedValue(null),
+			setSecret: vi.fn().mockRejectedValue(new Error("write failed")),
+		});
+
+		const changed = await migrateUserScriptSecretSettings(app, command, {
+			options: {
+				"API Key": { type: "secret" },
+			},
+		});
+
+		expect(changed).toBe(false);
+		expect(command.settings["API Key"]).toBe("legacy-secret");
+		expect(logWarningMock).toHaveBeenCalledWith(
+			expect.stringContaining("Failed to write user script SecretStorage entry"),
+		);
+	});
+
+	it("is a no-op for already migrated secret settings", async () => {
+		const command = createCommand({
+			"API Key": createUserScriptSecretRef(
+				"quickadd-user-script-command-1-api-key",
+			),
+		});
+		const setSecret = vi.fn();
+		const app = createApp({
+			getSecret: vi.fn().mockResolvedValue("existing-secret"),
+			setSecret,
+		});
+
+		const changed = await migrateUserScriptSecretSettings(app, command, {
+			options: {
+				"API Key": { type: "secret" },
+			},
+		});
+
+		expect(changed).toBe(false);
+		expect(setSecret).not.toHaveBeenCalled();
 	});
 });

--- a/src/utils/userScriptSecrets.test.ts
+++ b/src/utils/userScriptSecrets.test.ts
@@ -83,6 +83,29 @@ describe("userScriptSecrets", () => {
 		expect([...detection.names].sort()).toEqual(["API Key", "Token"]);
 	});
 
+	it("detects secret option names inside markdown note script fences", () => {
+		const detection = detectUserScriptSecretOptions(
+			[
+				"# Script note",
+				"",
+				"```js",
+				"module.exports = {",
+				"  settings: {",
+				"    options: {",
+				"      \"API Key\": { \"type\": \"secret\" },",
+				"      Model: { type: \"text\" },",
+				"    },",
+				"  },",
+				"};",
+				"```",
+			].join("\n"),
+			"Scripts/script.md",
+		);
+
+		expect(detection.foundSecretOptions).toBe(true);
+		expect([...detection.names]).toEqual(["API Key"]);
+	});
+
 	it("ignores options-looking text inside comments and string literals", () => {
 		const detection = detectUserScriptSecretOptions(`
 			const help = "options: { Model: { type: \\"secret\\" } }";
@@ -106,6 +129,22 @@ describe("userScriptSecrets", () => {
 				settings: {
 					options: {
 						[process.env.SECRET_NAME]: { type: "secret" },
+					},
+				},
+			};
+		`);
+
+		expect(detection.foundSecretOptions).toBe(true);
+		expect(detection.names.size).toBe(0);
+	});
+
+	it("treats computed expressions as unknown secret option names", () => {
+		const detection = detectUserScriptSecretOptions(`
+			const PREFIX = "API";
+			module.exports = {
+				settings: {
+					options: {
+						[PREFIX + " Key"]: { type: "secret" },
 					},
 				},
 			};

--- a/src/utils/userScriptSecrets.test.ts
+++ b/src/utils/userScriptSecrets.test.ts
@@ -19,11 +19,13 @@ const {
 	clearUserScriptSecret,
 	clearUserScriptSecretsFromCommand,
 	createUserScriptSecretRef,
+	detectUserScriptSecretOptions,
 	isSecretUserScriptOption,
 	isUserScriptSecretRef,
 	migrateUserScriptSecretSettings,
 	resolveUserScriptSettings,
 	storeUserScriptSecret,
+	stripUserScriptSecretRefsFromCommand,
 } = await import("./userScriptSecrets");
 
 function createCommand(settings: Record<string, unknown> = {}): IUserScript {
@@ -61,6 +63,56 @@ describe("userScriptSecrets", () => {
 			isSecretUserScriptOption({ type: "textarea", secret: true }),
 		).toBe(false);
 		expect(isSecretUserScriptOption({ type: "text" })).toBe(false);
+	});
+
+	it("detects secret option names from user-script source", () => {
+		const detection = detectUserScriptSecretOptions(`
+			const TOKEN = "Token";
+			module.exports = {
+				settings: {
+					options: {
+						"API Key": { "type": "secret" },
+						[TOKEN]: { "type": "text", "secret": true },
+						Model: { type: "text" },
+					},
+				},
+			};
+		`);
+
+		expect(detection.foundSecretOptions).toBe(true);
+		expect([...detection.names].sort()).toEqual(["API Key", "Token"]);
+	});
+
+	it("ignores options-looking text inside comments and string literals", () => {
+		const detection = detectUserScriptSecretOptions(`
+			const help = "options: { Model: { type: \\"secret\\" } }";
+			// options: { Token: { type: "secret" } }
+			module.exports = {
+				settings: {
+					options: {
+						Model: { type: "text" },
+					},
+				},
+			};
+		`);
+
+		expect(detection.foundSecretOptions).toBe(false);
+		expect(detection.names.size).toBe(0);
+	});
+
+	it("tracks dynamic secret options even when the setting name is not static", () => {
+		const detection = detectUserScriptSecretOptions(`
+			module.exports = {
+				settings: {
+					options: {
+						[process.env.SECRET_NAME]: { type: "secret" },
+					},
+				},
+			};
+		`);
+
+		expect(detection.foundSecretOptions).toBe(true);
+		expect(detection.names.size).toBe(0);
 	});
 
 	it("does not initialize secret default values into command settings", () => {
@@ -195,6 +247,12 @@ describe("userScriptSecrets", () => {
 		expect(setSecret).toHaveBeenCalledWith("secret-ref", "");
 	});
 
+	it("treats missing SecretStorage as a clear no-op", async () => {
+		await expect(
+			clearUserScriptSecret(undefined, "secret-ref"),
+		).resolves.toBe(true);
+	});
+
 	it("migrates legacy plaintext secret settings into SecretStorage", async () => {
 		const command = createCommand({
 			"API Key": "legacy-secret",
@@ -313,9 +371,59 @@ describe("userScriptSecrets", () => {
 			],
 		};
 
-		await clearUserScriptSecretsFromCommand(app, commandTree);
+		await expect(
+			clearUserScriptSecretsFromCommand(app, commandTree),
+		).resolves.toBe(true);
 
 		expect(deleteSecret).toHaveBeenCalledWith("then-secret");
 		expect(deleteSecret).toHaveBeenCalledWith("nested-secret");
+	});
+
+	it("reports recursive clear failure when a SecretStorage delete fails", async () => {
+		const app = createApp({
+			delete: vi.fn().mockRejectedValue(new Error("delete failed")),
+		});
+		const command = createCommand({
+			"API Key": createUserScriptSecretRef("secret-ref"),
+		});
+
+		await expect(
+			clearUserScriptSecretsFromCommand(app, command),
+		).resolves.toBe(false);
+		expect(logWarningMock).toHaveBeenCalledWith(
+			expect.stringContaining("Failed to clear user script SecretStorage entry"),
+		);
+	});
+
+	it("strips markers and detected legacy plaintext secret settings", () => {
+		const command = createCommand({
+			"API Key": "legacy-secret",
+			Token: createUserScriptSecretRef("local-secret-ref"),
+			Model: "gpt-4",
+		});
+
+		stripUserScriptSecretRefsFromCommand(command, {
+			secretOptionNamesByPath: new Map([
+				["scripts/script.js", new Set(["API Key", "Token"])],
+			]),
+			stripUnknownStringSettings: true,
+		});
+
+		expect(command.settings).toEqual({ Model: "gpt-4" });
+	});
+
+	it("conservatively strips string settings when secret names are unknown", () => {
+		const command = createCommand({
+			"API Key": "legacy-secret",
+			Enabled: true,
+			Model: "gpt-4",
+		});
+
+		stripUserScriptSecretRefsFromCommand(command, {
+			secretOptionNamesByPath: new Map([["scripts/script.js", null]]),
+			stripUnknownStringSettings: true,
+		});
+
+		expect(command.settings).toEqual({ Enabled: true });
 	});
 });

--- a/src/utils/userScriptSecrets.test.ts
+++ b/src/utils/userScriptSecrets.test.ts
@@ -1,0 +1,183 @@
+import type { App } from "obsidian";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandType } from "../types/macros/CommandType";
+import type { IUserScript } from "../types/macros/IUserScript";
+import { initializeUserScriptSettings } from "./userScriptSettings";
+
+const { logWarningMock } = vi.hoisted(() => ({
+	logWarningMock: vi.fn(),
+}));
+
+vi.mock("../logger/logManager", () => ({
+	log: {
+		logWarning: logWarningMock,
+	},
+}));
+
+const {
+	buildUserScriptSecretId,
+	clearUserScriptSecret,
+	createUserScriptSecretRef,
+	isSecretUserScriptOption,
+	isUserScriptSecretRef,
+	resolveUserScriptSettings,
+	storeUserScriptSecret,
+} = await import("./userScriptSecrets");
+
+function createCommand(settings: Record<string, unknown> = {}): IUserScript {
+	return {
+		id: "command-1",
+		name: "Script",
+		type: CommandType.UserScript,
+		path: "scripts/script.js",
+		settings,
+	};
+}
+
+function createApp(secretStorage: {
+	getSecret?: (name: string) => Promise<string | null> | string | null;
+	setSecret?: (name: string, value: string) => Promise<void> | void;
+	delete?: (name: string) => Promise<void> | void;
+}): App {
+	return { secretStorage } as unknown as App;
+}
+
+describe("userScriptSecrets", () => {
+	beforeEach(() => {
+		logWarningMock.mockReset();
+	});
+
+	it("detects explicit and legacy secret option declarations", () => {
+		expect(isSecretUserScriptOption({ type: "secret" })).toBe(true);
+		expect(
+			isSecretUserScriptOption({ type: "text", secret: true }),
+		).toBe(true);
+		expect(
+			isSecretUserScriptOption({ type: "input", secret: true }),
+		).toBe(true);
+		expect(
+			isSecretUserScriptOption({ type: "textarea", secret: true }),
+		).toBe(false);
+		expect(isSecretUserScriptOption({ type: "text" })).toBe(false);
+	});
+
+	it("does not initialize secret default values into command settings", () => {
+		const settings: Record<string, unknown> = {};
+
+		initializeUserScriptSettings(settings, {
+			options: {
+				"API Key": {
+					type: "secret",
+					defaultValue: "must-not-persist",
+				},
+				Model: {
+					type: "text",
+					defaultValue: "gpt-4",
+				},
+			},
+		});
+
+		expect(settings).toEqual({ Model: "gpt-4" });
+	});
+
+	it("builds valid deterministic SecretStorage IDs", () => {
+		expect(buildUserScriptSecretId(createCommand(), "API Key")).toBe(
+			"quickadd-user-script-command-1-api-key",
+		);
+	});
+
+	it("stores a secret and creates a marker without exposing the value", async () => {
+		const setSecret = vi.fn().mockResolvedValue(undefined);
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const app = createApp({ getSecret, setSecret });
+		const command = createCommand();
+
+		const secretRef = await storeUserScriptSecret(
+			app,
+			command,
+			"API Key",
+			"super-secret",
+		);
+
+		expect(secretRef).toBe("quickadd-user-script-command-1-api-key");
+		expect(setSecret).toHaveBeenCalledWith(
+			"quickadd-user-script-command-1-api-key",
+			"super-secret",
+		);
+		const marker = createUserScriptSecretRef(secretRef!);
+		expect(isUserScriptSecretRef(marker)).toBe(true);
+		expect(JSON.stringify(marker)).not.toContain("super-secret");
+	});
+
+	it("resolves markers into an ephemeral settings object", async () => {
+		const command = createCommand({
+			"API Key": createUserScriptSecretRef(
+				"quickadd-user-script-command-1-api-key",
+			),
+			Model: "gpt-4",
+		});
+		const app = createApp({
+			getSecret: vi.fn().mockResolvedValue("secret-value"),
+		});
+
+		const resolved = await resolveUserScriptSettings(app, command, {
+			options: {
+				"API Key": { type: "secret" },
+				Model: { type: "text" },
+			},
+		});
+
+		expect(resolved).toEqual({
+			"API Key": "secret-value",
+			Model: "gpt-4",
+		});
+		expect(command.settings["API Key"]).toEqual(
+			createUserScriptSecretRef("quickadd-user-script-command-1-api-key"),
+		);
+	});
+
+	it("preserves legacy plaintext secret settings when migration has not run", async () => {
+		const command = createCommand({
+			"API Key": "legacy-secret",
+		});
+
+		const resolved = await resolveUserScriptSettings(undefined, command, {
+			options: {
+				"API Key": { type: "text", secret: true },
+			},
+		});
+
+		expect(resolved["API Key"]).toBe("legacy-secret");
+		expect(command.settings["API Key"]).toBe("legacy-secret");
+	});
+
+	it("throws a clear error when a marker cannot resolve on this device", async () => {
+		const command = createCommand({
+			"API Key": createUserScriptSecretRef(
+				"quickadd-user-script-command-1-api-key",
+			),
+		});
+
+		await expect(
+			resolveUserScriptSettings(undefined, command, {
+				options: { "API Key": { type: "secret" } },
+			}),
+		).rejects.toThrow(/Re-enter it on this device/);
+	});
+
+	it("clears through SecretStorage delete when available", async () => {
+		const deleteSecret = vi.fn().mockResolvedValue(undefined);
+		const app = createApp({ delete: deleteSecret });
+
+		await expect(clearUserScriptSecret(app, "secret-ref")).resolves.toBe(true);
+		expect(deleteSecret).toHaveBeenCalledWith("secret-ref");
+	});
+
+	it("falls back to overwriting with an empty value when delete is unavailable", async () => {
+		const setSecret = vi.fn().mockResolvedValue(undefined);
+		const app = createApp({ setSecret });
+
+		await expect(clearUserScriptSecret(app, "secret-ref")).resolves.toBe(true);
+		expect(setSecret).toHaveBeenCalledWith("secret-ref", "");
+	});
+});

--- a/src/utils/userScriptSecrets.ts
+++ b/src/utils/userScriptSecrets.ts
@@ -1,9 +1,11 @@
 import type { App } from "obsidian";
 import { log } from "../logger/logManager";
 import type { IUserScript } from "../types/macros/IUserScript";
+import { extractScriptFromMarkdown } from "./extractScriptFromMarkdown";
 
 const USER_SCRIPT_SECRET_PREFIX = "quickadd-user-script";
 const SECRET_MARKER = "__quickaddSecret";
+const MARKDOWN_FILE_EXTENSION_REGEX = /\.md$/i;
 
 type SecretStorageLike = {
 	getSecret?: (id: string) => string | null | Promise<string | null>;
@@ -262,13 +264,19 @@ function readOptionKey(
 	}
 
 	if (source[index] === "[") {
-		let current = skipWhitespaceAndComments(source, index + 1);
+		const current = skipWhitespaceAndComments(source, index + 1);
 		const identifier = readIdentifier(source, current);
 		const end = findMatchingDelimiter(source, index, "[", "]");
 		if (end === -1) return null;
+		const afterIdentifier = identifier
+			? skipWhitespaceAndComments(source, identifier.end)
+			: current;
 
 		return {
-			name: identifier ? (constants.get(identifier.value) ?? null) : null,
+			name:
+				identifier && afterIdentifier === end
+					? (constants.get(identifier.value) ?? null)
+					: null,
 			end: end + 1,
 		};
 	}
@@ -363,44 +371,54 @@ function optionBodyDeclaresSecret(body: string): boolean {
 
 export function detectUserScriptSecretOptions(
 	source: string,
+	path?: string,
 ): UserScriptSecretOptionDetection {
+	const sourceToInspect =
+		path && MARKDOWN_FILE_EXTENSION_REGEX.test(path)
+			? (extractScriptFromMarkdown(source).code ?? "")
+			: source;
 	const names = new Set<string>();
 	let foundSecretOptions = false;
-	const constants = collectStringConstants(source);
+	const constants = collectStringConstants(sourceToInspect);
 
-	for (const { start, end } of findOptionsObjectSpans(source)) {
+	for (const { start, end } of findOptionsObjectSpans(sourceToInspect)) {
 		let current = start;
 
 		while (current < end) {
-			current = skipWhitespaceAndComments(source, current);
-			if (source[current] === ",") {
+			current = skipWhitespaceAndComments(sourceToInspect, current);
+			if (sourceToInspect[current] === ",") {
 				current += 1;
 				continue;
 			}
 			if (current >= end) break;
 
-			const key = readOptionKey(source, current, constants);
+			const key = readOptionKey(sourceToInspect, current, constants);
 			if (!key) {
 				current += 1;
 				continue;
 			}
 
-			current = skipWhitespaceAndComments(source, key.end);
-			if (source[current] !== ":") {
+			current = skipWhitespaceAndComments(sourceToInspect, key.end);
+			if (sourceToInspect[current] !== ":") {
 				current += 1;
 				continue;
 			}
 
-			current = skipWhitespaceAndComments(source, current + 1);
-			if (source[current] !== "{") {
+			current = skipWhitespaceAndComments(sourceToInspect, current + 1);
+			if (sourceToInspect[current] !== "{") {
 				current += 1;
 				continue;
 			}
 
-			const valueEnd = findMatchingDelimiter(source, current, "{", "}");
+			const valueEnd = findMatchingDelimiter(
+				sourceToInspect,
+				current,
+				"{",
+				"}",
+			);
 			if (valueEnd === -1 || valueEnd > end) break;
 
-			const body = source.slice(current + 1, valueEnd);
+			const body = sourceToInspect.slice(current + 1, valueEnd);
 			if (optionBodyDeclaresSecret(body)) {
 				foundSecretOptions = true;
 				if (key.name) names.add(key.name);

--- a/src/utils/userScriptSecrets.ts
+++ b/src/utils/userScriptSecrets.ts
@@ -357,3 +357,52 @@ export async function clearUserScriptSecretsFromCommands(
 		await clearUserScriptSecretsFromCommand(app, command);
 	}
 }
+
+function stripSecretRefsFromSettings(settings: unknown): void {
+	if (!isRecord(settings)) return;
+
+	for (const [name, value] of Object.entries(settings)) {
+		if (isUserScriptSecretRef(value)) {
+			delete settings[name];
+		}
+	}
+}
+
+export function stripUserScriptSecretRefsFromCommand(command: unknown): void {
+	if (!isRecord(command)) return;
+
+	if (command.type === "UserScript") {
+		stripSecretRefsFromSettings(command.settings);
+	}
+
+	if (Array.isArray(command.thenCommands)) {
+		stripUserScriptSecretRefsFromCommands(command.thenCommands);
+	}
+	if (Array.isArray(command.elseCommands)) {
+		stripUserScriptSecretRefsFromCommands(command.elseCommands);
+	}
+
+	stripUserScriptSecretRefsFromChoice(command.choice);
+}
+
+export function stripUserScriptSecretRefsFromCommands(commands: unknown): void {
+	if (!Array.isArray(commands)) return;
+
+	for (const command of commands) {
+		stripUserScriptSecretRefsFromCommand(command);
+	}
+}
+
+export function stripUserScriptSecretRefsFromChoice(choice: unknown): void {
+	if (!isRecord(choice)) return;
+
+	if (choice.type === "Macro" && isRecord(choice.macro)) {
+		stripUserScriptSecretRefsFromCommands(choice.macro.commands);
+	}
+
+	if (choice.type === "Multi" && Array.isArray(choice.choices)) {
+		for (const child of choice.choices) {
+			stripUserScriptSecretRefsFromChoice(child);
+		}
+	}
+}

--- a/src/utils/userScriptSecrets.ts
+++ b/src/utils/userScriptSecrets.ts
@@ -29,6 +29,21 @@ export type UserScriptSecretRef = {
 	secretRef: string;
 };
 
+export type UserScriptSecretSanitizerOptions = {
+	/**
+	 * Map a user-script path to the secret option names found in that script.
+	 * `null` means the script declares at least one secret option but the setting
+	 * name could not be statically recovered.
+	 */
+	secretOptionNamesByPath?: ReadonlyMap<string, ReadonlySet<string> | null>;
+	stripUnknownStringSettings?: boolean;
+};
+
+export type UserScriptSecretOptionDetection = {
+	names: Set<string>;
+	foundSecretOptions: boolean;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object";
 }
@@ -48,6 +63,354 @@ function normalizeSecretIdPart(value: string): string {
 
 function formatSecretError(error: unknown): string {
 	return (error as Error)?.message ?? String(error);
+}
+
+function skipWhitespaceAndComments(source: string, index: number): number {
+	let current = index;
+	while (current < source.length) {
+		const char = source[current];
+		const next = source[current + 1];
+
+		if (/\s/.test(char)) {
+			current += 1;
+			continue;
+		}
+
+		if (char === "/" && next === "/") {
+			const newline = source.indexOf("\n", current + 2);
+			current = newline === -1 ? source.length : newline + 1;
+			continue;
+		}
+
+		if (char === "/" && next === "*") {
+			const end = source.indexOf("*/", current + 2);
+			current = end === -1 ? source.length : end + 2;
+			continue;
+		}
+
+		return current;
+	}
+
+	return current;
+}
+
+function readStringLiteral(
+	source: string,
+	index: number,
+): { value: string; end: number } | null {
+	const quote = source[index];
+	if (quote !== "\"" && quote !== "'" && quote !== "`") return null;
+
+	let value = "";
+	for (let current = index + 1; current < source.length; current++) {
+		const char = source[current];
+
+		if (char === "\\") {
+			const escaped = source[current + 1];
+			if (escaped === undefined) return null;
+			value += escaped;
+			current += 1;
+			continue;
+		}
+
+		if (char === quote) {
+			return { value, end: current + 1 };
+		}
+
+		value += char;
+	}
+
+	return null;
+}
+
+function readIdentifier(
+	source: string,
+	index: number,
+): { value: string; end: number } | null {
+	const match = /^[A-Za-z_$][\w$]*/.exec(source.slice(index));
+	if (!match) return null;
+
+	return {
+		value: match[0],
+		end: index + match[0].length,
+	};
+}
+
+function findMatchingDelimiter(
+	source: string,
+	openIndex: number,
+	open: "{" | "[",
+	close: "}" | "]",
+): number {
+	let depth = 0;
+
+	for (let current = openIndex; current < source.length; current++) {
+		const char = source[current];
+		const next = source[current + 1];
+
+		if (char === "\"" || char === "'" || char === "`") {
+			const literal = readStringLiteral(source, current);
+			if (!literal) return -1;
+			current = literal.end - 1;
+			continue;
+		}
+
+		if (char === "/" && next === "/") {
+			const newline = source.indexOf("\n", current + 2);
+			current = newline === -1 ? source.length : newline;
+			continue;
+		}
+
+		if (char === "/" && next === "*") {
+			const end = source.indexOf("*/", current + 2);
+			if (end === -1) return -1;
+			current = end + 1;
+			continue;
+		}
+
+		if (char === open) {
+			depth += 1;
+			continue;
+		}
+
+		if (char === close) {
+			depth -= 1;
+			if (depth === 0) return current;
+		}
+	}
+
+	return -1;
+}
+
+function collectStringConstants(source: string): Map<string, string> {
+	const constants = new Map<string, string>();
+	const regex = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(["'`])/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(source)) !== null) {
+		const literal = readStringLiteral(source, regex.lastIndex - 1);
+		if (!literal) continue;
+		constants.set(match[1], literal.value);
+		regex.lastIndex = literal.end;
+	}
+
+	return constants;
+}
+
+function findOptionsObjectSpans(source: string): Array<{ start: number; end: number }> {
+	const spans: Array<{ start: number; end: number }> = [];
+	const constants = collectStringConstants(source);
+	let current = 0;
+
+	while (current < source.length) {
+		current = skipWhitespaceAndComments(source, current);
+		const char = source[current];
+		const next = source[current + 1];
+
+		if (char === "\"" || char === "'" || char === "`") {
+			const literal = readStringLiteral(source, current);
+			current = literal ? literal.end : current + 1;
+			continue;
+		}
+
+		if (char === "/" && next === "/") {
+			const newline = source.indexOf("\n", current + 2);
+			current = newline === -1 ? source.length : newline + 1;
+			continue;
+		}
+
+		if (char === "/" && next === "*") {
+			const end = source.indexOf("*/", current + 2);
+			current = end === -1 ? source.length : end + 2;
+			continue;
+		}
+
+		const key = readOptionKey(source, current, constants);
+		if (!key) {
+			current += 1;
+			continue;
+		}
+
+		current = skipWhitespaceAndComments(source, key.end);
+		if (source[current] !== ":") {
+			current = key.end;
+			continue;
+		}
+
+		current = skipWhitespaceAndComments(source, current + 1);
+		if (key.name !== "options") continue;
+		if (source[current] !== "{") continue;
+
+		const end = findMatchingDelimiter(source, current, "{", "}");
+		if (end === -1) break;
+		spans.push({ start: current + 1, end });
+		current = end + 1;
+	}
+
+	return spans;
+}
+
+function readOptionKey(
+	source: string,
+	index: number,
+	constants: ReadonlyMap<string, string>,
+): { name: string | null; end: number } | null {
+	if (source[index] === "\"" || source[index] === "'" || source[index] === "`") {
+		const literal = readStringLiteral(source, index);
+		if (!literal) return null;
+		return { name: literal.value, end: literal.end };
+	}
+
+	if (source[index] === "[") {
+		let current = skipWhitespaceAndComments(source, index + 1);
+		const identifier = readIdentifier(source, current);
+		const end = findMatchingDelimiter(source, index, "[", "]");
+		if (end === -1) return null;
+
+		return {
+			name: identifier ? (constants.get(identifier.value) ?? null) : null,
+			end: end + 1,
+		};
+	}
+
+	const identifier = readIdentifier(source, index);
+	if (!identifier) return null;
+
+	return {
+		name: identifier.value,
+		end: identifier.end,
+	};
+}
+
+function readTopLevelObjectProperties(source: string): Map<string, unknown> {
+	const properties = new Map<string, unknown>();
+	let current = 0;
+
+	while (current < source.length) {
+		current = skipWhitespaceAndComments(source, current);
+		if (source[current] === ",") {
+			current += 1;
+			continue;
+		}
+		if (current >= source.length) break;
+
+		const key = readOptionKey(source, current, new Map());
+		if (!key?.name) {
+			current += 1;
+			continue;
+		}
+
+		current = skipWhitespaceAndComments(source, key.end);
+		if (source[current] !== ":") {
+			current += 1;
+			continue;
+		}
+
+		current = skipWhitespaceAndComments(source, current + 1);
+		if (
+			source[current] === "\"" ||
+			source[current] === "'" ||
+			source[current] === "`"
+		) {
+			const literal = readStringLiteral(source, current);
+			if (!literal) break;
+			properties.set(key.name, literal.value);
+			current = literal.end;
+			continue;
+		}
+
+		if (source.slice(current, current + 4) === "true") {
+			properties.set(key.name, true);
+			current += 4;
+			continue;
+		}
+
+		if (source.slice(current, current + 5) === "false") {
+			properties.set(key.name, false);
+			current += 5;
+			continue;
+		}
+
+		if (source[current] === "{") {
+			const end = findMatchingDelimiter(source, current, "{", "}");
+			if (end === -1) break;
+			current = end + 1;
+			continue;
+		}
+
+		if (source[current] === "[") {
+			const end = findMatchingDelimiter(source, current, "[", "]");
+			if (end === -1) break;
+			current = end + 1;
+			continue;
+		}
+
+		while (current < source.length && source[current] !== ",") {
+			current += 1;
+		}
+	}
+
+	return properties;
+}
+
+function optionBodyDeclaresSecret(body: string): boolean {
+	const properties = readTopLevelObjectProperties(body);
+	const type = properties.get("type");
+	const secret = properties.get("secret");
+
+	return type === "secret" || ((type === "text" || type === "input") && secret === true);
+}
+
+export function detectUserScriptSecretOptions(
+	source: string,
+): UserScriptSecretOptionDetection {
+	const names = new Set<string>();
+	let foundSecretOptions = false;
+	const constants = collectStringConstants(source);
+
+	for (const { start, end } of findOptionsObjectSpans(source)) {
+		let current = start;
+
+		while (current < end) {
+			current = skipWhitespaceAndComments(source, current);
+			if (source[current] === ",") {
+				current += 1;
+				continue;
+			}
+			if (current >= end) break;
+
+			const key = readOptionKey(source, current, constants);
+			if (!key) {
+				current += 1;
+				continue;
+			}
+
+			current = skipWhitespaceAndComments(source, key.end);
+			if (source[current] !== ":") {
+				current += 1;
+				continue;
+			}
+
+			current = skipWhitespaceAndComments(source, current + 1);
+			if (source[current] !== "{") {
+				current += 1;
+				continue;
+			}
+
+			const valueEnd = findMatchingDelimiter(source, current, "{", "}");
+			if (valueEnd === -1 || valueEnd > end) break;
+
+			const body = source.slice(current + 1, valueEnd);
+			if (optionBodyDeclaresSecret(body)) {
+				foundSecretOptions = true;
+				if (key.name) names.add(key.name);
+			}
+
+			current = valueEnd + 1;
+		}
+	}
+
+	return { names, foundSecretOptions };
 }
 
 export function isSecretUserScriptOption(option: unknown): boolean {
@@ -185,7 +548,7 @@ export async function clearUserScriptSecret(
 	if (!trimmedRef) return true;
 
 	const secretStorage = getSecretStorage(app);
-	if (!secretStorage) return false;
+	if (!secretStorage) return true;
 
 	const deleteMethod =
 		secretStorage.deleteSecret ??
@@ -298,111 +661,167 @@ export function getSecretRefFromCommandSetting(
 async function clearRefsFromSettings(
 	app: App | undefined,
 	settings: unknown,
-): Promise<void> {
-	if (!isRecord(settings)) return;
+): Promise<boolean> {
+	if (!isRecord(settings)) return true;
 
 	const secretRefs = Object.values(settings)
 		.filter(isUserScriptSecretRef)
 		.map((value) => value.secretRef);
 
-	await Promise.all(
+	const results = await Promise.all(
 		secretRefs.map((secretRef) => clearUserScriptSecret(app, secretRef)),
 	);
+	return results.every(Boolean);
 }
 
 async function clearSecretsFromChoice(
 	app: App | undefined,
 	choice: unknown,
-): Promise<void> {
-	if (!isRecord(choice)) return;
+): Promise<boolean> {
+	if (!isRecord(choice)) return true;
+
+	let cleared = true;
 
 	if (choice.type === "Macro" && isRecord(choice.macro)) {
-		await clearUserScriptSecretsFromCommands(app, choice.macro.commands);
+		cleared =
+			(await clearUserScriptSecretsFromCommands(app, choice.macro.commands)) &&
+			cleared;
 	}
 
 	if (choice.type === "Multi" && Array.isArray(choice.choices)) {
 		for (const child of choice.choices) {
-			await clearSecretsFromChoice(app, child);
+			cleared = (await clearSecretsFromChoice(app, child)) && cleared;
 		}
 	}
+
+	return cleared;
 }
 
 export async function clearUserScriptSecretsFromCommand(
 	app: App | undefined,
 	command: unknown,
-): Promise<void> {
-	if (!isRecord(command)) return;
+): Promise<boolean> {
+	if (!isRecord(command)) return true;
+
+	let cleared = true;
 
 	if (command.type === "UserScript") {
-		await clearRefsFromSettings(app, command.settings);
+		cleared = (await clearRefsFromSettings(app, command.settings)) && cleared;
 	}
 
 	if (Array.isArray(command.thenCommands)) {
-		await clearUserScriptSecretsFromCommands(app, command.thenCommands);
+		cleared =
+			(await clearUserScriptSecretsFromCommands(app, command.thenCommands)) &&
+			cleared;
 	}
 	if (Array.isArray(command.elseCommands)) {
-		await clearUserScriptSecretsFromCommands(app, command.elseCommands);
+		cleared =
+			(await clearUserScriptSecretsFromCommands(app, command.elseCommands)) &&
+			cleared;
 	}
 
-	await clearSecretsFromChoice(app, command.choice);
+	cleared = (await clearSecretsFromChoice(app, command.choice)) && cleared;
+	return cleared;
 }
 
 export async function clearUserScriptSecretsFromCommands(
 	app: App | undefined,
 	commands: unknown,
-): Promise<void> {
-	if (!Array.isArray(commands)) return;
+): Promise<boolean> {
+	if (!Array.isArray(commands)) return true;
+
+	let cleared = true;
 
 	for (const command of commands) {
-		await clearUserScriptSecretsFromCommand(app, command);
+		cleared = (await clearUserScriptSecretsFromCommand(app, command)) && cleared;
 	}
+
+	return cleared;
 }
 
-function stripSecretRefsFromSettings(settings: unknown): void {
+function getSecretOptionNamesForCommand(
+	command: Record<string, unknown>,
+	options?: UserScriptSecretSanitizerOptions,
+): ReadonlySet<string> | null | undefined {
+	const path = command.path;
+	if (typeof path !== "string") return undefined;
+
+	return options?.secretOptionNamesByPath?.get(path);
+}
+
+function stripSecretRefsFromSettings(
+	settings: unknown,
+	secretOptionNames: ReadonlySet<string> | null | undefined,
+	options?: UserScriptSecretSanitizerOptions,
+): void {
 	if (!isRecord(settings)) return;
 
 	for (const [name, value] of Object.entries(settings)) {
 		if (isUserScriptSecretRef(value)) {
 			delete settings[name];
+			continue;
+		}
+
+		if (
+			typeof value === "string" &&
+			(secretOptionNames === null ||
+				secretOptionNames?.has(name) ||
+				(secretOptionNames === undefined &&
+					options?.stripUnknownStringSettings === true))
+		) {
+			delete settings[name];
 		}
 	}
 }
 
-export function stripUserScriptSecretRefsFromCommand(command: unknown): void {
+export function stripUserScriptSecretRefsFromCommand(
+	command: unknown,
+	options?: UserScriptSecretSanitizerOptions,
+): void {
 	if (!isRecord(command)) return;
 
 	if (command.type === "UserScript") {
-		stripSecretRefsFromSettings(command.settings);
+		stripSecretRefsFromSettings(
+			command.settings,
+			getSecretOptionNamesForCommand(command, options),
+			options,
+		);
 	}
 
 	if (Array.isArray(command.thenCommands)) {
-		stripUserScriptSecretRefsFromCommands(command.thenCommands);
+		stripUserScriptSecretRefsFromCommands(command.thenCommands, options);
 	}
 	if (Array.isArray(command.elseCommands)) {
-		stripUserScriptSecretRefsFromCommands(command.elseCommands);
+		stripUserScriptSecretRefsFromCommands(command.elseCommands, options);
 	}
 
-	stripUserScriptSecretRefsFromChoice(command.choice);
+	stripUserScriptSecretRefsFromChoice(command.choice, options);
 }
 
-export function stripUserScriptSecretRefsFromCommands(commands: unknown): void {
+export function stripUserScriptSecretRefsFromCommands(
+	commands: unknown,
+	options?: UserScriptSecretSanitizerOptions,
+): void {
 	if (!Array.isArray(commands)) return;
 
 	for (const command of commands) {
-		stripUserScriptSecretRefsFromCommand(command);
+		stripUserScriptSecretRefsFromCommand(command, options);
 	}
 }
 
-export function stripUserScriptSecretRefsFromChoice(choice: unknown): void {
+export function stripUserScriptSecretRefsFromChoice(
+	choice: unknown,
+	options?: UserScriptSecretSanitizerOptions,
+): void {
 	if (!isRecord(choice)) return;
 
 	if (choice.type === "Macro" && isRecord(choice.macro)) {
-		stripUserScriptSecretRefsFromCommands(choice.macro.commands);
+		stripUserScriptSecretRefsFromCommands(choice.macro.commands, options);
 	}
 
 	if (choice.type === "Multi" && Array.isArray(choice.choices)) {
 		for (const child of choice.choices) {
-			stripUserScriptSecretRefsFromChoice(child);
+			stripUserScriptSecretRefsFromChoice(child, options);
 		}
 	}
 }

--- a/src/utils/userScriptSecrets.ts
+++ b/src/utils/userScriptSecrets.ts
@@ -238,12 +238,6 @@ export async function resolveUserScriptSettings(
 		}
 	}
 
-	for (const name of secretOptionNames) {
-		if (!(name in resolvedSettings)) {
-			resolvedSettings[name] = "";
-		}
-	}
-
 	return resolvedSettings;
 }
 
@@ -299,4 +293,67 @@ export function getSecretRefFromCommandSetting(
 ): string | undefined {
 	const value = command.settings?.[settingName];
 	return isUserScriptSecretRef(value) ? value.secretRef : undefined;
+}
+
+async function clearRefsFromSettings(
+	app: App | undefined,
+	settings: unknown,
+): Promise<void> {
+	if (!isRecord(settings)) return;
+
+	const secretRefs = Object.values(settings)
+		.filter(isUserScriptSecretRef)
+		.map((value) => value.secretRef);
+
+	await Promise.all(
+		secretRefs.map((secretRef) => clearUserScriptSecret(app, secretRef)),
+	);
+}
+
+async function clearSecretsFromChoice(
+	app: App | undefined,
+	choice: unknown,
+): Promise<void> {
+	if (!isRecord(choice)) return;
+
+	if (choice.type === "Macro" && isRecord(choice.macro)) {
+		await clearUserScriptSecretsFromCommands(app, choice.macro.commands);
+	}
+
+	if (choice.type === "Multi" && Array.isArray(choice.choices)) {
+		for (const child of choice.choices) {
+			await clearSecretsFromChoice(app, child);
+		}
+	}
+}
+
+export async function clearUserScriptSecretsFromCommand(
+	app: App | undefined,
+	command: unknown,
+): Promise<void> {
+	if (!isRecord(command)) return;
+
+	if (command.type === "UserScript") {
+		await clearRefsFromSettings(app, command.settings);
+	}
+
+	if (Array.isArray(command.thenCommands)) {
+		await clearUserScriptSecretsFromCommands(app, command.thenCommands);
+	}
+	if (Array.isArray(command.elseCommands)) {
+		await clearUserScriptSecretsFromCommands(app, command.elseCommands);
+	}
+
+	await clearSecretsFromChoice(app, command.choice);
+}
+
+export async function clearUserScriptSecretsFromCommands(
+	app: App | undefined,
+	commands: unknown,
+): Promise<void> {
+	if (!Array.isArray(commands)) return;
+
+	for (const command of commands) {
+		await clearUserScriptSecretsFromCommand(app, command);
+	}
 }

--- a/src/utils/userScriptSecrets.ts
+++ b/src/utils/userScriptSecrets.ts
@@ -1,0 +1,256 @@
+import type { App } from "obsidian";
+import { log } from "../logger/logManager";
+import type { IUserScript } from "../types/macros/IUserScript";
+
+const USER_SCRIPT_SECRET_PREFIX = "quickadd-user-script";
+const SECRET_MARKER = "__quickaddSecret";
+
+type SecretStorageLike = {
+	getSecret?: (id: string) => string | null | Promise<string | null>;
+	setSecret?: (id: string, value: string) => void | Promise<void>;
+	listSecrets?: () => string[] | Promise<string[]>;
+	deleteSecret?: (id: string) => void | Promise<void>;
+	removeSecret?: (id: string) => void | Promise<void>;
+	delete?: (id: string) => void | Promise<void>;
+};
+
+export type UserScriptOptionDefinition = {
+	type?: unknown;
+	secret?: unknown;
+	defaultValue?: unknown;
+};
+
+export type UserScriptSettingsDefinition = {
+	options?: Record<string, UserScriptOptionDefinition>;
+};
+
+export type UserScriptSecretRef = {
+	[SECRET_MARKER]: true;
+	secretRef: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function getSecretStorage(app: App | undefined): SecretStorageLike | undefined {
+	return app?.secretStorage as SecretStorageLike | undefined;
+}
+
+function normalizeSecretIdPart(value: string): string {
+	const normalized = value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+
+	return normalized || "setting";
+}
+
+function formatSecretError(error: unknown): string {
+	return (error as Error)?.message ?? String(error);
+}
+
+export function isSecretUserScriptOption(option: unknown): boolean {
+	if (!isRecord(option)) return false;
+
+	if (option.type === "secret") return true;
+	if (
+		(option.type === "text" || option.type === "input") &&
+		option.secret === true
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+export function isUserScriptSecretRef(
+	value: unknown,
+): value is UserScriptSecretRef {
+	return (
+		isRecord(value) &&
+		value[SECRET_MARKER] === true &&
+		typeof value.secretRef === "string" &&
+		value.secretRef.trim().length > 0
+	);
+}
+
+export function createUserScriptSecretRef(secretRef: string): UserScriptSecretRef {
+	return {
+		[SECRET_MARKER]: true,
+		secretRef,
+	};
+}
+
+export function buildUserScriptSecretId(
+	command: IUserScript,
+	settingName: string,
+): string {
+	const commandId = command.id?.trim() || command.path || command.name || "script";
+	return [
+		USER_SCRIPT_SECRET_PREFIX,
+		normalizeSecretIdPart(commandId),
+		normalizeSecretIdPart(settingName),
+	].join("-");
+}
+
+export function getSecretOptionNames(
+	userScriptSettings: UserScriptSettingsDefinition | undefined,
+): string[] {
+	const options = userScriptSettings?.options;
+	if (!options) return [];
+
+	return Object.entries(options)
+		.filter(([, option]) => isSecretUserScriptOption(option))
+		.map(([name]) => name);
+}
+
+async function readSecretStorageEntry(
+	app: App | undefined,
+	secretRef: string,
+): Promise<string | null> {
+	const secretStorage = getSecretStorage(app);
+	if (!secretStorage?.getSecret) return null;
+
+	try {
+		return await Promise.resolve(secretStorage.getSecret(secretRef));
+	} catch (error) {
+		log.logWarning(
+			`Failed to read user script SecretStorage entry "${secretRef}": ${formatSecretError(error)}`,
+		);
+		return null;
+	}
+}
+
+async function writeSecretStorageEntry(
+	app: App | undefined,
+	secretRef: string,
+	value: string,
+): Promise<boolean> {
+	const secretStorage = getSecretStorage(app);
+	if (!secretStorage?.setSecret) return false;
+
+	try {
+		await Promise.resolve(secretStorage.setSecret(secretRef, value));
+		return true;
+	} catch (error) {
+		log.logWarning(
+			`Failed to write user script SecretStorage entry "${secretRef}": ${formatSecretError(error)}`,
+		);
+		return false;
+	}
+}
+
+async function buildAvailableSecretRef(
+	app: App | undefined,
+	command: IUserScript,
+	settingName: string,
+	value: string,
+): Promise<string> {
+	const base = buildUserScriptSecretId(command, settingName);
+	let candidate = base;
+	let suffix = 1;
+
+	while (true) {
+		const existing = await readSecretStorageEntry(app, candidate);
+		if (!existing || existing === value) return candidate;
+
+		suffix += 1;
+		candidate = `${base}-${suffix}`;
+	}
+}
+
+export async function storeUserScriptSecret(
+	app: App | undefined,
+	command: IUserScript,
+	settingName: string,
+	value: string,
+	existingRef?: string,
+): Promise<string | null> {
+	if (value.length === 0) return null;
+
+	const secretRef =
+		existingRef?.trim() ||
+		(await buildAvailableSecretRef(app, command, settingName, value));
+	const stored = await writeSecretStorageEntry(app, secretRef, value);
+
+	return stored ? secretRef : null;
+}
+
+export async function clearUserScriptSecret(
+	app: App | undefined,
+	secretRef: string | undefined,
+): Promise<boolean> {
+	const trimmedRef = secretRef?.trim();
+	if (!trimmedRef) return true;
+
+	const secretStorage = getSecretStorage(app);
+	if (!secretStorage) return false;
+
+	const deleteMethod =
+		secretStorage.deleteSecret ??
+		secretStorage.removeSecret ??
+		secretStorage.delete;
+
+	try {
+		if (deleteMethod) {
+			await Promise.resolve(deleteMethod.call(secretStorage, trimmedRef));
+			return true;
+		}
+
+		if (secretStorage.setSecret) {
+			await Promise.resolve(secretStorage.setSecret(trimmedRef, ""));
+			return true;
+		}
+	} catch (error) {
+		log.logWarning(
+			`Failed to clear user script SecretStorage entry "${trimmedRef}": ${formatSecretError(error)}`,
+		);
+	}
+
+	return false;
+}
+
+export async function resolveUserScriptSettings(
+	app: App | undefined,
+	command: IUserScript,
+	userScriptSettings: UserScriptSettingsDefinition | undefined,
+): Promise<Record<string, unknown>> {
+	const commandSettings = command.settings ?? {};
+	const resolvedSettings = { ...commandSettings };
+	const secretOptionNames = new Set(getSecretOptionNames(userScriptSettings));
+
+	for (const [name, value] of Object.entries(commandSettings)) {
+		if (isUserScriptSecretRef(value)) {
+			const secret = await readSecretStorageEntry(app, value.secretRef);
+			if (secret) {
+				resolvedSettings[name] = secret;
+				continue;
+			}
+
+			throw new Error(
+				`Secret setting "${name}" for user script "${command.name}" is unavailable. Re-enter it on this device.`,
+			);
+		}
+
+		if (secretOptionNames.has(name)) {
+			resolvedSettings[name] = typeof value === "string" ? value : "";
+		}
+	}
+
+	for (const name of secretOptionNames) {
+		if (!(name in resolvedSettings)) {
+			resolvedSettings[name] = "";
+		}
+	}
+
+	return resolvedSettings;
+}
+
+export function getSecretRefFromCommandSetting(
+	command: IUserScript,
+	settingName: string,
+): string | undefined {
+	const value = command.settings?.[settingName];
+	return isUserScriptSecretRef(value) ? value.secretRef : undefined;
+}

--- a/src/utils/userScriptSecrets.ts
+++ b/src/utils/userScriptSecrets.ts
@@ -247,6 +247,52 @@ export async function resolveUserScriptSettings(
 	return resolvedSettings;
 }
 
+export async function migrateUserScriptSecretSettings(
+	app: App | undefined,
+	command: IUserScript,
+	userScriptSettings: UserScriptSettingsDefinition | undefined,
+): Promise<boolean> {
+	const secretOptionNames = getSecretOptionNames(userScriptSettings);
+	if (secretOptionNames.length === 0) return false;
+
+	const secretStorage = getSecretStorage(app);
+	if (!secretStorage?.getSecret || !secretStorage?.setSecret) {
+		const hasLegacySecrets = secretOptionNames.some((name) => {
+			const value = command.settings?.[name];
+			return typeof value === "string" && value.length > 0;
+		});
+
+		if (hasLegacySecrets) {
+			log.logWarning(
+				`SecretStorage unavailable; leaving plaintext user script secret settings for "${command.name}" unchanged.`,
+			);
+		}
+
+		return false;
+	}
+
+	let migrated = false;
+
+	for (const settingName of secretOptionNames) {
+		const value = command.settings?.[settingName];
+		if (isUserScriptSecretRef(value)) continue;
+		if (typeof value !== "string" || value.length === 0) continue;
+
+		const secretRef = await storeUserScriptSecret(
+			app,
+			command,
+			settingName,
+			value,
+		);
+		if (!secretRef) continue;
+
+		command.settings[settingName] = createUserScriptSecretRef(secretRef);
+		migrated = true;
+	}
+
+	return migrated;
+}
+
 export function getSecretRefFromCommandSetting(
 	command: IUserScript,
 	settingName: string,

--- a/src/utils/userScriptSettings.ts
+++ b/src/utils/userScriptSettings.ts
@@ -1,3 +1,8 @@
+import {
+	isSecretUserScriptOption,
+	type UserScriptOptionDefinition,
+} from "./userScriptSecrets";
+
 /**
  * Initializes default values for user script settings.
  *
@@ -13,9 +18,7 @@ export function initializeUserScriptSettings(
 	userScriptSettings: {
 		[key: string]: unknown;
 		options?: {
-			[key: string]: {
-				defaultValue?: unknown;
-			};
+			[key: string]: UserScriptOptionDefinition;
 		};
 	}
 ): void {
@@ -29,7 +32,11 @@ export function initializeUserScriptSettings(
 			"defaultValue" in userScriptSettings.options[setting] &&
 			userScriptSettings.options[setting].defaultValue !== undefined;
 
-		if (valueIsNotSetAlready && defaultValueAvailable) {
+		if (
+			valueIsNotSetAlready &&
+			defaultValueAvailable &&
+			!isSecretUserScriptOption(userScriptSettings.options[setting])
+		) {
 			commandSettings[setting] =
 				userScriptSettings.options[setting].defaultValue;
 		}

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -516,9 +516,32 @@ export class FuzzySuggestModal<T = unknown> {
 };
 
 export const Modal = class {
-  constructor(app: any) {}
-  open() {}
-  close() {}
+  app: any;
+  containerEl: HTMLElement;
+  modalEl: HTMLElement;
+  contentEl: HTMLElement;
+  titleEl: HTMLElement;
+
+  constructor(app: any) {
+    this.app = app;
+    this.containerEl = document.createElement("div");
+    this.modalEl = document.createElement("div");
+    this.titleEl = document.createElement("div");
+    this.contentEl = document.createElement("div");
+    this.modalEl.appendChild(this.titleEl);
+    this.modalEl.appendChild(this.contentEl);
+    this.containerEl.appendChild(this.modalEl);
+    document.body.appendChild(this.containerEl);
+  }
+
+  open() {
+    (this as any).onOpen?.();
+  }
+
+  close() {
+    (this as any).onClose?.();
+    this.containerEl.remove();
+  }
 };
 
 export const Scope = class {

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -516,32 +516,32 @@ export class FuzzySuggestModal<T = unknown> {
 };
 
 export const Modal = class {
-  app: any;
-  containerEl: HTMLElement;
-  modalEl: HTMLElement;
-  contentEl: HTMLElement;
-  titleEl: HTMLElement;
+	app: any;
+	containerEl: HTMLElement;
+	modalEl: HTMLElement;
+	contentEl: HTMLElement;
+	titleEl: HTMLElement;
 
-  constructor(app: any) {
-    this.app = app;
-    this.containerEl = document.createElement("div");
-    this.modalEl = document.createElement("div");
-    this.titleEl = document.createElement("div");
-    this.contentEl = document.createElement("div");
-    this.modalEl.appendChild(this.titleEl);
-    this.modalEl.appendChild(this.contentEl);
-    this.containerEl.appendChild(this.modalEl);
-    document.body.appendChild(this.containerEl);
-  }
+	constructor(app: any) {
+		this.app = app;
+		this.containerEl = document.createElement("div");
+		this.modalEl = document.createElement("div");
+		this.titleEl = document.createElement("div");
+		this.contentEl = document.createElement("div");
+		this.modalEl.appendChild(this.titleEl);
+		this.modalEl.appendChild(this.contentEl);
+		this.containerEl.appendChild(this.modalEl);
+		document.body.appendChild(this.containerEl);
+	}
 
-  open() {
-    (this as any).onOpen?.();
-  }
+	open() {
+		(this as any).onOpen?.();
+	}
 
-  close() {
-    (this as any).onClose?.();
-    this.containerEl.remove();
-  }
+	close() {
+		(this as any).onClose?.();
+		this.containerEl.remove();
+	}
 };
 
 export const Scope = class {

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -24,7 +24,56 @@ for (const proto of [HTMLElement.prototype, SVGElement.prototype]) {
 	const p = proto as unknown as {
 		setCssStyles?: unknown;
 		setCssProps?: unknown;
+		addClass?: unknown;
+		removeClass?: unknown;
+		empty?: unknown;
+		createDiv?: unknown;
+		createEl?: unknown;
 	};
 	if (typeof p.setCssStyles !== "function") p.setCssStyles = setCssStyles;
 	if (typeof p.setCssProps !== "function") p.setCssProps = setCssProps;
+	if (typeof p.addClass !== "function") {
+		p.addClass = function addClass(this: Element, ...classes: string[]) {
+			this.classList.add(...classes);
+		};
+	}
+	if (typeof p.removeClass !== "function") {
+		p.removeClass = function removeClass(this: Element, ...classes: string[]) {
+			this.classList.remove(...classes);
+		};
+	}
+	if (typeof p.empty !== "function") {
+		p.empty = function empty(this: Element) {
+			this.textContent = "";
+		};
+	}
+	if (typeof p.createDiv !== "function") {
+		p.createDiv = function createDiv(
+			this: Element,
+			cls?: string | { cls?: string; text?: string },
+		) {
+			const div = document.createElement("div");
+			if (typeof cls === "string") div.className = cls;
+			if (typeof cls === "object") {
+				if (cls.cls) div.className = cls.cls;
+				if (cls.text) div.textContent = cls.text;
+			}
+			this.appendChild(div);
+			return div;
+		};
+	}
+	if (typeof p.createEl !== "function") {
+		p.createEl = function createEl(
+			this: Element,
+			tag: string,
+			options?: { cls?: string; text?: string; href?: string },
+		) {
+			const el = document.createElement(tag);
+			if (options?.cls) el.className = options.cls;
+			if (options?.text) el.textContent = options.text;
+			if (options?.href) el.setAttribute("href", options.href);
+			this.appendChild(el);
+			return el;
+		};
+	}
 }


### PR DESCRIPTION
## Summary
- Add `type: "secret"` user-script settings backed by Obsidian `app.secretStorage`, with legacy `type: "text" | "input", secret: true` treated the same way.
- Resolve secret markers into ephemeral runtime settings for user scripts, without writing plaintext back to `data.json`.
- Lazily migrate existing plaintext user-script secret settings into SecretStorage when script settings are known; if SecretStorage is unavailable or write fails, leave plaintext untouched to avoid data loss.
- Mask secret inputs in the user-script settings modal with explicit save/clear actions, and clear local SecretStorage refs when commands/choices are deleted.
- Strip local secret refs and detected legacy plaintext secret settings from package export/import and macro duplication paths.
- Update user-script docs for secret settings and local-only package behavior.

## Design notes
- Secret IDs are namespaced per command and setting (`quickadd-user-script-<command>-<setting>`) and persisted in settings as `{ __quickaddSecret: true, secretRef }` markers.
- Runtime resolution returns a copied settings object so command settings stay marker-only after migration.
- Migration is idempotent and only replaces plaintext after a successful SecretStorage write.
- Package export/import inspects bundled user-script source for secret option declarations, including quoted property names, and strips matching legacy plaintext values. Dynamic/unknown secret option names fall back conservatively.
- Macro duplication uses the current vault to inspect referenced user scripts before copying, preserving normal string settings while removing detected secret values.

## Issue tracker check
- Searched GitHub issues for user-script secret/API-key requests. Found related SecretStorage precedent for AI provider keys (#732) and user-script settings enhancements (#544), but no existing user-script secret setting support.

## Validation
- `pnpm exec tsc --noEmit --skipLibCheck --pretty false`
- `pnpm run lint`
- `pnpm run check` (0 errors, existing 4 warnings)
- `pnpm run test` (218 files passed, 2533 tests passed, 31 skipped)
- `pnpm run build`

## Real Obsidian E2E evidence
Used this worktree's isolated vault via `pnpm run obsidian:e2e -- ...`.

- Set a secret through the real QuickAdd settings UI and `UserScriptSettingsModal` password input.
- Confirmed UI affordances: password input, `Save API Key`, `Clear API Key`.
- Confirmed SecretStorage contained `qa-e2e-secret-value-173` while `data.json` contained only the marker and did not contain plaintext.
- Ran `quickadd:run choice='Secret Roundtrip'`; user script read the resolved secret and wrote it to `secret-output.txt`, while `data.json` still had no plaintext.
- Updated the secret through the UI, reran the macro, and confirmed the script received the updated value without plaintext persistence.
- Cleared the secret through the UI, confirmed settings no longer contained `API Key`, SecretStorage returned `null`, runtime output was empty, and `data.json` contained neither old nor updated plaintext.
- Seeded legacy plaintext in `data.json`, reloaded QuickAdd, ran the macro, and confirmed lazy migration wrote SecretStorage, persisted the marker, removed plaintext from `data.json`, and passed the secret to the script.

## Release / migration impact
- New feature for user-script settings.
- Existing plaintext user-script secrets are migrated lazily and safely when SecretStorage is available. On old/mobile builds without SecretStorage, QuickAdd leaves plaintext untouched and warns instead of dropping data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added first-class **`secret`** option type for user scripts with password-style input and “API Key” example.

* **Improvements**
  * Secrets are stored locally in the app profile, referenced safely during use, and omitted from exports/sync.
  * Automatic migration from legacy plaintext secrets to secure storage during execution, duplication/deletion, and package import/export.
  * Secret clearing now fails safely with clear notices when removal isn’t possible.

* **Documentation**
  * Updated advanced and user script docs with `secret` guidance and backward compatibility.

* **Tests**
  * Expanded coverage for migration, sanitization, UI, and package behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->