### PR TITLE
feat: append links to frontmatter properties

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -170,10 +170,10 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
     -   **New line** - Places the link on a new line below the cursor
     -   **In frontmatter property** - Adds the link to a named frontmatter property
 
-    When **In frontmatter property** is selected, set the property name and choose how QuickAdd handles missing or non-list properties:
-    -   **Require existing list** - Append only to an existing list property. Empty/null properties are treated as empty lists; missing properties and existing scalar/object values throw an error.
-    -   **Create missing property** - Create the property if it is missing. Existing scalar/object values still throw an error.
-    -   **Create or convert to list** - Create the property if it is missing, or convert an existing scalar value into a list before appending the new link. Object values still throw an error.
+    When **In frontmatter property** is selected, set the property name and choose how strictly QuickAdd should handle missing or non-list properties:
+    -   **Create or convert** (default) - Create the property if it is missing, or convert an existing scalar value into a list before appending the new link. Object values still throw an error.
+    -   **Create if missing** - Create the property if it is missing. Existing scalar/object values still throw an error.
+    -   **Require list** - Append only to an existing list property. Empty/null properties are treated as empty lists; missing properties and existing scalar/object values throw an error.
 
     If the cursor is in an editable Obsidian Properties field when the Capture
     choice starts, and the placement is not **In frontmatter property**, QuickAdd

--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -168,12 +168,18 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
     -   **After selection** - Preserves selected text and places the link after it
     -   **End of line** - Places the link at the end of the current line
     -   **New line** - Places the link on a new line below the cursor
+    -   **In frontmatter property** - Adds the link to a named frontmatter property
+
+    When **In frontmatter property** is selected, set the property name and choose how QuickAdd handles missing or non-list properties:
+    -   **Require existing list** - Append only to an existing list property. Empty/null properties are treated as empty lists; missing properties and existing scalar/object values throw an error.
+    -   **Create missing property** - Create the property if it is missing. Existing scalar/object values still throw an error.
+    -   **Create or convert to list** - Create the property if it is missing, or convert an existing scalar value into a list before appending the new link. Object values still throw an error.
 
     If the cursor is in an editable Obsidian Properties field when the Capture
-    choice starts, QuickAdd appends the link to that property instead of using
-    the stale editor cursor behind the Properties panel. Text properties receive
-    the link at the end of the value, and list properties receive a new list
-    item.
+    choice starts, and the placement is not **In frontmatter property**, QuickAdd
+    appends the link to that focused property instead of using the stale editor
+    cursor behind the Properties panel. Text properties receive the link at the
+    end of the value, and list properties receive a new list item.
 
     When placement is **Replace selection**, an extra _Link type_ dropdown appears, letting you choose **Link** or **Embed**. Embed is only respected for the Replace selection placement.
 

--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -169,6 +169,12 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
     -   **End of line** - Places the link at the end of the current line
     -   **New line** - Places the link on a new line below the cursor
 
+    If the cursor is in an editable Obsidian Properties field when the Capture
+    choice starts, QuickAdd appends the link to that property instead of using
+    the stale editor cursor behind the Properties panel. Text properties receive
+    the link at the end of the value, and list properties receive a new list
+    item.
+
     When placement is **Replace selection**, an extra _Link type_ dropdown appears, letting you choose **Link** or **Embed**. Embed is only respected for the Replace selection placement.
 
     For the **Specified note** destination, choose an existing Markdown file. QuickAdd appends a normal link at the bottom of that file after each successful capture. It does not create the index file, insert under a heading, update properties, or remove duplicate links.

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -71,11 +71,18 @@ For the **Current note** destination, **Link placement** lets you choose where t
 - **After selection** - Preserves selected text and places the link after it  
 - **End of line** - Places the link at the end of the current line
 - **New line** - Places the link on a new line below the cursor
+- **In frontmatter property** - Adds the link to a named frontmatter property
+
+When **In frontmatter property** is selected, set the property name and choose how QuickAdd handles missing or non-list properties:
+- **Require existing list** - Append only to an existing list property. Empty/null properties are treated as empty lists; missing properties and existing scalar/object values throw an error.
+- **Create missing property** - Create the property if it is missing. Existing scalar/object values still throw an error.
+- **Create or convert to list** - Create the property if it is missing, or convert an existing scalar value into a list before appending the new link. Object values still throw an error.
 
 If the cursor is in an editable Obsidian Properties field when the Template
-choice starts, QuickAdd appends the link to that property instead of using the
-stale editor cursor behind the Properties panel. Text properties receive the link
-at the end of the value, and list properties receive a new list item.
+choice starts, and the placement is not **In frontmatter property**, QuickAdd
+appends the link to that focused property instead of using the stale editor
+cursor behind the Properties panel. Text properties receive the link at the end
+of the value, and list properties receive a new list item.
 
 **Link type**. Shown only when **Link placement** is **Replace selection**. Choose whether replacing the selection should insert a **Link** or an **Embed**.
 

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -73,10 +73,10 @@ For the **Current note** destination, **Link placement** lets you choose where t
 - **New line** - Places the link on a new line below the cursor
 - **In frontmatter property** - Adds the link to a named frontmatter property
 
-When **In frontmatter property** is selected, set the property name and choose how QuickAdd handles missing or non-list properties:
-- **Require existing list** - Append only to an existing list property. Empty/null properties are treated as empty lists; missing properties and existing scalar/object values throw an error.
-- **Create missing property** - Create the property if it is missing. Existing scalar/object values still throw an error.
-- **Create or convert to list** - Create the property if it is missing, or convert an existing scalar value into a list before appending the new link. Object values still throw an error.
+When **In frontmatter property** is selected, set the property name and choose how strictly QuickAdd should handle missing or non-list properties:
+- **Create or convert** (default) - Create the property if it is missing, or convert an existing scalar value into a list before appending the new link. Object values still throw an error.
+- **Create if missing** - Create the property if it is missing. Existing scalar/object values still throw an error.
+- **Require list** - Append only to an existing list property. Empty/null properties are treated as empty lists; missing properties and existing scalar/object values throw an error.
 
 If the cursor is in an editable Obsidian Properties field when the Template
 choice starts, and the placement is not **In frontmatter property**, QuickAdd

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -72,6 +72,11 @@ For the **Current note** destination, **Link placement** lets you choose where t
 - **End of line** - Places the link at the end of the current line
 - **New line** - Places the link on a new line below the cursor
 
+If the cursor is in an editable Obsidian Properties field when the Template
+choice starts, QuickAdd appends the link to that property instead of using the
+stale editor cursor behind the Properties panel. Text properties receive the link
+at the end of the value, and list properties receive a new list item.
+
 **Link type**. Shown only when **Link placement** is **Replace selection**. Choose whether replacing the selection should insert a **Link** or an **Embed**.
 
 For the **Specified note** destination, choose an existing Markdown file. QuickAdd appends a normal link at the bottom of that file. It does not create the index file, insert under a heading, update properties, or remove duplicate links.

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -3,6 +3,7 @@ import type ITemplateChoice from "./types/choices/ITemplateChoice";
 import type ICaptureChoice from "./types/choices/ICaptureChoice";
 import type { MacroAbortError } from "./errors/MacroAbortError";
 import type { ChoiceOutcome } from "./types/ChoiceOutcome";
+import type { FrontmatterPropertyTarget } from "./utils/frontmatterPropertyLinks";
 
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
@@ -18,6 +19,12 @@ export interface IChoiceExecutor {
 		choice: ITemplateChoice | ICaptureChoice,
 	): Promise<ChoiceOutcome>;
 	variables: Map<string, unknown>;
