### PR TITLE
feat: support multi-select field suggestions

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -366,10 +366,11 @@ Example: `project: {{FIELD:project}}`.
 - `{{FIELD:fieldname|default:Status - To Do}}` - Prepend a default suggestion; the modal placeholder shows it and pressing Enter accepts it.
 - `{{FIELD:fieldname|default:Draft|default-empty:true}}` - Only add the default when no matching values are found.
 - `{{FIELD:fieldname|default:Draft|default-always:true}}` - Keep the default first even if other suggestions exist.
+- `{{FIELD:fieldname|multi}}` - Select multiple values from the field suggestions. In YAML frontmatter, this writes a list; elsewhere, the selected values are inserted as comma-separated text.
 - Combine filters: `{{FIELD:fieldname|folder:daily|tag:work|exclude-folder:templates|inline:true|inline-code-blocks:ad-note}}`
 - Multiple exclusions: `{{FIELD:fieldname|exclude-folder:templates|exclude-folder:archive}}`
 
-Examples: `status: {{FIELD:status|default:Draft|default-always:true}}` or `id: {{FIELD:Id|inline:true|inline-code-blocks:ad-note}}`.
+Examples: `status: {{FIELD:status|default:Draft|default-always:true}}`, `people: {{FIELD:person|multi}}`, or `id: {{FIELD:Id|inline:true|inline-code-blocks:ad-note}}`.
 
 This is currently in beta, and the syntax can change—leave your thoughts [here](https://github.com/chhoumann/quickadd/issues/337).
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -748,6 +748,53 @@ describe("CompleteFormatter - field suggestion (suggestForField)", () => {
 		expect(mocks.inputSuggesterSuggest).toHaveBeenCalled();
 	});
 
+	it("uses the multi suggester for explicit FIELD multi-select", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "people",
+			filters: { multiSelect: true },
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Alice", "Bob"],
+			hasDefaultValue: false,
+		});
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Alice", "Bob"]);
+
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{FIELD:people|multi}}")).resolves.toBe(
+			"Alice,Bob",
+		);
+		expect(mocks.multiSuggesterSuggest).toHaveBeenCalledWith(
+			expect.anything(),
+			["Alice", "Bob"],
+			["Alice", "Bob"],
+			expect.objectContaining({ allowCustomValue: true }),
+		);
+		expect(mocks.inputSuggesterSuggest).not.toHaveBeenCalled();
+	});
+
+	it("collects FIELD multi-select arrays as structured YAML frontmatter", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "people",
+			filters: { multiSelect: true },
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Alice", "Bob"],
+			hasDefaultValue: false,
+		});
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Alice", "Bob"]);
+
+		const f = defaultFormatter();
+		const output = await f.withTemplatePropertyCollection(() =>
+			f.formatFileContent("---\npeople: {{FIELD:people|multi}}\n---\n"),
+		);
+
+		expect(output).toBe("---\npeople: []\n---\n");
+		expect(f.getAndClearTemplatePropertyVars().get("people")).toEqual([
+			"Alice",
+			"Bob",
+		]);
+	});
+
 	it("falls back to a free-form prompt when no values are found", async () => {
 		mocks.fieldParse.mockReturnValue({
 			fieldName: "status",

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -553,6 +553,9 @@ export class CompleteFormatter extends Formatter {
 			if (values.length === 0) {
 				// No values found even after processing defaults
 				let fallbackPrompt = `No existing values were found in your vault.`;
+				if (filters.multiSelect) {
+					fallbackPrompt += `\n\nEnter multiple values separated by commas.`;
+				}
 
 				// Suggest smart defaults if no custom default was provided
 				if (!filters.defaultValue) {
@@ -565,19 +568,31 @@ export class CompleteFormatter extends Formatter {
 					}
 				}
 
-				return await GenericInputPrompt.PromptWithContext(
-				this.app,
-				`Enter value for ${fieldName}`,
-				fallbackPrompt,
-				undefined,
-				this.getLinkSourcePath() ?? undefined
+				const fallbackValue = await GenericInputPrompt.PromptWithContext(
+					this.app,
+					`Enter value for ${fieldName}`,
+					fallbackPrompt,
+					undefined,
+					this.getLinkSourcePath() ?? undefined,
 				);
+				return filters.multiSelect
+					? fallbackValue
+							.split(",")
+							.map((value) => value.trim())
+							.filter(Boolean)
+					: fallbackValue;
 			}
 
 			// Enhance placeholder with context
 			let placeholder = `Enter value for ${fieldName}`;
 			if (hasDefaultValue) {
 				placeholder = `Enter value for ${fieldName} (default: ${filters.defaultValue})`;
+			}
+
+			if (filters.multiSelect) {
+				return await this.suggestForValueMulti(values, true, {
+					placeholder,
+				});
 			}
 
 			return await InputSuggester.Suggest(this.app, values, values, {

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -888,9 +888,22 @@ export abstract class Formatter {
 					);
 				}
 
-				const replacement = this.hasConcreteVariable(fieldVariableKey)
-					? String(this.variables.get(fieldVariableKey))
+				const rawValue = this.hasConcreteVariable(fieldVariableKey)
+					? this.variables.get(fieldVariableKey)
 					: this.getVariableValue(fullMatch);
+				const structuredYamlValue = this.propertyCollector.maybeCollect({
+					input,
+					matchStart: match.index,
+					matchEnd: match.index + match[0].length,
+					rawValue,
+					fallbackKey: fullMatch,
+					collectionActive: this.templatePropertyCollectionDepth > 0,
+					heuristicEnabled: false,
+				});
+				const placeholder = getYamlPlaceholder(structuredYamlValue);
+				const replacement = placeholder ?? (
+					Array.isArray(rawValue) ? rawValue.join(",") : String(rawValue ?? "")
+				);
 
 				output += replacement;
 			} else {
@@ -1101,7 +1114,7 @@ export abstract class Formatter {
 		return [];
 	}
 
-	protected abstract suggestForField(variableName: string): Promise<string>;
+	protected abstract suggestForField(variableName: string): Promise<unknown>;
 
 	protected async replaceDateVariableInString(input: string) {
 		let output: string = input;

--- a/src/gui/suggesters/FieldValueInputSuggest.test.ts
+++ b/src/gui/suggesters/FieldValueInputSuggest.test.ts
@@ -1,0 +1,81 @@
+import type { App } from "obsidian";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	FIELD_MULTI_VALUES_DATA_KEY,
+	FieldValueInputSuggest,
+} from "./FieldValueInputSuggest";
+
+const mocks = vi.hoisted(() => ({
+	collectFieldValuesProcessed: vi.fn(),
+	renderMatch: vi.fn(),
+}));
+
+vi.mock("src/utils/FieldValueCollector", () => ({
+	collectFieldValuesProcessed: mocks.collectFieldValuesProcessed,
+}));
+
+vi.mock("./suggest", () => ({
+	TextInputSuggest: class {
+		protected app: App;
+		protected inputEl: HTMLInputElement;
+
+		constructor(app: App, inputEl: HTMLInputElement) {
+			this.app = app;
+			this.inputEl = inputEl;
+		}
+
+		protected renderMatch(el: HTMLElement, item: string, query: string) {
+			mocks.renderMatch(el, item, query);
+		}
+
+		protected getCurrentQuery() {
+			return this.inputEl.value;
+		}
+
+		protected close() {}
+	},
+}));
+
+describe("FieldValueInputSuggest", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.collectFieldValuesProcessed.mockResolvedValue([
+			"Alice",
+			"Bob",
+			"Carol",
+		]);
+	});
+
+	it("filters multi-select suggestions by the active term and excludes selected values", async () => {
+		const input = document.createElement("input");
+		const suggest = new FieldValueInputSuggest({} as App, input, "person|multi");
+
+		await expect(suggest.getSuggestions("Alice, B")).resolves.toEqual(["Bob"]);
+		expect(input.getAttribute("aria-multiselectable")).toBe("true");
+	});
+
+	it("highlights multi-select suggestions with only the active term", () => {
+		const input = document.createElement("input");
+		input.value = "Alice, B";
+		const suggest = new FieldValueInputSuggest({} as App, input, "person|multi");
+		const el = document.createElement("div");
+
+		suggest.renderSuggestion("Bob", el);
+
+		expect(mocks.renderMatch).toHaveBeenCalledWith(el, "Bob", "B");
+	});
+
+	it("stores exact selected multi values separately from the comma-delimited display text", async () => {
+		mocks.collectFieldValuesProcessed.mockResolvedValue(["Doe, Jane", "Alice"]);
+		const input = document.createElement("input");
+		const suggest = new FieldValueInputSuggest({} as App, input, "person|multi");
+		await suggest.getSuggestions("");
+
+		suggest.selectSuggestion("Doe, Jane");
+
+		expect(input.value).toBe("Doe, Jane, ");
+		expect(input.dataset[FIELD_MULTI_VALUES_DATA_KEY]).toBe(
+			JSON.stringify(["Doe, Jane"]),
+		);
+	});
+});

--- a/src/gui/suggesters/FieldValueInputSuggest.ts
+++ b/src/gui/suggesters/FieldValueInputSuggest.ts
@@ -8,8 +8,11 @@ import {
 } from "src/utils/FieldValueCollector";
 import { TextInputSuggest } from "./suggest";
 
+export const FIELD_MULTI_VALUES_DATA_KEY = "quickaddFieldMultiValues";
+
 type CompletionInputEvent = Event & {
 	fromCompletion?: boolean;
+	keepOpen?: boolean;
 };
 
 export class FieldValueInputSuggest extends TextInputSuggest<string> {
@@ -17,6 +20,7 @@ export class FieldValueInputSuggest extends TextInputSuggest<string> {
 	private readonly fieldName: string;
 	private readonly filters: FieldFilter;
 	private cachedValues: string[] | null = null;
+	private readonly multiSelect: boolean;
 
 	constructor(app: App, inputEl: HTMLInputElement, fieldInput: string) {
 		super(app, inputEl);
@@ -24,6 +28,10 @@ export class FieldValueInputSuggest extends TextInputSuggest<string> {
 		const parsed = FieldSuggestionParser.parse(fieldInput);
 		this.fieldName = parsed.fieldName;
 		this.filters = parsed.filters;
+		this.multiSelect = parsed.filters.multiSelect ?? false;
+		if (this.multiSelect) {
+			this.inputEl.setAttribute("aria-multiselectable", "true");
+		}
 	}
 
 	async getSuggestions(inputStr: string): Promise<string[]> {
@@ -35,24 +43,84 @@ export class FieldValueInputSuggest extends TextInputSuggest<string> {
 			);
 		}
 
-		const query = (inputStr || "").toLowerCase();
-		if (!query) return this.cachedValues.slice(0, 200);
-		return this.cachedValues
+		const { alreadySelected, activeTerm } = this.parseMultiSelectInput(inputStr || "");
+		const available = this.cachedValues.filter(
+			(value) => !alreadySelected.includes(value),
+		);
+		const query = activeTerm.toLowerCase();
+		if (!query) return available.slice(0, 200);
+		return available
 			.filter((v) => v.toLowerCase().includes(query))
 			.slice(0, 200);
 	}
 
 	renderSuggestion(item: string, el: HTMLElement): void {
-		this.renderMatch(el, item, this.getCurrentQuery());
+		this.renderMatch(
+			el,
+			item,
+			this.parseMultiSelectInput(this.getCurrentQuery()).activeTerm,
+		);
 	}
 
 	selectSuggestion(item: string): void {
+		if (this.multiSelect) {
+			this.selectMultipleItem(item);
+			return;
+		}
+
 		// Fill input and dispatch a synthetic input event to trigger onChange listeners
 		this.inputEl.value = item;
 		const event = new Event("input", { bubbles: true });
 		(event as CompletionInputEvent).fromCompletion = true;
 		this.inputEl.dispatchEvent(event);
 		this.close();
+	}
+
+	private parseMultiSelectInput(input: string): {
+		alreadySelected: string[];
+		activeTerm: string;
+	} {
+		if (!this.multiSelect) {
+			return { alreadySelected: [], activeTerm: input };
+		}
+
+		const parts = input.split(",").map((part) => part.trim());
+		return {
+			alreadySelected: parts.slice(0, -1).filter(Boolean),
+			activeTerm: parts[parts.length - 1] || "",
+		};
+	}
+
+	private selectMultipleItem(item: string): void {
+		const { alreadySelected } = this.parseMultiSelectInput(this.inputEl.value);
+		alreadySelected.push(item);
+		this.inputEl.dataset[FIELD_MULTI_VALUES_DATA_KEY] =
+			JSON.stringify(alreadySelected);
+
+		const hasMoreItems = Boolean(
+			this.cachedValues?.some((value) => !alreadySelected.includes(value)),
+		);
+
+		this.inputEl.value = hasMoreItems
+			? alreadySelected.join(", ") + ", "
+			: alreadySelected.join(", ");
+		this.inputEl.setSelectionRange(
+			this.inputEl.value.length,
+			this.inputEl.value.length,
+		);
+
+		const event = new Event("input", { bubbles: true });
+		const completionEvent = event as CompletionInputEvent;
+		completionEvent.fromCompletion = true;
+		if (hasMoreItems) {
+			completionEvent.keepOpen = true;
+		}
+		this.inputEl.dispatchEvent(event);
+		if (hasMoreItems) {
+			this.inputEl.focus();
+		} else {
+			this.close();
+		}
 	}
 
 	private escapeRegex(s: string): string {

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -3,6 +3,7 @@ import type { App } from "obsidian";
 import type { FieldRequirement } from "./RequirementCollector";
 import { OnePageInputModal } from "./OnePageInputModal";
 import { buildValueVariableKey } from "src/utils/valueSyntax";
+import { decodeMultiSelectValues } from "./multiSelectEncoding";
 
 vi.mock("obsidian", () => {
 	class Modal {
@@ -179,6 +180,7 @@ const { fieldSuggestConstructorArgs } = vi.hoisted(() => ({
 }));
 
 vi.mock("src/gui/suggesters/FieldValueInputSuggest", () => ({
+	FIELD_MULTI_VALUES_DATA_KEY: "quickaddFieldMultiValues",
 	FieldValueInputSuggest: class {
 		constructor(...args: unknown[]) {
 			fieldSuggestConstructorArgs.push(args);
@@ -407,6 +409,46 @@ describe("OnePageInputModal", () => {
 			});
 			expect(fieldSuggestConstructorArgs).toHaveLength(1);
 			expect(fieldSuggestConstructorArgs[0][2]).toBe("People");
+		});
+
+		it("preserves exact FIELD multi selections that contain commas", async () => {
+			const requirements: FieldRequirement[] = [
+				{
+					id: "FIELD:People|multi",
+					label: "People|multi",
+					type: "field-suggest",
+					suggesterConfig: { multiSelect: true, allowCustomInput: true },
+				},
+			];
+
+			const modal = new OnePageInputModal({} as App, requirements, new Map());
+			const contentEl = (modal as any).contentEl as HTMLElement;
+			const fieldInput = contentEl.querySelector(
+				"input",
+			) as HTMLInputElement;
+			fieldInput.value = "Doe, Jane, ";
+			fieldInput.dataset.quickaddFieldMultiValues = JSON.stringify([
+				"Doe, Jane",
+			]);
+			const completionEvent = new Event("input", { bubbles: true }) as Event & {
+				fromCompletion?: boolean;
+			};
+			completionEvent.fromCompletion = true;
+			fieldInput.dispatchEvent(completionEvent);
+
+			const submitButton = Array.from(
+				contentEl.querySelectorAll(
+					"button",
+				) as NodeListOf<HTMLButtonElement>,
+			).find(
+				(button) => button.textContent === "Submit",
+			) as HTMLButtonElement;
+			submitButton.click();
+
+			const result = await modal.waitForClose;
+			expect(decodeMultiSelectValues(result["FIELD:People|multi"])).toEqual([
+				"Doe, Jane",
+			]);
 		});
 	});
 

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -9,7 +9,10 @@ import {
 } from "obsidian";
 import { FIELD_VARIABLE_PREFIX } from "src/constants";
 import { createDatePicker } from "src/gui/date-picker/datePicker";
-import { FieldValueInputSuggest } from "src/gui/suggesters/FieldValueInputSuggest";
+import {
+	FIELD_MULTI_VALUES_DATA_KEY,
+	FieldValueInputSuggest,
+} from "src/gui/suggesters/FieldValueInputSuggest";
 import { SuggesterInputSuggest } from "src/gui/suggesters/SuggesterInputSuggest";
 import { formatISODate, parseNaturalLanguageDate } from "src/utils/dateParser";
 import {
@@ -26,6 +29,7 @@ import {
 	mapMappedSuggesterValue,
 	resolveDropdownInitialValue,
 } from "./suggesterValueMapping";
+import { encodeMultiSelectValues } from "./multiSelectEncoding";
 
 type PreviewComputer = (
 	values: Record<string, string>,
@@ -373,6 +377,34 @@ export class OnePageInputModal extends Modal {
 					.setPlaceholder(req.placeholder ?? "")
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
+				if (req.suggesterConfig?.multiSelect) {
+					input.inputEl.addEventListener("input", (event) => {
+						const fromCompletion = Boolean(
+							(event as CompletionInputEvent).fromCompletion,
+						);
+						if (!fromCompletion) return;
+
+						const encodedValues =
+							input.inputEl.dataset[FIELD_MULTI_VALUES_DATA_KEY];
+						if (!encodedValues) return;
+
+						try {
+							const parsed = JSON.parse(encodedValues);
+							if (Array.isArray(parsed)) {
+								setValue(
+									req.id,
+									encodeMultiSelectValues(
+										parsed.filter(
+											(item): item is string => typeof item === "string",
+										),
+									),
+								);
+							}
+						} catch {
+							// Ignore malformed internal state and keep the visible text.
+						}
+					});
+				}
 				// Attach inline suggester powered by vault data & filters encoded in
 				// req.id. Collected FIELD requirements are keyed "FIELD:<specifier>";
 				// strip the prefix so the suggester parses the bare field specifier.

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -249,6 +249,30 @@ Body`);
         type: "field-suggest",
       });
     });
+
+    it("registers explicit FIELD multi-select without changing scalar FIELD", async () => {
+      const app = makeApp();
+      const plugin = makePlugin();
+      const rc = new RequirementCollector(app, plugin);
+      await rc.scanString(
+        "{{FIELD:People}} {{FIELD:People|folder:Contacts|multi}}",
+      );
+
+      expect(rc.requirements.get("FIELD:People")).toMatchObject({
+        type: "field-suggest",
+      });
+      expect(
+        rc.requirements.get("FIELD:People|folder:Contacts|multi"),
+      ).toMatchObject({
+        type: "field-suggest",
+        multiEmit: "text",
+        suggesterConfig: {
+          allowCustomInput: true,
+          caseSensitive: false,
+          multiSelect: true,
+        },
+      });
+    });
   });
 });
 

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -18,6 +18,7 @@ import {
 } from "src/utils/valueSyntax";
 import { parseVDateOptions } from "src/utils/vdateSyntax";
 import { EnhancedFieldSuggestionFileFilter } from "src/utils/EnhancedFieldSuggestionFileFilter";
+import { FieldSuggestionParser } from "src/utils/FieldSuggestionParser";
 import {
 	buildFileDisplayLabels,
 	FILE_PICK_PREFIX,
@@ -431,11 +432,20 @@ export class RequirementCollector extends Formatter {
 		// in the one-page form land where replaceFieldVarInString looks them up
 		// (issue #1184). Actual suggestions are provided by the UI.
 		const key = `${FIELD_VARIABLE_PREFIX}${variableName}`;
+		const { filters } = FieldSuggestionParser.parse(variableName);
 		if (!this.requirements.has(key)) {
 			this.requirements.set(key, {
 				id: key,
 				label: variableName,
 				type: "field-suggest",
+				multiEmit: filters.multiSelect ? "text" : undefined,
+				suggesterConfig: filters.multiSelect
+					? {
+							allowCustomInput: true,
+							caseSensitive: filters.caseSensitive ?? false,
+							multiSelect: true,
+						}
+					: undefined,
 				source: "collected",
 			});
 		}

--- a/src/preflight/multiSelectEncoding.test.ts
+++ b/src/preflight/multiSelectEncoding.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+	decodeMultiSelectValues,
+	encodeMultiSelectValues,
+} from "./multiSelectEncoding";
+
+describe("multi-select value encoding", () => {
+	it("round-trips selected values that contain commas", () => {
+		const values = ["Doe, Jane", "Alice"];
+
+		expect(decodeMultiSelectValues(encodeMultiSelectValues(values))).toEqual(
+			values,
+		);
+	});
+
+	it("ignores ordinary visible input strings", () => {
+		expect(decodeMultiSelectValues("Doe, Jane, Alice")).toBeNull();
+	});
+});

--- a/src/preflight/multiSelectEncoding.ts
+++ b/src/preflight/multiSelectEncoding.ts
@@ -1,0 +1,17 @@
+const MULTI_SELECT_VALUES_PREFIX = "__quickadd_multi_select_values__:";
+
+export function encodeMultiSelectValues(values: string[]): string {
+	return `${MULTI_SELECT_VALUES_PREFIX}${JSON.stringify(values)}`;
+}
+
+export function decodeMultiSelectValues(value: string): string[] | null {
+	if (!value.startsWith(MULTI_SELECT_VALUES_PREFIX)) return null;
+
+	try {
+		const parsed = JSON.parse(value.slice(MULTI_SELECT_VALUES_PREFIX.length));
+		if (!Array.isArray(parsed)) return null;
+		return parsed.filter((item): item is string => typeof item === "string");
+	} catch {
+		return null;
+	}
+}

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -10,6 +10,7 @@ import {
 	FILE_VARIABLE_PREFIX,
 } from "src/utils/fileSyntax";
 import { toWikiLink } from "src/utils/linkWrap";
+import { decodeMultiSelectValues } from "./multiSelectEncoding";
 import {
 	collectChoiceRequirements,
 	getUnresolvedRequirements,
@@ -111,19 +112,22 @@ export async function runOnePagePreflight(
 		Object.entries(values).forEach(([k, v]) => {
 			const multiInfo = multiInfoByKey.get(k);
 			if (multiInfo !== undefined) {
-				const items = String(v)
-					.split(",")
-					.map((s) => s.trim())
-					.filter(Boolean)
-					// Drop typed entries that aren't options unless the token opted
-					// into custom input, matching the runtime MultiSuggester.
-					.filter(
-						(label) =>
-							multiInfo.allowCustom || multiInfo.displayToValue.has(label),
-					)
-					// Map the display label back to its value; a typed custom value
-					// (no mapping) passes through unchanged.
-					.map((label) => multiInfo.displayToValue.get(label) ?? label);
+				const decodedItems = decodeMultiSelectValues(String(v));
+				const items =
+					decodedItems ??
+					String(v)
+						.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean)
+						// Drop typed entries that aren't options unless the token opted
+						// into custom input, matching the runtime MultiSuggester.
+						.filter(
+							(label) =>
+								multiInfo.allowCustom || multiInfo.displayToValue.has(label),
+						)
+						// Map the display label back to its value; a typed custom value
+						// (no mapping) passes through unchanged.
+						.map((label) => multiInfo.displayToValue.get(label) ?? label);
 				choiceExecutor.variables.set(
 					k,
 					multiInfo.emit === "linklist" ? items.map(toWikiLink) : items,

--- a/src/utils/FieldSuggestionParser.test.ts
+++ b/src/utils/FieldSuggestionParser.test.ts
@@ -165,9 +165,25 @@ describe("FieldSuggestionParser", () => {
 			});
 		});
 
+		it("should parse bare multi-select mode", () => {
+			const result = FieldSuggestionParser.parse("fieldname|multi");
+			expect(result).toEqual({
+				fieldName: "fieldname",
+				filters: { multiSelect: true },
+			});
+		});
+
+		it("should parse keyed multi-select mode", () => {
+			const result = FieldSuggestionParser.parse("fieldname|multi:false");
+			expect(result).toEqual({
+				fieldName: "fieldname",
+				filters: { multiSelect: false },
+			});
+		});
+
 		it("should handle complex combinations with all filter types", () => {
 			const result = FieldSuggestionParser.parse(
-				"fieldname|folder:active|tag:project|exclude-folder:archive|default:Planning|default-empty:true|case-sensitive:false",
+				"fieldname|folder:active|tag:project|exclude-folder:archive|default:Planning|default-empty:true|case-sensitive:false|multi",
 			);
 			expect(result).toEqual({
 				fieldName: "fieldname",
@@ -178,6 +194,7 @@ describe("FieldSuggestionParser", () => {
 					defaultValue: "Planning",
 					defaultEmpty: true,
 					caseSensitive: false,
+					multiSelect: true,
 				},
 			});
 		});

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -9,6 +9,7 @@ export interface FieldFilter {
 	defaultEmpty?: boolean;
 	defaultAlways?: boolean;
 	caseSensitive?: boolean;
+	multiSelect?: boolean;
 	excludeFolders?: string[];
 	excludeTags?: string[];
 	excludeFiles?: string[];
@@ -32,6 +33,11 @@ export class FieldSuggestionParser {
 
 		for (let i = 1; i < parts.length; i++) {
 			const filterPart = parts[i];
+			if (filterPart.toLowerCase() === "multi") {
+				filters.multiSelect = true;
+				continue;
+			}
+
 			const parsed = parsePipeKeyValue(filterPart);
 			if (!parsed) continue; // Skip invalid filter format
 
@@ -78,6 +84,9 @@ export class FieldSuggestionParser {
 					break;
 				case "case-sensitive":
 					filters.caseSensitive = filterValue.toLowerCase() === "true";
+					break;
+				case "multi":
+					filters.multiSelect = filterValue.toLowerCase() !== "false";
 					break;
 				case "exclude-folder":
 					if (!filters.excludeFolders) {

--- a/src/utils/FieldValueCollector.ts
+++ b/src/utils/FieldValueCollector.ts
@@ -15,6 +15,7 @@ export function generateFieldCacheKey(filters: FieldFilter): string {
 		parts.push(`inline-code-blocks:${filters.inlineCodeBlocks.join(",")}`);
 	}
 	if (filters.caseSensitive) parts.push("case-sensitive:true");
+	if (filters.multiSelect) parts.push("multi:true");
 	if (filters.excludeFolders)
 		parts.push(`exclude-folders:${filters.excludeFolders.join(",")}`);
 	if (filters.excludeTags)

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -53,7 +53,7 @@ export class TemplatePropertyCollector {
     const propertyKeyMatch = lineContent.match(/^\s*([^:]+):/);
     const fallbackPathKey = propertyKeyMatch ? propertyKeyMatch[1].trim() : fallbackKey;
 
-    const listItemPattern = /^-\s*['"]?\{\{VALUE:[^}]+\}\}['"]?\s*$/i;
+    const listItemPattern = /^-\s*['"]?\{\{(?:VALUE|FIELD):[^}]+\}\}['"]?\s*$/i;
     let propertyPath: string[] | null = null;
 
     if (context.isKeyValuePosition) {


### PR DESCRIPTION
Adds explicit multi-select support for FIELD suggestions via `{{FIELD:name|multi}}`.

Underlying problem: FIELD suggestions already reuse values from vault metadata, but users had no coherent way to select multiple existing values for list-like metadata. The issue proposed repeated prompts or separator-triggered suggestions; I chose an explicit `|multi` mode because it matches QuickAdd's existing `VALUE|multi` syntax, keeps `{{FIELD:name}}` fully backward-compatible as a scalar picker, and composes with existing FIELD filters such as `folder:`, `tag:`, and defaults.

What changed:
- `FieldSuggestionParser` recognizes `|multi` / `|multi:false` as FIELD mode flags.
- Runtime FIELD formatting uses the existing multi-suggester for `|multi` and stores selected values as arrays.
- FIELD replacement now participates in structured YAML frontmatter collection, so `people: {{FIELD:person|multi}}` writes a real YAML list instead of `Alice,Bob`.
- One-page preflight renders FIELD multi-selects through the field-value suggester and stores exact selected arrays, including values that themselves contain commas.
- Current docs describe the new syntax and frontmatter/body output behavior.

Tradeoffs and notes:
- Multi FIELD is opt-in only; existing `{{FIELD:name}}` behavior remains scalar even when source metadata values came from YAML arrays.
- Outside YAML frontmatter, multi FIELD output is comma-joined text, matching existing VALUE multi fallback behavior.
- The one-page form still allows manual comma-separated entry for custom values, but selected FIELD suggestions are preserved internally as exact arrays so existing values like `Doe, Jane` are not split.

Validation:
- `pnpm run build-with-lint`
- `pnpm run check` (0 errors; existing 4 warnings)
- `pnpm test` (227 passed, 5 skipped; 2650 tests passed, 37 skipped)
- Isolated Obsidian vault via `pnpm run obsidian:e2e -- ...`:
  - Reloaded QuickAdd successfully.
  - `quickadd:run-template` without FIELD values reported missing `FIELD:person|multi` and `FIELD:person` separately.
  - `quickadd:run-template` with `FIELD:person|multi` set to `["Doe, Jane", "Alice"]` created `Field Multi Comma Result.md`.
  - Readback confirmed frontmatter `people` is `["Doe, Jane", "Alice"]`, scalar `lead` is `Alice`, body text is comma-joined, and `dev:errors` reported no captured runtime errors.

Fixes #692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced multi-select field input functionality, enabling users to select multiple values (comma-separated) within a single field prompt.

* **Documentation**
  * Updated format syntax documentation with details about the new multi-select option, including reorganized examples and behavior clarifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->