### PR TITLE
fix(capture): keep cursor after opened captures

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -149,6 +149,8 @@ When _Capture to active file_ is disabled, the **Behavior** section shows an _Op
 -   _View Mode_ - how to display the opened file: **Source**, **Preview**, **Live Preview**, or **Default**.
 -   _Focus new pane_ - a toggle to focus the opened tab immediately after opening. Shown for every location except **Reuse current tab**.
 
+When QuickAdd opens and focuses a Markdown capture target in an editable mode, it places the editor cursor at the end of the inserted capture so you can keep typing there. This is skipped for preview/unfocused opens and when Templater cursor markers take over.
+
 ### Run Templater on entire destination file after capture
 
 The **Behavior** section also has a _Run Templater on entire destination file after capture_ toggle. This is an advanced / legacy option: it executes any `<% %>` anywhere in the destination file, including inside code blocks. Leave it off unless you specifically need that whole-file Templater pass.

--- a/src/engine/CaptureChoiceEngine.merge.test.ts
+++ b/src/engine/CaptureChoiceEngine.merge.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { formatContentWithFileMock } = vi.hoisted(() => ({
+const { formatContentWithFileMock, getCaptureInsertionEndOffsetMock } = vi.hoisted(() => ({
 	formatContentWithFileMock: vi.fn(),
+	getCaptureInsertionEndOffsetMock: vi.fn(),
 }));
 
 vi.mock("../quickAddSettingsTab", () => {
@@ -75,6 +76,9 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 		consumeCreatedClipboardAttachmentPaths() {
 			return [];
 		}
+		getCaptureInsertionEndOffset() {
+			return getCaptureInsertionEndOffsetMock();
+		}
 	},
 }));
 
@@ -93,6 +97,7 @@ vi.mock("../utilityObsidian", () => ({
 	overwriteTemplaterOnce: vi.fn(),
 	templaterParseTemplate: vi.fn(async (_app, content) => content),
 	waitForTemplaterTriggerOnCreateToComplete: vi.fn(),
+	setMarkdownCursorAtOffset: vi.fn(),
 }));
 
 vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
@@ -205,6 +210,7 @@ const createEngine = ({
 	);
 
 	formatContentWithFileMock.mockResolvedValue(formattedFileContent);
+	getCaptureInsertionEndOffsetMock.mockReturnValue(formattedFileContent.length);
 
 	return { engine, filePath };
 };
@@ -212,6 +218,7 @@ const createEngine = ({
 describe("CaptureChoiceEngine concurrent-edit merge", () => {
 	beforeEach(() => {
 		formatContentWithFileMock.mockReset();
+		getCaptureInsertionEndOffsetMock.mockReset();
 	});
 
 	it("proceeds when concurrent edits can be merged cleanly", async () => {
@@ -230,6 +237,7 @@ describe("CaptureChoiceEngine concurrent-edit merge", () => {
 			"alpha changed by sync\nbeta\ngamma\ncaptured ours\n",
 		);
 		expect(result.captureContent).toBe("captured ours");
+		expect(result.cursorPlacementSafe).toBe(false);
 	});
 
 	it("aborts when concurrent edits conflict", async () => {
@@ -259,5 +267,7 @@ describe("CaptureChoiceEngine concurrent-edit merge", () => {
 		const result = await (engine as any).onFileExists(filePath, "captured ours");
 
 		expect(result.newFileContent).toBe(formattedFileContent);
+		expect(result.cursorPlacementSafe).toBe(true);
+		expect(result.cursorEndOffset).toBe(formattedFileContent.length);
 	});
 });

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -9,7 +9,10 @@ import {
 	insertOnNewLineBelow,
 	insertFileLinkToActiveView,
 	isFolder,
+	jumpToNextTemplaterCursorIfPossible,
 	openFile,
+	overwriteTemplaterOnce,
+	setMarkdownCursorAtOffset,
 } from "../utilityObsidian";
 import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "../constants";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
@@ -88,6 +91,9 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 		consumeCreatedClipboardAttachmentPaths() {
 			return createdClipboardAttachmentPaths.splice(0);
 		}
+		getCaptureInsertionEndOffset() {
+			return null;
+		}
 	},
 	setUseSelectionAsCaptureValueMock,
 }));
@@ -107,6 +113,7 @@ vi.mock("../utilityObsidian", () => ({
 	openExistingFileTab: vi.fn(() => null),
 	openFile: vi.fn(),
 	overwriteTemplaterOnce: vi.fn(),
+	setMarkdownCursorAtOffset: vi.fn(() => true),
 	templaterParseTemplate: vi.fn(async (_app, content) => content),
 	waitForTemplaterTriggerOnCreateToComplete: vi.fn(),
 }));
@@ -214,6 +221,10 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 		vi.mocked(openFile).mockClear();
 		vi.mocked(insertFileLinkToActiveView).mockReset();
 		vi.mocked(insertOnNewLineBelow).mockReturnValue(true);
+		vi.mocked(overwriteTemplaterOnce).mockClear();
+		vi.mocked(jumpToNextTemplaterCursorIfPossible).mockReset();
+		vi.mocked(jumpToNextTemplaterCursorIfPossible).mockResolvedValue(false);
+		vi.mocked(setMarkdownCursorAtOffset).mockClear();
 	});
 
 	it("uses global setting when no override is set", async () => {
@@ -291,6 +302,141 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 				focus: true,
 			}),
 		);
