### PR TITLE
feat(multi): add context menu launch mode

### DIFF
--- a/docs/docs/Choices/MultiChoice.md
+++ b/docs/docs/Choices/MultiChoice.md
@@ -16,6 +16,19 @@ You can optionally set a placeholder for each Multi choice. This text shows up i
 
 Keep in mind that [searching covers everything nested under the multi](#searching-nested-choices), so word the placeholder accordingly.
 
+## Opening as a context menu
+
+By default, opening a Multi choice shows the normal QuickAdd choice picker. This is still the best option for large menus because it supports fuzzy search and nested search results.
+
+If you use a small Multi choice as an editing toolbar, set **Open with** to **Context menu at editor caret** in the Multi choice settings. When that Multi runs from an active editor, QuickAdd opens a compact Obsidian menu near the caret so you can pick a nested Template, Capture, Macro, or Multi choice without moving to the center of the screen.
+
+A few details:
+
+- Context menu mode is per Multi choice. Existing Multi choices keep using the choice picker.
+- Nested Multi choices open as another small menu at the same caret position, with a back item to return to the previous level.
+- Context menu mode does not include fuzzy search. Keep these menus short and focused.
+- If QuickAdd cannot find an active editor caret, it falls back to the normal choice picker instead of failing.
+
 ## Searching nested choices
 
 Typing in the choice picker searches every choice nested inside the current level's multis — not just the level you are looking at. Nested matches show their folder path (for example `Work / Meetings`) beneath the choice name. This also applies to the root picker opened by the **QuickAdd: Run** command or the ribbon icon.

--- a/docs/docs/Choices/MultiChoice.md
+++ b/docs/docs/Choices/MultiChoice.md
@@ -16,18 +16,20 @@ You can optionally set a placeholder for each Multi choice. This text shows up i
 
 Keep in mind that [searching covers everything nested under the multi](#searching-nested-choices), so word the placeholder accordingly.
 
-## Opening as a context menu
+## Opening as a compact menu
 
 By default, opening a Multi choice shows the normal QuickAdd choice picker. This is still the best option for large menus because it supports fuzzy search and nested search results.
 
-If you use a small Multi choice as an editing toolbar, set **Open with** to **Context menu at editor caret** in the Multi choice settings. When that Multi runs from an active editor, QuickAdd opens a compact Obsidian menu near the caret so you can pick a nested Template, Capture, Macro, or Multi choice without moving to the center of the screen.
+If you use a small Multi choice as a quick launcher, set **Open with** to **Compact menu near editor** in the Multi choice settings. When that Multi runs from an active editor, QuickAdd opens a compact Obsidian menu near the editor content so you can pick a nested Template, Capture, Macro, or Multi choice without moving to the center of the screen.
+
+This only changes how you choose the next QuickAdd choice. It does not change what the child choices do. For example, a Capture choice only writes at the cursor if that Capture is configured to capture to the active file at the cursor, and a Macro only manipulates selected text if its own commands or scripts do that.
 
 A few details:
 
 - Context menu mode is per Multi choice. Existing Multi choices keep using the choice picker.
-- Nested Multi choices open as another small menu at the same caret position, with a back item to return to the previous level.
+- Nested Multi choices open as another small menu, with a back item to return to the previous level.
 - Context menu mode does not include fuzzy search. Keep these menus short and focused.
-- If QuickAdd cannot find an active editor caret, it falls back to the normal choice picker instead of failing.
+- If QuickAdd cannot find an active editor position, it falls back to the normal choice picker instead of failing.
 
 ## Searching nested choices
 

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -14,7 +14,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 - **Search nested choices** — When searching in the choice picker, also match choices nested inside Multi choices and show their path. Note that nested matches can outrank same-level ones. Disable to search only the open level.
 - **"New note from template" in the launcher** — Where the row that lists templates from your configured template folder appears in Run QuickAdd, so you can create a note from a template without a dedicated Template choice. *Show at the bottom* (default) keeps your most-used choice in the first slot; *Show at the top* makes it the first item; *Hide* removes it. Only appears when a [template folder](#templates--properties) is configured; the **New note from template** command works regardless.
 
-Individual [Multi Choices](./Choices/MultiChoice#opening-as-a-context-menu) can also open as a compact context menu at the editor caret instead of using the choice picker.
+Individual [Multi Choices](./Choices/MultiChoice#opening-as-a-compact-menu) can also open as a compact launch menu near the active editor instead of using the choice picker.
 
 ## Input
 

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -14,6 +14,8 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 - **Search nested choices** — When searching in the choice picker, also match choices nested inside Multi choices and show their path. Note that nested matches can outrank same-level ones. Disable to search only the open level.
 - **"New note from template" in the launcher** — Where the row that lists templates from your configured template folder appears in Run QuickAdd, so you can create a note from a template without a dedicated Template choice. *Show at the bottom* (default) keeps your most-used choice in the first slot; *Show at the top* makes it the first item; *Hide* removes it. Only appears when a [template folder](#templates--properties) is configured; the **New note from template** command works regardless.
 
+Individual [Multi Choices](./Choices/MultiChoice#opening-as-a-context-menu) can also open as a compact context menu at the editor caret instead of using the choice picker.
+
 ## Input
 
 - **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt.

--- a/src/choiceExecutor.multi-context-menu.test.ts
+++ b/src/choiceExecutor.multi-context-menu.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import type QuickAdd from "./main";
+import type IChoice from "./types/choices/IChoice";
+import type IMultiChoice from "./types/choices/IMultiChoice";
+import { DEFAULT_SETTINGS } from "./settings";
+import { settingsStore } from "./settingsStore";
+import { deepClone } from "./utils/deepClone";
+
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+const choiceSuggesterOpen = vi.fn();
+const openMultiChoiceContextMenu = vi.fn();
+
+vi.mock("./gui/suggesters/choiceSuggester", () => ({
+	default: {
+		Open: choiceSuggesterOpen,
+	},
+}));
+
+vi.mock("./gui/suggesters/choiceContextMenu", () => ({
+	openMultiChoiceContextMenu,
+}));
+
+const { ChoiceExecutor } = await import("./choiceExecutor");
+
+function makePlugin(): QuickAdd {
+	const app = new App();
+	return {
+		app,
+		settings: deepClone(DEFAULT_SETTINGS),
+	} as unknown as QuickAdd;
+}
+
+function childChoice(): IChoice {
+	return {
+		id: "child",
+		name: "Child",
+		type: "Template",
+		command: false,
+	} as IChoice;
+}
+
+function multiChoice(overrides: Partial<IMultiChoice> = {}): IMultiChoice {
+	return {
+		id: "multi",
+		name: "Multi",
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: [childChoice()],
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	choiceSuggesterOpen.mockReset();
+	openMultiChoiceContextMenu.mockReset();
+	settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+});
+
+describe("ChoiceExecutor Multi context-menu launch mode", () => {
+	it("opens opt-in Multi choices through the context menu helper", async () => {
+		const plugin = makePlugin();
+		const executor = new ChoiceExecutor(plugin.app, plugin);
+		const choice = multiChoice({ displayMode: "context-menu" });
+		openMultiChoiceContextMenu.mockReturnValue(true);
+
+		await executor.execute(choice);
+
+		expect(openMultiChoiceContextMenu).toHaveBeenCalledWith(plugin, choice, {
+			choiceExecutor: executor,
+		});
+		expect(choiceSuggesterOpen).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the existing choice picker when context-menu positioning fails", async () => {
+		const plugin = makePlugin();
+		const executor = new ChoiceExecutor(plugin.app, plugin);
+		const choice = multiChoice({
+			displayMode: "context-menu",
+			placeholder: "Pick a child",
+		});
+		openMultiChoiceContextMenu.mockReturnValue(false);
+
+		await executor.execute(choice);
+
+		expect(choiceSuggesterOpen).toHaveBeenCalledWith(plugin, choice.choices, {
+			choiceExecutor: executor,
+			placeholder: "Pick a child",
+		});
+	});
+
+	it("keeps legacy Multi choices on the existing choice picker", async () => {
+		const plugin = makePlugin();
+		const executor = new ChoiceExecutor(plugin.app, plugin);
+		const choice = multiChoice();
+
+		await executor.execute(choice);
+
+		expect(openMultiChoiceContextMenu).not.toHaveBeenCalled();
+		expect(choiceSuggesterOpen).toHaveBeenCalledWith(plugin, choice.choices, {
+			choiceExecutor: executor,
+			placeholder: undefined,
+		});
+	});
+});

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -10,6 +10,7 @@ import { MacroChoiceEngine } from "./engine/MacroChoiceEngine";
 import type { IChoiceExecutor } from "./IChoiceExecutor";
 import type IMultiChoice from "./types/choices/IMultiChoice";
 import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
+import { openMultiChoiceContextMenu } from "./gui/suggesters/choiceContextMenu";
 import { settingsStore } from "./settingsStore";
 import { runOnePagePreflight } from "./preflight/runOnePagePreflight";
 import { MacroAbortError } from "./errors/MacroAbortError";
@@ -224,6 +225,15 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	}
 
 	private onChooseMultiType(multiChoice: IMultiChoice) {
+		if (
+			multiChoice.displayMode === "context-menu" &&
+			openMultiChoiceContextMenu(this.plugin, multiChoice, {
+				choiceExecutor: this,
+			})
+		) {
+			return;
+		}
+
 		ChoiceSuggester.Open(this.plugin, multiChoice.choices, {
 			choiceExecutor: this,
 			placeholder: multiChoice.placeholder,

--- a/src/gui/MultiChoiceSettingsModal.test.ts
+++ b/src/gui/MultiChoiceSettingsModal.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { App } from "obsidian";
+import { MultiChoiceSettingsModal } from "./MultiChoiceSettingsModal";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+
+function makeMultiChoice(overrides: Partial<IMultiChoice> = {}): IMultiChoice {
+	return {
+		id: "multi",
+		name: "Multi",
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: [],
+		...overrides,
+	};
+}
+
+function selectDisplayMode(modal: MultiChoiceSettingsModal, value: string) {
+	const dropdown = modal.containerEl.querySelector("select");
+	expect(dropdown).toBeInstanceOf(HTMLSelectElement);
+	dropdown!.value = value;
+	dropdown!.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function clickSave(modal: MultiChoiceSettingsModal) {
+	const saveButton = Array.from(
+		modal.containerEl.querySelectorAll("button"),
+	).find((button) => button.textContent === "Save");
+	expect(saveButton).toBeInstanceOf(HTMLButtonElement);
+	saveButton!.click();
+}
+
+beforeEach(() => {
+	document.body.empty();
+});
+
+describe("MultiChoiceSettingsModal", () => {
+	it("persists the opt-in context-menu display mode", async () => {
+		const choice = makeMultiChoice();
+		const modal = new MultiChoiceSettingsModal(new App(), choice);
+
+		selectDisplayMode(modal, "context-menu");
+		clickSave(modal);
+
+		await expect(modal.waitForClose).resolves.toMatchObject({
+			displayMode: "context-menu",
+		});
+	});
+
+	it("omits the default choice-picker mode from saved choices", async () => {
+		const choice = makeMultiChoice({ displayMode: "context-menu" });
+		const modal = new MultiChoiceSettingsModal(new App(), choice);
+
+		selectDisplayMode(modal, "suggester");
+		clickSave(modal);
+
+		await expect(modal.waitForClose).resolves.toMatchObject({
+			displayMode: undefined,
+		});
+	});
+});

--- a/src/gui/MultiChoiceSettingsModal.ts
+++ b/src/gui/MultiChoiceSettingsModal.ts
@@ -58,12 +58,12 @@ export class MultiChoiceSettingsModal extends Modal {
 		new Setting(this.contentEl)
 			.setName("Open with")
 			.setDesc(
-				"The normal choice picker supports fuzzy search. Context menu opens a small menu near the editor caret and falls back to the picker when no editor caret is available.",
+				"The normal choice picker supports fuzzy search. Compact menu opens a small launch menu near the active editor when possible. Child choices keep their own configured behavior.",
 			)
 			.addDropdown((dropdown) => {
 				dropdown
 					.addOption("suggester", "Choice picker")
-					.addOption("context-menu", "Context menu at editor caret")
+					.addOption("context-menu", "Compact menu near editor")
 					.setValue(this.displayMode)
 					.onChange((value) => {
 						this.displayMode =

--- a/src/gui/MultiChoiceSettingsModal.ts
+++ b/src/gui/MultiChoiceSettingsModal.ts
@@ -1,6 +1,7 @@
 import type { App } from "obsidian";
 import { ButtonComponent, Modal, Setting } from "obsidian";
 import type IMultiChoice from "../types/choices/IMultiChoice";
+import type { MultiChoiceDisplayMode } from "../types/choices/IMultiChoice";
 
 export class MultiChoiceSettingsModal extends Modal {
 	public waitForClose: Promise<IMultiChoice | undefined>;
@@ -10,11 +11,13 @@ export class MultiChoiceSettingsModal extends Modal {
 
 	private name: string;
 	private placeholder: string;
+	private displayMode: MultiChoiceDisplayMode;
 
 	constructor(app: App, private choice: IMultiChoice) {
 		super(app);
 		this.name = choice.name;
 		this.placeholder = choice.placeholder ?? "";
+		this.displayMode = choice.displayMode ?? "suggester";
 
 		this.waitForClose = new Promise<IMultiChoice | undefined>(
 			(resolve, reject) => {
@@ -52,6 +55,22 @@ export class MultiChoiceSettingsModal extends Modal {
 				});
 			});
 
+		new Setting(this.contentEl)
+			.setName("Open with")
+			.setDesc(
+				"The normal choice picker supports fuzzy search. Context menu opens a small menu near the editor caret and falls back to the picker when no editor caret is available.",
+			)
+			.addDropdown((dropdown) => {
+				dropdown
+					.addOption("suggester", "Choice picker")
+					.addOption("context-menu", "Context menu at editor caret")
+					.setValue(this.displayMode)
+					.onChange((value) => {
+						this.displayMode =
+							value === "context-menu" ? "context-menu" : "suggester";
+					});
+			});
+
 		const buttonRow = this.contentEl.createDiv();
 		new ButtonComponent(buttonRow)
 			.setButtonText("Save")
@@ -85,6 +104,8 @@ export class MultiChoiceSettingsModal extends Modal {
 			...this.choice,
 			name: this.name.trim() || this.choice.name,
 			placeholder: trimmedPlaceholder ? trimmedPlaceholder : undefined,
+			displayMode:
+				this.displayMode === "context-menu" ? "context-menu" : undefined,
 		};
 		this.resolvePromise(updated);
 	}

--- a/src/gui/suggesters/choiceContextMenu.test.ts
+++ b/src/gui/suggesters/choiceContextMenu.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App, Menu } from "obsidian";
+import type { Editor } from "obsidian";
+import type { Menu as StubMenu } from "../../../tests/obsidian-stub";
+import type QuickAdd from "../../main";
+import type { IChoiceExecutor } from "../../IChoiceExecutor";
+import type IChoice from "../../types/choices/IChoice";
+import type IMultiChoice from "../../types/choices/IMultiChoice";
+import {
+	getEditorCaretMenuPosition,
+	openMultiChoiceContextMenu,
+} from "./choiceContextMenu";
+
+const ShownMenu = Menu as unknown as typeof StubMenu;
+
+function choice(id: string, name: string, type: IChoice["type"]): IChoice {
+	return { id, name, type, command: false } as IChoice;
+}
+
+function multi(id: string, name: string, choices: IChoice[]): IMultiChoice {
+	return {
+		id,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices,
+		displayMode: "context-menu",
+	};
+}
+
+function pluginWithEditor(coords: { left: number; bottom: number }): QuickAdd {
+	const app = new App();
+	(app.workspace as unknown as { activeEditor: { editor: Editor } }).activeEditor = {
+		editor: {
+			getCursor: () => ({ line: 1, ch: 2 }),
+			posToOffset: () => 12,
+			cm: {
+				coordsAtPos: vi.fn(() => ({
+					left: coords.left,
+					right: coords.left,
+					top: coords.bottom - 18,
+					bottom: coords.bottom,
+				})),
+			},
+		} as unknown as Editor,
+	};
+	return { app } as unknown as QuickAdd;
+}
+
+function makeExecutor(): IChoiceExecutor & {
+	execute: ReturnType<typeof vi.fn>;
+} {
+	return {
+		variables: new Map<string, unknown>(),
+		execute: vi.fn(async () => {}),
+	};
+}
+
+beforeEach(() => {
+	ShownMenu.lastShown = null;
+	document.body.empty();
+});
+
+describe("choice context menu", () => {
+	it("opens a Multi as a menu at the editor caret and executes leaf choices", () => {
+		const plugin = pluginWithEditor({ left: 14, bottom: 32 });
+		const executor = makeExecutor();
+		const root = multi("root", "Root", [
+			choice("template", "Insert template", "Template"),
+		]);
+
+		expect(
+			openMultiChoiceContextMenu(plugin, root, { choiceExecutor: executor }),
+		).toBe(true);
+
+		expect(ShownMenu.lastShown?.shownAt).toEqual({
+			type: "position",
+			detail: { x: 14, y: 32 },
+		});
+		expect(ShownMenu.lastShown?.useNativeMenu).toBe(false);
+		const item = ShownMenu.lastShown?.items.find(
+			(menuItem) => menuItem.title === "Insert template",
+		);
+		expect(item?.icon).toBe("file-text");
+
+		item?.clickHandler?.();
+		expect(executor.execute).toHaveBeenCalledWith(root.choices[0]);
+	});
+
+	it("drills into nested Multi choices and offers a back item", () => {
+		const plugin = pluginWithEditor({ left: 5, bottom: 9 });
+		const executor = makeExecutor();
+		const child = choice("capture", "Capture text", "Capture");
+		const nested = multi("nested", "Text actions", [child]);
+		const root = multi("root", "Root", [nested]);
+
+		openMultiChoiceContextMenu(plugin, root, { choiceExecutor: executor });
+		ShownMenu.lastShown?.items
+			.find((menuItem) => menuItem.title === "Text actions ›")
+			?.clickHandler?.();
+
+		expect(ShownMenu.lastShown?.items.map((item) => item.title)).toEqual([
+			"← Root",
+			"Capture text",
+		]);
+		ShownMenu.lastShown?.items
+			.find((menuItem) => menuItem.title === "Capture text")
+			?.clickHandler?.();
+		expect(executor.execute).toHaveBeenCalledWith(child);
+	});
+
+	it("returns false when there is no editor caret position", () => {
+		const app = new App();
+		const plugin = { app } as unknown as QuickAdd;
+		const executor = makeExecutor();
+
+		expect(
+			openMultiChoiceContextMenu(plugin, multi("root", "Root", []), {
+				choiceExecutor: executor,
+			}),
+		).toBe(false);
+		expect(ShownMenu.lastShown).toBeNull();
+	});
+
+	it("can derive position from a visible CodeMirror cursor element", () => {
+		const app = new App();
+		const cursor = document.body.createDiv({ cls: "cm-cursor-primary" });
+		cursor.getBoundingClientRect = () =>
+			({
+				left: 30,
+				right: 31,
+				top: 40,
+				bottom: 58,
+				width: 1,
+				height: 18,
+			}) as DOMRect;
+
+		expect(getEditorCaretMenuPosition(app)).toEqual({ x: 30, y: 58 });
+	});
+});

--- a/src/gui/suggesters/choiceContextMenu.ts
+++ b/src/gui/suggesters/choiceContextMenu.ts
@@ -1,0 +1,178 @@
+import type { App, Editor, MenuPositionDef } from "obsidian";
+import { Menu, MarkdownView } from "obsidian";
+import type { IChoiceExecutor } from "../../IChoiceExecutor";
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import type IMultiChoice from "../../types/choices/IMultiChoice";
+import { log } from "../../logger/logManager";
+import { resolveChoiceIcon } from "../../utils/choiceUtils";
+
+type ContextMenuLevel = {
+	label: string;
+	choices: IChoice[];
+};
+
+type ContextMenuOptions = {
+	choiceExecutor: IChoiceExecutor;
+	position?: MenuPositionDef | null;
+};
+
+type CodeMirrorViewLike = {
+	coordsAtPos?: (pos: number) => { left: number; right: number; top: number; bottom: number } | null;
+	state?: { selection?: { main?: { head?: number } } };
+};
+
+type EditorWithCodeMirror = Editor & {
+	cm?: CodeMirrorViewLike;
+};
+
+const CURSOR_SELECTORS = [
+	".workspace-leaf.mod-active .markdown-source-view.mod-cm6 .cm-cursor-primary",
+	".workspace-leaf.mod-active .cm-cursor-primary",
+	".cm-editor.cm-focused .cm-cursor-primary",
+	".cm-cursor-primary",
+	".cm-cursor",
+].join(", ");
+
+export function openMultiChoiceContextMenu(
+	plugin: QuickAdd,
+	multiChoice: IMultiChoice,
+	options: ContextMenuOptions,
+): boolean {
+	const position = options.position ?? getEditorCaretMenuPosition(plugin.app);
+	if (!position) return false;
+
+	showChoiceMenu({
+		choiceExecutor: options.choiceExecutor,
+		position,
+		current: { label: multiChoice.name, choices: multiChoice.choices },
+		stack: [],
+	});
+	return true;
+}
+
+export function getEditorCaretMenuPosition(app: App): MenuPositionDef | null {
+	const editor =
+		app.workspace.activeEditor?.editor ??
+		app.workspace.getActiveViewOfType(MarkdownView)?.editor;
+	const positionFromEditor = editor ? getPositionFromEditor(editor) : null;
+	return positionFromEditor ?? getPositionFromCursorElement();
+}
+
+function getPositionFromEditor(editor: Editor): MenuPositionDef | null {
+	const editorWithCodeMirror = editor as EditorWithCodeMirror;
+	const cm = editorWithCodeMirror.cm;
+	if (!cm?.coordsAtPos) return null;
+
+	const offset = getCursorOffset(editorWithCodeMirror, cm);
+	if (typeof offset !== "number") return null;
+
+	const coords = cm.coordsAtPos(offset);
+	if (!coords) return null;
+
+	return positionFromRect(coords);
+}
+
+function getCursorOffset(
+	editor: EditorWithCodeMirror,
+	cm: CodeMirrorViewLike,
+): number | null {
+	const selectionHead = cm.state?.selection?.main?.head;
+	if (typeof selectionHead === "number") return selectionHead;
+
+	try {
+		return editor.posToOffset(editor.getCursor());
+	} catch {
+		return null;
+	}
+}
+
+function getPositionFromCursorElement(): MenuPositionDef | null {
+	const cursor = document.querySelector(CURSOR_SELECTORS);
+	if (!(cursor instanceof HTMLElement)) return null;
+
+	const rect = cursor.getBoundingClientRect();
+	if (rect.width === 0 && rect.height === 0) return null;
+
+	return positionFromRect(rect);
+}
+
+function positionFromRect(rect: {
+	left: number;
+	right?: number;
+	top: number;
+	bottom: number;
+}): MenuPositionDef {
+	return {
+		x: rect.left,
+		y: rect.bottom,
+	};
+}
+
+function showChoiceMenu(options: {
+		choiceExecutor: IChoiceExecutor;
+		position: MenuPositionDef;
+		current: ContextMenuLevel;
+		stack: ContextMenuLevel[];
+}): void {
+	const menu = new Menu().setUseNativeMenu(false);
+
+	if (options.stack.length > 0) {
+		const previous = options.stack[options.stack.length - 1];
+		menu.addItem((item) =>
+			item
+				.setTitle(`← ${previous.label}`)
+				.setIcon("arrow-left")
+				.onClick(() => {
+					showChoiceMenu({
+						...options,
+						current: previous,
+						stack: options.stack.slice(0, -1),
+					});
+				}),
+		);
+		menu.addSeparator();
+	}
+
+	if (options.current.choices.length === 0) {
+		menu.addItem((item) =>
+			item.setTitle("No choices in this Multi").setIcon("folder").setDisabled(true),
+		);
+		menu.showAtPosition(options.position);
+		return;
+	}
+
+	for (const choice of options.current.choices) {
+		if (choice.type === "Multi") {
+			menu.addItem((item) =>
+				item
+					.setTitle(`${choice.name} ›`)
+					.setIcon(resolveChoiceIcon(choice))
+					.onClick(() => {
+						showChoiceMenu({
+							...options,
+							current: {
+								label: choice.name,
+								choices: (choice as IMultiChoice).choices,
+							},
+							stack: [...options.stack, options.current],
+						});
+					}),
+			);
+			continue;
+		}
+
+		menu.addItem((item) =>
+			item
+				.setTitle(choice.name)
+				.setIcon(resolveChoiceIcon(choice))
+				.onClick(() => {
+					void options.choiceExecutor.execute(choice).catch((error) => {
+						log.logError(`Failed to execute selected choice: ${error}`);
+					});
+				}),
+		);
+	}
+
+	menu.showAtPosition(options.position);
+}

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -290,4 +290,15 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 			"“New note from template” in the launcher",
 		]);
 	});
+
+	it("display renders the settings tab from declarative definitions for older settings runtimes", () => {
+		const tab = makeTab();
+
+		expect(() => tab.display()).not.toThrow();
+
+		expect(tab.containerEl.textContent).toContain("Choices & Packages");
+		expect(tab.containerEl.textContent).toContain("Choice Picker");
+		expect(tab.containerEl.textContent).toContain("Search nested choices");
+		expect(tab.containerEl.querySelector(".qa-setting-full-width")).not.toBeNull();
+	});
 });

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -1,14 +1,17 @@
 import type {
 	App,
-	Setting,
+	SettingControl,
 	SettingDefinitionGroup,
 	SettingDefinitionItem,
+	SettingGroupItem,
 	TextAreaComponent,
 } from "obsidian";
 import {
 	ButtonComponent,
 	ExtraButtonComponent,
 	PluginSettingTab,
+	Setting,
+	SettingGroup,
 	TextComponent,
 } from "obsidian";
 import type QuickAdd from "./main";
@@ -38,11 +41,15 @@ import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 /** String-named keys of {@link QuickAddSettings} — used to type the declarative
  * `control` keys so a mistyped key is caught at compile time. */
 type SettingsKey = Extract<keyof QuickAddSettings, string>;
+type QuickAddSettingItem =
+	| SettingGroupItem<SettingsKey>
+	| SettingDefinitionGroup<SettingsKey>;
 
 export class QuickAddSettingsTab extends PluginSettingTab {
 	public plugin: QuickAdd;
 	private choiceViewHandle: MountHandle | null = null;
 	private globalVariablesViewHandle: MountHandle | null = null;
+	private settingRenderCleanups: Array<() => void> = [];
 
 	constructor(app: App, plugin: QuickAdd) {
 		super(app, plugin);
@@ -114,6 +121,16 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		return groups;
 	}
 
+	override display(): void {
+		this.cleanupRenderedSettings();
+		this.destroySettingViews();
+		this.containerEl.empty();
+
+		for (const definition of this.getSettingDefinitions()) {
+			this.renderSettingDefinition(this.containerEl, definition);
+		}
+	}
+
 	override hide(): void {
 		// In declarative mode the framework owns row teardown — unloading the
 		// control Components and running each render def's cleanup closure —
@@ -122,7 +139,14 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		// then; it is not now). destroySettingViews() is the idempotent safety
 		// net for the two Svelte mounts.
 		super.hide();
+		this.cleanupRenderedSettings();
 		this.destroySettingViews();
+	}
+
+	private cleanupRenderedSettings(): void {
+		for (const cleanup of this.settingRenderCleanups.splice(0)) {
+			cleanup();
+		}
 	}
 
 	private destroySettingViews(): void {
@@ -130,6 +154,147 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.choiceViewHandle = null;
 		this.globalVariablesViewHandle?.destroy();
 		this.globalVariablesViewHandle = null;
+	}
+
+	private renderSettingDefinition(
+		containerEl: HTMLElement,
+		definition: SettingDefinitionItem<SettingsKey>,
+	): void {
+		if (!this.isVisible(definition)) return;
+
+		if (this.isSettingGroupDefinition(definition)) {
+			this.renderSettingGroup(containerEl, definition);
+			return;
+		}
+
+		if ("type" in definition && definition.type === "page") {
+			this.renderUnsupportedPage(containerEl, definition.name, definition.desc);
+			return;
+		}
+
+		const syntheticGroup = new SettingGroup(document.createElement("div"));
+		this.renderSettingItem(containerEl, definition, syntheticGroup);
+	}
+
+	private renderSettingGroup(
+		containerEl: HTMLElement,
+		groupDefinition: SettingDefinitionGroup<SettingsKey>,
+	): void {
+		const group = new SettingGroup(containerEl);
+		if (groupDefinition.heading) {
+			group.setHeading(groupDefinition.heading);
+		}
+		if (groupDefinition.cls) {
+			group.addClass(groupDefinition.cls);
+		}
+
+		for (const item of groupDefinition.items ?? []) {
+			this.renderSettingItem(group.listEl, item, group);
+		}
+	}
+
+	private renderSettingItem(
+		containerEl: HTMLElement,
+		item: QuickAddSettingItem,
+		group: SettingGroup,
+	): void {
+		if (!this.isVisible(item)) return;
+
+		if (this.isSettingGroupDefinition(item)) {
+			this.renderSettingGroup(containerEl, item);
+			return;
+		}
+
+		if ("type" in item && item.type === "page") {
+			this.renderUnsupportedPage(containerEl, item.name, item.desc);
+			return;
+		}
+
+		const setting = new Setting(containerEl);
+		setting.setName(item.name);
+		if (item.desc) {
+			setting.setDesc(item.desc);
+		}
+
+		if ("render" in item && item.render) {
+			const cleanup = item.render(setting, group);
+			if (typeof cleanup === "function") {
+				this.settingRenderCleanups.push(cleanup);
+			}
+			return;
+		}
+
+		if ("control" in item && item.control) {
+			this.renderControl(setting, item.control);
+		}
+	}
+
+	private renderControl(
+		setting: Setting,
+		control: SettingControl<SettingsKey>,
+	): void {
+		switch (control.type) {
+			case "toggle":
+				setting.addToggle((toggle) => {
+					toggle
+						.setValue(Boolean(this.getControlValue(control.key)))
+						.onChange((value) => {
+							void this.setControlValue(control.key, value);
+						});
+				});
+				return;
+
+			case "dropdown":
+				setting.addDropdown((dropdown) => {
+					for (const [value, label] of Object.entries(control.options)) {
+						dropdown.addOption(value, String(label));
+					}
+					dropdown
+						.setValue(
+							String(
+								this.getControlValue(control.key) ??
+									control.defaultValue ??
+									"",
+							),
+						)
+						.onChange((value) => {
+							void this.setControlValue(control.key, value);
+						});
+				});
+				return;
+
+			default:
+				setting.setDesc(
+					`${setting.descEl.textContent ? `${setting.descEl.textContent} ` : ""}` +
+						`This setting requires Obsidian 1.13's declarative renderer.`,
+				);
+		}
+	}
+
+	private renderUnsupportedPage(
+		containerEl: HTMLElement,
+		name: string,
+		desc?: string | DocumentFragment,
+	): void {
+		const setting = new Setting(containerEl).setName(name);
+		if (desc) setting.setDesc(desc);
+	}
+
+	private isSettingGroupDefinition(
+		definition: SettingDefinitionItem<SettingsKey>,
+	): definition is SettingDefinitionGroup<SettingsKey> {
+		return (
+			"type" in definition &&
+			(definition.type === "group" || definition.type === "list")
+		);
+	}
+
+	private isVisible(
+		definition: SettingDefinitionItem<SettingsKey> | QuickAddSettingItem,
+	): boolean {
+		if (!("visible" in definition)) return true;
+		const { visible } = definition;
+		return typeof visible === "function" ? visible() : visible !== false;
 	}
 
 	// ----- group builders -----

--- a/src/types/choices/IMultiChoice.ts
+++ b/src/types/choices/IMultiChoice.ts
@@ -1,7 +1,10 @@
 import type IChoice from "./IChoice";
 
+export type MultiChoiceDisplayMode = "suggester" | "context-menu";
+
 export default interface IMultiChoice extends IChoice {
 	choices: IChoice[];
 	collapsed: boolean;
 	placeholder?: string;
+	displayMode?: MultiChoiceDisplayMode;
 }

--- a/src/types/choices/MultiChoice.ts
+++ b/src/types/choices/MultiChoice.ts
@@ -1,11 +1,13 @@
 import { Choice } from "./Choice";
 import type IChoice from "./IChoice";
 import type IMultiChoice from "./IMultiChoice";
+import type { MultiChoiceDisplayMode } from "./IMultiChoice";
 
 export class MultiChoice extends Choice implements IMultiChoice {
 	choices: IChoice[] = [];
 	collapsed = false;
 	placeholder?: string;
+	displayMode?: MultiChoiceDisplayMode;
 
 	constructor(name: string) {
 		super(name, "Multi");

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -536,6 +536,10 @@ export const Modal = class {
 		document.body.appendChild(this.containerEl);
 	}
 
+	onOpen() {}
+
+	onClose() {}
+
 	open() {
 		(this as any).onOpen?.();
 	}
@@ -798,7 +802,12 @@ export class MenuItem {
 export class Menu {
   static lastShown: Menu | null = null;
   items: MenuItem[] = [];
+  useNativeMenu: boolean | null = null;
   shownAt: { type: "mouse" | "position"; detail: unknown } | null = null;
+  setUseNativeMenu(useNativeMenu: boolean): this {
+    this.useNativeMenu = useNativeMenu;
+    return this;
+  }
   addItem(cb: (item: MenuItem) => void): this {
     const item = new MenuItem();
     cb(item);

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -290,10 +290,12 @@ export class Setting {
 }
 
 export class SettingGroup {
+  listEl: HTMLElement;
   groupEl: HTMLElement;
 
   constructor(containerEl: HTMLElement) {
     this.groupEl = document.createElement("div");
+    this.listEl = this.groupEl;
     containerEl.appendChild(this.groupEl);
   }
 

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -27,6 +27,7 @@ for (const proto of [HTMLElement.prototype, SVGElement.prototype]) {
 		addClass?: unknown;
 		removeClass?: unknown;
 		empty?: unknown;
+		setText?: unknown;
 		createDiv?: unknown;
 		createEl?: unknown;
 	};
@@ -45,6 +46,11 @@ for (const proto of [HTMLElement.prototype, SVGElement.prototype]) {
 	if (typeof p.empty !== "function") {
 		p.empty = function empty(this: Element) {
 			this.textContent = "";
+		};
+	}
+	if (typeof p.setText !== "function") {
+		p.setText = function setText(this: Element, text: string) {
+			this.textContent = text;
 		};
 	}
 	if (typeof p.createDiv !== "function") {


### PR DESCRIPTION
Add an opt-in compact launch mode for Multi choices. A Multi can now keep the normal choice picker, or open a compact Obsidian menu near the active editor for small, curated sets of existing QuickAdd choices.

The issue proposes a new Context Menu choice type, but the underlying problem is faster access to a nested set of existing choices while writing. This keeps the feature inside Multi instead of adding a fifth persisted choice type: Multi already owns nested choice structure, import/export behavior, commands, and child routing. Existing Multi choices remain unchanged, and compact-menu mode falls back to the normal picker when there is no active editor position.

Important product boundary: this is only a different launch surface. Child Template, Capture, Macro, and Multi choices keep their own configured behavior. The compact menu does not make arbitrary children cursor-inserting, selection-transforming, or editor-action-aware unless those children already do that themselves.

Implementation notes:
- Adds `displayMode?: "context-menu"` to Multi choices; the default picker mode is omitted from saved data for back-compat.
- Uses Obsidian `Menu` anchored near the active editor position, with DOM menus forced so the compact menu is visible/testable and nested Multi drill-down can be rendered consistently.
- Adds a settings dropdown, focused dispatch/menu/modal tests, and docs for the tradeoff: compact-menu mode is best for small curated launch menus and does not provide fuzzy search.
- Includes a compatibility fix for the declarative settings tab in the isolated Obsidian runtime so live settings validation can actually open the QuickAdd tab.

Validation:
- `pnpm run build`
- `pnpm run provision:e2e-vault`
- `pnpm run obsidian:e2e -- plugin:reload id=quickadd`
- Live isolated Obsidian validation with seeded `__qa-453-context-multi`: menu opened near the active editor and showed `QA 453 Capture Child` plus `QA 453 Nested Multi ›`; CDP click on the direct child wrote `QA453-CAPTURED`; nested drill-down showed `← QA 453 Context Multi` plus `QA 453 Nested Capture`; CDP click on nested child wrote `QA453-NESTED`; `pnpm run obsidian:e2e -- dev:errors` reported no captured errors.
- `pnpm run build-with-lint`
- `pnpm run check` (0 errors, 4 existing warnings)
- `pnpm run test` (228 files passed, 5 skipped; 2649 tests passed, 37 skipped)

Fixes #453


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi choices can now be configured to open as a compact context menu near the editor as an alternative to the standard choice picker.
  * Added a new "Open with" display mode setting to configure this behavior per Multi choice.

* **Documentation**
  * Updated documentation explaining the new Multi choice display modes and compact menu behavior, including fallback handling and nested Multi choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->