+	/**
+	 * Frontmatter property value focused when the outermost choice execution began.
+	 * Append Link uses this to avoid the stale CodeMirror cursor Obsidian reports
+	 * while a Properties field owns focus.
+	 */
+	focusedProperty?: FrontmatterPropertyTarget | null;
 	/**
 	 * Records the structured outcome of the current execution so an orchestrator
 	 * (the URI x-callback handler, via {@link ChoiceExecutor.executeWithOutcome}) can

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -8,6 +8,15 @@ import type { FrontmatterPropertyTarget } from "./utils/frontmatterPropertyLinks
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
 	/**
+	 * Executes a choice while reusing a frontmatter property target captured before
+	 * an intermediate UI layer, such as a Multi-choice suggester, stole focus.
+	 * Optional so existing stubs can fall back to {@link execute}.
+	 */
+	executeWithFocusedProperty?(
+		choice: IChoice,
+		focusedProperty: FrontmatterPropertyTarget | null,
+	): Promise<void>;
+	/**
 	 * Executes a Template/Capture choice and returns its structured outcome
 	 * (success with the affected file, error, or cancelled) instead of the void
 	 * {@link execute}. Callers that must report real success/failure — the URI

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -18,11 +18,17 @@ import { isCancellationError, reportError } from "./utils/errorUtils";
 import { getOpenFileOriginLeaf } from "./utilityObsidian";
 import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
 import type { ChoiceOutcome } from "./types/ChoiceOutcome";
+import {
+	getFocusedPropertyTarget,
+	type FrontmatterPropertyTarget,
+} from "./utils/frontmatterPropertyLinks";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
+	public focusedProperty: FrontmatterPropertyTarget | null = null;
 	private pendingAbort: MacroAbortError | null = null;
 	private pendingResult: ChoiceOutcome | null = null;
+	private executionDepth = 0;
 
 	constructor(private app: App, private plugin: QuickAdd) {}
 
@@ -40,6 +46,20 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		this.pendingResult = result;
 	}
 
+	private beginExecutionContext(): void {
+		if (this.executionDepth === 0) {
+			this.focusedProperty = getFocusedPropertyTarget(this.app);
+		}
+		this.executionDepth++;
+	}
+
+	private endExecutionContext(): void {
+		this.executionDepth = Math.max(0, this.executionDepth - 1);
+		if (this.executionDepth === 0) {
+			this.focusedProperty = null;
+		}
+	}
+
 	async execute(choice: IChoice): Promise<void> {
 		this.pendingAbort = null;
 		// Keep a nested execute() (e.g. a {{MACRO}} in a Template/Capture body that runs
@@ -47,6 +67,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		// enclosing executeWithOutcome(): snapshot and restore pendingResult so the nested
 		// choice's recorded result never leaks into the outer choice's reported outcome.
 		const savedResult = this.pendingResult;
+		this.beginExecutionContext();
 		const originLeaf = getOpenFileOriginLeaf(this.app);
 		const promptDraftStore = InputPromptDraftStore.getInstance();
 		promptDraftStore.beginExecutionScope();
@@ -90,6 +111,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			throw error;
 		} finally {
 			this.pendingResult = savedResult;
+			this.endExecutionContext();
 		}
 	}
 
@@ -109,6 +131,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	): Promise<ChoiceOutcome> {
 		this.pendingAbort = null;
 		this.pendingResult = null;
+		this.beginExecutionContext();
 		const originLeaf = getOpenFileOriginLeaf(this.app);
 		const promptDraftStore = InputPromptDraftStore.getInstance();
 		promptDraftStore.beginExecutionScope();
@@ -145,6 +168,8 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			}
 			reportError(error, "Error executing choice from URI");
 			return { status: "error" };
+		} finally {
+			this.endExecutionContext();
 		}
 	}
 

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -29,6 +29,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	private pendingAbort: MacroAbortError | null = null;
 	private pendingResult: ChoiceOutcome | null = null;
 	private executionDepth = 0;
+	private focusedPropertyOverride: FrontmatterPropertyTarget | null | undefined;
 
 	constructor(private app: App, private plugin: QuickAdd) {}
 
@@ -48,7 +49,10 @@ export class ChoiceExecutor implements IChoiceExecutor {
 
 	private beginExecutionContext(): void {
 		if (this.executionDepth === 0) {
-			this.focusedProperty = getFocusedPropertyTarget(this.app);
+			this.focusedProperty =
+				this.focusedPropertyOverride !== undefined
+					? this.focusedPropertyOverride
+					: getFocusedPropertyTarget(this.app);
 		}
 		this.executionDepth++;
 	}
@@ -112,6 +116,19 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		} finally {
 			this.pendingResult = savedResult;
 			this.endExecutionContext();
+		}
+	}
+
+	async executeWithFocusedProperty(
+		choice: IChoice,
+		focusedProperty: FrontmatterPropertyTarget | null,
+	): Promise<void> {
+		const previousOverride = this.focusedPropertyOverride;
+		this.focusedPropertyOverride = focusedProperty;
+		try {
+			await this.execute(choice);
+		} finally {
+			this.focusedPropertyOverride = previousOverride;
 		}
 	}
 
@@ -251,6 +268,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	private onChooseMultiType(multiChoice: IMultiChoice) {
 		ChoiceSuggester.Open(this.plugin, multiChoice.choices, {
 			choiceExecutor: this,
+			focusedProperty: this.focusedProperty,
 			placeholder: multiChoice.placeholder,
 		});
 	}

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1403,7 +1403,10 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(insertFileLinkToActiveView).toHaveBeenCalledWith(
 			app,
 			linkedFile,
-			appendLink,
+			expect.objectContaining({
+				...appendLink,
+				destination: { type: "activeFile" },
+			}),
 		);
 	});
 

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1326,6 +1326,87 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(insertFileLinkToActiveView).not.toHaveBeenCalled();
 	});
 
+	it("does not skip configured frontmatter link insertion for canvas file-card capture", async () => {
+		vi.mocked(insertFileLinkToActiveView).mockImplementation(() => {
+			throw new Error("frontmatter link insertion failed");
+		});
+
+		const canvasFile = {
+			path: "Boards/Map.canvas",
+			basename: "Map",
+			extension: "canvas",
+		};
+		const linkedFile = {
+			path: "Folder/Note.md",
+			basename: "Note",
+			extension: "md",
+		} as TFile;
+		const app = createApp() as any;
+		app.workspace.activeLeaf = {
+			view: {
+				getViewType: () => "canvas",
+				file: canvasFile,
+				canvas: {
+					selection: new Set([
+						{ type: "file", file: { path: "Folder/Note.md" } },
+					]),
+				},
+			},
+		};
+		app.workspace.getActiveFile = vi.fn(() => canvasFile);
+		app.workspace.getActiveViewOfType = vi.fn(() => null);
+		app.vault.getAbstractFileByPath = vi.fn((path: string) =>
+			path === "Folder/Note.md" ? linkedFile : null,
+		);
+		app.vault.modify = vi.fn(async () => {});
+
+		const executor = createExecutor();
+		executor.recordExecutionResult = vi.fn();
+		const appendLink = {
+			enabled: true,
+			placement: "inFrontmatter" as const,
+			requireActiveFile: true,
+			linkType: "link" as const,
+			frontmatterProperty: "related",
+			frontmatterHandling: "error" as const,
+		};
+		const engine = new CaptureChoiceEngine(
+			app,
+			{
+				settings: {
+					useSelectionAsCaptureValue: false,
+					showCaptureNotification: false,
+				},
+			} as any,
+			createChoice({
+				appendLink,
+				captureToActiveFile: true,
+				activeFileWritePosition: "top",
+			}),
+			executor,
+		);
+
+		(engine as any).fileExists = vi.fn(async () => true);
+		(engine as any).onFileExists = vi.fn(async () => ({
+			file: linkedFile,
+			newFileContent: "updated",
+			captureContent: "capture",
+		}));
+
+		await engine.run();
+
+		expect(app.vault.modify).toHaveBeenCalledWith(linkedFile, "updated");
+		expect(executor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: linkedFile,
+		});
+		expect(insertFileLinkToActiveView).toHaveBeenCalledWith(
+			app,
+			linkedFile,
+			appendLink,
+		);
+	});
+
 	it("skips required append-link insertion for active canvas text-card capture without markdown context", async () => {
 		vi.mocked(insertFileLinkToActiveView).mockImplementation(() => {
 			throw new Error("link insertion should be skipped");

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -28,6 +28,7 @@ import type QuickAdd from "../main";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import {
 	normalizeAppendLinkOptions,
+	placementSupportsFrontmatter,
 	type AppendLinkOptions,
 } from "../types/linkPlacement";
 import {
@@ -232,6 +233,16 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			return;
 		}
 
+		if (linkOptions.destination?.type === "specifiedFile") {
+			await appendFileLinkToDestinationFile(this.app, file, linkOptions);
+			return;
+		}
+
+		if (placementSupportsFrontmatter(linkOptions.placement)) {
+			await insertFileLinkToActiveView(this.app, file, linkOptions);
+			return;
+		}
+
 		if (
 			this.shouldSkipRequiredCanvasLinkInsertion(linkOptions, isCanvasTriggered)
 		) {
@@ -244,18 +255,13 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			return;
 		}
 
-		if (linkOptions.destination?.type === "specifiedFile") {
-			await appendFileLinkToDestinationFile(this.app, file, linkOptions);
-			return;
-		}
-
 		const propertyTarget = this.choiceExecutor.focusedProperty;
 		if (propertyTarget) {
 			await appendLinkToFrontmatterProperty(this.app, propertyTarget, file);
 			return;
 		}
 
-		insertFileLinkToActiveView(this.app, file, linkOptions);
+		await insertFileLinkToActiveView(this.app, file, linkOptions);
 	}
 
 	private validateAppendLinkDestination(
@@ -487,10 +493,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				expectedCursorContent = canPlaceCursorAtCapture ? newFileContent : null;
 			}
 
-			// Content is committed. Record success BEFORE the cosmetic steps below
-			// (notice / link / open / cursor jump) so a later cosmetic failure cannot
-			// downgrade the outcome — otherwise an x-callback caller would see an error,
-			// retry, and duplicate the capture.
+			// Content is committed. Record success before append-link/open-file steps
+			// so a later post-commit failure cannot make automation callers retry and
+			// duplicate the Capture side effect.
 			this.choiceExecutor.recordExecutionResult?.({ status: "success", file });
 
 			// Show success notification
@@ -628,7 +633,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		await setCanvasTextCaptureContent(this.app, target, nextText);
 		markContentCommitted();
 
-		// Committed; record success before cosmetic steps (see run() for rationale).
+		// Committed; append-link/open-file steps remain post-commit (see run()).
 		this.choiceExecutor.recordExecutionResult?.({ status: "success", file });
 
 		if (this.plugin.settings.showCaptureNotification) {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -60,6 +60,7 @@ import {
 } from "../utils/fileLinks";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
+import { appendLinkToFrontmatterProperty } from "../utils/frontmatterPropertyLinks";
 import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
 import { buildFileDisplayLabels } from "../utils/fileSyntax";
 import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
@@ -245,6 +246,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 		if (linkOptions.destination?.type === "specifiedFile") {
 			await appendFileLinkToDestinationFile(this.app, file, linkOptions);
+			return;
+		}
+
+		const propertyTarget = this.choiceExecutor.focusedProperty;
+		if (propertyTarget) {
+			await appendLinkToFrontmatterProperty(this.app, propertyTarget, file);
 			return;
 		}
 

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -615,7 +615,10 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 		expect(insertFileLinkToActiveView).toHaveBeenCalledWith(
 			app,
 			createdFile,
-			engine.choice.appendLink,
+			expect.objectContaining({
+				...(engine.choice.appendLink as object),
+				destination: { type: "activeFile" },
+			}),
 		);
 		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
 			status: "success",

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -136,6 +136,7 @@ import { MacroAbortError } from "../errors/MacroAbortError";
 import { UserCancelError } from "../errors/UserCancelError";
 import { settingsStore } from "../settingsStore";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
+import { insertFileLinkToActiveView } from "../utilityObsidian";
 
 const defaultSettingsState = structuredClone(settingsStore.getState());
 
@@ -236,14 +237,15 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 	beforeEach(() => {
 		settingsStore.setState(structuredClone(defaultSettingsState));
 		noticeClass.instances.length = 0;
-			InputPromptDraftStore.getInstance().clearAll();
-			appendFileLinkToDestinationFileMock.mockReset();
-			appendFileLinkToDestinationFileMock.mockResolvedValue(true);
-			copyFileLinkToClipboardMock.mockReset();
-			copyFileLinkToClipboardMock.mockResolvedValue(true);
-			getAppendLinkDestinationFileMock.mockReset();
-			getAppendLinkDestinationFileMock.mockReturnValue(null);
-			formatFileNameMock.mockReset();
+		InputPromptDraftStore.getInstance().clearAll();
+		appendFileLinkToDestinationFileMock.mockReset();
+		appendFileLinkToDestinationFileMock.mockResolvedValue(true);
+		copyFileLinkToClipboardMock.mockReset();
+		copyFileLinkToClipboardMock.mockResolvedValue(true);
+		getAppendLinkDestinationFileMock.mockReset();
+		getAppendLinkDestinationFileMock.mockReturnValue(null);
+		vi.mocked(insertFileLinkToActiveView).mockReset();
+		formatFileNameMock.mockReset();
 		formatFileContentMock.mockReset();
 		formatFileContentMock.mockResolvedValue("");
 	});
@@ -578,6 +580,47 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 			file: createdFile,
 		});
 		expect(store.get(draftKey)).toBeUndefined();
+	});
+
+	it("keeps template execution successful when configured frontmatter link insertion fails after creation", async () => {
+		const { engine, choiceExecutor, app } = createEngine("ignored", {
+			throwDuringFileName: false,
+		});
+		const createdFile = new TFile();
+		createdFile.path = "Test Template.md";
+		createdFile.name = "Test Template.md";
+		createdFile.extension = "md";
+		createdFile.basename = "Test Template";
+
+		engine.choice.appendLink = {
+			enabled: true,
+			placement: "inFrontmatter",
+			requireActiveFile: true,
+			linkType: "link",
+			frontmatterProperty: "related",
+			frontmatterHandling: "error",
+		};
+		choiceExecutor.recordExecutionResult = vi.fn();
+		(
+			engine as unknown as {
+				createFileWithTemplate: () => Promise<TFile | null>;
+			}
+		).createFileWithTemplate = vi.fn().mockResolvedValue(createdFile);
+		vi.mocked(insertFileLinkToActiveView).mockRejectedValueOnce(
+			new Error("frontmatter property is missing"),
+		);
+
+		await engine.run();
+
+		expect(insertFileLinkToActiveView).toHaveBeenCalledWith(
+			app,
+			createdFile,
+			engine.choice.appendLink,
+		);
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: createdFile,
+		});
 	});
 });
 

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -17,7 +17,10 @@ import {
 	shouldRunTemplateNoteDiscovery,
 } from "./templateNoteDiscovery";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
-import { normalizeAppendLinkOptions } from "../types/linkPlacement";
+import {
+	normalizeAppendLinkOptions,
+	placementSupportsFrontmatter,
+} from "../types/linkPlacement";
 import {
 	getAllFolderPathsInVault,
 	insertFileLinkToActiveView,
@@ -203,9 +206,9 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				}
 			}
 
-			// File is created/resolved (the commit point). Record success BEFORE the
-			// cosmetic steps below (link / open / templater jump) so a later cosmetic
-			// failure cannot downgrade the outcome for an x-callback caller.
+			// File is created/resolved (the commit point). Record success before
+			// append-link/open-file steps so a later post-commit failure cannot make
+			// automation callers retry and duplicate the Template side effect.
 			this.choiceExecutor.recordExecutionResult?.({
 				status: "success",
 				file: createdFile,
@@ -218,6 +221,8 @@ export class TemplateChoiceEngine extends TemplateEngine {
 						createdFile,
 						linkOptions,
 					);
+				} else if (placementSupportsFrontmatter(linkOptions.placement)) {
+					await insertFileLinkToActiveView(this.app, createdFile, linkOptions);
 				} else if (this.choiceExecutor.focusedProperty) {
 					await appendLinkToFrontmatterProperty(
 						this.app,
@@ -225,7 +230,11 @@ export class TemplateChoiceEngine extends TemplateEngine {
 						createdFile,
 					);
 				} else {
-					insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+					await insertFileLinkToActiveView(
+						this.app,
+						createdFile,
+						linkOptions,
+					);
 				}
 			}
 

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -37,6 +37,7 @@ import {
 	copyFileLinkToClipboard,
 	getAppendLinkDestinationFile,
 } from "../utils/fileLinks";
+import { appendLinkToFrontmatterProperty } from "../utils/frontmatterPropertyLinks";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { TemplateEngine } from "./TemplateEngine";
 import { UserCancelError } from "../errors/UserCancelError";
@@ -216,6 +217,12 @@ export class TemplateChoiceEngine extends TemplateEngine {
 						this.app,
 						createdFile,
 						linkOptions,
+					);
+				} else if (this.choiceExecutor.focusedProperty) {
+					await appendLinkToFrontmatterProperty(
+						this.app,
+						this.choiceExecutor.focusedProperty,
+						createdFile,
 					);
 				} else {
 					insertFileLinkToActiveView(this.app, createdFile, linkOptions);

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
@@ -5,12 +5,14 @@ import Dropdown from "../../components/Dropdown.svelte";
 import ValidatedInput from "./ValidatedInput.svelte";
 import type {
 	AppendLinkOptions,
+	FrontmatterHandling,
 	LinkPlacement,
 	LinkType,
 } from "../../../types/linkPlacement";
 import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
+	placementSupportsFrontmatter,
 } from "../../../types/linkPlacement";
 import { normalizeAppendLinkDestinationPath } from "../../../utils/fileLinks";
 
@@ -35,6 +37,9 @@ type AppendLinkDestinationMode = "activeFile" | "specifiedFile";
 
 const normalized = $derived(normalizeAppendLinkOptions(appendLink));
 const normalizedLinkType = $derived(normalized.linkType ?? "link");
+const normalizedFrontmatterHandling = $derived(
+	normalized.frontmatterHandling ?? "error",
+);
 const destinationPath = $derived(
 	normalized.destination.type === "specifiedFile"
 		? normalized.destination.path
@@ -66,76 +71,82 @@ const placementOptions = [
 	{ value: "afterSelection", label: "After selection" },
 	{ value: "endOfLine", label: "End of line" },
 	{ value: "newLine", label: "New line" },
+	{ value: "inFrontmatter", label: "In frontmatter property" },
 ];
 const linkTypeOptions = [
 	{ value: "link", label: "Link" },
 	{ value: "embed", label: "Embed" },
 ];
+const frontmatterHandlingOptions = [
+	{ value: "error", label: "Require existing list" },
+	{ value: "createProperty", label: "Create missing property" },
+	{ value: "alwaysAppend", label: "Create or convert to list" },
+];
+
+function nextOptions(overrides: Partial<AppendLinkOptions>): AppendLinkOptions {
+	const current = appendLink;
+	const currentOptions =
+		typeof current === "boolean" ? normalized : current;
+	const placement = overrides.placement ?? currentOptions.placement;
+	const destination =
+		overrides.destination ?? currentOptions.destination ?? normalized.destination;
+	const linkType =
+		destination.type === "activeFile" && placementSupportsEmbed(placement)
+			? overrides.linkType ?? currentOptions.linkType ?? normalizedLinkType
+			: "link";
+
+	return {
+		enabled: overrides.enabled ?? true,
+		placement,
+		requireActiveFile:
+			overrides.requireActiveFile ??
+			currentOptions.requireActiveFile ??
+			normalized.requireActiveFile,
+		linkType,
+		destination,
+		frontmatterProperty:
+			overrides.frontmatterProperty ?? currentOptions.frontmatterProperty,
+		frontmatterHandling:
+			overrides.frontmatterHandling ?? currentOptions.frontmatterHandling,
+	};
+}
 
 function onModeChange(value: string) {
 	switch (value as AppendLinkMode) {
 		case "disabled":
-			appendLink = false;
+			appendLink = nextOptions({ enabled: false });
 			break;
 		case "required":
-			appendLink = {
-				enabled: true,
-				placement: normalized.placement,
-				requireActiveFile: true,
-				linkType: normalizedLinkType,
-				destination: normalized.destination,
-			};
+			appendLink = nextOptions({ requireActiveFile: true });
 			break;
 		case "optional":
-			appendLink = {
-				enabled: true,
-				placement: normalized.placement,
-				requireActiveFile: false,
-				linkType: normalizedLinkType,
-				destination: normalized.destination,
-			};
+			appendLink = nextOptions({ requireActiveFile: false });
 			break;
 	}
 }
 
 function onPlacementChange(value: string) {
-	const placement = value as LinkPlacement;
-	const current = appendLink;
-	const requireActiveFile =
-		typeof current === "boolean"
-			? normalized.requireActiveFile
-			: current.requireActiveFile;
-	const previousLinkType =
-		typeof current === "boolean"
-			? normalizedLinkType
-			: current.linkType ?? normalizedLinkType;
-	const nextLinkType = placementSupportsEmbed(placement)
-		? previousLinkType
-		: "link";
-	appendLink = {
-		enabled: true,
-		placement,
-		requireActiveFile,
-		linkType: nextLinkType,
-		destination: normalized.destination,
-	};
+	appendLink = nextOptions({
+		placement: value as LinkPlacement,
+	});
 }
 
 function onLinkTypeChange(value: string) {
-	const current = appendLink;
-	const requireActiveFile =
-		typeof current === "boolean"
-			? normalized.requireActiveFile
-			: current.requireActiveFile;
-	const placement =
-		typeof current === "boolean" ? normalized.placement : current.placement;
-	appendLink = {
-		enabled: true,
-		placement,
-		requireActiveFile,
+	appendLink = nextOptions({
 		linkType: value as LinkType,
-		destination: normalized.destination,
-	};
+	});
+}
+
+function onFrontmatterPropertyInput(event: Event) {
+	appendLink = nextOptions({
+		frontmatterProperty: (event.currentTarget as HTMLInputElement).value,
+	});
+}
+
+function onFrontmatterHandlingChange(value: string) {
+	appendLink = nextOptions({
+		frontmatterHandling: value as FrontmatterHandling,
+	});
 }
 
 function onDestinationChange(value: string) {
@@ -143,23 +154,13 @@ function onDestinationChange(value: string) {
 		(value as AppendLinkDestinationMode) === "specifiedFile"
 			? { type: "specifiedFile" as const, path: destinationPath }
 			: { type: "activeFile" as const };
-	appendLink = {
-		enabled: true,
-		placement: normalized.placement,
-		requireActiveFile: normalized.requireActiveFile,
-		linkType: destination.type === "specifiedFile" ? "link" : normalizedLinkType,
-		destination,
-	};
+	appendLink = nextOptions({ destination });
 }
 
 function onDestinationPathChange(value: string) {
-	appendLink = {
-		enabled: true,
-		placement: normalized.placement,
-		requireActiveFile: normalized.requireActiveFile,
-		linkType: "link",
+	appendLink = nextOptions({
 		destination: { type: "specifiedFile", path: value.trim() },
-	};
+	});
 }
 
 function validateDestinationFile(raw: string) {
@@ -223,6 +224,39 @@ function validateDestinationFile(raw: string) {
 						value={normalizedLinkType}
 						options={linkTypeOptions}
 						onchange={onLinkTypeChange}
+					/>
+				{/snippet}
+			</SettingItem>
+		{/if}
+
+		{#if placementSupportsFrontmatter(normalized.placement)}
+			<SettingItem
+				name="Frontmatter property"
+				desc="Required property to insert the link into."
+			>
+				{#snippet control()}
+					<input
+						type="text"
+						class="text-input"
+						value={normalized.frontmatterProperty ?? ""}
+						aria-label="Frontmatter property"
+						aria-invalid={!(normalized.frontmatterProperty?.trim())}
+						placeholder="related"
+						required
+						oninput={onFrontmatterPropertyInput}
+					/>
+				{/snippet}
+			</SettingItem>
+
+			<SettingItem
+				name="Frontmatter appending behavior"
+				desc="Choose what QuickAdd should do when the property is missing or not a list."
+			>
+				{#snippet control()}
+					<Dropdown
+						value={normalizedFrontmatterHandling}
+						options={frontmatterHandlingOptions}
+						onchange={onFrontmatterHandlingChange}
 					/>
 				{/snippet}
 			</SettingItem>

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
@@ -10,6 +10,7 @@ import type {
 	LinkType,
 } from "../../../types/linkPlacement";
 import {
+	DEFAULT_FRONTMATTER_HANDLING,
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
 	placementSupportsFrontmatter,
@@ -38,7 +39,7 @@ type AppendLinkDestinationMode = "activeFile" | "specifiedFile";
 const normalized = $derived(normalizeAppendLinkOptions(appendLink));
 const normalizedLinkType = $derived(normalized.linkType ?? "link");
 const normalizedFrontmatterHandling = $derived(
-	normalized.frontmatterHandling ?? "error",
+	normalized.frontmatterHandling ?? DEFAULT_FRONTMATTER_HANDLING,
 );
 const destinationPath = $derived(
 	normalized.destination.type === "specifiedFile"
@@ -78,9 +79,9 @@ const linkTypeOptions = [
 	{ value: "embed", label: "Embed" },
 ];
 const frontmatterHandlingOptions = [
-	{ value: "error", label: "Require existing list" },
-	{ value: "createProperty", label: "Create missing property" },
-	{ value: "alwaysAppend", label: "Create or convert to list" },
+	{ value: "alwaysAppend", label: "Create or convert" },
+	{ value: "createProperty", label: "Create if missing" },
+	{ value: "error", label: "Require list" },
 ];
 
 function nextOptions(overrides: Partial<AppendLinkOptions>): AppendLinkOptions {
@@ -249,8 +250,8 @@ function validateDestinationFile(raw: string) {
 			</SettingItem>
 
 			<SettingItem
-				name="Frontmatter appending behavior"
-				desc="Choose what QuickAdd should do when the property is missing or not a list."
+				name="Property handling"
+				desc="Choose how strict QuickAdd should be when the property is missing or not a list."
 			>
 				{#snippet control()}
 					<Dropdown

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
@@ -95,7 +95,7 @@ describe("AppendLinkSetting", () => {
 			"Link destination",
 			"Link placement",
 			"Frontmatter property",
-			"Frontmatter appending behavior",
+			"Property handling",
 		]);
 		expect(
 			(
@@ -112,6 +112,27 @@ describe("AppendLinkSetting", () => {
 				.querySelector('input[aria-label="Frontmatter property"]')
 				?.getAttribute("aria-invalid"),
 		).toBe("false");
+	});
+
+	it("defaults frontmatter handling to create or convert", () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "inFrontmatter",
+			requireActiveFile: true,
+			linkType: "link",
+			frontmatterProperty: "related",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		const handlingSelect = Array.from(container.querySelectorAll("select")).at(
+			-1,
+		) as HTMLSelectElement;
+		expect(handlingSelect.value).toBe("alwaysAppend");
+		expect(
+			Array.from(handlingSelect.options).map((option) => option.textContent),
+		).toEqual(["Create or convert", "Create if missing", "Require list"]);
 	});
 
 	it("marks an empty frontmatter property as invalid", () => {
@@ -186,7 +207,7 @@ describe("AppendLinkSetting", () => {
 			"Link destination",
 			"Link placement",
 			"Frontmatter property",
-			"Frontmatter appending behavior",
+			"Property handling",
 		]);
 		expect(
 			(

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { render } from "@testing-library/svelte";
+import { fireEvent, render } from "@testing-library/svelte";
 import AppendLinkSetting from "./AppendLinkSetting.svelte";
 import type { AppendLinkOptions } from "../../../types/linkPlacement";
 
@@ -17,7 +17,7 @@ describe("AppendLinkSetting", () => {
 		expect(settingNames(container)).toEqual(["Link to created file"]);
 	});
 
-	it("shows placement + link type when enabled with an embed-capable placement", () => {
+	it("shows destination + placement + link type when enabled with an embed-capable placement", () => {
 		const appendLink: AppendLinkOptions = {
 			enabled: true,
 			placement: "replaceSelection",
@@ -27,6 +27,7 @@ describe("AppendLinkSetting", () => {
 		const { container } = render(AppendLinkSetting, {
 			props: { appendLink, fileLabel: "captured" },
 		});
+
 		expect(settingNames(container)).toEqual([
 			"Link to captured file",
 			"Link destination",
@@ -45,6 +46,7 @@ describe("AppendLinkSetting", () => {
 		const { container } = render(AppendLinkSetting, {
 			props: { appendLink, fileLabel: "captured" },
 		});
+
 		expect(settingNames(container)).toEqual([
 			"Link to captured file",
 			"Link destination",
@@ -64,6 +66,7 @@ describe("AppendLinkSetting", () => {
 		const { container } = render(AppendLinkSetting, {
 			props: { appendLink, fileLabel: "created" },
 		});
+
 		expect(settingNames(container)).toEqual([
 			"Link to created file",
 			"Link destination",
@@ -71,5 +74,129 @@ describe("AppendLinkSetting", () => {
 		]);
 		expect(settingNames(container)).not.toContain("Link placement");
 		expect(settingNames(container)).not.toContain("Link type");
+		expect(settingNames(container)).not.toContain("Frontmatter property");
+	});
+
+	it("shows frontmatter property controls for current-note frontmatter placement", () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "inFrontmatter",
+			requireActiveFile: true,
+			linkType: "link",
+			frontmatterProperty: "related",
+			frontmatterHandling: "alwaysAppend",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		expect(settingNames(container)).toEqual([
+			"Link to created file",
+			"Link destination",
+			"Link placement",
+			"Frontmatter property",
+			"Frontmatter appending behavior",
+		]);
+		expect(
+			(
+				container.querySelector(
+					'input[aria-label="Frontmatter property"]',
+				) as HTMLInputElement
+			).value,
+		).toBe("related");
+		expect(
+			Array.from(container.querySelectorAll("select")).at(-1)?.value,
+		).toBe("alwaysAppend");
+		expect(
+			container
+				.querySelector('input[aria-label="Frontmatter property"]')
+				?.getAttribute("aria-invalid"),
+		).toBe("false");
+	});
+
+	it("marks an empty frontmatter property as invalid", () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "inFrontmatter",
+			requireActiveFile: true,
+			linkType: "link",
+			frontmatterProperty: "   ",
+			frontmatterHandling: "error",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		expect(
+			container
+				.querySelector('input[aria-label="Frontmatter property"]')
+				?.getAttribute("aria-invalid"),
+		).toBe("true");
+	});
+
+	it("preserves frontmatter settings when changing append-link mode", async () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "inFrontmatter",
+			requireActiveFile: true,
+			linkType: "link",
+			frontmatterProperty: "related",
+			frontmatterHandling: "createProperty",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "captured" },
+		});
+
+		const modeSelect = container.querySelector("select") as HTMLSelectElement;
+		await fireEvent.change(modeSelect, { target: { value: "optional" } });
+
+		expect(
+			(
+				container.querySelector(
+					'input[aria-label="Frontmatter property"]',
+				) as HTMLInputElement
+			).value,
+		).toBe("related");
+		expect(
+			Array.from(container.querySelectorAll("select")).at(-1)?.value,
+		).toBe("createProperty");
+	});
+
+	it("preserves frontmatter settings when disabled and re-enabled", async () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "inFrontmatter",
+			requireActiveFile: true,
+			linkType: "link",
+			frontmatterProperty: "related",
+			frontmatterHandling: "alwaysAppend",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		const modeSelect = container.querySelector("select") as HTMLSelectElement;
+		await fireEvent.change(modeSelect, { target: { value: "disabled" } });
+		expect(settingNames(container)).toEqual(["Link to created file"]);
+
+		await fireEvent.change(modeSelect, { target: { value: "required" } });
+
+		expect(settingNames(container)).toEqual([
+			"Link to created file",
+			"Link destination",
+			"Link placement",
+			"Frontmatter property",
+			"Frontmatter appending behavior",
+		]);
+		expect(
+			(
+				container.querySelector(
+					'input[aria-label="Frontmatter property"]',
+				) as HTMLInputElement
+			).value,
+		).toBe("related");
+		expect(
+			Array.from(container.querySelectorAll("select")).at(-1)?.value,
+		).toBe("alwaysAppend");
 	});
 });

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -13,10 +13,20 @@ vi.mock("../../engine/runTemplateFromFolder", async (importOriginal) => {
 	return { ...actual, runTemplateFromFolder: vi.fn().mockResolvedValue(undefined) };
 });
 
+vi.mock("../../utils/frontmatterPropertyLinks", async (importOriginal) => {
+	const actual =
+		await importOriginal<Record<string, unknown>>();
+	return { ...actual, getFocusedPropertyTarget: vi.fn(() => null) };
+});
+
 import type QuickAdd from "../../main";
 import type IChoice from "../../types/choices/IChoice";
 import type IMultiChoice from "../../types/choices/IMultiChoice";
 import type { IChoiceExecutor } from "../../IChoiceExecutor";
+import {
+	getFocusedPropertyTarget,
+	type FrontmatterPropertyTarget,
+} from "../../utils/frontmatterPropertyLinks";
 import { MultiChoice } from "../../types/choices/MultiChoice";
 import { settingsStore } from "../../settingsStore";
 import { runTemplateFromFolder } from "../../engine/runTemplateFromFolder";
@@ -115,14 +125,21 @@ describe("ChoiceSuggester", () => {
 		rootChoices = [topNote, work, footnotes];
 
 		settingsStore.setState({ searchNestedChoices: true });
+		vi.mocked(getFocusedPropertyTarget).mockReturnValue(null);
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
-	function makeSuggester(choices: IChoice[]): ChoiceSuggester {
-		return new ChoiceSuggester(plugin, choices, { choiceExecutor: executor });
+	function makeSuggester(
+		choices: IChoice[],
+		options: { focusedProperty?: FrontmatterPropertyTarget | null } = {},
+	): ChoiceSuggester {
+		return new ChoiceSuggester(plugin, choices, {
+			choiceExecutor: executor,
+			...options,
+		});
 	}
 
 	describe("template folder launcher row", () => {
@@ -396,11 +413,53 @@ describe("ChoiceSuggester", () => {
 			expect(executed).toEqual([newMeeting]);
 		});
 
+		it("executes leaves with a focused property captured before the suggester opened", () => {
+			const focusedProperty = {
+				file: { path: "Host.md" },
+				key: "related",
+			} as FrontmatterPropertyTarget;
+			const executeWithFocusedProperty = vi.fn(async () => {});
+			executor.executeWithFocusedProperty = executeWithFocusedProperty;
+			const suggester = makeSuggester(rootChoices, { focusedProperty });
+
+			suggester.onChooseItem(newMeeting, new MouseEvent("click"));
+
+			expect(executeWithFocusedProperty).toHaveBeenCalledWith(
+				newMeeting,
+				focusedProperty,
+			);
+			expect(executed).toEqual([]);
+		});
+
+		it("captures the focused property by default for a top-level suggester", () => {
+			const focusedProperty = {
+				file: { path: "Host.md" },
+				key: "related",
+			} as FrontmatterPropertyTarget;
+			vi.mocked(getFocusedPropertyTarget).mockReturnValue(focusedProperty);
+			const executeWithFocusedProperty = vi.fn(async () => {});
+			executor.executeWithFocusedProperty = executeWithFocusedProperty;
+
+			const suggester = makeSuggester(rootChoices);
+			suggester.onChooseItem(newMeeting, new MouseEvent("click"));
+
+			expect(getFocusedPropertyTarget).toHaveBeenCalledWith(app);
+			expect(executeWithFocusedProperty).toHaveBeenCalledWith(
+				newMeeting,
+				focusedProperty,
+			);
+			expect(executed).toEqual([]);
+		});
+
 		it("appends a sentinel back item when drilling into a Multi", () => {
 			const openSpy = vi
 				.spyOn(ChoiceSuggester, "Open")
 				.mockImplementation(() => {});
-			const suggester = makeSuggester(rootChoices);
+			const focusedProperty = {
+				file: { path: "Host.md" },
+				key: "related",
+			} as FrontmatterPropertyTarget;
+			const suggester = makeSuggester(rootChoices, { focusedProperty });
 
 			suggester.onChooseItem(work, new MouseEvent("click"));
 
@@ -409,6 +468,7 @@ describe("ChoiceSuggester", () => {
 				IChoice[],
 				{
 					choiceExecutor?: IChoiceExecutor;
+					focusedProperty?: FrontmatterPropertyTarget | null;
 					placeholder?: string;
 					placeholderStack?: Array<string | undefined>;
 				},
@@ -420,6 +480,7 @@ describe("ChoiceSuggester", () => {
 			// The same executor is threaded through, so variables survive
 			// drill-down, and the placeholder stack records the origin level.
 			expect(options.choiceExecutor).toBe(executor);
+			expect(options.focusedProperty).toBe(focusedProperty);
 			expect(options.placeholder).toBe("Work");
 			expect(options.placeholderStack).toEqual([undefined]);
 		});

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -15,6 +15,8 @@ import type { IChoiceExecutor } from "../../IChoiceExecutor";
 import { log } from "../../logger/logManager";
 import { settingsStore } from "../../settingsStore";
 import { flattenChoicesWithPath } from "../../utils/choiceUtils";
+import type { FrontmatterPropertyTarget } from "../../utils/frontmatterPropertyLinks";
+import { getFocusedPropertyTarget } from "../../utils/frontmatterPropertyLinks";
 import {
 	hasConfiguredTemplateFolders,
 	runTemplateFromFolder,
@@ -78,6 +80,7 @@ type NestedSearchCandidate = {
 
 type ChoiceSuggesterOptions = {
 	choiceExecutor?: IChoiceExecutor;
+	focusedProperty?: FrontmatterPropertyTarget | null;
 	placeholder?: string;
 	placeholderStack?: Array<string | undefined>;
 	/**
@@ -98,6 +101,7 @@ function createTemplateFolderRow(): IChoice {
 }
 export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 	private choiceExecutor: IChoiceExecutor;
+	private focusedProperty: FrontmatterPropertyTarget | null = null;
 	private placeholderStack: Array<string | undefined> = [];
 	private currentPlaceholder?: string;
 	private nestedSearchCandidates?: NestedSearchCandidate[];
@@ -128,6 +132,10 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		// property is already assigned; a field initializer runs before it.
 		this.choiceExecutor =
 			options?.choiceExecutor ?? new ChoiceExecutor(this.app, this.plugin);
+		this.focusedProperty =
+			options && "focusedProperty" in options
+				? options.focusedProperty ?? null
+				: getFocusedPropertyTarget(this.app);
 		this.placeholderStack = options?.placeholderStack ?? [];
 		this.currentPlaceholder = options?.placeholder?.trim() || undefined;
 		if (this.currentPlaceholder) this.setPlaceholder(this.currentPlaceholder);
@@ -290,7 +298,14 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		if (item.type === "Multi")
 			this.onChooseMultiType(<IMultiChoice>item);
 		else {
-			void this.choiceExecutor.execute(item).catch((error) => {
+			const execute =
+				this.focusedProperty && this.choiceExecutor.executeWithFocusedProperty
+					? this.choiceExecutor.executeWithFocusedProperty(
+							item,
+							this.focusedProperty,
+						)
+					: this.choiceExecutor.execute(item);
+			void execute.catch((error) => {
 				log.logError(`Failed to execute selected choice: ${error}`);
 			});
 		}
@@ -315,6 +330,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 
 		ChoiceSuggester.Open(this.plugin, choices, {
 			choiceExecutor: this.choiceExecutor,
+			focusedProperty: this.focusedProperty,
 			placeholder: nextPlaceholder,
 			placeholderStack: nextStack,
 		});

--- a/src/types/linkPlacement.test.ts
+++ b/src/types/linkPlacement.test.ts
@@ -152,6 +152,19 @@ describe("LinkPlacement", () => {
 				destination: { type: "activeFile" },
 			});
 		});
+
+		it("should default frontmatter handling to create or convert", () => {
+			const options: AppendLinkOptions = {
+				enabled: true,
+				placement: "inFrontmatter",
+				requireActiveFile: true,
+				frontmatterProperty: "related",
+			};
+
+			expect(normalizeAppendLinkOptions(options).frontmatterHandling).toBe(
+				"alwaysAppend",
+			);
+		});
 	});
 
 	describe("isAppendLinkEnabled", () => {

--- a/src/types/linkPlacement.test.ts
+++ b/src/types/linkPlacement.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-	type LinkPlacement,
 	type AppendLinkOptions,
+	type LinkPlacement,
+	isAppendLinkEnabled,
 	isAppendLinkOptions,
 	normalizeAppendLinkOptions,
-	isAppendLinkEnabled,
 	placementSupportsEmbed,
+	placementSupportsFrontmatter,
 } from "./linkPlacement";
 
 describe("LinkPlacement", () => {
@@ -36,46 +37,48 @@ describe("LinkPlacement", () => {
 				enabled: true,
 				placement: "afterSelection",
 				requireActiveFile: false,
-				};
-				expect(normalizeAppendLinkOptions(options)).toEqual({
-					...options,
-					linkType: "link",
-					destination: { type: "activeFile" },
-				});
+			};
+
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
+				linkType: "link",
+				destination: { type: "activeFile" },
 			});
+		});
 
 		it("should convert true to enabled with default placement", () => {
 			const result = normalizeAppendLinkOptions(true);
 			expect(result).toEqual({
 				enabled: true,
-					placement: "replaceSelection",
-					requireActiveFile: true,
-					linkType: "link",
-					destination: { type: "activeFile" },
-				});
+				placement: "replaceSelection",
+				requireActiveFile: true,
+				linkType: "link",
+				destination: { type: "activeFile" },
 			});
+		});
 
 		it("should convert false to disabled with default placement", () => {
 			const result = normalizeAppendLinkOptions(false);
 			expect(result).toEqual({
 				enabled: false,
-					placement: "replaceSelection",
-					requireActiveFile: false,
-					linkType: "link",
-					destination: { type: "activeFile" },
-				});
+				placement: "replaceSelection",
+				requireActiveFile: false,
+				linkType: "link",
+				destination: { type: "activeFile" },
 			});
+		});
 
 		it("should keep embed linkType when placement supports embeds", () => {
 			const options: AppendLinkOptions = {
 				enabled: true,
 				placement: "replaceSelection",
-					requireActiveFile: true,
-					linkType: "embed",
-					destination: { type: "activeFile" },
-				};
-				expect(normalizeAppendLinkOptions(options)).toEqual(options);
-			});
+				requireActiveFile: true,
+				linkType: "embed",
+				destination: { type: "activeFile" },
+			};
+
+			expect(normalizeAppendLinkOptions(options)).toEqual(options);
+		});
 
 		it("should sanitize embed linkType when placement does not support embeds", () => {
 			const options: AppendLinkOptions = {
@@ -84,49 +87,71 @@ describe("LinkPlacement", () => {
 				requireActiveFile: true,
 				linkType: "embed",
 			};
-				expect(normalizeAppendLinkOptions(options)).toEqual({
-					...options,
-					linkType: "link",
-					destination: { type: "activeFile" },
-				});
+
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
+				linkType: "link",
+				destination: { type: "activeFile" },
 			});
+		});
 
 		it("should default linkType to link when omitted", () => {
 			const options: AppendLinkOptions = {
 				enabled: true,
 				placement: "newLine",
 				requireActiveFile: true,
-				};
-				expect(normalizeAppendLinkOptions(options).linkType).toBe("link");
-			});
+			};
 
-			it("preserves and trims a specified file destination", () => {
-				const options: AppendLinkOptions = {
-					enabled: true,
-					placement: "newLine",
-					requireActiveFile: false,
-					destination: { type: "specifiedFile", path: "  Indexes/MOC.md  " },
-				};
-				expect(normalizeAppendLinkOptions(options)).toEqual({
-					...options,
-					linkType: "link",
-					destination: { type: "specifiedFile", path: "Indexes/MOC.md" },
-				});
-			});
+			expect(normalizeAppendLinkOptions(options).linkType).toBe("link");
+		});
 
-			it("sanitizes embeds for specified file destinations", () => {
-				const options: AppendLinkOptions = {
-					enabled: true,
-					placement: "replaceSelection",
-					requireActiveFile: true,
-					linkType: "embed",
-					destination: { type: "specifiedFile", path: "Index.md" },
-				};
-				expect(normalizeAppendLinkOptions(options)).toEqual({
-					...options,
-					linkType: "link",
-				});
+		it("preserves and trims a specified file destination", () => {
+			const options: AppendLinkOptions = {
+				enabled: true,
+				placement: "newLine",
+				requireActiveFile: false,
+				destination: { type: "specifiedFile", path: "  Indexes/MOC.md  " },
+			};
+
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
+				linkType: "link",
+				destination: { type: "specifiedFile", path: "Indexes/MOC.md" },
 			});
+		});
+
+		it("sanitizes embeds for specified file destinations", () => {
+			const options: AppendLinkOptions = {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+				linkType: "embed",
+				destination: { type: "specifiedFile", path: "Index.md" },
+			};
+
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
+				linkType: "link",
+				destination: { type: "specifiedFile", path: "Index.md" },
+			});
+		});
+
+		it("should preserve frontmatter placement options", () => {
+			const options: AppendLinkOptions = {
+				enabled: true,
+				placement: "inFrontmatter",
+				requireActiveFile: true,
+				linkType: "embed",
+				frontmatterProperty: "related",
+				frontmatterHandling: "alwaysAppend",
+			};
+
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
+				linkType: "link",
+				destination: { type: "activeFile" },
+			});
+		});
 	});
 
 	describe("isAppendLinkEnabled", () => {
@@ -159,6 +184,7 @@ describe("LinkPlacement", () => {
 				"afterSelection",
 				"endOfLine",
 				"newLine",
+				"inFrontmatter",
 			];
 
 			for (const placement of placements) {
@@ -178,6 +204,17 @@ describe("LinkPlacement", () => {
 			expect(placementSupportsEmbed("afterSelection")).toBe(false);
 			expect(placementSupportsEmbed("endOfLine")).toBe(false);
 			expect(placementSupportsEmbed("newLine")).toBe(false);
+			expect(placementSupportsEmbed("inFrontmatter")).toBe(false);
+		});
+	});
+
+	describe("placementSupportsFrontmatter", () => {
+		it("should return true only for frontmatter placement", () => {
+			expect(placementSupportsFrontmatter("inFrontmatter")).toBe(true);
+			expect(placementSupportsFrontmatter("replaceSelection")).toBe(false);
+			expect(placementSupportsFrontmatter("afterSelection")).toBe(false);
+			expect(placementSupportsFrontmatter("endOfLine")).toBe(false);
+			expect(placementSupportsFrontmatter("newLine")).toBe(false);
 		});
 	});
 });

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -5,7 +5,8 @@ export type LinkPlacement =
 	| "replaceSelection"  // Replace the current selection with the link
 	| "afterSelection"    // Insert the link after the current selection
 	| "endOfLine"         // Insert the link at the end of the current line
-	| "newLine";          // Insert the link on a new line
+	| "newLine"           // Insert the link on a new line
+	| "inFrontmatter";    // Insert the link into a frontmatter property
 
 export type LinkType = "link" | "embed";
 
@@ -13,8 +14,19 @@ export type AppendLinkDestination =
 	| { type: "activeFile" }
 	| { type: "specifiedFile"; path: string };
 
+export type FrontmatterHandling =
+	| "error"
+	| "createProperty"
+	| "alwaysAppend";
+
 export function placementSupportsEmbed(placement: LinkPlacement): boolean {
 	return placement === "replaceSelection";
+}
+
+export function placementSupportsFrontmatter(
+	placement: LinkPlacement,
+): boolean {
+	return placement === "inFrontmatter";
 }
 
 function sanitizeLinkType(
@@ -59,13 +71,21 @@ export interface AppendLinkOptions {
 	/**
 	 * Controls how the link renders. "embed" is only respected when placement is replaceSelection.
 	 * Defaults to "link" for legacy settings.
-	 */
+ */
 	linkType?: LinkType;
 	/**
 	 * Where the generated link should be written. Omitted legacy settings target
 	 * the active Markdown editor.
 	 */
 	destination?: AppendLinkDestination;
