### PR TITLE
feat(multi): add editor menu display mode

### DIFF
--- a/docs/docs/Choices/MultiChoice.md
+++ b/docs/docs/Choices/MultiChoice.md
@@ -16,6 +16,14 @@ You can optionally set a placeholder for each Multi choice. This text shows up i
 
 Keep in mind that [searching covers everything nested under the multi](#searching-nested-choices), so word the placeholder accordingly.
 
+## Editor menu mode
+
+By default, opening a Multi choice shows the searchable choice picker. You can change a Multi choice's **Open as** setting to **Editor menu** when you want a compact menu for quick actions while editing.
+
+Editor menu mode is useful for small action groups such as text formatting, inserting snippets, or running editor macros from a hotkey. It opens a menu near the active editor and runs the selected child choice through the same QuickAdd execution path as the picker.
+
+Nested Multi choices are shown as flat path labels, for example `Formatting / Case / Uppercase`. This keeps the menu reliable across Obsidian desktop and mobile surfaces. Use the regular choice picker mode when you need fuzzy search, step-by-step browsing, placeholders, or large nested menus.
+
 ## Searching nested choices
 
 Typing in the choice picker searches every choice nested inside the current level's multis — not just the level you are looking at. Nested matches show their folder path (for example `Work / Meetings`) beneath the choice name. This also applies to the root picker opened by the **QuickAdd: Run** command or the ribbon icon.

--- a/src/choiceExecutor.multiMenu.test.ts
+++ b/src/choiceExecutor.multiMenu.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { ChoiceExecutor } from "./choiceExecutor";
+import type IChoice from "./types/choices/IChoice";
+import type IMultiChoice from "./types/choices/IMultiChoice";
+
+const { showChoiceMenuMock, choiceSuggesterOpenMock } = vi.hoisted(() => ({
+	showChoiceMenuMock: vi.fn(),
+	choiceSuggesterOpenMock: vi.fn(),
+}));
+
+vi.mock("./gui/choiceMenu", () => ({
+	showChoiceMenu: showChoiceMenuMock,
+}));
+
+vi.mock("./gui/suggesters/choiceSuggester", () => ({
+	default: {
+		Open: choiceSuggesterOpenMock,
+	},
+}));
+
+vi.mock("./engine/TemplateChoiceEngine", () => ({
+	TemplateChoiceEngine: class {
+		run = vi.fn();
+	},
+}));
+
+vi.mock("./engine/CaptureChoiceEngine", () => ({
+	CaptureChoiceEngine: class {
+		run = vi.fn();
+	},
+}));
+
+vi.mock("./engine/MacroChoiceEngine", () => ({
+	MacroChoiceEngine: class {
+		params = { variables: {} };
+		run = vi.fn();
+	},
+}));
+
+vi.mock("./preflight/runOnePagePreflight", () => ({
+	runOnePagePreflight: vi.fn(),
+}));
+
+vi.mock("./utilityObsidian", () => ({
+	getOpenFileOriginLeaf: vi.fn(() => null),
+}));
+
+const child: IChoice = {
+	id: "child",
+	name: "Child",
+	type: "Template",
+	command: false,
+};
+
+const multi = (overrides: Partial<IMultiChoice> = {}): IMultiChoice => ({
+	id: "multi",
+	name: "Multi",
+	type: "Multi",
+	command: false,
+	collapsed: false,
+	choices: [child],
+	...overrides,
+});
+
+describe("ChoiceExecutor Multi display modes", () => {
+	beforeEach(() => {
+		showChoiceMenuMock.mockClear();
+		choiceSuggesterOpenMock.mockClear();
+	});
+
+	it("opens menu-mode Multi choices with the compact menu", async () => {
+		const app = new App();
+		const plugin = { app } as never;
+		const executor = new ChoiceExecutor(app, plugin);
+		const choice = multi({ displayMode: "menu" });
+
+		await executor.execute(choice);
+
+		expect(showChoiceMenuMock).toHaveBeenCalledWith(app, [child], executor);
+		expect(choiceSuggesterOpenMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps picker mode as the default for existing Multi choices", async () => {
+		const app = new App();
+		const plugin = { app } as never;
+		const executor = new ChoiceExecutor(app, plugin);
+		const choice = multi({ placeholder: "Pick one" });
+
+		await executor.execute(choice);
+
+		expect(choiceSuggesterOpenMock).toHaveBeenCalledWith(plugin, [child], {
+			choiceExecutor: executor,
+			placeholder: "Pick one",
+		});
+		expect(showChoiceMenuMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -18,6 +18,7 @@ import { isCancellationError, reportError } from "./utils/errorUtils";
 import { getOpenFileOriginLeaf } from "./utilityObsidian";
 import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
 import type { ChoiceOutcome } from "./types/ChoiceOutcome";
+import { showChoiceMenu } from "./gui/choiceMenu";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
@@ -224,6 +225,11 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	}
 
 	private onChooseMultiType(multiChoice: IMultiChoice) {
+		if (multiChoice.displayMode === "menu") {
+			showChoiceMenu(this.app, multiChoice.choices, this);
+			return;
+		}
+
 		ChoiceSuggester.Open(this.plugin, multiChoice.choices, {
 			choiceExecutor: this,
 			placeholder: multiChoice.placeholder,

--- a/src/gui/MultiChoiceSettingsModal.ts
+++ b/src/gui/MultiChoiceSettingsModal.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
 import { ButtonComponent, Modal, Setting } from "obsidian";
+import type { MultiChoiceDisplayMode } from "../types/choices/IMultiChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
 
 export class MultiChoiceSettingsModal extends Modal {
@@ -10,11 +11,13 @@ export class MultiChoiceSettingsModal extends Modal {
 
 	private name: string;
 	private placeholder: string;
+	private displayMode: MultiChoiceDisplayMode;
 
 	constructor(app: App, private choice: IMultiChoice) {
 		super(app);
 		this.name = choice.name;
 		this.placeholder = choice.placeholder ?? "";
+		this.displayMode = choice.displayMode ?? "picker";
 
 		this.waitForClose = new Promise<IMultiChoice | undefined>(
 			(resolve, reject) => {
@@ -52,6 +55,21 @@ export class MultiChoiceSettingsModal extends Modal {
 				});
 			});
 
+		new Setting(this.contentEl)
+			.setName("Open as")
+			.setDesc(
+				"Picker keeps search and browsing. Menu opens a compact flat menu near the editor and labels nested choices by path.",
+			)
+			.addDropdown((dropdown) => {
+				dropdown
+					.addOption("picker", "Choice picker")
+					.addOption("menu", "Editor menu")
+					.setValue(this.displayMode)
+					.onChange((value) => {
+						this.displayMode = value as MultiChoiceDisplayMode;
+					});
+			});
+
 		const buttonRow = this.contentEl.createDiv();
 		new ButtonComponent(buttonRow)
 			.setButtonText("Save")
@@ -85,6 +103,8 @@ export class MultiChoiceSettingsModal extends Modal {
 			...this.choice,
 			name: this.name.trim() || this.choice.name,
 			placeholder: trimmedPlaceholder ? trimmedPlaceholder : undefined,
+			displayMode:
+				this.displayMode === "menu" ? this.displayMode : undefined,
 		};
 		this.resolvePromise(updated);
 	}

--- a/src/gui/choiceMenu.test.ts
+++ b/src/gui/choiceMenu.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App, MarkdownView, Menu } from "obsidian";
+import {
+	collectChoicesForMenu,
+	getEditorMenuPosition,
+	showChoiceMenu,
+} from "./choiceMenu";
+import type IChoice from "../types/choices/IChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+
+const choice = (
+	id: string,
+	name: string,
+	type: IChoice["type"] = "Template",
+): IChoice => ({
+	id,
+	name,
+	type,
+	command: false,
+});
+
+const multi = (
+	id: string,
+	name: string,
+	choices: IChoice[],
+): IMultiChoice => ({
+	id,
+	name,
+	type: "Multi",
+	command: false,
+	collapsed: false,
+	choices,
+});
+
+describe("choice menu", () => {
+	beforeEach(() => {
+		Menu.lastShown = null;
+	});
+
+	it("flattens nested multis into path-labeled executable choices", () => {
+		const choices = [
+			multi("parent", "Formatting", [
+				choice("bold", "Bold"),
+				multi("case", "Case", [choice("upper", "Uppercase", "Macro")]),
+			]),
+		];
+
+		expect(collectChoicesForMenu(choices)).toEqual([
+			{ choice: choices[0].choices[0], title: "Formatting / Bold" },
+			{
+				choice: (choices[0].choices[1] as IMultiChoice).choices[0],
+				title: "Formatting / Case / Uppercase",
+			},
+		]);
+	});
+
+	it("shows a disabled empty-state item when no executable choices exist", () => {
+		const app = new App();
+		const executor = { execute: vi.fn() } as unknown as IChoiceExecutor;
+
+		showChoiceMenu(app, [multi("empty", "Empty", [])], executor);
+
+		expect(Menu.lastShown?.items).toHaveLength(1);
+		expect(Menu.lastShown?.items[0].title).toBe("No choices");
+		expect(Menu.lastShown?.items[0].disabled).toBe(true);
+	});
+
+	it("executes the selected leaf choice through the provided executor", () => {
+		const app = new App();
+		const leaf = choice("leaf", "Run me", "Capture");
+		const executor = {
+			execute: vi.fn().mockResolvedValue(undefined),
+		} as unknown as IChoiceExecutor;
+
+		showChoiceMenu(app, [leaf], executor);
+		Menu.lastShown?.items[0].clickHandler?.();
+
+		expect(executor.execute).toHaveBeenCalledWith(leaf);
+	});
+
+	it("positions the menu inside the active editor when an editor container is available", () => {
+		const app = new App();
+		const view = new MarkdownView();
+		const editorEl = view.containerEl.createDiv({ cls: "cm-editor" });
+		vi.spyOn(editorEl, "getBoundingClientRect").mockReturnValue({
+			left: 100,
+			top: 200,
+			width: 600,
+			height: 300,
+			right: 700,
+			bottom: 500,
+			x: 100,
+			y: 200,
+			toJSON: () => ({}),
+		} as DOMRect);
+		app.workspace.getActiveViewOfType = () => view;
+
+		expect(getEditorMenuPosition(app)).toEqual({ x: 310, y: 305 });
+	});
+});

--- a/src/gui/choiceMenu.test.ts
+++ b/src/gui/choiceMenu.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { App, MarkdownView, Menu } from "obsidian";
+import { App, Menu } from "obsidian";
+import type { MarkdownView } from "obsidian";
 import {
 	collectChoicesForMenu,
 	getEditorMenuPosition,
@@ -8,6 +9,21 @@ import {
 import type IChoice from "../types/choices/IChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
+
+type RecordedMenu = Menu & {
+	items: Array<{
+		title: string;
+		disabled: boolean;
+		clickHandler: (() => void) | null;
+	}>;
+};
+
+const getLastShownMenu = (): RecordedMenu | null =>
+	(Menu as unknown as { lastShown: RecordedMenu | null }).lastShown;
+
+const setLastShownMenu = (menu: RecordedMenu | null): void => {
+	(Menu as unknown as { lastShown: RecordedMenu | null }).lastShown = menu;
+};
 
 const choice = (
 	id: string,
@@ -35,7 +51,7 @@ const multi = (
 
 describe("choice menu", () => {
 	beforeEach(() => {
-		Menu.lastShown = null;
+		setLastShownMenu(null);
 	});
 
 	it("flattens nested multis into path-labeled executable choices", () => {
@@ -61,9 +77,9 @@ describe("choice menu", () => {
 
 		showChoiceMenu(app, [multi("empty", "Empty", [])], executor);
 
-		expect(Menu.lastShown?.items).toHaveLength(1);
-		expect(Menu.lastShown?.items[0].title).toBe("No choices");
-		expect(Menu.lastShown?.items[0].disabled).toBe(true);
+		expect(getLastShownMenu()?.items).toHaveLength(1);
+		expect(getLastShownMenu()?.items[0].title).toBe("No choices");
+		expect(getLastShownMenu()?.items[0].disabled).toBe(true);
 	});
 
 	it("executes the selected leaf choice through the provided executor", () => {
@@ -74,14 +90,16 @@ describe("choice menu", () => {
 		} as unknown as IChoiceExecutor;
 
 		showChoiceMenu(app, [leaf], executor);
-		Menu.lastShown?.items[0].clickHandler?.();
+		getLastShownMenu()?.items[0].clickHandler?.();
 
 		expect(executor.execute).toHaveBeenCalledWith(leaf);
 	});
 
 	it("positions the menu inside the active editor when an editor container is available", () => {
 		const app = new App();
-		const view = new MarkdownView();
+		const view = {
+			containerEl: document.createElement("div"),
+		} as unknown as MarkdownView;
 		const editorEl = view.containerEl.createDiv({ cls: "cm-editor" });
 		vi.spyOn(editorEl, "getBoundingClientRect").mockReturnValue({
 			left: 100,
@@ -94,7 +112,7 @@ describe("choice menu", () => {
 			y: 200,
 			toJSON: () => ({}),
 		} as DOMRect);
-		app.workspace.getActiveViewOfType = () => view;
+		app.workspace.getActiveViewOfType = () => view as never;
 
 		expect(getEditorMenuPosition(app)).toEqual({ x: 310, y: 305 });
 	});

--- a/src/gui/choiceMenu.test.ts
+++ b/src/gui/choiceMenu.test.ts
@@ -116,4 +116,28 @@ describe("choice menu", () => {
 
 		expect(getEditorMenuPosition(app)).toEqual({ x: 310, y: 305 });
 	});
+
+	it("prefers caret coordinates when the editor exposes CodeMirror geometry", () => {
+		const app = new App();
+		const view = {
+			containerEl: document.createElement("div"),
+			editor: {
+				getCursor: () => ({ line: 3, ch: 7 }),
+				posToOffset: (pos: { line: number; ch: number }) => pos.line * 100 + pos.ch,
+				cm: {
+					coordsAtPos: vi.fn().mockReturnValue({
+						left: 420,
+						top: 240,
+						bottom: 258,
+					}),
+				},
+			},
+		} as unknown as MarkdownView;
+		app.workspace.getActiveViewOfType = () => view as never;
+
+		expect(getEditorMenuPosition(app)).toEqual({ x: 420, y: 258 });
+		expect(
+			(view.editor as unknown as { cm: { coordsAtPos: unknown } }).cm.coordsAtPos,
+		).toHaveBeenCalledWith(307);
+	});
 });

--- a/src/gui/choiceMenu.ts
+++ b/src/gui/choiceMenu.ts
@@ -1,0 +1,80 @@
+import type { App } from "obsidian";
+import { MarkdownView, Menu } from "obsidian";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { log } from "../logger/logManager";
+import type IChoice from "../types/choices/IChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import { resolveChoiceIcon } from "../utils/choiceUtils";
+
+type MenuChoice = {
+	choice: IChoice;
+	title: string;
+};
+
+export function collectChoicesForMenu(
+	choices: IChoice[],
+	prefix: string[] = [],
+): MenuChoice[] {
+	const items: MenuChoice[] = [];
+
+	for (const choice of choices) {
+		if (choice.type === "Multi") {
+			const multi = choice as IMultiChoice;
+			items.push(...collectChoicesForMenu(multi.choices ?? [], [...prefix, choice.name]));
+			continue;
+		}
+
+		items.push({
+			choice,
+			title: [...prefix, choice.name].join(" / "),
+		});
+	}
+
+	return items;
+}
+
+export function showChoiceMenu(
+	app: App,
+	choices: IChoice[],
+	choiceExecutor: IChoiceExecutor,
+): void {
+	const menu = new Menu();
+	const menuChoices = collectChoicesForMenu(choices);
+
+	if (menuChoices.length === 0) {
+		menu.addItem((item) => item.setTitle("No choices").setDisabled(true));
+	} else {
+		for (const { choice, title } of menuChoices) {
+			menu.addItem((item) =>
+				item
+					.setTitle(title)
+					.setIcon(resolveChoiceIcon(choice))
+					.onClick(() => {
+						void choiceExecutor.execute(choice).catch((error) => {
+							log.logError(`Failed to execute menu choice: ${error}`);
+						});
+					}),
+			);
+		}
+	}
+
+	menu.showAtPosition(getEditorMenuPosition(app));
+}
+
+export function getEditorMenuPosition(app: App): { x: number; y: number } {
+	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	const editorEl = view?.containerEl.querySelector(".cm-editor, .markdown-source-view");
+	const rect = editorEl?.getBoundingClientRect();
+
+	if (rect && rect.width > 0 && rect.height > 0) {
+		return {
+			x: rect.left + Math.min(rect.width * 0.35, 240),
+			y: rect.top + Math.min(rect.height * 0.35, 180),
+		};
+	}
+
+	return {
+		x: window.innerWidth / 2,
+		y: window.innerHeight / 2,
+	};
+}

--- a/src/gui/choiceMenu.ts
+++ b/src/gui/choiceMenu.ts
@@ -39,6 +39,7 @@ export function showChoiceMenu(
 	choiceExecutor: IChoiceExecutor,
 ): void {
 	const menu = new Menu();
+	menu.setUseNativeMenu(false);
 	const menuChoices = collectChoicesForMenu(choices);
 
 	if (menuChoices.length === 0) {

--- a/src/gui/choiceMenu.ts
+++ b/src/gui/choiceMenu.ts
@@ -6,6 +6,14 @@ import type IChoice from "../types/choices/IChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
 import { resolveChoiceIcon } from "../utils/choiceUtils";
 
+type EditorWithCoordinates = {
+	getCursor?: () => { line: number; ch: number };
+	posToOffset?: (pos: { line: number; ch: number }) => number;
+	cm?: {
+		coordsAtPos?: (offset: number) => { left: number; top: number; bottom: number } | null;
+	};
+};
+
 type MenuChoice = {
 	choice: IChoice;
 	title: string;
@@ -64,6 +72,20 @@ export function showChoiceMenu(
 
 export function getEditorMenuPosition(app: App): { x: number; y: number } {
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	const editor = view?.editor as EditorWithCoordinates | undefined;
+	const cursor = editor?.getCursor?.();
+	const offset =
+		cursor && editor?.posToOffset ? editor.posToOffset(cursor) : undefined;
+	const cursorRect =
+		typeof offset === "number" ? editor?.cm?.coordsAtPos?.(offset) : null;
+
+	if (cursorRect) {
+		return {
+			x: cursorRect.left,
+			y: cursorRect.bottom,
+		};
+	}
+
 	const editorEl = view?.containerEl.querySelector(".cm-editor, .markdown-source-view");
 	const rect = editorEl?.getBoundingClientRect();
 

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -194,11 +194,12 @@ describe("choiceService", () => {
 			expect(copy.id).not.toBe(original.id);
 		});
 
-		it("preserves command and onePageInput when duplicating a Multi", () => {
+		it("preserves command, onePageInput, and display mode when duplicating a Multi", () => {
 			const original = createChoice("Multi", "M") as IMultiChoice;
 			(original as unknown as { command: boolean }).command = true;
 			(original as unknown as { onePageInput: string }).onePageInput =
 				"always";
+			original.displayMode = "menu";
 			original.choices = [createChoice("Capture", "Child")];
 
 			const copy = duplicateChoice(original) as IMultiChoice;
@@ -207,6 +208,7 @@ describe("choiceService", () => {
 			expect(
 				(copy as unknown as { onePageInput?: string }).onePageInput,
 			).toBe("always");
+			expect(copy.displayMode).toBe("menu");
 			// children still duplicated with fresh ids
 			expect(copy.choices[0].id).not.toBe(original.choices[0].id);
 		});

--- a/src/types/choices/IMultiChoice.ts
+++ b/src/types/choices/IMultiChoice.ts
@@ -1,7 +1,10 @@
 import type IChoice from "./IChoice";
 
+export type MultiChoiceDisplayMode = "picker" | "menu";
+
 export default interface IMultiChoice extends IChoice {
 	choices: IChoice[];
 	collapsed: boolean;
 	placeholder?: string;
+	displayMode?: MultiChoiceDisplayMode;
 }

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -419,6 +419,7 @@ export class TFolder {
 }
 
 export class MarkdownView { 
+  containerEl: HTMLElement = document.createElement("div");
   editor = { 
     getCursor() {return {line:0,ch:0};}, 
     replaceSelection() {}, 

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -798,6 +798,11 @@ export class Menu {
   static lastShown: Menu | null = null;
   items: MenuItem[] = [];
   shownAt: { type: "mouse" | "position"; detail: unknown } | null = null;
+  useNativeMenu: boolean | null = null;
+  setUseNativeMenu(useNativeMenu: boolean): this {
+    this.useNativeMenu = useNativeMenu;
+    return this;
+  }
   addItem(cb: (item: MenuItem) => void): this {
     const item = new MenuItem();
     cb(item);


### PR DESCRIPTION
Add an optional **Editor menu** display mode for Multi choices.

The underlying problem in #453 is that users need a low-disruption way to run a small group of existing QuickAdd actions while editing. I modeled this as a Multi presentation mode instead of a new choice type so existing Multi nesting, command registration, package traversal, duplication, and old settings keep working. Existing Multis default to the current searchable picker because `displayMode` is optional and only persisted for menu mode.

Design tradeoffs:
- Uses `Multi.displayMode = \"menu\"` rather than adding a fifth choice type.
- Renders through Obsidian `Menu` and forces DOM menu mode so it is testable and consistent across QuickAdd UI surfaces.
- Prefers caret coordinates when the active editor exposes CodeMirror geometry; falls back to the editor container and then viewport center.
- Flattens nested Multi children as path labels like `Formatting / Case / Uppercase`. I considered literal submenus, but the installed Obsidian public typings expose no submenu API, and this repo already flattens menu paths where reliability matters.

Validation evidence:
- `pnpm run build`
- `pnpm run lint`
- `pnpm run check` (0 errors; existing 4 warnings in 1 file)
- `pnpm test` (2646 passed, 37 skipped)
- `pnpm run build-with-lint`
- Isolated Obsidian vault: `pnpm run provision:e2e-vault`, `pnpm run obsidian:e2e -- plugin:reload id=quickadd`, seeded a real menu-mode Multi command with a Capture child, ran `quickadd:choice:qa-menu-parent`, clicked the rendered `.menu-item`, verified `Menu validation.md` changed from `Before` to `MENU_EXECUTEDBefore`, and `pnpm run obsidian:e2e -- dev:errors` reported no errors.

Docs updated in `docs/docs/Choices/MultiChoice.md` with the mode behavior and limitations.

Fixes #453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi choices now support "Editor menu" mode—a compact alternative to the default choice picker. Configure via the new "Open as" setting in multi choice settings. Nested choices display as flat path labels for consistency across platforms.

* **Documentation**
  * Added "Editor menu mode" guide to Multi choice documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->