### PR TITLE
fix(capture): keep cursor at active-file capture position

### DIFF
--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { App, EditorPosition } from "obsidian";
+import { appendToCurrentLine, insertOnNewLine } from "./editorInsertion";
+
+class TextEditor {
+	private value: string;
+	private cursor: EditorPosition;
+
+	constructor(value: string, cursor: EditorPosition) {
+		this.value = value;
+		this.cursor = { ...cursor };
+	}
+
+	getValue(): string {
+		return this.value;
+	}
+
+	getCursor(): EditorPosition {
+		return { ...this.cursor };
+	}
+
+	setCursor(position: EditorPosition): void {
+		this.cursor = { ...position };
+	}
+
+	getLine(line: number): string {
+		return this.value.split("\n")[line] ?? "";
+	}
+
+	posToOffset(position: EditorPosition): number {
+		const lines = this.value.split("\n");
+		let offset = 0;
+		for (let line = 0; line < position.line; line++) {
+			offset += (lines[line]?.length ?? 0) + 1;
+		}
+		return offset + position.ch;
+	}
+
+	offsetToPos(offset: number): EditorPosition {
+		const bounded = Math.max(0, Math.min(offset, this.value.length));
+		const before = this.value.slice(0, bounded);
+		const lines = before.split("\n");
+		return {
+			line: lines.length - 1,
+			ch: lines[lines.length - 1]?.length ?? 0,
+		};
+	}
+
+	replaceSelection(text: string): void {
+		const offset = this.posToOffset(this.cursor);
+		this.value = `${this.value.slice(0, offset)}${text}${this.value.slice(offset)}`;
+		this.cursor = this.offsetToPos(offset + text.length);
+	}
+
+	replaceRange(text: string, position: EditorPosition): void {
+		const offset = this.posToOffset(position);
+		this.value = `${this.value.slice(0, offset)}${text}${this.value.slice(offset)}`;
+		this.cursor = this.offsetToPos(offset + text.length);
+	}
+}
+
+function appWithEditor(editor: TextEditor): App {
+	return {
+		workspace: {
+			getActiveViewOfType: () => ({ editor }),
+		},
+	} as unknown as App;
+}
+
+describe("editor insertion cursor preservation", () => {
+	it("keeps the cursor at the capture position after current-line insertion", () => {
+		const editor = new TextEditor("alpha beta", { line: 0, ch: 6 });
+
+		const inserted = appendToCurrentLine("CAPTURED ", appWithEditor(editor));
+
+		expect(inserted).toBe(true);
+		expect(editor.getValue()).toBe("alpha CAPTURED beta");
+		expect(editor.getCursor()).toEqual({ line: 0, ch: 6 });
+	});
+
+	it("keeps the cursor with the original text when inserting above", () => {
+		const editor = new TextEditor("alpha\nbeta", { line: 1, ch: 2 });
+
+		const inserted = insertOnNewLine("one\ntwo", "above", appWithEditor(editor));
+
+		expect(inserted).toBe(true);
+		expect(editor.getValue()).toBe("alpha\none\ntwo\nbeta");
+		expect(editor.getCursor()).toEqual({ line: 3, ch: 2 });
+	});
+
+	it("keeps the cursor in place when inserting below the current line", () => {
+		const editor = new TextEditor("alpha\nbeta", { line: 0, ch: 2 });
+
+		const inserted = insertOnNewLine("one\ntwo", "below", appWithEditor(editor));
+
+		expect(inserted).toBe(true);
+		expect(editor.getValue()).toBe("alpha\none\ntwo\nbeta");
+		expect(editor.getCursor()).toEqual({ line: 0, ch: 2 });
+	});
+});