+	});
+
+	it("places the cursor after a focused opened file-based capture", async () => {
+		const app = createApp();
+		const choice = createChoice({
+			openFile: true,
+			captureToActiveFile: false,
+		});
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: true } } as any,
+			choice,
+			createExecutor(),
+		);
+		const file = { path: "Test.md", basename: "Test", extension: "md" } as any;
+
+		(engine as any).getFormattedPathToCaptureTo = vi
+			.fn()
+			.mockResolvedValue("Test.md");
+		(engine as any).fileExists = vi.fn().mockResolvedValue(true);
+		(engine as any).onFileExists = vi.fn().mockResolvedValue({
+			file,
+			newFileContent: "Line A\nCAPTURE\nLine B",
+			captureContent: "CAPTURE\n",
+			cursorEndOffset: "Line A\nCAPTURE\n".length,
+			cursorPlacementSafe: true,
+		});
+
+		await engine.run();
+
+		expect(setMarkdownCursorAtOffset).toHaveBeenCalledWith(
+			app,
+			file,
+			"Line A\nCAPTURE\n".length,
+			"Line A\nCAPTURE\nLine B",
+		);
+	});
+
+	it("does not place the cursor when the opened file is not focused", async () => {
+		const choice = createChoice({
+			openFile: true,
+			captureToActiveFile: false,
+			fileOpening: {
+				location: "tab",
+				direction: "vertical",
+				mode: "default",
+				focus: false,
+			},
+		});
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: true } } as any,
+			choice,
+			createExecutor(),
+		);
+		const file = { path: "Test.md", basename: "Test", extension: "md" } as any;
+
+		(engine as any).getFormattedPathToCaptureTo = vi
+			.fn()
+			.mockResolvedValue("Test.md");
+		(engine as any).fileExists = vi.fn().mockResolvedValue(true);
+		(engine as any).onFileExists = vi.fn().mockResolvedValue({
+			file,
+			newFileContent: "CAPTURE",
+			captureContent: "CAPTURE",
+			cursorEndOffset: "CAPTURE".length,
+			cursorPlacementSafe: true,
+		});
+
+		await engine.run();
+
+		expect(setMarkdownCursorAtOffset).not.toHaveBeenCalled();
+	});
+
+	it("does not override Templater cursor jumps", async () => {
+		vi.mocked(jumpToNextTemplaterCursorIfPossible).mockResolvedValue(true);
+		const choice = createChoice({
+			openFile: true,
+			captureToActiveFile: false,
+		});
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: true } } as any,
+			choice,
+			createExecutor(),
+		);
+		const file = { path: "Test.md", basename: "Test", extension: "md" } as any;
+
+		(engine as any).getFormattedPathToCaptureTo = vi
+			.fn()
+			.mockResolvedValue("Test.md");
+		(engine as any).fileExists = vi.fn().mockResolvedValue(true);
+		(engine as any).onFileExists = vi.fn().mockResolvedValue({
+			file,
+			newFileContent: "CAPTURE",
+			captureContent: "CAPTURE",
+			cursorEndOffset: "CAPTURE".length,
+			cursorPlacementSafe: true,
+		});
+
+		await engine.run();
+
+		expect(setMarkdownCursorAtOffset).not.toHaveBeenCalled();
+	});
+
+	it("does not place the cursor after whole-file Templater post-processing", async () => {
+		const choice = createChoice({
+			openFile: true,
+			captureToActiveFile: false,
+			templater: { afterCapture: "wholeFile" },
+		});
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: true } } as any,
+			choice,
+			createExecutor(),
+		);
+		const file = { path: "Test.md", basename: "Test", extension: "md" } as any;
+
+		(engine as any).getFormattedPathToCaptureTo = vi
+			.fn()
+			.mockResolvedValue("Test.md");
+		(engine as any).fileExists = vi.fn().mockResolvedValue(true);
+		(engine as any).onFileExists = vi.fn().mockResolvedValue({
+			file,
+			newFileContent: "CAPTURE",
+			captureContent: "CAPTURE",
+			cursorEndOffset: "CAPTURE".length,
+			cursorPlacementSafe: true,
+		});
+
+		await engine.run();
+
+		expect(overwriteTemplaterOnce).toHaveBeenCalled();
+		expect(setMarkdownCursorAtOffset).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -41,6 +41,7 @@ import {
 	openExistingFileTab,
 	openFile,
 	overwriteTemplaterOnce,
+	setMarkdownCursorAtOffset,
 	templaterParseTemplate,
 	waitForTemplaterTriggerOnCreateToComplete,
 } from "../utilityObsidian";
@@ -71,6 +72,14 @@ import {
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 
 const DEFAULT_NOTICE_DURATION = 4000;
+
+type CaptureWriteResult = {
+	file: TFile;
+	newFileContent: string;
+	captureContent: string;
+	cursorEndOffset?: number;
+	cursorPlacementSafe?: boolean;
+};
 
 export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	choice: ICaptureChoice;
@@ -305,7 +314,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				path: string,
 				capture: string,
 				linkOptions?: AppendLinkOptions,
-			) => Promise<{ file: TFile; newFileContent: string; captureContent: string }>;
+			) => Promise<CaptureWriteResult>;
 			let getFileAndAddContentFn: GetFileAndAddContentFn;
 			const fileAlreadyExists = await this.fileExists(filePath);
 
@@ -368,8 +377,16 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				);
 			}
 
-			const { file, newFileContent, captureContent } =
+			const {
+				file,
+				newFileContent,
+				captureContent,
+				cursorEndOffset,
+				cursorPlacementSafe = true,
+			} =
 				await getFileAndAddContentFn(filePath, content);
+			let expectedCursorContent: string | null = null;
+			let canPlaceCursorAtCapture = cursorPlacementSafe;
 
 			this.captureResolvedOrderedHeading();
 
@@ -413,8 +430,14 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				contentCommitted = true;
 				if (this.choice.templater?.afterCapture === "wholeFile") {
 					await overwriteTemplaterOnce(this.app, file);
+					canPlaceCursorAtCapture = false;
 				}
-				await this.applyCapturePropertyVars(file);
+				const frontmatterPostProcessed =
+					await this.applyCapturePropertyVars(file);
+				if (frontmatterPostProcessed) {
+					canPlaceCursorAtCapture = false;
+				}
+				expectedCursorContent = canPlaceCursorAtCapture ? newFileContent : null;
 			}
 
 			// Content is committed. Record success BEFORE the cosmetic steps below
@@ -447,7 +470,22 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					});
 				}
 
