### PR TITLE
feat(capture): support file-backed capture formats

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -429,6 +429,18 @@ If you do not enable this, QuickAdd will default to `{{VALUE}}`, which will inse
 
 You can use [format syntax](/FormatSyntax.md) here, which allows you to use dynamic values in your capture format.
 
+Long capture formats can live in a normal vault file. Put the body in a
+template file, then reference it from **Capture format**:
+
+```md
+{{TEMPLATE:Templates/Capture Body.md}}
+```
+
+QuickAdd renders that file as the capture body, so the file can still contain
+normal format syntax, inline `js quickadd` blocks, macros, and nested template
+includes. Use an explicit `.md`, `.canvas`, or `.base` extension in the
+`{{TEMPLATE:...}}` path.
+
 If you want to insert `.base` content into your current note, keep **Capture to active file** enabled and use a `.base` template token in the capture format. See [Capture: Insert a Related Notes Base into an MOC Note](/Examples/Capture_InsertBaseTemplateIntoActiveFile.md).
 If you want QuickAdd to create a brand new note that already contains an
 embedded Base, use a Template choice instead. See

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -336,6 +336,10 @@ Include templates in your `format`. Supports Templater syntax.
 
 Example: `{{TEMPLATE:Templates/Meeting.md}}`.
 
+The path must include an explicit `.md`, `.canvas`, or `.base` extension. In
+Capture format, this is the recommended way to keep a long capture body in an
+editable vault file.
+
 ## `{{GLOBAL_VAR:<name>}}` {#global-var}
 
 Inserts the value of a globally defined snippet from QuickAdd settings. Snippet values can include other QuickAdd tokens (e.g., `{{VALUE:...}}`, `{{VDATE:...}}`) and are processed by the usual formatter passes. The `GLOBAL_VAR` keyword itself is case‑insensitive, but the snippet name must match the name you defined (it is case‑sensitive).

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -134,7 +134,10 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 	{/snippet}
 </SettingItem>
 
-<SettingItem name="Capture format" desc="Set the format of the capture.">
+<SettingItem
+	name="Capture format"
+	desc="Set the format of the capture. Use the TEMPLATE format token to keep long capture bodies in a vault file."
+>
 	{#snippet control()}
 		<Toggle bind:checked={choice.format.enabled} />
 	{/snippet}

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -473,4 +473,41 @@ describe("collectChoiceRequirements - template path format syntax (issue #620)",
 		// Dynamic path → body not pre-read.
 		expect(getTemplateFileMock).not.toHaveBeenCalled();
 	});
