### PR TITLE
feat: copy produced note links to clipboard

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -130,6 +130,8 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
     -   **Enabled (skip if no active file)** – inserts the link when possible and silently drops `{{LINKCURRENT}}` if nothing is open
     -   **Disabled** – never append a link
 
+    Enable _Copy link to clipboard_ to copy the captured file's Obsidian link after the Capture choice finishes. This can be used by itself, so the link is available for pasting somewhere else without inserting it into the active note.
+
     When either enabled mode is selected, a _Link placement_ dropdown appears so you can choose where the link is placed:
     -   **Replace selection** - Replaces any selected text with the link (default)
     -   **After selection** - Preserves selected text and places the link after it

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -45,6 +45,8 @@ Switching modes hides the fields that don't apply, but your configured folder li
 - **Enabled (skip if no active file)** – insert the link when possible and skip silently otherwise
 - **Disabled** – never append a link
 
+Enable **Copy link to clipboard** to copy the created file's Obsidian link after the Template choice finishes. This can be used on its own, so a choice can create a note and place its link on the clipboard without inserting anything into the active note.
+
 When either enabled mode is selected, **Link placement** lets you choose where the link is placed:
 - **Replace selection** - Replaces any selected text with the link (default)
 - **After selection** - Preserves selected text and places the link after it  