--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -4,11 +4,14 @@ import { appendToCurrentLine, insertOnNewLine } from "./editorInsertion";
 
 class TextEditor {
 	private value: string;
-	private cursor: EditorPosition;
+	private selection: { anchor: EditorPosition; head: EditorPosition };
 
-	constructor(value: string, cursor: EditorPosition) {
+	constructor(value: string, cursor: EditorPosition, head: EditorPosition = cursor) {
 		this.value = value;
-		this.cursor = { ...cursor };
+		this.selection = {
+			anchor: { ...cursor },
+			head: { ...head },
+		};
 	}
 
 	getValue(): string {
@@ -16,11 +19,23 @@ class TextEditor {
 	}
 
 	getCursor(): EditorPosition {
-		return { ...this.cursor };
+		return { ...this.selection.head };
 	}
 
 	setCursor(position: EditorPosition): void {
-		this.cursor = { ...position };
+		this.selection = {
+			anchor: { ...position },
+			head: { ...position },
+		};
+	}
+
+	listSelections() {
+		return [
+			{
+				anchor: { ...this.selection.anchor },
+				head: { ...this.selection.head },
+			},
+		];
 	}
 
 	getLine(line: number): string {
@@ -47,15 +62,18 @@ class TextEditor {
 	}
 
 	replaceSelection(text: string): void {
-		const offset = this.posToOffset(this.cursor);
-		this.value = `${this.value.slice(0, offset)}${text}${this.value.slice(offset)}`;
-		this.cursor = this.offsetToPos(offset + text.length);
+		const anchorOffset = this.posToOffset(this.selection.anchor);
+		const headOffset = this.posToOffset(this.selection.head);
+		const from = Math.min(anchorOffset, headOffset);
+		const to = Math.max(anchorOffset, headOffset);
+		this.value = `${this.value.slice(0, from)}${text}${this.value.slice(to)}`;
+		this.setCursor(this.offsetToPos(from + text.length));
 	}
 
 	replaceRange(text: string, position: EditorPosition): void {
 		const offset = this.posToOffset(position);
 		this.value = `${this.value.slice(0, offset)}${text}${this.value.slice(offset)}`;
-		this.cursor = this.offsetToPos(offset + text.length);
+		this.setCursor(this.offsetToPos(offset + text.length));
 	}
 }
 
@@ -79,13 +97,13 @@ describe("editor insertion cursor preservation", () => {
 	});
 
 	it("keeps the cursor with the original text when inserting above", () => {
-		const editor = new TextEditor("alpha\nbeta", { line: 1, ch: 2 });
+		const editor = new TextEditor("alpha\nbravo", { line: 1, ch: 4 });
 
-		const inserted = insertOnNewLine("one\ntwo", "above", appWithEditor(editor));
+		const inserted = insertOnNewLine("x\ntwo", "above", appWithEditor(editor));
 
 		expect(inserted).toBe(true);
-		expect(editor.getValue()).toBe("alpha\none\ntwo\nbeta");
-		expect(editor.getCursor()).toEqual({ line: 3, ch: 2 });
+		expect(editor.getValue()).toBe("alpha\nx\ntwo\nbravo");
+		expect(editor.getCursor()).toEqual({ line: 3, ch: 4 });
 	});
 
 	it("keeps the cursor in place when inserting below the current line", () => {
@@ -96,5 +114,19 @@ describe("editor insertion cursor preservation", () => {
 		expect(inserted).toBe(true);
 		expect(editor.getValue()).toBe("alpha\none\ntwo\nbeta");
 		expect(editor.getCursor()).toEqual({ line: 0, ch: 2 });
+	});
+
+	it("does not override editor selection behavior for current-line replacement", () => {
+		const editor = new TextEditor(
+			"alpha beta",
+			{ line: 0, ch: 6 },
+			{ line: 0, ch: 10 },
+		);
+
+		const inserted = appendToCurrentLine("CAPTURED", appWithEditor(editor));
+
+		expect(inserted).toBe(true);
+		expect(editor.getValue()).toBe("alpha CAPTURED");
+		expect(editor.getCursor()).toEqual({ line: 0, ch: 14 });
 	});
 });

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -1,9 +1,28 @@
-import type { App, TFile } from "obsidian";
+import type { App, Editor, EditorPosition, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
 import { log } from "../logger/logManager";
 import type { AppendLinkOptions, LinkPlacement } from "../types/linkPlacement";
 import { placementSupportsEmbed } from "../types/linkPlacement";
 import { convertLinkToEmbed } from "./markdownLinks";
+
+function clonePosition(position: EditorPosition): EditorPosition {
+	return { line: position.line, ch: position.ch };
+}
+
+function restoreCursorAfterInsert(
+	editor: Editor,
+	originalCursor: EditorPosition,
+	insertOffset: number,
+	insertedText: string,
+): void {
+	const originalOffset = editor.posToOffset(originalCursor);
+	const restoredOffset =
+		originalOffset > insertOffset
+			? originalOffset + insertedText.length
+			: originalOffset;
+
+	editor.setCursor(editor.offsetToPos(restoredOffset));
+}
 
 /**
  * Returns the active markdown view if it is showing the given file,
@@ -32,7 +51,11 @@ export function appendToCurrentLine(toAppend: string, app: App): boolean {
 			return false;
 		}
 
-		activeView.editor.replaceSelection(toAppend);
+		const editor = activeView.editor;
+		const cursor = clonePosition(editor.getCursor());
+
+		editor.replaceSelection(toAppend);
+		editor.setCursor(cursor);
 		return true;
 	} catch {
 		log.logError(`unable to append '${toAppend}' to current line.`);
@@ -51,23 +74,23 @@ export function insertOnNewLine(toInsert: string, direction: "above" | "below", 
 		}
 
 		const editor = activeView.editor;
-		const cursor = editor.getCursor();
+		const cursor = clonePosition(editor.getCursor());
 		const lineNumber = cursor.line;
-		const insertedLines = toInsert.split("\n");
-		const insertedLineCount = insertedLines.length;
-		const lastInsertedLineLength =
-			insertedLines[insertedLineCount - 1]?.length ?? 0;
 		if (direction === "above") {
 			// Insert at the beginning of the current line, add content + newline
-			editor.replaceRange(toInsert + "\n", { line: lineNumber, ch: 0 });
-			// Move cursor to end of inserted content (before the newline)
-			editor.setCursor({ line: lineNumber + insertedLineCount - 1, ch: lastInsertedLineLength });
+			const insertPosition = { line: lineNumber, ch: 0 };
+			const insertedText = toInsert + "\n";
+			const insertOffset = editor.posToOffset(insertPosition);
+			editor.replaceRange(insertedText, insertPosition);
+			restoreCursorAfterInsert(editor, cursor, insertOffset, insertedText);
 		} else {
 			// Insert at the end of the current line, add newline + content
 			const currentLine = editor.getLine(lineNumber);
-			editor.replaceRange("\n" + toInsert, { line: lineNumber, ch: currentLine.length });
-			// Move cursor to end of inserted content
-			editor.setCursor({ line: lineNumber + insertedLineCount, ch: lastInsertedLineLength });
+			const insertPosition = { line: lineNumber, ch: currentLine.length };
+			const insertedText = "\n" + toInsert;
+			const insertOffset = editor.posToOffset(insertPosition);
+			editor.replaceRange(insertedText, insertPosition);
+			restoreCursorAfterInsert(editor, cursor, insertOffset, insertedText);
 		}
 		return true;
 	} catch {

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -11,17 +11,25 @@ function clonePosition(position: EditorPosition): EditorPosition {
 
 function restoreCursorAfterInsert(
 	editor: Editor,
-	originalCursor: EditorPosition,
+	originalOffset: number,
 	insertOffset: number,
 	insertedText: string,
 ): void {
-	const originalOffset = editor.posToOffset(originalCursor);
 	const restoredOffset =
 		originalOffset > insertOffset
 			? originalOffset + insertedText.length
 			: originalOffset;
 
 	editor.setCursor(editor.offsetToPos(restoredOffset));
+}
+
+function hasSingleCollapsedSelection(editor: Editor): boolean {
+	const selections = editor.listSelections();
+	return (
+		selections.length === 1 &&
+		selections[0].anchor.line === selections[0].head.line &&
+		selections[0].anchor.ch === selections[0].head.ch
+	);
 }
 
 /**
@@ -53,9 +61,12 @@ export function appendToCurrentLine(toAppend: string, app: App): boolean {
 
 		const editor = activeView.editor;
 		const cursor = clonePosition(editor.getCursor());
+		const shouldRestoreCursor = hasSingleCollapsedSelection(editor);
 
 		editor.replaceSelection(toAppend);
-		editor.setCursor(cursor);
+		if (shouldRestoreCursor) {
+			editor.setCursor(cursor);
+		}
 		return true;
 	} catch {
 		log.logError(`unable to append '${toAppend}' to current line.`);
@@ -75,6 +86,7 @@ export function insertOnNewLine(toInsert: string, direction: "above" | "below", 
 
 		const editor = activeView.editor;
 		const cursor = clonePosition(editor.getCursor());
+		const originalOffset = editor.posToOffset(cursor);
 		const lineNumber = cursor.line;
 		if (direction === "above") {
 			// Insert at the beginning of the current line, add content + newline
@@ -82,7 +94,7 @@ export function insertOnNewLine(toInsert: string, direction: "above" | "below", 
 			const insertedText = toInsert + "\n";
 			const insertOffset = editor.posToOffset(insertPosition);
 			editor.replaceRange(insertedText, insertPosition);
-			restoreCursorAfterInsert(editor, cursor, insertOffset, insertedText);
+			restoreCursorAfterInsert(editor, originalOffset, insertOffset, insertedText);
 		} else {
 			// Insert at the end of the current line, add newline + content
 			const currentLine = editor.getLine(lineNumber);
@@ -90,7 +102,7 @@ export function insertOnNewLine(toInsert: string, direction: "above" | "below", 
 			const insertedText = "\n" + toInsert;
 			const insertOffset = editor.posToOffset(insertPosition);
 			editor.replaceRange(insertedText, insertPosition);
-			restoreCursorAfterInsert(editor, cursor, insertOffset, insertedText);
+			restoreCursorAfterInsert(editor, originalOffset, insertOffset, insertedText);
 		}
 		return true;
 	} catch {

--- a/tests/e2e/capture-cursor-position.test.ts
+++ b/tests/e2e/capture-cursor-position.test.ts
@@ -99,7 +99,7 @@ async function seedChoices() {
 			}),
 			captureChoice({
 				id: `${TEST_PREFIX}above`,
-				content: "ABOVE-1\nABOVE-2",
+				content: "A\nABOVE-2",
 				newLineCapture: { enabled: true, direction: "above" },
 			}),
 			captureChoice({
@@ -212,14 +212,14 @@ describe("Capture active-file cursor position", () => {
 
 	it("keeps the cursor with the original line after inserting above", async () => {
 		const note = sandbox.path("above.md");
-		await openNoteAtCursor(note, "alpha\nbeta", { line: 1, ch: 2 });
+		await openNoteAtCursor(note, "alpha\nbravo", { line: 1, ch: 4 });
 
 		await runCapture(`${TEST_PREFIX}above`);
 
 		const result = await inspectEditor();
 		expect(result.activeFile).toBe(note);
-		expect(result.content).toBe("alpha\nABOVE-1\nABOVE-2\nbeta");
-		expect(result.cursor).toEqual({ line: 3, ch: 2 });
+		expect(result.content).toBe("alpha\nA\nABOVE-2\nbravo");
+		expect(result.cursor).toEqual({ line: 3, ch: 4 });
 	});
 
 	it("keeps the cursor in place after inserting below", async () => {

--- a/tests/e2e/capture-cursor-position.test.ts
+++ b/tests/e2e/capture-cursor-position.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	captureFailureArtifacts,
+	clearVaultRunLockMarker,
+	createSandboxApi,
+} from "obsidian-e2e";
+import type {
+	ObsidianClient,
+	PluginHandle,
+	SandboxApi,
+	VaultRunLock,
+} from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
+
+const PLUGIN_ID = "quickadd";
+const TEST_PREFIX = "__qa-capture-cursor-";
+const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
+
+let obsidian: ObsidianClient;
+let sandbox: SandboxApi;
+let qa: PluginHandle;
+let lock: VaultRunLock | undefined;
+
+type QuickAddData = {
+	choices: Record<string, unknown>[];
+};
+
+type CursorResult = {
+	activeFile: string | null;
+	content: string;
+	cursor: { line: number; ch: number };
+	selections: Array<{
+		anchor: { line: number; ch: number };
+		head: { line: number; ch: number };
+	}>;
+};
+
+function clearTestChoices(data: QuickAddData) {
+	data.choices = data.choices.filter(
+		(choice) => !String(choice.id ?? "").startsWith(TEST_PREFIX),
+	);
+}
+
+function captureChoice({
+	id,
+	content,
+	newLineCapture,
+}: {
+	id: string;
+	content: string;
+	newLineCapture?: { enabled: boolean; direction: "above" | "below" };
+}) {
+	return {
+		id,
+		name: id,
+		type: "Capture",
+		command: false,
+		captureTo: "",
+		captureToActiveFile: true,
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: false,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: true, format: content },
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: {
+			enabled: false,
+			after: "",
+			insertAtEnd: false,
+			considerSubsections: false,
+			createIfNotFound: false,
+			createIfNotFoundLocation: "",
+		},
+		newLineCapture: newLineCapture ?? { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: false,
+		},
+	};
+}
+
+async function seedChoices() {
+	await qa.data<QuickAddData>().patch((data) => {
+		clearTestChoices(data);
+		data.choices.push(
+			captureChoice({
+				id: `${TEST_PREFIX}current-line`,
+				content: "CAPTURED ",
+			}),
+			captureChoice({
+				id: `${TEST_PREFIX}above`,
+				content: "ABOVE-1\nABOVE-2",
+				newLineCapture: { enabled: true, direction: "above" },
+			}),
+			captureChoice({
+				id: `${TEST_PREFIX}below`,
+				content: "BELOW-1\nBELOW-2",
+				newLineCapture: { enabled: true, direction: "below" },
+			}),
+		);
+	});
+	await qa.reload();
+}
+
+async function openNoteAtCursor(
+	notePath: string,
+	content: string,
+	cursor: { line: number; ch: number },
+) {
+	await obsidian.dev.evalRaw(`(async () => {
+		window.__qaCaptureCursorReady = false;
+		const path = ${JSON.stringify(notePath)};
+		let file = app.vault.getAbstractFileByPath(path);
+		if (file) await app.vault.modify(file, ${JSON.stringify(content)});
+		else file = await app.vault.create(path, ${JSON.stringify(content)});
+		const leaf = app.workspace.getLeaf(false);
+		await leaf.openFile(file);
+		app.workspace.setActiveLeaf(leaf, { focus: true });
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		leaf.view.editor.setCursor(${JSON.stringify(cursor)});
+		window.__qaCaptureCursorReady = true;
+	})()`);
+
+	await obsidian.waitFor(
+		() => obsidian.dev.evalJson<boolean>("window.__qaCaptureCursorReady === true"),
+		WAIT_OPTS,
+	);
+}
+
+async function inspectEditor(): Promise<CursorResult> {
+	return await obsidian.dev.evalJson<CursorResult>(`(() => {
+		const view = app.workspace.activeLeaf.view;
+		return {
+			activeFile: app.workspace.getActiveFile()?.path ?? null,
+			content: view.editor.getValue(),
+			cursor: view.editor.getCursor(),
+			selections: view.editor.listSelections(),
+		};
+	})()`);
+}
+
+async function runCapture(choice: string) {
+	await obsidian.exec("quickadd:run", { choice });
+}
+
+beforeAll(async () => {
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
+	await lock.publishMarker(obsidian);
+
+	qa = obsidian.plugin(PLUGIN_ID);
+	sandbox = await createSandboxApi({
+		obsidian,
+		sandboxRoot: "__obsidian_e2e__",
+		testName: "capture-cursor-position",
+	});
+
+	await seedChoices();
+}, 60_000);
+
+afterAll(async () => {
+	const errors: unknown[] = [];
+
+	await qa?.restoreData?.().catch((error) => errors.push(error));
+	await qa?.reload?.().catch((error) => errors.push(error));
+	await sandbox?.cleanup?.().catch((error) => errors.push(error));
+	await (obsidian
+		? clearVaultRunLockMarker(obsidian).catch((error) => errors.push(error))
+		: undefined);
+	await lock?.release?.().catch((error) => errors.push(error));
+
+	if (errors.length > 0) {
+		throw errors[0];
+	}
+}, 30_000);
+
+beforeEach((ctx) => {
+	ctx.onTestFailed(async () => {
+		await captureFailureArtifacts(
+			{ id: ctx.task.id, name: ctx.task.name },
+			obsidian,
+			{ plugin: qa, captureOnFailure: true },
+		);
+	});
+});
+
+describe("Capture active-file cursor position", () => {
+	it("keeps the cursor at the capture position after current-line insertion", async () => {
+		const note = sandbox.path("current-line.md");
+		await openNoteAtCursor(note, "alpha beta", { line: 0, ch: 6 });
+
+		await runCapture(`${TEST_PREFIX}current-line`);
+
+		const result = await inspectEditor();
+		expect(result.activeFile).toBe(note);
+		expect(result.content).toBe("alpha CAPTURED beta");
+		expect(result.cursor).toEqual({ line: 0, ch: 6 });
+		expect(result.selections).toEqual([
+			{ anchor: { line: 0, ch: 6 }, head: { line: 0, ch: 6 } },
+		]);
+	});
+
+	it("keeps the cursor with the original line after inserting above", async () => {
+		const note = sandbox.path("above.md");
+		await openNoteAtCursor(note, "alpha\nbeta", { line: 1, ch: 2 });
+
+		await runCapture(`${TEST_PREFIX}above`);
+
+		const result = await inspectEditor();
+		expect(result.activeFile).toBe(note);
+		expect(result.content).toBe("alpha\nABOVE-1\nABOVE-2\nbeta");
+		expect(result.cursor).toEqual({ line: 3, ch: 2 });
+	});
+
+	it("keeps the cursor in place after inserting below", async () => {
+		const note = sandbox.path("below.md");
+		await openNoteAtCursor(note, "alpha\nbeta", { line: 0, ch: 2 });
+
+		await runCapture(`${TEST_PREFIX}below`);
+
+		const result = await inspectEditor();
+		expect(result.activeFile).toBe(note);
+		expect(result.content).toBe("alpha\nBELOW-1\nBELOW-2\nbeta");
+		expect(result.cursor).toEqual({ line: 0, ch: 2 });
+	});
+});


### PR DESCRIPTION
Fixes #348.

Active-file Capture insertions currently leave the editor cursor after the inserted capture text. That breaks the quick writing flow for users who capture a snippet and then want to keep typing or add a link at the original position without reaching for the mouse.

This keeps the change scoped to Capture modes that write through the active Markdown editor:

- current-line / at-cursor Capture restores the original collapsed cursor after inserting the capture text
- new-line-above Capture restores the cursor with the original line after the inserted block shifts it down
- new-line-below Capture keeps the cursor in its original position

I did not add a setting. The behavior is a bug fix for an existing placement mode rather than a new convention, and keeping the cursor at the capture position matches the user intent of “capture here, then continue here.” File append/prepend, insert-after/before, Canvas, open-file behavior, and link insertion behavior are left unchanged. Non-collapsed selections keep the editor default replacement behavior so this does not collapse or discard selection state for selection-based captures.

Implementation notes:

- Cursor restoration uses pre-insert editor offsets, then maps back to a position after mutation. That matters for multiline insertions, especially inserting above a line when the first inserted line is shorter than the cursor column.
- Unit tests cover current-line, above, below, multiline inserted content, and selected-text replacement behavior.
- E2E coverage drives real Obsidian through the isolated worktree vault for all three active-file Capture modes.

Validation:

- Reproduced current behavior in the isolated Obsidian vault before the fix: inserting `CAPTURED ` into `alpha beta` at cursor `0:6` produced `alpha CAPTURED beta` and moved the cursor to `0:15`.
- Verified after the fix in the isolated Obsidian vault: the same capture produces `alpha CAPTURED beta` and leaves the cursor at `0:6` with no captured runtime errors.
- `pnpm run build-with-lint`
- `pnpm run check` (0 errors, existing warnings only)
- `pnpm test`
- `eval "$(pnpm run start:e2e-obsidian -- --print-env | sed -n '/^export QUICKADD_E2E_/p')" && pnpm exec vitest run --config vitest.e2e.config.mts tests/e2e/capture-cursor-position.test.ts`

Docs: not updated; this is a behavior fix for existing Capture placement modes, with no new setting, syntax, or migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cursor position preservation when inserting captured content at the current line, above, or below in the editor.

* **Tests**
  * Added comprehensive unit tests for cursor and selection preservation during text insertion operations.
  * Added end-to-end test suite validating that QuickAdd Capture maintains stable editor cursor and selection positions across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->