+
+	it("collects tokens from templates included in Capture format", async () => {
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const templateFile = { path: "Templates/Capture Body.md" };
+		getTemplateFileMock.mockReturnValue(templateFile as any);
+		const appWithTemplate = {
+			vault: {
+				cachedRead: vi.fn(async () => "{{VALUE:fromFile}}"),
+			},
+		} as unknown as App;
+
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "Before {{TEMPLATE:Templates/Capture Body.md}} after",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			appWithTemplate,
+			{ settings: { inputPrompt: "single-line" } } as any,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(getTemplateFileMock).toHaveBeenCalledWith(
+			appWithTemplate,
+			"Templates/Capture Body.md",
+		);
+		expect(requirements).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: "fromFile" })]),
+		);
+	});
 });

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -193,6 +193,11 @@ async function collectForCaptureChoice(
 
 	if (choice.format?.enabled) {
 		await collector.scanString(choice.format.format);
+		const nested = [...collector.templatesToScan];
+		collector.templatesToScan.clear();
+		for (const ref of nested) {
+			await scanTemplateSource(app, collector, ref);
+		}
 	}
 
 	// Capture's "create file if it doesn't exist → with template" runs through

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -507,6 +507,35 @@ describe("buildPackage", () => {
 		expect(result.pkg.assets[0].originalPath).toBe("Templates/capture.md");
 	});
 
+	it("collects nested template includes from capture-template assets", async () => {
+		const capture = makeCaptureChoice(
+			"cap1",
+			"Capture",
+			"Templates/capture.md",
+		);
+		const { app } = makeFakeApp({
+			files: {
+				"Templates/capture.md": "capture {{TEMPLATE:Templates/footer.md}}",
+				"Templates/footer.md": "footer",
+			},
+		});
+
+		const result = await buildPackage(
+			app as never,
+			buildOptions({ choices: [capture], rootChoiceIds: ["cap1"] }),
+		);
+
+		expect(result.missingAssets).toHaveLength(0);
+		expect(result.pkg.assets.map((asset) => asset.originalPath)).toEqual([
+			"Templates/capture.md",
+			"Templates/footer.md",
+		]);
+		expect(result.pkg.assets.map((asset) => asset.kind)).toEqual([
+			"capture-template",
+			"capture-template",
+		]);
+	});
+
 	it("records missing assets when the file does not exist and does not encode them", async () => {
 		const template = makeTemplateChoice(
 			"t1",

--- a/src/services/packageExportService.ts
+++ b/src/services/packageExportService.ts
@@ -22,6 +22,7 @@ import {
 	detectUserScriptSecretOptions,
 	stripUserScriptSecretRefsFromChoice,
 } from "../utils/userScriptSecrets";
+import { TEMPLATE_REGEX } from "../constants";
 
 export interface BuildPackageOptions {
 	choices: IChoice[];
@@ -112,6 +113,17 @@ interface AssetDescriptor {
 	kind: QuickAddPackageAssetKind;
 }
 
+function collectTemplateInclusions(input: string): string[] {
+	const refs: string[] = [];
+	const re = new RegExp(TEMPLATE_REGEX.source, "gi");
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(input)) !== null) {
+		const path = match[1]?.trim();
+		if (path) refs.push(path);
+	}
+	return refs;
+}
+
 interface EncodedAssets {
 	encodedAssets: QuickAddPackageAsset[];
 	missingAssets: MissingAsset[];
@@ -154,8 +166,14 @@ async function encodeAssets(
 ): Promise<EncodedAssets> {
 	const encodedAssets: QuickAddPackageAsset[] = [];
 	const missingAssets: MissingAsset[] = [];
+	const queue = [...descriptors];
+	const queuedPaths = new Set(queue.map((descriptor) => descriptor.path));
+	const processedPaths = new Set<string>();
 
-	for (const { path, kind } of descriptors) {
+	for (let i = 0; i < queue.length; i += 1) {
+		const { path, kind } = queue[i];
+		if (processedPaths.has(path)) continue;
+		processedPaths.add(path);
 		try {
 			const exists = await app.vault.adapter.exists(path);
 			if (!exists) {
@@ -172,6 +190,17 @@ async function encodeAssets(
 				contentEncoding: "base64",
 				content: encodeToBase64(content),
 			});
+
+			if (kind === "template" || kind === "capture-template") {
+				for (const nestedPath of collectTemplateInclusions(content)) {
+					if (queuedPaths.has(nestedPath)) continue;
+					queuedPaths.add(nestedPath);
+					queue.push({
+						path: nestedPath,
+						kind: "capture-template",
+					});
+				}
+			}
 		} catch (error) {
 			missingAssets.push({ path, kind });
 			log.logWarning(

--- a/src/services/packagePreview.test.ts
+++ b/src/services/packagePreview.test.ts
@@ -648,6 +648,41 @@ describe("buildPackagePreview - files manifest, overwrites, orphans, captures", 
 		);
 	});
 
+	it("reports missing nested template includes from bundled capture templates", () => {
+		const capture = {
+			id: "cap1",
+			name: "Cap",
+			type: "Capture",
+			command: false,
+			captureTo: "Inbox.md",
+			captureToActiveFile: false,
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:templates/capture-body.md}}",
+			},
+		} as unknown as ICaptureChoice;
+		const pkg = makePackage(
+			[pkgChoice(capture, ["Cap"])],
+			[
+				asset(
+					"capture-template",
+					"templates/capture-body.md",
+					"{{TEMPLATE:templates/footer.md}}",
+				),
+			],
+		);
+
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+
+		expect(preview.missingReferences).toEqual([
+			expect.objectContaining({
+				path: "templates/footer.md",
+				asScript: false,
+				breadcrumb: "Cap › capture format template › template include",
+			}),
+		]);
+	});
+
 	it("flags an existing choice id as an overwrite", () => {
 		const m = macro("m1", "Existing", []);
 		const pkg = makePackage([pkgChoice(m, ["Existing"])]);
@@ -670,6 +705,58 @@ describe("collectReferencedAssetPaths", () => {
 		const pkg = makePackage([pkgChoice(m, ["Multi-ref"])]);
 		const paths = collectReferencedAssetPaths(pkg).sort();
 		expect(paths).toEqual(["scripts/a.js", "scripts/cond.js"]);
+	});
+
+	it("collects template inclusions from capture format", () => {
+		const capture = {
+			id: "cap1",
+			name: "Cap",
+			type: "Capture",
+			command: false,
+			captureTo: "Inbox.md",
+			captureToActiveFile: false,
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:templates/capture-body.md}}",
+			},
+		} as unknown as ICaptureChoice;
+		const pkg = makePackage([pkgChoice(capture, ["Cap"])]);
+
+		const paths = collectReferencedAssetPaths(pkg);
+
+		expect(paths).toEqual(["templates/capture-body.md"]);
+	});
+
+	it("collects nested template inclusions from bundled capture format templates", () => {
+		const capture = {
+			id: "cap1",
+			name: "Cap",
+			type: "Capture",
+			command: false,
+			captureTo: "Inbox.md",
+			captureToActiveFile: false,
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:templates/capture-body.md}}",
+			},
+		} as unknown as ICaptureChoice;
+		const pkg = makePackage(
+			[pkgChoice(capture, ["Cap"])],
+			[
+				asset(
+					"capture-template",
+					"templates/capture-body.md",
+					"{{TEMPLATE:templates/footer.md}}",
+				),
+			],
+		);
+
+		const paths = collectReferencedAssetPaths(pkg);
+
+		expect(paths).toEqual([
+			"templates/capture-body.md",
+			"templates/footer.md",
+		]);
 	});
 });
 

