### PR TITLE
feat: support text template source extensions

### DIFF
--- a/docs/docs/ApplyTemplateToNote.md
+++ b/docs/docs/ApplyTemplateToNote.md
@@ -20,7 +20,7 @@ You can also right-click a markdown file (in the file explorer, tab header, etc.
 
 The template runs through the full QuickAdd [format syntax](./FormatSyntax.md) pipeline, and Templater syntax is processed as usual.
 
-Only markdown templates can be applied: canvas (`.canvas`) and base (`.base`) templates contain data for their own file types and are excluded from the picker (use a regular [Template choice](./Choices/TemplateChoice.md) to create those). Likewise, the target must be a markdown note.
+Only templates that render into markdown can be applied to an existing note. Markdown templates and text-template source files with explicit extensions such as `.eta`, `.njk`, or `.txt` are included. Canvas (`.canvas`) and base (`.base`) templates contain data for their own file types and are excluded from the picker (use a regular [Template choice](./Choices/TemplateChoice.md) to create those). Likewise, the target must be a markdown note.
 
 ## Smart behaviors
 

--- a/docs/docs/ApplyTemplateToNote.md
+++ b/docs/docs/ApplyTemplateToNote.md
@@ -20,7 +20,7 @@ You can also right-click a markdown file (in the file explorer, tab header, etc.
 
 The template runs through the full QuickAdd [format syntax](./FormatSyntax.md) pipeline, and Templater syntax is processed as usual.
 
-Only templates that render into markdown can be applied to an existing note. Markdown templates and text-template source files with explicit extensions such as `.eta`, `.njk`, or `.txt` are included. Canvas (`.canvas`) and base (`.base`) templates contain data for their own file types and are excluded from the picker (use a regular [Template choice](./Choices/TemplateChoice.md) to create those). Likewise, the target must be a markdown note.
+Only templates that render into markdown can be applied to an existing note. Markdown templates and supported text-template source files such as `.eta`, `.njk`, `.hbs`, `.handlebars`, `.mustache`, and `.txt` are included. Canvas (`.canvas`) and base (`.base`) templates contain data for their own file types and are excluded from the picker (use a regular [Template choice](./Choices/TemplateChoice.md) to create those). Likewise, the target must be a markdown note.
 
 ## Smart behaviors
 

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -23,7 +23,7 @@ The path is resolved with a **path-safe** subset of the format syntax: macros, i
 A few things don't apply to a *dynamic* template path: the path can't be auto-bundled when exporting a QuickAdd package (it isn't a literal file), and if you use the [one-page input](/Advanced/onePageInputs.md) form, prompts inside the resolved template's body are gathered when the choice runs rather than in the up-front form.
 :::
 
-QuickAdd supports markdown (`.md`), canvas (`.canvas`), and base (`.base`) templates. The created file uses the same extension as the template.
+QuickAdd can read template source files with any explicit extension, such as `.md`, `.eta`, `.njk`, or `.txt`. Extensionless template paths still default to `.md` for compatibility. Markdown templates create markdown notes; canvas (`.canvas`) and base (`.base`) templates create files of their own type. Other template source extensions are treated as text templates and create markdown notes.
 If you want a new markdown note to include a live embedded Base dashboard, see
 [Template: Create an MOC Note with a Link Dashboard](/Examples/Template_CreateMOCNoteWithLinkDashboard.md).
 

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -23,7 +23,7 @@ The path is resolved with a **path-safe** subset of the format syntax: macros, i
 A few things don't apply to a *dynamic* template path: the path can't be auto-bundled when exporting a QuickAdd package (it isn't a literal file), and if you use the [one-page input](/Advanced/onePageInputs.md) form, prompts inside the resolved template's body are gathered when the choice runs rather than in the up-front form.
 :::
 
-QuickAdd can read template source files with any explicit extension, such as `.md`, `.eta`, `.njk`, or `.txt`. Extensionless template paths still default to `.md` for compatibility. Markdown templates create markdown notes; canvas (`.canvas`) and base (`.base`) templates create files of their own type. Other template source extensions are treated as text templates and create markdown notes.
+QuickAdd can read template source files with supported text-template extensions: `.md`, `.eta`, `.ejs`, `.njk`, `.hbs`, `.handlebars`, `.mustache`, and `.txt`. Extensionless template paths still default to `.md` for compatibility. Markdown templates create markdown notes; canvas (`.canvas`) and base (`.base`) templates create files of their own type. Other supported text-template source extensions create markdown notes.
 If you want a new markdown note to include a live embedded Base dashboard, see
 [Template: Create an MOC Note with a Link Dashboard](/Examples/Template_CreateMOCNoteWithLinkDashboard.md).
 

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -24,7 +24,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 ## Templates & Properties
 
-- **Template folder paths** — Folders where templates are stored, used to suggest template files when configuring QuickAdd. Add as many folders as you like: type a folder (with autocomplete) and press **Add** or Enter, then remove one with its row's trash button. Leave the list empty to suggest every template file in the vault. Note that an empty list also disables the **New note from template** launcher row and command, which need at least one configured folder.
+- **Template folder paths** — Folders where templates are stored, used to suggest template files when configuring QuickAdd. Add as many folders as you like: type a folder (with autocomplete) and press **Add** or Enter, then remove one with its row's trash button. Leave the list empty to suggest every explicit-extension template source file in the vault. Note that an empty list also disables the **New note from template** launcher row and command, which need at least one configured folder.
 - **Convert string front matter variables to typed properties (Beta)** — List/object values from scripts are **always** written as proper Obsidian properties (a list value becomes a List property), so templates produce valid front matter out of the box. This toggle **additionally** converts string values into typed properties: a comma or bullet-list string becomes a List, `"42"` becomes a Number, `"true"` becomes a Checkbox, etc. Disabled by default; the string conversion is a beta heuristic that may have edge cases. See [Template Property Types (Beta)](./TemplatePropertyTypes).
 
 ## Notifications

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -24,7 +24,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 ## Templates & Properties
 
-- **Template folder paths** — Folders where templates are stored, used to suggest template files when configuring QuickAdd. Add as many folders as you like: type a folder (with autocomplete) and press **Add** or Enter, then remove one with its row's trash button. Leave the list empty to suggest every explicit-extension template source file in the vault. Note that an empty list also disables the **New note from template** launcher row and command, which need at least one configured folder.
+- **Template folder paths** — Folders where templates are stored, used to suggest template files when configuring QuickAdd. Add as many folders as you like: type a folder (with autocomplete) and press **Add** or Enter, then remove one with its row's trash button. Leave the list empty to suggest every supported template source file in the vault. Note that an empty list also disables the **New note from template** launcher row and command, which need at least one configured folder.
 - **Convert string front matter variables to typed properties (Beta)** — List/object values from scripts are **always** written as proper Obsidian properties (a list value becomes a List property), so templates produce valid front matter out of the box. This toggle **additionally** converts string values into typed properties: a comma or bullet-list string becomes a List, `"42"` becomes a Number, `"true"` becomes a Checkbox, etc. Disabled by default; the string conversion is a beta heuristic that may have edge cases. See [Template Property Types (Beta)](./TemplatePropertyTypes).
 
 ## Notifications

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -162,7 +162,7 @@ export const BASE_FILE_EXTENSION_REGEX = new RegExp(/\.base$/i);
 export const JAVASCRIPT_FILE_EXTENSION_REGEX = new RegExp(/\.js$/);
 export const MACRO_REGEX = new RegExp(/{{MACRO:([^\n\r}]*)}}/i);
 export const TEMPLATE_REGEX = new RegExp(
-	/{{TEMPLATE:([^\n\r}]*\.[^\n\r}\/.]+)}}/i,
+	/{{TEMPLATE:([^\n\r}]*\.(?:md|canvas|base|eta|ejs|njk|hbs|handlebars|mustache|txt))}}/i,
 );
 export const GLOBAL_VAR_REGEX = new RegExp(/{{GLOBAL_VAR:([^\n\r}]*)}}/i);
 export const INLINE_JAVASCRIPT_REGEX = new RegExp(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -162,7 +162,7 @@ export const BASE_FILE_EXTENSION_REGEX = new RegExp(/\.base$/i);
 export const JAVASCRIPT_FILE_EXTENSION_REGEX = new RegExp(/\.js$/);
 export const MACRO_REGEX = new RegExp(/{{MACRO:([^\n\r}]*)}}/i);
 export const TEMPLATE_REGEX = new RegExp(
-	/{{TEMPLATE:([^\n\r}]*\.(?:md|canvas|base))}}/i,
+	/{{TEMPLATE:([^\n\r}]*\.[^\n\r}\/.]+)}}/i,
 );
 export const GLOBAL_VAR_REGEX = new RegExp(/{{GLOBAL_VAR:([^\n\r}]*)}}/i);
 export const INLINE_JAVASCRIPT_REGEX = new RegExp(

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -556,6 +556,38 @@ describe("TemplateChoiceEngine destination path resolution", () => {
 		);
 	});
 
