### PR TITLE
feat(template): copy created note link

### DIFF
--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -55,6 +55,12 @@ When either enabled mode is selected, **Link placement** lets you choose where t
 
 **Link type**. Shown only when **Link placement** is **Replace selection**. Choose whether replacing the selection should insert a **Link** or an **Embed**.
 
+**Copy link to clipboard**. Copies a link to the created file after the Template
+choice runs. This works separately from **Link to created file**, so you can copy
+the link without inserting it into the current note, or do both. The copied link
+is generated without a destination note, which makes it suitable for pasting into
+another note.
+
 **If the target file already exists**. Choose whether QuickAdd should ask what to do, update the existing file, create another file, or keep the existing file.
 
 **Open**. Will open the created file. When enabled, additional file-opening controls appear (these are shared with the Capture choice):

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -58,8 +58,7 @@ When either enabled mode is selected, **Link placement** lets you choose where t
 **Copy link to clipboard**. Copies a link to the created file after the Template
 choice runs. This works separately from **Link to created file**, so you can copy
 the link without inserting it into the current note, or do both. The copied link
-is generated without a destination note, which makes it suitable for pasting into
-another note.
+is a vault-path wikilink, which makes it suitable for pasting into another note.
 
 **If the target file already exists**. Choose whether QuickAdd should ask what to do, update the existing file, create another file, or keep the existing file.
 

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -495,6 +495,7 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 		await engine.run();
 		store.commitExecutionScope();
 
+		expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(createdFile);
 		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
 			status: "success",
 			file: createdFile,

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -416,7 +416,7 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 	});
 
 	it("copies the created file link without requiring append-link insertion", async () => {
-		const { engine, app } = createEngine("ignored", {
+		const { engine } = createEngine("ignored", {
 			throwDuringFileName: false,
 		});
 		const createdFile = new TFile();
@@ -434,7 +434,7 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 
 		await engine.run();
 
-		expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(app, createdFile);
+		expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(createdFile);
 	});
 
 	it("keeps template execution successful when clipboard copying reports failure", async () => {

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -463,6 +463,44 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 			file: createdFile,
 		});
 	});