-				await jumpToNextTemplaterCursorIfPossible(this.app, file);
+				const templaterHandledCursor =
+					await jumpToNextTemplaterCursorIfPossible(this.app, file);
+				if (
+					!templaterHandledCursor &&
+					canPlaceCursorAtCapture &&
+					focus &&
+					expectedCursorContent !== null &&
+					typeof cursorEndOffset === "number"
+				) {
+					setMarkdownCursorAtOffset(
+						this.app,
+						file,
+						cursorEndOffset,
+						expectedCursorContent,
+					);
+				}
 			}
 		} catch (err) {
 			if (!contentCommitted) {
@@ -1040,11 +1078,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	private async onFileExists(
 		filePath: string,
 		content: string,
-	): Promise<{
-		file: TFile;
-		newFileContent: string;
-		captureContent: string;
-	}> {
+	): Promise<CaptureWriteResult> {
 		const file: TFile = this.getFileByPath(filePath);
 		if (!file) throw new Error("File not found");
 
@@ -1073,10 +1107,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				),
 			);
 		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
+		const cursorEndOffset = this.formatter.getCaptureInsertionEndOffset();
 
 		const secondReadFileContent: string = await this.app.vault.read(file);
 
 		let newFileContent = formattedFileContent;
+		let cursorPlacementSafe = true;
 		if (secondReadFileContent !== fileContent) {
 			const res = merge(
 				secondReadFileContent,
@@ -1090,20 +1126,23 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			);
 
 			newFileContent = res.joinedResults() as string;
+			cursorPlacementSafe = false;
 		}
 
-		return { file, newFileContent, captureContent: formatted };
+		return {
+			file,
+			newFileContent,
+			captureContent: formatted,
+			cursorEndOffset: cursorEndOffset ?? undefined,
+			cursorPlacementSafe,
+		};
 	}
 
 	private async onCreateFileIfItDoesntExist(
 		filePath: string,
 		captureContent: string,
 		linkOptions?: AppendLinkOptions,
-	): Promise<{
-		file: TFile;
-		newFileContent: string;
-		captureContent: string;
-	}> {
+	): Promise<CaptureWriteResult> {
 		// Extract filename without extension from the full path.
 		const fileBasename = basenameWithoutMdOrCanvas(filePath);
 		this.formatter.setTitle(fileBasename);
@@ -1190,8 +1229,15 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				),
 			);
 		this.mergeCapturePropertyVars(this.formatter.getAndClearTemplatePropertyVars());
+		const cursorEndOffset = this.formatter.getCaptureInsertionEndOffset();
 
-		return { file, newFileContent, captureContent: formattedCaptureContent };
+		return {
+			file,
+			newFileContent,
+			captureContent: formattedCaptureContent,
+			cursorEndOffset: cursorEndOffset ?? undefined,
+			cursorPlacementSafe: true,
+		};
 	}
 
 	private async formatFilePath(captureTo: string) {
@@ -1274,14 +1320,14 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		);
 	}
 
-	private async applyCapturePropertyVars(file: TFile): Promise<void> {
+	private async applyCapturePropertyVars(file: TFile): Promise<boolean> {
 		if (this.capturePropertyVars.size === 0) {
-			return;
+			return false;
 		}
 
 		if (!shouldPostProcessFrontMatter(file, this.capturePropertyVars)) {
 			this.capturePropertyVars.clear();
-			return;
+			return false;
 		}
 
 		log.logMessage(
@@ -1289,5 +1335,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		);
 		await postProcessFrontMatter(this.app, file, this.capturePropertyVars);
 		this.capturePropertyVars.clear();
+		return true;
 	}
 }

--- a/src/formatters/captureChoiceFormatter-write-position.test.ts
+++ b/src/formatters/captureChoiceFormatter-write-position.test.ts
@@ -206,6 +206,33 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("CAPTURE\nLine A\nLine B");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe("CAPTURE\n".length);
+	});
+
+	it("tracks cursor after top insertion below frontmatter", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"CAPTURE",
+			createChoice({ captureToActiveFile: false, prepend: false }),
+			"---\ntitle: Test\n---\nBody",
+			createFile(),
+		);
+
+		expect(result).toBe("---\ntitle: Test\n---\nCAPTURE\nBody");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE") + "CAPTURE".length,
+		);
 	});
 
 	it("writes to bottom for non-active targets when prepend is true", async () => {
@@ -229,6 +256,7 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("Line A\nLine B\nCAPTURE");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(result.length);
 	});
 
 	it("writes to bottom for active-file targets when mode is bottom", async () => {
@@ -286,6 +314,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("# Inbox\nBody\nCAPTURE\n## Later\nNext");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE\n") + "CAPTURE\n".length,
+		);
 	});
 
 	it("separates capture content from the matched line when inserting before", async () => {
@@ -316,6 +347,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("Line A\nCAPTURE\nLine B");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE") + "CAPTURE".length,
+		);
 	});
 
 	it("resolves format syntax in insert-before target lines", async () => {
@@ -347,6 +381,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("# Inbox\nCAPTURE\nProject Alpha\nBody");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE\n") + "CAPTURE\n".length,
+		);
 	});
 
 	it("creates a missing insert-before target below the capture", async () => {
@@ -377,6 +414,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("# Inbox\nCAPTURE\n## Missing");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE") + "CAPTURE".length,
+		);
 	});
 
 	it("keeps existing body content separated when creating a missing insert-before target at top", async () => {
@@ -407,6 +447,7 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("CAPTURE\n## Missing\nBody");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe("CAPTURE".length);
 	});
 
 	it("keeps frontmatter body content separated when creating a missing insert-before target at top", async () => {
@@ -437,6 +478,47 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("---\ntitle: Test\n---\nCAPTURE\n## Missing\nBody");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE") + "CAPTURE".length,
+		);
+	});
+
+	it("tracks cursor after inline insert-after in the matched occurrence", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			" CAPTURE",
+			createChoice({
+				insertAfter: {
+					enabled: true,
+					after: "Status:",
+					insertAtEnd: false,
+					considerSubsections: false,
+					createIfNotFound: false,
+					createIfNotFoundLocation: "",
+					inline: true,
+					replaceExisting: false,
+					blankLineAfterMatchMode: "auto",
+				},
+			}),
+			"Status: first\nStatus: second",
+			createFile(),
+		);
+
+		expect(result).toBe("Status: CAPTURE first\nStatus: second");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			"Status: CAPTURE".length,
+		);
 	});
 
 	it("captures a non-breaking-space-only payload instead of dropping it as empty (issue #760)", async () => {
@@ -571,6 +653,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("# Title\n## Foo\nCAPTURE\nexisting\n## Bar");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE\n") + "CAPTURE\n".length,
+		);
 	});
 
 	it("matches the heading override literally, never resolving token-like heading text (#738)", async () => {
@@ -613,6 +698,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("## {{DATE}}\nCAPTURE\nbody");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE\n") + "CAPTURE\n".length,
+		);
 	});
 
 	it("takes the block (section) path for a heading override even if a stale inline flag is set (#738 blocker)", async () => {
@@ -654,6 +742,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("## Foo\nCAPTURE\nexisting");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE\n") + "CAPTURE\n".length,
+		);
 	});
 
 	it("creates a typed heading override via create-if-not-found, byte-symmetric with search (#738/#742)", async () => {
@@ -694,6 +785,7 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 
 		expect(result).toBe("# Title\nbody\n## Tasks\nCAPTURE\n");
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(result.length);
 	});
 
 	it("inserts under the FIRST occurrence when the note has duplicate heading text (#738)", async () => {
@@ -736,6 +828,9 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 
 		expect(result).toBe(
 			"## Tasks\nCAPTURE\nfirst\n\n## Other\nx\n\n## Tasks\nsecond",
+		);
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			result.indexOf("CAPTURE\n") + "CAPTURE\n".length,
 		);
 	});
 });

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -20,7 +20,7 @@ import {
 } from "./helpers/orderedSectionPlacement";
 import {
 	getBodyStartOffset,
-	insertAtNoteBodyStart,
+	insertAtNoteBodyStartWithResult,
 } from "../utils/noteContentInsertion";
 import { parentFolderPath } from "../utils/pathUtils";
 
