### PR TITLE
fix(format): add trim option for value tokens

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -143,7 +143,7 @@ Example: `priority: {{VALUE:🔽,🔼,⏫|text:Low,Normal,High}}`.
 
 ## `{{VALUE:<variable name>|<default>}}` {#value-default}
 
-Same as above, but with a default value. For single-value prompts (e.g., `{{VALUE:name|Anonymous}}`), the default is pre-populated in the input field - press Enter to accept or clear/edit it. For multi-value suggesters without `|custom`, you must select one of the provided options (no default applies). If you combine keyed options like `|label:`, `|default:`, `|type:`, or `|case:`, shorthand defaults like `|Anonymous` are ignored; use `|default:Anonymous` instead. The bare `|optional` flag is the exception: `{{VALUE:name|Anonymous|optional}}` keeps the shorthand default. Because `optional` is now a reserved flag word, a literal default of "optional" needs the keyed form: `|default:optional`.
+Same as above, but with a default value. For single-value prompts (e.g., `{{VALUE:name|Anonymous}}`), the default is pre-populated in the input field - press Enter to accept or clear/edit it. For multi-value suggesters without `|custom`, you must select one of the provided options (no default applies). If you combine keyed options like `|label:`, `|default:`, `|type:`, `|case:`, or `|trim:`, shorthand defaults like `|Anonymous` are ignored; use `|default:Anonymous` instead. The bare `|optional` flag is the exception: `{{VALUE:name|Anonymous|optional}}` keeps the shorthand default. Because `optional` and `trim` are now reserved flag words, literal defaults of "optional" or "trim" need the keyed form, e.g. `|default:trim`.
 
 Example: `status: {{VALUE:status|Draft}}`.
 
@@ -224,7 +224,7 @@ Variants and combinations:
 
 - `|multi:linklist` wraps each pick as a wikilink, for List properties of links: `{{VALUE:Alice,Bob,Carol|multi:linklist}}` → `- "[[Alice]]"` / `- "[[Bob]]"`.
 - `|multi|custom` lets you add values not in the list (a text box in the picker).
