### PR TITLE
feat(capture): support clipboard image attachments

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -415,6 +415,8 @@ Example: `> {{selected}}`.
 
 The current clipboard content. Will be empty if clipboard access fails due to permissions or security restrictions.
 
+In Capture choice content, if the clipboard has no text but contains a supported image, QuickAdd saves the image using Obsidian's attachment location settings and inserts an embedded attachment link. Clipboard text takes precedence when both text and an image are available.
+
 Example: `Copied: {{CLIPBOARD}}`.
 
 ## `{{RANDOM:<length>}}` {#random}

--- a/src/engine/CaptureChoiceEngine.heading-picker.test.ts
+++ b/src/engine/CaptureChoiceEngine.heading-picker.test.ts
@@ -18,6 +18,9 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 		setInsertAfterTargetOverride(target: string | null) {
 			setInsertAfterTargetOverrideMock(target);
 		}
+		consumeCreatedClipboardAttachmentPaths() {
+			return [];
+		}
 	},
 }));
 

--- a/src/engine/CaptureChoiceEngine.merge.test.ts
+++ b/src/engine/CaptureChoiceEngine.merge.test.ts
@@ -72,6 +72,9 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 		getAndClearTemplatePropertyVars() {
 			return new Map();
 		}
+		consumeCreatedClipboardAttachmentPaths() {
+			return [];
+		}
 	},
 }));
 

--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -63,6 +63,9 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 		getAndClearTemplatePropertyVars() {
 			return new Map();
 		}
+		consumeCreatedClipboardAttachmentPaths() {
+			return [];
+		}
 	}
 	return {
 		CaptureChoiceFormatter: CaptureChoiceFormatterMock,

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -72,6 +72,11 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 			return content.replace(/\{\{value\}\}/gi, submitted);
 		}
 		async formatContentWithFile(content: string) {
+			if (/\{\{clipboard\}\}/i.test(content)) {
+				createdClipboardAttachmentPaths.push("Clipboard image.png");
+				return content.replace(/\{\{clipboard\}\}/gi, "![[Clipboard image.png]]");
+			}
+
 			return content;
 		}
 		async formatFileName(name: string) {
@@ -207,6 +212,7 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 		createdClipboardAttachmentPaths.length = 0;
 		InputPromptDraftStore.getInstance().clearAll();
 		vi.mocked(openFile).mockClear();
+		vi.mocked(insertFileLinkToActiveView).mockReset();
 		vi.mocked(insertOnNewLineBelow).mockReturnValue(true);
 	});
 
@@ -990,6 +996,70 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 
 		expect(setTextMock).toHaveBeenCalled();
 		expect(insertFileLinkToActiveView).not.toHaveBeenCalled();