+	it("creates markdown files from non-native template source extensions", async () => {
+		const { engine } = createEngine("ignored", {
+			throwDuringFileName: false,
+			stubTemplateContent: true,
+		});
+		const createdFile = new TFile();
+		const createSpy = vi
+			.spyOn(
+				engine as unknown as {
+					createFileWithTemplate: (
+						filePath: string,
+						templatePath: string,
+					) => Promise<TFile | null>;
+				},
+				"createFileWithTemplate",
+			)
+			.mockResolvedValue(createdFile);
+
+		engine.choice.templatePath = "Templates/t_general.eta";
+		engine.choice.folder.enabled = false;
+		engine.choice.fileNameFormat.enabled = true;
+		engine.choice.fileNameFormat.format = "{{VALUE:name}}";
+		formatFileNameMock.mockResolvedValueOnce("Eta Output");
+
+		await engine.run();
+
+		expect(createSpy).toHaveBeenCalledWith(
+			"Eta Output.md",
+			"Templates/t_general.eta",
+		);
+	});
+
 	it("treats leading-slash filename formats as vault-relative paths", async () => {
 		const { engine, app } = createEngine("ignored", {
 			throwDuringFileName: false,

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -112,9 +112,10 @@ describe("isNoteEffectivelyEmpty", () => {
 });
 
 describe("isMarkdownTemplatePath", () => {
-	it("accepts markdown and extensionless template paths", () => {
+	it("accepts markdown, extensionless, and text-template source paths", () => {
 		expect(isMarkdownTemplatePath("templates/tpl.md")).toBe(true);
 		expect(isMarkdownTemplatePath("templates/tpl")).toBe(true);
+		expect(isMarkdownTemplatePath("templates/t_general.eta")).toBe(true);
 	});
 
 	it("rejects canvas and base templates", () => {
@@ -180,6 +181,21 @@ describe("buildTemplatePickerItems", () => {
 			choice: { name: "Note" },
 		});
 		expect(items[1]).toEqual({ kind: "file", path: "templates/other.md" });
+	});
+
+	it("includes text-template source extensions that apply to markdown notes", () => {
+		const etaChoice = makeTemplateChoice("Eta", "templates/t_general.eta");
+		const choices: IChoice[] = [etaChoice];
+
+		const items = buildTemplatePickerItems(choices, [
+			"templates/t_general.eta",
+			"templates/other.njk",
+		]);
+
+		expect(items).toEqual([
+			{ kind: "choice", choice: etaChoice },
+			{ kind: "file", path: "templates/other.njk" },
+		]);
 	});
 
 	it("skips non-Template choices and Template choices without a template path", () => {
@@ -270,6 +286,21 @@ describe("applyTemplateToNote (non-interactive)", () => {
 		});
 
 		expect(engineConstructorMock.mock.calls[0][4]).toBe("top");
+	});
+
+	it("applies text-template source extensions to markdown notes", async () => {
+		const file = makeFile();
+		const result = await applyTemplateToNote(makeApp("", file), plugin, {
+			templatePath: "templates/t_general.eta",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(result).toBe(file);
+		expect(engineConstructorMock).toHaveBeenCalledTimes(1);
+		expect(engineConstructorMock.mock.calls[0][3]).toBe(
+			"templates/t_general.eta",
+		);
+		expect(engineApplyMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("pre-fills {{VALUE}} with the note's basename", async () => {

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -183,7 +183,7 @@ describe("buildTemplatePickerItems", () => {
 		expect(items[1]).toEqual({ kind: "file", path: "templates/other.md" });
 	});
 
-	it("includes text-template source extensions that apply to markdown notes", () => {
+	it("includes supported text-template source extensions that apply to markdown notes", () => {
 		const etaChoice = makeTemplateChoice("Eta", "templates/t_general.eta");
 		const choices: IChoice[] = [etaChoice];
 

--- a/src/engine/canvas-integration.test.ts
+++ b/src/engine/canvas-integration.test.ts
@@ -57,6 +57,7 @@ describe('Canvas Template Integration', () => {
 			expect(getTemplateExtension('template.md')).toBe('.md');
 			expect(getTemplateExtension('template')).toBe('.md');
 			expect(getTemplateExtension('template.txt')).toBe('.md');
+			expect(getTemplateExtension('template.eta')).toBe('.md');
 		});
 
 		it('should return .base for base templates', () => {

--- a/src/engine/runTemplateFromFolder.test.ts
+++ b/src/engine/runTemplateFromFolder.test.ts
@@ -83,6 +83,9 @@ describe("createFolderTemplateChoice", () => {
 		expect(createFolderTemplateChoice("Canvas Tpl.canvas").name).toBe(
 			"Canvas Tpl",
 		);
+		expect(createFolderTemplateChoice("Templates/t_general.eta").name).toBe(
+			"t_general",
+		);
 	});
 
 	it("returns a fresh uuid id each call (never persisted, no deterministic collision)", () => {

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -349,6 +349,14 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 		).resolves.toBe("TEMPLATE_BODY");
 	});
 
+	it("replaces {{TEMPLATE:path}} with explicit text-template source extensions", async () => {
+		mocks.templateRun.mockResolvedValue("ETA_TEMPLATE_BODY");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{TEMPLATE:notes/t_general.eta}}"),
+		).resolves.toBe("ETA_TEMPLATE_BODY");
+	});
+
 	it("propagates the target folder into included templates so {{FOLDER}} resolves", async () => {
 		mockTemplateVault({
 			"Partials/Filing.md": "folder={{FOLDER}} name={{FOLDER|name}}",

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -349,7 +349,7 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 		).resolves.toBe("TEMPLATE_BODY");
 	});
 
-	it("replaces {{TEMPLATE:path}} with explicit text-template source extensions", async () => {
+	it("replaces {{TEMPLATE:path}} with supported text-template source extensions", async () => {
 		mocks.templateRun.mockResolvedValue("ETA_TEMPLATE_BODY");
 		const f = defaultFormatter();
 		await expect(

--- a/src/utilityObsidian.templateFolders.test.ts
+++ b/src/utilityObsidian.templateFolders.test.ts
@@ -2,6 +2,7 @@ import { type App, TFile, TFolder } from "obsidian";
 import { describe, expect, it } from "vitest";
 import {
 	getTemplateFile,
+	hasTemplateExtension,
 	isPathWithinTemplateFolders,
 	normalizeTemplateFolderPaths,
 } from "./utilityObsidian";
@@ -86,6 +87,20 @@ describe("isPathWithinTemplateFolders", () => {
 	});
 });
 
+describe("hasTemplateExtension", () => {
+	it("recognizes native template extensions and explicit text-template extensions", () => {
+		expect(hasTemplateExtension("Templates/Daily.md")).toBe(true);
+		expect(hasTemplateExtension("Templates/Board.canvas")).toBe(true);
+		expect(hasTemplateExtension("Templates/View.base")).toBe(true);
+		expect(hasTemplateExtension("Templates/t_general.eta")).toBe(true);
+	});
+
+	it("keeps extensionless template paths on the legacy .md default path", () => {
+		expect(hasTemplateExtension("Templates/Daily")).toBe(false);
+		expect(hasTemplateExtension("Templates/Folder.With.Dot/Daily")).toBe(false);
+	});
+});
+
 describe("getTemplateFile", () => {
 	it("appends .md when no template extension is present", () => {
 		const app = appWith([file("Templates/Daily.md")]);
@@ -111,6 +126,19 @@ describe("getTemplateFile", () => {
 		);
 		expect(getTemplateFile(app, "Templates/View.base")?.path).toBe(
 			"Templates/View.base",
+		);
+	});
+
+	it("resolves explicit non-native template extensions without appending .md", () => {
+		const app = appWith([
+			file("Templates/t_general.eta"),
+			file("Templates/Prompt.njk"),
+		]);
+		expect(getTemplateFile(app, "Templates/t_general.eta")?.path).toBe(
+			"Templates/t_general.eta",
+		);
+		expect(getTemplateFile(app, "Templates/Prompt.njk")?.path).toBe(
+			"Templates/Prompt.njk",
 		);
 	});
 

--- a/src/utilityObsidian.templateFolders.test.ts
+++ b/src/utilityObsidian.templateFolders.test.ts
@@ -88,16 +88,24 @@ describe("isPathWithinTemplateFolders", () => {
 });
 
 describe("hasTemplateExtension", () => {
-	it("recognizes native template extensions and explicit text-template extensions", () => {
+	it("recognizes native template extensions and supported text-template extensions", () => {
 		expect(hasTemplateExtension("Templates/Daily.md")).toBe(true);
 		expect(hasTemplateExtension("Templates/Board.canvas")).toBe(true);
 		expect(hasTemplateExtension("Templates/View.base")).toBe(true);
 		expect(hasTemplateExtension("Templates/t_general.eta")).toBe(true);
+		expect(hasTemplateExtension("Templates/Prompt.njk")).toBe(true);
+		expect(hasTemplateExtension("Templates/Card.handlebars")).toBe(true);
 	});
 
 	it("keeps extensionless template paths on the legacy .md default path", () => {
 		expect(hasTemplateExtension("Templates/Daily")).toBe(false);
 		expect(hasTemplateExtension("Templates/Folder.With.Dot/Daily")).toBe(false);
+	});
+
+	it("does not treat arbitrary asset extensions as template sources", () => {
+		expect(hasTemplateExtension("Templates/logo.png")).toBe(false);
+		expect(hasTemplateExtension("Templates/schema.json")).toBe(false);
+		expect(hasTemplateExtension("Templates/styles.css")).toBe(false);
 	});
 });
 
@@ -129,7 +137,7 @@ describe("getTemplateFile", () => {
 		);
 	});
 
-	it("resolves explicit non-native template extensions without appending .md", () => {
+	it("resolves supported non-native template extensions without appending .md", () => {
 		const app = appWith([
 			file("Templates/t_general.eta"),
 			file("Templates/Prompt.njk"),
@@ -139,6 +147,16 @@ describe("getTemplateFile", () => {
 		);
 		expect(getTemplateFile(app, "Templates/Prompt.njk")?.path).toBe(
 			"Templates/Prompt.njk",
+		);
+	});
+
+	it("falls back to .md for unsupported explicit extensions", () => {
+		const app = appWith([
+			file("Templates/logo.png"),
+			file("Templates/logo.png.md"),
+		]);
+		expect(getTemplateFile(app, "Templates/logo.png")?.path).toBe(
+			"Templates/logo.png.md",
 		);
 	});
 

--- a/src/utils/templateFolderUtils.ts
+++ b/src/utils/templateFolderUtils.ts
@@ -6,28 +6,24 @@ import {
 	MARKDOWN_FILE_EXTENSION_REGEX,
 } from "../constants";
 
-const EXPLICIT_FILE_EXTENSION_REGEX = /(?:^|\/)[^/.][^/]*\.[^/.]+$/;
+const TEXT_TEMPLATE_SOURCE_EXTENSION_REGEX =
+	/\.(?:md|canvas|base|eta|ejs|njk|hbs|handlebars|mustache|txt)$/i;
 
 /**
- * Whether a path already carries an explicit template source extension.
- * Extensionless paths keep the legacy `.md` default; any explicit extension is
- * read as a text template source so users can keep files like `.eta` templates
- * without renaming them to Markdown.
+ * Whether a path already carries a supported template source extension.
+ * Extensionless paths keep the legacy `.md` default. Non-native extensions are
+ * limited to common text template files so image/CSS/JSON assets in template
+ * folders do not become selectable templates.
  */
 export function hasTemplateExtension(path: string): boolean {
-	return (
-		MARKDOWN_FILE_EXTENSION_REGEX.test(path) ||
-		CANVAS_FILE_EXTENSION_REGEX.test(path) ||
-		BASE_FILE_EXTENSION_REGEX.test(path) ||
-		EXPLICIT_FILE_EXTENSION_REGEX.test(path)
-	);
+	return TEXT_TEMPLATE_SOURCE_EXTENSION_REGEX.test(path);
 }
 
 /**
  * Resolve a template path to its vault file exactly the way the template engine
- * does at run time: strip a leading slash, append `.md` only when no explicit
- * template source extension is present, then look the file up. Returns null when nothing
- * resolves.
+ * does at run time: strip a leading slash, append `.md` only when no supported
+ * template source extension is present, then look the file up. Returns null
+ * when nothing resolves.
  *
  * Single source of truth shared by engine execution, choice-builder validation,
  * and preflight scanning so the three never drift (they previously each had

--- a/src/utils/templateFolderUtils.ts
+++ b/src/utils/templateFolderUtils.ts
@@ -6,24 +6,27 @@ import {
 	MARKDOWN_FILE_EXTENSION_REGEX,
 } from "../constants";
 
+const EXPLICIT_FILE_EXTENSION_REGEX = /(?:^|\/)[^/.][^/]*\.[^/.]+$/;
+
 /**
- * Whether a path already carries a template extension the engine can read
- * (`.md`/`.canvas`/`.base`). The three extension regexes are the single source
- * of truth; both {@link getTemplateFile} (to decide whether to append `.md`)
- * and the suggestion filter consume this so they can never disagree.
+ * Whether a path already carries an explicit template source extension.
+ * Extensionless paths keep the legacy `.md` default; any explicit extension is
+ * read as a text template source so users can keep files like `.eta` templates
+ * without renaming them to Markdown.
  */
 export function hasTemplateExtension(path: string): boolean {
 	return (
 		MARKDOWN_FILE_EXTENSION_REGEX.test(path) ||
 		CANVAS_FILE_EXTENSION_REGEX.test(path) ||
-		BASE_FILE_EXTENSION_REGEX.test(path)
+		BASE_FILE_EXTENSION_REGEX.test(path) ||
+		EXPLICIT_FILE_EXTENSION_REGEX.test(path)
 	);
 }
 
 /**
  * Resolve a template path to its vault file exactly the way the template engine
- * does at run time: strip a leading slash, append `.md` when no template
- * extension is present, then look the file up. Returns null when nothing
+ * does at run time: strip a leading slash, append `.md` only when no explicit
+ * template source extension is present, then look the file up. Returns null when nothing
  * resolves.
  *
  * Single source of truth shared by engine execution, choice-builder validation,

--- a/src/utils/templateFolderUtils.ts
+++ b/src/utils/templateFolderUtils.ts
@@ -1,10 +1,5 @@
 import type { App } from "obsidian";
 import { TFile } from "obsidian";
-import {
-	BASE_FILE_EXTENSION_REGEX,
-	CANVAS_FILE_EXTENSION_REGEX,
-	MARKDOWN_FILE_EXTENSION_REGEX,
-} from "../constants";
 
 const TEXT_TEMPLATE_SOURCE_EXTENSION_REGEX =
 	/\.(?:md|canvas|base|eta|ejs|njk|hbs|handlebars|mustache|txt)$/i;


### PR DESCRIPTION
Support non-Markdown text template source files for Template choices and related template pickers.

The underlying problem in #164 is that users may keep template source files in a templating-engine extension such as `.eta`, but QuickAdd previously treated those paths as missing by appending `.md` unless the source was one of the native Obsidian template file types. This keeps extensionless paths on the existing `.md` fallback while allowing supported text-template extensions: `.eta`, `.ejs`, `.njk`, `.hbs`, `.handlebars`, `.mustache`, and `.txt`.

The source/destination behavior is intentionally conservative: `.canvas` and `.base` template sources still create files of their own type; other supported text-template sources create Markdown notes. I initially considered accepting any explicit extension, but narrowed this after adversarial review because template folders often contain supporting assets like `.png`, `.json`, or `.css`, and those should not become selectable templates or pass validation.

Validation evidence:
- Reproduced the old behavior path conceptually in the resolver: `Templates/t_general.eta` used to resolve as `Templates/t_general.eta.md` unless renamed to `.md`.
- Live isolated Obsidian vault: seeded `Templates/t_general.eta`, ran `quickadd:run-template path=Templates/t_general.eta value-value='Eta Runtime Note'`, got `ok:true` and `file: Eta Runtime Note.md`.
- Live readback: `Eta Runtime Note.md` exists, `Eta Runtime Note.eta` does not, content is `# Eta Runtime Note\nfrom eta template`.
- Live suggestion check with mixed assets: configured `Templates`, seeded `Templates/logo.png`, and `getTemplateFiles()` returned only `Templates/t_general.eta`.
- `pnpm run check` passed with 0 errors and existing warnings.
- `pnpm test` passed: 225 files passed, 5 skipped; 2648 tests passed, 37 skipped.
- `pnpm run build-with-lint` passed.

Docs updated for Template choices, Apply Template to Note, and template folder settings. No persisted settings or migration changes.

Fixes #164