### PR TITLE
feat(linking): append file links to specified notes

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -127,18 +127,26 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
     -   **After line…** — insert after a target line. You can either type the target now, or enable **Choose heading when capturing** to pick a heading from the note at run time. See [Insert after](#insert-after).
     -   **Before line…**
     -   **Bottom of file**
--   _Link to captured file_ is a dropdown that controls whether QuickAdd inserts a link to the captured file in the current note. You can choose between three modes:
-    -   **Enabled (requires active file)** – keeps the legacy behavior and throws an error if no note is focused (except Canvas-triggered capture, where link insertion is skipped)
-    -   **Enabled (skip if no active file)** – inserts the link when possible and silently drops `{{LINKCURRENT}}` if nothing is open
+-   _Link to captured file_ is a dropdown that controls whether QuickAdd inserts a link to the captured file. You can choose between three modes:
+    -   **Enabled (strict)** – require the configured link destination to be available
+    -   **Enabled (skip if unavailable)** – inserts the link when possible and silently drops current-note link insertion when nothing is open
     -   **Disabled** – never append a link
 
-    When either enabled mode is selected, a _Link placement_ dropdown appears so you can choose where the link is placed:
+    When either enabled mode is selected, _Link destination_ controls where the link is written:
+    -   **Current note** – insert the link into the active Markdown editor
+    -   **Specified note** – append the link to the bottom of an existing Markdown note, such as an index or MOC, without opening that note
+
+    For **Current note**, strict mode keeps the legacy behavior and requires a focused Markdown editor, except Canvas-triggered capture skips link insertion when no Markdown editor is available. For **Specified note**, QuickAdd validates the destination note before writing the capture.
+
+    For the **Current note** destination, a _Link placement_ dropdown appears so you can choose where the link is placed:
     -   **Replace selection** - Replaces any selected text with the link (default)
     -   **After selection** - Preserves selected text and places the link after it
     -   **End of line** - Places the link at the end of the current line
     -   **New line** - Places the link on a new line below the cursor
 
     When placement is **Replace selection**, an extra _Link type_ dropdown appears, letting you choose **Link** or **Embed**. Embed is only respected for the Replace selection placement.
+
+    For the **Specified note** destination, choose an existing Markdown file. QuickAdd appends a normal link at the bottom of that file after each successful capture. It does not create the index file, insert under a heading, update properties, or remove duplicate links.
 
 ### Opening the captured file
 

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -55,18 +55,26 @@ append template content, insert links, or copy links. Selecting the explicit
 
 Switching modes hides the fields that don't apply, but your configured folder list is kept — switching back restores it.
 
-**Link to created file**. Choose how QuickAdd should insert a link to the created file in the current note. Pick one of three modes:
-- **Enabled (requires active file)** – throw an error if no note is focused (legacy behavior)
-- **Enabled (skip if no active file)** – insert the link when possible and skip silently otherwise
+**Link to created file**. Choose whether QuickAdd should insert a link to the created file. Pick one of three modes:
+- **Enabled (strict)** – require the configured link destination to be available
+- **Enabled (skip if unavailable)** – insert the link when possible and skip silently when a current-note destination has no focused Markdown editor
 - **Disabled** – never append a link
 
-When either enabled mode is selected, **Link placement** lets you choose where the link is placed:
+When either enabled mode is selected, **Link destination** controls where the link is written:
+- **Current note** – insert the link into the active Markdown editor
+- **Specified note** – append the link to the bottom of an existing Markdown note, such as an index or MOC, without opening that note
+
+For **Current note**, strict mode keeps the legacy behavior and requires a focused Markdown editor. For **Specified note**, QuickAdd validates the destination note before creating the new note.
+
+For the **Current note** destination, **Link placement** lets you choose where the link is placed:
 - **Replace selection** - Replaces any selected text with the link (default)
 - **After selection** - Preserves selected text and places the link after it  
 - **End of line** - Places the link at the end of the current line
 - **New line** - Places the link on a new line below the cursor
 
 **Link type**. Shown only when **Link placement** is **Replace selection**. Choose whether replacing the selection should insert a **Link** or an **Embed**.
+
+For the **Specified note** destination, choose an existing Markdown file. QuickAdd appends a normal link at the bottom of that file. It does not create the index file, insert under a heading, update properties, or remove duplicate links.
 
 **Copy link to clipboard**. Copies a link to the created file after the Template
 choice runs. This works separately from **Link to created file**, so you can copy

--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -43,6 +43,14 @@ vi.mock("../quickAddSettingsTab", () => {
 	};
 });
 
+const {
+	appendFileLinkToDestinationFileMock,
+	getAppendLinkDestinationFileMock,
+} = vi.hoisted(() => ({
+	appendFileLinkToDestinationFileMock: vi.fn(),
+	getAppendLinkDestinationFileMock: vi.fn(),
+}));
+
 vi.mock("../formatters/captureChoiceFormatter", () => {
 	class CaptureChoiceFormatterMock {
 		constructor() {}
@@ -63,6 +71,9 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 		getAndClearTemplatePropertyVars() {
 			return new Map();
 		}
+		getCaptureInsertionEndOffset() {
+			return undefined;
+		}
 		consumeCreatedClipboardAttachmentPaths() {
 			return [];
 		}
@@ -72,20 +83,25 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 	};
 });
 