-- Combines with `|name:`, `|label:`, `|text:`, and `|optional`. `|case:` is ignored with `|multi` (a list isn't case-transformed).
+- Combines with `|name:`, `|label:`, `|text:`, and `|optional`. `|case:` and `|trim` are ignored with `|multi` (a list isn't string-transformed).
 
 Notes:
 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -190,6 +190,14 @@ Transforms the resolved value into a casing style. Supported: `kebab`, `snake`, 
 
 Example: `{{DATE:YYYY-MM-DD}}-{{VALUE:title|case:slug}}.md`.
 
+## `{{VALUE|trim}}` / `{{NAME|trim}}` / `{{VALUE:<variable>|trim}}` {#value-trim}
+
+Trims leading and trailing whitespace from the resolved value. This is useful in file names and links where an accidental mobile keyboard space would create a different note.
+
+Example: `People/{{VALUE:name|trim}}.md`.
+
+`|trim` only changes the token where it appears. The stored value is still available unchanged to another token, so `{{VALUE:name}}` can preserve spaces while `{{VALUE:name|trim}}` removes them.
+
 ## `{{VALUE:<options>|custom}}` {#value-custom}
 
 Allows you to type custom values in addition to selecting from the provided options. Example: `{{VALUE:Red,Green,Blue|custom}}` will suggest Red, Green, and Blue, but also allows you to type any other value like "Purple". This is useful when you have common options but want flexibility for edge cases. **Note:** You cannot combine `|custom` with a shorthand default value - use `|default:` if you need both.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,8 @@ export const VARIABLE_OPTIONAL_SYNTAX =
 	"{{value:<variable name>|optional}}";
 export const VDATE_OPTIONAL_SYNTAX =
 	"{{vdate:<variable name>, <date format>|optional}}";
+export const VALUE_TRIM_SYNTAX = "{{value|trim}}";
+export const VARIABLE_TRIM_SYNTAX = "{{value:<variable name>|trim}}";
 export const VALUE_CASE_SYNTAX = "{{value|case:kebab}}";
 export const VARIABLE_CASE_SYNTAX = "{{value:<variable name>|case:kebab}}";
 export const FIELD_VAR_SYNTAX = "{{field:<field name>}}";
@@ -45,6 +47,8 @@ export const FORMAT_SYNTAX: string[] = [
 	GLOBAL_VAR_SYNTAX,
 	VALUE_SYNTAX,
 	NAME_SYNTAX,
+	VALUE_TRIM_SYNTAX,
+	VARIABLE_TRIM_SYNTAX,
 	VALUE_CASE_SYNTAX,
 	VARIABLE_CASE_SYNTAX,
 	VARIABLE_SYNTAX,
@@ -86,6 +90,8 @@ export const FILE_NAME_FORMAT_SYNTAX: string[] = [
 	GLOBAL_VAR_SYNTAX,
 	VALUE_SYNTAX,
 	NAME_SYNTAX,
+	VALUE_TRIM_SYNTAX,
+	VARIABLE_TRIM_SYNTAX,
 	VALUE_CASE_SYNTAX,
 	VARIABLE_CASE_SYNTAX,
 	VARIABLE_SYNTAX,

--- a/src/formatters/formatter-case.test.ts
+++ b/src/formatters/formatter-case.test.ts
@@ -37,7 +37,7 @@ class CaseTestFormatter extends Formatter {
 
 	protected getVariableValue(variableName: string): string {
 		const value = this.variables.get(variableName);
-		return typeof value === "string" ? value : "";
+		return (value as string) ?? "";
 	}
 
 	protected suggestForValue(
@@ -150,6 +150,17 @@ describe("Formatter case: pipe option", () => {
 			"slug={{VALUE:title|trim|case:slug}}",
 		);
 		expect(result).toBe("slug=my-new-blog");
+	});
+
+	it("coerces seeded non-string values before trimming", async () => {
+		formatter.setVariable("count", 42);
+		formatter.setVariable("meta", { toString: () => "  Object Title  " });
+
+		const result = await formatter.testFormat(
+			"count={{VALUE:count|trim}} meta={{VALUE:meta|trim}}",
+		);
+
+		expect(result).toBe("count=42 meta=Object Title");
 	});
 
 	it("supports snake/camel/pascal/title/lower/slug transforms", async () => {

--- a/src/formatters/formatter-case.test.ts
+++ b/src/formatters/formatter-case.test.ts
@@ -126,6 +126,32 @@ describe("Formatter case: pipe option", () => {
 		expect(result).toBe("a=My New Blog b=my-new-blog c=MY NEW BLOG");
 	});
 
+	it("trims anonymous VALUE/NAME per token without mutating the stored value", async () => {
+		formatter.setValueResponse("  Mobile Title  ");
+		const result = await formatter.testFormat(
+			"a={{VALUE}} b={{VALUE|trim}} c={{NAME|trim:false}}",
+		);
+		expect(result).toBe("a=  Mobile Title   b=Mobile Title c=  Mobile Title  ");
+	});
+
+	it("trims named variables per token without mutating stored values", async () => {
+		formatter.setVariable("title", "  Mobile Title  ");
+		const result = await formatter.testFormat(
+			"title={{VALUE:title}} trimmed={{VALUE:title|trim}} raw={{VALUE:title}}",
+		);
+		expect(result).toBe(
+			"title=  Mobile Title   trimmed=Mobile Title raw=  Mobile Title  ",
+		);
+	});
+
+	it("applies trim before case transforms", async () => {
+		formatter.setVariable("title", "  My New Blog  ");
+		const result = await formatter.testFormat(
+			"slug={{VALUE:title|trim|case:slug}}",
+		);
+		expect(result).toBe("slug=my-new-blog");
+	});
+
 	it("supports snake/camel/pascal/title/lower/slug transforms", async () => {
 		formatter.setValueResponse("my new blog");
 		const result = await formatter.testFormat(

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -73,6 +73,14 @@ export interface TemplateInclusionState {
 
 const MAX_TEMPLATE_INCLUSION_DEPTH = 10;
 
+function transformValueText(
+	value: string,
+	options: { trim?: boolean; caseStyle?: string },
+): string {
+	const trimmed = options.trim ? value.trim() : value;
+	return transformCase(trimmed, options.caseStyle);
+}
+
 export abstract class Formatter {
 	protected value: string;
 	protected variables: Map<string, unknown> = new Map<string, unknown>();
@@ -230,7 +238,7 @@ export abstract class Formatter {
 			if (optionsIndex === -1) return this.value;
 			const rawOptions = inner.slice(optionsIndex);
 			const parsed = parseAnonymousValueOptions(rawOptions);
-			const transformed = transformCase(this.value, parsed.caseStyle);
+			const transformed = transformValueText(this.value, parsed);
 			// |type:text on the anonymous {{VALUE|...}} form quotes the same way
 			// as the named form (see replaceVariableInString).
 			if (
@@ -800,8 +808,8 @@ export abstract class Formatter {
 			// Get the raw value from variables
 			const rawValue = this.variables.get(effectiveKey);
 			const rawValueForCollector =
-				caseStyle && typeof rawValue === "string"
-					? transformCase(rawValue, caseStyle)
+				(caseStyle || parsed.trim) && typeof rawValue === "string"
+					? transformValueText(rawValue, parsed)
 					: rawValue;
 
 			// Offer this variable to the property collector for YAML post-processing.
@@ -841,7 +849,7 @@ export abstract class Formatter {
 				replacement = rawValue.join(",");
 			} else {
 				const stringVal = String(
-					transformCase(this.getVariableValue(effectiveKey), caseStyle) ?? "",
+					transformValueText(this.getVariableValue(effectiveKey), parsed) ?? "",
 				);
 				// |type:text (#757): write the value as a quoted YAML string at a
 				// sole-value front-matter position so Obsidian can't retype it

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -74,10 +74,11 @@ export interface TemplateInclusionState {
 const MAX_TEMPLATE_INCLUSION_DEPTH = 10;
 
 function transformValueText(
-	value: string,
+	value: unknown,
 	options: { trim?: boolean; caseStyle?: string },
 ): string {
-	const trimmed = options.trim ? value.trim() : value;
+	const stringValue = String(value ?? "");
+	const trimmed = options.trim ? stringValue.trim() : stringValue;
 	return transformCase(trimmed, options.caseStyle);
 }
 

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -84,11 +84,32 @@ describe("RequirementCollector", () => {
     expect(requirement?.defaultValue).toBeUndefined();
   });
 
+  it("does not treat trim option as a legacy default for named VALUE", async () => {
+    const app = makeApp();
+    const plugin = makePlugin();
+    const rc = new RequirementCollector(app, plugin);
+    await rc.scanString("{{VALUE:title|trim}}");
+
+    const requirement = rc.requirements.get("title");
+    expect(requirement?.defaultValue).toBeUndefined();
+  });
+
   it("does not treat case option as a legacy default for unnamed VALUE", async () => {
     const app = makeApp();
     const plugin = makePlugin();
     const rc = new RequirementCollector(app, plugin);
     await rc.scanString("{{VALUE|case:kebab|label:Notes}}");
+
+    const requirement = rc.requirements.get("value");
+    expect(requirement?.description).toBe("Notes");
+    expect(requirement?.defaultValue).toBeUndefined();
+  });
+
+  it("does not treat trim option as a legacy default for unnamed VALUE", async () => {
+    const app = makeApp();
+    const plugin = makePlugin();
+    const rc = new RequirementCollector(app, plugin);
+    await rc.scanString("{{VALUE|trim|label:Notes}}");
 
     const requirement = rc.requirements.get("value");
     expect(requirement?.description).toBe("Notes");

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -42,6 +42,17 @@ describe("parseValueToken", () => {
 		expect(parsed?.defaultValue).toBe("");
 	});
 
+	it("parses trim without treating it as legacy default", () => {
+		const parsed = parseValueToken("title|trim");
+		expect(parsed?.trim).toBe(true);
+		expect(parsed?.defaultValue).toBe("");
+	});
+
+	it("supports keyed trim false overriding bare trim", () => {
+		expect(parseValueToken("title|trim|trim:false")?.trim).toBe(false);
+		expect(parseValueToken("title|trim:0")?.trim).toBe(false);
+	});
+
 	it("parses title case style", () => {
 		const parsed = parseValueToken("title|case:title");
 		expect(parsed?.caseStyle).toBe("title");
@@ -185,6 +196,14 @@ describe("parseValueToken", () => {
 		expect(warnSpy).toHaveBeenCalled();
 	});
 
+	it("drops |trim when combined with |multi (a list is not string-transformed)", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("a,b,c|multi|trim");
+		expect(parsed?.multiSelect).toBe(true);
+		expect(parsed?.trim).toBe(false);
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
 	it("leaves multiSelect false for ordinary option lists", () => {
 		expect(parseValueToken("a,b,c")?.multiSelect).toBe(false);
 		expect(parseValueToken("a,b,c|custom")?.multiSelect).toBe(false);
@@ -210,6 +229,15 @@ describe("parseAnonymousValueOptions", () => {
 			"|case:kebab|label:Notes|default:Hello",
 		);
 		expect(parsed.caseStyle).toBe("kebab");
+		expect(parsed.label).toBe("Notes");
+		expect(parsed.defaultValue).toBe("Hello");
+	});
+
+	it("parses trim for unnamed VALUE tokens", () => {
+		const parsed = parseAnonymousValueOptions(
+			"|trim|label:Notes|default:Hello",
+		);
+		expect(parsed.trim).toBe(true);
 		expect(parsed.label).toBe("Notes");
 		expect(parsed.defaultValue).toBe("Hello");
 	});

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -26,6 +26,7 @@ const VALUE_OPTION_KEYS = new Set([
 	"custom",
 	"type",
 	"case",
+	"trim",
 	"text",
 	"optional",
 	"multi",
@@ -49,6 +50,7 @@ export type ParsedValueToken = {
 	aliasName?: string;
 	label?: string;
 	caseStyle?: string;
+	trim?: boolean;
 	defaultValue: string;
 	allowCustomInput: boolean;
 	suggestedValues: string[];
@@ -126,6 +128,7 @@ type ParsedOptions = {
 	inputTypeOverride?: string;
 	displayValuesRaw?: string;
 	optionalExplicit?: boolean;
+	trimExplicit?: boolean;
 	name?: string;
 	multiSelect?: boolean;
 	multiEmit?: MultiEmit;
@@ -143,6 +146,14 @@ function extractBareOptionalFlag(parts: string[]): {
 } {
 	const { remaining, found } = extractBareFlagPart(parts, "optional");
 	return { remaining, optional: found };
+}
+
+function extractBareTrimFlag(parts: string[]): {
+	remaining: string[];
+	trim: boolean;
+} {
+	const { remaining, found } = extractBareFlagPart(parts, "trim");
+	return { remaining, trim: found };
 }
 
 function hasRecognizedOption(part: string, allowName: boolean): boolean {
@@ -197,6 +208,7 @@ function parseOptions(
 	let inputTypeOverride: string | undefined;
 	let displayValuesRaw: string | undefined;
 	let optionalExplicit: boolean | undefined;
+	let trimExplicit: boolean | undefined;
 	let name: string | undefined;
 	let multiSelect = false;
 	let multiEmit: MultiEmit | undefined;
@@ -226,6 +238,9 @@ function parseOptions(
 				break;
 			case "case":
 				if (value) caseStyle = value;
+				break;
+			case "trim":
+				trimExplicit = parseBooleanFlag(value);
 				break;
 			case "default":
 				defaultValue = value;
@@ -271,6 +286,7 @@ function parseOptions(
 		inputTypeOverride,
 		displayValuesRaw,
 		optionalExplicit,
+		trimExplicit,
 		multiSelect,
 		multiEmit,
 	};
@@ -424,13 +440,16 @@ export function parseValueToken(
 		.filter(Boolean);
 	const hasOptions = suggestedValues.length > 1;
 
-	const { remaining: optionParts, optional: bareOptional } =
+	const { remaining: withoutOptional, optional: bareOptional } =
 		extractBareOptionalFlag(parts);
+	const { remaining: optionParts, trim: bareTrim } =
+		extractBareTrimFlag(withoutOptional);
 	const options = parseOptions(optionParts, hasOptions, true, quiet);
 	let { label, caseStyle, defaultValue, allowCustomInput } = options;
 	let multiSelect = options.multiSelect ?? false;
 	const multiEmit: MultiEmit = options.multiEmit ?? "text";
 	const optional = options.optionalExplicit ?? bareOptional;
+	let trim = options.trimExplicit ?? bareTrim;
 
 	if (!options.usesOptions) {
 		const legacyDefault = defaultValue;
@@ -522,6 +541,13 @@ export function parseValueToken(
 			);
 		caseStyle = undefined;
 	}
+	if (multiSelect && trim) {
+		if (!quiet)
+			console.warn(
+				`QuickAdd: |trim is ignored with |multi in "${tokenDisplay}" — a list is not string-transformed.`,
+			);
+		trim = false;
+	}
 
 	const variableKey = aliasName
 		? aliasName
@@ -534,6 +560,7 @@ export function parseValueToken(
 		variableKey,
 		label,
 		caseStyle,
+		trim,
 		defaultValue,
 		allowCustomInput,
 		suggestedValues,
@@ -551,6 +578,7 @@ export function parseAnonymousValueOptions(
 ): {
 	label?: string;
 	caseStyle?: string;
+	trim: boolean;
 	defaultValue: string;
 	inputTypeOverride?: ValueInputType;
 	optional: boolean;
@@ -560,11 +588,13 @@ export function parseAnonymousValueOptions(
 		.map((part) => part.trim())
 		.filter(Boolean);
 
-	const { remaining: parts, optional: bareOptional } =
+	const { remaining: withoutOptional, optional: bareOptional } =
 		extractBareOptionalFlag(allParts);
+	const { remaining: parts, trim: bareTrim } =
+		extractBareTrimFlag(withoutOptional);
 
 	if (parts.length === 0) {
-		return { defaultValue: "", optional: bareOptional };
+		return { defaultValue: "", optional: bareOptional, trim: bareTrim };
 	}
 
 	const options = parseOptions(parts, false, false);
@@ -588,6 +618,7 @@ export function parseAnonymousValueOptions(
 	return {
 		label,
 		caseStyle,
+		trim: options.trimExplicit ?? bareTrim,
 		defaultValue,
 		inputTypeOverride,
 		optional: options.optionalExplicit ?? bareOptional,


### PR DESCRIPTION
Add an explicit `|trim` VALUE option so users can render captured input without leading/trailing whitespace when that value is used in note names, links, or other whitespace-sensitive locations.

The underlying problem in #685 is not that QuickAdd needs another top-level placeholder; it is that mobile/keyboard input can accidentally include surrounding spaces, and using raw `{{VALUE}}` in a capture target can create a different note path than intended. This keeps `{{VALUE}}` fully backwards-compatible and makes trimming opt-in per token:

- `{{VALUE|trim}}` / `{{NAME|trim}}`
- `{{VALUE:title|trim}}`
- composition with existing transforms, e.g. `{{VALUE:title|trim|case:slug}}`

Alternatives considered:

- `{{TRIMMEDVALUE}}`: rejected because it duplicates the VALUE grammar and does not generalize to named VALUE tokens or existing pipe options.
- Auto-trimming all capture values: rejected because users may intentionally capture surrounding whitespace or want raw and trimmed forms in the same format.
- Capture-only setting: rejected because the formatter already has per-token transform syntax and this is useful anywhere VALUE syntax is used.

Implementation notes:

- `|trim` is a render transform only; cached/stored variables remain raw, so `{{VALUE:title}}` and `{{VALUE:title|trim}}` can be used together.
- Trim is applied before `|case:` and before YAML property collection sees transformed string values.
- `|trim:false` is accepted for shared-snippet override consistency.
- `|trim` is ignored with `|multi` arrays, matching the existing `|case` guard.
- Because `trim` is now a reserved bare flag, a literal default value of `trim` should use `|default:trim`.

Live Obsidian validation, isolated worktree vault:

- Built and provisioned with `pnpm run build` and `pnpm run provision:e2e-vault`.
- Reproduced current behavior: capture target `__qa_685/plain/{{VALUE}}` with `value="  Mobile Title  "` created `__qa_685/plain/  Mobile Title.md` and body `Plain:   Mobile Title  `.
- Verified fix: capture target `__qa_685/trim/{{VALUE|trim}}` with the same value created `__qa_685/trim/Mobile Title.md` while body output showed raw `{{VALUE}}`, trimmed `{{VALUE|trim}}`, and `{{VALUE|trim|case:slug}}` as expected.
- Verified named value path: `{{VALUE:title|trim}}` created `__qa_685/named/Named Title.md` while raw `{{VALUE:title}}` still preserved spaces.
- `pnpm run obsidian:e2e -- dev:errors` reported no captured runtime errors.

Validation:

- `pnpm run build`
- `pnpm run provision:e2e-vault`
- `pnpm run obsidian:e2e -- plugin:reload id=quickadd`
- `pnpm run obsidian:e2e -- quickadd:run ...` for plain, trimmed, and named trimmed capture choices
- `pnpm run obsidian:e2e -- dev:errors`
- `pnpm run lint`
- `pnpm run check` (0 errors, existing 4 warnings)
- `pnpm test` (225 files passed, 5 skipped; 2648 tests passed, 37 skipped)
- `pnpm run build-with-lint`

Fixes #685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `trim` modifier for `VALUE` and variable tokens (including file-name contexts) to strip leading/trailing whitespace (e.g., `{{VALUE|trim}}`, `{{VALUE:<name>|trim}}`).
  * `trim` is applied per token and no longer affects stored underlying values.
  * `trim` composes with case transformations and runs before `case` (e.g., `trim|case:slug`).

* **Documentation**
  * Updated format syntax docs to clarify default handling rules and the `trim`/`optional` reserved-flag behavior, plus `multi` compatibility notes.

* **Tests / Bug Fixes**
  * Improved parsing and added coverage to ensure `trim` isn’t treated as a legacy default and behaves correctly across token types and non-string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->