### PR TITLE
feat(format): add bounded slider value inputs

### DIFF
--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -25,6 +25,7 @@ Each choice builder has a **One-page input override** dropdown that lets you ove
   - `{{VALUE}}`, `{{VALUE:name}}`, `{{VDATE:name, YYYY-MM-DD}}`, `{{FIELD:name|...}}`
   - Nested `{{TEMPLATE:path}}` are scanned recursively.
 - `{{VALUE|type:multiline}}` and `{{VALUE:name|type:multiline}}` render as textareas in the one-page modal.
+- `{{VALUE:name|type:number|min:1|max:10}}` renders as a bounded numeric input, and `{{VALUE:name|type:slider|min:0|max:100|step:5}}` renders as a slider plus numeric input.
 - Capture target file when capturing to a folder or tag.
 - Script-declared inputs (from user scripts inside macros), if provided.
 
@@ -72,6 +73,7 @@ export const quickadd = {
   inputs: [
     { id: "project", label: "Project", type: "text", defaultValue: "Inbox" },
     { id: "due", label: "Due date", type: "date", dateFormat: "YYYY-MM-DD" },
+    { id: "confidence", label: "Confidence", type: "slider", defaultValue: "50", sliderConfig: { min: 0, max: 100, step: 5 } },
     { id: "status", label: "Status", type: "dropdown", options: ["Todo","Doing","Done"] }
   ]
 };
