### PR TITLE
fix: sanitize generated note paths

### DIFF
--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -483,6 +483,32 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(resolved).toBe("Inbox/note.md");
 	});
 
+	it("collapses newlines in generated capture target file names", async () => {
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "Inbox/This is the VALUE\n" }),
+			createExecutor(),
+		);
+
+		const resolved = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(resolved).toBe("Inbox/This is the VALUE.md");
+	});
+
+	it("collapses newlines before an explicit capture target extension", async () => {
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "Inbox/This is the VALUE\n.md" }),
+			createExecutor(),
+		);
+
+		const resolved = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(resolved).toBe("Inbox/This is the VALUE.md");
+	});
+
 	it("orders the folder picker by recency and gates the create row when enabled", async () => {
 		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([
 			{ path: "Inbox/Apple.md", basename: "Apple" },

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -50,6 +50,7 @@ import type { FieldFilter } from "../utils/FieldSuggestionParser";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
+import { normalizeGeneratedFilePath } from "../utils/pathValidation";
 import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
 import {
 	postProcessFrontMatter,
@@ -1138,16 +1139,19 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	}
 
 	private normalizeCaptureFilePath(path: string): string {
-		const normalizedPath = this.stripLeadingSlash(path);
+		const extensionMatch = path.match(/\.(md|canvas)$/i);
+		const extensionlessPath = this.stripLeadingSlash(path)
+			.replace(MARKDOWN_FILE_EXTENSION_REGEX, "")
+			.replace(CANVAS_FILE_EXTENSION_REGEX, "");
+		const normalizedPath = normalizeGeneratedFilePath(extensionlessPath);
 		if (BASE_FILE_EXTENSION_REGEX.test(normalizedPath)) {
 			throw new ChoiceAbortError(
 				`Capture to '.base' files is not supported (${normalizedPath}). Use a Template choice instead.`,
 			);
 		}
 		const finalPath =
-			MARKDOWN_FILE_EXTENSION_REGEX.test(normalizedPath) ||
-			CANVAS_FILE_EXTENSION_REGEX.test(normalizedPath)
-				? normalizedPath
+			extensionMatch
+				? `${normalizedPath}${extensionMatch[0]}`
 				: this.normalizeMarkdownFilePath("", normalizedPath);
 
 		// A formatted target like 'notes/.md' has no usable file name (e.g. an

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -667,6 +667,70 @@ describe("TemplateChoiceEngine destination path resolution", () => {
 		);
 	});
 
+	it("collapses newlines in generated note names before creating files", async () => {
+		const { engine } = createEngine("ignored", {
+			throwDuringFileName: false,
+			stubTemplateContent: true,
+		});
+		const createdFile = new TFile();
+		const createSpy = vi
+			.spyOn(
+				engine as unknown as {
+					createFileWithTemplate: (
+						filePath: string,
+						templatePath: string,
+					) => Promise<TFile | null>;
+				},
+				"createFileWithTemplate",
+			)
+			.mockResolvedValue(createdFile);
+
+		engine.choice.folder.enabled = false;
+		engine.choice.fileNameFormat.enabled = true;
+		engine.choice.fileNameFormat.format = "{{VALUE:name}}";
+
+		formatFileNameMock.mockResolvedValueOnce("This is the VALUE\n");
+
+		await engine.run();
+
+		expect(createSpy).toHaveBeenCalledWith(
+			"This is the VALUE.md",
+			engine.choice.templatePath,
+		);
+	});
+
+	it("collapses control characters within generated subpaths", async () => {
+		const { engine } = createEngine("ignored", {
+			throwDuringFileName: false,
+			stubTemplateContent: true,
+		});
+		const createdFile = new TFile();
+		const createSpy = vi
+			.spyOn(
+				engine as unknown as {
+					createFileWithTemplate: (
+						filePath: string,
+						templatePath: string,
+					) => Promise<TFile | null>;
+				},
+				"createFileWithTemplate",
+			)
+			.mockResolvedValue(createdFile);
+
+		engine.choice.folder.enabled = false;
+		engine.choice.fileNameFormat.enabled = true;
+		engine.choice.fileNameFormat.format = "{{VALUE:path}}";
+
+		formatFileNameMock.mockResolvedValueOnce("Projects/This\r\n\tNote");
+
+		await engine.run();
+
+		expect(createSpy).toHaveBeenCalledWith(
+			"Projects/This Note.md",
+			engine.choice.templatePath,
+		);
+	});
+
 	it("keeps relative subpaths under the default location when the first segment does not exist at vault root", async () => {
 		const { engine, app } = createEngine("ignored", {
 			throwDuringFileName: false,

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -31,6 +31,7 @@ import {
 	INVALID_FOLDER_CONTROL_CHARS_REGEX,
 	INVALID_FOLDER_TRAILING_CHARS_REGEX,
 	isReservedWindowsDeviceName,
+	normalizeGeneratedFilePath,
 } from "../utils/pathValidation";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { UserCancelError } from "../errors/UserCancelError";
@@ -511,10 +512,12 @@ export abstract class TemplateEngine extends QuickAddEngine {
 		const safeFolderPath = this.stripLeadingSlash(folderPath);
 		const actualFolderPath: string = safeFolderPath ? `${safeFolderPath}/` : "";
 		const extension = this.getTemplateExtension(templatePath);
-		const formattedFileName: string = this.stripLeadingSlash(fileName)
-			.replace(MARKDOWN_FILE_EXTENSION_REGEX, "")
-			.replace(CANVAS_FILE_EXTENSION_REGEX, "")
-			.replace(BASE_FILE_EXTENSION_REGEX, "");
+		const formattedFileName: string = normalizeGeneratedFilePath(
+			this.stripLeadingSlash(fileName)
+				.replace(MARKDOWN_FILE_EXTENSION_REGEX, "")
+				.replace(CANVAS_FILE_EXTENSION_REGEX, "")
+				.replace(BASE_FILE_EXTENSION_REGEX, ""),
+		);
 		// Validate the final path segment, not just the whole string — a
 		// trailing-slash name like "Projects/" (optional leaf token left
 		// empty) would otherwise still produce "Projects/.md".

--- a/src/utils/pathValidation.ts
+++ b/src/utils/pathValidation.ts
@@ -6,6 +6,10 @@ export const INVALID_FOLDER_CONTROL_CHARS_REGEX = new RegExp(
 	`[${String.fromCharCode(0x00)}-${String.fromCharCode(0x1f)}]`,
 	"u",
 );
+const INVALID_FOLDER_CONTROL_CHARS_RUN_REGEX = new RegExp(
+	`${INVALID_FOLDER_CONTROL_CHARS_REGEX.source}+`,
+	"gu",
+);
 export const INVALID_FOLDER_CHARS_REGEX = /[\\/:*?"<>|]/u;
 export const INVALID_FOLDER_TRAILING_CHARS_REGEX = /[. ]$/u;
 
@@ -36,4 +40,17 @@ export const RESERVED_WINDOWS_DEVICE_NAMES = new Set([
 
 export function isReservedWindowsDeviceName(name: string): boolean {
 	return RESERVED_WINDOWS_DEVICE_NAMES.has(name.toUpperCase());
+}
+
+export function normalizeGeneratedFilePath(path: string): string {
+	return path
+		.split("/")
+		.map((segment) => {
+			const normalized = segment.replace(
+				INVALID_FOLDER_CONTROL_CHARS_RUN_REGEX,
+				" ",
+			);
+			return normalized === segment ? segment : normalized.trim();
+		})
+		.join("/");
 }


### PR DESCRIPTION
Fixes #221

QuickAdd could create notes whose generated file name contained hidden newline/control characters when a value used in a Template or Capture destination came from a multi-line prompt or another variable source. Obsidian can create those files, but links and heading/block resolution become unreliable because the visible note title does not match the actual path.

This fixes the invariant at the file-path boundary instead of changing VALUE prompt semantics: generated Template and Capture note paths now collapse C0 control-character runs inside path segments before checking collisions or creating files. Normal path separators are still preserved, and explicit `.md` / `.canvas` capture suffixes are handled after normalizing the generated stem so `{{VALUE}}.md` with a trailing newline becomes `Value.md`, not `Value .md`.

I considered making Enter submit for all filename prompts, but single-line prompts already do that and multi-line VALUE prompts are valid for note bodies and captures. Path normalization protects CLI, URI, script, global-variable, and prompt-driven inputs consistently without narrowing `{{VALUE}}` globally.

Validation evidence:
- Reproduced current bug in this worktree's isolated Obsidian vault: newline input created `qa-issue-221-before/This is the VALUE\n.md`.
- Verified fix live after reload: the same Template input created `qa-issue-221-after/This is the VALUE.md` with no runtime errors.
- Verified final bundle live: Template `Template {{VALUE}}` and Capture `Capture {{VALUE}}.md` both created normal `Name.md` paths from `Name\n`; `dev:errors` reported no errors.
- `pnpm run lint`
- `pnpm run check` (0 errors, existing 4 warnings)
- `pnpm test`
- `pnpm run build-with-lint`

No settings migration or user-facing docs change is needed; this only prevents QuickAdd from committing invalid hidden-control-character note paths.