+
+	it("keeps template execution successful when clipboard copying throws", async () => {
+		const store = InputPromptDraftStore.getInstance();
+		const draftKey = store.makeKey({
+			kind: "single",
+			header: "Test Template Choice",
+			placeholder: "",
+		});
+		const { engine, choiceExecutor } = createEngine("ignored", {
+			throwDuringFileName: false,
+		});
+		const createdFile = new TFile();
+		createdFile.path = "Test Template.md";
+		createdFile.name = "Test Template.md";
+		createdFile.extension = "md";
+		createdFile.basename = "Test Template";
+
+		engine.choice.copyLinkToClipboard = true;
+		choiceExecutor.recordExecutionResult = vi.fn();
+		copyFileLinkToClipboardMock.mockRejectedValue(new Error("clipboard denied"));
+		(
+			engine as unknown as {
+				createFileWithTemplate: () => Promise<TFile | null>;
+			}
+		).createFileWithTemplate = vi.fn().mockResolvedValue(createdFile);
+
+		store.beginExecutionScope();
+		store.handleSubmittedDraft(draftKey, "Submitted template name");
+
+		await engine.run();
+		store.commitExecutionScope();
+
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: createdFile,
+		});
+		expect(store.get(draftKey)).toBeUndefined();
+	});
 });
 
 describe("TemplateChoiceEngine file casing resolution", () => {

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -43,13 +43,20 @@ vi.mock("../quickAddSettingsTab", () => {
 	};
 });
 
-const { formatFileNameMock, formatFileContentMock } = vi.hoisted(() => {
-	const formatName = vi.fn<(format: string, prompt: string) => Promise<string>>();
+const {
+	copyFileLinkToClipboardMock,
+	formatFileNameMock,
+	formatFileContentMock,
+} = vi.hoisted(() => {
+	const copyFileLink = vi.fn();
+	const formatName =
+		vi.fn<(format: string, prompt: string) => Promise<string>>();
 	const formatContent = vi
 		.fn<(...args: unknown[]) => Promise<string>>()
 		.mockResolvedValue("");
 
 	return {
+		copyFileLinkToClipboardMock: copyFileLink,
 		formatFileNameMock: formatName,
 		formatFileContentMock: formatContent,
 	};
@@ -85,14 +92,18 @@ vi.mock("../formatters/completeFormatter", () => {
 	};
 });
 
-	vi.mock("../utilityObsidian", () => ({
-		getTemplater: vi.fn(() => ({})),
-		overwriteTemplaterOnce: vi.fn(),
-		getAllFolderPathsInVault: vi.fn(() => []),
-		insertFileLinkToActiveView: vi.fn(),
-		openExistingFileTab: vi.fn(() => null),
-		openFile: vi.fn(),
-	}));
+vi.mock("../utils/fileLinks", () => ({
+	copyFileLinkToClipboard: copyFileLinkToClipboardMock,
+}));
+
+vi.mock("../utilityObsidian", () => ({
+	getTemplater: vi.fn(() => ({})),
+	overwriteTemplaterOnce: vi.fn(),
+	getAllFolderPathsInVault: vi.fn(() => []),
+	insertFileLinkToActiveView: vi.fn(),
+	openExistingFileTab: vi.fn(() => null),
+	openFile: vi.fn(),
+}));
 
 vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
 	default: {
@@ -218,6 +229,8 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 		settingsStore.setState(structuredClone(defaultSettingsState));
 		noticeClass.instances.length = 0;
 		InputPromptDraftStore.getInstance().clearAll();
+		copyFileLinkToClipboardMock.mockReset();
+		copyFileLinkToClipboardMock.mockResolvedValue(true);
 		formatFileNameMock.mockReset();
 		formatFileContentMock.mockReset();
 		formatFileContentMock.mockResolvedValue("");
@@ -400,6 +413,55 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 		store.commitExecutionScope();
 
 		expect(store.get(draftKey)).toBe("Submitted template name");
+	});
+
+	it("copies the created file link without requiring append-link insertion", async () => {
+		const { engine, app } = createEngine("ignored", {
+			throwDuringFileName: false,
+		});
+		const createdFile = new TFile();
+		createdFile.path = "Test Template.md";
+		createdFile.name = "Test Template.md";
+		createdFile.extension = "md";
+		createdFile.basename = "Test Template";
+
+		engine.choice.copyLinkToClipboard = true;
+		(
+			engine as unknown as {
+				createFileWithTemplate: () => Promise<TFile | null>;
+			}
+		).createFileWithTemplate = vi.fn().mockResolvedValue(createdFile);
+
+		await engine.run();
+
+		expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(app, createdFile);
+	});
+
+	it("keeps template execution successful when clipboard copying reports failure", async () => {
+		const { engine, choiceExecutor } = createEngine("ignored", {
+			throwDuringFileName: false,
+		});
+		const createdFile = new TFile();
+		createdFile.path = "Test Template.md";
+		createdFile.name = "Test Template.md";
+		createdFile.extension = "md";
+		createdFile.basename = "Test Template";
+
+		engine.choice.copyLinkToClipboard = true;
+		choiceExecutor.recordExecutionResult = vi.fn();
+		copyFileLinkToClipboardMock.mockResolvedValue(false);
+		(
+			engine as unknown as {
+				createFileWithTemplate: () => Promise<TFile | null>;
+			}
+		).createFileWithTemplate = vi.fn().mockResolvedValue(createdFile);
+
+		await engine.run();
+
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: createdFile,
+		});
 	});
 });
 

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -28,6 +28,7 @@ import {
 } from "../utils/folder-sorting";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
+import { copyFileLinkToClipboard } from "../utils/fileLinks";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { TemplateEngine } from "./TemplateEngine";
 import { UserCancelError } from "../errors/UserCancelError";
