### PR TITLE
feat: support clipboard images in captures

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -415,6 +415,8 @@ Example: `> {{selected}}`.
 
 The current clipboard content. Will be empty if clipboard access fails due to permissions or security restrictions.
 
+In Capture choices, if the clipboard has no text but contains an image, QuickAdd saves the image using Obsidian's attachment location settings and inserts an embedded attachment link. If the clipboard has text, the text is used.
+
 Example: `Copied: {{CLIPBOARD}}`.
 
 ## `{{RANDOM:<length>}}` {#random}

--- a/src/formatters/captureChoiceFormatter-clipboard.test.ts
+++ b/src/formatters/captureChoiceFormatter-clipboard.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory() {
+			return { Prompt: vi.fn().mockResolvedValue("") };
+		}
+	},
+}));
+
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: class {},
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../utils/errorUtils", () => ({
+	__esModule: true,
+	reportError: vi.fn(),
+}));
+
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+	},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+const createTFile = (path: string): TFile => {
+	const name = path.split("/").pop() ?? path;
+	return {
+		path,
+		name,
+		basename: name.replace(/\.[^.]+$/, ""),
+		extension: name.includes(".") ? name.split(".").pop() : "",
+	} as unknown as TFile;
+};
+
+function createMockApp() {
+	const createBinary = vi.fn(async (path: string) => createTFile(path));
+	const getAvailablePathForAttachment = vi.fn(async () => "Assets/clip.png");
+	const generateMarkdownLink = vi.fn((file: TFile) => `[[${file.path}]]`);
+	const app = {
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(null),
+		},
+		metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		fileManager: {
+			generateMarkdownLink,
+			getAvailablePathForAttachment,
+			processFrontMatter: vi.fn(),
+		},
+		vault: {
+			adapter: { exists: vi.fn() },
+			cachedRead: vi.fn(),
+			createBinary,
+		},
+	} as unknown as App;
+
+	return { app, createBinary, getAvailablePathForAttachment, generateMarkdownLink };
+}
+
+function createFormatter(app: App) {
+	const plugin = {
+		settings: {
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+			showCaptureNotification: false,
+		},
+	};
+	return new CaptureChoiceFormatter(app, plugin as never);
+}
+
+describe("CaptureChoiceFormatter clipboard image support", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+		(globalThis as typeof globalThis & { navigator: Navigator }).navigator = {
+			clipboard: {
+				readText: vi.fn().mockResolvedValue(""),
+			},
+		} as unknown as Navigator;
+	});
+
+	it("keeps text clipboard behavior ahead of image attachment fallback", async () => {
+		const { app, createBinary } = createMockApp();
+		const read = vi.fn().mockResolvedValue([
+			{
+				types: ["image/png"],
+				getType: vi.fn(),
+			},
+		]);
+		(globalThis.navigator.clipboard as Clipboard & { read: typeof read }).read =
+			read;
+		vi.mocked(globalThis.navigator.clipboard.readText).mockResolvedValue(
+			"copied text",
+		);
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		const result = await formatter.formatContentOnly("Copied: {{clipboard}}");
+
+		expect(result).toBe("Copied: copied text");
+		expect(read).not.toHaveBeenCalled();
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("saves an image-only clipboard as one attachment and inserts an embed", async () => {
+		vi.setSystemTime(new Date("2026-06-17T10:11:12Z"));
+		const { app, createBinary, generateMarkdownLink, getAvailablePathForAttachment } =
+			createMockApp();
+		const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+		(globalThis.navigator.clipboard as Clipboard & {
+			read: () => Promise<ClipboardItem[]>;
+		}).read = vi.fn().mockResolvedValue([
+			{
+				types: ["image/png"],
+				getType: vi.fn().mockResolvedValue(blob),
+			},
+		] as unknown as ClipboardItem[]);
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		const result = await formatter.formatContentOnly(
+			"One {{clipboard}} Two {{clipboard}}",
+		);
+
+		expect(result).toBe("One ![[Assets/clip.png]] Two ![[Assets/clip.png]]");
+		expect(getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/^Clipboard image \d{4}-\d{2}-\d{2} \d{2}\.\d{2}\.\d{2}\.png$/,
+			),
+			"Notes/Clip.md",
+		);
+		expect(createBinary).toHaveBeenCalledTimes(1);
+		expect(createBinary).toHaveBeenCalledWith(
+			"Assets/clip.png",
+			expect.any(ArrayBuffer),
+		);
+		expect(generateMarkdownLink).toHaveBeenCalledWith(
+			expect.objectContaining({ path: "Assets/clip.png" }),
+			"Notes/Clip.md",
+		);
+	});
+
+	it("inserts clipboard text literally when it contains the clipboard token", async () => {
+		const { app } = createMockApp();
+		vi.mocked(globalThis.navigator.clipboard.readText).mockResolvedValue(
+			"{{clipboard}}",
+		);
+		const formatter = createFormatter(app);
+
+		const result = await formatter.formatContentOnly("A {{clipboard}} B");
+
+		expect(result).toBe("A {{clipboard}} B");
+	});
+
+	it("falls back to empty when image clipboard read is unavailable", async () => {
+		const { app, createBinary } = createMockApp();
+		const formatter = createFormatter(app);
+
+		const result = await formatter.formatContentOnly("[{{clipboard}}]");
+
+		expect(result).toBe("[]");
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+});

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -30,6 +30,14 @@ import { parentFolderPath } from "../utils/pathUtils";
 	* dropped, even though String.prototype.trim() strips them (issue #760).
 	*/
 const ASCII_WHITESPACE_ONLY_REGEX = /^[ \t\r\n\f\v]*$/;
+const IMAGE_CLIPBOARD_MIME_EXTENSIONS: Record<string, string> = {
+	"image/png": "png",
+	"image/jpeg": "jpg",
+	"image/jpg": "jpg",
+	"image/gif": "gif",
+	"image/webp": "webp",
+	"image/svg+xml": "svg",
+};
 
 function isCaptureContentEmpty(content: string): boolean {
 	return ASCII_WHITESPACE_ONLY_REGEX.test(content);
@@ -41,6 +49,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	private fileContent = "";
 	private sourcePath: string | null = null;
 	private useSelectionAsCaptureValue = true;
+	private clipboardAttachmentLink: string | null | undefined;
 	/**
 		* Tracks whether the current formatter instance has already run Templater on the
 		* capture payload.  This prevents the same content from being parsed twice in
@@ -127,6 +136,78 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 	protected getLinkSourcePath(): string | null {
 		return this.sourcePath ?? this.file?.path ?? null;
+	}
+
+	protected async getClipboardContent(): Promise<string> {
+		const text = await super.getClipboardContent();
+		if (text.length > 0) return text;
+
+		if (this.clipboardAttachmentLink !== undefined) {
+			return this.clipboardAttachmentLink ?? "";
+		}
+
+		this.clipboardAttachmentLink = await this.saveClipboardImageAsAttachment();
+		return this.clipboardAttachmentLink ?? "";
+	}
+
+	private async saveClipboardImageAsAttachment(): Promise<string | null> {
+		const clipboard = navigator.clipboard as Clipboard & {
+			read?: () => Promise<ClipboardItem[]>;
+		};
+		if (typeof clipboard?.read !== "function") {
+			return null;
+		}
+
+		try {
+			const item = await this.getFirstClipboardImageItem(clipboard);
+			if (!item) return null;
+
+			const blob = await item.clipboardItem.getType(item.mimeType);
+			const extension = IMAGE_CLIPBOARD_MIME_EXTENSIONS[item.mimeType];
+			const filename = `Clipboard image ${this.formatAttachmentTimestamp(new Date())}.${extension}`;
+			const attachmentPath =
+				await this.app.fileManager.getAvailablePathForAttachment(
+					filename,
+					this.getLinkSourcePath() ?? undefined,
+				);
+			const file = await this.app.vault.createBinary(
+				attachmentPath,
+				await blob.arrayBuffer(),
+			);
+			const link = this.app.fileManager.generateMarkdownLink(
+				file,
+				this.getLinkSourcePath() ?? "",
+			);
+
+			return link.startsWith("!") ? link : `!${link}`;
+		} catch {
+			return null;
+		}
+	}
+
+	private async getFirstClipboardImageItem(clipboard: {
+		read: () => Promise<ClipboardItem[]>;
+	}): Promise<{ clipboardItem: ClipboardItem; mimeType: string } | null> {
+		const items = await clipboard.read();
+		for (const clipboardItem of items) {
+			const mimeType = clipboardItem.types.find(
+				(type) => IMAGE_CLIPBOARD_MIME_EXTENSIONS[type] !== undefined,
+			);
+			if (mimeType) {
+				return { clipboardItem, mimeType };
+			}
+		}
+
+		return null;
+	}
+
+	private formatAttachmentTimestamp(date: Date): string {
+		const pad = (value: number) => String(value).padStart(2, "0");
+		return [
+			date.getFullYear(),
+			pad(date.getMonth() + 1),
+			pad(date.getDate()),
+		].join("-") + ` ${pad(date.getHours())}.${pad(date.getMinutes())}.${pad(date.getSeconds())}`;
 	}
 
 	protected getCurrentFileLink(): string | null {

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -291,15 +291,9 @@ export abstract class Formatter {
 	}
 
 	protected async replaceClipboardInString(input: string): Promise<string> {
-		let output: string = input;
-
 		const clipboardContent = await this.getClipboardContent();
-
-		while (CLIPBOARD_REGEX.test(output)) {
-			output = this.replacer(output, CLIPBOARD_REGEX, clipboardContent);
-		}
-
-		return output;
+		const regex = new RegExp(CLIPBOARD_REGEX.source, "gi");
+		return input.replace(regex, () => clipboardContent);
 	}
 
 


### PR DESCRIPTION
Add image fallback support for `{{clipboard}}` in Capture choice content.

The underlying problem is that users can capture text from the clipboard but cannot capture an image-only clipboard into an Obsidian note. This keeps the existing token instead of adding a one-off image token because the user intent is still “insert clipboard contents.” To preserve compatibility, clipboard text continues to win; only when the clipboard text is empty does QuickAdd look for a supported image item.

Design notes:
- Scoped to `CaptureChoiceFormatter`, so templates, file names, previews, API formatting, and macro formatting remain text-only and side-effect free.
- Uses Obsidian’s `getAvailablePathForAttachment()` and `vault.createBinary()` so attachment folder settings and filename de-duping stay native.
- Reuses one saved attachment link for repeated `{{clipboard}}` tokens in a single capture run.
- Makes clipboard token replacement single-pass so clipboard text containing `{{clipboard}}` is inserted literally instead of being re-expanded.

Validation:
- Reproduced issue in this worktree’s isolated Obsidian vault: image-only clipboard produced `Copied: ` and no attachment.
- Verified fix in the same isolated vault: image-only clipboard produced `Copied: ![[Clipboard image 2026-06-17 20.35.48.png]]` and created the PNG attachment.
- Verified text clipboard still produces `Copied: plain text after fix` and does not read image data when text exists.
- `pnpm run obsidian:e2e -- dev:errors` -> no errors captured.
- `pnpm run check` -> 0 errors, existing 4 warnings.
- `pnpm test` -> 2643 passed, 37 skipped.
- `pnpm run build-with-lint` -> passed.

Fixes #1161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Clipboard images are now supported. When using the `{{CLIPBOARD}}` token with an image in your clipboard, it is automatically saved as an attachment and embedded in your note. Text content takes precedence if both are available.

* **Documentation**
  * Updated `{{CLIPBOARD}}` token documentation to reflect image capture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->