-	vi.mock("../utilityObsidian", () => ({
-		appendToCurrentLine: vi.fn(),
-		getMarkdownFilesInFolder: vi.fn(async () => []),
-		getMarkdownFilesWithTag: vi.fn(async () => []),
-		insertFileLinkToActiveView: vi.fn(),
-		insertOnNewLineAbove: vi.fn(),
-		insertOnNewLineBelow: vi.fn(),
-		isFolder: vi.fn(() => false),
-		openExistingFileTab: vi.fn(() => null),
-		openFile: vi.fn(),
-		overwriteTemplaterOnce: vi.fn(),
-		templaterParseTemplate: vi.fn(async (_app, content) => content),
-		getTemplater: vi.fn(() => ({})),
-	}));
+vi.mock("../utils/fileLinks", () => ({
+	appendFileLinkToDestinationFile: appendFileLinkToDestinationFileMock,
+	getAppendLinkDestinationFile: getAppendLinkDestinationFileMock,
+}));
+
+vi.mock("../utilityObsidian", () => ({
+	appendToCurrentLine: vi.fn(),
+	getMarkdownFilesInFolder: vi.fn(async () => []),
+	getMarkdownFilesWithTag: vi.fn(async () => []),
+	insertFileLinkToActiveView: vi.fn(),
+	insertOnNewLineAbove: vi.fn(),
+	insertOnNewLineBelow: vi.fn(),
+	isFolder: vi.fn(() => false),
+	openExistingFileTab: vi.fn(() => null),
+	openFile: vi.fn(),
+	overwriteTemplaterOnce: vi.fn(),
+	templaterParseTemplate: vi.fn(async (_app, content) => content),
+	getTemplater: vi.fn(() => ({})),
+}));
 
 vi.mock("three-way-merge", () => ({
 	default: vi.fn(() => ({})),
@@ -104,7 +120,7 @@ vi.mock("obsidian-dataview", () => ({
 	getAPI: vi.fn(),
 }));
 
-import type { App } from "obsidian";
+import { TFile, type App } from "obsidian";
 import { Notice } from "obsidian";
 import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
@@ -121,6 +137,15 @@ type NoticeTestClass = typeof Notice & {
 };
 
 const noticeClass = Notice as unknown as NoticeTestClass;
+
+function createTestFile(path: string): TFile {
+	const file = new TFile();
+	file.path = path;
+	file.name = path.slice(path.lastIndexOf("/") + 1);
+	file.extension = file.name.slice(file.name.lastIndexOf(".") + 1);
+	file.basename = file.name.replace(/\.[^.]+$/, "");
+	return file;
+}
 
 const createCaptureChoice = (): ICaptureChoice => ({
 	name: "Test Capture Choice",
@@ -201,6 +226,8 @@ describe("CaptureChoiceEngine cancellation notices", () => {
 	beforeEach(() => {
 		settingsStore.setState(structuredClone(defaultSettingsState));
 		noticeClass.instances.length = 0;
+		appendFileLinkToDestinationFileMock.mockReset();
+		getAppendLinkDestinationFileMock.mockReset();
 	});
 
 	it("shows a cancellation notice when the setting is enabled", async () => {
@@ -307,5 +334,102 @@ describe("CaptureChoiceEngine cancellation notices", () => {
 		expect(noticeClass.instances[0]?.message).toContain(
 			"Capture execution aborted: Target file missing",
 		);
+	});
+});
+
+describe("CaptureChoiceEngine append-link destination", () => {
+	beforeEach(() => {
+		settingsStore.setState(structuredClone(defaultSettingsState));
+		noticeClass.instances.length = 0;
+		appendFileLinkToDestinationFileMock.mockReset();
+		appendFileLinkToDestinationFileMock.mockResolvedValue(true);
+		getAppendLinkDestinationFileMock.mockReset();
+	});
+
+	function createAppendLinkHarness() {
+		const captureFile = createTestFile("Daily/Test.md");
+		const destinationFile = createTestFile("Indexes/MOC.md");
+		const app = {
+			vault: {
+				adapter: {
+					exists: vi.fn(async (path: string) => path === captureFile.path),
+				},
+				getAbstractFileByPath: vi.fn((path: string) =>
+					path === captureFile.path ? captureFile : null,
+				),
+				read: vi.fn(async () => "existing"),
+				modify: vi.fn(),
+				create: vi.fn(),
+			},
+			workspace: {
+				getActiveFile: vi.fn(() => null),
+				getActiveViewOfType: vi.fn(() => null),
+			},
+			fileManager: {
+				getNewFileParent: vi.fn(() => ({ path: "" })),
+			},
+		} as unknown as App;
+
+		const plugin = {
+			settings: {
+				...settingsStore.getState(),
+				showCaptureNotification: false,
+			},
+		} as any;
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			recordExecutionResult: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const choice = createCaptureChoice();
+		choice.appendLink = {
+			enabled: true,
+			placement: "replaceSelection",
+			requireActiveFile: true,
+			linkType: "embed",
+			destination: { type: "specifiedFile", path: destinationFile.path },
+		};
+
+		return {
+			app,
+			captureFile,
+			destinationFile,
+			choiceExecutor,
+			engine: new CaptureChoiceEngine(app, plugin, choice, choiceExecutor),
+		};
+	}
+
+	it("appends the captured file link to a specified destination without an active editor", async () => {
+		const { app, captureFile, destinationFile, choiceExecutor, engine } =
+			createAppendLinkHarness();
+		getAppendLinkDestinationFileMock.mockReturnValue(destinationFile);
+
+		await engine.run();
+
+		expect(app.vault.modify).toHaveBeenCalledWith(captureFile, "");
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: captureFile,
+		});
+		expect(appendFileLinkToDestinationFileMock).toHaveBeenCalledWith(
+			app,
+			captureFile,
+			expect.objectContaining({
+				destination: { type: "specifiedFile", path: destinationFile.path },
+				linkType: "link",
+			}),
+		);
+	});
+
+	it("does not write the capture when a specified append-link destination is missing", async () => {
+		const { app, engine, choiceExecutor } = createAppendLinkHarness();
+		getAppendLinkDestinationFileMock.mockReturnValue(null);
+
+		await engine.run();
+
+		expect(app.vault.adapter.exists).not.toHaveBeenCalled();
+		expect(app.vault.modify).not.toHaveBeenCalled();
+		expect(choiceExecutor.recordExecutionResult).not.toHaveBeenCalled();
+		expect(appendFileLinkToDestinationFileMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -26,7 +26,10 @@ import { getLinesInString } from "../utility";
 import { log } from "../logger/logManager";
 import type QuickAdd from "../main";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
-import { normalizeAppendLinkOptions, type AppendLinkOptions } from "../types/linkPlacement";
+import {
+	normalizeAppendLinkOptions,
+	type AppendLinkOptions,
+} from "../types/linkPlacement";
 import {
 	appendToCurrentLine,
 	getMarkdownFilesInFolder,
@@ -49,6 +52,10 @@ import { isCancellationError, reportError } from "../utils/errorUtils";
 import { parsePropertyTarget } from "../utils/propertyTarget";
 import type { FieldFilter } from "../utils/FieldSuggestionParser";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
+import {
+	appendFileLinkToDestinationFile,
+	getAppendLinkDestinationFile,
+} from "../utils/fileLinks";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
@@ -72,6 +79,8 @@ import {
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 
 const DEFAULT_NOTICE_DURATION = 4000;
+
+type NormalizedAppendLinkOptions = ReturnType<typeof normalizeAppendLinkOptions>;
 
 type CaptureWriteResult = {
 	file: TFile;
@@ -204,16 +213,17 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	): boolean {
 		return (
 			isCanvasTriggered &&
+			linkOptions.destination?.type !== "specifiedFile" &&
 			linkOptions.requireActiveFile &&
 			!this.hasActiveMarkdownCaptureContext()
 		);
 	}
 
-	private insertCaptureLink(
+	private async insertCaptureLink(
 		file: TFile,
 		linkOptions: AppendLinkOptions,
 		{ isCanvasTriggered }: { isCanvasTriggered: boolean },
-	): void {
+	): Promise<void> {
 		if (!linkOptions.enabled) {
 			return;
 		}
@@ -230,7 +240,33 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			return;
 		}
 
+		if (linkOptions.destination?.type === "specifiedFile") {
+			await appendFileLinkToDestinationFile(this.app, file, linkOptions);
+			return;
+		}
+
 		insertFileLinkToActiveView(this.app, file, linkOptions);
+	}
+
+	private validateAppendLinkDestination(
+		linkOptions: NormalizedAppendLinkOptions,
+	): boolean {
+		if (
+			!linkOptions.enabled ||
+			linkOptions.destination.type !== "specifiedFile"
+		) {
+			return true;
+		}
+
+		if (getAppendLinkDestinationFile(this.app, linkOptions.destination)) {
+			return true;
+		}
+
+		InputPromptDraftStore.getInstance().markExecutionScopeFailed();
+		log.logError(
+			`Append link target file not found or is not a Markdown file: ${linkOptions.destination.path}`,
+		);
+		return false;
 	}
 
 	async run(): Promise<void> {
@@ -244,6 +280,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					? "optional"
 					: "required",
 			);
+			if (!this.validateAppendLinkDestination(linkOptions)) return;
 			const selectionOverride = this.choice.useSelectionAsCaptureValue;
 			const globalSelectionAsValue =
 				this.plugin.settings.useSelectionAsCaptureValue ?? true;
@@ -454,7 +491,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				});
 			}
 
-			this.insertCaptureLink(file, linkOptions, {
+			await this.insertCaptureLink(file, linkOptions, {
 				isCanvasTriggered: !!canvasTarget,
 			});
 
@@ -591,7 +628,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			});
 		}
 
-		this.insertCaptureLink(file, linkOptions, {
+		await this.insertCaptureLink(file, linkOptions, {
 			isCanvasTriggered: true,
 		});
 

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -45,10 +45,14 @@ vi.mock("../quickAddSettingsTab", () => {
 
 const {
 	copyFileLinkToClipboardMock,
+	appendFileLinkToDestinationFileMock,
+	getAppendLinkDestinationFileMock,
 	formatFileNameMock,
 	formatFileContentMock,
 } = vi.hoisted(() => {
 	const copyFileLink = vi.fn();
+	const appendFileLink = vi.fn();
+	const getDestinationFile = vi.fn();
 	const formatName =
 		vi.fn<(format: string, prompt: string) => Promise<string>>();
 	const formatContent = vi
@@ -57,6 +61,8 @@ const {
 
 	return {
 		copyFileLinkToClipboardMock: copyFileLink,
+		appendFileLinkToDestinationFileMock: appendFileLink,
+		getAppendLinkDestinationFileMock: getDestinationFile,
 		formatFileNameMock: formatName,
 		formatFileContentMock: formatContent,
 	};
@@ -93,7 +99,9 @@ vi.mock("../formatters/completeFormatter", () => {
 });
 
 vi.mock("../utils/fileLinks", () => ({
+	appendFileLinkToDestinationFile: appendFileLinkToDestinationFileMock,
 	copyFileLinkToClipboard: copyFileLinkToClipboardMock,
+	getAppendLinkDestinationFile: getAppendLinkDestinationFileMock,
 }));
 
 vi.mock("../utilityObsidian", () => ({
@@ -228,10 +236,14 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 	beforeEach(() => {
 		settingsStore.setState(structuredClone(defaultSettingsState));
 		noticeClass.instances.length = 0;
-		InputPromptDraftStore.getInstance().clearAll();
-		copyFileLinkToClipboardMock.mockReset();
-		copyFileLinkToClipboardMock.mockResolvedValue(true);
-		formatFileNameMock.mockReset();
+			InputPromptDraftStore.getInstance().clearAll();
+			appendFileLinkToDestinationFileMock.mockReset();
+			appendFileLinkToDestinationFileMock.mockResolvedValue(true);
+			copyFileLinkToClipboardMock.mockReset();
+			copyFileLinkToClipboardMock.mockResolvedValue(true);
+			getAppendLinkDestinationFileMock.mockReset();
+			getAppendLinkDestinationFileMock.mockReturnValue(null);
+			formatFileNameMock.mockReset();
 		formatFileContentMock.mockReset();
 		formatFileContentMock.mockResolvedValue("");
 	});
@@ -415,9 +427,9 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 		expect(store.get(draftKey)).toBe("Submitted template name");
 	});
 
-	it("copies the created file link without requiring append-link insertion", async () => {
-		const { engine } = createEngine("ignored", {
-			throwDuringFileName: false,
+		it("copies the created file link without requiring append-link insertion", async () => {
+			const { engine } = createEngine("ignored", {
+				throwDuringFileName: false,
 		});
 		const createdFile = new TFile();
 		createdFile.path = "Test Template.md";
@@ -434,11 +446,76 @@ describe("TemplateChoiceEngine cancellation notices", () => {
 
 		await engine.run();
 
-		expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(createdFile);
-	});
+			expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(createdFile);
+		});
 
-	it("keeps template execution successful when clipboard copying reports failure", async () => {
-		const { engine, choiceExecutor } = createEngine("ignored", {
+		it("appends the created file link to a specified destination without an active editor", async () => {
+			const { engine, app } = createEngine("ignored", {
+				throwDuringFileName: false,
+			});
+			const createdFile = new TFile();
+			createdFile.path = "Test Template.md";
+			createdFile.name = "Test Template.md";
+			createdFile.extension = "md";
+			createdFile.basename = "Test Template";
+			const destinationFile = new TFile();
+			destinationFile.path = "Indexes/MOC.md";
+			destinationFile.name = "MOC.md";
+			destinationFile.extension = "md";
+			destinationFile.basename = "MOC";
+
+			engine.choice.appendLink = {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+				linkType: "embed",
+				destination: { type: "specifiedFile", path: "Indexes/MOC.md" },
+			};
+			getAppendLinkDestinationFileMock.mockReturnValue(destinationFile);
+			(
+				engine as unknown as {
+					createFileWithTemplate: () => Promise<TFile | null>;
+				}
+			).createFileWithTemplate = vi.fn().mockResolvedValue(createdFile);
+
+			await engine.run();
+
+			expect(appendFileLinkToDestinationFileMock).toHaveBeenCalledWith(
+				app,
+				createdFile,
+				expect.objectContaining({
+					destination: { type: "specifiedFile", path: "Indexes/MOC.md" },
+					linkType: "link",
+				}),
+			);
+		});
+
+		it("does not create the template note when a specified append-link destination is missing", async () => {
+			const { engine } = createEngine("ignored", {
+				throwDuringFileName: false,
+			});
+			const createFileWithTemplate = vi.fn();
+
+			engine.choice.appendLink = {
+				enabled: true,
+				placement: "newLine",
+				requireActiveFile: false,
+				destination: { type: "specifiedFile", path: "Indexes/Missing.md" },
+			};
+			(
+				engine as unknown as {
+					createFileWithTemplate: () => Promise<TFile | null>;
+				}
+			).createFileWithTemplate = createFileWithTemplate;
+
+			await engine.run();
+
+			expect(createFileWithTemplate).not.toHaveBeenCalled();
+			expect(appendFileLinkToDestinationFileMock).not.toHaveBeenCalled();
+		});
+
+		it("keeps template execution successful when clipboard copying reports failure", async () => {
+			const { engine, choiceExecutor } = createEngine("ignored", {
 			throwDuringFileName: false,
 		});
 		const createdFile = new TFile();

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -32,12 +32,18 @@ import {
 } from "../utils/folder-sorting";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
-import { copyFileLinkToClipboard } from "../utils/fileLinks";
+import {
+	appendFileLinkToDestinationFile,
+	copyFileLinkToClipboard,
+	getAppendLinkDestinationFile,
+} from "../utils/fileLinks";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { TemplateEngine } from "./TemplateEngine";
 import { UserCancelError } from "../errors/UserCancelError";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { parentFolderPath } from "../utils/pathUtils";
+
+type NormalizedAppendLinkOptions = ReturnType<typeof normalizeAppendLinkOptions>;
 
 export class TemplateChoiceEngine extends TemplateEngine {
 	public choice: ITemplateChoice;
@@ -73,6 +79,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					? "optional"
 					: "required",
 			);
+			if (!this.validateAppendLinkDestination(linkOptions)) return;
 
 			const format = this.choice.fileNameFormat.enabled
 				? this.choice.fileNameFormat.format
@@ -204,7 +211,15 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			});
 
 			if (linkOptions.enabled && createdFile) {
-				insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+				if (linkOptions.destination.type === "specifiedFile") {
+					await appendFileLinkToDestinationFile(
+						this.app,
+						createdFile,
+						linkOptions,
+					);
+				} else {
+					insertFileLinkToActiveView(this.app, createdFile, linkOptions);
+				}
 			}
 
 			if (this.choice.copyLinkToClipboard && createdFile) {
@@ -269,6 +284,27 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			}
 			variables.delete("value");
 		};
+	}
+
+	private validateAppendLinkDestination(
+		linkOptions: NormalizedAppendLinkOptions,
+	): boolean {
+		if (
+			!linkOptions.enabled ||
+			linkOptions.destination.type !== "specifiedFile"
+		) {
+			return true;
+		}
+
+		if (getAppendLinkDestinationFile(this.app, linkOptions.destination)) {
+			return true;
+		}
+
+		InputPromptDraftStore.getInstance().markExecutionScopeFailed();
+		log.logError(
+			`Append link target file not found or is not a Markdown file: ${linkOptions.destination.path}`,
+		);
+		return false;
 	}
 
 	private async getSelectedFileExistsMode(): Promise<FileExistsModeId> {

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -126,7 +126,7 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 <WritePositionSetting bind:choice {app} {plugin} />
 
 <SettingItem name="Linking" heading />
-<AppendLinkSetting bind:appendLink={choice.appendLink} fileLabel="captured" />
+<AppendLinkSetting bind:appendLink={choice.appendLink} fileLabel="captured" {app} />
 
 <SettingItem name="Content" heading />
 <SettingItem name="Task" desc="Formats the value as a task.">

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -268,7 +268,7 @@ function onModeChange(value: string) {
 {/if}
 
 <SettingItem name="Linking" heading />
-<AppendLinkSetting bind:appendLink={choice.appendLink} fileLabel="created" />
+<AppendLinkSetting bind:appendLink={choice.appendLink} fileLabel="created" {app} />
 <SettingItem
 	name="Copy link to clipboard"
 	desc="Copy a link to the created file after the Template choice runs."

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+import { TFile, type App } from "obsidian";
 import SettingItem from "../../components/SettingItem.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
+import ValidatedInput from "./ValidatedInput.svelte";
 import type {
 	AppendLinkOptions,
 	LinkPlacement,
@@ -10,6 +12,7 @@ import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
 } from "../../../types/linkPlacement";
+import { normalizeAppendLinkDestinationPath } from "../../../utils/fileLinks";
 
 /**
  * Shared append-link configuration — collapses the near-identical
@@ -20,15 +23,23 @@ import {
 let {
 	appendLink = $bindable(),
 	fileLabel,
+	app = undefined,
 }: {
 	appendLink: boolean | AppendLinkOptions;
 	fileLabel: "captured" | "created";
+	app?: App | undefined;
 } = $props();
 
 type AppendLinkMode = "required" | "optional" | "disabled";
+type AppendLinkDestinationMode = "activeFile" | "specifiedFile";
 
 const normalized = $derived(normalizeAppendLinkOptions(appendLink));
 const normalizedLinkType = $derived(normalized.linkType ?? "link");
+const destinationPath = $derived(
+	normalized.destination.type === "specifiedFile"
+		? normalized.destination.path
+		: "",
+);
 const currentMode = $derived(
 	normalized.enabled
 		? normalized.requireActiveFile
@@ -36,11 +47,19 @@ const currentMode = $derived(
 			: "optional"
 		: "disabled",
 );
+const destinationMode = $derived(normalized.destination.type);
+const markdownFilePaths = $derived(
+	app ? app.vault.getMarkdownFiles().map((file) => file.path) : [],
+);
 
 const modeOptions = [
-	{ value: "required", label: "Enabled (requires active file)" },
-	{ value: "optional", label: "Enabled (skip if no active file)" },
+	{ value: "required", label: "Enabled (strict)" },
+	{ value: "optional", label: "Enabled (skip if unavailable)" },
 	{ value: "disabled", label: "Disabled" },
+];
+const destinationOptions = [
+	{ value: "activeFile", label: "Current note" },
+	{ value: "specifiedFile", label: "Specified note" },
 ];
 const placementOptions = [
 	{ value: "replaceSelection", label: "Replace selection" },
@@ -64,6 +83,7 @@ function onModeChange(value: string) {
 				placement: normalized.placement,
 				requireActiveFile: true,
 				linkType: normalizedLinkType,
+				destination: normalized.destination,
 			};
 			break;
 		case "optional":
@@ -72,6 +92,7 @@ function onModeChange(value: string) {
 				placement: normalized.placement,
 				requireActiveFile: false,
 				linkType: normalizedLinkType,
+				destination: normalized.destination,
 			};
 			break;
 	}
@@ -96,6 +117,7 @@ function onPlacementChange(value: string) {
 		placement,
 		requireActiveFile,
 		linkType: nextLinkType,
+		destination: normalized.destination,
 	};
 }
 
@@ -112,13 +134,51 @@ function onLinkTypeChange(value: string) {
 		placement,
 		requireActiveFile,
 		linkType: value as LinkType,
+		destination: normalized.destination,
 	};
+}
+
+function onDestinationChange(value: string) {
+	const destination =
+		(value as AppendLinkDestinationMode) === "specifiedFile"
+			? { type: "specifiedFile" as const, path: destinationPath }
+			: { type: "activeFile" as const };
+	appendLink = {
+		enabled: true,
+		placement: normalized.placement,
+		requireActiveFile: normalized.requireActiveFile,
+		linkType: destination.type === "specifiedFile" ? "link" : normalizedLinkType,
+		destination,
+	};
+}
+
+function onDestinationPathChange(value: string) {
+	appendLink = {
+		enabled: true,
+		placement: normalized.placement,
+		requireActiveFile: normalized.requireActiveFile,
+		linkType: "link",
+		destination: { type: "specifiedFile", path: value.trim() },
+	};
+}
+
+function validateDestinationFile(raw: string) {
+	const value = raw.trim();
+	if (!value) return "Destination file is required";
+	if (!app) return true;
+
+	const target = app.vault.getAbstractFileByPath(
+		normalizeAppendLinkDestinationPath(value),
+	);
+	return target instanceof TFile && target.extension === "md"
+		? true
+		: "Markdown file not found";
 }
 </script>
 
 <SettingItem
 	name={`Link to ${fileLabel} file`}
-	desc={`Choose how QuickAdd should insert a link to the ${fileLabel} file in the current note.`}
+	desc={`Choose whether QuickAdd should insert a link to the ${fileLabel} file.`}
 >
 	{#snippet control()}
 		<Dropdown value={currentMode} options={modeOptions} onchange={onModeChange} />
@@ -126,26 +186,64 @@ function onLinkTypeChange(value: string) {
 </SettingItem>
 
 {#if currentMode !== "disabled"}
-	<SettingItem name="Link placement" desc="Where to place the link when appending">
+	<SettingItem
+		name="Link destination"
+		desc={`Where QuickAdd writes the link to the ${fileLabel} file.`}
+	>
 		{#snippet control()}
 			<Dropdown
-				value={normalized.placement}
-				options={placementOptions}
-				onchange={onPlacementChange}
+				value={destinationMode}
+				options={destinationOptions}
+				onchange={onDestinationChange}
 			/>
 		{/snippet}
 	</SettingItem>
 
-	{#if placementSupportsEmbed(normalized.placement)}
+	{#if destinationMode === "activeFile"}
 		<SettingItem
-			name="Link type"
-			desc="Choose whether replacing the selection inserts a link or an embed."
+			name="Link placement"
+			desc="Where to place the link when appending"
 		>
 			{#snippet control()}
 				<Dropdown
-					value={normalizedLinkType}
-					options={linkTypeOptions}
-					onchange={onLinkTypeChange}
+					value={normalized.placement}
+					options={placementOptions}
+					onchange={onPlacementChange}
+				/>
+			{/snippet}
+		</SettingItem>
+
+		{#if placementSupportsEmbed(normalized.placement)}
+			<SettingItem
+				name="Link type"
+				desc="Choose whether replacing the selection inserts a link or an embed."
+			>
+				{#snippet control()}
+					<Dropdown
+						value={normalizedLinkType}
+						options={linkTypeOptions}
+						onchange={onLinkTypeChange}
+					/>
+				{/snippet}
+			</SettingItem>
+		{/if}
+	{:else}
+		<SettingItem
+			name="Destination file"
+			desc="Existing Markdown note that receives the link at the bottom."
+		>
+			{#snippet control()}
+				<ValidatedInput
+					value={destinationPath}
+					placeholder="Index.md"
+					{app}
+					suggestions={markdownFilePaths}
+					maxSuggestions={50}
+					required
+					requiredMessage="Destination file is required"
+					validator={validateDestinationFile}
+					ariaLabel="Append link destination file"
+					onChange={onDestinationPathChange}
 				/>
 			{/snippet}
 		</SettingItem>

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
@@ -29,6 +29,7 @@ describe("AppendLinkSetting", () => {
 		});
 		expect(settingNames(container)).toEqual([
 			"Link to captured file",
+			"Link destination",
 			"Link placement",
 			"Link type",
 		]);
@@ -46,8 +47,29 @@ describe("AppendLinkSetting", () => {
 		});
 		expect(settingNames(container)).toEqual([
 			"Link to captured file",
+			"Link destination",
 			"Link placement",
 		]);
+		expect(settingNames(container)).not.toContain("Link type");
+	});
+
+	it("shows a destination file input instead of placement controls for specified-note links", () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "replaceSelection",
+			requireActiveFile: false,
+			linkType: "embed",
+			destination: { type: "specifiedFile", path: "Indexes/MOC.md" },
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+		expect(settingNames(container)).toEqual([
+			"Link to created file",
+			"Link destination",
+			"Destination file",
+		]);
+		expect(settingNames(container)).not.toContain("Link placement");
 		expect(settingNames(container)).not.toContain("Link type");
 	});
 });

--- a/src/types/linkPlacement.test.ts
+++ b/src/types/linkPlacement.test.ts
@@ -36,42 +36,46 @@ describe("LinkPlacement", () => {
 				enabled: true,
 				placement: "afterSelection",
 				requireActiveFile: false,
-			};
-			expect(normalizeAppendLinkOptions(options)).toEqual({
-				...options,
-				linkType: "link",
+				};
+				expect(normalizeAppendLinkOptions(options)).toEqual({
+					...options,
+					linkType: "link",
+					destination: { type: "activeFile" },
+				});
 			});
-		});
 
 		it("should convert true to enabled with default placement", () => {
 			const result = normalizeAppendLinkOptions(true);
 			expect(result).toEqual({
 				enabled: true,
-				placement: "replaceSelection",
-				requireActiveFile: true,
-				linkType: "link",
+					placement: "replaceSelection",
+					requireActiveFile: true,
+					linkType: "link",
+					destination: { type: "activeFile" },
+				});
 			});
-		});
 
 		it("should convert false to disabled with default placement", () => {
 			const result = normalizeAppendLinkOptions(false);
 			expect(result).toEqual({
 				enabled: false,
-				placement: "replaceSelection",
-				requireActiveFile: false,
-				linkType: "link",
+					placement: "replaceSelection",
+					requireActiveFile: false,
+					linkType: "link",
+					destination: { type: "activeFile" },
+				});
 			});
-		});
 
 		it("should keep embed linkType when placement supports embeds", () => {
 			const options: AppendLinkOptions = {
 				enabled: true,
 				placement: "replaceSelection",
-				requireActiveFile: true,
-				linkType: "embed",
-			};
-			expect(normalizeAppendLinkOptions(options)).toEqual(options);
-		});
+					requireActiveFile: true,
+					linkType: "embed",
+					destination: { type: "activeFile" },
+				};
+				expect(normalizeAppendLinkOptions(options)).toEqual(options);
+			});
 
 		it("should sanitize embed linkType when placement does not support embeds", () => {
 			const options: AppendLinkOptions = {
@@ -80,20 +84,49 @@ describe("LinkPlacement", () => {
 				requireActiveFile: true,
 				linkType: "embed",
 			};
-			expect(normalizeAppendLinkOptions(options)).toEqual({
-				...options,
-				linkType: "link",
+				expect(normalizeAppendLinkOptions(options)).toEqual({
+					...options,
+					linkType: "link",
+					destination: { type: "activeFile" },
+				});
 			});
-		});
 
 		it("should default linkType to link when omitted", () => {
 			const options: AppendLinkOptions = {
 				enabled: true,
 				placement: "newLine",
 				requireActiveFile: true,
-			};
-			expect(normalizeAppendLinkOptions(options).linkType).toBe("link");
-		});
+				};
+				expect(normalizeAppendLinkOptions(options).linkType).toBe("link");
+			});
+
+			it("preserves and trims a specified file destination", () => {
+				const options: AppendLinkOptions = {
+					enabled: true,
+					placement: "newLine",
+					requireActiveFile: false,
+					destination: { type: "specifiedFile", path: "  Indexes/MOC.md  " },
+				};
+				expect(normalizeAppendLinkOptions(options)).toEqual({
+					...options,
+					linkType: "link",
+					destination: { type: "specifiedFile", path: "Indexes/MOC.md" },
+				});
+			});
+
+			it("sanitizes embeds for specified file destinations", () => {
+				const options: AppendLinkOptions = {
+					enabled: true,
+					placement: "replaceSelection",
+					requireActiveFile: true,
+					linkType: "embed",
+					destination: { type: "specifiedFile", path: "Index.md" },
+				};
+				expect(normalizeAppendLinkOptions(options)).toEqual({
+					...options,
+					linkType: "link",
+				});
+			});
 	});
 
 	describe("isAppendLinkEnabled", () => {

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -9,6 +9,10 @@ export type LinkPlacement =
 
 export type LinkType = "link" | "embed";
 
+export type AppendLinkDestination =
+	| { type: "activeFile" }
+	| { type: "specifiedFile"; path: string };
+
 export function placementSupportsEmbed(placement: LinkPlacement): boolean {
 	return placement === "replaceSelection";
 }
@@ -16,10 +20,26 @@ export function placementSupportsEmbed(placement: LinkPlacement): boolean {
 function sanitizeLinkType(
 	linkType: LinkType | undefined,
 	placement: LinkPlacement,
+	destination: AppendLinkDestination,
 ): LinkType {
-	return linkType === "embed" && placementSupportsEmbed(placement)
+	return linkType === "embed" &&
+		destination.type === "activeFile" &&
+		placementSupportsEmbed(placement)
 		? "embed"
 		: "link";
+}
+
+function normalizeAppendLinkDestination(
+	destination: AppendLinkDestination | undefined,
+): AppendLinkDestination {
+	if (destination?.type === "specifiedFile") {
+		return {
+			type: "specifiedFile",
+			path: typeof destination.path === "string" ? destination.path.trim() : "",
+		};
+	}
+
+	return { type: "activeFile" };
 }
 
 /**
@@ -41,6 +61,11 @@ export interface AppendLinkOptions {
 	 * Defaults to "link" for legacy settings.
 	 */
 	linkType?: LinkType;
+	/**
+	 * Where the generated link should be written. Omitted legacy settings target
+	 * the active Markdown editor.
+	 */
+	destination?: AppendLinkDestination;
 }
 
 /**
@@ -64,15 +89,17 @@ export function isAppendLinkOptions(appendLink: boolean | AppendLinkOptions): ap
  * @param appendLink - Legacy boolean or new options format
  * @returns Normalized AppendLinkOptions
  */
-export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptions): AppendLinkOptions & { linkType: LinkType } {
+export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptions): AppendLinkOptions & { linkType: LinkType; destination: AppendLinkDestination } {
 	if (isAppendLinkOptions(appendLink)) {
 		const placement = appendLink.placement ?? "replaceSelection";
+		const destination = normalizeAppendLinkDestination(appendLink.destination);
 
 		return {
 			enabled: appendLink.enabled,
 			placement,
 			requireActiveFile: appendLink.requireActiveFile ?? true,
-			linkType: sanitizeLinkType(appendLink.linkType, placement),
+			linkType: sanitizeLinkType(appendLink.linkType, placement, destination),
+			destination,
 		};
 	}
 
@@ -82,6 +109,7 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 		placement: "replaceSelection", // Default placement for backward compatibility
 		requireActiveFile: appendLink ? true : false,
 		linkType: "link",
+		destination: { type: "activeFile" },
 	};
 }
 

--- a/src/utils/fileLinks.test.ts
+++ b/src/utils/fileLinks.test.ts
@@ -155,16 +155,20 @@ describe("file link helpers", () => {
 		expect(normalizeAppendLinkDestinationPath("Indexes/MOC.md")).toBe(
 			"Indexes/MOC.md",
 		);
+		expect(normalizeAppendLinkDestinationPath("Daily/2026.06.18")).toBe(
+			"Daily/2026.06.18.md",
+		);
 		expect(normalizeAppendLinkDestinationPath("Boards/MOC.canvas")).toBe(
-			"Boards/MOC.canvas",
+			"Boards/MOC.canvas.md",
 		);
 	});
 
 	it("resolves only existing Markdown files as append-link destinations", () => {
 		const contents = new Map<string, string>();
 		const index = makeFile("Indexes/MOC.md");
+		const dotted = makeFile("Daily/2026.06.18.md");
 		const canvas = makeFile("Indexes/MOC.canvas");
-		const app = makeDestinationApp([index, canvas], contents);
+		const app = makeDestinationApp([index, dotted, canvas], contents);
 
 		expect(
 			getAppendLinkDestinationFile(app, {
@@ -172,6 +176,12 @@ describe("file link helpers", () => {
 				path: "Indexes/MOC",
 			}),
 		).toBe(index);
+		expect(
+			getAppendLinkDestinationFile(app, {
+				type: "specifiedFile",
+				path: "Daily/2026.06.18",
+			}),
+		).toBe(dotted);
 		expect(
 			getAppendLinkDestinationFile(app, {
 				type: "specifiedFile",

--- a/src/utils/fileLinks.test.ts
+++ b/src/utils/fileLinks.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { App, TFile } from "obsidian";
-import { Notice } from "obsidian";
+import type { App } from "obsidian";
+import { Notice, TFile } from "obsidian";
 import {
+	appendFileLinkToDestinationFile,
 	buildFileLinkText,
 	buildPortableFileLinkText,
 	copyFileLinkToClipboard,
+	getAppendLinkDestinationFile,
+	normalizeAppendLinkDestinationPath,
 	writeTextToClipboard,
 } from "./fileLinks";
+import type { AppendLinkOptions } from "../types/linkPlacement";
 
 type NoticeTestClass = typeof Notice & {
 	instances: Array<{ message: string; timeout?: number }>;
@@ -27,6 +31,42 @@ function createFile(): TFile {
 		basename: "Created Note",
 		path: "Projects/Created Note.md",
 	} as TFile;
+}
+
+function makeFile(path: string): TFile {
+	const file = new TFile();
+	file.path = path;
+	file.name = path.split("/").pop() ?? path;
+	file.extension = file.name.split(".").pop() ?? "";
+	file.basename = file.name.replace(/\.[^.]+$/, "");
+	return file;
+}
+
+function makeDestinationApp(files: TFile[], contents: Map<string, string>): App {
+	const fileMap = new Map(files.map((file) => [file.path, file]));
+	return {
+		vault: {
+			getAbstractFileByPath: vi.fn((path: string) => fileMap.get(path) ?? null),
+			process: vi.fn(async (file: TFile, change: (content: string) => string) => {
+				contents.set(file.path, change(contents.get(file.path) ?? ""));
+			}),
+		},
+		fileManager: {
+			generateMarkdownLink: vi.fn((file: TFile, sourcePath: string) => {
+				return `[[${sourcePath}->${file.path}]]`;
+			}),
+		},
+	} as unknown as App;
+}
+
+function specifiedLinkOptions(path: string): AppendLinkOptions {
+	return {
+		enabled: true,
+		placement: "newLine",
+		requireActiveFile: false,
+		linkType: "link",
+		destination: { type: "specifiedFile", path },
+	};
 }
 
 describe("file link helpers", () => {
@@ -106,5 +146,94 @@ describe("file link helpers", () => {
 		expect(noticeClass.instances.at(-1)?.message).toContain(
 			"could not copy its link",
 		);
+	});
+
+	it("normalizes note paths for specified append-link destinations", () => {
+		expect(normalizeAppendLinkDestinationPath("/Indexes/MOC")).toBe(
+			"Indexes/MOC.md",
+		);
+		expect(normalizeAppendLinkDestinationPath("Indexes/MOC.md")).toBe(
+			"Indexes/MOC.md",
+		);
+		expect(normalizeAppendLinkDestinationPath("Boards/MOC.canvas")).toBe(
+			"Boards/MOC.canvas",
+		);
+	});
+
+	it("resolves only existing Markdown files as append-link destinations", () => {
+		const contents = new Map<string, string>();
+		const index = makeFile("Indexes/MOC.md");
+		const canvas = makeFile("Indexes/MOC.canvas");
+		const app = makeDestinationApp([index, canvas], contents);
+
+		expect(
+			getAppendLinkDestinationFile(app, {
+				type: "specifiedFile",
+				path: "Indexes/MOC",
+			}),
+		).toBe(index);
+		expect(
+			getAppendLinkDestinationFile(app, {
+				type: "specifiedFile",
+				path: "Indexes/MOC.canvas",
+			}),
+		).toBeNull();
+		expect(
+			getAppendLinkDestinationFile(app, {
+				type: "activeFile",
+			}),
+		).toBeNull();
+	});
+
+	it("appends the generated link to the destination file with that file as source", async () => {
+		const contents = new Map([["Indexes/MOC.md", "# Index\n"]]);
+		const index = makeFile("Indexes/MOC.md");
+		const created = makeFile("Notes/New.md");
+		const app = makeDestinationApp([index, created], contents);
+
+		await appendFileLinkToDestinationFile(
+			app,
+			created,
+			specifiedLinkOptions("Indexes/MOC"),
+		);
+
+		expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(
+			created,
+			"Indexes/MOC.md",
+		);
+		expect(contents.get("Indexes/MOC.md")).toBe(
+			"# Index\n[[Indexes/MOC.md->Notes/New.md]]",
+		);
+	});
+
+	it("inserts a separating newline when the destination has no trailing newline", async () => {
+		const contents = new Map([["Indexes/MOC.md", "# Index"]]);
+		const index = makeFile("Indexes/MOC.md");
+		const created = makeFile("Notes/New.md");
+		const app = makeDestinationApp([index, created], contents);
+
+		await appendFileLinkToDestinationFile(
+			app,
+			created,
+			specifiedLinkOptions("Indexes/MOC.md"),
+		);
+
+		expect(contents.get("Indexes/MOC.md")).toBe(
+			"# Index\n[[Indexes/MOC.md->Notes/New.md]]",
+		);
+	});
+
+	it("throws when the destination file is missing", async () => {
+		const contents = new Map<string, string>();
+		const created = makeFile("Notes/New.md");
+		const app = makeDestinationApp([created], contents);
+
+		await expect(
+			appendFileLinkToDestinationFile(
+				app,
+				created,
+				specifiedLinkOptions("Indexes/Missing.md"),
+			),
+		).rejects.toThrow("Append link target file not found");
 	});
 });

--- a/src/utils/fileLinks.ts
+++ b/src/utils/fileLinks.ts
@@ -1,7 +1,12 @@
-import type { App, TFile } from "obsidian";
-import { Notice } from "obsidian";
+import type { App } from "obsidian";
+import { Notice, TFile } from "obsidian";
 import { log } from "../logger/logManager";
-import type { LinkPlacement, LinkType } from "../types/linkPlacement";
+import type {
+	AppendLinkDestination,
+	AppendLinkOptions,
+	LinkPlacement,
+	LinkType,
+} from "../types/linkPlacement";
 import { placementSupportsEmbed } from "../types/linkPlacement";
 import { convertLinkToEmbed } from "./markdownLinks";
 
@@ -30,6 +35,61 @@ export function buildFileLinkText(
 		(!options.placement || placementSupportsEmbed(options.placement));
 
 	return shouldEmbed ? convertLinkToEmbed(baseLink) : baseLink;
+}
+
+function hasExplicitExtension(path: string): boolean {
+	const fileName = path.split("/").pop() ?? "";
+	return /\.[^./\\]+$/.test(fileName);
+}
+
+export function normalizeAppendLinkDestinationPath(rawPath: string): string {
+	const path = rawPath.trim().replace(/^\/+/, "");
+	if (!path) return "";
+	return hasExplicitExtension(path) ? path : `${path}.md`;
+}
+
+export function getAppendLinkDestinationFile(
+	app: App,
+	destination: AppendLinkDestination,
+): TFile | null {
+	if (destination.type !== "specifiedFile") return null;
+
+	const normalizedPath = normalizeAppendLinkDestinationPath(destination.path);
+	if (!normalizedPath) return null;
+
+	const target = app.vault.getAbstractFileByPath(normalizedPath);
+	if (!(target instanceof TFile) || target.extension !== "md") return null;
+
+	return target;
+}
+
+function appendLine(content: string, line: string): string {
+	if (content.length === 0) return line;
+	return content.endsWith("\n") ? `${content}${line}` : `${content}\n${line}`;
+}
+
+export async function appendFileLinkToDestinationFile(
+	app: App,
+	file: TFile,
+	linkOptions: AppendLinkOptions,
+): Promise<boolean> {
+	const destination = linkOptions.destination;
+	if (destination?.type !== "specifiedFile") return false;
+
+	const targetFile = getAppendLinkDestinationFile(app, destination);
+	if (!targetFile) {
+		throw new Error(
+			`Append link target file not found or is not a Markdown file: ${destination.path}`,
+		);
+	}
+
+	const linkText = buildFileLinkText(app, file, {
+		sourcePath: targetFile.path,
+		linkType: "link",
+	});
+
+	await app.vault.process(targetFile, (content) => appendLine(content, linkText));
+	return true;
 }
 
 export async function writeTextToClipboard(text: string): Promise<boolean> {

--- a/src/utils/fileLinks.ts
+++ b/src/utils/fileLinks.ts
@@ -37,15 +37,10 @@ export function buildFileLinkText(
 	return shouldEmbed ? convertLinkToEmbed(baseLink) : baseLink;
 }
 
-function hasExplicitExtension(path: string): boolean {
-	const fileName = path.split("/").pop() ?? "";
-	return /\.[^./\\]+$/.test(fileName);
-}
-
 export function normalizeAppendLinkDestinationPath(rawPath: string): string {
 	const path = rawPath.trim().replace(/^\/+/, "");
 	if (!path) return "";
-	return hasExplicitExtension(path) ? path : `${path}.md`;
+	return /\.md$/i.test(path) ? path : `${path}.md`;
 }
 
 export function getAppendLinkDestinationFile(


### PR DESCRIPTION
Adds a shared append-link destination for Template and Capture choices so the generated file link can be written to an existing Markdown note, such as an index or MOC, instead of only the current editor.

The underlying workflow in #146 is not just "choose another active pane"; it is routing the created/captured note link to a stable index note without opening or focusing that note. This keeps the feature in the existing append-link model instead of adding a separate macro-only action or broader file mutation system.

Design boundaries:
- Existing `appendLink` booleans/objects remain backward-compatible and normalize to the current-note destination.
- `Specified note` requires an existing Markdown file and validates it before creating/writing the generated note.
- Specified-note links are appended to the bottom of the destination note using Obsidian's link generation with that destination as the source path.
- Embeds are sanitized to normal links for specified-note append, since embedding into an index note would be surprising and the existing embed option is a selection-replacement affordance.
- This intentionally does not auto-create the index note, insert under headings, update properties, or dedupe links. Those are separate behaviors with different failure modes and overlap with the append-link/properties work.

Validation evidence:
- Reproduced the pre-fix behavior in this worktree's isolated Obsidian vault: Template append-link wrote `[[Created]]` to the active note while `QA146/Index.md` stayed unchanged.
- Verified Template specified-note append live: `QA146/Index.md` received `[[Created]]`, `QA146/Active.md` stayed byte-for-byte unchanged, and the created note was written.
- Verified missing specified destination live: no generated note was created, no missing index was created, and the existing index note was unchanged.
- Verified Capture specified-note append live: capture wrote its target note and appended `[[CapturedNote]]` to `QA146/Index.md` without touching the active note.
- Verified isolated Obsidian runtime errors after the live runs: `pnpm run obsidian:e2e -- dev:errors` reported no captured errors.

Local gates:
- `pnpm run build`
- `pnpm run check` (0 errors; existing warning threshold output remains warnings-only)
- `pnpm run lint`
- `pnpm run test` (229 files passed, 2750 tests passed, 5 files skipped)
- `pnpm run build-with-lint`
- Focused regression tests for Template, Capture, append-link normalization, file-link helpers, and append-link settings UI.

Overlap note for #768:
A separate worker is reworking the active-editor append-link/properties area. This PR deliberately keeps the #146 behavior minimal and routes specified-note writes before active-editor insertion. If #768 lands first, the combined precedence should remain: specified destination first, then focused property handling, then active editor insertion. A naive rebase could otherwise let focused-property insertion hijack a choice explicitly configured to append to an index note.

Fixes #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded “Append link” for captures/templates to support appending to a specified destination note, with strict/skip behavior and destination-type-aware link handling.
  * Added destination validation (Markdown-only) and consistent destination path normalization when specifying a destination note.
  * Updated the append-link UI to expose link-destination controls and appropriate placement/type options.

* **Bug Fixes**
  * Corrected canvas text capture so required link insertion isn’t skipped for specified-file destinations.

* **Documentation**
  * Rewrote capture/template “link to captured/created file” documentation with clearer mode-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->