--- a/src/services/packagePreview.ts
+++ b/src/services/packagePreview.ts
@@ -17,7 +17,7 @@ import type {
 import { flattenChoices } from "../utils/choiceUtils";
 import { decodeFromBase64 } from "../utils/base64";
 import { extractScriptFromMarkdown } from "../utils/extractScriptFromMarkdown";
-import { MARKDOWN_FILE_EXTENSION_REGEX } from "../constants";
+import { MARKDOWN_FILE_EXTENSION_REGEX, TEMPLATE_REGEX } from "../constants";
 
 /**
  * Pure, App-free analysis of a QuickAdd package for the import preview.
@@ -362,6 +362,74 @@ function joinCrumb(parts: Array<string | undefined>): string {
 	return parts.filter((part): part is string => Boolean(part)).join(" › ");
 }
 
+function collectTemplateInclusions(input: string | undefined): string[] {
+	if (!input) return [];
+	const refs: string[] = [];
+	const re = new RegExp(TEMPLATE_REGEX.source, "gi");
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(input)) !== null) {
+		const path = match[1]?.trim();
+		if (path) refs.push(path);
+	}
+	return refs;
+}
+
+function expandBundledTemplateUsages(
+	pkg: QuickAddPackage,
+	usagesByPath: Map<string, PreviewUsageSite[]>,
+): void {
+	const assetsByPath = new Map(
+		pkg.assets.map((asset) => [asset.originalPath, asset]),
+	);
+	const queue = [...usagesByPath.keys()];
+	const scanned = new Set<string>();
+
+	for (let i = 0; i < queue.length; i += 1) {
+		const path = queue[i];
+		if (scanned.has(path)) continue;
+		scanned.add(path);
+
+		const asset = assetsByPath.get(path);
+		if (!asset) continue;
+		if (asset.kind !== "template" && asset.kind !== "capture-template") continue;
+
+		let content: string;
+		try {
+			content = decodeFromBase64(asset.content);
+		} catch {
+			continue;
+		}
+
+		const parentUsages = usagesByPath.get(path) ?? [];
+		for (const nestedPath of collectTemplateInclusions(content)) {
+			const existing = usagesByPath.get(nestedPath) ?? [];
+			const nestedUsages = parentUsages.map((usage) => ({
+				...usage,
+				path: nestedPath,
+				asScript: false,
+				impliedKind: "capture-template" as QuickAddPackageAssetKind,
+				breadcrumb: `${usage.breadcrumb} › template include`,
+			}));
+			usagesByPath.set(nestedPath, [...existing, ...nestedUsages]);
+			queue.push(nestedPath);
+		}
+	}
+}
+
+function collectUsagesByPath(pkg: QuickAddPackage): Map<string, PreviewUsageSite[]> {
+	const { choiceWalks } = walkPackage(pkg);
+	const usagesByPath = new Map<string, PreviewUsageSite[]>();
+	for (const walk of choiceWalks) {
+		for (const usage of walk.usages) {
+			const list = usagesByPath.get(usage.path) ?? [];
+			list.push(usage);
+			usagesByPath.set(usage.path, list);
+		}
+	}
+	expandBundledTemplateUsages(pkg, usagesByPath);
+	return usagesByPath;
+}
+
 function commandLabel(command: ICommand): string {
 	const name = command.name?.trim();
 	return name && name.length > 0 ? name : String(command.type);
@@ -492,6 +560,18 @@ function collectChoice(
 				impliedKind: "capture-template",
 				breadcrumb: joinCrumb([...crumbs, "new-file template"]),
 			});
+		}
+
+		if (choice.format?.enabled) {
+			for (const path of collectTemplateInclusions(choice.format.format)) {
+				walk.usages.push({
+					choiceId: walk.choiceId,
+					path,
+					asScript: false,
+					impliedKind: "capture-template",
+					breadcrumb: joinCrumb([...crumbs, "capture format template"]),
+				});
+			}
 		}
 	}
 
@@ -683,14 +763,7 @@ function collectCommands(
  * single vault pass.
  */
 export function collectReferencedAssetPaths(pkg: QuickAddPackage): string[] {
-	const { choiceWalks } = walkPackage(pkg);
-	const paths = new Set<string>();
-	for (const walk of choiceWalks) {
-		for (const usage of walk.usages) {
-			if (usage.path) paths.add(usage.path);
-		}
-	}
-	return Array.from(paths);
+	return Array.from(collectUsagesByPath(pkg).keys());
 }
 
 // Cheap decoded-size estimate (no decode). Assumes RFC 4648 base64 as produced
@@ -725,15 +798,7 @@ export function buildPackagePreview(
 		flattenChoices(existingChoices).map((choice) => choice.id),
 	);
 
-	// Index usage sites by referenced path.
-	const usagesByPath = new Map<string, PreviewUsageSite[]>();
-	for (const walk of choiceWalks) {
-		for (const usage of walk.usages) {
-			const list = usagesByPath.get(usage.path) ?? [];
-			list.push(usage);
-			usagesByPath.set(usage.path, list);
-		}
-	}
+	const usagesByPath = collectUsagesByPath(pkg);
 	const referencedAsScript = new Set<string>();
 	for (const [path, usages] of usagesByPath) {
 		if (usages.some((u) => u.asScript)) referencedAsScript.add(path);

--- a/src/utils/packageTraversal.test.ts
+++ b/src/utils/packageTraversal.test.ts
@@ -58,6 +58,7 @@ function makeCapture(
 	name: string,
 	createFileIfItDoesntExist?: ICaptureChoice["createFileIfItDoesntExist"],
 	id = uid("capture"),
+	format?: ICaptureChoice["format"],
 ): ICaptureChoice {
 	return {
 		id,
@@ -65,6 +66,7 @@ function makeCapture(
 		type: "Capture",
 		command: false,
 		createFileIfItDoesntExist,
+		format,
 	} as unknown as ICaptureChoice;
 }
 
@@ -660,6 +662,43 @@ describe("collectFileDependencies", () => {
 			"templates/cap.md",
 		]);
 		expect(result.templatePaths.size).toBe(0);
+	});
+
+	it("collects template inclusions from capture format", () => {
+		const cap = makeCapture(
+			"C",
+			undefined,
+			"c",
+			{
+				enabled: true,
+				format: "Before {{TEMPLATE:templates/capture-body.md}} after",
+			},
+		);
+		const { catalog, choiceIds } = closureFor([cap], ["c"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect([...result.captureTemplatePaths]).toEqual([
+			"templates/capture-body.md",
+		]);
+		expect(result.templatePaths.size).toBe(0);
+	});
+
+	it("ignores template inclusion tokens in disabled capture format", () => {
+		const cap = makeCapture(
+			"C",
+			undefined,
+			"c",
+			{
+				enabled: false,
+				format: "{{TEMPLATE:templates/ignored.md}}",
+			},
+		);
+		const { catalog, choiceIds } = closureFor([cap], ["c"]);
+
+		const result = collectFileDependencies(catalog, choiceIds);
+
+		expect(result.captureTemplatePaths.size).toBe(0);
 	});
 
 	it("does not collect a capture template when createFileIfItDoesntExist is disabled", () => {

--- a/src/utils/packageTraversal.ts
+++ b/src/utils/packageTraversal.ts
@@ -9,6 +9,7 @@ import type { IUserScript } from "../types/macros/IUserScript";
 import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
 import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
 import { CommandType } from "../types/macros/CommandType";
+import { TEMPLATE_REGEX } from "../constants";
 
 export interface ChoiceCatalogEntry {
 	choice: IChoice;
@@ -33,6 +34,18 @@ export interface FileDependencyCollection {
 }
 
 const EMPTY_SET = new Set<string>();
+
+function collectTemplateInclusions(input: string | undefined): string[] {
+	if (!input) return [];
+	const refs: string[] = [];
+	const re = new RegExp(TEMPLATE_REGEX.source, "gi");
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(input)) !== null) {
+		const path = match[1]?.trim();
+		if (path) refs.push(path);
+	}
+	return refs;
+}
 
 function isMultiChoice(choice: IChoice): choice is IMultiChoice {
 	return choice.type === "Multi";
@@ -352,6 +365,12 @@ export function collectFileDependencies(
 			choice.createFileIfItDoesntExist.template
 		) {
 			captureTemplatePaths.add(choice.createFileIfItDoesntExist.template);
+		}
+
+		if (isCaptureChoice(choice) && choice.format?.enabled) {
+			for (const path of collectTemplateInclusions(choice.format.format)) {
+				captureTemplatePaths.add(path);
+			}
 		}
 
 		if (isMultiChoice(choice) && Array.isArray(choice.choices)) {


### PR DESCRIPTION
Fixes #614

Capture format already had the right runtime primitive for this request: `{{TEMPLATE:path}}` can render a vault file through the same formatter pipeline as inline capture text. This PR makes that capability complete and discoverable instead of adding a second persisted “use template file” mode that would duplicate format syntax and complicate choice settings.

What changed:
- Documents the Capture-specific workflow for keeping long capture bodies in vault files with `{{TEMPLATE:Templates/Capture Body.md}}`.
- Updates the Capture form description so users can discover the TEMPLATE token from the setting itself.
- Preflights `{{TEMPLATE:...}}` files referenced from Capture format, so one-page input / CLI collection sees prompts inside the file-backed body.
- Includes Capture-format template files in package export and import preview, including nested `{{TEMPLATE:...}}` includes discovered inside bundled template assets.

Design tradeoffs:
- I did not add a new `Use template file` setting. The existing format token is more general: it works inline, can include multiple files, can nest, and preserves all Capture-specific positioning/target behavior.
- `{{TEMPLATE:...}}` still requires an explicit `.md`, `.canvas`, or `.base` extension because that is the current formatter contract. The docs now say this directly rather than broadening path resolution in a package/discoverability fix.

Validation:
- Reproduced the underlying issue in the current product shape: long Capture bodies can only be discovered as generic format syntax, and package traversal did not treat Capture-format template references as package assets.
- Live Obsidian validation in this worktree’s isolated vault:
  - `pnpm run build`
  - `pnpm run provision:e2e-vault`
  - Seeded `Templates/Capture Body.md` with `File-backed body: {{VALUE:topic}}`
  - Seeded a Capture choice whose format is `{{TEMPLATE:Templates/Capture Body.md}}`
  - Ran `pnpm run obsidian:e2e -- quickadd:run choice="Issue 614 Capture" value-topic="validated from file"`
  - Verified `Issue614 Target.md` contained `File-backed body: validated from file`
  - Verified `pnpm run obsidian:e2e -- dev:errors` reported `No errors captured`
- Automated gates:
  - `pnpm exec vitest run src/services/packageExportService.test.ts src/services/packagePreview.test.ts src/preflight/collectChoiceRequirements.test.ts src/utils/packageTraversal.test.ts`
  - `pnpm run check` (0 errors; existing warnings remain)
  - `pnpm test`
  - `pnpm run build-with-lint`

Notes for reviewers:
- Package export discovers nested template includes while reading template assets, not in pure choice traversal, because nested include discovery requires file contents.
- Import preview expands nested references only from bundled template assets; unbundled/missing template files cannot be inspected until they exist in the vault.
