### PR TITLE
feat(format): support FIELD multi-select

### DIFF
--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -35,6 +35,7 @@ Each choice builder has a **One-page input override** dropdown that lets you ove
 
 ## FIELD UX
 - FIELD inputs get inline suggestions from your vault (Dataview if available, with a manual fallback).
+- `{{FIELD:...|multi}}` is collected by the runtime multi-select after the one-page modal. It is not rendered inline in the one-page form because vault field values can contain commas.
 
 ## Optional fields
 - Fields whose tokens carry the `|optional` flag (see [Optional fields](../FormatSyntax.md#optional-fields)) show an "(optional)" badge and may be left empty. An empty optional field stores an intentional empty value — the sequential prompt will not re-ask for it.

--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -35,7 +35,7 @@ Each choice builder has a **One-page input override** dropdown that lets you ove
 
 ## FIELD UX
 - FIELD inputs get inline suggestions from your vault (Dataview if available, with a manual fallback).
-- `{{FIELD:...|multi}}` is collected by the runtime multi-select after the one-page modal. It is not rendered inline in the one-page form because vault field values can contain commas.
+- `{{FIELD:...|multi}}` is collected by the runtime multi-select after the one-page modal, when one is shown. It is not rendered inline in the one-page form because vault field values can contain commas.
 
 ## Optional fields
 - Fields whose tokens carry the `|optional` flag (see [Optional fields](../FormatSyntax.md#optional-fields)) show an "(optional)" badge and may be left empty. An empty optional field stores an intentional empty value — the sequential prompt will not re-ask for it.

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -354,6 +354,37 @@ Suggest the values of `FIELDNAME` anywhere `{{FIELD:FIELDNAME}}` is used. Fields
 
 Example: `project: {{FIELD:project}}`.
 
+### `{{FIELD:<FIELDNAME>|multi}}` {#field-multi}
+
+Turns FIELD suggestions into a multi-select. Pick several existing field values,
+or add custom values in the picker.
+
+```markdown
+---
+topics: {{FIELD:topic|multi}}
+---
+```
+
+picks `Alpha` and `Beta` →
+
+```yaml
+topics:
+  - Alpha
+  - Beta
+```
+
+Inside front matter, `|multi` writes a real YAML **List** when the token is the
+complete property value. In note bodies, file names, and other text positions it
+renders the selected values as comma-separated text. `|multi` combines with the
+same FIELD filters and defaults as single-value FIELD prompts, for example
+`{{FIELD:topic|multi|folder:Projects|tag:active|default:Inbox}}`.
+
+The one-page input form intentionally does not inline FIELD multi-selects yet:
+vault field values can contain commas, and the current one-page multi input uses
+commas as separators. When a format contains `{{FIELD:...|multi}}`, QuickAdd
+collects other one-page inputs first, then opens the runtime multi-select for
+the FIELD value.
+
 **Enhanced Filtering Options:**
 
 - `{{FIELD:fieldname|folder:path/to/folder}}` - Only suggest values from files in specific folder

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const VDATE_OPTIONAL_SYNTAX =
 export const VALUE_CASE_SYNTAX = "{{value|case:kebab}}";
 export const VARIABLE_CASE_SYNTAX = "{{value:<variable name>|case:kebab}}";
 export const FIELD_VAR_SYNTAX = "{{field:<field name>}}";
+export const FIELD_VAR_MULTI_SYNTAX = "{{field:<field name>|multi}}";
 export const FILE_SYNTAX = "{{file:<folder>}}";
 export const FILE_LINK_SYNTAX = "{{file:<folder>|link}}";
 export const FILE_PATH_SYNTAX = "{{file:<folder>|path}}";
@@ -55,6 +56,7 @@ export const FORMAT_SYNTAX: string[] = [
 	VARIABLE_NAME_SYNTAX,
 	VARIABLE_OPTIONAL_SYNTAX,
 	FIELD_VAR_SYNTAX,
+	FIELD_VAR_MULTI_SYNTAX,
 	"{{field:<fieldname>|folder:<path>}}",
 	"{{field:<fieldname>|tag:<tagname>}}",
 	"{{field:<fieldname>|inline:true}}",

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -55,6 +55,7 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 		templatePath: string;
 		inclusion?: TemplateInclusionState;
 		targetFolderPath: string | null = null;
+		templatePropertyVars: Map<string, unknown> = new Map();
 
 		constructor(
 			_app: unknown,
@@ -73,6 +74,12 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 
 		run() {
 			return mocks.templateRun.call(this);
+		}
+
+		getAndClearTemplatePropertyVars() {
+			const vars = new Map(this.templatePropertyVars);
+			this.templatePropertyVars.clear();
+			return vars;
 		}
 	},
 }));
@@ -214,6 +221,7 @@ function mockTemplateVault(templates: Record<string, string>) {
 		templatePath: string;
 		inclusion?: TemplateInclusionState;
 		targetFolderPath?: string | null;
+		templatePropertyVars?: Map<string, unknown>;
 	}) {
 		const child = defaultFormatter();
 		if (this.inclusion) {
@@ -223,7 +231,11 @@ function mockTemplateVault(templates: Record<string, string>) {
 		// propagated from the including formatter (so {{FOLDER}} resolves).
 		child.setTargetFolderPath(this.targetFolderPath ?? null);
 
-		return await child.formatFileContent(templates[this.templatePath] ?? "");
+		const content = await child.withTemplatePropertyCollection(() =>
+			child.formatFileContent(templates[this.templatePath] ?? ""),
+		);
+		this.templatePropertyVars = child.getAndClearTemplatePropertyVars();
+		return content;
 	});
 }
 
@@ -359,6 +371,31 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 		const result = await f.formatFileContent("{{TEMPLATE:Partials/Filing.md}}");
 
 		expect(result).toBe("folder=Projects/Acme name=Acme");
+	});
+
+	it("propagates structured frontmatter values collected by included templates", async () => {
+		mockTemplateVault({
+			"Partials/Topics.md": "---\ntopics: {{FIELD:topic|multi}}\n---\n",
+		});
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "topic",
+			filters: {},
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Alpha", "Beta"],
+			hasDefaultValue: false,
+		});
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Alpha", "Beta"]);
+		const f = defaultFormatter();
+
+		const result = await f.withTemplatePropertyCollection(() =>
+			f.formatFileContent("{{TEMPLATE:Partials/Topics.md}}"),
+		);
+		const vars = f.getAndClearTemplatePropertyVars();
+
+		expect(result).toBe("---\ntopics: []\n---\n");
+		expect(vars.get("topics")).toEqual(["Alpha", "Beta"]);
 	});
 
 	it("terminates self-including templates with a visible placeholder", async () => {

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -748,6 +748,59 @@ describe("CompleteFormatter - field suggestion (suggestForField)", () => {
 		expect(mocks.inputSuggesterSuggest).toHaveBeenCalled();
 	});
 
+	it("uses the multi-suggester for FIELD multi-select values", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "topic",
+			filters: {},
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Alpha", "Beta"],
+			hasDefaultValue: false,
+		});
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Alpha", "Beta"]);
+
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{FIELD:topic|multi}}")).resolves.toBe(
+			"Alpha,Beta",
+		);
+		expect(mocks.multiSuggesterSuggest).toHaveBeenCalledWith(
+			expect.anything(),
+			["Alpha", "Beta"],
+			["Alpha", "Beta"],
+			expect.objectContaining({
+				placeholder: "Select values for topic",
+				allowCustomValue: true,
+			}),
+		);
+		expect(mocks.inputSuggesterSuggest).not.toHaveBeenCalled();
+	});
+
+	it("keeps FIELD multi-select usable when no existing values are found", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "topic",
+			filters: {},
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: [],
+			hasDefaultValue: false,
+		});
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Manual"]);
+
+		const f = defaultFormatter();
+		await expect(f.formatFolderPath("{{FIELD:topic|multi}}")).resolves.toBe(
+			"Manual",
+		);
+		expect(mocks.multiSuggesterSuggest).toHaveBeenCalledWith(
+			expect.anything(),
+			[],
+			[],
+			expect.objectContaining({ allowCustomValue: true }),
+		);
+		expect(mocks.genericInputPromptWithContext).not.toHaveBeenCalled();
+	});
+
 	it("falls back to a free-form prompt when no values are found", async () => {
 		mocks.fieldParse.mockReturnValue({
 			fieldName: "status",

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -541,14 +541,32 @@ export class CompleteFormatter extends Formatter {
 		}
 	}
 
-	protected async suggestForField(fieldInput: string) {
+	protected async suggestForField(fieldInput: string): Promise<string | string[]> {
 		try {
 			// Parse the field input to extract field name and filters
-			const { fieldName, filters } = FieldSuggestionParser.parse(fieldInput);
+			const { fieldName, filters, multiSelect } =
+				FieldSuggestionParser.parse(fieldInput);
 
 			// Collect and process via shared collector
 			const { values, hasDefaultValue } =
 				await collectFieldValuesProcessedDetailed(this.app, fieldName, filters);
+
+			// Enhance placeholder with context
+			let placeholder = multiSelect
+				? `Select values for ${fieldName}`
+				: `Enter value for ${fieldName}`;
+			if (hasDefaultValue) {
+				placeholder = multiSelect
+					? `Select values for ${fieldName} (default: ${filters.defaultValue})`
+					: `Enter value for ${fieldName} (default: ${filters.defaultValue})`;
+			}
+
+			if (multiSelect) {
+				return await MultiSuggester.Suggest(this.app, values, values, {
+					placeholder,
+					allowCustomValue: true,
+				});
+			}
 
 			if (values.length === 0) {
 				// No values found even after processing defaults
@@ -566,18 +584,12 @@ export class CompleteFormatter extends Formatter {
 				}
 
 				return await GenericInputPrompt.PromptWithContext(
-				this.app,
-				`Enter value for ${fieldName}`,
-				fallbackPrompt,
-				undefined,
-				this.getLinkSourcePath() ?? undefined
+					this.app,
+					`Enter value for ${fieldName}`,
+					fallbackPrompt,
+					undefined,
+					this.getLinkSourcePath() ?? undefined,
 				);
-			}
-
-			// Enhance placeholder with context
-			let placeholder = `Enter value for ${fieldName}`;
-			if (hasDefaultValue) {
-				placeholder = `Enter value for ${fieldName} (default: ${filters.defaultValue})`;
 			}
 
 			return await InputSuggester.Suggest(this.app, values, values, {

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -725,7 +725,11 @@ export class CompleteFormatter extends Formatter {
 		// templates ({{TEMPLATE:...}}), which render via this child engine's own
 		// formatter.
 		childEngine.setTargetFolderPath(this.targetFolderPath);
-		return await childEngine.run();
+		const content = await childEngine.run();
+		this.mergeTemplatePropertyVars(
+			childEngine.getAndClearTemplatePropertyVars(),
+		);
+		return content;
 	}
 
 	protected async getSelectedText(): Promise<string> {

--- a/src/formatters/formatter-field-title-regression.test.ts
+++ b/src/formatters/formatter-field-title-regression.test.ts
@@ -3,13 +3,13 @@ import { Formatter } from "./formatter";
 
 class FieldTitleFormatter extends Formatter {
 	public fieldCalls: string[] = [];
-	private fieldResponses: Map<string, string> = new Map();
+	private fieldResponses: Map<string, string | string[]> = new Map();
 
 	constructor() {
 		super();
 	}
 
-	public setMockFieldResponse(specifier: string, value: string): void {
+	public setMockFieldResponse(specifier: string, value: string | string[]): void {
 		this.fieldResponses.set(specifier, value);
 	}
 
@@ -28,11 +28,15 @@ class FieldTitleFormatter extends Formatter {
 		return await this.format(input);
 	}
 
+	public async runFormatWithPropertyCollection(input: string): Promise<string> {
+		return await this.withTemplatePropertyCollection(() => this.format(input));
+	}
+
 	protected suggestForFile(): string {
 		return "";
 	}
 
-	protected async suggestForField(specifier: string): Promise<string> {
+	protected async suggestForField(specifier: string): Promise<string | string[]> {
 		this.fieldCalls.push(specifier);
 		const value = this.fieldResponses.get(specifier);
 
@@ -169,5 +173,40 @@ describe("Formatter FIELD and TITLE namespace handling", () => {
 
 		expect(result).toBe("{{FIELD:type}}");
 		expect(formatter.fieldCalls).toEqual(["type"]);
+	});
+
+	it("collects FIELD multi arrays as YAML list properties", async () => {
+		formatter.setMockFieldResponse("topic|multi", ["Alpha", "Beta"]);
+
+		const output = await formatter.runFormatWithPropertyCollection(
+			"---\ntopics: {{FIELD:topic|multi}}\n---\n",
+		);
+		const vars = formatter.getAndClearTemplatePropertyVars();
+
+		expect(output).toBe("---\ntopics: []\n---\n");
+		expect(vars.get("topics")).toEqual(["Alpha", "Beta"]);
+	});
+
+	it("joins FIELD multi arrays outside frontmatter property positions", async () => {
+		formatter.setMockFieldResponse("topic|multi", ["Alpha", "Beta"]);
+
+		await expect(
+			formatter.runFormatWithPropertyCollection(
+				"Body topics: {{FIELD:topic|multi}}",
+			),
+		).resolves.toBe("Body topics: Alpha,Beta");
+		expect(formatter.getAndClearTemplatePropertyVars().size).toBe(0);
+	});
+
+	it("collects FIELD multi arrays from YAML list item token positions", async () => {
+		formatter.setMockFieldResponse("topic|multi", ["Alpha", "Beta"]);
+
+		const output = await formatter.runFormatWithPropertyCollection(
+			"---\ntopics:\n  - \"{{FIELD:topic|multi}}\"\n---\n",
+		);
+		const vars = formatter.getAndClearTemplatePropertyVars();
+
+		expect(output).toBe("---\ntopics:\n  - \"[]\"\n---\n");
+		expect(vars.get("topics")).toEqual(["Alpha", "Beta"]);
 	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -39,6 +39,7 @@ import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
 import { quoteYamlDouble, shouldQuoteTextScalar } from "../utils/yamlScalarQuoting";
 import { toWikiLink } from "../utils/linkWrap";
+import { FieldSuggestionParser } from "../utils/FieldSuggestionParser";
 import {
 	type ParsedValueToken,
 	parseAnonymousValueOptions,
@@ -880,6 +881,7 @@ export abstract class Formatter {
 
 			if (fullMatch) {
 				const fieldVariableKey = this.getFieldVariableKey(fullMatch);
+				const parsed = FieldSuggestionParser.parse(fullMatch);
 
 				if (!this.hasConcreteVariable(fieldVariableKey)) {
 					this.variables.set(
@@ -888,9 +890,26 @@ export abstract class Formatter {
 					);
 				}
 
-				const replacement = this.hasConcreteVariable(fieldVariableKey)
-					? String(this.variables.get(fieldVariableKey))
+				const rawValue = this.hasConcreteVariable(fieldVariableKey)
+					? this.variables.get(fieldVariableKey)
 					: this.getVariableValue(fullMatch);
+				let replacement: string;
+
+				if (Array.isArray(rawValue)) {
+					const structuredYamlValue = this.propertyCollector.maybeCollect({
+						input,
+						matchStart: match.index,
+						matchEnd: match.index + match[0].length,
+						rawValue,
+						fallbackKey: parsed.fieldName,
+						collectionActive: this.templatePropertyCollectionDepth > 0,
+						heuristicEnabled: false,
+					});
+					replacement =
+						getYamlPlaceholder(structuredYamlValue) ?? rawValue.join(",");
+				} else {
+					replacement = String(rawValue ?? "");
+				}
 
 				output += replacement;
 			} else {
@@ -1101,7 +1120,9 @@ export abstract class Formatter {
 		return [];
 	}
 
-	protected abstract suggestForField(variableName: string): Promise<string>;
+	protected abstract suggestForField(
+		variableName: string,
+	): Promise<string | string[]>;
 
 	protected async replaceDateVariableInString(input: string) {
 		let output: string = input;

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -558,6 +558,10 @@ export abstract class Formatter {
 		return this.propertyCollector.drain();
 	}
 
+	public mergeTemplatePropertyVars(vars: Map<string, unknown>): void {
+		this.propertyCollector.merge(vars);
+	}
+
 	/**
 	 * Runs a formatting operation in a scope where structured YAML values should
 	 * be collected and replaced with temporary placeholders for later

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -249,6 +249,20 @@ Body`);
         type: "field-suggest",
       });
     });
+
+    it("marks FIELD multi-select requirements as runtime-only", async () => {
+      const app = makeApp();
+      const plugin = makePlugin();
+      const rc = new RequirementCollector(app, plugin);
+      await rc.scanString("{{FIELD:People|multi|folder:Contacts}}");
+
+      expect(rc.requirements.get("FIELD:People|multi|folder:Contacts")).toMatchObject({
+        id: "FIELD:People|multi|folder:Contacts",
+        label: "People",
+        type: "field-suggest",
+        runtimeOnly: true,
+      });
+    });
   });
 });
 

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -18,6 +18,7 @@ import {
 } from "src/utils/valueSyntax";
 import { parseVDateOptions } from "src/utils/vdateSyntax";
 import { EnhancedFieldSuggestionFileFilter } from "src/utils/EnhancedFieldSuggestionFileFilter";
+import { FieldSuggestionParser } from "src/utils/FieldSuggestionParser";
 import {
 	buildFileDisplayLabels,
 	FILE_PICK_PREFIX,
@@ -50,6 +51,8 @@ export interface FieldRequirement {
 	multiEmit?: "text" | "linklist"; // |multi:linklist wraps picks as [[name]]
 	filters?: string; // serialized filters for FIELD variables
 	source?: "collected" | "script"; // provenance for UX badges
+	/** Prompt at runtime instead of the one-page form when the form has no safe widget. */
+	runtimeOnly?: boolean;
 	/** True only when EVERY scanned occurrence of the variable is |optional. */
 	optional?: boolean;
 	suggesterConfig?: {
@@ -430,13 +433,15 @@ export class RequirementCollector extends Formatter {
 		// Key the requirement with the runtime "FIELD:" prefix so values entered
 		// in the one-page form land where replaceFieldVarInString looks them up
 		// (issue #1184). Actual suggestions are provided by the UI.
+		const parsed = FieldSuggestionParser.parse(variableName);
 		const key = `${FIELD_VARIABLE_PREFIX}${variableName}`;
 		if (!this.requirements.has(key)) {
 			this.requirements.set(key, {
 				id: key,
-				label: variableName,
+				label: parsed.fieldName || variableName,
 				type: "field-suggest",
 				source: "collected",
+				runtimeOnly: parsed.multiSelect,
 			});
 		}
 		return "";

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -243,4 +243,45 @@ describe("runOnePagePreflight template extension handling", () => {
 			"Templates/Kanban.base.md",
 		);
 	});
+
+	it("leaves FIELD multi-select prompts for runtime instead of the one-page modal", async () => {
+		const templateFile = new TFile();
+		templateFile.path = "Templates/FieldMulti.md";
+		templateFile.name = "FieldMulti.md";
+		templateFile.basename = "FieldMulti";
+		templateFile.extension = "md";
+
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn().mockReturnValue(null),
+			},
+			vault: {
+				getAbstractFileByPath: vi.fn((path: string) =>
+					path === "Templates/FieldMulti.md" ? templateFile : null,
+				),
+				cachedRead: vi.fn(async () => "topics: {{FIELD:topic|multi}}"),
+			},
+		} as unknown as App;
+
+		const plugin = {
+			settings: {
+				inputPrompt: "single-line",
+				globalVariables: {},
+				useSelectionAsCaptureValue: true,
+			},
+		} as any;
+
+		const executor = createExecutor();
+
+		const result = await runOnePagePreflight(
+			app,
+			plugin,
+			executor,
+			createTemplateChoice("Templates/FieldMulti.md"),
+		);
+
+		expect(result).toBe(false);
+		expect(modalOpenMock).not.toHaveBeenCalled();
+		expect(executor.variables.has("FIELD:topic|multi")).toBe(false);
+	});
 });

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -39,6 +39,11 @@ export async function runOnePagePreflight(
 
 		if (unresolved.length === 0) return false; // Everything prefilled, skip modal
 
+		const modalRequirements = unresolved.filter(
+			(requirement) => !requirement.runtimeOnly,
+		);
+		if (modalRequirements.length === 0) return false;
+
 		// Show modal
 		// Optional live preview of a couple of key outputs (best-effort)
 		const computePreview = async (values: Record<string, string>) => {
@@ -64,7 +69,7 @@ export async function runOnePagePreflight(
 
 		const modal = new OnePageInputModal(
 			app,
-			unresolved,
+			modalRequirements,
 			choiceExecutor.variables,
 			computePreview,
 		);
@@ -88,7 +93,7 @@ export async function runOnePagePreflight(
 				displayToValue: Map<string, string>;
 			}
 		>();
-		for (const req of unresolved) {
+		for (const req of modalRequirements) {
 			if (req.id.startsWith(FILE_VARIABLE_PREFIX)) {
 				fileOptionsByKey.set(req.id, req.options ?? []);
 			}

--- a/src/utils/FieldSuggestionParser.test.ts
+++ b/src/utils/FieldSuggestionParser.test.ts
@@ -76,6 +76,28 @@ describe("FieldSuggestionParser", () => {
 			});
 		});
 
+		it("should parse multi-select as FIELD behavior, not a filter", () => {
+			const result = FieldSuggestionParser.parse(
+				"fieldname|multi|folder:daily|tag:work",
+			);
+			expect(result).toEqual({
+				fieldName: "fieldname",
+				filters: {
+					folder: "daily",
+					tags: ["work"],
+				},
+				multiSelect: true,
+			});
+		});
+
+		it("should allow multi-select to be explicitly disabled", () => {
+			const result = FieldSuggestionParser.parse("fieldname|multi:false");
+			expect(result).toEqual({
+				fieldName: "fieldname",
+				filters: {},
+			});
+		});
+
 		it("should handle tags with # prefix", () => {
 			const result = FieldSuggestionParser.parse("fieldname|tag:#work");
 			expect(result).toEqual({

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -1,4 +1,8 @@
-import { parsePipeKeyValue, splitPipeParts } from "./pipeSyntax";
+import {
+	parseBooleanFlag,
+	parsePipeKeyValue,
+	splitPipeParts,
+} from "./pipeSyntax";
 
 export interface FieldFilter {
 	folder?: string;
@@ -25,13 +29,20 @@ export class FieldSuggestionParser {
 	static parse(input: string): {
 		fieldName: string;
 		filters: FieldFilter;
+		multiSelect?: boolean;
 	} {
 		const parts = splitPipeParts(input).map((p) => p.trim());
 		const fieldName = parts[0];
 		const filters: FieldFilter = {};
+		let multiSelect = false;
 
 		for (let i = 1; i < parts.length; i++) {
 			const filterPart = parts[i];
+			if (filterPart.toLowerCase() === "multi") {
+				multiSelect = true;
+				continue;
+			}
+
 			const parsed = parsePipeKeyValue(filterPart);
 			if (!parsed) continue; // Skip invalid filter format
 
@@ -39,6 +50,9 @@ export class FieldSuggestionParser {
 			const filterValue = parsed.value;
 
 			switch (filterType) {
+				case "multi":
+					multiSelect = parseBooleanFlag(filterValue);
+					break;
 				case "folder":
 					filters.folder = filterValue;
 					break;
@@ -105,6 +119,8 @@ export class FieldSuggestionParser {
 			}
 		}
 
-		return { fieldName, filters };
+		return multiSelect
+			? { fieldName, filters, multiSelect }
+			: { fieldName, filters };
 	}
 }

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -53,7 +53,7 @@ export class TemplatePropertyCollector {
     const propertyKeyMatch = lineContent.match(/^\s*([^:]+):/);
     const fallbackPathKey = propertyKeyMatch ? propertyKeyMatch[1].trim() : fallbackKey;
 
-    const listItemPattern = /^-\s*['"]?\{\{(?:VALUE|FIELD):[^}]+\}\}['"]?\s*$/i;
+	const listItemPattern = /^-\s*['"]?\{\{(?:VALUE|FIELD):[^}]+\}\}['"]?\s*$/i;
     let propertyPath: string[] | null = null;
 
     if (context.isKeyValuePosition) {
@@ -98,11 +98,11 @@ export class TemplatePropertyCollector {
     return result;
   }
 
-  public merge(vars: Map<string, unknown>): void {
-    for (const [key, value] of vars) {
-      this.map.set(key, value);
-    }
-  }
+	public merge(vars: Map<string, unknown>): void {
+		for (const [key, value] of vars) {
+			this.map.set(key, value);
+		}
+	}
 
   private buildParseOptions(propertyKey: string): ParseOptions {
     return {

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -98,6 +98,12 @@ export class TemplatePropertyCollector {
     return result;
   }
 
+  public merge(vars: Map<string, unknown>): void {
+    for (const [key, value] of vars) {
+      this.map.set(key, value);
+    }
+  }
+
   private buildParseOptions(propertyKey: string): ParseOptions {
     return {
       propertyKey,

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -53,7 +53,7 @@ export class TemplatePropertyCollector {
     const propertyKeyMatch = lineContent.match(/^\s*([^:]+):/);
     const fallbackPathKey = propertyKeyMatch ? propertyKeyMatch[1].trim() : fallbackKey;
 
-    const listItemPattern = /^-\s*['"]?\{\{VALUE:[^}]+\}\}['"]?\s*$/i;
+    const listItemPattern = /^-\s*['"]?\{\{(?:VALUE|FIELD):[^}]+\}\}['"]?\s*$/i;
     let propertyPath: string[] | null = null;
 
     if (context.isKeyValuePosition) {


### PR DESCRIPTION
Add opt-in multi-select support for `{{FIELD:...|multi}}`.

The underlying problem in #692 is that users can reuse vault-derived field values, but FIELD prompts only let them pick one value. This adds `|multi` as FIELD behavior instead of a file/filter option: the runtime prompt uses the existing multi-select modal, collected values are cached under the normal `FIELD:` key, and array-valued FIELD replacements are routed through the template property collector so a complete frontmatter value becomes a real YAML list. Outside frontmatter property positions, selected values render as comma-separated text, matching existing multi-value VALUE behavior.

Design notes:
- FIELD filters and defaults still work with `|multi`, e.g. `{{FIELD:topic|multi|folder:Projects|tag:active|default:Inbox}}`.
- I intentionally did not force FIELD multi through the one-page form comma-separated inline input. Vault field values can contain commas, so the one-page form now collects other inputs first and leaves FIELD multi to the runtime multi-select.
- Included templates propagate collected structured values back to the parent formatter, so `{{TEMPLATE:...}}` frontmatter does not drop FIELD multi arrays before final frontmatter post-processing.
- No persisted settings migration is needed.

Validation:
- Reproduced current behavior in the isolated Obsidian worktree vault: `topics: {{FIELD:topic|multi}}` with `FIELD:topic|multi=["Alpha","Beta"]` wrote `topics: Alpha,Beta` and Obsidian parsed it as a scalar string.
- Verified the rebuilt plugin in the isolated Obsidian worktree vault by launching a command-backed Template choice, selecting `Alpha` and `Beta` in the runtime FIELD multi-select, and reading back raw content plus metadata: frontmatter was `topics:\n  - Alpha\n  - Beta`, metadata was `topics: ["Alpha", "Beta"]`, and body text was `Alpha,Beta`.
- Verified one-page interaction in the isolated vault: the one-page modal collected `{{VALUE:title}}`, then FIELD multi opened as the runtime multi-select; the resulting metadata was `topics: ["Beta"]`.
- Verified the included-template edge case in the isolated vault: parent `{{TEMPLATE:__qa_692_include_child.md}}` rendered child frontmatter `topics: {{FIELD:topic|multi}}`, selected `Alpha` and `Beta`, wrote a YAML list in `__qa_692_include_output.md`, and Obsidian metadata read `topics: ["Alpha", "Beta"]`.
- `pnpm run build`
- `pnpm run lint`
- `pnpm run check` (0 errors; svelte-check reports 4 existing warnings)
- `pnpm test` (2649 passed, 37 skipped)
- `pnpm run build-with-lint`

Fixes #692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-select support for FIELD prompts using `{{FIELD:<fieldname>|multi}}` syntax.
  * Multi-select fields render as runtime prompts instead of inline in one-page forms.

* **Documentation**
  * Documented multi-select field syntax, including rendering behavior and interaction with defaults/filters.
  * Clarified that multi-selections display differently in YAML front-matter vs. text body/filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->