@@ -170,7 +171,11 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			});
 
 			if (linkOptions.enabled && createdFile) {
-			insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+				insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+			}
+
+			if (this.choice.copyLinkToClipboard && createdFile) {
+				await copyFileLinkToClipboard(this.app, createdFile);
 			}
 
 			if ((this.choice.openFile || shouldAutoOpen) && createdFile) {

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -175,7 +175,15 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			}
 
 			if (this.choice.copyLinkToClipboard && createdFile) {
-				await copyFileLinkToClipboard(createdFile);
+				try {
+					await copyFileLinkToClipboard(createdFile);
+				} catch (error) {
+					log.logWarning(
+						`Could not copy link to clipboard for '${createdFile.path}': ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					);
+				}
 			}
 
 			if ((this.choice.openFile || shouldAutoOpen) && createdFile) {

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -175,7 +175,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			}
 
 			if (this.choice.copyLinkToClipboard && createdFile) {
-				await copyFileLinkToClipboard(this.app, createdFile);
+				await copyFileLinkToClipboard(createdFile);
 			}
 
 			if ((this.choice.openFile || shouldAutoOpen) && createdFile) {

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -253,6 +253,17 @@ function onModeChange(value: string) {
 
 <SettingItem name="Linking" heading />
 <AppendLinkSetting bind:appendLink={choice.appendLink} fileLabel="created" />
+<SettingItem
+	name="Copy link to clipboard"
+	desc="Copy a link to the created file after the Template choice runs."
+>
+	{#snippet control()}
+		<Toggle
+			checked={choice.copyLinkToClipboard ?? false}
+			onchange={(value) => (choice.copyLinkToClipboard = value)}
+		/>
+	{/snippet}
+</SettingItem>
 
 <SettingItem name="Behavior" heading />
 

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -45,6 +45,15 @@ function settingNames(container: HTMLElement): string[] {
 	);
 }
 
+function settingItem(container: HTMLElement, name: string): HTMLElement {
+	const item = Array.from(container.querySelectorAll(".setting-item")).find(
+		(el) =>
+			el.querySelector(".setting-item-name")?.textContent?.trim() === name,
+	);
+	if (!item) throw new Error(`Setting item not found: ${name}`);
+	return item as HTMLElement;
+}
+
 function locationDropdown(container: HTMLElement): HTMLSelectElement {
 	const el = container.querySelector<HTMLSelectElement>(
 		'select.dropdown[aria-label="New note location"]',
@@ -199,5 +208,19 @@ describe("TemplateChoiceForm", () => {
 		expect(
 			names.includes("New file naming") || names.includes("Update action"),
 		).toBe(true);
+	});
+
+	it("persists the copy-link-to-clipboard toggle", async () => {
+		const { container, props } = mountForm();
+		expect(props.choice.copyLinkToClipboard).toBeUndefined();
+
+		const toggle = settingItem(container, "Copy link to clipboard").querySelector(
+			".checkbox-container",
+		) as HTMLElement;
+		await fireEvent.click(toggle);
+		flushSync();
+
+		expect(props.choice.copyLinkToClipboard).toBe(true);
+		expect(toggle.classList.contains("is-enabled")).toBe(true);
 	});
 });

--- a/src/types/choices/ITemplateChoice.ts
+++ b/src/types/choices/ITemplateChoice.ts
@@ -27,6 +27,8 @@ export default interface ITemplateChoice extends IChoice {
 	 * - AppendLinkOptions: New format with configurable placement options
 	 */
 	appendLink: boolean | AppendLinkOptions;
+	/** Copy a link to the created/resolved file after the template runs. */
+	copyLinkToClipboard?: boolean;
 	openFile: boolean;
 	fileOpening: {
 		location: OpenLocation;

--- a/src/types/choices/TemplateChoice.ts
+++ b/src/types/choices/TemplateChoice.ts
@@ -8,6 +8,7 @@ import type { TemplateFileExistsBehavior } from "../../template/fileExistsPolicy
 
 export class TemplateChoice extends Choice implements ITemplateChoice {
 	appendLink: boolean | AppendLinkOptions;
+	copyLinkToClipboard: boolean;
 	fileNameFormat: { enabled: boolean; format: string };
 	folder: TemplateFolderConfig;
 	openFile: boolean;
@@ -33,6 +34,7 @@ export class TemplateChoice extends Choice implements ITemplateChoice {
 			chooseFromSubfolders: false,
 		};
 		this.appendLink = false;
+		this.copyLinkToClipboard = false;
 		this.openFile = false;
 		this.fileOpening = normalizeFileOpening();
 		this.fileExistsBehavior = { kind: "prompt" };

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -2,8 +2,7 @@ import type { App, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
 import { log } from "../logger/logManager";
 import type { AppendLinkOptions, LinkPlacement } from "../types/linkPlacement";
-import { placementSupportsEmbed } from "../types/linkPlacement";
-import { convertLinkToEmbed } from "./markdownLinks";
+import { buildFileLinkText } from "./fileLinks";
 
 /**
  * Returns the active markdown view if it is showing the given file,
@@ -217,11 +216,11 @@ export function insertFileLinkToActiveView(
 	}
 
 	const sourcePath = activeFile?.path ?? "";
-	const baseLink = app.fileManager.generateMarkdownLink(file, sourcePath);
-	const shouldEmbed =
-		linkOptions.linkType === "embed" &&
-		placementSupportsEmbed(linkOptions.placement);
-	const linkText = shouldEmbed ? convertLinkToEmbed(baseLink) : baseLink;
+	const linkText = buildFileLinkText(app, file, {
+		sourcePath,
+		linkType: linkOptions.linkType,
+		placement: linkOptions.placement,
+	});
 
 	insertLinkWithPlacement(
 		app,

--- a/src/utils/fileLinks.test.ts
+++ b/src/utils/fileLinks.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import { Notice } from "obsidian";
+import {
+	buildFileLinkText,
+	copyFileLinkToClipboard,
+	writeTextToClipboard,
+} from "./fileLinks";
+
+type NoticeTestClass = typeof Notice & {
+	instances: Array<{ message: string; timeout?: number }>;
+};
+
+const noticeClass = Notice as unknown as NoticeTestClass;
+
+function createApp(linkText = "[[Created Note]]"): App {
+	return {
+		fileManager: {
+			generateMarkdownLink: vi.fn(() => linkText),
+		},
+	} as unknown as App;
+}
+
+function createFile(): TFile {
+	return {
+		basename: "Created Note",
+		path: "Projects/Created Note.md",
+	} as TFile;
+}
+
+describe("file link helpers", () => {
+	beforeEach(() => {
+		noticeClass.instances.length = 0;
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("builds a destination-agnostic link by default", () => {
+		const app = createApp("[[Projects/Created Note]]");
+		const file = createFile();
+
+		expect(buildFileLinkText(app, file)).toBe("[[Projects/Created Note]]");
+		expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(file, "");
+	});
+
+	it("can build embed text for embed-capable editor insertion", () => {
+		const app = createApp("[[Created Note]]");
+
+		expect(
+			buildFileLinkText(app, createFile(), {
+				linkType: "embed",
+				placement: "replaceSelection",
+				sourcePath: "Inbox.md",
+			}),
+		).toBe("![[Created Note]]");
+	});
+
+	it("returns false when clipboard writes are unavailable", async () => {
+		vi.stubGlobal("navigator", {});
+
+		await expect(writeTextToClipboard("[[Created Note]]")).resolves.toBe(false);
+	});
+
+	it("copies file links and reports success", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+		await expect(
+			copyFileLinkToClipboard(createApp(), createFile()),
+		).resolves.toBe(true);
+
+		expect(writeText).toHaveBeenCalledWith("[[Created Note]]");
+		expect(noticeClass.instances.at(-1)?.message).toContain(
+			"Copied link to 'Created Note'",
+		);
+	});
+
+	it("treats clipboard write rejection as non-fatal", async () => {
+		const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+		vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+		await expect(
+			copyFileLinkToClipboard(createApp(), createFile()),
+		).resolves.toBe(false);
+
+		expect(noticeClass.instances.at(-1)?.message).toContain(
+			"could not copy its link",
+		);
+	});
+});

--- a/src/utils/fileLinks.test.ts
+++ b/src/utils/fileLinks.test.ts
@@ -3,6 +3,7 @@ import type { App, TFile } from "obsidian";
 import { Notice } from "obsidian";
 import {
 	buildFileLinkText,
+	buildPortableFileLinkText,
 	copyFileLinkToClipboard,
 	writeTextToClipboard,
 } from "./fileLinks";
@@ -37,12 +38,29 @@ describe("file link helpers", () => {
 		vi.unstubAllGlobals();
 	});
 
-	it("builds a destination-agnostic link by default", () => {
+	it("builds editor links through Obsidian with an explicit source path", () => {
 		const app = createApp("[[Projects/Created Note]]");
 		const file = createFile();
 
-		expect(buildFileLinkText(app, file)).toBe("[[Projects/Created Note]]");
-		expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(file, "");
+		expect(buildFileLinkText(app, file, { sourcePath: "Inbox.md" })).toBe(
+			"[[Projects/Created Note]]",
+		);
+		expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(
+			file,
+			"Inbox.md",
+		);
+	});
+
+	it("builds destination-independent clipboard links from vault paths", () => {
+		expect(buildPortableFileLinkText(createFile())).toBe(
+			"[[Projects/Created Note]]",
+		);
+		expect(
+			buildPortableFileLinkText({
+				basename: "Board",
+				path: "Canvases/Board.canvas",
+			} as TFile),
+		).toBe("[[Canvases/Board.canvas]]");
 	});
 
 	it("can build embed text for embed-capable editor insertion", () => {
@@ -68,10 +86,10 @@ describe("file link helpers", () => {
 		vi.stubGlobal("navigator", { clipboard: { writeText } });
 
 		await expect(
-			copyFileLinkToClipboard(createApp(), createFile()),
+			copyFileLinkToClipboard(createFile()),
 		).resolves.toBe(true);
 
-		expect(writeText).toHaveBeenCalledWith("[[Created Note]]");
+		expect(writeText).toHaveBeenCalledWith("[[Projects/Created Note]]");
 		expect(noticeClass.instances.at(-1)?.message).toContain(
 			"Copied link to 'Created Note'",
 		);
@@ -82,7 +100,7 @@ describe("file link helpers", () => {
 		vi.stubGlobal("navigator", { clipboard: { writeText } });
 
 		await expect(
-			copyFileLinkToClipboard(createApp(), createFile()),
+			copyFileLinkToClipboard(createFile()),
 		).resolves.toBe(false);
 
 		expect(noticeClass.instances.at(-1)?.message).toContain(

--- a/src/utils/fileLinks.ts
+++ b/src/utils/fileLinks.ts
@@ -1,0 +1,70 @@
+import type { App, TFile } from "obsidian";
+import { Notice } from "obsidian";
+import { log } from "../logger/logManager";
+import type { LinkPlacement, LinkType } from "../types/linkPlacement";
+import { placementSupportsEmbed } from "../types/linkPlacement";
+import { convertLinkToEmbed } from "./markdownLinks";
+
+const CLIPBOARD_NOTICE_DURATION_MS = 4000;
+
+type FileLinkTextOptions = {
+	sourcePath?: string;
+	linkType?: LinkType;
+	placement?: LinkPlacement;
+};
+
+export function buildFileLinkText(
+	app: App,
+	file: TFile,
+	options: FileLinkTextOptions = {},
+): string {
+	const sourcePath = options.sourcePath ?? "";
+	const baseLink = app.fileManager.generateMarkdownLink(file, sourcePath);
+	const shouldEmbed =
+		options.linkType === "embed" &&
+		(!options.placement || placementSupportsEmbed(options.placement));
+
+	return shouldEmbed ? convertLinkToEmbed(baseLink) : baseLink;
+}
+
+export async function writeTextToClipboard(text: string): Promise<boolean> {
+	const clipboard = globalThis.navigator?.clipboard;
+	if (!clipboard?.writeText) {
+		log.logWarning("QuickAdd: Clipboard API is unavailable.");
+		return false;
+	}
+
+	try {
+		await clipboard.writeText(text);
+		return true;
+	} catch (error) {
+		log.logWarning(
+			`QuickAdd: Could not copy link to clipboard: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return false;
+	}
+}
+
+export async function copyFileLinkToClipboard(
+	app: App,
+	file: TFile,
+): Promise<boolean> {
+	const linkText = buildFileLinkText(app, file);
+	const copied = await writeTextToClipboard(linkText);
+
+	if (copied) {
+		new Notice(
+			`Copied link to '${file.basename}' to clipboard.`,
+			CLIPBOARD_NOTICE_DURATION_MS,
+		);
+		return true;
+	}
+
+	new Notice(
+		`Created '${file.basename}', but QuickAdd could not copy its link to the clipboard.`,
+		CLIPBOARD_NOTICE_DURATION_MS,
+	);
+	return false;
+}

--- a/src/utils/fileLinks.ts
+++ b/src/utils/fileLinks.ts
@@ -13,6 +13,11 @@ type FileLinkTextOptions = {
 	placement?: LinkPlacement;
 };
 
+export function buildPortableFileLinkText(file: TFile): string {
+	const path = file.path.replace(/\.md$/i, "");
+	return `[[${path}]]`;
+}
+
 export function buildFileLinkText(
 	app: App,
 	file: TFile,
@@ -48,10 +53,9 @@ export async function writeTextToClipboard(text: string): Promise<boolean> {
 }
 
 export async function copyFileLinkToClipboard(
-	app: App,
 	file: TFile,
 ): Promise<boolean> {
-	const linkText = buildFileLinkText(app, file);
+	const linkText = buildPortableFileLinkText(file);
 	const copied = await writeTextToClipboard(linkText);
 
 	if (copied) {


### PR DESCRIPTION
## Summary

Adds a Template choice option to copy a link to the created/resolved file after the template runs. This solves #600's underlying workflow problem: the created-note link should be portable when the user wants to paste it somewhere other than the currently active note.

## Changes

- Added `copyLinkToClipboard` as a Template choice setting, separate from the existing editor-focused `appendLink` configuration.
- Extracted link helpers so editor insertion still uses Obsidian's active-note-aware link generation, while clipboard copies use destination-independent vault-path wikilinks.
- Treats clipboard write failure as non-fatal after the file has been created: QuickAdd logs/shows a notice but keeps the Template execution successful.
- Documented the new Template setting.

Design tradeoff: I kept this Template-scoped for #600. Capture can target existing notes, active notes, and Canvas cards, and only sometimes creates a new file; adding Capture clipboard behavior needs a separate product decision about whether to copy every captured target or only newly-created targets.

Release/migration impact: no migration required. Existing Template choices omit `copyLinkToClipboard` and continue to behave as disabled.

## Testing / validation

Automated:

- `pnpm exec vitest run --config vitest.config.mts src/utils/fileLinks.test.ts src/utilityObsidian.test.ts src/engine/TemplateChoiceEngine.notice.test.ts src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts --passWithNoTests` — 73 passed
- `pnpm run build` — passed
- `pnpm run build-with-lint` — passed
- `pnpm run check` — 0 errors, 4 existing warnings in 1 file
- `pnpm run test` — 226 files passed, 5 skipped; 2648 tests passed, 37 skipped

Live Obsidian validation in this worktree's isolated vault (`quickadd-600-copy-link-new-note-v2`):

- `pnpm run provision:e2e-vault`
- `pnpm run obsidian:e2e -- plugin:reload id=quickadd`
- Copy-only Template choice: created `__issue600_live/CopyOnly.md`, left `ActiveCopyOnly.md` unchanged, and `pbpaste` returned `[[__issue600_live/CopyOnly]]`; `dev:errors` reported no errors.
- Copy plus append Template choice: created `__issue600_live/Both.md`, appended `[[Both]]` to the active note, and `pbpaste` returned `[[Both]]`; `dev:errors` reported no errors.
- No active Markdown note edge case: with `active:null` and zero Markdown leaves, copy-only Template choice created `__issue600_live/NoActive.md`, and `pbpaste` returned `[[NoActive]]`; `dev:errors` reported no errors.

Review feedback addressed:

- CodeRabbit noted that clipboard copies should not use destination-relative link generation. The follow-up commit now copies vault-path wikilinks such as `[[__issue600_live/CopyOnly]]`.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
      — it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s).
- [x] Noted release/migration impact, if any.

Fixes #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **“Copy link to clipboard”** toggle for Template choices to copy a link to the newly created/resolved item after execution, independent of link insertion.

* **Bug Fixes**
  * Clipboard copying is non-blocking: missing clipboard access or write errors no longer fail template execution, and failures only show a warning/notice.
  * Link insertion now happens only when linking is enabled and a created item exists.

* **Documentation**
  * Documented the new **Template choice** setting.

* **Refactor**
  * Centralized file-link text building and clipboard helper logic into shared utilities.

* **Tests**
  * Added/updated engine and UI tests covering clipboard success/failure and toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->