### PR TITLE
feat(format): add trim option for value tokens

### DIFF
--- a/docs/docs/Advanced/CLI.md
+++ b/docs/docs/Advanced/CLI.md
@@ -83,6 +83,8 @@ obsidian vault=dev quickadd \
   vars='{"project":"QuickAdd","sprint":42}'
 ```
 
+Values are passed through exactly as provided. If a choice should ignore accidental leading or trailing whitespace for a specific token, use `|trim` in that format string, for example `{{VALUE:project|trim}}`.
+
 ## Non-interactive behavior
 
 By default, `quickadd` and `quickadd:run` are non-interactive. If QuickAdd
@@ -94,4 +96,3 @@ Use `ui` to allow interactive prompts:
 ```bash
 obsidian vault=dev quickadd choice="Daily log" ui
 ```
-

--- a/docs/docs/Advanced/ObsidianUri.md
+++ b/docs/docs/Advanced/ObsidianUri.md
@@ -21,6 +21,8 @@ The only required parameter is `choice` which selects the choice to run by its n
 
 [Variables to your choice](../FormatSyntax.md) are passed as additional `value-VARIABLE_NAME` parameters, with `value-` prefixing the name. Variables with a space in their name can still be used, but the spaces in the name must be encoded as `%20` as usual. For example, a capture asking for a variable named `log notes` would be passed as `value-log%20notes=...` in the URI.
 
+Variable values are used exactly as encoded in the URI. If a format should ignore accidental leading or trailing whitespace for one token, add `|trim` to that token, for example `{{VALUE:log notes|trim}}`.
+
 Keep in mind that unnamed variables (a bare `{{VALUE}}`/`{{NAME}}` or `{{MVALUE}}`) cannot be filled by the URI and you will instead be prompted inside Obsidian as usual.
 
 ## Vault parameter

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -190,6 +190,21 @@ Transforms the resolved value into a casing style. Supported: `kebab`, `snake`, 
 
 Example: `{{DATE:YYYY-MM-DD}}-{{VALUE:title|case:slug}}.md`.
 
+## `{{VALUE|trim}}` / `{{NAME|trim}}` / `{{VALUE:<variable>|trim}}` {#value-trim}
+
+Trims leading and trailing whitespace from the resolved value for this token. This is useful for file names, links, and properties where accidental spaces from mobile keyboards or pasted text would create a different note or link target.
+
+Example: `[[{{VALUE:title|trim}}]]`.
+
+`|trim` is applied per token and does not mutate the stored value. This means you can reuse the same answer in raw and trimmed forms:
+
+```markdown
+Raw: {{VALUE:title}}
+Link: [[{{VALUE:title|trim}}]]
+```
+
+It composes with other VALUE options, for example `{{VALUE:title|trim|case:slug}}`. For `|multi` values, string entries are trimmed while the value stays a List. The keyed form `|trim:false` turns trimming off when a shared snippet adds it.
+
 ## `{{VALUE:<options>|custom}}` {#value-custom}
 
 Allows you to type custom values in addition to selecting from the provided options. Example: `{{VALUE:Red,Green,Blue|custom}}` will suggest Red, Green, and Blue, but also allows you to type any other value like "Purple". This is useful when you have common options but want flexibility for edge cases. **Note:** You cannot combine `|custom` with a shorthand default value - use `|default:` if you need both.
@@ -216,7 +231,7 @@ Variants and combinations:
 
 - `|multi:linklist` wraps each pick as a wikilink, for List properties of links: `{{VALUE:Alice,Bob,Carol|multi:linklist}}` → `- "[[Alice]]"` / `- "[[Bob]]"`.
 - `|multi|custom` lets you add values not in the list (a text box in the picker).
-- Combines with `|name:`, `|label:`, `|text:`, and `|optional`. `|case:` is ignored with `|multi` (a list isn't case-transformed).
+- Combines with `|name:`, `|label:`, `|text:`, `|optional`, and `|trim`. `|case:` is ignored with `|multi` (a list isn't case-transformed).
 
 Notes:
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,8 @@ export const VDATE_OPTIONAL_SYNTAX =
 	"{{vdate:<variable name>, <date format>|optional}}";
 export const VALUE_CASE_SYNTAX = "{{value|case:kebab}}";
 export const VARIABLE_CASE_SYNTAX = "{{value:<variable name>|case:kebab}}";
+export const VALUE_TRIM_SYNTAX = "{{value|trim}}";
+export const VARIABLE_TRIM_SYNTAX = "{{value:<variable name>|trim}}";
 export const FIELD_VAR_SYNTAX = "{{field:<field name>}}";
 export const FILE_SYNTAX = "{{file:<folder>}}";
 export const FILE_LINK_SYNTAX = "{{file:<folder>|link}}";
@@ -47,6 +49,8 @@ export const FORMAT_SYNTAX: string[] = [
 	NAME_SYNTAX,
 	VALUE_CASE_SYNTAX,
 	VARIABLE_CASE_SYNTAX,
+	VALUE_TRIM_SYNTAX,
+	VARIABLE_TRIM_SYNTAX,
 	VARIABLE_SYNTAX,
 	VARIABLE_DEFAULT_SYNTAX,
 	VARIABLE_DEFAULT_OPTION_SYNTAX,
@@ -88,6 +92,8 @@ export const FILE_NAME_FORMAT_SYNTAX: string[] = [
 	NAME_SYNTAX,
 	VALUE_CASE_SYNTAX,
 	VARIABLE_CASE_SYNTAX,
+	VALUE_TRIM_SYNTAX,
+	VARIABLE_TRIM_SYNTAX,
 	VARIABLE_SYNTAX,
 	VARIABLE_DEFAULT_SYNTAX,
 	VARIABLE_DEFAULT_OPTION_SYNTAX,

--- a/src/formatters/formatter-case.test.ts
+++ b/src/formatters/formatter-case.test.ts
@@ -136,6 +136,34 @@ describe("Formatter case: pipe option", () => {
 		);
 	});
 
+	it("trims anonymous VALUE/NAME per token without mutating the shared value", async () => {
+		formatter.setValueResponse("  My New Blog  ");
+		const result = await formatter.testFormat(
+			"raw=[{{VALUE}}] trimmed=[{{VALUE|trim}}] slug=[{{NAME|trim|case:slug}}]",
+		);
+		expect(result).toBe(
+			"raw=[  My New Blog  ] trimmed=[My New Blog] slug=[my-new-blog]",
+		);
+	});
+
+	it("trims named VALUE per token without mutating cached variables", async () => {
+		formatter.setVariable("title", "  My New Blog  ");
+		const result = await formatter.testFormat(
+			"raw=[{{VALUE:title}}] trimmed=[{{VALUE:title|trim}}] raw2=[{{VALUE:title}}] slug=[{{VALUE:title|trim|case:slug}}]",
+		);
+		expect(result).toBe(
+			"raw=[  My New Blog  ] trimmed=[My New Blog] raw2=[  My New Blog  ] slug=[my-new-blog]",
+		);
+	});
+
+	it("quotes the trimmed value for type:text YAML scalars", async () => {
+		formatter.setVariable("id", "  0042  ");
+		const result = await formatter.testFormat(
+			"---\nid: {{VALUE:id|trim|type:text}}\n---",
+		);
+		expect(result).toBe("---\nid: \"0042\"\n---");
+	});
+
 	it("ignores unknown case styles (pass-through)", async () => {
 		formatter.setVariable("title", "My New Blog");
 		const result = await formatter.testFormat(

--- a/src/formatters/formatter-template-property-types.test.ts
+++ b/src/formatters/formatter-template-property-types.test.ts
@@ -236,6 +236,16 @@ describe('Formatter template property type inference', () => {
 			expect(vars.size).toBe(0);
 		});
 
+		it('coerces non-string values before applying text-only trim options', async () => {
+			(formatter as any).variables.set('rating', 8.5);
+			const output = await formatter.testFormatWithTemplatePropertyCollection(
+				'---\nrating: {{VALUE:rating|trim}}\n---',
+			);
+			const vars = formatter.getAndClearTemplatePropertyVars();
+			expect(output).toBe('---\nrating: 8.5\n---');
+			expect(vars.size).toBe(0);
+		});
+
 		it('does NOT collect plain strings (stays raw)', async () => {
 			(formatter as any).variables.set('title', 'Phantom Menace');
 			const output = await formatter.testFormatWithTemplatePropertyCollection(

--- a/src/formatters/formatter-template-property-types.test.ts
+++ b/src/formatters/formatter-template-property-types.test.ts
@@ -168,6 +168,26 @@ describe('Formatter template property type inference', () => {
 		expect(vars.get('tags')).toEqual(['[[John Doe]]', '[[Jane Doe]]']);
 	});
 
+	it('passes trimmed scalar values to YAML property inference', async () => {
+		(formatter as any).variables.set('tags', '  tag1, tag2  ');
+		await formatter.testFormatWithTemplatePropertyCollection(
+			'---\ntags: {{VALUE:tags|trim}}\n---',
+		);
+		const vars = formatter.getAndClearTemplatePropertyVars();
+		expect(vars.get('tags')).toEqual(['tag1', 'tag2']);
+	});
+
+	it('trims array elements while preserving collected YAML arrays', async () => {
+		(formatter as any).variables.set('tags', [' [[John Doe]] ', ' [[Jane Doe]] ']);
+		const output = await formatter.testFormatWithTemplatePropertyCollection(
+			'---\ntags: {{VALUE:tags|trim}}\n---',
+		);
+		const vars = formatter.getAndClearTemplatePropertyVars();
+
+		expect(output).toBe('---\ntags: []\n---');
+		expect(vars.get('tags')).toEqual(['[[John Doe]]', '[[Jane Doe]]']);
+	});
+
 	it('does not apply case transforms to YAML placeholders', async () => {
 		(formatter as any).variables.set('done', null);
 		const output =

--- a/src/formatters/formatter-text-mapping.test.ts
+++ b/src/formatters/formatter-text-mapping.test.ts
@@ -201,6 +201,15 @@ describe("Formatter VALUE text mapping", () => {
 		expect(formatter.lastSuggestCall?.allowCustomInput).toBe(true);
 	});
 
+	it("trims custom typed option-list values at replacement time", async () => {
+		formatter.setNextSuggestionResult("  urgent!  ");
+		const result = await formatter.testFormat(
+			"{{VALUE:🔼,⏫|text:Normal,High|custom|trim}}",
+		);
+
+		expect(result).toBe("urgent!");
+	});
+
 	it("does not remap typed custom values that equal display labels", async () => {
 		formatter.setNextSuggestionResult("High");
 		const result = await formatter.testFormat(

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -230,7 +230,7 @@ export abstract class Formatter {
 			if (optionsIndex === -1) return this.value;
 			const rawOptions = inner.slice(optionsIndex);
 			const parsed = parseAnonymousValueOptions(rawOptions);
-			const transformed = transformCase(this.value, parsed.caseStyle);
+			const transformed = this.applyValueTextOptions(this.value, parsed);
 			// |type:text on the anonymous {{VALUE|...}} form quotes the same way
 			// as the named form (see replaceVariableInString).
 			if (
@@ -244,6 +244,31 @@ export abstract class Formatter {
 		});
 
 		return output;
+	}
+
+	private applyValueTextOptions(
+		value: string,
+		options: { trim?: boolean; caseStyle?: string },
+	): string {
+		const trimmed = options.trim ? value.trim() : value;
+		return transformCase(trimmed, options.caseStyle);
+	}
+
+	private applyValueTokenOptions(
+		value: unknown,
+		parsed: ParsedValueToken,
+	): unknown {
+		if (Array.isArray(value)) {
+			return parsed.trim
+				? value.map((item) =>
+						typeof item === "string" ? item.trim() : item,
+					)
+				: value;
+		}
+		if (typeof value === "string") {
+			return this.applyValueTextOptions(value, parsed);
+		}
+		return value;
 	}
 
 	private getValuePromptContext(input: string): PromptContext | undefined {
@@ -790,19 +815,13 @@ export abstract class Formatter {
 				throw new Error(`Unable to parse variable. Invalid syntax in: "${output.substring(Math.max(0, match.index - 10), Math.min(output.length, match.index + 30))}..."`);
 			}
 
-			const {
-				variableName,
-				caseStyle,
-			} = parsed;
+			const { variableName } = parsed;
 
 			const effectiveKey = await this.ensureValueVariableResolved(parsed);
 
 			// Get the raw value from variables
 			const rawValue = this.variables.get(effectiveKey);
-			const rawValueForCollector =
-				caseStyle && typeof rawValue === "string"
-					? transformCase(rawValue, caseStyle)
-					: rawValue;
+			const effectiveRawValue = this.applyValueTokenOptions(rawValue, parsed);
 
 			// Offer this variable to the property collector for YAML post-processing.
 			// Collecting structured values (arrays/objects/numbers/booleans) into a
@@ -814,7 +833,7 @@ export abstract class Formatter {
 				input: output,
 				matchStart: match.index,
 				matchEnd: match.index + match[0].length,
-				rawValue: rawValueForCollector,
+				rawValue: effectiveRawValue,
 				fallbackKey: variableName,
 				collectionActive,
 				// |type:text forces a string: never run the string->structured
@@ -834,14 +853,17 @@ export abstract class Formatter {
 			let replacement: string;
 			if (placeholder !== undefined) {
 				replacement = placeholder;
-			} else if (Array.isArray(rawValue)) {
+			} else if (Array.isArray(effectiveRawValue)) {
 				// A |multi (or script) array that was NOT collected (body text, or a
 				// capture flow that suppresses frontmatter collection): join with
 				// commas. Guards against transformCase()/String() on an array.
-				replacement = rawValue.join(",");
+				replacement = effectiveRawValue.join(",");
 			} else {
 				const stringVal = String(
-					transformCase(this.getVariableValue(effectiveKey), caseStyle) ?? "",
+					this.applyValueTextOptions(
+						this.getVariableValue(effectiveKey),
+						parsed,
+					) ?? "",
 				);
 				// |type:text (#757): write the value as a quoted YAML string at a
 				// sole-value front-matter position so Obsidian can't retype it

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -247,10 +247,11 @@ export abstract class Formatter {
 	}
 
 	private applyValueTextOptions(
-		value: string,
+		value: unknown,
 		options: { trim?: boolean; caseStyle?: string },
 	): string {
-		const trimmed = options.trim ? value.trim() : value;
+		const text = String(value ?? "");
+		const trimmed = options.trim ? text.trim() : text;
 		return transformCase(trimmed, options.caseStyle);
 	}
 

--- a/src/gui/suggesters/formatSyntaxSuggester.case.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.case.test.ts
@@ -102,5 +102,25 @@ describe("FormatSyntaxSuggester case style suggestions", () => {
 		expect(suggestions).toContain("upper");
 		suggester.destroy();
 	});
-});
 
+	it("includes a trim example in VALUE variable suggestions", async () => {
+		const app = {
+			dom: { appContainerEl: document.body },
+			keymap: { pushScope: () => {}, popScope: () => {} },
+		} as any;
+		const plugin = {
+			settings: { choices: [], globalVariables: {} },
+			getTemplateFiles: () => [],
+		} as any;
+
+		const inputEl = document.createElement("input");
+		inputEl.value = "{{VALUE";
+		inputEl.selectionStart = inputEl.value.length;
+		inputEl.selectionEnd = inputEl.value.length;
+
+		const suggester = new FormatSyntaxSuggester(app, inputEl, plugin);
+		const suggestions = await suggester.getSuggestions(inputEl.value);
+		expect(suggestions).toContain("{{VALUE:title|trim}}");
+		suggester.destroy();
+	});
+});

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -325,6 +325,7 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 					"{{VALUE:title|label:Helper text}}",
 					"{{VALUE:option1,option2|label:Pick one}}",
 					"{{VALUE:title|label:Snake case|default:My_Title}}",
+					"{{VALUE:title|trim}}",
 					"{{VALUE:title|optional}}"
 				);
 			} else if (tokenDef.token === FormatSyntaxToken.File) {

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -42,6 +42,19 @@ describe("parseValueToken", () => {
 		expect(parsed?.defaultValue).toBe("");
 	});
 
+	it("parses trim without treating it as a legacy default", () => {
+		const parsed = parseValueToken("title|trim");
+		expect(parsed?.trim).toBe(true);
+		expect(parsed?.defaultValue).toBe("");
+		expect(parsed?.variableKey).toBe("title");
+	});
+
+	it("supports keyed trim flags", () => {
+		expect(parseValueToken("title|trim:true")?.trim).toBe(true);
+		expect(parseValueToken("title|trim:false")?.trim).toBe(false);
+		expect(parseValueToken("title|trim|trim:false")?.trim).toBe(false);
+	});
+
 	it("parses title case style", () => {
 		const parsed = parseValueToken("title|case:title");
 		expect(parsed?.caseStyle).toBe("title");
@@ -212,6 +225,13 @@ describe("parseAnonymousValueOptions", () => {
 		expect(parsed.caseStyle).toBe("kebab");
 		expect(parsed.label).toBe("Notes");
 		expect(parsed.defaultValue).toBe("Hello");
+	});
+
+	it("parses trim for unnamed VALUE tokens", () => {
+		const parsed = parseAnonymousValueOptions("|trim|label:Notes");
+		expect(parsed.trim).toBe(true);
+		expect(parsed.label).toBe("Notes");
+		expect(parsed.defaultValue).toBe("");
 	});
 
 	it("warns and ignores unknown type for unnamed VALUE tokens", () => {
@@ -420,6 +440,16 @@ describe("optional flag (issue #1259)", () => {
 		expect(withDefault.optional).toBe(true);
 		expect(withDefault.defaultValue).toBe("My default");
 		expect(parseAnonymousValueOptions("|My default").optional).toBe(false);
+	});
+
+	it("keeps shorthand defaults when combined with trim", () => {
+		const parsed = parseValueToken("x|tomorrow|trim");
+		expect(parsed?.trim).toBe(true);
+		expect(parsed?.defaultValue).toBe("tomorrow");
+
+		const anonymous = parseAnonymousValueOptions("|My default|trim");
+		expect(anonymous.trim).toBe(true);
+		expect(anonymous.defaultValue).toBe("My default");
 	});
 });
 

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -28,6 +28,7 @@ const VALUE_OPTION_KEYS = new Set([
 	"case",
 	"text",
 	"optional",
+	"trim",
 	"multi",
 ]);
 
@@ -56,6 +57,8 @@ export type ParsedValueToken = {
 	hasOptions: boolean;
 	inputTypeOverride?: ValueInputType;
 	optional: boolean;
+	/** Trims leading/trailing whitespace from this token's rendered value. */
+	trim: boolean;
 	/** |multi: pick several options into a YAML list (option-list tokens only). */
 	multiSelect: boolean;
 	/** |multi:linklist wraps each pick as [[name]]; defaults to plain text. */
@@ -126,6 +129,7 @@ type ParsedOptions = {
 	inputTypeOverride?: string;
 	displayValuesRaw?: string;
 	optionalExplicit?: boolean;
+	trimExplicit?: boolean;
 	name?: string;
 	multiSelect?: boolean;
 	multiEmit?: MultiEmit;
@@ -143,6 +147,20 @@ function extractBareOptionalFlag(parts: string[]): {
 } {
 	const { remaining, found } = extractBareFlagPart(parts, "optional");
 	return { remaining, optional: found };
+}
+
+function extractBareValueFlags(parts: string[]): {
+	remaining: string[];
+	optional: boolean;
+	trim: boolean;
+} {
+	const { remaining: withoutOptional, optional } =
+		extractBareOptionalFlag(parts);
+	const { remaining, found: trim } = extractBareFlagPart(
+		withoutOptional,
+		"trim",
+	);
+	return { remaining, optional, trim };
 }
 
 function hasRecognizedOption(part: string, allowName: boolean): boolean {
@@ -197,6 +215,7 @@ function parseOptions(
 	let inputTypeOverride: string | undefined;
 	let displayValuesRaw: string | undefined;
 	let optionalExplicit: boolean | undefined;
+	let trimExplicit: boolean | undefined;
 	let name: string | undefined;
 	let multiSelect = false;
 	let multiEmit: MultiEmit | undefined;
@@ -242,6 +261,9 @@ function parseOptions(
 			case "optional":
 				optionalExplicit = parseBooleanFlag(value);
 				break;
+			case "trim":
+				trimExplicit = parseBooleanFlag(value);
+				break;
 			case "multi":
 				multiSelect = true;
 				multiEmit =
@@ -271,6 +293,7 @@ function parseOptions(
 		inputTypeOverride,
 		displayValuesRaw,
 		optionalExplicit,
+		trimExplicit,
 		multiSelect,
 		multiEmit,
 	};
@@ -424,13 +447,17 @@ export function parseValueToken(
 		.filter(Boolean);
 	const hasOptions = suggestedValues.length > 1;
 
-	const { remaining: optionParts, optional: bareOptional } =
-		extractBareOptionalFlag(parts);
+	const {
+		remaining: optionParts,
+		optional: bareOptional,
+		trim: bareTrim,
+	} = extractBareValueFlags(parts);
 	const options = parseOptions(optionParts, hasOptions, true, quiet);
 	let { label, caseStyle, defaultValue, allowCustomInput } = options;
 	let multiSelect = options.multiSelect ?? false;
 	const multiEmit: MultiEmit = options.multiEmit ?? "text";
 	const optional = options.optionalExplicit ?? bareOptional;
+	const trim = options.trimExplicit ?? bareTrim;
 
 	if (!options.usesOptions) {
 		const legacyDefault = defaultValue;
@@ -541,6 +568,7 @@ export function parseValueToken(
 		hasOptions,
 		inputTypeOverride,
 		optional,
+		trim,
 		multiSelect,
 		multiEmit,
 	};
@@ -554,17 +582,21 @@ export function parseAnonymousValueOptions(
 	defaultValue: string;
 	inputTypeOverride?: ValueInputType;
 	optional: boolean;
+	trim: boolean;
 } {
 	const normalized = stripLeadingPipe(rawOptions);
 	const allParts = splitPipeParts(normalized)
 		.map((part) => part.trim())
 		.filter(Boolean);
 
-	const { remaining: parts, optional: bareOptional } =
-		extractBareOptionalFlag(allParts);
+	const {
+		remaining: parts,
+		optional: bareOptional,
+		trim: bareTrim,
+	} = extractBareValueFlags(allParts);
 
 	if (parts.length === 0) {
-		return { defaultValue: "", optional: bareOptional };
+		return { defaultValue: "", optional: bareOptional, trim: bareTrim };
 	}
 
 	const options = parseOptions(parts, false, false);
@@ -591,5 +623,6 @@ export function parseAnonymousValueOptions(
 		defaultValue,
 		inputTypeOverride,
 		optional: options.optionalExplicit ?? bareOptional,
+		trim: options.trimExplicit ?? bareTrim,
 	};
 }


### PR DESCRIPTION
Adds an opt-in `|trim` option to the existing VALUE/NAME format syntax:

- `{{VALUE|trim}}` and `{{NAME|trim}}` trim the anonymous capture value at the token site.
- `{{VALUE:title|trim}}` trims a named value at the token site.
- `|trim` composes with existing options such as `|case` and `|type:text`.
- Raw cached values remain unchanged, so a template can use both trimmed and untrimmed forms in the same capture.
- Multi/array values preserve their array shape while trimming string elements.

The underlying issue is not that QuickAdd needs a second VALUE token; it is that file names, links, and properties sometimes need boundary-whitespace normalization without changing existing capture behavior globally. I rejected global trimming because it would silently change existing workflows, and I rejected a new `{{TRIMEDVALUE}}` token because it would add one-off syntax and bake in a misspelled name. A pipe option fits QuickAdd's existing format language and generalizes to anonymous, named, CLI, URI, script/API, capture, and template usage.

No settings migration is needed. CLI/URI/API-provided values are still accepted exactly as supplied unless a rendered token opts into `|trim`.

Validation evidence:

- Live isolated Obsidian worktree vault after rebuilding and `plugin:reload id=quickadd`: control `{{VALUE}}` created `__qa-685/  Mobile Title  .md` with `link=[[  Mobile Title  ]]`.
- Live isolated Obsidian worktree vault: `{{VALUE|trim}}` created `__qa-685-trim/Mobile Title.md` with `link=[[Mobile Title]]` while `{{VALUE}}` in the same body preserved `raw=[  Mobile Title  ]`.
- Live isolated Obsidian worktree vault: `{{VALUE:title|trim}}` created `__qa-685-named/Named Title.md` with `link=[[Named Title]]` while `{{VALUE:title}}` preserved `raw=[  Named Title  ]`.
- `pnpm run obsidian:e2e -- dev:errors`: No errors captured.
- `pnpm run build-with-lint`: passed.
- `pnpm run check`: passed with 0 errors and 4 existing warnings.
- `pnpm run test`: passed with 2651 tests passing and 37 skipped.

Fixes #685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `|trim` modifier to VALUE tokens to strip leading/trailing whitespace (e.g., `{{VALUE|trim}}`, `{{VALUE:project|trim}}`).
  * Trim option composes with other VALUE modifiers and can be disabled with `|trim:false`.

* **Documentation**
  * Clarified how CLI and Obsidian URI handle token values and whitespace trimming.
  * Updated format syntax documentation with complete `|trim` option usage and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->