+	/**
+	 * Frontmatter property to append to when placement is "inFrontmatter".
+	 */
+	frontmatterProperty?: string;
+	/**
+	 * How to handle missing and non-list frontmatter properties.
+	 */
+	frontmatterHandling?: FrontmatterHandling;
 }
 
 /**
@@ -100,6 +120,8 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 			requireActiveFile: appendLink.requireActiveFile ?? true,
 			linkType: sanitizeLinkType(appendLink.linkType, placement, destination),
 			destination,
+			frontmatterProperty: appendLink.frontmatterProperty,
+			frontmatterHandling: appendLink.frontmatterHandling,
 		};
 	}
 

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -19,6 +19,8 @@ export type FrontmatterHandling =
 	| "createProperty"
 	| "alwaysAppend";
 
+export const DEFAULT_FRONTMATTER_HANDLING: FrontmatterHandling = "alwaysAppend";
+
 export function placementSupportsEmbed(placement: LinkPlacement): boolean {
 	return placement === "replaceSelection";
 }
@@ -71,7 +73,7 @@ export interface AppendLinkOptions {
 	/**
 	 * Controls how the link renders. "embed" is only respected when placement is replaceSelection.
 	 * Defaults to "link" for legacy settings.
- */
+	 */
 	linkType?: LinkType;
 	/**
 	 * Where the generated link should be written. Omitted legacy settings target
@@ -121,7 +123,10 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 			linkType: sanitizeLinkType(appendLink.linkType, placement, destination),
 			destination,
 			frontmatterProperty: appendLink.frontmatterProperty,
-			frontmatterHandling: appendLink.frontmatterHandling,
+			frontmatterHandling:
+				placementSupportsFrontmatter(placement)
+					? appendLink.frontmatterHandling ?? DEFAULT_FRONTMATTER_HANDLING
+					: appendLink.frontmatterHandling,
 		};
 	}
 

--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -134,6 +134,40 @@ describe("insertFileLinkToActiveView", () => {
 		expect(editor.replaceRange).not.toHaveBeenCalled();
 	});
 
+	it("uses create-or-convert handling by default for frontmatter links", async () => {
+		const frontmatter: Record<string, unknown> = { related: "[[Existing]]" };
+		const activeFile = { path: "Folder/Host.md" } as TFile;
+		const createdFile = { path: "Folder/Created.md" } as TFile;
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn(() => ({
+					file: activeFile,
+					editor: {},
+				})),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Created]]"),
+				processFrontMatter: vi.fn(
+					async (
+						_file: TFile,
+						update: (fm: Record<string, unknown>) => void,
+					) => update(frontmatter),
+				),
+			},
+		} as unknown as App;
+
+		await expect(
+			insertFileLinkToActiveView(app, createdFile, {
+				enabled: true,
+				placement: "inFrontmatter",
+				requireActiveFile: true,
+				frontmatterProperty: "related",
+			}),
+		).resolves.toBe(true);
+
+		expect(frontmatter.related).toEqual(["[[Existing]]", "[[Created]]"]);
+	});
+
 	it("propagates configured frontmatter insertion failures", async () => {
 		const app = {
 			workspace: {

--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { App, TFile } from "obsidian";
-import { setMarkdownCursorAtOffset } from "./editorInsertion";
+import {
+	insertFileLinkToActiveView,
+	setMarkdownCursorAtOffset,
+} from "./editorInsertion";
 
 function createHarness({
 	mode = "source",
@@ -77,5 +80,87 @@ describe("setMarkdownCursorAtOffset", () => {
 
 		expect(placed).toBe(false);
 		expect(setCursor).not.toHaveBeenCalled();
+	});
+});
+
+describe("insertFileLinkToActiveView", () => {
+	it("appends configured frontmatter links through the active file", async () => {
+		const frontmatter: Record<string, unknown> = {};
+		const activeFile = { path: "Folder/Host.md" } as TFile;
+		const createdFile = { path: "Folder/Created.md" } as TFile;
+		const editor = {
+			listSelections: vi.fn(),
+			replaceSelection: vi.fn(),
+			replaceRange: vi.fn(),
+		};
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn(() => ({
+					file: activeFile,
+					editor,
+				})),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Created]]"),
+				processFrontMatter: vi.fn(
+					async (
+						_file: TFile,
+						update: (fm: Record<string, unknown>) => void,
+					) => update(frontmatter),
+				),
+			},
+		} as unknown as App;
+
+		await expect(
+			insertFileLinkToActiveView(app, createdFile, {
+				enabled: true,
+				placement: "inFrontmatter",
+				requireActiveFile: true,
+				frontmatterProperty: "related",
+				frontmatterHandling: "createProperty",
+			}),
+		).resolves.toBe(true);
+
+		expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(
+			createdFile,
+			"Folder/Host.md",
+		);
+		expect(app.fileManager.processFrontMatter).toHaveBeenCalledWith(
+			activeFile,
+			expect.any(Function),
+		);
+		expect(frontmatter.related).toEqual(["[[Created]]"]);
+		expect(editor.replaceSelection).not.toHaveBeenCalled();
+		expect(editor.replaceRange).not.toHaveBeenCalled();
+	});
+
+	it("propagates configured frontmatter insertion failures", async () => {
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn(() => ({
+					file: { path: "Host.md" },
+					editor: {},
+				})),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Created]]"),
+				processFrontMatter: vi.fn(
+					async (
+						_file: TFile,
+						update: (fm: Record<string, unknown>) => void,
+					) => update({}),
+				),
+			},
+		} as unknown as App;
+
+		await expect(
+			insertFileLinkToActiveView(app, { path: "Created.md" } as TFile, {
+				enabled: true,
+				placement: "inFrontmatter",
+				requireActiveFile: true,
+				frontmatterProperty: "related",
+				frontmatterHandling: "error",
+			}),
+		).rejects.toThrow(/does not exist/);
 	});
 });

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -1,10 +1,11 @@
 import type { App, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
 import { log } from "../logger/logManager";
-import type {
-	AppendLinkOptions,
-	FrontmatterHandling,
-	LinkPlacement,
+import {
+	DEFAULT_FRONTMATTER_HANDLING,
+	type AppendLinkOptions,
+	type FrontmatterHandling,
+	type LinkPlacement,
 } from "../types/linkPlacement";
 import { buildFileLinkText } from "./fileLinks";
 import { appendConfiguredFrontmatterPropertyLinkValue } from "./frontmatterPropertyLinks";
@@ -110,7 +111,7 @@ export async function insertLinkWithPlacement(
 	const {
 		requireActiveView = true,
 		frontmatterProperty,
-		frontmatterHandling = "error",
+		frontmatterHandling = DEFAULT_FRONTMATTER_HANDLING,
 	} = options;
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
 	if (!view) {

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -1,8 +1,13 @@
 import type { App, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
 import { log } from "../logger/logManager";
-import type { AppendLinkOptions, LinkPlacement } from "../types/linkPlacement";
+import type {
+	AppendLinkOptions,
+	FrontmatterHandling,
+	LinkPlacement,
+} from "../types/linkPlacement";
 import { buildFileLinkText } from "./fileLinks";
+import { appendConfiguredFrontmatterPropertyLinkValue } from "./frontmatterPropertyLinks";
 
 /**
  * Returns the active markdown view if it is showing the given file,
@@ -92,13 +97,21 @@ export function insertOnNewLineBelow(toInsert: string, app: App): boolean {
  * – Keeps the editor's undo history clean by performing a single
  *   CodeMirror transaction.
  */