@@ -89,6 +89,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		* (issue #527).
 		*/
 	private linebreaksProcessed = false;
+	private captureInsertionEndOffset: number | null = null;
 
 	public setDestinationFile(file: TFile): void {
 		this.file = file;
@@ -133,6 +134,17 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		const paths = this.createdClipboardAttachmentPaths;
 		this.createdClipboardAttachmentPaths = [];
 		return paths;
+	}
+
+	public getCaptureInsertionEndOffset(): number | null {
+		return this.captureInsertionEndOffset;
+	}
+
+	private setCaptureInsertionEndOffset(offset: number | null): void {
+		this.captureInsertionEndOffset =
+			typeof offset === "number" && Number.isFinite(offset) && offset >= 0
+				? offset
+				: null;
 	}
 
 	protected shouldUseSelectionForValue(): boolean {
@@ -246,6 +258,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		fileContent: string,
 		file: TFile,
 	): Promise<string> {
+		this.setCaptureInsertionEndOffset(null);
 		this.choice = choice;
 		this.file = file;
 		this.fileContent = fileContent;
@@ -314,6 +327,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 				!formatted.startsWith("\n");
 			const separator = shouldInsertLinebreak || needsLeadingNewline ? "\n" : "";
 
+			this.setCaptureInsertionEndOffset(
+				this.fileContent.length + separator.length + formatted.length,
+			);
 			return `${this.fileContent}${separator}${formatted}`;
 		}
 
@@ -327,7 +343,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 		// Default "write to top" path: insert after any frontmatter so the YAML block
 		// is never broken, and never glue the capture onto the first body line (#647).
-		return insertAtNoteBodyStart(this.fileContent, formatted);
+		return this.insertAtNoteBodyStartTracking(formatted);
 	}
 
 	async formatContentOnly(input: string): Promise<string> {
@@ -787,6 +803,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		}
 
 		const matchEnd = matchIndex + targetString.length;
+		this.setCaptureInsertionEndOffset(matchEnd + formatted.length);
 		if (this.choice.insertAfter?.replaceExisting) {
 			const endOfLine = this.getInlineEndOfLine(matchEnd);
 			return (
@@ -817,16 +834,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_TOP
 		) {
-			return insertAtNoteBodyStart(
-				this.fileContent,
-				insertAfterLineAndFormatted,
-			);
+			return this.insertAtNoteBodyStartTracking(insertAfterLineAndFormatted);
 		}
 
 		if (
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_BOTTOM
 		) {
+			this.setCaptureInsertionEndOffset(
+				this.fileContent.length + 1 + insertAfterLineAndFormatted.length,
+			);
 			return `${this.fileContent}\n${insertAfterLineAndFormatted}`;
 		}
 
@@ -953,7 +970,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 		// Non-heading anchor: ordered placement is meaningless → graceful TOP degrade.
 		if (level === 0) {
-			return insertAtNoteBodyStart(this.fileContent, payload);
+			return this.insertAtNoteBodyStartTracking(payload);
 		}
 
 		// CRLF-safe line model: the helper detects headings on \r-stripped lines;
@@ -1021,7 +1038,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		);
 
 		if (slot.mode === "bodyStart") {
-			return insertAtNoteBodyStart(this.fileContent, payload);
+			return this.insertAtNoteBodyStartTracking(payload);
 		}
 
 		return this.spliceOrderedSection(rawLines, slot, payload);
@@ -1088,6 +1105,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		const lead = before.length > 0 && !/\n$/.test(before) ? eol : "";
 		const trail =
 			after.length > 0 || /\n$/.test(content) ? eol : "";
+		const insertedStartOffset = before.length + lead.length;
+		this.setCaptureInsertionEndOffset(insertedStartOffset + blockText.length);
 		return `${before}${lead}${blockText}${trail}${after}`;
 	}
 
@@ -1111,9 +1130,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			insertBefore.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_TOP
 		) {
-			return insertAtNoteBodyStart(
-				this.fileContent,
+			return this.insertAtNoteBodyStartTracking(
 				formattedAndInsertBeforeLine,
+				formatted.length,
 			);
 		}
 
@@ -1121,6 +1140,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			insertBefore.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_BOTTOM
 		) {
+			this.setCaptureInsertionEndOffset(
+				this.fileContent.length + 1 + formatted.length,
+			);
 			return `${this.fileContent}\n${formattedAndInsertBeforeLine}`;
 		}
 
@@ -1141,6 +1163,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 					formattedAndInsertBeforeLine,
 					this.fileContent,
 					cursor.line,