+	});
+
+	it("does not delete a clipboard attachment after a canvas text-card write if later link insertion fails", async () => {
+		vi.mocked(insertFileLinkToActiveView).mockImplementation(() => {
+			throw new Error("link insertion failed after canvas write");
+		});
+
+		const canvasFile = new TFile();
+		canvasFile.path = "Boards/Map.canvas";
+		canvasFile.basename = "Map";
+		canvasFile.extension = "canvas";
+		const attachmentFile = new TFile();
+		attachmentFile.path = "Clipboard image.png";
+		attachmentFile.basename = "Clipboard image";
+		const setTextMock = vi.fn();
+		const app = createApp() as any;
+		app.workspace.activeLeaf = {
+			view: {
+				getViewType: () => "canvas",
+				file: canvasFile,
+				canvas: {
+					selection: new Set([
+						{
+							id: "text-node-1",
+							type: "text",
+							text: "Current",
+							setText: setTextMock,
+						},
+					]),
+					getData: vi.fn(() => ({
+						nodes: [{ id: "text-node-1", type: "text", text: "Current" }],
+					})),
+					requestSave: vi.fn(),
+				},
+			},
+		};
+		app.workspace.getActiveFile = vi.fn(() => canvasFile);
+		app.workspace.getActiveViewOfType = vi.fn(() => ({}));
+		app.vault.getAbstractFileByPath = vi.fn((path: string) =>
+			path === "Clipboard image.png" ? attachmentFile : null,
+		);
+
+		const engine = new CaptureChoiceEngine(
+			app,
+			{
+				settings: {
+					useSelectionAsCaptureValue: false,
+					showCaptureNotification: true,
+				},
+			} as any,
+			createChoice({
+				appendLink: true,
+				captureToActiveFile: true,
+				activeFileWritePosition: "top",
+				format: { enabled: true, format: "{{clipboard}}" },
+			}),
+			createExecutor(),
+		);
+
+		await engine.run();
+
+		expect(setTextMock).toHaveBeenCalledWith("![[Clipboard image.png]]");
+		expect(insertFileLinkToActiveView).toHaveBeenCalled();
+		expect(app.vault.delete).not.toHaveBeenCalledWith(attachmentFile);
 	});
 
 	it("creates missing linked markdown file for configured canvas file-card targets", async () => {

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Notice, type App } from "obsidian";
+import { Notice, TFile, type App } from "obsidian";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
 import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import {
 	getMarkdownFilesInFolder,
+	insertOnNewLineBelow,
 	insertFileLinkToActiveView,
 	isFolder,
 	openFile,
@@ -22,12 +23,14 @@ const {
 	singleTemplateRunMock,
 	promptResponses,
 	promptHydratedValues,
+	createdClipboardAttachmentPaths,
 } = vi.hoisted(() => ({
 	setUseSelectionAsCaptureValueMock: vi.fn(),
 	setTitleMock: vi.fn(),
 	singleTemplateRunMock: vi.fn(async () => ""),
 	promptResponses: [] as string[],
 	promptHydratedValues: [] as string[],
+	createdClipboardAttachmentPaths: [] as string[],
 }));
 
 vi.mock("../formatters/captureChoiceFormatter", () => ({
@@ -45,6 +48,11 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 			return await work();
 		}
 		async formatContentOnly(content: string) {
+			if (/\{\{clipboard\}\}/i.test(content)) {
+				createdClipboardAttachmentPaths.push("Clipboard image.png");
+				return content.replace(/\{\{clipboard\}\}/gi, "![[Clipboard image.png]]");
+			}
+
 			if (!/\{\{value\}\}/i.test(content)) return content;
 
 			const draftHandler = new InputPromptDraftHandler(
@@ -71,6 +79,9 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 		}
 		getAndClearTemplatePropertyVars() {
 			return new Map();
+		}
+		consumeCreatedClipboardAttachmentPaths() {
+			return createdClipboardAttachmentPaths.splice(0);
 		}
 	},
 	setUseSelectionAsCaptureValueMock,
@@ -131,6 +142,7 @@ const createApp = () =>
 				exists: vi.fn(async () => false),
 			},
 			getAbstractFileByPath: vi.fn(() => null),
+			delete: vi.fn(async () => {}),
 			modify: vi.fn(async () => {}),
 			read: vi.fn(async () => ""),
 		},
@@ -192,8 +204,10 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 		setTitleMock.mockClear();
 		promptResponses.length = 0;
 		promptHydratedValues.length = 0;
+		createdClipboardAttachmentPaths.length = 0;
 		InputPromptDraftStore.getInstance().clearAll();
 		vi.mocked(openFile).mockClear();
+		vi.mocked(insertOnNewLineBelow).mockReturnValue(true);
 	});
 
 	it("uses global setting when no override is set", async () => {
@@ -627,6 +641,47 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		await engine.run();
 
 		expect(clipboardWriteText).not.toHaveBeenCalled();
+	});
+
+	it("removes a created clipboard attachment when editor insertion fails before commit", async () => {
+		const targetFile = new TFile();
+		targetFile.path = "Inbox.md";
+		targetFile.basename = "Inbox";
+		const attachmentFile = new TFile();
+		attachmentFile.path = "Clipboard image.png";
+		attachmentFile.basename = "Clipboard image";
+		const app = createApp() as any;
+		app.workspace.getActiveFile = vi.fn(() => targetFile);
+		app.vault.adapter.exists = vi.fn(async () => true);
+		app.vault.getAbstractFileByPath = vi.fn((path: string) =>
+			path === "Inbox.md" ? targetFile : attachmentFile,
+		);
+		vi.mocked(insertOnNewLineBelow).mockReturnValue(false);
+
+		const executor = createExecutor();
+		executor.recordExecutionResult = vi.fn();
+		const engine = new CaptureChoiceEngine(
+			app,
+			{
+				settings: {
+					useSelectionAsCaptureValue: false,
+					showCaptureNotification: true,
+				},
+			} as any,
+			createChoice({
+				captureToActiveFile: true,
+				newLineCapture: { enabled: true, direction: "below" },
+				format: { enabled: true, format: "{{clipboard}}" },
+			}),
+			executor,
+		);
+
+		await engine.run();
+
+		expect(app.vault.delete).toHaveBeenCalledWith(attachmentFile);
+		expect(executor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "error",
+		});
 	});
 
 	it("keeps submitted VALUE prompt draft after failed target creation and clears it after success", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -224,6 +224,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	}
 
 	async run(): Promise<void> {
+		let contentCommitted = false;
 		try {
 			// Reset any pending structured values before starting a new capture run
 			this.capturePropertyVars.clear();
@@ -256,6 +257,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 			if (canvasTarget?.kind === "text") {
 				await this.handleCanvasTextCapture(canvasTarget, action, linkOptions);
+				contentCommitted = true;
 				return;
 			}
 
@@ -390,6 +392,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				if (!inserted) {
 					// No active Markdown editor — the capture did not land. Report a
 					// failure instead of falling through to the success notice/callback.
+					await this.cleanupCreatedClipboardAttachments();
 					InputPromptDraftStore.getInstance().markExecutionScopeFailed();
 					log.logError(
 						`Capture "${this.choice.name}": no active Markdown editor to insert into.`,
@@ -397,8 +400,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					this.choiceExecutor.recordExecutionResult?.({ status: "error" });
 					return;
 				}
+				contentCommitted = true;
 			} else {
 				await this.app.vault.modify(file, newFileContent);
+				contentCommitted = true;
 				if (this.choice.templater?.afterCapture === "wholeFile") {
 					await overwriteTemplaterOnce(this.app, file);
 				}
@@ -438,6 +443,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				await jumpToNextTemplaterCursorIfPossible(this.app, file);
 			}
 		} catch (err) {
+			if (!contentCommitted) {
+				await this.cleanupCreatedClipboardAttachments();
+			}
 			if (
 				handleMacroAbort(err, {
 					logPrefix: "Capture execution aborted",
@@ -450,6 +458,26 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			}
 			InputPromptDraftStore.getInstance().markExecutionScopeFailed();
 			reportError(err, `Error running capture choice "${this.choice.name}"`);
+		} finally {
+			if (contentCommitted) {
+				this.formatter.consumeCreatedClipboardAttachmentPaths();
+			}
+		}
+	}
+
+	private async cleanupCreatedClipboardAttachments(): Promise<void> {
+		const paths = this.formatter.consumeCreatedClipboardAttachmentPaths();
+		for (const path of paths) {
+			try {
+				const file = this.app.vault.getAbstractFileByPath(path);
+				if (file instanceof TFile) {
+					await this.app.vault.delete(file);
+				}
+			} catch (error) {
+				log.logWarning(
+					`QuickAdd: failed to clean up clipboard attachment '${path}': ${String(error)}`,
+				);
+			}
 		}
 	}
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -256,8 +256,14 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			const canvasTarget = activeCanvasTarget ?? configuredCanvasTarget;
 
 			if (canvasTarget?.kind === "text") {
-				await this.handleCanvasTextCapture(canvasTarget, action, linkOptions);
-				contentCommitted = true;
+				await this.handleCanvasTextCapture(
+					canvasTarget,
+					action,
+					linkOptions,
+					() => {
+						contentCommitted = true;
+					},
+				);
 				return;
 			}
 
@@ -485,6 +491,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		target: CanvasTextCaptureTarget,
 		action: CaptureAction,
 		linkOptions: AppendLinkOptions,
+		markContentCommitted: () => void,
 	): Promise<void> {
 		if (
 			action === "currentLine" ||
@@ -533,6 +540,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		this.captureResolvedOrderedHeading();
 
 		await setCanvasTextCaptureContent(this.app, target, nextText);
+		markContentCommitted();
 
 		// Committed; record success before cosmetic steps (see run() for rationale).
 		this.choiceExecutor.recordExecutionResult?.({ status: "success", file });

--- a/src/formatters/captureChoiceFormatter-clipboard.test.ts
+++ b/src/formatters/captureChoiceFormatter-clipboard.test.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+
+vi.mock("obsidian", () => ({
+	MarkdownView: class {},
+	normalizePath: (path: string) => path.replace(/\\/g, "/").replace(/\/+/g, "/"),
+}));
+
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory() {
+			return {
+				Prompt: vi.fn().mockResolvedValue(""),
+				PromptWithContext: vi.fn().mockResolvedValue(""),
+			};
+		}
+	},
+}));
+
+vi.mock("src/gui/GenericInputPrompt/GenericInputPrompt", () => ({
+	__esModule: true,
+	default: { PromptWithContext: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("src/gui/MultiSuggester/multiSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock("src/gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		async runAndGetOutput() {
+			return "";
+		}
+		getVariables() {
+			return new Map();
+		}
+	},
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+		setTargetFolderPath() {}
+	},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../logger/logManager", () => ({
+	log: {
+		logError: vi.fn(),
+		logWarning: vi.fn(),
+		logMessage: vi.fn(),
+	},
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+function createTFile(path: string): TFile {
+	const name = path.split("/").pop() ?? path;
+	return {
+		path,
+		name,
+		basename: name.replace(/\.[^.]+$/, ""),
+		extension: name.includes(".") ? name.split(".").pop() : "",
+	} as unknown as TFile;
+}
+
+function createMockApp() {
+	const createBinary = vi.fn(async (path: string) => createTFile(path));
+	const getAvailablePathForAttachment = vi.fn(async () => "Assets/clip.png");
+	const generateMarkdownLink = vi.fn((file: TFile) => `[[${file.path}]]`);
+	const app = {
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(null),
+		},
+		metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		fileManager: {
+			generateMarkdownLink,
+			getAvailablePathForAttachment,
+			processFrontMatter: vi.fn(),
+		},
+		vault: {
+			adapter: { exists: vi.fn() },
+			cachedRead: vi.fn(),
+			createBinary,
+		},
+	} as unknown as App;
+
+	return {
+		app,
+		createBinary,
+		generateMarkdownLink,
+		getAvailablePathForAttachment,
+	};
+}
+
+function createFormatter(app: App) {
+	const plugin = {
+		settings: {
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+			inputPrompt: "single-line",
+			showCaptureNotification: false,
+		},
+	};
+	return new CaptureChoiceFormatter(app, plugin as never);
+}
+
+function setClipboard({
+	text = "",
+	items = [],
+	readRejects = false,
+}: {
+	text?: string;
+	items?: ClipboardItem[];
+	readRejects?: boolean;
+}) {
+	const readText = vi.fn().mockResolvedValue(text);
+	const read = readRejects
+		? vi.fn().mockRejectedValue(new Error("not focused"))
+		: vi.fn().mockResolvedValue(items);
+	Object.defineProperty(globalThis, "navigator", {
+		value: { clipboard: { readText, read } },
+		configurable: true,
+	});
+	return { read, readText };
+}
+
+function createClipboardItem(mimeType: string, bytes: number[]): ClipboardItem {
+	const blob = new Blob([new Uint8Array(bytes)], { type: mimeType });
+	return {
+		types: [mimeType],
+		getType: vi.fn().mockResolvedValue(blob),
+	} as unknown as ClipboardItem;
+}
+
+describe("CaptureChoiceFormatter clipboard image support", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+		setClipboard({});
+	});
+
+	it("uses clipboard text before trying image attachment fallback", async () => {
+		const { app, createBinary } = createMockApp();
+		const item = createClipboardItem("image/png", [1, 2, 3]);
+		const { read } = setClipboard({ text: "copied text", items: [item] });
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		const result = await formatter.formatContentOnly("Copied: {{clipboard}}");
+
+		expect(result).toBe("Copied: copied text");
+		expect(read).not.toHaveBeenCalled();
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("saves an image-only clipboard as one attachment and inserts an embed", async () => {
+		vi.setSystemTime(new Date("2026-06-17T10:11:12Z"));
+		const {
+			app,
+			createBinary,
+			generateMarkdownLink,
+			getAvailablePathForAttachment,
+		} = createMockApp();
+		const item = createClipboardItem("image/png", [1, 2, 3]);
+		setClipboard({ items: [item] });
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		const result = await formatter.formatContentOnly(
+			"One {{clipboard}} Two {{clipboard}}",
+		);
+
+		expect(result).toBe("One ![[Assets/clip.png]] Two ![[Assets/clip.png]]");
+		expect(getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.stringMatching(
+				/^Clipboard image \d{4}-\d{2}-\d{2} \d{2}\.\d{2}\.\d{2}\.png$/,
+			),
+			"Notes/Clip.md",
+		);
+		expect(createBinary).toHaveBeenCalledTimes(1);
+		expect(createBinary).toHaveBeenCalledWith(
+			"Assets/clip.png",
+			expect.any(ArrayBuffer),
+		);
+		expect(generateMarkdownLink).toHaveBeenCalledWith(
+			expect.objectContaining({ path: "Assets/clip.png" }),
+			"Notes/Clip.md",
+		);
+	});
+
+	it("inserts clipboard text literally when it contains the clipboard token", async () => {
+		const { app } = createMockApp();
+		setClipboard({ text: "{{clipboard}}" });
+		const formatter = createFormatter(app);
+
+		const result = await formatter.formatContentOnly("A {{clipboard}} B");
+
+		expect(result).toBe("A {{clipboard}} B");
+	});
+
+	it("keeps image fallback disabled for file name formatting", async () => {
+		const { app, createBinary } = createMockApp();
+		const item = createClipboardItem("image/png", [1, 2, 3]);
+		const { read } = setClipboard({ items: [item] });
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		const result = await formatter.formatFileName("{{clipboard}}", "Capture");
+
+		expect(result).toBe("");
+		expect(read).not.toHaveBeenCalled();
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("falls back to empty when image clipboard access is unavailable", async () => {
+		const { app, createBinary } = createMockApp();
+		const { read } = setClipboard({ readRejects: true });
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		const result = await formatter.formatContentOnly("[{{clipboard}}]");
+
+		expect(result).toBe("[]");
+		expect(read).toHaveBeenCalledOnce();
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("throws when an attachment write fails after finding an image", async () => {
+		const { app, createBinary } = createMockApp();
+		createBinary.mockRejectedValueOnce(new Error("write failed"));
+		const item = createClipboardItem("image/png", [1, 2, 3]);
+		setClipboard({ items: [item] });
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		await expect(formatter.formatContentOnly("{{clipboard}}")).rejects.toThrow(
+			"write failed",
+		);
+	});
+
+	it("keeps a created attachment path available for rollback when link generation fails", async () => {
+		const { app, generateMarkdownLink } = createMockApp();
+		generateMarkdownLink.mockImplementationOnce(() => {
+			throw new Error("link failed");
+		});
+		const item = createClipboardItem("image/png", [1, 2, 3]);
+		setClipboard({ items: [item] });
+		const formatter = createFormatter(app);
+		formatter.setDestinationSourcePath("Notes/Clip.md");
+
+		await expect(formatter.formatContentOnly("{{clipboard}}")).rejects.toThrow(
+			"link failed",
+		);
+		expect(formatter.consumeCreatedClipboardAttachmentPaths()).toEqual([
+			"Assets/clip.png",
+		]);
+	});
+});

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -30,6 +30,14 @@ import { parentFolderPath } from "../utils/pathUtils";
 	* dropped, even though String.prototype.trim() strips them (issue #760).
 	*/
 const ASCII_WHITESPACE_ONLY_REGEX = /^[ \t\r\n\f\v]*$/;
+const imageClipboardMimeExtensions: Record<string, string> = {
+	"image/png": "png",
+	"image/jpeg": "jpg",
+	"image/jpg": "jpg",
+	"image/gif": "gif",
+	"image/webp": "webp",
+	"image/svg+xml": "svg",
+};
 
 function isCaptureContentEmpty(content: string): boolean {
 	return ASCII_WHITESPACE_ONLY_REGEX.test(content);
@@ -41,6 +49,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	private fileContent = "";
 	private sourcePath: string | null = null;
 	private useSelectionAsCaptureValue = true;
+	private clipboardImageFallbackEnabled = false;
+	private clipboardAttachmentLink: string | null | undefined;
+	private createdClipboardAttachmentPaths: string[] = [];
 	/**
 		* Tracks whether the current formatter instance has already run Templater on the
 		* capture payload.  This prevents the same content from being parsed twice in
@@ -82,6 +93,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	public setDestinationFile(file: TFile): void {
 		this.file = file;
 		this.sourcePath = file.path;
+		this.clipboardAttachmentLink = undefined;
 		// {{FOLDER}} in a capture body resolves to the destination file's folder.
 		this.setTargetFolderPath(parentFolderPath(file.path));
 	}
@@ -89,6 +101,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	public setDestinationSourcePath(path: string): void {
 		this.sourcePath = path;
 		this.file = null;
+		this.clipboardAttachmentLink = undefined;
 		this.setTargetFolderPath(parentFolderPath(path));
 	}
 
@@ -116,6 +129,12 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		return this.lastResolvedInsertAfterHeading;
 	}
 
+	public consumeCreatedClipboardAttachmentPaths(): string[] {
+		const paths = this.createdClipboardAttachmentPaths;
+		this.createdClipboardAttachmentPaths = [];
+		return paths;
+	}
+
 	protected shouldUseSelectionForValue(): boolean {
 		return this.useSelectionAsCaptureValue;
 	}
@@ -127,6 +146,86 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 
 	protected getLinkSourcePath(): string | null {
 		return this.sourcePath ?? this.file?.path ?? null;
+	}
+
+	protected async getClipboardContent(): Promise<string> {
+		const text = await super.getClipboardContent();
+		if (text.length > 0 || !this.clipboardImageFallbackEnabled) {
+			return text;
+		}
+
+		if (this.clipboardAttachmentLink !== undefined) {
+			return this.clipboardAttachmentLink ?? "";
+		}
+
+		this.clipboardAttachmentLink = await this.saveClipboardImageAsAttachment();
+		return this.clipboardAttachmentLink ?? "";
+	}
+
+	private async withClipboardImageFallback<T>(work: () => Promise<T>): Promise<T> {
+		const previous = this.clipboardImageFallbackEnabled;
+		this.clipboardImageFallbackEnabled = true;
+		try {
+			return await work();
+		} finally {
+			this.clipboardImageFallbackEnabled = previous;
+		}
+	}
+
+	private async saveClipboardImageAsAttachment(): Promise<string | null> {
+		const clipboard = navigator.clipboard as Clipboard & {
+			read?: () => Promise<ClipboardItem[]>;
+		};
+		if (typeof clipboard?.read !== "function") return null;
+
+		let item: { clipboardItem: ClipboardItem; mimeType: string } | null;
+		let data: ArrayBuffer;
+		try {
+			item = await this.getFirstClipboardImageItem(clipboard);
+			if (!item) return null;
+
+			const blob = await item.clipboardItem.getType(item.mimeType);
+			data = await blob.arrayBuffer();
+		} catch {
+			return null;
+		}
+
+		const extension = imageClipboardMimeExtensions[item.mimeType];
+		const filename = `Clipboard image ${this.formatAttachmentTimestamp(new Date())}.${extension}`;
+		const sourcePath = this.getLinkSourcePath() ?? "";
+		const attachmentPath =
+			await this.app.fileManager.getAvailablePathForAttachment(
+				filename,
+				sourcePath || undefined,
+			);
+		const file = await this.app.vault.createBinary(attachmentPath, data);
+		this.createdClipboardAttachmentPaths.push(file.path);
+		const link = this.app.fileManager.generateMarkdownLink(file, sourcePath);
+
+		return link.startsWith("!") ? link : `!${link}`;
+	}
+
+	private async getFirstClipboardImageItem(clipboard: {
+		read: () => Promise<ClipboardItem[]>;
+	}): Promise<{ clipboardItem: ClipboardItem; mimeType: string } | null> {
+		const items = await clipboard.read();
+		for (const clipboardItem of items) {
+			const mimeType = clipboardItem.types.find(
+				(type) => imageClipboardMimeExtensions[type] !== undefined,
+			);
+			if (mimeType) return { clipboardItem, mimeType };
+		}
+
+		return null;
+	}
+
+	private formatAttachmentTimestamp(date: Date): string {
+		const pad = (value: number) => String(value).padStart(2, "0");
+		return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+			date.getDate(),
+		)} ${pad(date.getHours())}.${pad(date.getMinutes())}.${pad(
+			date.getSeconds(),
+		)}`;
 	}
 
 	protected getCurrentFileLink(): string | null {
@@ -178,8 +277,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	async formatFileContent(input: string, runTemplater = true): Promise<string> {
-		let formatted = await super.formatFileContent(
-			await this.expandTemplateLinebreaksOnce(input),
+		let formatted = await this.withClipboardImageFallback(async () =>
+			super.formatFileContent(await this.expandTemplateLinebreaksOnce(input)),
 		);
 
 		// Run templater only once per capture payload to prevent #533 double execution
@@ -234,8 +333,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	async formatContentOnly(input: string): Promise<string> {
 		// Process the input with templater (if needed) at this stage
 		// This is the first pass where we want to run any templater code
-		const formatted = await super.formatFileContent(
-			await this.expandTemplateLinebreaksOnce(input),
+		const formatted = await this.withClipboardImageFallback(async () =>
+			super.formatFileContent(await this.expandTemplateLinebreaksOnce(input)),
 		);
 
 		// DON'T run templater parsing here - it will be handled either by:

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -291,15 +291,11 @@ export abstract class Formatter {
 	}
 
 	protected async replaceClipboardInString(input: string): Promise<string> {
-		let output: string = input;
+		if (!CLIPBOARD_REGEX.test(input)) return input;
 
 		const clipboardContent = await this.getClipboardContent();
-
-		while (CLIPBOARD_REGEX.test(output)) {
-			output = this.replacer(output, CLIPBOARD_REGEX, clipboardContent);
-		}
-
-		return output;
+		const regex = new RegExp(CLIPBOARD_REGEX.source, "gi");
+		return input.replace(regex, () => clipboardContent);
 	}
 
 


### PR DESCRIPTION
Support image-only clipboards for Capture choice content that already uses `{{clipboard}}`.

The underlying problem is that users can build a Capture choice that accepts copied text, but the same workflow fails for copied screenshots/images: `{{clipboard}}` resolves through `navigator.clipboard.readText()`, so an image-only clipboard becomes an empty insertion. This keeps the existing token instead of adding a second image-specific token so one capture can accept either text or an image.

Design choices:
- Text clipboard content still wins. If the clipboard has text, `{{clipboard}}` behaves exactly as before and no image read/write is attempted.
- Image fallback is enabled only while formatting Capture choice content. File names, destination paths, insert-after selectors, and other formatter contexts stay text-only and side-effect-free.
- Supported image clipboard MIME types are saved through Obsidian's attachment APIs, using the vault's attachment-location rules, then inserted as an embedded markdown link.
- Repeated `{{clipboard}}` tokens in one capture reuse the same saved attachment instead of creating duplicates.
- Clipboard read failures, unfocused documents, unsupported clipboard contents, and missing image clipboard APIs preserve the existing empty-token behavior.
- Attachment path/write/link failures now abort the capture instead of silently inserting an empty string; attachments created before an uncommitted capture failure are rolled back.

I did not add RTF support here. I also kept the implementation scoped to direct Capture content; included template bodies still render through the template engine's existing formatter path and are not widened in this PR.

Validation evidence:
- Reproduced the current issue in this worktree's isolated Obsidian vault: image clipboard + `Copied: {{clipboard}}` produced `Copied: ` and no attachment.
- Final live app validation after `pnpm run build-with-lint` and `pnpm run obsidian:e2e -- plugin:reload id=quickadd`: with CDP focus emulation, the isolated renderer saw clipboard types `[["image/png"]]`; `quickadd:run` inserted `Copied: ![[Clipboard image 2026-06-17 23.55.31.png]]` and created the PNG attachment in the vault.
- Final text regression validation in the same isolated vault inserted `Copied: plain text final final`, created no attachment, and preserved the existing text-first behavior.
- `pnpm run obsidian:e2e -- dev:errors` reported no errors after both live runs.
- `pnpm run check` passed (`0` errors, `4` existing warnings).
- `pnpm test` passed (`226` files passed, `5` skipped; `2647` tests passed, `37` skipped).
- `pnpm run build-with-lint` passed (`tsc --noEmit`, ESLint, production bundle).

Fixes #1161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image fallback for `{{CLIPBOARD}}`—when clipboard contains only an image, it automatically saves the image as a vault attachment and embeds it.

* **Documentation**
  * Updated `{{CLIPBOARD}}` documentation to clarify image handling and attachment insertion behavior.

* **Tests**
  * Added comprehensive test coverage for clipboard image functionality and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->