-export function insertLinkWithPlacement(
+export async function insertLinkWithPlacement(
 	app: App,
 	text: string,
 	mode: LinkPlacement = "replaceSelection",
-	options: { requireActiveView?: boolean; } = {},
-) {
-	const { requireActiveView = true } = options;
+	options: {
+		requireActiveView?: boolean;
+		frontmatterProperty?: string;
+		frontmatterHandling?: FrontmatterHandling;
+	} = {},
+): Promise<void> {
+	const {
+		requireActiveView = true,
+		frontmatterProperty,
+		frontmatterHandling = "error",
+	} = options;
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
 	if (!view) {
 		const message = "Cannot append link because no active Markdown view is available.";
@@ -106,6 +119,23 @@ export function insertLinkWithPlacement(
 			throw new Error(message);
 		}
 		log.logMessage(message);
+		return;
+	}
+
+	if (mode === "inFrontmatter") {
+		const file = view.file;
+		if (!file) {
+			throw new Error("Cannot append link because the active Markdown view has no file.");
+		}
+
+		await app.fileManager.processFrontMatter(file, (frontmatter) => {
+			appendConfiguredFrontmatterPropertyLinkValue(
+				frontmatter,
+				frontmatterProperty ?? "",
+				text,
+				frontmatterHandling,
+			);
+		});
 		return;
 	}
 
@@ -195,38 +225,37 @@ export function insertLinkWithPlacement(
  * @param linkOptions - Options controlling link insertion behavior
  * @returns True if the link was inserted, false otherwise
  */
-export function insertFileLinkToActiveView(
+export async function insertFileLinkToActiveView(
 	app: App,
 	file: TFile,
 	linkOptions: AppendLinkOptions,
-): boolean {
+): Promise<boolean> {
 	if (!linkOptions?.enabled) return false;
 
-	const activeFile = app.workspace.getActiveFile();
-	if (!activeFile && linkOptions.requireActiveFile) {
-		throw new Error("Append link is enabled but there's no active file to insert into.");
-	}
-
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
-	if (!view) {
+	if (!view || !view.file) {
 		if (linkOptions.requireActiveFile) {
 			throw new Error("Cannot append link because no active Markdown view is available.");
 		}
 		return false;
 	}
 
-	const sourcePath = activeFile?.path ?? "";
+	const sourcePath = view.file.path;
 	const linkText = buildFileLinkText(app, file, {
 		sourcePath,
 		linkType: linkOptions.linkType,
 		placement: linkOptions.placement,
 	});
 
-	insertLinkWithPlacement(
+	await insertLinkWithPlacement(
 		app,
 		linkText,
 		linkOptions.placement,
-		{ requireActiveView: false },
+		{
+			requireActiveView: false,
+			frontmatterProperty: linkOptions.frontmatterProperty,
+			frontmatterHandling: linkOptions.frontmatterHandling,
+		},
 	);
 
 	return true;

--- a/src/utils/frontmatterPropertyLinks.test.ts
+++ b/src/utils/frontmatterPropertyLinks.test.ts
@@ -151,6 +151,24 @@ describe("appendFrontmatterPropertyLinkValue", () => {
 		expect(frontmatter.related).toEqual(["[[Existing]]", "[[Created]]"]);
 	});
 
+	it("preserves existing property key casing when the DOM key is normalized", () => {
+		const frontmatter: Record<string, unknown> = {
+			"Related Items": ["[[Existing]]"],
+		};
+
+		appendFrontmatterPropertyLinkValue(
+			frontmatter,
+			"related items",
+			"[[Created]]",
+		);
+
+		expect(frontmatter["Related Items"]).toEqual([
+			"[[Existing]]",
+			"[[Created]]",
+		]);
+		expect(frontmatter["related items"]).toBeUndefined();
+	});
+
 	it("appends links to string properties", () => {
 		const frontmatter = { related: "existing" };
 
@@ -187,6 +205,21 @@ describe("appendFrontmatterPropertyLinkValue", () => {
 		expect(() =>
 			appendFrontmatterPropertyLinkValue({}, "   ", "[[Created]]"),
 		).toThrow(/empty frontmatter property key/);
+	});
+
+	it("rejects ambiguous property keys instead of guessing which one to update", () => {
+		const frontmatter = {
+			"Related Items": "",
+			"related items": "",
+		};
+
+		expect(() =>
+			appendFrontmatterPropertyLinkValue(
+				frontmatter,
+				"related items",
+				"[[Created]]",
+			),
+		).toThrow(/multiple properties/);
 	});
 });
 

--- a/src/utils/frontmatterPropertyLinks.test.ts
+++ b/src/utils/frontmatterPropertyLinks.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TFile, type App } from "obsidian";
+import {
+	appendFrontmatterPropertyLinkValue,
+	appendLinkToFrontmatterProperty,
+	getFocusedPropertyTarget,
+	type FrontmatterPropertyTarget,
+} from "./frontmatterPropertyLinks";
+
+afterEach(() => {
+	document.body.innerHTML = "";
+	vi.restoreAllMocks();
+});
+
+function makeFile(path: string): TFile {
+	const file = new TFile();
+	file.path = path;
+	file.name = path.split("/").pop() ?? path;
+	file.basename = file.name.replace(/\.md$/i, "");
+	file.extension = "md";
+	return file;
+}
+
+function createPropertyRow(options: {
+	key: string;
+	focus: "value" | "key" | "none";
+	valueType?: string;
+}) {
+	const container = document.createElement("div");
+	const row = document.createElement("div");
+	row.className = "metadata-property";
+	row.setAttribute("data-property-key", options.key);
+
+	const keyCell = document.createElement("div");
+	keyCell.className = "metadata-property-key";
+	const keyInput = document.createElement("input");
+	keyInput.className = "metadata-property-key-input";
+	keyCell.appendChild(keyInput);
+
+	const valueCell = document.createElement("div");
+	valueCell.className = "metadata-property-value";
+	const valueInput = options.valueType
+		? document.createElement("input")
+		: document.createElement("div");
+	if (options.valueType) {
+		(valueInput as HTMLInputElement).type = options.valueType;
+	} else {
+		valueInput.className = "metadata-input-longtext";
+		valueInput.setAttribute("contenteditable", "true");
+		valueInput.tabIndex = 0;
+	}
+	valueCell.appendChild(valueInput);
+
+	row.append(keyCell, valueCell);
+	container.appendChild(row);
+	document.body.appendChild(container);
+
+	if (options.focus === "value") valueInput.focus();
+	if (options.focus === "key") keyInput.focus();
+
+	return { container, keyInput, valueInput };
+}
+
+function makeAppWithLeaves(
+	leaves: Array<{ containerEl: HTMLElement; file: TFile }>,
+): App {
+	return {
+		workspace: {
+			getLeavesOfType: (type: string) =>
+				type === "markdown"
+					? leaves.map((view) => ({ view }))
+					: [],
+		},
+	} as unknown as App;
+}
+
+describe("getFocusedPropertyTarget", () => {
+	it("returns the focused property value key and owning file", () => {
+		const file = makeFile("Host.md");
+		const { container } = createPropertyRow({
+			key: "related",
+			focus: "value",
+		});
+
+		expect(getFocusedPropertyTarget(makeAppWithLeaves([{ containerEl: container, file }]))).toEqual<FrontmatterPropertyTarget>({
+			file,
+			key: "related",
+		});
+	});
+
+	it("binds the target to the markdown view that owns the focused property", () => {
+		const first = createPropertyRow({ key: "related", focus: "none" });
+		const second = createPropertyRow({ key: "related", focus: "value" });
+		const firstFile = makeFile("First.md");
+		const secondFile = makeFile("Second.md");
+
+		expect(
+			getFocusedPropertyTarget(
+				makeAppWithLeaves([
+					{ containerEl: first.container, file: firstFile },
+					{ containerEl: second.container, file: secondFile },
+				]),
+			),
+		).toEqual({ file: secondFile, key: "related" });
+	});
+
+	it("returns null when focus is in the property key", () => {
+		const file = makeFile("Host.md");
+		const { container } = createPropertyRow({
+			key: "related",
+			focus: "key",
+		});
+
+		expect(getFocusedPropertyTarget(makeAppWithLeaves([{ containerEl: container, file }]))).toBeNull();
+	});
+
+	it.each(["number", "date", "datetime-local", "time", "month", "checkbox"])(
+		"returns null for typed property input %s",
+		(valueType) => {
+			const file = makeFile("Host.md");
+			const { container } = createPropertyRow({
+				key: "related",
+				focus: "value",
+				valueType,
+			});
+
+			expect(getFocusedPropertyTarget(makeAppWithLeaves([{ containerEl: container, file }]))).toBeNull();
+		},
+	);
+
+	it("returns null when no property value is focused", () => {
+		const file = makeFile("Host.md");
+		const { container } = createPropertyRow({
+			key: "related",
+			focus: "none",
+		});
+		const input = document.createElement("input");
+		document.body.appendChild(input);
+		input.focus();
+
+		expect(getFocusedPropertyTarget(makeAppWithLeaves([{ containerEl: container, file }]))).toBeNull();
+	});
+});
+
+describe("appendFrontmatterPropertyLinkValue", () => {
+	it("pushes links into list properties", () => {
+		const frontmatter = { related: ["[[Existing]]"] };
+
+		appendFrontmatterPropertyLinkValue(frontmatter, "related", "[[Created]]");
+
+		expect(frontmatter.related).toEqual(["[[Existing]]", "[[Created]]"]);
+	});
+
+	it("appends links to string properties", () => {
+		const frontmatter = { related: "existing" };
+
+		appendFrontmatterPropertyLinkValue(frontmatter, "related", "[[Created]]");
+
+		expect(frontmatter.related).toBe("existing [[Created]]");
+	});
+
+	it("sets missing, null, and empty properties to the link", () => {
+		const frontmatter: Record<string, unknown> = {
+			nullish: null,
+			empty: "",
+		};
+
+		appendFrontmatterPropertyLinkValue(frontmatter, "missing", "[[Created]]");
+		appendFrontmatterPropertyLinkValue(frontmatter, "nullish", "[[Created]]");
+		appendFrontmatterPropertyLinkValue(frontmatter, "empty", "[[Created]]");
+
+		expect(frontmatter.missing).toBe("[[Created]]");
+		expect(frontmatter.nullish).toBe("[[Created]]");
+		expect(frontmatter.empty).toBe("[[Created]]");
+	});
+
+	it("rejects object and non-string scalar values instead of coercing property types", () => {
+		expect(() =>
+			appendFrontmatterPropertyLinkValue({ related: { nested: true } }, "related", "[[Created]]"),
+		).toThrow(/object value/);
+		expect(() =>
+			appendFrontmatterPropertyLinkValue({ related: 5 }, "related", "[[Created]]"),
+		).toThrow(/number value/);
+	});
+
+	it("rejects empty property keys", () => {
+		expect(() =>
+			appendFrontmatterPropertyLinkValue({}, "   ", "[[Created]]"),
+		).toThrow(/empty frontmatter property key/);
+	});
+});
+
+describe("appendLinkToFrontmatterProperty", () => {
+	it("uses the focused property's file as the markdown link source", async () => {
+		const targetFile = makeFile("Folder/Host.md");
+		const createdFile = makeFile("Folder/Sub/Created.md");
+		const target: FrontmatterPropertyTarget = {
+			file: targetFile,
+			key: "related",
+		};
+		const frontmatter: Record<string, unknown> = { related: "existing" };
+		const generateMarkdownLink = vi.fn(() => "[[Sub/Created|Created]]");
+		const processFrontMatter = vi.fn(
+			async (_file: TFile, update: (fm: Record<string, unknown>) => void) => {
+				update(frontmatter);
+			},
+		);
+		const app = {
+			fileManager: {
+				generateMarkdownLink,
+				processFrontMatter,
+			},
+		} as unknown as App;
+
+		await expect(
+			appendLinkToFrontmatterProperty(app, target, createdFile),
+		).resolves.toBe(true);
+
+		expect(generateMarkdownLink).toHaveBeenCalledWith(
+			createdFile,
+			"Folder/Host.md",
+		);
+		expect(processFrontMatter).toHaveBeenCalledWith(
+			targetFile,
+			expect.any(Function),
+		);
+		expect(frontmatter.related).toBe("existing [[Sub/Created|Created]]");
+	});
+
+	it("reports failure without throwing when frontmatter persistence fails", async () => {
+		const targetFile = makeFile("Host.md");
+		const createdFile = makeFile("Created.md");
+		const app = {
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Created]]"),
+				processFrontMatter: vi.fn(async () => {
+					throw new Error("write failed");
+				}),
+			},
+		} as unknown as App;
+
+		await expect(
+			appendLinkToFrontmatterProperty(
+				app,
+				{ file: targetFile, key: "related" },
+				createdFile,
+			),
+		).resolves.toBe(false);
+	});
+});

--- a/src/utils/frontmatterPropertyLinks.test.ts
+++ b/src/utils/frontmatterPropertyLinks.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TFile, type App } from "obsidian";
 import {
+	appendConfiguredFrontmatterPropertyLinkValue,
 	appendFrontmatterPropertyLinkValue,
+	appendLinkToConfiguredFrontmatterProperty,
 	appendLinkToFrontmatterProperty,
 	getFocusedPropertyTarget,
 	type FrontmatterPropertyTarget,
@@ -223,6 +225,176 @@ describe("appendFrontmatterPropertyLinkValue", () => {
 	});
 });
 
+describe("appendConfiguredFrontmatterPropertyLinkValue", () => {
+	it("appends links into list properties in every handling mode", () => {
+		for (const frontmatterHandling of [
+			"error",
+			"createProperty",
+			"alwaysAppend",
+		] as const) {
+			const frontmatter = { related: ["[[Existing]]"] };
+
+			appendConfiguredFrontmatterPropertyLinkValue(
+				frontmatter,
+				"related",
+				"[[Created]]",
+				frontmatterHandling,
+			);
+
+			expect(frontmatter.related).toEqual(["[[Existing]]", "[[Created]]"]);
+		}
+	});
+
+	it("creates missing properties for createProperty and alwaysAppend", () => {
+		const createPropertyFrontmatter: Record<string, unknown> = {};
+		const alwaysAppendFrontmatter: Record<string, unknown> = {};
+
+		appendConfiguredFrontmatterPropertyLinkValue(
+			createPropertyFrontmatter,
+			"related",
+			"[[Created]]",
+			"createProperty",
+		);
+		appendConfiguredFrontmatterPropertyLinkValue(
+			alwaysAppendFrontmatter,
+			"related",
+			"[[Created]]",
+			"alwaysAppend",
+		);
+
+		expect(createPropertyFrontmatter.related).toEqual(["[[Created]]"]);
+		expect(alwaysAppendFrontmatter.related).toEqual(["[[Created]]"]);
+	});
+
+	it("treats null and empty string properties as empty lists", () => {
+		const frontmatter: Record<string, unknown> = {
+			empty: "",
+			related: null,
+		};
+
+		appendConfiguredFrontmatterPropertyLinkValue(
+			frontmatter,
+			"related",
+			"[[Created]]",
+			"error",
+		);
+		appendConfiguredFrontmatterPropertyLinkValue(
+			frontmatter,
+			"empty",
+			"[[Created]]",
+			"error",
+		);
+
+		expect(frontmatter.related).toEqual(["[[Created]]"]);
+		expect(frontmatter.empty).toEqual(["[[Created]]"]);
+	});
+
+	it("converts scalar values to lists only for alwaysAppend", () => {
+		const frontmatter = { related: "[[Existing]]", count: 1 };
+
+		appendConfiguredFrontmatterPropertyLinkValue(
+			frontmatter,
+			"related",
+			"[[Created]]",
+			"alwaysAppend",
+		);
+		appendConfiguredFrontmatterPropertyLinkValue(
+			frontmatter,
+			"count",
+			"[[Created]]",
+			"alwaysAppend",
+		);
+
+		expect(frontmatter.related).toEqual(["[[Existing]]", "[[Created]]"]);
+		expect(frontmatter.count).toEqual([1, "[[Created]]"]);
+		expect(() =>
+			appendConfiguredFrontmatterPropertyLinkValue(
+				{ related: "[[Existing]]" },
+				"related",
+				"[[Created]]",
+				"createProperty",
+			),
+		).toThrow(/not a list/);
+	});
+
+	it("rejects missing properties in error mode", () => {
+		expect(() =>
+			appendConfiguredFrontmatterPropertyLinkValue(
+				{},
+				"related",
+				"[[Created]]",
+				"error",
+			),
+		).toThrow(/does not exist/);
+	});
+
+	it("rejects object values in every handling mode", () => {
+		for (const frontmatterHandling of [
+			"error",
+			"createProperty",
+			"alwaysAppend",
+		] as const) {
+			const frontmatter = { related: { nested: true } };
+
+			expect(() =>
+				appendConfiguredFrontmatterPropertyLinkValue(
+					frontmatter,
+					"related",
+					"[[Created]]",
+					frontmatterHandling,
+				),
+			).toThrow(/object value/);
+			expect(frontmatter.related).toEqual({ nested: true });
+		}
+	});
+
+	it("trims and rejects empty configured property keys", () => {
+		expect(() =>
+			appendConfiguredFrontmatterPropertyLinkValue(
+				{},
+				"   ",
+				"[[Created]]",
+				"alwaysAppend",
+			),
+		).toThrow(/empty frontmatter property key/);
+	});
+
+	it("preserves existing property key casing when configured key is normalized", () => {
+		const frontmatter: Record<string, unknown> = {
+			"Related Items": ["[[Existing]]"],
+		};
+
+		appendConfiguredFrontmatterPropertyLinkValue(
+			frontmatter,
+			"related items",
+			"[[Created]]",
+			"alwaysAppend",
+		);
+
+		expect(frontmatter["Related Items"]).toEqual([
+			"[[Existing]]",
+			"[[Created]]",
+		]);
+		expect(frontmatter["related items"]).toBeUndefined();
+	});
+
+	it("rejects ambiguous configured property keys", () => {
+		const frontmatter = {
+			"Related Items": [],
+			"related items": [],
+		};
+
+		expect(() =>
+			appendConfiguredFrontmatterPropertyLinkValue(
+				frontmatter,
+				"related items",
+				"[[Created]]",
+				"alwaysAppend",
+			),
+		).toThrow(/multiple properties/);
+	});
+});
+
 describe("appendLinkToFrontmatterProperty", () => {
 	it("uses the focused property's file as the markdown link source", async () => {
 		const targetFile = makeFile("Folder/Host.md");
@@ -279,5 +451,46 @@ describe("appendLinkToFrontmatterProperty", () => {
 				createdFile,
 			),
 		).resolves.toBe(false);
+	});
+});
+
+describe("appendLinkToConfiguredFrontmatterProperty", () => {
+	it("uses the configured property's file as the markdown link source", async () => {
+		const targetFile = makeFile("Folder/Host.md");
+		const createdFile = makeFile("Folder/Sub/Created.md");
+		const frontmatter: Record<string, unknown> = { related: ["[[Existing]]"] };
+		const generateMarkdownLink = vi.fn(() => "[[Sub/Created|Created]]");
+		const processFrontMatter = vi.fn(
+			async (_file: TFile, update: (fm: Record<string, unknown>) => void) => {
+				update(frontmatter);
+			},
+		);
+		const app = {
+			fileManager: {
+				generateMarkdownLink,
+				processFrontMatter,
+			},
+		} as unknown as App;
+
+		await appendLinkToConfiguredFrontmatterProperty(
+			app,
+			targetFile,
+			"related",
+			createdFile,
+			"error",
+		);
+
+		expect(generateMarkdownLink).toHaveBeenCalledWith(
+			createdFile,
+			"Folder/Host.md",
+		);
+		expect(processFrontMatter).toHaveBeenCalledWith(
+			targetFile,
+			expect.any(Function),
+		);
+		expect(frontmatter.related).toEqual([
+			"[[Existing]]",
+			"[[Sub/Created|Created]]",
+		]);
 	});
 });

--- a/src/utils/frontmatterPropertyLinks.test.ts
+++ b/src/utils/frontmatterPropertyLinks.test.ts
@@ -317,6 +317,25 @@ describe("appendConfiguredFrontmatterPropertyLinkValue", () => {
 		).toThrow(/not a list/);
 	});
 