+					formatted.length,
 				);
 			} catch {
 				throw new ChoiceAbortError(
@@ -1164,16 +1187,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_TOP
 		) {
-			return insertAtNoteBodyStart(
-				this.fileContent,
-				insertAfterLineAndFormatted,
-			);
+			return this.insertAtNoteBodyStartTracking(insertAfterLineAndFormatted);
 		}
 
 		if (
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_BOTTOM
 		) {
+			this.setCaptureInsertionEndOffset(
+				this.fileContent.length + 1 + insertAfterLineAndFormatted.length,
+			);
 			return `${this.fileContent}\n${insertAfterLineAndFormatted}`;
 		}
 
@@ -1206,6 +1229,26 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		throw new ChoiceAbortError(
 			`Unknown createIfNotFoundLocation: ${this.choice.insertAfter?.createIfNotFoundLocation}`,
 		);
+	}
+
+	private insertAtNoteBodyStartTracking(
+		text: string,
+		cursorOffsetInText = text.length,
+	): string {
+		const result = insertAtNoteBodyStartWithResult(this.fileContent, text);
+		if (result.insertedStartOffset === null) {
+			this.setCaptureInsertionEndOffset(null);
+			return result.content;
+		}
+
+		const clampedOffset = Math.max(
+			0,
+			Math.min(cursorOffsetInText, text.length),
+		);
+		this.setCaptureInsertionEndOffset(
+			result.insertedStartOffset + clampedOffset,
+		);
+		return result.content;
 	}
 
 	private insertTextAfterPositionInBody(
@@ -1250,6 +1293,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 				? rawText.slice(0, -1)
 				: rawText;
 
+		this.setCaptureInsertionEndOffset(pre.length + 1 + text.length);
 		return `${pre}\n${text}${post}`;
 	}
 
@@ -1257,10 +1301,16 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		text: string,
 		body: string,
 		pos: number,
+		cursorOffsetInText = text.length,
 	): string {
 		const separator = body.length > 0 && !text.endsWith("\n") ? "\n" : "";
+		const clampedOffset = Math.max(
+			0,
+			Math.min(cursorOffsetInText, text.length),
+		);
 
 		if (pos <= 0) {
+			this.setCaptureInsertionEndOffset(clampedOffset);
 			return `${text}${separator}${body}`;
 		}
 
@@ -1268,6 +1318,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		const pre = splitContent.slice(0, pos).join("\n");
 		const post = splitContent.slice(pos).join("\n");
 
+		this.setCaptureInsertionEndOffset(pre.length + 1 + clampedOffset);
 		return `${pre}\n${text}${separator}${post}`;
 	}
 }

--- a/src/utilityObsidian.templater-binding.test.ts
+++ b/src/utilityObsidian.templater-binding.test.ts
@@ -91,6 +91,102 @@ describe("jumpToNextTemplaterCursorIfPossible", () => {
 		).resolves.toBe(true);
 	});
 