--- a/src/engine/CaptureChoiceEngine.heading-picker.test.ts
+++ b/src/engine/CaptureChoiceEngine.heading-picker.test.ts
@@ -30,6 +30,7 @@ vi.mock("../utilityObsidian", () => ({
 	getMarkdownFilesInFolder: vi.fn(() => []),
 	getMarkdownFilesWithTag: vi.fn(() => []),
 	insertFileLinkToActiveView: vi.fn(),
+	copyFileLinkToClipboard: vi.fn(async () => false),
 	insertOnNewLineAbove: vi.fn(() => true),
 	insertOnNewLineBelow: vi.fn(() => true),
 	isFolder: vi.fn(() => false),

--- a/src/engine/CaptureChoiceEngine.merge.test.ts
+++ b/src/engine/CaptureChoiceEngine.merge.test.ts
@@ -80,6 +80,7 @@ vi.mock("../utilityObsidian", () => ({
 	getMarkdownFilesInFolder: vi.fn(async () => []),
 	getMarkdownFilesWithTag: vi.fn(async () => []),
 	insertFileLinkToActiveView: vi.fn(),
+	copyFileLinkToClipboard: vi.fn(async () => false),
 	insertOnNewLineAbove: vi.fn(),
 	insertOnNewLineBelow: vi.fn(),
 	isFolder: vi.fn(() => false),
@@ -109,6 +110,7 @@ import { TFile } from "obsidian";
 import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import * as utilityObsidian from "../utilityObsidian";
 
 const createCaptureChoice = (): ICaptureChoice => ({
 	name: "Test Capture Choice",
@@ -209,6 +211,7 @@ const createEngine = ({
 describe("CaptureChoiceEngine concurrent-edit merge", () => {
 	beforeEach(() => {
 		formatContentWithFileMock.mockReset();
+		vi.mocked(utilityObsidian.copyFileLinkToClipboard).mockClear();
 	});
 
 	it("proceeds when concurrent edits can be merged cleanly", async () => {
@@ -256,5 +259,31 @@ describe("CaptureChoiceEngine concurrent-edit merge", () => {
 		const result = await (engine as any).onFileExists(filePath, "captured ours");
 
 		expect(result.newFileContent).toBe(formattedFileContent);
+	});
+
+	it("copies the captured file link after a successful capture", async () => {
+		const { engine } = createEngine({
+			firstRead: "existing\n",
+			secondRead: "existing\n",
+			formattedFileContent: "existing\ncaptured\n",
+		});
+		engine.choice.appendLink = {
+			enabled: false,
+			copyToClipboard: true,
+			placement: "replaceSelection",
+			requireActiveFile: false,
+			linkType: "link",
+		};
+
+		await engine.run();
+
+		expect(utilityObsidian.copyFileLinkToClipboard).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ path: "Daily/Test.md" }),
+			expect.objectContaining({
+				enabled: false,
+				copyToClipboard: true,
+			}),
+		);
 	});
 });

--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -74,6 +74,7 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 		getMarkdownFilesInFolder: vi.fn(async () => []),
 		getMarkdownFilesWithTag: vi.fn(async () => []),
 		insertFileLinkToActiveView: vi.fn(),
+	copyFileLinkToClipboard: vi.fn(async () => false),
 		insertOnNewLineAbove: vi.fn(),
 		insertOnNewLineBelow: vi.fn(),
 		isFolder: vi.fn(() => false),

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -83,6 +83,7 @@ vi.mock("../utilityObsidian", () => ({
 	getMarkdownFilesInFolder: vi.fn(() => []),
 	getMarkdownFilesWithTag: vi.fn(() => []),
 	insertFileLinkToActiveView: vi.fn(),
+	copyFileLinkToClipboard: vi.fn(async () => false),
 	insertOnNewLineAbove: vi.fn(() => true),
 	insertOnNewLineBelow: vi.fn(() => true),
 	isFolder: vi.fn(() => false),

--- a/src/engine/CaptureChoiceEngine.template-property-types.test.ts
+++ b/src/engine/CaptureChoiceEngine.template-property-types.test.ts
@@ -125,6 +125,7 @@ vi.mock("../utilityObsidian", () => ({
 	getMarkdownFilesInFolder: vi.fn().mockResolvedValue([]),
 	getMarkdownFilesWithTag: vi.fn().mockResolvedValue([]),
 	insertFileLinkToActiveView: vi.fn(),
+	copyFileLinkToClipboard: vi.fn(async () => false),
 		insertOnNewLineAbove: vi.fn(),
 		insertOnNewLineBelow: vi.fn(),
 		isTemplaterTriggerOnCreateEnabled: vi.fn().mockReturnValue(false),

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -29,6 +29,7 @@ import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import { normalizeAppendLinkOptions, type AppendLinkOptions } from "../types/linkPlacement";
 import {
 	appendToCurrentLine,
+	copyFileLinkToClipboard,
 	getMarkdownFilesInFolder,
 	getMarkdownFilesWithTag,
 	getMarkdownFilesWithProperty,
@@ -199,28 +200,27 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		);
 	}
 
-	private insertCaptureLink(
+	private async applyCaptureLinkSideEffects(
 		file: TFile,
 		linkOptions: AppendLinkOptions,
 		{ isCanvasTriggered }: { isCanvasTriggered: boolean },
-	): void {
-		if (!linkOptions.enabled) {
-			return;
-		}
-
-		if (
-			this.shouldSkipRequiredCanvasLinkInsertion(linkOptions, isCanvasTriggered)
-		) {
-			if (this.plugin.settings.showCaptureNotification) {
-				new Notice(
-					"Canvas capture skipped link insertion because no Markdown editor is focused.",
-					DEFAULT_NOTICE_DURATION,
-				);
+	): Promise<void> {
+		if (linkOptions.enabled) {
+			if (
+				this.shouldSkipRequiredCanvasLinkInsertion(linkOptions, isCanvasTriggered)
+			) {
+				if (this.plugin.settings.showCaptureNotification) {
+					new Notice(
+						"Canvas capture skipped link insertion because no Markdown editor is focused.",
+						DEFAULT_NOTICE_DURATION,
+					);
+				}
+			} else {
+				insertFileLinkToActiveView(this.app, file, linkOptions);
 			}
-			return;
 		}
 
-		insertFileLinkToActiveView(this.app, file, linkOptions);
+		await copyFileLinkToClipboard(this.app, file, linkOptions);
 	}
 
 	async run(): Promise<void> {
@@ -419,7 +419,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				});
 			}
 
-			this.insertCaptureLink(file, linkOptions, {
+			await this.applyCaptureLinkSideEffects(file, linkOptions, {
 				isCanvasTriggered: !!canvasTarget,
 			});
 
@@ -516,7 +516,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			});
 		}
 
-		this.insertCaptureLink(file, linkOptions, {
+		await this.applyCaptureLinkSideEffects(file, linkOptions, {
 			isCanvasTriggered: true,
 		});
 

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -96,6 +96,7 @@ vi.mock("../utilityObsidian", () => ({
 	overwriteTemplaterOnce: vi.fn(),
 	getAllFolderPathsInVault: vi.fn(() => []),
 	insertFileLinkToActiveView: vi.fn(),
+	copyFileLinkToClipboard: vi.fn(async () => false),
 	openExistingFileTab: vi.fn(() => null),
 	openFile: vi.fn(),
 }));
@@ -120,6 +121,7 @@ import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { settingsStore } from "../settingsStore";
 import { getPromptModes } from "../template/fileExistsPolicy";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import * as utilityObsidian from "../utilityObsidian";
 import { TemplateChoiceEngine } from "./TemplateChoiceEngine";
 
 const defaultSettingsState = structuredClone(settingsStore.getState());
@@ -214,6 +216,7 @@ describe("TemplateChoiceEngine collision behavior", () => {
 		formatTemplatePathMock.mockReset();
 		formatTemplatePathMock.mockImplementation(async (input: string) => input);
 		vi.mocked(GenericSuggester.Suggest).mockReset();
+		vi.mocked(utilityObsidian.copyFileLinkToClipboard).mockClear();
 	});
 
 	it("uses the RESOLVED template path for both the target extension and the read (issue #620)", async () => {
@@ -247,6 +250,43 @@ describe("TemplateChoiceEngine collision behavior", () => {
 		expect(createSpy).toHaveBeenCalledWith(
 			"My Board.canvas",
 			"Templates/Board.canvas",
+		);
+	});
+
+	it("copies the link for the final created file after template creation", async () => {
+		const { app, engine } = createEngine();
+		const createdFile = createExistingFile("Test Template.md");
+		engine.choice.appendLink = {
+			enabled: false,
+			copyToClipboard: true,
+			placement: "replaceSelection",
+			requireActiveFile: false,
+			linkType: "link",
+		};
+
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(
+			false,
+		);
+
+		vi.spyOn(
+			engine as unknown as {
+				createFileWithTemplate: (
+					filePath: string,
+					templatePath: string,
+				) => Promise<TFile | null>;
+			},
+			"createFileWithTemplate",
+		).mockResolvedValue(createdFile);
+
+		await engine.run();
+
+		expect(utilityObsidian.copyFileLinkToClipboard).toHaveBeenCalledWith(
+			app,
+			createdFile,
+			expect.objectContaining({
+				enabled: false,
+				copyToClipboard: true,
+			}),
 		);
 	});
 

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -90,6 +90,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		overwriteTemplaterOnce: vi.fn(),
 		getAllFolderPathsInVault: vi.fn(() => []),
 		insertFileLinkToActiveView: vi.fn(),
+	copyFileLinkToClipboard: vi.fn(async () => false),
 		openExistingFileTab: vi.fn(() => null),
 		openFile: vi.fn(),
 	}));

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -16,6 +16,7 @@ import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { normalizeAppendLinkOptions } from "../types/linkPlacement";
 import {
 	getAllFolderPathsInVault,
+	copyFileLinkToClipboard,
 	insertFileLinkToActiveView,
 	jumpToNextTemplaterCursorIfPossible,
 	openExistingFileTab,
@@ -168,7 +169,11 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			});
 
 			if (linkOptions.enabled && createdFile) {
-			insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+				insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+			}
+
+			if (createdFile) {
+				await copyFileLinkToClipboard(this.app, createdFile, linkOptions);
 			}
 
 			if ((this.choice.openFile || shouldAutoOpen) && createdFile) {

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import SettingItem from "../../components/SettingItem.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
+import Toggle from "../../components/Toggle.svelte";
 import type {
 	AppendLinkOptions,
 	LinkPlacement,
@@ -29,6 +30,7 @@ type AppendLinkMode = "required" | "optional" | "disabled";
 
 const normalized = $derived(normalizeAppendLinkOptions(appendLink));
 const normalizedLinkType = $derived(normalized.linkType ?? "link");
+const copyToClipboard = $derived(normalized.copyToClipboard ?? false);
 const currentMode = $derived(
 	normalized.enabled
 		? normalized.requireActiveFile
@@ -56,11 +58,20 @@ const linkTypeOptions = [
 function onModeChange(value: string) {
 	switch (value as AppendLinkMode) {
 		case "disabled":
-			appendLink = false;
+			appendLink = copyToClipboard
+				? {
+					enabled: false,
+					copyToClipboard: true,
+					placement: normalized.placement,
+					requireActiveFile: false,
+					linkType: normalizedLinkType,
+				}
+				: false;
 			break;
 		case "required":
 			appendLink = {
 				enabled: true,
+				copyToClipboard,
 				placement: normalized.placement,
 				requireActiveFile: true,
 				linkType: normalizedLinkType,
@@ -69,6 +80,7 @@ function onModeChange(value: string) {
 		case "optional":
 			appendLink = {
 				enabled: true,
+				copyToClipboard,
 				placement: normalized.placement,
 				requireActiveFile: false,
 				linkType: normalizedLinkType,
@@ -93,6 +105,7 @@ function onPlacementChange(value: string) {
 		: "link";
 	appendLink = {
 		enabled: true,
+		copyToClipboard,
 		placement,
 		requireActiveFile,
 		linkType: nextLinkType,
@@ -109,9 +122,36 @@ function onLinkTypeChange(value: string) {
 		typeof current === "boolean" ? normalized.placement : current.placement;
 	appendLink = {
 		enabled: true,
+		copyToClipboard,
 		placement,
 		requireActiveFile,
 		linkType: value as LinkType,
+	};
+}
+
+function onCopyToClipboardChange(value: boolean) {
+	const current = appendLink;
+	const enabled = typeof current === "boolean" ? normalized.enabled : current.enabled;
+	const requireActiveFile =
+		typeof current === "boolean"
+			? normalized.requireActiveFile
+			: current.requireActiveFile;
+	const placement =
+		typeof current === "boolean" ? normalized.placement : current.placement;
+	const linkType =
+		typeof current === "boolean" ? normalizedLinkType : current.linkType ?? normalizedLinkType;
+
+	if (!value && !enabled) {
+		appendLink = false;
+		return;
+	}
+
+	appendLink = {
+		enabled,
+		copyToClipboard: value,
+		placement,
+		requireActiveFile,
+		linkType,
 	};
 }
 </script>
@@ -122,6 +162,19 @@ function onLinkTypeChange(value: string) {
 >
 	{#snippet control()}
 		<Dropdown value={currentMode} options={modeOptions} onchange={onModeChange} />
+	{/snippet}
+</SettingItem>
+
+<SettingItem
+	name="Copy link to clipboard"
+	desc={`Copy the ${fileLabel} file's Obsidian link after QuickAdd finishes.`}
+>
+	{#snippet control()}
+		<Toggle
+			checked={copyToClipboard}
+			ariaLabel="Copy link to clipboard"
+			onchange={onCopyToClipboardChange}
+		/>
 	{/snippet}
 </SettingItem>
 

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
@@ -14,7 +14,10 @@ describe("AppendLinkSetting", () => {
 		const { container } = render(AppendLinkSetting, {
 			props: { appendLink: false, fileLabel: "created" },
 		});
-		expect(settingNames(container)).toEqual(["Link to created file"]);
+		expect(settingNames(container)).toEqual([
+			"Link to created file",
+			"Copy link to clipboard",
+		]);
 	});
 
 	it("shows placement + link type when enabled with an embed-capable placement", () => {
@@ -29,6 +32,7 @@ describe("AppendLinkSetting", () => {
 		});
 		expect(settingNames(container)).toEqual([
 			"Link to captured file",
+			"Copy link to clipboard",
 			"Link placement",
 			"Link type",
 		]);
@@ -46,8 +50,32 @@ describe("AppendLinkSetting", () => {
 		});
 		expect(settingNames(container)).toEqual([
 			"Link to captured file",
+			"Copy link to clipboard",
 			"Link placement",
 		]);
 		expect(settingNames(container)).not.toContain("Link type");
+	});
+
+	it("renders copy-only configuration while insertion is disabled", () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: false,
+			copyToClipboard: true,
+			placement: "replaceSelection",
+			requireActiveFile: false,
+			linkType: "link",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		expect(settingNames(container)).toEqual([
+			"Link to created file",
+			"Copy link to clipboard",
+		]);
+		expect(
+			container
+				.querySelector('[role="switch"][aria-label="Copy link to clipboard"]')
+				?.getAttribute("aria-checked"),
+		).toBe("true");
 	});
 });

--- a/src/types/linkPlacement.test.ts
+++ b/src/types/linkPlacement.test.ts
@@ -39,6 +39,20 @@ describe("LinkPlacement", () => {
 			};
 			expect(normalizeAppendLinkOptions(options)).toEqual({
 				...options,
+				copyToClipboard: false,
+				linkType: "link",
+			});
+		});
+
+		it("should preserve copyToClipboard when present", () => {
+			const options: AppendLinkOptions = {
+				enabled: false,
+				copyToClipboard: true,
+				placement: "replaceSelection",
+				requireActiveFile: false,
+			};
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
 				linkType: "link",
 			});
 		});
@@ -47,6 +61,7 @@ describe("LinkPlacement", () => {
 			const result = normalizeAppendLinkOptions(true);
 			expect(result).toEqual({
 				enabled: true,
+				copyToClipboard: false,
 				placement: "replaceSelection",
 				requireActiveFile: true,
 				linkType: "link",
@@ -57,6 +72,7 @@ describe("LinkPlacement", () => {
 			const result = normalizeAppendLinkOptions(false);
 			expect(result).toEqual({
 				enabled: false,
+				copyToClipboard: false,
 				placement: "replaceSelection",
 				requireActiveFile: false,
 				linkType: "link",
@@ -70,7 +86,10 @@ describe("LinkPlacement", () => {
 				requireActiveFile: true,
 				linkType: "embed",
 			};
-			expect(normalizeAppendLinkOptions(options)).toEqual(options);
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
+				copyToClipboard: false,
+			});
 		});
 
 		it("should sanitize embed linkType when placement does not support embeds", () => {
@@ -82,6 +101,7 @@ describe("LinkPlacement", () => {
 			};
 			expect(normalizeAppendLinkOptions(options)).toEqual({
 				...options,
+				copyToClipboard: false,
 				linkType: "link",
 			});
 		});

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -29,6 +29,8 @@ function sanitizeLinkType(
 export interface AppendLinkOptions {
 	/** Whether link appending is enabled */
 	enabled: boolean;
+	/** Whether to copy the generated link to the clipboard after the file is produced */
+	copyToClipboard?: boolean;
 	/** Where to place the appended link */
 	placement: LinkPlacement;
 	/**
@@ -70,6 +72,7 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 
 		return {
 			enabled: appendLink.enabled,
+			copyToClipboard: appendLink.copyToClipboard ?? false,
 			placement,
 			requireActiveFile: appendLink.requireActiveFile ?? true,
 			linkType: sanitizeLinkType(appendLink.linkType, placement),
@@ -79,6 +82,7 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 	// Convert legacy boolean format to new options format
 	return {
 		enabled: appendLink,
+		copyToClipboard: false,
 		placement: "replaceSelection", // Default placement for backward compatibility
 		requireActiveFile: appendLink ? true : false,
 		linkType: "link",

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -9,6 +9,8 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import {
 	areSameVaultFilePath,
+	buildFileMarkdownLink,
+	copyFileLinkToClipboard,
 	getAllFolderPathsInVault,
 	getUserScript,
 	normalizeVaultFilePath,
@@ -399,6 +401,79 @@ describe("getUserScript", () => {
 		// CommonJS contract: a note script must assign module.exports/exports.default.
 		// Without it, the export is the empty module object, never a runnable function.
 		expect(typeof script).not.toBe("function");
+	});
+});
+
+describe("file link clipboard helpers", () => {
+	it("builds markdown links through Obsidian's file manager", () => {
+		const file = createFile("Folder/Target.md");
+		const app = {
+			workspace: {
+				getActiveFile: vi.fn(() => createFile("Source.md")),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Target]]"),
+			},
+		} as unknown as App;
+
+		expect(buildFileMarkdownLink(app, file)).toBe("[[Target]]");
+		expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(
+			file,
+			"Source.md",
+		);
+	});
+
+	it("copies the generated link to the clipboard", async () => {
+		const writeText = vi.fn(async () => undefined);
+		vi.stubGlobal("navigator", { clipboard: { writeText } });
+		const file = createFile("Folder/Target.md");
+		const app = {
+			workspace: {
+				getActiveFile: vi.fn(() => null),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Folder/Target]]"),
+			},
+		} as unknown as App;
+
+		await expect(
+			copyFileLinkToClipboard(app, file, {
+				enabled: false,
+				copyToClipboard: true,
+				placement: "replaceSelection",
+				requireActiveFile: false,
+			}),
+		).resolves.toBe(true);
+
+		expect(writeText).toHaveBeenCalledWith("[[Folder/Target]]");
+	});
+
+	it("treats clipboard write failure as a non-fatal side effect", async () => {
+		vi.stubGlobal("navigator", {
+			clipboard: {
+				writeText: vi.fn(async () => {
+					throw new Error("denied");
+				}),
+			},
+		});
+		const file = createFile("Target.md");
+		const app = {
+			workspace: {
+				getActiveFile: vi.fn(() => null),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Target]]"),
+			},
+		} as unknown as App;
+
+		await expect(
+			copyFileLinkToClipboard(app, file, {
+				enabled: false,
+				copyToClipboard: true,
+				placement: "replaceSelection",
+				requireActiveFile: false,
+			}),
+		).resolves.toBe(false);
 	});
 });
 

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -37,6 +37,8 @@ export {
 	insertOnNewLineBelow,
 	insertLinkWithPlacement,
 	insertFileLinkToActiveView,
+	buildFileMarkdownLink,
+	copyFileLinkToClipboard,
 } from "./utils/editorInsertion";
 
 export {

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -1,5 +1,4 @@
-import type { App, TFile } from "obsidian";
-import { MarkdownView } from "obsidian";
+import { MarkdownView, Notice, type App, type TFile } from "obsidian";
 import { log } from "../logger/logManager";
 import type { AppendLinkOptions, LinkPlacement } from "../types/linkPlacement";
 import { placementSupportsEmbed } from "../types/linkPlacement";
@@ -217,7 +216,7 @@ export function insertFileLinkToActiveView(
 	}
 
 	const sourcePath = activeFile?.path ?? "";
-	const baseLink = app.fileManager.generateMarkdownLink(file, sourcePath);
+	const baseLink = buildFileMarkdownLink(app, file, sourcePath);
 	const shouldEmbed =
 		linkOptions.linkType === "embed" &&
 		placementSupportsEmbed(linkOptions.placement);
@@ -231,4 +230,33 @@ export function insertFileLinkToActiveView(
 	);
 
 	return true;
+}
+
+export function buildFileMarkdownLink(
+	app: App,
+	file: TFile,
+	sourcePath = app.workspace.getActiveFile()?.path ?? "",
+): string {
+	return app.fileManager.generateMarkdownLink(file, sourcePath);
+}
+
+export async function copyFileLinkToClipboard(
+	app: App,
+	file: TFile,
+	linkOptions: AppendLinkOptions,
+): Promise<boolean> {
+	if (!linkOptions.copyToClipboard) return false;
+
+	const linkText = buildFileMarkdownLink(app, file);
+
+	try {
+		await navigator.clipboard.writeText(linkText);
+		new Notice("Copied link to clipboard.");
+		return true;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		log.logError(`Could not copy link to clipboard: ${message}`);
+		new Notice("QuickAdd could not copy the link to the clipboard.");
+		return false;
+	}
 }

--- a/tests/e2e/copy-link-to-clipboard.test.ts
+++ b/tests/e2e/copy-link-to-clipboard.test.ts
@@ -22,6 +22,7 @@ let obsidian: ObsidianClient;
 let sandbox: SandboxApi;
 let qa: PluginHandle;
 let lock: VaultRunLock | undefined;
+const ACTIVE_NOTE_CONTENT = "Active note must not receive the copied link.";
 
 type QuickAddData = {
 	choices: Record<string, unknown>[];
@@ -126,6 +127,16 @@ async function runChoice(name: string) {
 	await obsidian.exec("quickadd:run", { choice: name });
 }
 
+async function openSandboxFile(path: string) {
+	await obsidian.exec("eval", {
+		code: `(async () => {
+			const file = app.vault.getAbstractFileByPath(${JSON.stringify(sandbox.path(path))});
+			await app.workspace.getLeaf().openFile(file);
+			return app.workspace.getActiveFile()?.path;
+		})()`,
+	});
+}
+
 async function reloadPluginCode() {
 	await obsidian.exec("eval", {
 		code: '(async () => { await app.plugins.disablePlugin("quickadd"); await app.plugins.enablePlugin("quickadd"); return true; })()',
@@ -133,6 +144,12 @@ async function reloadPluginCode() {
 }
 
 beforeAll(async () => {
+	if (!process.env.QUICKADD_E2E_VAULT_PATH) {
+		throw new Error(
+			"copy-link-to-clipboard E2E must run with start:e2e-obsidian -- --print-env exports.",
+		);
+	}
+
 	obsidian = createQuickAddObsidianClient();
 	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
@@ -145,6 +162,10 @@ beforeAll(async () => {
 	});
 
 	await sandbox.write("template.md", "Template content", {
+		waitForContent: true,
+		waitOptions: WAIT_OPTS,
+	});
+	await sandbox.write("active-note.md", ACTIVE_NOTE_CONTENT, {
 		waitForContent: true,
 		waitOptions: WAIT_OPTS,
 	});
@@ -192,6 +213,7 @@ describe("copy produced file link to clipboard", () => {
 
 	it("copies the created Template choice link without inserting it", async () => {
 		await setClipboard("before-template");
+		await openSandboxFile("active-note.md");
 
 		await runChoice("__qa-test-600-template-copy");
 		await sandbox.waitForContent(
@@ -201,10 +223,12 @@ describe("copy produced file link to clipboard", () => {
 		);
 
 		expect(await readClipboard()).toBe("[[template-created]]");
+		expect(await sandbox.read("active-note.md")).toBe(ACTIVE_NOTE_CONTENT);
 	});
 
 	it("copies the captured file link without requiring an active target note", async () => {
 		await setClipboard("before-capture");
+		await openSandboxFile("active-note.md");
 
 		await runChoice("__qa-test-600-capture-copy");
 		await sandbox.waitForContent(
@@ -214,5 +238,6 @@ describe("copy produced file link to clipboard", () => {
 		);
 
 		expect(await readClipboard()).toBe("[[capture-created]]");
+		expect(await sandbox.read("active-note.md")).toBe(ACTIVE_NOTE_CONTENT);
 	});
 });

--- a/tests/e2e/copy-link-to-clipboard.test.ts
+++ b/tests/e2e/copy-link-to-clipboard.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	captureFailureArtifacts,
+	clearVaultRunLockMarker,
+	createSandboxApi,
+} from "obsidian-e2e";
+import type {
+	ObsidianClient,
+	PluginHandle,
+	SandboxApi,
+	VaultRunLock,
+} from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
+
+const PLUGIN_ID = "quickadd";
+const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
+
+let obsidian: ObsidianClient;
+let sandbox: SandboxApi;
+let qa: PluginHandle;
+let lock: VaultRunLock | undefined;
+
+type QuickAddData = {
+	choices: Record<string, unknown>[];
+};
+
+function copyOnlyLinkOptions() {
+	return {
+		enabled: false,
+		copyToClipboard: true,
+		placement: "replaceSelection",
+		requireActiveFile: false,
+		linkType: "link",
+	};
+}
+
+function fileOpening() {
+	return {
+		location: "tab",
+		direction: "vertical",
+		mode: "source",
+		focus: false,
+	};
+}
+
+function templateChoice(id: string, templatePath: string, fileName: string) {
+	return {
+		id,
+		name: id,
+		type: "Template",
+		command: false,
+		templatePath,
+		fileNameFormat: { enabled: true, format: fileName },
+		folder: {
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		},
+		appendLink: copyOnlyLinkOptions(),
+		openFile: false,
+		fileOpening: fileOpening(),
+		fileExistsBehavior: { kind: "apply", mode: "overwrite" },
+	};
+}
+
+function captureChoice(id: string, captureTo: string) {
+	return {
+		id,
+		name: id,
+		type: "Capture",
+		command: false,
+		captureTo,
+		captureToActiveFile: false,
+		createFileIfItDoesntExist: {
+			enabled: true,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: true, format: "Captured content" },
+		prepend: false,
+		appendLink: copyOnlyLinkOptions(),
+		task: false,
+		insertAfter: {
+			enabled: false,
+			after: "",
+			insertAtEnd: false,
+			considerSubsections: false,
+			createIfNotFound: false,
+			createIfNotFoundLocation: "",
+		},
+		newLineCapture: {
+			enabled: false,
+			direction: "below",
+		},
+		openFile: false,
+		fileOpening: fileOpening(),
+	};
+}
+
+function clearTestChoices(data: QuickAddData) {
+	data.choices = data.choices.filter(
+		(choice) => !String(choice.id ?? "").startsWith("__qa-test-600-"),
+	);
+}
+
+async function readClipboard() {
+	const result = await obsidian.exec("eval", {
+		code: "navigator.clipboard.readText()",
+	});
+	const stdout = String(result.stdout ?? "").trim();
+	return stdout.replace(/^=>\s*/, "");
+}
+
+async function setClipboard(text: string) {
+	await obsidian.exec("eval", {
+		code: `navigator.clipboard.writeText(${JSON.stringify(text)})`,
+	});
+}
+
+async function runChoice(name: string) {
+	await obsidian.exec("quickadd:run", { choice: name });
+}
+
+async function reloadPluginCode() {
+	await obsidian.exec("eval", {
+		code: '(async () => { await app.plugins.disablePlugin("quickadd"); await app.plugins.enablePlugin("quickadd"); return true; })()',
+	});
+}
+
+beforeAll(async () => {
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
+	await lock.publishMarker(obsidian);
+
+	qa = obsidian.plugin(PLUGIN_ID);
+	sandbox = await createSandboxApi({
+		obsidian,
+		sandboxRoot: "__obsidian_e2e__",
+		testName: "copy-link-to-clipboard",
+	});
+
+	await sandbox.write("template.md", "Template content", {
+		waitForContent: true,
+		waitOptions: WAIT_OPTS,
+	});
+}, 30_000);
+
+afterAll(async () => {
+	await qa.restoreData();
+	await qa.reload();
+	await sandbox.cleanup();
+	await clearVaultRunLockMarker(obsidian).catch(() => {});
+	await lock?.release();
+}, 15_000);
+
+beforeEach((ctx) => {
+	ctx.onTestFailed(async () => {
+		await captureFailureArtifacts(
+			{ id: ctx.task.id, name: ctx.task.name },
+			obsidian,
+			{ plugin: qa, captureOnFailure: true },
+		);
+	});
+});
+
+describe("copy produced file link to clipboard", () => {
+	beforeAll(async () => {
+		const root = sandbox.root;
+
+		await qa.data<QuickAddData>().patch((data) => {
+			clearTestChoices(data);
+			data.choices.push(
+				templateChoice(
+					"__qa-test-600-template-copy",
+					sandbox.path("template.md"),
+					`${root}/template-created`,
+				),
+				captureChoice(
+					"__qa-test-600-capture-copy",
+					`${root}/capture-created.md`,
+				),
+			);
+		});
+
+		await reloadPluginCode();
+	}, 15_000);
+
+	it("copies the created Template choice link without inserting it", async () => {
+		await setClipboard("before-template");
+
+		await runChoice("__qa-test-600-template-copy");
+		await sandbox.waitForContent(
+			"template-created.md",
+			(content) => content.includes("Template content"),
+			WAIT_OPTS,
+		);
+
+		expect(await readClipboard()).toBe("[[template-created]]");
+	});
+
+	it("copies the captured file link without requiring an active target note", async () => {
+		await setClipboard("before-capture");
+
+		await runChoice("__qa-test-600-capture-copy");
+		await sandbox.waitForContent(
+			"capture-created.md",
+			(content) => content.includes("Captured content"),
+			WAIT_OPTS,
+		);
+
+		expect(await readClipboard()).toBe("[[capture-created]]");
+	});
+});


### PR DESCRIPTION
Adds a copy-to-clipboard link action for Template and Capture choices, so users can create or capture to a note and paste that note link somewhere else without requiring insertion into the active note.

The underlying problem in #600 is not just Template insertion placement: the produced note link needs to be portable. I extended the existing `appendLink` model with `copyToClipboard` instead of adding a Template-only setting, so Template and Capture choices share the same Linking section and can be configured as insert-only, copy-only, both, or neither. The copied text is generated through Obsidian's `fileManager.generateMarkdownLink`, matching the existing inserted-link behavior and respecting vault link settings.

Compatibility notes:
- Existing boolean `appendLink` settings still normalize to copy disabled, so no migration is required.
- Clipboard write failures are treated as non-fatal post-commit side effects: the note/capture remains successful and QuickAdd shows/logs the copy failure.
- This applies to configured Template/Capture choices. The ad hoc "New note from template" launcher does not get a new global copy default in this PR.

Validation:
- Reproduced baseline in the isolated worktree vault: Template choice created `qa-600-created.md` while clipboard stayed `BASELINE_CLIPBOARD`.
- Verified fix in the isolated worktree vault: Template copy-only choice created `qa-600-manual-created.md` and clipboard became `[[qa-600-manual-created]]`.
- Verified Capture fix in the isolated worktree vault: Capture copy-only choice wrote `qa-600-manual-capture-created.md` and clipboard became `[[qa-600-manual-capture-created]]`.
- `pnpm run check`
- `pnpm run test`
- `pnpm run build-with-lint`
- `QUICKADD_E2E_* ... pnpm exec vitest run --config vitest.e2e.config.mts tests/e2e/copy-link-to-clipboard.test.ts`

Fixes #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Copy link to clipboard" toggle for Capture and Template choices, enabling users to automatically copy created file links to the clipboard without inserting them into the active note. This option operates independently from link insertion settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->