+	it("defaults to creating missing properties and converting scalars", () => {
+		const missingFrontmatter: Record<string, unknown> = {};
+		const scalarFrontmatter = { related: "[[Existing]]" };
+
+		appendConfiguredFrontmatterPropertyLinkValue(
+			missingFrontmatter,
+			"related",
+			"[[Created]]",
+		);
+		appendConfiguredFrontmatterPropertyLinkValue(
+			scalarFrontmatter,
+			"related",
+			"[[Created]]",
+		);
+
+		expect(missingFrontmatter.related).toEqual(["[[Created]]"]);
+		expect(scalarFrontmatter.related).toEqual(["[[Existing]]", "[[Created]]"]);
+	});
+
 	it("rejects missing properties in error mode", () => {
 		expect(() =>
 			appendConfiguredFrontmatterPropertyLinkValue(

--- a/src/utils/frontmatterPropertyLinks.ts
+++ b/src/utils/frontmatterPropertyLinks.ts
@@ -1,0 +1,106 @@
+import type { App, TFile } from "obsidian";
+import { log } from "../logger/logManager";
+import { getOwnerDocument } from "./activeWindow";
+
+const TYPED_PROPERTY_INPUT_SELECTOR = [
+	'input[type="number"]',
+	'input[type="date"]',
+	'input[type="datetime-local"]',
+	'input[type="time"]',
+	'input[type="month"]',
+	'input[type="checkbox"]',
+].join(", ");
+
+export interface FrontmatterPropertyTarget {
+	file: TFile;
+	key: string;
+}
+
+type MarkdownPropertyView = {
+	containerEl?: HTMLElement;
+	file?: TFile | null;
+};
+
+export function getFocusedPropertyTarget(
+	app: App,
+): FrontmatterPropertyTarget | null {
+	for (const leaf of app.workspace.getLeavesOfType("markdown")) {
+		const view = leaf.view as MarkdownPropertyView;
+		if (!view.containerEl || !view.file || view.file.extension !== "md") {
+			continue;
+		}
+
+		try {
+			const focused = getOwnerDocument(view.containerEl).activeElement;
+			if (!focused || !view.containerEl.contains(focused)) continue;
+			if (!focused.closest(".metadata-property-value")) continue;
+			if (focused.matches(TYPED_PROPERTY_INPUT_SELECTOR)) continue;
+
+			const row = focused.closest(".metadata-property");
+			const key = row?.getAttribute("data-property-key");
+			if (!key) continue;
+
+			return { file: view.file, key };
+		} catch {
+			continue;
+		}
+	}
+
+	return null;
+}
+
+export function appendFrontmatterPropertyLinkValue(
+	frontmatter: Record<string, unknown>,
+	propertyKey: string,
+	linkText: string,
+): void {
+	const key = propertyKey.trim();
+	if (!key) {
+		throw new Error("Cannot append link to an empty frontmatter property key.");
+	}
+
+	const existing = frontmatter[key];
+	if (Array.isArray(existing)) {
+		existing.push(linkText);
+		return;
+	}
+
+	if (existing === undefined || existing === null || existing === "") {
+		frontmatter[key] = linkText;
+		return;
+	}
+
+	if (typeof existing === "string") {
+		frontmatter[key] = `${existing} ${linkText}`;
+		return;
+	}
+
+	throw new Error(
+		`Cannot append link to frontmatter property '${key}' because it contains a ${typeof existing} value.`,
+	);
+}
+
+export async function appendLinkToFrontmatterProperty(
+	app: App,
+	target: FrontmatterPropertyTarget,
+	fileToLink: TFile,
+): Promise<boolean> {
+	const linkText = app.fileManager.generateMarkdownLink(
+		fileToLink,
+		target.file.path,
+	);
+
+	try {
+		await app.fileManager.processFrontMatter(target.file, (frontmatter) => {
+			appendFrontmatterPropertyLinkValue(frontmatter, target.key, linkText);
+		});
+		return true;
+	} catch (error) {
+		log.logWarning(
+			`QuickAdd: could not append link to frontmatter property '${target.key}' in '${target.file.path}': ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+		return false;
+	}
+}

--- a/src/utils/frontmatterPropertyLinks.ts
+++ b/src/utils/frontmatterPropertyLinks.ts
@@ -1,6 +1,9 @@
 import type { App, TFile } from "obsidian";
 import { log } from "../logger/logManager";
-import type { FrontmatterHandling } from "../types/linkPlacement";
+import {
+	DEFAULT_FRONTMATTER_HANDLING,
+	type FrontmatterHandling,
+} from "../types/linkPlacement";
 import { getOwnerDocument } from "./activeWindow";
 
 const TYPED_PROPERTY_INPUT_SELECTOR = [
@@ -86,7 +89,7 @@ export function appendConfiguredFrontmatterPropertyLinkValue(
 	frontmatter: Record<string, unknown>,
 	propertyKey: string,
 	linkText: string,
-	frontmatterHandling: FrontmatterHandling = "error",
+	frontmatterHandling: FrontmatterHandling = DEFAULT_FRONTMATTER_HANDLING,
 ): void {
 	const requestedKey = propertyKey.trim();
 	if (!requestedKey) {
@@ -157,7 +160,7 @@ export async function appendLinkToConfiguredFrontmatterProperty(
 	targetFile: TFile,
 	propertyKey: string,
 	fileToLink: TFile,
-	frontmatterHandling: FrontmatterHandling = "error",
+	frontmatterHandling: FrontmatterHandling = DEFAULT_FRONTMATTER_HANDLING,
 ): Promise<void> {
 	const linkText = app.fileManager.generateMarkdownLink(
 		fileToLink,

--- a/src/utils/frontmatterPropertyLinks.ts
+++ b/src/utils/frontmatterPropertyLinks.ts
@@ -1,5 +1,6 @@
 import type { App, TFile } from "obsidian";
 import { log } from "../logger/logManager";
+import type { FrontmatterHandling } from "../types/linkPlacement";
 import { getOwnerDocument } from "./activeWindow";
 
 const TYPED_PROPERTY_INPUT_SELECTOR = [
@@ -81,6 +82,54 @@ export function appendFrontmatterPropertyLinkValue(
 	);
 }
 
+export function appendConfiguredFrontmatterPropertyLinkValue(
+	frontmatter: Record<string, unknown>,
+	propertyKey: string,
+	linkText: string,
+	frontmatterHandling: FrontmatterHandling = "error",
+): void {
+	const requestedKey = propertyKey.trim();
+	if (!requestedKey) {
+		throw new Error("Cannot append link to an empty frontmatter property key.");
+	}
+
+	const key = resolveFrontmatterPropertyKey(frontmatter, requestedKey);
+	const existing = frontmatter[key];
+	if (Array.isArray(existing)) {
+		existing.push(linkText);
+		return;
+	}
+
+	if (existing === null || existing === "") {
+		frontmatter[key] = [linkText];
+		return;
+	}
+
+	if (existing === undefined) {
+		if (frontmatterHandling === "error") {
+			throw new Error(
+				`Cannot append link to frontmatter property '${key}' because it does not exist.`,
+			);
+		}
+		frontmatter[key] = [linkText];
+		return;
+	}
+
+	if (typeof existing === "object") {
+		throw new Error(
+			`Cannot append link to frontmatter property '${key}' because it contains an object value.`,
+		);
+	}
+
+	if (frontmatterHandling !== "alwaysAppend") {
+		throw new Error(
+			`Cannot append link to frontmatter property '${key}' because it is not a list and frontmatter handling is '${frontmatterHandling}'.`,
+		);
+	}
+
+	frontmatter[key] = [existing, linkText];
+}
+
 function resolveFrontmatterPropertyKey(
 	frontmatter: Record<string, unknown>,
 	propertyKey: string,
@@ -101,6 +150,28 @@ function resolveFrontmatterPropertyKey(
 
 function normalizePropertyKey(propertyKey: string): string {
 	return propertyKey.trim().toLowerCase();
+}
+
+export async function appendLinkToConfiguredFrontmatterProperty(
+	app: App,
+	targetFile: TFile,
+	propertyKey: string,
+	fileToLink: TFile,
+	frontmatterHandling: FrontmatterHandling = "error",
+): Promise<void> {
+	const linkText = app.fileManager.generateMarkdownLink(
+		fileToLink,
+		targetFile.path,
+	);
+
+	await app.fileManager.processFrontMatter(targetFile, (frontmatter) => {
+		appendConfiguredFrontmatterPropertyLinkValue(
+			frontmatter,
+			propertyKey,
+			linkText,
+			frontmatterHandling,
+		);
+	});
 }
 
 export async function appendLinkToFrontmatterProperty(

--- a/src/utils/frontmatterPropertyLinks.ts
+++ b/src/utils/frontmatterPropertyLinks.ts
@@ -54,11 +54,12 @@ export function appendFrontmatterPropertyLinkValue(
 	propertyKey: string,
 	linkText: string,
 ): void {
-	const key = propertyKey.trim();
-	if (!key) {
+	const requestedKey = propertyKey.trim();
+	if (!requestedKey) {
 		throw new Error("Cannot append link to an empty frontmatter property key.");
 	}
 
+	const key = resolveFrontmatterPropertyKey(frontmatter, requestedKey);
 	const existing = frontmatter[key];
 	if (Array.isArray(existing)) {
 		existing.push(linkText);
@@ -78,6 +79,28 @@ export function appendFrontmatterPropertyLinkValue(
 	throw new Error(
 		`Cannot append link to frontmatter property '${key}' because it contains a ${typeof existing} value.`,
 	);
+}
+
+function resolveFrontmatterPropertyKey(
+	frontmatter: Record<string, unknown>,
+	propertyKey: string,
+): string {
+	const normalizedPropertyKey = normalizePropertyKey(propertyKey);
+	const matchingKeys = Object.keys(frontmatter).filter(
+		(key) => normalizePropertyKey(key) === normalizedPropertyKey,
+	);
+
+	if (matchingKeys.length > 1) {
+		throw new Error(
+			`Cannot append link to frontmatter property '${propertyKey}' because the note has multiple properties that normalize to that key.`,
+		);
+	}
+
+	return matchingKeys[0] ?? propertyKey;
+}
+
+function normalizePropertyKey(propertyKey: string): string {
+	return propertyKey.trim().toLowerCase();
 }
 
 export async function appendLinkToFrontmatterProperty(


### PR DESCRIPTION
## Summary

This consolidates the work from #1276 and #1340 into one maintained PR for #768.

The core feature here is Arjan's configurable append-link placement from #1276: Template and Capture choices can now insert the created/captured-file link into a named frontmatter property on the active note. Arjan's implementation was the right product direction for this issue; I ported that work onto current `master`, adapted it to the shared `AppendLinkSetting.svelte` settings UI, and kept the focused-property caret fix from #1340/#1394 as the fallback for normal append-link placements.

Credit where it is due:
- @ArjanSeijs did the substantial feature work for the explicit **In frontmatter property** placement, including the settings direction and the frontmatter value-shape handling that this PR now carries forward.
- @Ivikhostrup did the live Obsidian investigation for #768 and established the important `processFrontMatter` direction for the focused-property caret bug.

This PR supersedes #1276 and #1340. I am not pushing to either contributor branch.

## Problem

The underlying problem is broader than the issue title. Obsidian Properties are separate editable controls from the Markdown editor, so QuickAdd cannot assume that the Markdown editor cursor is the user's current insertion target. Users need two coherent behaviors:

1. A deliberate setting for writing append links into a chosen frontmatter property.
2. A fallback for the #768 caret case where a normal append-link placement starts while focus is inside an editable Obsidian Properties value.

## Design

- Add `Link placement -> In frontmatter property` for Template and Capture append links.
- Add a required `Frontmatter property` setting and three handling modes, with `Create or convert` as the default:
  - `Create or convert`: create the property when absent, or convert existing scalars to a list before appending.
  - `Create if missing`: create the property when absent, but reject existing scalar/object values.
  - `Require list`: append only to an existing list, treating empty/null as an empty list.
- Persist frontmatter changes through `app.fileManager.processFrontMatter` instead of mutating Obsidian's property DOM.
- Preserve property key casing and reject ambiguous keys that normalize to the same name.
- Keep embeds unsupported for frontmatter placement; YAML receives a normal wikilink string.
- Compose with the `master` append-link destination feature by keeping `Specified note` destinations as bottom-appends to that specified note; frontmatter placement is intentionally scoped to `Current note` because Obsidian Properties focus only identifies the active note.
- Preserve frontmatter settings when switching append-link modes, including disable/re-enable.
- Keep the focused-property #768 fallback only for non-`In frontmatter property` placements. Explicit configuration wins over the currently focused property.
- Carry focused-property context through QuickAdd suggesters, including top-level `Run QuickAdd` and Multi-choice child selection, so opening the modal does not erase the Properties-field target.
- Keep append-link insertion post-commit, matching existing QuickAdd behavior. If frontmatter append fails after a Template/Capture has already created or written its target file, QuickAdd logs/reports that error but preserves the successful primary side effect for URI/automation callers so retries do not duplicate notes or captures.

## Validation

Automated gates:
- `pnpm run build-with-lint` passes.
- `pnpm run check` passes with 0 errors and the existing 4 warnings.
- `pnpm run test` passes: 237 files passed, 5 skipped; 2875 tests passed, 37 skipped.
- `git diff --check` passes.

Targeted regression coverage added for:
- `LinkPlacement` normalization and frontmatter support detection.
- Frontmatter helper behavior for arrays, missing/null/empty properties, scalars, objects, casing, and ambiguous keys.
- `insertFileLinkToActiveView` writing through `processFrontMatter` and propagating insertion failures to the engine.
- Append-link settings defaulting frontmatter handling to `Create or convert`, preserving `frontmatterProperty`/`frontmatterHandling` across mode changes, including disable/re-enable.
- Template/Capture engine post-commit behavior when configured frontmatter insertion fails.
- Canvas-triggered Capture does not silently skip explicit frontmatter placement.
- Focused Properties-field context surviving top-level and nested/Multi QuickAdd suggesters.

Live Obsidian validation in this worktree's isolated vault:
- Template with `In frontmatter property` + `Create if missing` wrote the created-file link into `related` on the active note.
- Capture with `In frontmatter property` + `Create if missing` wrote the captured-file link into `captures` on the active note and wrote the capture body.
- Default `Create or convert` handling converted a scalar `related: "[[Existing]]"` into a list and appended the new link.
- `Require list` treated `related: ""` as an empty list and appended the new link.
- Explicit configured property won over a simultaneously focused different property.
- Normal `replaceSelection` append-link still used the focused-property fallback for the original #768 case.
- A command-backed Multi choice with a child Template, selected through the real suggester UI while the `focused` Properties field was active, created the child note and updated the host note to `focused: seed [[Created child ...]]`.
- The top-level `quickadd:runQuickAdd` suggester path, opened while the `focused` Properties field was active, created the selected Template note and updated the host note to `focused: seed [[Created root ...]]`.
- `Require list` with a missing property left the note unchanged and reported the expected QuickAdd error.
- After rebasing onto latest `master` (`19b52f83`), repeated the focused-property live smoke: with focus inside the `related` Properties value, `quickadd:run` created the Template note, appended `[[Created_...]]` into `Related`, and left the note body unchanged.
- After clearing the expected failure and final smoke seeds, `pnpm run obsidian:e2e -- dev:errors` reported no captured runtime errors.

## Migration / Release Notes

No migration is required. Existing boolean append-link settings still normalize at runtime. The new frontmatter fields are optional and only used when placement is `In frontmatter property`.

Fixes #768
Supersedes #1276
Supersedes #1340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **In frontmatter property** placement for Capture and Template, including configurable handling when the target frontmatter is missing or not a list (**error**, **createProperty**, **alwaysAppend**).
  * Added **newLine** placement support and new UI controls for frontmatter property and handling.
* **Bug Fixes**
  * Improved link insertion when a frontmatter Properties field or canvas context has focus, avoiding stale cursor behavior.
  * Ensured frontmatter/link insertion completes before follow-up actions.
* **Documentation**
  * Updated Capture/Template docs with placement rules and focus behavior.
* **Tests**
  * Expanded automated coverage for frontmatter modes and focus/cursor edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