+	it("returns true when Templater consumes a cursor marker at the current position", async () => {
+		const app = new App();
+		const file = new TFile();
+		file.path = "QA.md";
+		file.extension = "md";
+		let content = "<% tp.file.cursor() %>Capture text";
+
+		(app as any).workspace.getActiveFile = () => file;
+		(app as any).workspace.getActiveViewOfType = () => ({
+			file,
+			editor: {
+				getCursor: () => ({ line: 0, ch: 0 }),
+				getValue: () => content,
+			},
+		});
+
+		const editorHandler = {
+			jump_to_next_cursor_location: async () => {
+				content = "Capture text";
+			},
+		};
+
+		(app as any).plugins.plugins["templater-obsidian"] = {
+			settings: { auto_jump_to_cursor: true },
+			editor_handler: editorHandler,
+		};
+
+		await expect(
+			jumpToNextTemplaterCursorIfPossible(app as any, file as any),
+		).resolves.toBe(true);
+	});
+
+	it("returns true when Templater consumes an ordered cursor marker", async () => {
+		const app = new App();
+		const file = new TFile();
+		file.path = "QA.md";
+		file.extension = "md";
+		let content = "<% tp.file.cursor(1) %>Capture text";
+
+		(app as any).workspace.getActiveFile = () => file;
+		(app as any).workspace.getActiveViewOfType = () => ({
+			file,
+			editor: {
+				getCursor: () => ({ line: 0, ch: 0 }),
+				getValue: () => content,
+			},
+		});
+
+		const editorHandler = {
+			jump_to_next_cursor_location: async () => {
+				content = "Capture text";
+			},
+		};
+
+		(app as any).plugins.plugins["templater-obsidian"] = {
+			settings: { auto_jump_to_cursor: true },
+			editor_handler: editorHandler,
+		};
+
+		await expect(
+			jumpToNextTemplaterCursorIfPossible(app as any, file as any),
+		).resolves.toBe(true);
+	});
+
+	it("returns false when Templater neither moves nor consumes a cursor marker", async () => {
+		const app = new App();
+		const file = new TFile();
+		file.path = "QA.md";
+		file.extension = "md";
+
+		(app as any).workspace.getActiveFile = () => file;
+		(app as any).workspace.getActiveViewOfType = () => ({
+			file,
+			editor: {
+				getCursor: () => ({ line: 1, ch: 2 }),
+				getValue: () => "Capture text",
+			},
+		});
+
+		const editorHandler = {
+			jump_to_next_cursor_location: async () => {
+				// Templater returns void even when no cursor marker exists.
+				await Promise.resolve();
+			},
+		};
+
+		(app as any).plugins.plugins["templater-obsidian"] = {
+			settings: { auto_jump_to_cursor: true },
+			editor_handler: editorHandler,
+		};
+
+		await expect(
+			jumpToNextTemplaterCursorIfPossible(app as any, file as any),
+		).resolves.toBe(false);
+	});
+
 	it("returns false when Templater auto jump is disabled", async () => {
 		const app = new App();
 		const file = new TFile();

--- a/src/utilityObsidian.templater-binding.test.ts
+++ b/src/utilityObsidian.templater-binding.test.ts
@@ -36,6 +36,10 @@ describe("jumpToNextTemplaterCursorIfPossible", () => {
 		file.extension = "md";
 
 		(app as any).workspace.getActiveFile = () => file;
+		(app as any).workspace.getActiveViewOfType = () => ({
+			file,
+			editor: { getCursor: () => ({ line: 1, ch: 2 }) },
+		});
 
 		const editorHandler = {
 			plugin: { ok: true },
@@ -53,6 +57,53 @@ describe("jumpToNextTemplaterCursorIfPossible", () => {
 			editor_handler: editorHandler,
 		};
 
-		await jumpToNextTemplaterCursorIfPossible(app as any, file as any);
+		await expect(
+			jumpToNextTemplaterCursorIfPossible(app as any, file as any),
+		).resolves.toBe(false);
+	});
+
+	it("returns true when Templater moves the active editor cursor", async () => {
+		const app = new App();
+		const file = new TFile();
+		file.path = "QA.md";
+		file.extension = "md";
+		let cursor = { line: 1, ch: 2 };
+
+		(app as any).workspace.getActiveFile = () => file;
+		(app as any).workspace.getActiveViewOfType = () => ({
+			file,
+			editor: { getCursor: () => cursor },
+		});
+
+		const editorHandler = {
+			jump_to_next_cursor_location: async () => {
+				cursor = { line: 3, ch: 4 };
+			},
+		};
+
+		(app as any).plugins.plugins["templater-obsidian"] = {
+			settings: { auto_jump_to_cursor: true },
+			editor_handler: editorHandler,
+		};
+
+		await expect(
+			jumpToNextTemplaterCursorIfPossible(app as any, file as any),
+		).resolves.toBe(true);
+	});
+
+	it("returns false when Templater auto jump is disabled", async () => {
+		const app = new App();
+		const file = new TFile();
+		file.path = "QA.md";
+		file.extension = "md";
+
+		(app as any).workspace.getActiveFile = () => file;
+		(app as any).plugins.plugins["templater-obsidian"] = {
+			settings: { auto_jump_to_cursor: false },
+		};
+
+		await expect(
+			jumpToNextTemplaterCursorIfPossible(app as any, file as any),
+		).resolves.toBe(false);
 	});
 });

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -37,6 +37,7 @@ export {
 	insertOnNewLineBelow,
 	insertLinkWithPlacement,
 	insertFileLinkToActiveView,
+	setMarkdownCursorAtOffset,
 } from "./utils/editorInsertion";
 
 export {

--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import { setMarkdownCursorAtOffset } from "./editorInsertion";
+
+function createHarness({
+	mode = "source",
+	value = "Line A\nCAPTURE\nLine B",
+	path = "Target.md",
+}: {
+	mode?: "source" | "preview";
+	value?: string;
+	path?: string;
+} = {}) {
+	const setCursor = vi.fn();
+	const offsetToPos = vi.fn((offset: number) => ({ line: 1, ch: offset }));
+	const view = {
+		file: { path },
+		getMode: () => mode,
+		editor: {
+			getValue: () => value,
+			offsetToPos,
+			setCursor,
+		},
+	};
+	const app = {
+		workspace: {
+			getActiveViewOfType: vi.fn(() => view),
+		},
+	} as unknown as App;
+	const file = { path, extension: "md" } as TFile;
+
+	return { app, file, offsetToPos, setCursor };
+}
+
+describe("setMarkdownCursorAtOffset", () => {
+	it("sets the cursor in the active markdown editor when content matches", () => {
+		const { app, file, offsetToPos, setCursor } = createHarness();
+
+		const placed = setMarkdownCursorAtOffset(
+			app,
+			file,
+			"Line A\nCAPTURE\n".length,
+			"Line A\nCAPTURE\nLine B",
+		);
+
+		expect(placed).toBe(true);
+		expect(offsetToPos).toHaveBeenCalledWith("Line A\nCAPTURE\n".length);
+		expect(setCursor).toHaveBeenCalledWith({
+			line: 1,
+			ch: "Line A\nCAPTURE\n".length,
+		});
+	});
+
+	it("skips preview mode", () => {
+		const { app, file, setCursor } = createHarness({ mode: "preview" });
+
+		const placed = setMarkdownCursorAtOffset(
+			app,
+			file,
+			7,
+			"Line A\nCAPTURE\nLine B",
+		);
+
+		expect(placed).toBe(false);
+		expect(setCursor).not.toHaveBeenCalled();
+	});
+
+	it("skips when the editor buffer does not match the expected capture write", () => {
+		const { app, file, setCursor } = createHarness({ value: "stale" });
+
+		const placed = setMarkdownCursorAtOffset(
+			app,
+			file,
+			7,
+			"Line A\nCAPTURE\nLine B",
+		);
+
+		expect(placed).toBe(false);
+		expect(setCursor).not.toHaveBeenCalled();
+	});
+});

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -232,3 +232,31 @@ export function insertFileLinkToActiveView(
 
 	return true;
 }
+
+export function setMarkdownCursorAtOffset(
+	app: App,
+	file: TFile,
+	offset: number,
+	expectedContent: string,
+): boolean {
+	try {
+		if (file.extension !== "md") return false;
+		if (!Number.isSafeInteger(offset) || offset < 0) return false;
+		if (offset > expectedContent.length) return false;
+
+		const view = app.workspace.getActiveViewOfType(MarkdownView);
+		if (!view || view.file?.path !== file.path) return false;
+		if (view.getMode() === "preview") return false;
+
+		const editor = view.editor;
+		if (!editor || editor.getValue() !== expectedContent) return false;
+
+		editor.setCursor(editor.offsetToPos(offset));
+		return true;
+	} catch {
+		log.logMessage(
+			`Unable to place cursor after capture in '${file.path}'.`,
+		);
+		return false;
+	}
+}

--- a/src/utils/noteContentInsertion.ts
+++ b/src/utils/noteContentInsertion.ts
@@ -1,5 +1,11 @@
 import { getFrontMatterInfo } from "obsidian";
 
+export interface NoteBodyInsertionResult {
+	content: string;
+	insertedStartOffset: number | null;
+	insertedEndOffset: number | null;
+}
+
 /**
  * Offset at which the note body begins — immediately after the YAML frontmatter
  * block when present, otherwise 0.
@@ -33,10 +39,19 @@ export function getBodyStartOffset(content: string): number {
  * own line (leaving a blank-line separation when the body already ends in a newline).
  * Capture callers pass the payload as-is for tight single-snippet insertion.
  */
-export function insertAtNoteBodyStart(content: string, text: string): string {
+export function insertAtNoteBodyStartWithResult(
+	content: string,
+	text: string,
+): NoteBodyInsertionResult {
 	// Inserting nothing leaves the note untouched (defensive: capture callers
 	// already drop empty payloads upstream, but keep the helper safe in isolation).
-	if (text.length === 0) return content;
+	if (text.length === 0) {
+		return {
+			content,
+			insertedStartOffset: null,
+			insertedEndOffset: null,
+		};
+	}
 
 	const start = getBodyStartOffset(content);
 	const head = content.slice(0, start);
@@ -47,5 +62,16 @@ export function insertAtNoteBodyStart(content: string, text: string): string {
 	const trailingSeparator =
 		rest.length > 0 && !text.endsWith("\n") && !/^\r?\n/.test(rest) ? "\n" : "";
 
-	return `${head}${leadingSeparator}${text}${trailingSeparator}${rest}`;
+	const insertedStartOffset = head.length + leadingSeparator.length;
+	const insertedEndOffset = insertedStartOffset + text.length;
+
+	return {
+		content: `${head}${leadingSeparator}${text}${trailingSeparator}${rest}`,
+		insertedStartOffset,
+		insertedEndOffset,
+	};
+}
+
+export function insertAtNoteBodyStart(content: string, text: string): string {
+	return insertAtNoteBodyStartWithResult(content, text).content;
 }

--- a/src/utils/templaterIntegration.ts
+++ b/src/utils/templaterIntegration.ts
@@ -1,4 +1,4 @@
-import type { App, TFile } from "obsidian";
+import { MarkdownView, type App, type TFile } from "obsidian";
 import { log } from "../logger/logManager";
 import { reportError } from "./errorUtils";
 
@@ -29,6 +29,45 @@ export type TemplaterPluginLike = {
 		) => Promise<void>;
 	};
 };
+
+type CursorSnapshot = {
+	line: number;
+	ch: number;
+};
+
+function getActiveEditorCursorSnapshot(
+	app: App,
+	file: TFile,
+): CursorSnapshot | null {
+	try {
+		const view = app.workspace.getActiveViewOfType(MarkdownView);
+		if (!view || view.file?.path !== file.path) return null;
+
+		const cursor = view.editor?.getCursor?.();
+		if (
+			!cursor ||
+			typeof cursor.line !== "number" ||
+			typeof cursor.ch !== "number"
+		) {
+			return null;
+		}
+
+		return { line: cursor.line, ch: cursor.ch };
+	} catch {
+		return null;
+	}
+}
+
+function didCursorMove(
+	before: CursorSnapshot | null,
+	after: CursorSnapshot | null,
+): boolean {
+	return (
+		before !== null &&
+		after !== null &&
+		(before.line !== after.line || before.ch !== after.ch)
+	);
+}
 
 /**
  * Wait until the filesystem reports a stable mtime for the file or the timeout elapses.
@@ -406,22 +445,26 @@ export async function templaterParseTemplate(
 export async function jumpToNextTemplaterCursorIfPossible(
 	app: App,
 	file: TFile,
-): Promise<void> {
-	if (file.extension !== "md") return;
-	if (app.workspace.getActiveFile()?.path !== file.path) return;
+): Promise<boolean> {
+	if (file.extension !== "md") return false;
+	if (app.workspace.getActiveFile()?.path !== file.path) return false;
 
 	const plugin = getTemplaterPlugin(app);
 	const autoJumpEnabled = !!plugin?.settings?.auto_jump_to_cursor;
 	const editorHandler = plugin?.editor_handler;
 	const jump = editorHandler?.jump_to_next_cursor_location;
 
-	if (!autoJumpEnabled) return;
+	if (!autoJumpEnabled) return false;
+	const beforeCursor = getActiveEditorCursorSnapshot(app, file);
 
 	if (typeof jump === "function") {
 		try {
 			// Preserve Templater's internal `this` context.
 			await jump.call(editorHandler, file, true);
-			return;
+			return didCursorMove(
+				beforeCursor,
+				getActiveEditorCursorSnapshot(app, file),
+			);
 		} catch (err) {
 			log.logWarning(
 				`jumpToNextTemplaterCursorIfPossible: API failed – ${(err as Error).message}`,
@@ -430,14 +473,20 @@ export async function jumpToNextTemplaterCursorIfPossible(
 	}
 
 	try {
-		(
+		const commandRan = !!(
 			app.commands as unknown as {
 				executeCommandById?: (commandId: string) => boolean;
 			}
 		).executeCommandById?.(
 			"templater-obsidian:jump-to-next-cursor-location",
 		);
+		if (!commandRan) return false;
+		return didCursorMove(
+			beforeCursor,
+			getActiveEditorCursorSnapshot(app, file),
+		);
 	} catch {
 		// no-op
 	}
+	return false;
 }

--- a/src/utils/templaterIntegration.ts
+++ b/src/utils/templaterIntegration.ts
@@ -35,26 +35,40 @@ type CursorSnapshot = {
 	ch: number;
 };
 
-function getActiveEditorCursorSnapshot(
+type EditorSnapshot = {
+	cursor: CursorSnapshot | null;
+	value: string | null;
+};
+
+const TEMPLATER_CURSOR_MARKER_REGEX =
+	/<%\s*tp\.file\.cursor\([0-9]*\)\s*%>/g;
+
+function getActiveEditorSnapshot(
 	app: App,
 	file: TFile,
-): CursorSnapshot | null {
+): EditorSnapshot {
 	try {
 		const view = app.workspace.getActiveViewOfType(MarkdownView);
-		if (!view || view.file?.path !== file.path) return null;
-
-		const cursor = view.editor?.getCursor?.();
-		if (
-			!cursor ||
-			typeof cursor.line !== "number" ||
-			typeof cursor.ch !== "number"
-		) {
-			return null;
+		if (!view || view.file?.path !== file.path) {
+			return { cursor: null, value: null };
 		}
 
-		return { line: cursor.line, ch: cursor.ch };
+		const editor = view.editor;
+
+		const cursor = editor?.getCursor?.();
+		const cursorSnapshot =
+			cursor &&
+			typeof cursor.line === "number" &&
+			typeof cursor.ch === "number"
+				? { line: cursor.line, ch: cursor.ch }
+				: null;
+
+		const value =
+			typeof editor?.getValue === "function" ? editor.getValue() : null;
+
+		return { cursor: cursorSnapshot, value };
 	} catch {
-		return null;
+		return { cursor: null, value: null };
 	}
 }
 
@@ -66,6 +80,34 @@ function didCursorMove(
 		before !== null &&
 		after !== null &&
 		(before.line !== after.line || before.ch !== after.ch)
+	);
+}
+
+function countTemplaterCursorMarkers(value: string | null): number | null {
+	if (typeof value !== "string") return null;
+	return [...value.matchAll(TEMPLATER_CURSOR_MARKER_REGEX)].length;
+}
+
+function didConsumeTemplaterCursorMarker(
+	before: string | null,
+	after: string | null,
+): boolean {
+	const beforeMarkerCount = countTemplaterCursorMarkers(before);
+	const afterMarkerCount = countTemplaterCursorMarkers(after);
+	return (
+		beforeMarkerCount !== null &&
+		afterMarkerCount !== null &&
+		beforeMarkerCount > afterMarkerCount
+	);
+}
+
+function didTemplaterHandleCursor(
+	before: EditorSnapshot,
+	after: EditorSnapshot,
+): boolean {
+	return (
+		didCursorMove(before.cursor, after.cursor) ||
+		didConsumeTemplaterCursorMarker(before.value, after.value)
 	);
 }
 
@@ -455,15 +497,15 @@ export async function jumpToNextTemplaterCursorIfPossible(
 	const jump = editorHandler?.jump_to_next_cursor_location;
 
 	if (!autoJumpEnabled) return false;
-	const beforeCursor = getActiveEditorCursorSnapshot(app, file);
+	const beforeJump = getActiveEditorSnapshot(app, file);
 
 	if (typeof jump === "function") {
 		try {
 			// Preserve Templater's internal `this` context.
 			await jump.call(editorHandler, file, true);
-			return didCursorMove(
-				beforeCursor,
-				getActiveEditorCursorSnapshot(app, file),
+			return didTemplaterHandleCursor(
+				beforeJump,
+				getActiveEditorSnapshot(app, file),
 			);
 		} catch (err) {
 			log.logWarning(
@@ -481,9 +523,9 @@ export async function jumpToNextTemplaterCursorIfPossible(
 			"templater-obsidian:jump-to-next-cursor-location",
 		);
 		if (!commandRan) return false;
-		return didCursorMove(
-			beforeCursor,
-			getActiveEditorCursorSnapshot(app, file),
+		return didTemplaterHandleCursor(
+			beforeJump,
+			getActiveEditorSnapshot(app, file),
 		);
 	} catch {
 		// no-op


### PR DESCRIPTION
Fixes #348

Capture choices that wrote to another Markdown file could open the captured file afterward, but Obsidian left the editor cursor at the file's default position. That broke the quick-capture workflow when users wanted to keep typing, add a link, or continue editing right where the capture landed.

This keeps the existing Open captured file behavior and makes it more useful without adding a new setting: after a successful file-based Markdown capture, QuickAdd records the exact formatter insertion offset and, once the destination is opened and focused in an editable Markdown view, places the cursor at the end of the inserted capture.

Design notes:
- The formatter owns placement metadata instead of searching the final file for the captured text, so duplicate snippets and formatter-added separators do not confuse the cursor target.
- Cursor placement is intentionally conservative. It is skipped for preview/unfocused opens, non-Markdown targets, concurrent merge remaps, whole-file Templater rewrites, frontmatter post-processing, and any editor buffer that does not exactly match the content QuickAdd wrote.
- Templater cursor markers keep priority. QuickAdd treats Templater as having handled the cursor when the active editor cursor moves or a `tp.file.cursor(...)` marker is consumed; if Templater auto-jump is enabled but no marker exists, QuickAdd still places the cursor after the capture.

Validation:
- `pnpm run build-with-lint`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run check` (0 errors, existing 4 warnings)
- `pnpm run test` (226 passed, 5 skipped; 2653 passed tests, 37 skipped)
- Focused Vitest coverage for formatter offsets, capture engine cursor gates, Templater cursor ownership/marker consumption, merge safety, and editor cursor placement
- Isolated Obsidian vault via `pnpm run obsidian:e2e -- ...`:
  - reproduced current issue before the fix: opened target cursor at `{line:0,ch:0}` while capture landed under `## Log`
  - after fix: running `QA 348 Capture` opened `qa-348-target.md` with cursor `{line:3,ch:11}`, immediately after `CAPTURE-348` and before existing text
  - verified unfocused open writes the capture but does not apply QuickAdd cursor placement
  - live Templater 2.16.2 matrix in the same isolated vault:
    - auto-jump on, no marker: `NO-MARKER` capture opened with cursor `{line:3,ch:9}` after inserted capture text
    - auto-jump on, `<% tp.file.cursor() %>` marker: marker was consumed and cursor landed `{line:3,ch:0}` before `MARKER`
    - auto-jump on, ordered `<% tp.file.cursor(1) %>` marker: marker was consumed and cursor landed `{line:3,ch:1}` after `A`
    - whole-file Templater marker: marker was consumed and cursor stayed at the Templater marker `{line:2,ch:0}` instead of QuickAdd overriding to the capture end
    - auto-jump off, no marker: QuickAdd fallback placed cursor `{line:3,ch:8}` after `AUTO-OFF`
  - `dev:errors` reported no runtime errors after all live checks
- Adversarial review after implementation and after the Templater review fix found no blockers.
- PR babysitting after the final push: all 9 GitHub checks passed and merge state is `CLEAN`.

Release impact: no settings migration. Existing Capture choices that open focused Markdown targets become easier to continue editing; unsafe cases keep previous open behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced cursor placement after capture operations; cursor now positions at the end of inserted content when focused in edit mode and compatible with Templater cursor markers.

* **Documentation**
  * Added documentation describing cursor-placement behavior for Markdown capture targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->