@@ -92,10 +94,12 @@ export const quickadd = {
 Supported input fields:
 - `id` (string, required)
 - `label` (string)
-- `type` ("text" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester")
+- `type` ("text" | "number" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester" | "slider")
 - `placeholder` (string)
 - `defaultValue` (string)
 - `options` (string[] for dropdown and suggester)
+- `numericConfig` (object for number: `{ min?: number, max?: number, step?: number }`)
+- `sliderConfig` (object for slider: `{ min: number, max: number, step?: number }`; `min` and `max` are required, `step` defaults to `1`)
 - `dateFormat` (string for date)
 - `description` (string)
 - `optional` (boolean — field may be left empty; shows an "(optional)" badge)
@@ -103,10 +107,12 @@ Supported input fields:
 
 **Field Type Details:**
 - `text`: Single-line text input
+- `number`: Numeric input, optionally bounded by `numericConfig`
 - `textarea`: Multi-line text input
 - `dropdown`: Fixed dropdown menu (no search, must select from list)
 - `date`: Date input with natural language support
 - `field-suggest`: Vault field suggestions (uses `{{FIELD:...}}` syntax)
+- `slider`: Bounded numeric input with a slider and editable number field. Requires `sliderConfig.min` and `sliderConfig.max`; invalid configs fall back to `number`.
 - `suggester`: **NEW** - Searchable autocomplete with custom options (allows typing custom values)
   - Supports multi-select mode via `suggesterConfig.multiSelect: true`
   - Multi-select: Select multiple items, separated by commas. Suggestions stay open after each selection.
@@ -120,6 +126,7 @@ export default async function entry({ quickAddApi }) {
   const values = await quickAddApi.requestInputs([
     { id: "project", label: "Project", type: "text", defaultValue: "Inbox" },
     { id: "due", label: "Due", type: "date", dateFormat: "YYYY-MM-DD" },
+    { id: "confidence", label: "Confidence", type: "slider", defaultValue: "50", sliderConfig: { min: 0, max: 100, step: 5 } },
     { id: "status", label: "Status", type: "dropdown", options: ["Todo","Doing","Done"] },
     { 
       id: "tags", 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -166,23 +166,27 @@ Example:
 
 **Keyboard:** In the multi-line prompt, pressing **Tab** inserts a tab character at the cursor (handy for nested Markdown lists) instead of moving focus; with text selected, Tab indents every line the selection touches. **Shift+Tab** is left unbound, so it still moves focus out of the field.
 
-## `{{VALUE:<variable>|type:number}}` / `|type:checkbox` / `|type:text` {#value-property-types}
+## `{{VALUE:<variable>|type:number}}` / `|type:slider` / `|type:checkbox` / `|type:text` {#value-property-types}
 
 Tailors the input to an Obsidian property type. These are single-value prompts (no comma options / `|custom`):
 
-- `|type:number` shows a numeric input. The value is written unquoted (`rating: 42`), so Obsidian reads it as a **Number**.
+- `|type:number` shows a numeric input. The value is written unquoted (`rating: 42`), so Obsidian reads it as a **Number**. Add `|min:`, `|max:`, and/or `|step:` to constrain the input.
+- `|type:slider` shows a bounded number picker with a slider and numeric input. `|min:` and `|max:` are required; `|step:` defaults to `1`. If the slider range is missing or invalid, QuickAdd falls back to the numeric input instead of guessing a range.
 - `|type:checkbox` (alias `|type:boolean`) shows a forced **true / false** picker — useful for a `checkbox` property. The `|label:` becomes the picker's title so you know which property you're setting. Writes `done: true` (a boolean).
 - `|type:text` keeps the value a **string**. It writes the value as a quoted YAML scalar (`id: "0042"`), so Obsidian can't retype it — without it, a text property given `0042` is read as the number `42`, `true` as a boolean, and a value like `#todo` or `[a]` is mis-parsed entirely.
 
 ```markdown
 ---
-rating: {{VALUE:rating|type:number}}
+rating: {{VALUE:rating|type:number|min:1|max:10}}
+confidence: {{VALUE:confidence|type:slider|min:0|max:100|step:5|default:50}}
 done: {{VALUE:done|type:checkbox|label:Completed?}}
 id: {{VALUE:id|type:text}}
 ---
 ```
 
-**Good to know:** plain number and checkbox values already round-trip correctly without `|type:` — `count: {{VALUE:count}}` typed `42` becomes a Number, and `{{VALUE:true,false}}` becomes a Boolean. The `|type:` options add the right input widget and validation, and `|type:text` closes the cases Obsidian gets "wrong" (a text value that looks like a number/boolean, or one that starts with a YAML character like `#` or `[`). Dates like `2025-12-25` are always kept as text by Obsidian, so they never need `|type:text`.
+`|min:`, `|max:`, and `|step:` are only parsed as numeric options when the token also uses `|type:number` or `|type:slider`. Without a numeric type, they remain ordinary text/default syntax for backwards compatibility.
+
+**Good to know:** plain number and checkbox values already round-trip correctly without `|type:` — `count: {{VALUE:count}}` typed `42` becomes a Number, and `{{VALUE:true,false}}` becomes a Boolean. The `|type:` options add the right input widget and validation, `|type:slider` gives bounded numeric range ergonomics, and `|type:text` closes the cases Obsidian gets "wrong" (a text value that looks like a number/boolean, or one that starts with a YAML character like `#` or `[`). Dates like `2025-12-25` are always kept as text by Obsidian, so they never need `|type:text`.
 
 ## `{{VALUE|case:<style>}}` / `{{NAME|case:<style>}}` / `{{VALUE:<variable>|case:<style>}}` {#value-case}
 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -39,7 +39,7 @@ tR += result;
 
 ## User Input Methods
 
-### `requestInputs(inputs: Array<{ id: string; label?: string; type: "text" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester"; placeholder?: string; defaultValue?: string; options?: string[]; dateFormat?: string; description?: string; suggesterConfig?: { allowCustomInput?: boolean; caseSensitive?: boolean; multiSelect?: boolean; } }>): Promise<Record<string, string>>`
+### `requestInputs(inputs: Array<{ id: string; label?: string; type: "text" | "number" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester" | "slider"; placeholder?: string; defaultValue?: string; numericConfig?: { min?: number; max?: number; step?: number }; sliderConfig?: { min: number; max: number; step?: number }; options?: string[]; dateFormat?: string; description?: string; suggesterConfig?: { allowCustomInput?: boolean; caseSensitive?: boolean; multiSelect?: boolean; } }>): Promise<Record<string, string>>`
 Opens a one-page modal to collect multiple inputs in one go. Values already present in `variables` are used and not re-asked. Returned values are also stored into `variables`.
 
 **Behavior:**
@@ -49,10 +49,12 @@ Opens a one-page modal to collect multiple inputs in one go. Values already pres
 
 **Field Types:**
 - `text`: Single-line text input
+- `number`: Numeric input, optionally bounded by `numericConfig`
 - `textarea`: Multi-line text input
 - `dropdown`: Fixed dropdown menu (no search, must select from list)
 - `date`: Date input with natural language support (short aliases like `t`, `tm`, `yd` are supported and configurable in settings)
 - `field-suggest`: Vault field suggestions (uses `{{FIELD:...}}` syntax)
+- `slider`: Bounded numeric input with a slider and editable number field. Requires `sliderConfig.min` and `sliderConfig.max`; `sliderConfig.step` defaults to `1`. Invalid slider configs fall back to `number`.
 - `suggester`: **NEW** - Searchable autocomplete with custom options (allows custom input)
   - Supports multi-select mode via `suggesterConfig.multiSelect: true` for comma-separated selections
 
@@ -63,6 +65,7 @@ Opens a one-page modal to collect multiple inputs in one go. Values already pres
 const values = await quickAddApi.requestInputs([
   { id: "project", label: "Project", type: "text", defaultValue: "Inbox" },
   { id: "due", label: "Due", type: "date", dateFormat: "YYYY-MM-DD" },
+  { id: "confidence", label: "Confidence", type: "slider", defaultValue: "50", sliderConfig: { min: 0, max: 100, step: 5 } },
   { id: "status", label: "Status", type: "dropdown", options: ["Todo","Doing","Done"] },
   { 
     id: "tags", 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -39,7 +39,7 @@ tR += result;
 
 ## User Input Methods
 
-### `requestInputs(inputs: Array<{ id: string; label?: string; type: "text" | "number" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester" | "slider"; placeholder?: string; defaultValue?: string; numericConfig?: { min?: number; max?: number; step?: number }; sliderConfig?: { min: number; max: number; step?: number }; options?: string[]; dateFormat?: string; description?: string; suggesterConfig?: { allowCustomInput?: boolean; caseSensitive?: boolean; multiSelect?: boolean; } }>): Promise<Record<string, string>>`
+### `requestInputs(inputs: Array<{ id: string; label?: string; type: "text" | "number" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester" | "slider"; placeholder?: string; defaultValue?: string; numericConfig?: { min?: number; max?: number; step?: number }; sliderConfig?: { min: number; max: number; step?: number }; options?: string[]; dateFormat?: string; description?: string; optional?: boolean; suggesterConfig?: { allowCustomInput?: boolean; caseSensitive?: boolean; multiSelect?: boolean; } }>): Promise<Record<string, string>>`
 Opens a one-page modal to collect multiple inputs in one go. Values already present in `variables` are used and not re-asked. Returned values are also stored into `variables`.
 
 **Behavior:**

--- a/docs/docs/TemplatePropertyTypes.md
+++ b/docs/docs/TemplatePropertyTypes.md
@@ -20,7 +20,7 @@ The goal is to make note creation easier and more intuitive. While the string co
 
 **Prefer explicit format-syntax options** when you want a specific input or type, with no beta toggle required:
 
-- [`{{VALUE:x|type:number}}` / `|type:checkbox` / `|type:text`](./FormatSyntax#value-property-types) — pick the right input widget; `|type:text` keeps a number-looking value (e.g. `0042`) a string.
+- [`{{VALUE:x|type:number}}` / `|type:slider` / `|type:checkbox` / `|type:text`](./FormatSyntax#value-property-types) — pick the right input widget; `|type:slider|min:0|max:100` is useful for bounded Number properties, and `|type:text` keeps a number-looking value (e.g. `0042`) a string.
 - [`{{VALUE:a,b,c|multi}}`](./FormatSyntax#value-multi) — a multi-select picker that writes a real List (also `|multi:linklist` for link lists).
 - [`{{VDATE:when,fmt|time}}`](./FormatSyntax#vdate-time) — a date **and time** picker for `Date & time` properties.
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 	inlineParamsVariables: {} as Record<string, unknown>,
 	inputPromptPrompt: vi.fn(),
 	inputPromptPromptWithContext: vi.fn(),
+	inputPromptFactory: vi.fn(),
 	genericInputPromptWithContext: vi.fn(),
 	inputSuggesterSuggest: vi.fn(),
 	genericSuggesterSuggest: vi.fn(),
@@ -86,7 +87,8 @@ vi.mock("../engine/SingleInlineScriptEngine", () => ({
 
 vi.mock("../gui/InputPrompt", () => ({
 	default: class {
-		factory() {
+		factory(inputTypeOverride?: string) {
+			mocks.inputPromptFactory(inputTypeOverride);
 			return {
 				Prompt: mocks.inputPromptPrompt,
 				PromptWithContext: mocks.inputPromptPromptWithContext,
@@ -619,6 +621,23 @@ describe("CompleteFormatter - selection handling", () => {
 		// Selection short-circuits the prompt.
 		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
 	});
+
+	it("normalizes selected text for anonymous bounded number VALUE", async () => {
+		const f = defaultFormatter({}, { selection: "999" });
+		await expect(
+			f.formatFolderPath("v={{VALUE|type:number|min:1|max:10|step:2}}"),
+		).resolves.toBe("v=10");
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
+	});
+
+	it("prompts when selected text is invalid for anonymous number VALUE", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("4");
+		const f = defaultFormatter({}, { selection: "not a number" });
+		await expect(
+			f.formatFolderPath("v={{VALUE|type:number|min:1|max:10|step:1}}"),
+		).resolves.toBe("v=4");
+		expect(mocks.inputPromptPrompt).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("CompleteFormatter - clipboard handling", () => {
@@ -654,6 +673,29 @@ describe("CompleteFormatter - {{VALUE}} prompting", () => {
 		expect(mocks.inputPromptPrompt).toHaveBeenCalledTimes(1);
 	});
 
+	it("passes slider configuration to anonymous VALUE prompts", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("7");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath(
+				"{{VALUE|type:slider|min:1|max:10|step:1|default:5|optional}}",
+			),
+		).resolves.toBe("7");
+		expect(mocks.inputPromptFactory).toHaveBeenCalledWith("slider");
+		expect(mocks.inputPromptPrompt).toHaveBeenCalledWith(
+			expect.anything(),
+			"Enter value",
+			undefined,
+			"5",
+			undefined,
+			{
+				optional: true,
+				numeric: { min: 1, max: 10, step: 1 },
+				slider: { min: 1, max: 10, step: 1 },
+			},
+		);
+	});
+
 	it("wraps a user-cancellation in MacroAbortError", async () => {
 		// isCancellationError only treats specific string messages as cancels.
 		mocks.inputPromptPrompt.mockRejectedValue("No input given.");
@@ -677,6 +719,27 @@ describe("CompleteFormatter - {{VALUE:variable}} prompting", () => {
 		const f = defaultFormatter();
 		await expect(f.formatFolderPath("{{VALUE:name}}")).resolves.toBe(
 			"Alice",
+		);
+	});
+
+	it("passes numeric configuration to named VALUE prompts", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("5");
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("{{VALUE:rating|type:number|min:1|max:10|step:1}}"),
+		).resolves.toBe("5");
+		expect(mocks.inputPromptFactory).toHaveBeenCalledWith("number");
+		expect(mocks.inputPromptPrompt).toHaveBeenCalledWith(
+			expect.anything(),
+			"rating",
+			undefined,
+			"",
+			undefined,
+			{
+				optional: false,
+				numeric: { min: 1, max: 10, step: 1 },
+				slider: undefined,
+			},
 		);
 	});
 

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -11,6 +11,7 @@ import InputPrompt from "../gui/InputPrompt";
 import { MathModal } from "../gui/MathModal";
 import type QuickAdd from "../main";
 import type { IDateParser } from "../parsers/IDateParser";
+import type { InputPromptOptions } from "../types/inputPrompt";
 import { NLDParser } from "../parsers/NLDParser";
 import {
 	FieldSuggestionParser,
@@ -23,6 +24,7 @@ import {
 	FILE_PICK_PREFIX,
 	type ParsedFileToken,
 } from "../utils/fileSyntax";
+import { normalizeNumericValue } from "../utils/valueSyntax";
 import {
 	collectFieldValuesProcessedDetailed,
 	collectFieldValuesRaw,
@@ -335,8 +337,12 @@ export class CompleteFormatter extends Formatter {
 			if (this.shouldUseSelectionForValue()) {
 				const selectedText: string = await this.getSelectedTextForValue();
 				if (selectedText) {
-					this.value = selectedText;
-					return this.value;
+					const normalizedSelection =
+						this.normalizeSelectedTextForPrompt(selectedText);
+					if (normalizedSelection !== undefined) {
+						this.value = normalizedSelection;
+						return this.value;
+					}
 				}
 			}
 			// Anonymous {{VALUE|type:checkbox}} gets the same forced true/false
@@ -370,9 +376,9 @@ export class CompleteFormatter extends Formatter {
 				);
 				const defaultValue = this.valuePromptContext?.defaultValue;
 				const description = this.valuePromptContext?.description;
-				const promptOptions = this.valuePromptContext?.optional
-					? { optional: true }
-					: undefined;
+				const promptOptions = this.buildInputPromptOptions(
+					this.valuePromptContext,
+				);
 				if (linkSourcePath) {
 					this.value = await promptFactory.PromptWithContext(
 						this.app,
@@ -402,6 +408,35 @@ export class CompleteFormatter extends Formatter {
 		}
 
 		return this.value;
+	}
+
+	private normalizeSelectedTextForPrompt(
+		selectedText: string,
+	): string | undefined {
+		const context = this.valuePromptContext;
+		if (
+			context?.inputTypeOverride !== "number" &&
+			context?.inputTypeOverride !== "slider"
+		) {
+			return selectedText;
+		}
+
+		const numericConfig = context.sliderConfig ?? context.numericConfig;
+		const normalized = normalizeNumericValue(selectedText, numericConfig);
+		return normalized === "" ? undefined : normalized;
+	}
+
+	private buildInputPromptOptions(
+		context: PromptContext | undefined,
+	): InputPromptOptions | undefined {
+		if (!context?.optional && !context?.numericConfig && !context?.sliderConfig) {
+			return undefined;
+		}
+		return {
+			optional: context?.optional,
+			numeric: context?.numericConfig,
+			slider: context?.sliderConfig,
+		};
 	}
 
 	protected async promptForVariable(
@@ -447,7 +482,7 @@ export class CompleteFormatter extends Formatter {
 					(context?.defaultValue ? context.defaultValue : undefined),
 				context?.defaultValue,
 				context?.description,
-				context?.optional ? { optional: true } : undefined,
+				this.buildInputPromptOptions(context),
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -44,6 +44,8 @@ import {
 	parseAnonymousValueOptions,
 	parseValueToken,
 	resolveExistingVariableKey,
+	type NumericInputConfig,
+	type SliderConfig,
 	type ValueInputType,
 } from "../utils/valueSyntax";
 import { parseVDateOptions } from "../utils/vdateSyntax";
@@ -62,6 +64,8 @@ export interface PromptContext {
 	placeholder?: string;
 	variableKey?: string;
 	inputTypeOverride?: ValueInputType; // Undefined means use global input prompt setting.
+	numericConfig?: NumericInputConfig;
+	sliderConfig?: SliderConfig;
 	optional?: boolean; // Token carries |optional: empty submissions are accepted as the answer.
 	withTime?: boolean; // VDATE |time/|datetime: render a date AND time picker.
 }
@@ -269,6 +273,12 @@ export abstract class Formatter {
 			}
 			if (parsed.inputTypeOverride && !context.inputTypeOverride) {
 				context.inputTypeOverride = parsed.inputTypeOverride;
+			}
+			if (parsed.numericConfig && !context.numericConfig) {
+				context.numericConfig = parsed.numericConfig;
+			}
+			if (parsed.sliderConfig && !context.sliderConfig) {
+				context.sliderConfig = parsed.sliderConfig;
 			}
 			if (parsed.optional) {
 				context.optional = true;
@@ -687,6 +697,8 @@ export abstract class Formatter {
 				defaultValue,
 				description: helperText,
 				inputTypeOverride: parsed.inputTypeOverride,
+				numericConfig: parsed.numericConfig,
+				sliderConfig: parsed.sliderConfig,
 				variableKey,
 				optional: parsed.optional,
 			});

--- a/src/gui/InputPrompt.test.ts
+++ b/src/gui/InputPrompt.test.ts
@@ -4,6 +4,8 @@ import { setQuickAddInstance } from "../quickAddInstance";
 import InputPrompt from "./InputPrompt";
 import GenericInputPrompt from "./GenericInputPrompt/GenericInputPrompt";
 import GenericWideInputPrompt from "./GenericWideInputPrompt/GenericWideInputPrompt";
+import NumberInputPrompt from "./NumberInputPrompt/NumberInputPrompt";
+import SliderInputPrompt from "./SliderInputPrompt/SliderInputPrompt";
 
 const fakePlugin = (inputPrompt: "single-line" | "multi-line") =>
 	({ settings: { inputPrompt } }) as unknown as QuickAdd;
@@ -27,5 +29,15 @@ describe("InputPrompt factory", () => {
 	it("uses single-line when no override and global single-line", () => {
 		const prompt = new InputPrompt();
 		expect(prompt.factory()).toBe(GenericInputPrompt);
+	});
+
+	it("uses number prompt for number override", () => {
+		const prompt = new InputPrompt();
+		expect(prompt.factory("number")).toBe(NumberInputPrompt);
+	});
+
+	it("uses slider prompt for slider override", () => {
+		const prompt = new InputPrompt();
+		expect(prompt.factory("slider")).toBe(SliderInputPrompt);
 	});
 });

--- a/src/gui/InputPrompt.ts
+++ b/src/gui/InputPrompt.ts
@@ -1,6 +1,7 @@
 import GenericWideInputPrompt from "./GenericWideInputPrompt/GenericWideInputPrompt";
 import GenericInputPrompt from "./GenericInputPrompt/GenericInputPrompt";
 import NumberInputPrompt from "./NumberInputPrompt/NumberInputPrompt";
+import SliderInputPrompt from "./SliderInputPrompt/SliderInputPrompt";
 import { getQuickAddInstance } from "../quickAddInstance";
 import type { ValueInputType } from "../utils/valueSyntax";
 
@@ -11,6 +12,9 @@ export default class InputPrompt {
 		}
 		if (inputTypeOverride === "number") {
 			return NumberInputPrompt;
+		}
+		if (inputTypeOverride === "slider") {
+			return SliderInputPrompt;
 		}
 		// "checkbox" is resolved before the factory (a true/false suggester),
 		// and "text" only affects YAML quoting at write time — both fall

--- a/src/gui/NumberInputPrompt/NumberInputPrompt.ts
+++ b/src/gui/NumberInputPrompt/NumberInputPrompt.ts
@@ -2,6 +2,7 @@ import type { App } from "obsidian";
 import type { TextComponent } from "obsidian";
 import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
 import type { InputPromptOptions } from "../../types/inputPrompt";
+import { normalizeNumericValue } from "../../utils/valueSyntax";
 
 /**
  * A {@link GenericInputPrompt} that renders an `<input type="number">` for
@@ -70,8 +71,23 @@ export default class NumberInputPrompt extends GenericInputPrompt {
 		);
 		textComponent.inputEl.type = "number";
 		textComponent.inputEl.inputMode = "decimal";
-		// Allow decimals/scientific notation; the browser still rejects letters.
-		textComponent.inputEl.setAttr("step", "any");
+		const numeric = this.options?.numeric;
+		if (numeric?.min !== undefined) {
+			textComponent.inputEl.min = String(numeric.min);
+		}
+		if (numeric?.max !== undefined) {
+			textComponent.inputEl.max = String(numeric.max);
+		}
+		textComponent.inputEl.setAttr(
+			"step",
+			numeric?.step !== undefined ? String(numeric.step) : "any",
+		);
 		return textComponent;
+	}
+
+	protected transformInputOnSubmit(input: string): string {
+		if (!this.options?.numeric) return input;
+		if (input === "" && this.isOptionalPrompt) return "";
+		return normalizeNumericValue(input, this.options.numeric);
 	}
 }

--- a/src/gui/SliderInputPrompt/SliderInputPrompt.ts
+++ b/src/gui/SliderInputPrompt/SliderInputPrompt.ts
@@ -1,0 +1,117 @@
+import type { App, TextComponent } from "obsidian";
+import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
+import type { InputPromptOptions } from "../../types/inputPrompt";
+import {
+	normalizeNumericValue,
+	normalizeSliderValue,
+} from "../../utils/valueSyntax";
+
+const FALLBACK_SLIDER = { min: 0, max: 100, step: 1 };
+
+export default class SliderInputPrompt extends GenericInputPrompt {
+	private sliderEl?: HTMLInputElement;
+	private numberEl?: HTMLInputElement;
+
+	public static Prompt(
+		app: App,
+		header: string,
+		placeholder?: string,
+		value?: string,
+		description?: string,
+		options?: InputPromptOptions,
+	): Promise<string> {
+		const modal = new SliderInputPrompt(
+			app,
+			header,
+			placeholder,
+			value,
+			undefined,
+			description,
+			options,
+		);
+		return modal.waitForClose;
+	}
+
+	public static PromptWithContext(
+		app: App,
+		header: string,
+		placeholder?: string,
+		value?: string,
+		linkSourcePath?: string,
+		description?: string,
+		options?: InputPromptOptions,
+	): Promise<string> {
+		const modal = new SliderInputPrompt(
+			app,
+			header,
+			placeholder,
+			value,
+			linkSourcePath,
+			description,
+			options,
+		);
+		return modal.waitForClose;
+	}
+
+	protected createInputField(
+		container: HTMLElement,
+		_placeholder?: string,
+		value?: string,
+	): TextComponent {
+		const config = this.options?.slider ?? FALLBACK_SLIDER;
+		const isOptionalBlank = this.isOptionalPrompt && !value;
+		const initial = normalizeSliderValue(value, config);
+
+		this.sliderEl = container.createEl("input");
+		this.sliderEl.type = "range";
+		this.sliderEl.min = String(config.min);
+		this.sliderEl.max = String(config.max);
+		this.sliderEl.step = String(config.step);
+		this.sliderEl.value = initial;
+		this.sliderEl.setCssStyles({ width: "100%" });
+
+		const textComponent = super.createInputField(container, undefined, initial);
+		this.numberEl = textComponent.inputEl;
+		this.numberEl.type = "number";
+		this.numberEl.inputMode = "decimal";
+		this.numberEl.min = String(config.min);
+		this.numberEl.max = String(config.max);
+		this.numberEl.step = String(config.step);
+		if (isOptionalBlank) {
+			this.numberEl.value = "";
+		}
+
+		this.sliderEl.addEventListener("input", () => this.syncFromSlider());
+		this.numberEl.addEventListener("input", () => this.syncFromNumber());
+
+		return textComponent;
+	}
+
+	private syncFromSlider(): void {
+		if (!this.sliderEl || !this.numberEl) return;
+		this.numberEl.value = this.sliderEl.value;
+		this.onInputChanged(this.sliderEl.value);
+	}
+
+	private syncFromNumber(): void {
+		if (!this.sliderEl || !this.numberEl) return;
+		const value = this.numberEl.value;
+		if (value === "" && this.isOptionalPrompt) {
+			this.onInputChanged("");
+			return;
+		}
+		const normalized = normalizeNumericValue(
+			value,
+			this.options?.slider ?? FALLBACK_SLIDER,
+		);
+		if (normalized !== "") {
+			this.sliderEl.value = normalized;
+		}
+		this.onInputChanged(value);
+	}
+
+	protected transformInputOnSubmit(input: string): string {
+		if (input === "" && this.isOptionalPrompt) return "";
+		return normalizeSliderValue(input, this.options?.slider ?? FALLBACK_SLIDER);
+	}
+}

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -369,6 +369,45 @@ describe("OnePageInputModal", () => {
 		await expect(modal.waitForClose).resolves.toEqual({ rating: "7" });
 	});
 
+	it("lets negative slider values be typed through the numeric field", async () => {
+		const requirements: FieldRequirement[] = [
+			{
+				id: "score",
+				label: "Score",
+				type: "slider",
+				defaultValue: "0",
+				sliderConfig: { min: -5, max: 5, step: 1 },
+			},
+		];
+
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		const range = (modal as any).contentEl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+		const number = (modal as any).contentEl.querySelector(
+			'input[type="number"]',
+		) as HTMLInputElement;
+
+		number.value = "-";
+		number.dispatchEvent(new Event("input", { bubbles: true }));
+		expect(range.value).toBe("0");
+		expect(number.value).toBe("");
+
+		number.value = "-4";
+		number.dispatchEvent(new Event("input", { bubbles: true }));
+		expect(range.value).toBe("-4");
+		expect(number.value).toBe("-4");
+
+		const submitButton = Array.from(
+			(modal as any).contentEl.querySelectorAll(
+				"button",
+			) as NodeListOf<HTMLButtonElement>,
+		).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+		submitButton.click();
+
+		await expect(modal.waitForClose).resolves.toEqual({ score: "-4" });
+	});
+
 	it("leaves untouched optional sliders empty when they have no default", async () => {
 		const requirements: FieldRequirement[] = [
 			{

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -295,6 +295,107 @@ describe("OnePageInputModal", () => {
 		});
 	});
 
+	it("renders bounded number fields and submits the normalized value", async () => {
+		const requirements: FieldRequirement[] = [
+			{
+				id: "rating",
+				label: "Rating",
+				type: "number",
+				defaultValue: "999",
+				numericConfig: { min: 1, max: 10, step: 1 },
+			},
+		];
+
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		const number = (modal as any).contentEl.querySelector(
+			'input[type="number"]',
+		) as HTMLInputElement;
+		expect(number.min).toBe("1");
+		expect(number.max).toBe("10");
+		expect(number.step).toBe("1");
+		expect(number.value).toBe("10");
+
+		number.value = "-5";
+		number.dispatchEvent(new Event("input", { bubbles: true }));
+
+		const submitButton = Array.from(
+			(modal as any).contentEl.querySelectorAll(
+				"button",
+			) as NodeListOf<HTMLButtonElement>,
+		).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+		submitButton.click();
+
+		await expect(modal.waitForClose).resolves.toEqual({ rating: "1" });
+	});
+
+	it("renders slider fields and submits the selected numeric value", async () => {
+		const requirements: FieldRequirement[] = [
+			{
+				id: "rating",
+				label: "Rating",
+				type: "slider",
+				defaultValue: "5",
+				sliderConfig: { min: 1, max: 10, step: 1 },
+			},
+		];
+
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		const range = (modal as any).contentEl.querySelector(
+			'input[type="range"]',
+		) as HTMLInputElement;
+		const number = (modal as any).contentEl.querySelector(
+			'input[type="number"]',
+		) as HTMLInputElement;
+		expect(range.min).toBe("1");
+		expect(range.max).toBe("10");
+		expect(range.step).toBe("1");
+		expect(number.value).toBe("5");
+
+		number.value = "999";
+		number.dispatchEvent(new Event("input", { bubbles: true }));
+		expect(range.value).toBe("10");
+		expect(number.value).toBe("10");
+
+		range.value = "7";
+		range.dispatchEvent(new Event("input", { bubbles: true }));
+
+		const submitButton = Array.from(
+			(modal as any).contentEl.querySelectorAll(
+				"button",
+			) as NodeListOf<HTMLButtonElement>,
+		).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+		submitButton.click();
+
+		await expect(modal.waitForClose).resolves.toEqual({ rating: "7" });
+	});
+
+	it("leaves untouched optional sliders empty when they have no default", async () => {
+		const requirements: FieldRequirement[] = [
+			{
+				id: "rating",
+				label: "Rating",
+				type: "slider",
+				optional: true,
+				sliderConfig: { min: 1, max: 10, step: 1 },
+			},
+		];
+
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		const number = (modal as any).contentEl.querySelector(
+			'input[type="number"]',
+		) as HTMLInputElement;
+		expect(number.value).toBe("");
+
+		const submitButton = Array.from(
+			(modal as any).contentEl.querySelectorAll(
+				"button",
+			) as NodeListOf<HTMLButtonElement>,
+		).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+		submitButton.click();
+
+		await expect(modal.waitForClose).resolves.toEqual({ rating: "" });
+	});
+
 	// Regression: issue #1180 — One-page input dropped VALUE dropdown
 	// selections for labeled tokens like {{VALUE:option-a,option-b|label:Pick one}},
 	// resulting in an empty captured value instead of the first option.

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -26,6 +26,10 @@ import {
 	mapMappedSuggesterValue,
 	resolveDropdownInitialValue,
 } from "./suggesterValueMapping";
+import {
+	normalizeNumericValue,
+	normalizeSliderValue,
+} from "src/utils/valueSyntax";
 
 type PreviewComputer = (
 	values: Record<string, string>,
@@ -155,11 +159,71 @@ export class OnePageInputModal extends Modal {
 				const input = new TextComponent(setting.controlEl);
 				input.inputEl.type = "number";
 				input.inputEl.inputMode = "decimal";
-				input.inputEl.setAttr("step", "any");
+				if (req.numericConfig?.min !== undefined) {
+					input.inputEl.min = String(req.numericConfig.min);
+				}
+				if (req.numericConfig?.max !== undefined) {
+					input.inputEl.max = String(req.numericConfig.max);
+				}
+				input.inputEl.step =
+					req.numericConfig?.step !== undefined
+						? String(req.numericConfig.step)
+						: "any";
+				const normalizedStarting = req.numericConfig
+					? normalizeNumericValue(starting, req.numericConfig)
+					: starting;
 				input
 					.setPlaceholder(req.placeholder ?? "")
-					.setValue(starting)
-					.onChange((v) => setValue(req.id, v));
+					.setValue(normalizedStarting)
+					.onChange((v) =>
+						setValue(
+							req.id,
+							req.numericConfig ? normalizeNumericValue(v, req.numericConfig) : v,
+						),
+					);
+				setValue(req.id, normalizedStarting);
+				break;
+			}
+			case "slider": {
+				const setting = new Setting(this.contentEl).setName(
+					this.decorateLabel(req),
+				);
+				if (req.description) setting.setDesc(req.description);
+				const sliderConfig = req.sliderConfig ?? { min: 0, max: 100, step: 1 };
+				const isOptionalBlank = req.optional && starting === "";
+				const initial = normalizeSliderValue(starting, sliderConfig);
+				const container = setting.controlEl.createDiv({
+					cls: "qa-onepage-slider",
+				});
+				const range = container.createEl("input");
+				range.type = "range";
+				range.min = String(sliderConfig.min);
+				range.max = String(sliderConfig.max);
+				range.step = String(sliderConfig.step);
+				range.value = initial;
+				const input = new TextComponent(container);
+				input.inputEl.type = "number";
+				input.inputEl.inputMode = "decimal";
+				input.inputEl.min = String(sliderConfig.min);
+				input.inputEl.max = String(sliderConfig.max);
+				input.inputEl.step = String(sliderConfig.step);
+				input.setValue(isOptionalBlank ? "" : initial);
+				setValue(req.id, isOptionalBlank ? "" : initial);
+
+				range.addEventListener("input", () => {
+					input.inputEl.value = range.value;
+					setValue(req.id, range.value);
+				});
+				input.onChange((value) => {
+					if (value === "" && req.optional) {
+						setValue(req.id, "");
+						return;
+					}
+					const normalized = normalizeSliderValue(value, sliderConfig);
+					range.value = normalized;
+					input.inputEl.value = normalized;
+					setValue(req.id, normalized);
+				});
 				break;
 			}
 			case "dropdown": {

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -219,7 +219,8 @@ export class OnePageInputModal extends Modal {
 						setValue(req.id, "");
 						return;
 					}
-					const normalized = normalizeSliderValue(value, sliderConfig);
+					const normalized = normalizeNumericValue(value, sliderConfig);
+					if (normalized === "") return;
 					range.value = normalized;
 					input.inputEl.value = normalized;
 					setValue(req.id, normalized);

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -188,6 +188,9 @@ export class OnePageInputModal extends Modal {
 				const setting = new Setting(this.contentEl).setName(
 					this.decorateLabel(req),
 				);
+				setting.controlEl.parentElement?.addClass(
+					"qa-onepage-slider-setting",
+				);
 				if (req.description) setting.setDesc(req.description);
 				const sliderConfig = req.sliderConfig ?? { min: 0, max: 100, step: 1 };
 				const isOptionalBlank = req.optional && starting === "";

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -417,8 +417,36 @@ describe("RequirementCollector property types (#757)", () => {
   };
 
   it("maps |type:number to a number field", async () => {
-    const byId = await run("{{VALUE:rating|type:number}}");
+    const byId = await run("{{VALUE:rating|type:number|min:1|max:10|step:1}}");
     expect(byId["rating"].type).toBe("number");
+    expect(byId["rating"].numericConfig).toEqual({ min: 1, max: 10, step: 1 });
+  });
+
+  it("maps |type:slider to a slider field with config", async () => {
+    const byId = await run("{{VALUE:rating|type:slider|min:1|max:10|step:1}}");
+    expect(byId["rating"]).toMatchObject({
+      type: "slider",
+      numericConfig: { min: 1, max: 10, step: 1 },
+      sliderConfig: { min: 1, max: 10, step: 1 },
+    });
+  });
+
+  it("falls back to a number field for invalid slider config", async () => {
+    const byId = await run("{{VALUE:rating|type:slider|max:10}}");
+    expect(byId["rating"]).toMatchObject({
+      type: "number",
+      numericConfig: { max: 10 },
+    });
+    expect(byId["rating"].sliderConfig).toBeUndefined();
+  });
+
+  it("maps unnamed VALUE type:slider to a slider field", async () => {
+    const byId = await run("{{VALUE|type:slider|min:1|max:10|default:5}}");
+    expect(byId["value"]).toMatchObject({
+      type: "slider",
+      defaultValue: "5",
+      sliderConfig: { min: 1, max: 10, step: 1 },
+    });
   });
 
   it("maps |type:checkbox to a true/false dropdown", async () => {

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -14,6 +14,8 @@ import { NLDParser } from "src/parsers/NLDParser";
 import {
 	parseValueToken,
 	splitQuotedCommaList,
+	type NumericInputConfig,
+	type SliderConfig,
 	unwrapQuotedValue,
 } from "src/utils/valueSyntax";
 import { parseVDateOptions } from "src/utils/vdateSyntax";
@@ -30,6 +32,7 @@ export type FieldType =
 	| "number"
 	| "textarea"
 	| "dropdown"
+	| "slider"
 	| "date"
 	| "field-suggest"
 	| "file-picker"
@@ -42,6 +45,8 @@ export interface FieldRequirement {
 	description?: string;
 	placeholder?: string;
 	defaultValue?: string;
+	numericConfig?: NumericInputConfig;
+	sliderConfig?: SliderConfig;
 	options?: string[]; // for dropdowns and suggesters
 	displayOptions?: string[]; // visible labels for mapped VALUE lists
 	// Additional metadata
@@ -190,6 +195,8 @@ export class RequirementCollector extends Formatter {
 					!hasOptions && parsed.inputTypeOverride === "checkbox";
 				const isNumber =
 					!hasOptions && parsed.inputTypeOverride === "number";
+				const isSlider =
+					!hasOptions && parsed.inputTypeOverride === "slider";
 				const baseInputType: FieldType =
 					parsed.inputTypeOverride === "multiline" ||
 					this.plugin.settings.inputPrompt === "multi-line"
@@ -204,12 +211,19 @@ export class RequirementCollector extends Formatter {
 							? "dropdown"
 							: isNumber
 								? "number"
-								: baseInputType,
+								: isSlider
+									? "slider"
+									: baseInputType,
 					description,
 					optional: parsed.optional,
 				};
 				if (hasOptions) this.applyOptionFields(req, parsed);
 				else if (isCheckbox) req.options = ["true", "false"];
+				else if (isNumber) req.numericConfig = parsed.numericConfig;
+				else if (isSlider) {
+					req.numericConfig = parsed.numericConfig;
+					req.sliderConfig = parsed.sliderConfig;
+				}
 				if (defaultValue) req.defaultValue = defaultValue;
 				this.requirements.set(requirementId, req);
 			} else {
@@ -349,16 +363,31 @@ export class RequirementCollector extends Formatter {
 	protected async promptForValue(header?: string): Promise<string> {
 		const key = "value";
 		if (!this.requirements.has(key)) {
+			const isCheckbox =
+				this.valuePromptContext?.inputTypeOverride === "checkbox";
+			const isNumber =
+				this.valuePromptContext?.inputTypeOverride === "number";
+			const isSlider =
+				this.valuePromptContext?.inputTypeOverride === "slider";
 			this.requirements.set(key, {
 				id: key,
 				label: header || "Enter value",
 				type:
-					this.valuePromptContext?.inputTypeOverride === "multiline" ||
-					this.plugin.settings.inputPrompt === "multi-line"
+					isCheckbox
+						? "dropdown"
+						: isNumber
+							? "number"
+							: isSlider
+								? "slider"
+								: this.valuePromptContext?.inputTypeOverride === "multiline" ||
+									  this.plugin.settings.inputPrompt === "multi-line"
 						? "textarea"
 						: "text",
 				description: this.valuePromptContext?.description,
 				defaultValue: this.valuePromptContext?.defaultValue,
+				numericConfig: this.valuePromptContext?.numericConfig,
+				sliderConfig: this.valuePromptContext?.sliderConfig,
+				options: isCheckbox ? ["true", "false"] : undefined,
 				source: "collected",
 				optional: this.valuePromptContext?.optional,
 			});
@@ -391,6 +420,10 @@ export class RequirementCollector extends Formatter {
 				.map((s) => s.trim())
 				.filter(Boolean);
 			const hasOptions = optionValues.length > 1;
+			const isNumber = !hasOptions && context?.inputTypeOverride === "number";
+			const isSlider = !hasOptions && context?.inputTypeOverride === "slider";
+			const isCheckbox =
+				!hasOptions && context?.inputTypeOverride === "checkbox";
 			const baseInputType =
 				context?.inputTypeOverride === "multiline" ||
 				this.plugin.settings.inputPrompt === "multi-line"
@@ -399,12 +432,24 @@ export class RequirementCollector extends Formatter {
 			const req: FieldRequirement = {
 				id: key,
 				label: variableName,
-				type: hasOptions ? "dropdown" : baseInputType,
+				type: hasOptions
+					? "dropdown"
+					: isCheckbox
+						? "dropdown"
+						: isNumber
+							? "number"
+							: isSlider
+								? "slider"
+								: baseInputType,
 				description: context?.description,
+				numericConfig: context?.numericConfig,
+				sliderConfig: context?.sliderConfig,
 				source: "collected",
 			};
 			if (hasOptions) {
 				req.options = optionValues;
+			} else if (isCheckbox) {
+				req.options = ["true", "false"];
 			}
 			if (context?.defaultValue) req.defaultValue = context.defaultValue;
 			this.requirements.set(key, req);

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -180,6 +180,85 @@ describe("collectChoiceRequirements - macro script metadata", () => {
 		);
 	});
 
+	it("preserves script-declared number and slider inputs", async () => {
+		getUserScriptMock.mockResolvedValue({
+			quickadd: {
+				inputs: [
+					{
+						id: "rating",
+						type: "number",
+						label: "Rating",
+						numericConfig: { min: 1, max: 10, step: 1 },
+					},
+					{
+						id: "confidence",
+						type: "slider",
+						label: "Confidence",
+						defaultValue: "5",
+						sliderConfig: { min: 0, max: 100, step: 5 },
+					},
+				],
+			},
+		});
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createMacroChoice(scriptCommand),
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "rating",
+					type: "number",
+					numericConfig: { min: 1, max: 10, step: 1 },
+					source: "script",
+				}),
+				expect.objectContaining({
+					id: "confidence",
+					type: "slider",
+					defaultValue: "5",
+					numericConfig: { min: 0, max: 100, step: 5 },
+					sliderConfig: { min: 0, max: 100, step: 5 },
+					source: "script",
+				}),
+			]),
+		);
+	});
+
+	it("downgrades script-declared sliders with invalid config to number", async () => {
+		getUserScriptMock.mockResolvedValue({
+			quickadd: {
+				inputs: [
+					{
+						id: "confidence",
+						type: "slider",
+						label: "Confidence",
+						sliderConfig: { max: 100 },
+					},
+				],
+			},
+		});
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createMacroChoice(scriptCommand),
+		);
+
+		expect(requirements).toEqual([
+			expect.objectContaining({
+				id: "confidence",
+				type: "number",
+				sliderConfig: undefined,
+				source: "script",
+			}),
+		]);
+	});
+
 	it("ignores malformed input entries", async () => {
 		const exported = (() => {}) as ((...args: unknown[]) => unknown) & {
 			quickadd?: unknown;

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -29,6 +29,7 @@ import {
 	type FieldRequirement,
 	type FieldType,
 } from "./RequirementCollector";
+import type { NumericInputConfig, SliderConfig } from "src/utils/valueSyntax";
 
 interface CollectChoiceRequirementsOptions {
 	seedCaptureSelectionAsValue?: boolean;
@@ -36,8 +37,10 @@ interface CollectChoiceRequirementsOptions {
 
 const VALID_FIELD_TYPES: FieldType[] = [
 	"text",
+	"number",
 	"textarea",
 	"dropdown",
+	"slider",
 	"date",
 	"field-suggest",
 	"file-picker",
@@ -58,15 +61,20 @@ function toFieldRequirement(input: unknown): FieldRequirement | null {
 	const id = value.id;
 	const type = value.type;
 	if (typeof id !== "string" || !isFieldType(type)) return null;
+	const numericConfig = parseNumericConfig(value.numericConfig);
+	const sliderConfig = parseSliderConfig(value.sliderConfig);
+	const fieldType = type === "slider" && !sliderConfig ? "number" : type;
 
 	return {
 		id,
 		label: typeof value.label === "string" ? value.label : id,
-		type,
+		type: fieldType,
 		placeholder:
 			typeof value.placeholder === "string" ? value.placeholder : undefined,
 		defaultValue:
 			typeof value.defaultValue === "string" ? value.defaultValue : undefined,
+		numericConfig: sliderConfig ?? numericConfig,
+		sliderConfig,
 		options: Array.isArray(value.options)
 			? value.options.filter((entry): entry is string => typeof entry === "string")
 			: undefined,
@@ -77,6 +85,53 @@ function toFieldRequirement(input: unknown): FieldRequirement | null {
 		optional: typeof value.optional === "boolean" ? value.optional : undefined,
 		source: "script",
 	};
+}
+
+function parseNumericConfig(value: unknown): NumericInputConfig | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const raw = value as Record<string, unknown>;
+	const min = typeof raw.min === "number" && Number.isFinite(raw.min)
+		? raw.min
+		: undefined;
+	const max = typeof raw.max === "number" && Number.isFinite(raw.max)
+		? raw.max
+		: undefined;
+	const step = typeof raw.step === "number" && Number.isFinite(raw.step) && raw.step > 0
+		? raw.step
+		: undefined;
+	if (min !== undefined && max !== undefined && max < min) {
+		return step === undefined ? undefined : { step };
+	}
+	const config: NumericInputConfig = {};
+	if (min !== undefined) config.min = min;
+	if (max !== undefined) config.max = max;
+	if (step !== undefined) config.step = step;
+	return Object.keys(config).length > 0 ? config : undefined;
+}
+
+function parseSliderConfig(value: unknown): SliderConfig | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const raw = value as Record<string, unknown>;
+	const min = typeof raw.min === "number" ? raw.min : undefined;
+	const max = typeof raw.max === "number" ? raw.max : undefined;
+	const step = raw.step === undefined
+		? 1
+		: typeof raw.step === "number"
+			? raw.step
+			: undefined;
+	if (
+		min === undefined ||
+		max === undefined ||
+		step === undefined ||
+		!Number.isFinite(min) ||
+		!Number.isFinite(max) ||
+		!Number.isFinite(step) ||
+		max <= min ||
+		step <= 0
+	) {
+		return undefined;
+	}
+	return { min, max, step };
 }
 
 function getQuickAddScriptInputs(userScript: unknown): unknown[] {

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -1017,6 +1017,68 @@ describe("requestInputs", () => {
 		expect(missing[0].label).toBe("city");
 	});
 
+	it("forwards number and slider input metadata to the one-page modal", async () => {
+		mocks.onePageModalWaitForClose.mockResolvedValue({
+			rating: "5",
+			confidence: "80",
+		});
+		const { api } = getApi();
+
+		await api.requestInputs([
+			{
+				id: "rating",
+				type: "number",
+				numericConfig: { min: 1, max: 10, step: 1 },
+			},
+			{
+				id: "confidence",
+				type: "slider",
+				sliderConfig: { min: 0, max: 100, step: 5 },
+			},
+		]);
+
+		const missing = onePageModalCalls[0].missing as Array<{
+			id: string;
+			type: string;
+			numericConfig?: unknown;
+			sliderConfig?: unknown;
+		}>;
+		expect(missing).toEqual([
+			expect.objectContaining({
+				id: "rating",
+				type: "number",
+				numericConfig: { min: 1, max: 10, step: 1 },
+			}),
+			expect.objectContaining({
+				id: "confidence",
+				type: "slider",
+				numericConfig: { min: 0, max: 100, step: 5 },
+				sliderConfig: { min: 0, max: 100, step: 5 },
+			}),
+		]);
+	});
+
+	it("downgrades requestInputs sliders without valid config to number", async () => {
+		mocks.onePageModalWaitForClose.mockResolvedValue({ confidence: "80" });
+		const { api } = getApi();
+
+		await api.requestInputs([
+			{ id: "confidence", type: "slider" } as {
+				id: string;
+				type: "slider";
+			},
+		]);
+
+		const missing = onePageModalCalls[0].missing as Array<{
+			type: string;
+			sliderConfig?: unknown;
+		}>;
+		expect(missing[0]).toMatchObject({
+			type: "number",
+			sliderConfig: undefined,
+		});
+	});
+
 	it("formats a date field that returns an @date: value using dateFormat", async () => {
 		mocks.onePageModalWaitForClose.mockResolvedValue({
 			due: "@date:2025-06-21T00:00:00.000Z",

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -115,8 +115,14 @@ function sanitizeNumericConfig(
 	return Object.keys(config).length > 0 ? config : undefined;
 }
 
+type RequestSliderConfig = {
+	min: number;
+	max: number;
+	step?: number;
+};
+
 function sanitizeSliderConfig(
-	value: SliderConfig | undefined,
+	value: RequestSliderConfig | undefined,
 ): SliderConfig | undefined {
 	if (!value || typeof value !== "object") return undefined;
 	const { min, max } = value;
@@ -167,7 +173,7 @@ export class QuickAddApi {
 					placeholder?: string;
 					defaultValue?: string;
 					numericConfig?: NumericInputConfig;
-					sliderConfig?: SliderConfig;
+					sliderConfig?: RequestSliderConfig;
 					options?: string[];
 					dateFormat?: string;
 					description?: string;

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -55,6 +55,7 @@ import { MacroAbortError } from "./errors/MacroAbortError";
 import { UserCancelError } from "./errors/UserCancelError";
 import { formatISODate } from "./utils/dateParser";
 import type { InputPromptOptions } from "./types/inputPrompt";
+import type { NumericInputConfig, SliderConfig } from "./utils/valueSyntax";
 import {
 	applyTemplateToNote,
 	isMarkdownTemplatePath,
@@ -85,6 +86,56 @@ function restoreVariables(
 	}
 }
 
+function sanitizeNumericConfig(
+	value: NumericInputConfig | undefined,
+): NumericInputConfig | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const config: NumericInputConfig = {};
+	if (typeof value.min === "number" && Number.isFinite(value.min)) {
+		config.min = value.min;
+	}
+	if (typeof value.max === "number" && Number.isFinite(value.max)) {
+		config.max = value.max;
+	}
+	if (
+		config.min !== undefined &&
+		config.max !== undefined &&
+		config.max < config.min
+	) {
+		delete config.min;
+		delete config.max;
+	}
+	if (
+		typeof value.step === "number" &&
+		Number.isFinite(value.step) &&
+		value.step > 0
+	) {
+		config.step = value.step;
+	}
+	return Object.keys(config).length > 0 ? config : undefined;
+}
+
+function sanitizeSliderConfig(
+	value: SliderConfig | undefined,
+): SliderConfig | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const { min, max } = value;
+	const step = value.step ?? 1;
+	if (
+		typeof min !== "number" ||
+		typeof max !== "number" ||
+		typeof step !== "number" ||
+		!Number.isFinite(min) ||
+		!Number.isFinite(max) ||
+		!Number.isFinite(step) ||
+		max <= min ||
+		step <= 0
+	) {
+		return undefined;
+	}
+	return { min, max, step };
+}
+
 export class QuickAddApi {
 	public static GetApi(
 		app: App,
@@ -104,9 +155,19 @@ export class QuickAddApi {
 				inputs: Array<{
 					id: string;
 					label?: string;
-					type: "text" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester";
+					type:
+						| "text"
+						| "number"
+						| "textarea"
+						| "dropdown"
+						| "date"
+						| "field-suggest"
+						| "suggester"
+						| "slider";
 					placeholder?: string;
 					defaultValue?: string;
+					numericConfig?: NumericInputConfig;
+					sliderConfig?: SliderConfig;
 					options?: string[];
 					dateFormat?: string;
 					description?: string;
@@ -130,13 +191,20 @@ export class QuickAddApi {
 						existing[spec.id] = String(val);
 						continue;
 					}
+					const sliderConfig = sanitizeSliderConfig(spec.sliderConfig);
+					const numericConfig =
+						sliderConfig ?? sanitizeNumericConfig(spec.numericConfig);
+					const type =
+						spec.type === "slider" && !sliderConfig ? "number" : spec.type;
 
 					missing.push({
 						id: spec.id,
 						label: spec.label ?? spec.id,
-						type: spec.type,
+						type,
 						placeholder: spec.placeholder,
 						defaultValue: spec.defaultValue,
+						numericConfig,
+						sliderConfig,
 						options: spec.options,
 						dateFormat: spec.dateFormat,
 						description: spec.description,

--- a/src/styles.css
+++ b/src/styles.css
@@ -156,6 +156,24 @@
 	width: 5.5rem;
 }
 
+@media screen and (max-width: 540px) {
+	.quickAddModal .qa-onepage-slider-setting {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.5rem;
+	}
+
+	.quickAddModal .qa-onepage-slider-setting .setting-item-info,
+	.quickAddModal .qa-onepage-slider-setting .setting-item-control {
+		width: 100%;
+		margin-inline-end: 0;
+	}
+
+	.quickAddModal .qa-onepage-slider {
+		grid-template-columns: minmax(0, 1fr) 5.5rem;
+	}
+}
+
 .quickAddModal .qa-onepage-optional-badge {
 	color: var(--text-muted);
 	font-size: var(--font-ui-smaller);

--- a/src/styles.css
+++ b/src/styles.css
@@ -140,6 +140,22 @@
 	color: var(--text-muted);
 }
 
+.quickAddModal .qa-onepage-slider {
+	display: grid;
+	grid-template-columns: minmax(10rem, 1fr) 5.5rem;
+	align-items: center;
+	gap: 0.5rem;
+	width: 100%;
+}
+
+.quickAddModal .qa-onepage-slider input[type="range"] {
+	width: 100%;
+}
+
+.quickAddModal .qa-onepage-slider input[type="number"] {
+	width: 5.5rem;
+}
+
 .quickAddModal .qa-onepage-optional-badge {
 	color: var(--text-muted);
 	font-size: var(--font-ui-smaller);

--- a/src/types/inputPrompt.ts
+++ b/src/types/inputPrompt.ts
@@ -2,4 +2,14 @@ export interface InputPromptOptions {
 	cursorAtEnd?: boolean;
 	/** Token carries |optional: show a Skip button and accept empty submissions as the answer. */
 	optional?: boolean;
+	numeric?: {
+		min?: number;
+		max?: number;
+		step?: number;
+	};
+	slider?: {
+		min: number;
+		max: number;
+		step: number;
+	};
 }

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -7,6 +7,7 @@ import {
 	parseValueToken,
 	resolveExistingVariableKey,
 } from "./valueSyntax";
+import { log } from "../logger/logManager";
 
 describe("parseValueToken", () => {
 	afterEach(() => {
@@ -102,21 +103,21 @@ describe("parseValueToken", () => {
 	});
 
 	it("warns and ignores unknown type values", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("Body|type:wide");
 		expect(parsed?.inputTypeOverride).toBeUndefined();
 		expect(warnSpy).toHaveBeenCalled();
 	});
 
 	it("warns and ignores type for option lists", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("Red,Green|type:multiline");
 		expect(parsed?.inputTypeOverride).toBeUndefined();
 		expect(warnSpy).toHaveBeenCalled();
 	});
 
 	it("parses type:number / checkbox / text without warning", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		expect(parseValueToken("Rating|type:number")?.inputTypeOverride).toBe(
 			"number",
 		);
@@ -143,7 +144,7 @@ describe("parseValueToken", () => {
 	});
 
 	it("parses slider type only with an explicit valid range", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("Rating|type:slider|min:1|max:10|step:0.5");
 		expect(parsed?.inputTypeOverride).toBe("slider");
 		expect(parsed?.numericConfig).toEqual({ min: 1, max: 10, step: 0.5 });
@@ -152,7 +153,7 @@ describe("parseValueToken", () => {
 	});
 
 	it("falls back to number for slider tokens without finite min and max", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("Rating|type:slider|max:10");
 		expect(parsed?.inputTypeOverride).toBe("number");
 		expect(parsed?.numericConfig).toEqual({ max: 10 });
@@ -163,7 +164,7 @@ describe("parseValueToken", () => {
 	});
 
 	it("falls back to number for invalid slider ranges and steps", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const invalidRange = parseValueToken("Rating|type:slider|min:10|max:1");
 		const invalidStep = parseValueToken(
 			"Rating|type:slider|min:1|max:10|step:0",
@@ -207,7 +208,7 @@ describe("parseValueToken", () => {
 	});
 
 	it("still rejects an unknown type and names the new supported set", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		expect(parseValueToken("Body|type:wide")?.inputTypeOverride).toBeUndefined();
 		expect(warnSpy).toHaveBeenCalledWith(
 			expect.stringContaining("multiline, number, slider, checkbox, text"),
@@ -215,7 +216,7 @@ describe("parseValueToken", () => {
 	});
 
 	it("ignores a scalar type on an option-list token", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		expect(
 			parseValueToken("Red,Green|type:number")?.inputTypeOverride,
 		).toBeUndefined();
@@ -235,7 +236,7 @@ describe("parseValueToken", () => {
 	});
 
 	it("warns and ignores |multi without an option list", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		expect(parseValueToken("Only|multi")?.multiSelect).toBe(false);
 		expect(parseValueToken("Only|multi:linklist")?.multiSelect).toBe(false);
 		expect(warnSpy).toHaveBeenCalled();
@@ -251,7 +252,7 @@ describe("parseValueToken", () => {
 	});
 
 	it("drops |case when combined with |multi (a list is not case-transformed)", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("a,b,c|multi|case:upper");
 		expect(parsed?.multiSelect).toBe(true);
 		expect(parsed?.caseStyle).toBeUndefined();
@@ -298,7 +299,7 @@ describe("parseAnonymousValueOptions", () => {
 	});
 
 	it("warns and ignores unknown type for unnamed VALUE tokens", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseAnonymousValueOptions("|type:wide");
 		expect(parsed.inputTypeOverride).toBeUndefined();
 		expect(warnSpy).toHaveBeenCalled();
@@ -348,7 +349,7 @@ describe("named variables (|name:, issue #148)", () => {
 	});
 
 	it("warns and ignores reserved names", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("a,b|name:title");
 		expect(parsed?.aliasName).toBeUndefined();
 		// Falls back to the option-list key (no alias).
@@ -357,7 +358,7 @@ describe("named variables (|name:, issue #148)", () => {
 	});
 
 	it("warns and ignores a name containing the reserved key delimiter", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("a,b|name:foo\u001Fbar")
 		expect(parsed?.aliasName).toBeUndefined();
 		expect(parsed?.variableKey).toBe("a,b");
@@ -365,7 +366,7 @@ describe("named variables (|name:, issue #148)", () => {
 	});
 
 	it("stays silent when parsed in quiet mode", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		// Reserved name would normally warn; quiet mode (the pre-pass) suppresses it.
 		const parsed = parseValueToken("a,b|name:title", { quiet: true });
 		expect(parsed?.aliasName).toBeUndefined();
@@ -373,7 +374,7 @@ describe("named variables (|name:, issue #148)", () => {
 	});
 
 	it("warns and ignores an empty name", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("a,b|name:");
 		expect(parsed?.aliasName).toBeUndefined();
 		expect(parsed?.variableKey).toBe("a,b");
@@ -381,7 +382,7 @@ describe("named variables (|name:, issue #148)", () => {
 	});
 
 	it("honors but warns about name on a single value", () => {
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		const parsed = parseValueToken("Some prompt|name:bar");
 		expect(parsed?.hasOptions).toBe(false);
 		expect(parsed?.aliasName).toBe("bar");

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import {
 	buildValueVariableKey,
+	normalizeNumericValue,
+	normalizeSliderValue,
 	parseAnonymousValueOptions,
 	parseValueToken,
 	resolveExistingVariableKey,
@@ -127,6 +129,77 @@ describe("parseValueToken", () => {
 		expect(warnSpy).not.toHaveBeenCalled();
 	});
 
+	it("parses numeric constraints for number inputs", () => {
+		const parsed = parseValueToken("Rating|type:number|min:1|max:10|step:0.5");
+		expect(parsed?.inputTypeOverride).toBe("number");
+		expect(parsed?.numericConfig).toEqual({ min: 1, max: 10, step: 0.5 });
+	});
+
+	it("keeps min/max/step as shorthand defaults unless a numeric type is present", () => {
+		expect(parseValueToken("x|min:5")?.defaultValue).toBe("min:5");
+		expect(parseValueToken("x|min:5|max:10")?.defaultValue).toBe(
+			"min:5|max:10",
+		);
+	});
+
+	it("parses slider type only with an explicit valid range", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("Rating|type:slider|min:1|max:10|step:0.5");
+		expect(parsed?.inputTypeOverride).toBe("slider");
+		expect(parsed?.numericConfig).toEqual({ min: 1, max: 10, step: 0.5 });
+		expect(parsed?.sliderConfig).toEqual({ min: 1, max: 10, step: 0.5 });
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("falls back to number for slider tokens without finite min and max", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const parsed = parseValueToken("Rating|type:slider|max:10");
+		expect(parsed?.inputTypeOverride).toBe("number");
+		expect(parsed?.numericConfig).toEqual({ max: 10 });
+		expect(parsed?.sliderConfig).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("falling back to type:number"),
+		);
+	});
+
+	it("falls back to number for invalid slider ranges and steps", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const invalidRange = parseValueToken("Rating|type:slider|min:10|max:1");
+		const invalidStep = parseValueToken(
+			"Rating|type:slider|min:1|max:10|step:0",
+		);
+		expect(invalidRange?.inputTypeOverride).toBe("number");
+		expect(invalidRange?.numericConfig).toBeUndefined();
+		expect(invalidStep?.inputTypeOverride).toBe("number");
+		expect(invalidStep?.numericConfig).toEqual({ min: 1, max: 10 });
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("defaults slider step to one when omitted", () => {
+		const parsed = parseValueToken("Rating|type:slider|min:-5|max:5");
+		expect(parsed?.sliderConfig).toEqual({ min: -5, max: 5, step: 1 });
+	});
+
+	it("normalizes numeric values to bounds and step", () => {
+		expect(normalizeNumericValue("999", { min: 1, max: 10 })).toBe("10");
+		expect(normalizeNumericValue("-5", { min: 1, max: 10 })).toBe("1");
+		expect(normalizeNumericValue("4", { min: 1, max: 10, step: 2 })).toBe(
+			"5",
+		);
+		expect(normalizeNumericValue("0.26", { min: 0, max: 1, step: 0.25 })).toBe(
+			"0.25",
+		);
+		expect(normalizeNumericValue("garbage", { min: 1, max: 10 })).toBe("");
+	});
+
+	it("normalizes slider values to a concrete bounded value", () => {
+		const config = { min: 1, max: 10, step: 2 };
+		expect(normalizeSliderValue("999", config)).toBe("10");
+		expect(normalizeSliderValue("-5", config)).toBe("1");
+		expect(normalizeSliderValue("4", config)).toBe("5");
+		expect(normalizeSliderValue("garbage", config)).toBe("1");
+	});
+
 	it("treats type:boolean as an alias for checkbox", () => {
 		expect(parseValueToken("Done|type:boolean")?.inputTypeOverride).toBe(
 			"checkbox",
@@ -137,7 +210,7 @@ describe("parseValueToken", () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		expect(parseValueToken("Body|type:wide")?.inputTypeOverride).toBeUndefined();
 		expect(warnSpy).toHaveBeenCalledWith(
-			expect.stringContaining("multiline, number, checkbox, text"),
+			expect.stringContaining("multiline, number, slider, checkbox, text"),
 		);
 	});
 
@@ -203,6 +276,16 @@ describe("parseAnonymousValueOptions", () => {
 		expect(parsed.inputTypeOverride).toBe("multiline");
 		expect(parsed.label).toBe("Notes");
 		expect(parsed.defaultValue).toBe("Hello");
+	});
+
+	it("parses slider type and numeric config for unnamed VALUE tokens", () => {
+		const parsed = parseAnonymousValueOptions(
+			"|type:slider|min:1|max:10|step:1|default:5",
+		);
+		expect(parsed.inputTypeOverride).toBe("slider");
+		expect(parsed.numericConfig).toEqual({ min: 1, max: 10, step: 1 });
+		expect(parsed.sliderConfig).toEqual({ min: 1, max: 10, step: 1 });
+		expect(parsed.defaultValue).toBe("5");
 	});
 
 	it("parses case style for unnamed VALUE tokens", () => {

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -488,7 +488,11 @@ function resolveNumericInput(
 		return { inputTypeOverride: "number", numericConfig };
 	}
 
-	const sliderConfig = { min, max, step };
+	const sliderConfig: SliderConfig = {
+		min: min as number,
+		max: max as number,
+		step: step as number,
+	};
 	return {
 		inputTypeOverride,
 		numericConfig: sliderConfig,

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -9,16 +9,36 @@ import {
 // Internal-only delimiter for scoping labeled VALUE lists. Unlikely to appear in user input.
 export const VALUE_LABEL_KEY_DELIMITER = "\u001F";
 
-export type ValueInputType = "multiline" | "number" | "checkbox" | "text";
+export type ValueInputType =
+	| "multiline"
+	| "number"
+	| "slider"
+	| "checkbox"
+	| "text";
+
+export type NumericInputConfig = {
+	min?: number;
+	max?: number;
+	step?: number;
+};
+
+export type SliderConfig = {
+	min: number;
+	max: number;
+	step: number;
+};
 
 // Types that render a different input widget but are meaningless alongside a
 // comma option-list or |custom (those already pick from a fixed/free set).
 const OPTION_INCOMPATIBLE_TYPES = new Set<ValueInputType>([
 	"multiline",
 	"number",
+	"slider",
 	"checkbox",
 	"text",
 ]);
+
+const NUMERIC_RANGE_OPTION_KEYS = new Set(["min", "max", "step"]);
 
 const VALUE_OPTION_KEYS = new Set([
 	"label",
@@ -55,6 +75,8 @@ export type ParsedValueToken = {
 	displayValues?: string[];
 	hasOptions: boolean;
 	inputTypeOverride?: ValueInputType;
+	numericConfig?: NumericInputConfig;
+	sliderConfig?: SliderConfig;
 	optional: boolean;
 	/** |multi: pick several options into a YAML list (option-list tokens only). */
 	multiSelect: boolean;
@@ -124,6 +146,9 @@ type ParsedOptions = {
 	allowCustomInput: boolean;
 	usesOptions: boolean;
 	inputTypeOverride?: string;
+	minRaw?: string;
+	maxRaw?: string;
+	stepRaw?: string;
 	displayValuesRaw?: string;
 	optionalExplicit?: boolean;
 	name?: string;
@@ -154,6 +179,16 @@ function hasRecognizedOption(part: string, allowName: boolean): boolean {
 	return keys.has(parsed.key);
 }
 
+function hasNumericType(optionParts: string[], allowName: boolean): boolean {
+	const optionKeys = allowName ? NAMED_VALUE_OPTION_KEYS : VALUE_OPTION_KEYS;
+	return optionParts.some((part) => {
+		const parsed = parsePipeKeyValue(part.trim());
+		if (!parsed || parsed.key !== "type" || !optionKeys.has("type")) return false;
+		const value = parsed.value.trim().toLowerCase();
+		return value === "number" || value === "slider";
+	});
+}
+
 function parseOptions(
 	optionParts: string[],
 	hasOptions: boolean,
@@ -169,8 +204,13 @@ function parseOptions(
 	}
 
 	const optionKeys = allowName ? NAMED_VALUE_OPTION_KEYS : VALUE_OPTION_KEYS;
+	const allowNumericOptions = hasNumericType(optionParts, allowName);
 	const hasExplicitOption = optionParts.some((part) =>
-		hasRecognizedOption(part, allowName),
+		hasRecognizedOption(part, allowName) ||
+		(allowNumericOptions &&
+			NUMERIC_RANGE_OPTION_KEYS.has(
+				parsePipeKeyValue(part.trim())?.key ?? "",
+			)),
 	);
 	const hasCustomFlag =
 		hasOptions &&
@@ -195,6 +235,9 @@ function parseOptions(
 	let defaultValue = "";
 	let allowCustomInput = false;
 	let inputTypeOverride: string | undefined;
+	let minRaw: string | undefined;
+	let maxRaw: string | undefined;
+	let stepRaw: string | undefined;
 	let displayValuesRaw: string | undefined;
 	let optionalExplicit: boolean | undefined;
 	let name: string | undefined;
@@ -218,7 +261,11 @@ function parseOptions(
 		const parsed = parsePipeKeyValue(trimmed);
 		if (!parsed) continue;
 		const { key, value } = parsed;
-		if (!optionKeys.has(key)) continue;
+		if (
+			!optionKeys.has(key) &&
+			!(allowNumericOptions && NUMERIC_RANGE_OPTION_KEYS.has(key))
+		)
+			continue;
 
 		switch (key) {
 			case "label":
@@ -235,6 +282,15 @@ function parseOptions(
 				break;
 			case "type":
 				if (value) inputTypeOverride = value;
+				break;
+			case "min":
+				minRaw = value;
+				break;
+			case "max":
+				maxRaw = value;
+				break;
+			case "step":
+				stepRaw = value;
 				break;
 			case "text":
 				displayValuesRaw = value;
@@ -269,6 +325,9 @@ function parseOptions(
 		name,
 		usesOptions: true,
 		inputTypeOverride,
+		minRaw,
+		maxRaw,
+		stepRaw,
 		displayValuesRaw,
 		optionalExplicit,
 		multiSelect,
@@ -292,7 +351,7 @@ function resolveInputType(
 	if (!OPTION_INCOMPATIBLE_TYPES.has(normalized)) {
 		if (!quiet)
 			console.warn(
-				`QuickAdd: Unsupported VALUE type "${rawType}" in token "${tokenDisplay}". Supported types: multiline, number, checkbox, text.`,
+				`QuickAdd: Unsupported VALUE type "${rawType}" in token "${tokenDisplay}". Supported types: multiline, number, slider, checkbox, text.`,
 			);
 		return undefined;
 	}
@@ -304,6 +363,189 @@ function resolveInputType(
 		return undefined;
 	}
 	return normalized;
+}
+
+function parseFiniteNumber(value: string | undefined): number | undefined {
+	if (value === undefined) return undefined;
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	const parsed = Number(trimmed);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function hasNumericConfig(options: ParsedOptions): boolean {
+	return (
+		options.minRaw !== undefined ||
+		options.maxRaw !== undefined ||
+		options.stepRaw !== undefined
+	);
+}
+
+function buildNumericConfig(
+	options: ParsedOptions,
+	tokenDisplay: string,
+	quiet: boolean,
+): NumericInputConfig | undefined {
+	const min = parseFiniteNumber(options.minRaw);
+	const max = parseFiniteNumber(options.maxRaw);
+	const step = parseFiniteNumber(options.stepRaw);
+	const config: NumericInputConfig = {};
+
+	if (options.minRaw !== undefined) {
+		if (min === undefined) {
+			if (!quiet)
+				console.warn(
+					`QuickAdd: Ignoring invalid min in VALUE token "${tokenDisplay}".`,
+				);
+		} else {
+			config.min = min;
+		}
+	}
+
+	if (options.maxRaw !== undefined) {
+		if (max === undefined) {
+			if (!quiet)
+				console.warn(
+					`QuickAdd: Ignoring invalid max in VALUE token "${tokenDisplay}".`,
+				);
+		} else {
+			config.max = max;
+		}
+	}
+
+	if (
+		config.min !== undefined &&
+		config.max !== undefined &&
+		config.max < config.min
+	) {
+		if (!quiet)
+			console.warn(
+				`QuickAdd: Ignoring invalid numeric range in VALUE token "${tokenDisplay}"; max must be greater than or equal to min.`,
+			);
+		delete config.min;
+		delete config.max;
+	}
+
+	if (options.stepRaw !== undefined) {
+		if (step === undefined || step <= 0) {
+			if (!quiet)
+				console.warn(
+					`QuickAdd: Ignoring invalid step in VALUE token "${tokenDisplay}"; step must be greater than 0.`,
+				);
+		} else {
+			config.step = step;
+		}
+	}
+
+	return Object.keys(config).length > 0 ? config : undefined;
+}
+
+function resolveNumericInput(
+	options: ParsedOptions,
+	tokenDisplay: string,
+	inputTypeOverride: ValueInputType | undefined,
+	quiet: boolean,
+): {
+	inputTypeOverride?: ValueInputType;
+	numericConfig?: NumericInputConfig;
+	sliderConfig?: SliderConfig;
+} {
+	if (inputTypeOverride !== "number" && inputTypeOverride !== "slider") {
+		if (hasNumericConfig(options) && !quiet) {
+			console.warn(
+				`QuickAdd: Ignoring numeric range options in "${tokenDisplay}" because type is not number or slider.`,
+			);
+		}
+		return { inputTypeOverride };
+	}
+
+	if (inputTypeOverride !== "slider") {
+		const numericConfig = buildNumericConfig(options, tokenDisplay, quiet);
+		return { inputTypeOverride, numericConfig };
+	}
+
+	const min = parseFiniteNumber(options.minRaw);
+	const max = parseFiniteNumber(options.maxRaw);
+	const step = options.stepRaw === undefined
+		? 1
+		: parseFiniteNumber(options.stepRaw);
+	const invalidReason =
+		min === undefined || max === undefined
+			? "slider requires finite min and max values"
+			: max <= min
+				? "max must be greater than min"
+				: step === undefined || step <= 0
+					? "step must be greater than 0"
+					: undefined;
+
+	if (invalidReason) {
+		if (!quiet) {
+			console.warn(
+				`QuickAdd: Invalid slider configuration in "${tokenDisplay}" (${invalidReason}); falling back to type:number.`,
+			);
+		}
+		const numericConfig = buildNumericConfig(options, tokenDisplay, true);
+		return { inputTypeOverride: "number", numericConfig };
+	}
+
+	const sliderConfig = { min, max, step };
+	return {
+		inputTypeOverride,
+		numericConfig: sliderConfig,
+		sliderConfig,
+	};
+}
+
+function decimalPlaces(value: number): number {
+	const asString = String(value);
+	const exponentMatch = /e-(\d+)$/i.exec(asString);
+	if (exponentMatch) return Number(exponentMatch[1]);
+	const decimalIndex = asString.indexOf(".");
+	return decimalIndex === -1 ? 0 : asString.length - decimalIndex - 1;
+}
+
+function formatRoundedNumber(value: number, precision: number): string {
+	return String(Number(value.toFixed(precision)));
+}
+
+export function normalizeNumericValue(
+	value: string | undefined,
+	config?: NumericInputConfig,
+): string {
+	const trimmed = value?.trim() ?? "";
+	if (!trimmed) return "";
+
+	const parsed = Number(trimmed);
+	if (!Number.isFinite(parsed)) return "";
+
+	const min = config?.min;
+	const max = config?.max;
+	let normalized = parsed;
+	if (min !== undefined) normalized = Math.max(min, normalized);
+	if (max !== undefined) normalized = Math.min(max, normalized);
+
+	if (config?.step !== undefined && config.step > 0) {
+		const base = min ?? 0;
+		const stepsFromBase = Math.round((normalized - base) / config.step);
+		normalized = base + stepsFromBase * config.step;
+		if (min !== undefined) normalized = Math.max(min, normalized);
+		if (max !== undefined) normalized = Math.min(max, normalized);
+		const precision = Math.max(
+			decimalPlaces(base),
+			decimalPlaces(config.step),
+		);
+		return formatRoundedNumber(normalized, precision);
+	}
+
+	return String(normalized);
+}
+
+export function normalizeSliderValue(
+	value: string | undefined,
+	config: SliderConfig,
+): string {
+	const normalized = normalizeNumericValue(value, config);
+	return normalized || String(config.min);
 }
 
 // The "double-quote class" that opens/closes a quoted option: the straight
@@ -455,6 +697,12 @@ export function parseValueToken(
 		},
 		quiet,
 	);
+	const numericInput = resolveNumericInput(
+		options,
+		tokenDisplay,
+		inputTypeOverride,
+		quiet,
+	);
 	let displayValues: string[] | undefined;
 
 	if (options.displayValuesRaw !== undefined) {
@@ -539,7 +787,9 @@ export function parseValueToken(
 		suggestedValues,
 		displayValues,
 		hasOptions,
-		inputTypeOverride,
+		inputTypeOverride: numericInput.inputTypeOverride,
+		numericConfig: numericInput.numericConfig,
+		sliderConfig: numericInput.sliderConfig,
 		optional,
 		multiSelect,
 		multiEmit,
@@ -553,6 +803,8 @@ export function parseAnonymousValueOptions(
 	caseStyle?: string;
 	defaultValue: string;
 	inputTypeOverride?: ValueInputType;
+	numericConfig?: NumericInputConfig;
+	sliderConfig?: SliderConfig;
 	optional: boolean;
 } {
 	const normalized = stripLeadingPipe(rawOptions);
@@ -584,12 +836,20 @@ export function parseAnonymousValueOptions(
 		hasOptions: false,
 		allowCustomInput: options.allowCustomInput,
 	});
+	const numericInput = resolveNumericInput(
+		options,
+		tokenDisplay,
+		inputTypeOverride,
+		false,
+	);
 
 	return {
 		label,
 		caseStyle,
 		defaultValue,
-		inputTypeOverride,
+		inputTypeOverride: numericInput.inputTypeOverride,
+		numericConfig: numericInput.numericConfig,
+		sliderConfig: numericInput.sliderConfig,
 		optional: options.optionalExplicit ?? bareOptional,
 	};
 }

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -5,6 +5,7 @@ import {
 	splitPipeParts,
 	stripLeadingPipe,
 } from "./pipeSyntax";
+import { log } from "../logger/logManager";
 
 // Internal-only delimiter for scoping labeled VALUE lists. Unlikely to appear in user input.
 export const VALUE_LABEL_KEY_DELIMITER = "\u001F";
@@ -308,7 +309,7 @@ function parseOptions(
 				// no-op alias and warns so the author notices the typo.
 				if (value) name = value;
 				else if (!quiet)
-					console.warn(
+					log.logWarning(
 						`QuickAdd: empty |name: ignored; provide a variable name, e.g. {{VALUE:a,b|name:category}}.`,
 					);
 				break;
@@ -350,14 +351,14 @@ function resolveInputType(
 	const normalized = (raw === "boolean" ? "checkbox" : raw) as ValueInputType;
 	if (!OPTION_INCOMPATIBLE_TYPES.has(normalized)) {
 		if (!quiet)
-			console.warn(
+			log.logWarning(
 				`QuickAdd: Unsupported VALUE type "${rawType}" in token "${tokenDisplay}". Supported types: multiline, number, slider, checkbox, text.`,
 			);
 		return undefined;
 	}
 	if (hasOptions || allowCustomInput) {
 		if (!quiet)
-			console.warn(
+			log.logWarning(
 				`QuickAdd: Ignoring type:${normalized} for option-list VALUE token "${tokenDisplay}".`,
 			);
 		return undefined;
@@ -394,7 +395,7 @@ function buildNumericConfig(
 	if (options.minRaw !== undefined) {
 		if (min === undefined) {
 			if (!quiet)
-				console.warn(
+				log.logWarning(
 					`QuickAdd: Ignoring invalid min in VALUE token "${tokenDisplay}".`,
 				);
 		} else {
@@ -405,7 +406,7 @@ function buildNumericConfig(
 	if (options.maxRaw !== undefined) {
 		if (max === undefined) {
 			if (!quiet)
-				console.warn(
+				log.logWarning(
 					`QuickAdd: Ignoring invalid max in VALUE token "${tokenDisplay}".`,
 				);
 		} else {
@@ -419,7 +420,7 @@ function buildNumericConfig(
 		config.max < config.min
 	) {
 		if (!quiet)
-			console.warn(
+			log.logWarning(
 				`QuickAdd: Ignoring invalid numeric range in VALUE token "${tokenDisplay}"; max must be greater than or equal to min.`,
 			);
 		delete config.min;
@@ -429,7 +430,7 @@ function buildNumericConfig(
 	if (options.stepRaw !== undefined) {
 		if (step === undefined || step <= 0) {
 			if (!quiet)
-				console.warn(
+				log.logWarning(
 					`QuickAdd: Ignoring invalid step in VALUE token "${tokenDisplay}"; step must be greater than 0.`,
 				);
 		} else {
@@ -452,7 +453,7 @@ function resolveNumericInput(
 } {
 	if (inputTypeOverride !== "number" && inputTypeOverride !== "slider") {
 		if (hasNumericConfig(options) && !quiet) {
-			console.warn(
+			log.logWarning(
 				`QuickAdd: Ignoring numeric range options in "${tokenDisplay}" because type is not number or slider.`,
 			);
 		}
@@ -480,7 +481,7 @@ function resolveNumericInput(
 
 	if (invalidReason) {
 		if (!quiet) {
-			console.warn(
+			log.logWarning(
 				`QuickAdd: Invalid slider configuration in "${tokenDisplay}" (${invalidReason}); falling back to type:number.`,
 			);
 		}
@@ -738,14 +739,14 @@ export function parseValueToken(
 		// The delimiter is reserved for label-scoped keys; an alias containing it
 		// would corrupt resolveExistingVariableKey's base-name stripping.
 		if (!quiet)
-			console.warn(
+			log.logWarning(
 				`QuickAdd: |name in "${tokenDisplay}" contains a reserved control character and was ignored.`,
 			);
 		aliasName = undefined;
 	}
 	if (aliasName && RESERVED_VALUE_NAMES.has(aliasName.toLowerCase())) {
 		if (!quiet)
-			console.warn(
+			log.logWarning(
 				`QuickAdd: |name:${aliasName} is reserved and was ignored in "${tokenDisplay}". Choose a different name.`,
 			);
 		aliasName = undefined;
@@ -753,7 +754,7 @@ export function parseValueToken(
 	if (aliasName && !hasOptions && !quiet) {
 		// A named single value is just a renamed prompt; the option list is what
 		// makes |name useful. Honor it but steer authors to the simpler form.
-		console.warn(
+		log.logWarning(
 			`QuickAdd: |name on a single value in "${tokenDisplay}" is redundant — use {{VALUE:${aliasName}}} directly.`,
 		);
 	}
@@ -762,14 +763,14 @@ export function parseValueToken(
 	// case-transformed, and routing an array through transformCase would throw).
 	if (multiSelect && !hasOptions) {
 		if (!quiet)
-			console.warn(
+			log.logWarning(
 				`QuickAdd: |multi needs an option list (2+ comma-separated values) in "${tokenDisplay}"; ignoring.`,
 			);
 		multiSelect = false;
 	}
 	if (multiSelect && caseStyle) {
 		if (!quiet)
-			console.warn(
+			log.logWarning(
 				`QuickAdd: |case is ignored with |multi in "${tokenDisplay}" — a list is not case-transformed.`,
 			);
 		caseStyle = undefined;


### PR DESCRIPTION
## Summary

Adds slider-style VALUE inputs for bounded numeric properties so users can pick numbers in a range without typing every value manually. The underlying problem is numeric entry ergonomics, so this keeps the feature in QuickAdd's existing format-syntax and one-page input systems instead of adding a one-off setting.

The chosen syntax is `{{VALUE:rating|type:slider|min:1|max:10|step:1|default:5}}`. Sliders require explicit finite `min` and `max`; `step` defaults to `1`. Invalid slider configs fall back to the numeric input with a warning rather than guessing a range. I considered a default `0..100` slider, but rejected it because it would silently encode the wrong scale for many user properties.

## Changes

- Adds `|type:slider` plus shared numeric `|min:`, `|max:`, and `|step:` parsing for single-value VALUE tokens.
- Adds a sequential slider prompt with a range control and editable number field, plus bounded number prompt normalization.
- Extends one-page input collection/rendering and script/API declared inputs to support `number` and `slider` metadata consistently.
- Preserves compatibility: numeric range options are only parsed when `type:number` or `type:slider` is present, option-list VALUE tokens still ignore scalar input types, and malformed sliders downgrade to `number`.
- Addresses review feedback: negative one-page slider typing no longer clamps partial `-`, public `requestInputs.sliderConfig.step` is optional like runtime behavior, `optional?: boolean` is documented, and VALUE parser warnings route through `log.logWarning`.
- Documents the format syntax, one-page inputs, QuickAdd API, and property-type guide.

## Testing / validation

- Reproduced the original problem on current `master` before implementation in the isolated worktree vault: `{{VALUE:rating|type:slider|min:1|max:10|step:1|default:5}}` opened a plain text input (`range: 0`, `number: 0`, `text: 1`) instead of a slider.
- Live Obsidian validation via `pnpm run obsidian:e2e -- ...` in the worktree-local vault, Obsidian `1.12.7`:
  - Sequential slider rendered one range + one number input (`min=1`, `max=10`, `step=1`, `value=5`) and wrote `rating: 7` after changing the range.
  - One-page slider rendered the same paired controls and wrote `confidence: 85` after editing the number field.
  - Optional untouched slider preserved an empty value instead of coercing to the minimum.
  - Invalid slider config (`type:slider|max:10`) rendered as a bounded number input, warned, and clamped `99` to `10`.
  - Negative one-page slider (`min=-5`, `max=5`) kept the range at `0` while the numeric field held a partial `-`, then accepted `-4` and wrote `score: -4`.
  - `pnpm run obsidian:e2e -- dev:errors` reported no captured runtime errors.
- Final branch gates after late `git fetch` + `git rebase origin/master` no-op and after review-fix commits:
  - `pnpm run check` passed (`0 errors`, existing `4 warnings`).
  - `pnpm run lint` passed.
  - `pnpm run test` passed (`225` files, `2665` tests; repo skipped tests unchanged).
  - `pnpm run build-with-lint` passed (`tsc --noEmit`, ESLint, production bundle).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
      — it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s).
- [x] Noted release/migration impact, if any.

Release/migration impact: user-facing format syntax extension only; no persisted settings migration. The production build regenerated local ignored `main.js` / root `styles.css` artifacts in this worktree, while the tracked source changes remain committed.

Fixes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `number` and `slider` input types, including configurable bounds (`min`/`max`) and `step`, with slider + number fields synced for input.
  * Extended the one-page input UI and prompt behavior to render and submit normalized values based on the provided constraints.

* **Bug Fixes**
  * Improved handling of selected/anonymous values for numeric and slider prompts, including clamping/rounding and avoiding incorrect prompt results when normalization fails.

* **Documentation**
  * Updated one-page inputs, format syntax, QuickAdd API, and template property type docs with new examples and configuration rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->