### PR TITLE
feat(choice): support icons in picker rows

### DIFF
--- a/docs/docs/Choices/MultiChoice.md
+++ b/docs/docs/Choices/MultiChoice.md
@@ -16,6 +16,10 @@ You can optionally set a placeholder for each Multi choice. This text shows up i
 
 Keep in mind that [searching covers everything nested under the multi](#searching-nested-choices), so word the placeholder accordingly.
 
+## Icons
+
+Choices shown in the QuickAdd picker use the same Obsidian/Lucide icons as registered QuickAdd commands. Each choice type has a default icon, and you can override it from the choice's **Icon** setting. Icons are monochrome and inherit the active Obsidian theme color.
+
 ## Searching nested choices
 
 Typing in the choice picker searches every choice nested inside the current level's multis — not just the level you are looking at. Nested matches show their folder path (for example `Work / Meetings`) beneath the choice name. This also applies to the root picker opened by the **QuickAdd: Run** command or the ribbon icon.

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -46,7 +46,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 - **Show icon in sidebar** — Add QuickAdd icon to the sidebar ribbon. Requires a reload.
 
-## Command icons
+## Choice icons
 
-- **Automatic command icons** — When you turn a choice into a command (the ⚡ icon next to it), QuickAdd gives that command an icon based on the choice type — `file-text` for Template, `pencil` for Capture, `terminal` for Macro, and `folder` for Multi — so the command palette and the mobile editing toolbar show a meaningful glyph instead of a generic `?`. The icons are automatic; there is no setting for them.
-- **Override a choice's icon** — Add an `icon` field with any [Lucide](https://lucide.dev) icon id (for example `"icon": "star"`) to that choice in `data.json`, then reload Obsidian so the command re-registers with the new icon. There is currently no in-app control for this; edit `data.json` while the plugin is disabled, since QuickAdd rewrites the file when settings change.
+- **Automatic choice icons** — QuickAdd gives each choice type a default Obsidian/Lucide icon: `file-text` for Template, `pencil` for Capture, `terminal` for Macro, and `folder` for Multi. These icons show in the QuickAdd launcher, inside Multi choice pickers, and on registered commands in the command palette / mobile editing toolbar.
+- **Override a choice's icon** — Open a choice's configuration and set **Icon** to any [Lucide](https://lucide.dev) icon id (for example `star`). Leave the field empty to use the choice type default. Icons inherit the active Obsidian theme color; QuickAdd does not set per-choice icon colors.

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -17,6 +17,7 @@ import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
 import OnePageOverrideSetting from "./components/OnePageOverrideSetting.svelte";
 import CaptureTargetSetting from "./components/CaptureTargetSetting.svelte";
 import WritePositionSetting from "./components/WritePositionSetting.svelte";
+import ChoiceIconSetting from "./components/ChoiceIconSetting.svelte";
 
 /**
  * Reactive replacement for CaptureChoiceBuilder.display(). Every conditional row
@@ -87,6 +88,7 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 </script>
 
 <ChoiceNameHeader bind:name={choice.name} {app} />
+<ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />
 
 <SettingItem name="Location" heading />
 <CaptureTargetSetting bind:choice {app} {plugin} />

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -88,7 +88,6 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 </script>
 
 <ChoiceNameHeader bind:name={choice.name} {app} />
-<ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />
 
 <SettingItem name="Location" heading />
 <CaptureTargetSetting bind:choice {app} {plugin} />
@@ -187,3 +186,5 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 </SettingItem>
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
+
+<ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -180,4 +180,10 @@ describe("CaptureChoiceForm", () => {
 			container.querySelector(".qa-choice-icon-setting-preview svg"),
 		).toHaveAttribute("data-icon", "inbox");
 	});
+
+	it("keeps the optional icon override at the bottom of the form", () => {
+		const { container } = mountForm();
+
+		expect(settingNames(container).at(-1)).toBe("Icon");
+	});
 });

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -76,6 +76,14 @@ function selectUnderSetting(
 	return item?.querySelector("select") as HTMLSelectElement;
 }
 
+function choiceIconInput(container: HTMLElement): HTMLInputElement {
+	const el = container.querySelector<HTMLInputElement>(
+		'input[aria-label="Choice icon"]',
+	);
+	if (!el) throw new Error("Choice icon input not found");
+	return el;
+}
+
 function mountForm() {
 	const props = createCaptureChoiceFormProps({
 		choice: captureChoice(),
@@ -153,5 +161,23 @@ describe("CaptureChoiceForm", () => {
 		expect(props.choice.insertBefore?.enabled).toBe(true);
 		expect(props.choice.insertAfter.enabled).toBe(false);
 		expect(props.choice.prepend).toBe(false);
+	});
+
+	it("edits the choice icon override and previews the default", async () => {
+		const { container, props } = mountForm();
+		const input = choiceIconInput(container);
+
+		expect(input.placeholder).toBe("pencil");
+		expect(
+			container.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "pencil");
+
+		await fireEvent.input(input, { target: { value: "inbox" } });
+		flushSync();
+
+		expect(props.choice.icon).toBe("inbox");
+		expect(
+			container.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "inbox");
 	});
 });

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -37,6 +37,7 @@ import AppendLinkSetting from "./components/AppendLinkSetting.svelte";
 import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
 import OnePageOverrideSetting from "./components/OnePageOverrideSetting.svelte";
+import ChoiceIconSetting from "./components/ChoiceIconSetting.svelte";
 import { suggester } from "./components/suggesterAction";
 
 /**
@@ -168,6 +169,7 @@ function onModeChange(value: string) {
 </script>
 
 <ChoiceNameHeader bind:name={choice.name} {app} />
+<ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />
 
 <SettingItem name="Template" heading />
 

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -169,7 +169,6 @@ function onModeChange(value: string) {
 </script>
 
 <ChoiceNameHeader bind:name={choice.name} {app} />
-<ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />
 
 <SettingItem name="Template" heading />
 
@@ -309,3 +308,5 @@ function onModeChange(value: string) {
 {/if}
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
+
+<ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -62,6 +62,14 @@ function locationDropdown(container: HTMLElement): HTMLSelectElement {
 	return el;
 }
 
+function choiceIconInput(container: HTMLElement): HTMLInputElement {
+	const el = container.querySelector<HTMLInputElement>(
+		'input[aria-label="Choice icon"]',
+	);
+	if (!el) throw new Error("Choice icon input not found");
+	return el;
+}
+
 const plugin = {
 	getTemplateFiles: () => [],
 	settings: { choices: [] },
@@ -222,5 +230,29 @@ describe("TemplateChoiceForm", () => {
 
 		expect(props.choice.copyLinkToClipboard).toBe(true);
 		expect(toggle.classList.contains("is-enabled")).toBe(true);
+	});
+
+	it("edits the choice icon override and clears back to the default", async () => {
+		const { container, props } = mountForm();
+		const input = choiceIconInput(container);
+
+		expect(input.placeholder).toBe("file-text");
+		expect(
+			container.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "file-text");
+
+		await fireEvent.input(input, { target: { value: "star" } });
+		flushSync();
+		expect(props.choice.icon).toBe("star");
+		expect(
+			container.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "star");
+
+		await fireEvent.input(input, { target: { value: "   " } });
+		flushSync();
+		expect(props.choice.icon).toBeUndefined();
+		expect(
+			container.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "file-text");
 	});
 });

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -255,4 +255,10 @@ describe("TemplateChoiceForm", () => {
 			container.querySelector(".qa-choice-icon-setting-preview svg"),
 		).toHaveAttribute("data-icon", "file-text");
 	});
+
+	it("keeps the optional icon override at the bottom of the form", () => {
+		const { container } = mountForm();
+
+		expect(settingNames(container).at(-1)).toBe("Icon");
+	});
 });

--- a/src/gui/ChoiceBuilder/components/ChoiceIconSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/ChoiceIconSetting.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+import type { App } from "obsidian";
+import { ICON_LIST } from "../../../types/IconType";
+import type { ChoiceType } from "../../../types/choices/choiceType";
+import { defaultIconForChoiceType } from "../../../utils/choiceUtils";
+import ObsidianIcon from "../../components/ObsidianIcon.svelte";
+import SettingItem from "../../components/SettingItem.svelte";
+import { GenericTextSuggester } from "../../suggesters/genericTextSuggester";
+import { suggester } from "./suggesterAction";
+
+let {
+	icon = $bindable(),
+	type,
+	app,
+}: {
+	icon?: string | undefined;
+	type: ChoiceType;
+	app: App;
+} = $props();
+
+const defaultIcon = $derived(defaultIconForChoiceType(type));
+const inputValue = $derived(typeof icon === "string" ? icon : "");
+const resolvedIcon = $derived(inputValue.trim() || defaultIcon);
+
+function attachIconSuggester(
+	el: HTMLInputElement | HTMLTextAreaElement,
+): GenericTextSuggester {
+	return new GenericTextSuggester(app, el, ICON_LIST, 50);
+}
+
+function onInput(event: Event) {
+	const value = (event.currentTarget as HTMLInputElement).value.trim();
+	icon = value || undefined;
+}
+</script>
+
+<SettingItem
+	name="Icon"
+	desc={`Lucide/Obsidian icon id. Leave empty to use ${defaultIcon}.`}
+>
+	{#snippet control()}
+		<div class="qa-choice-icon-setting-control">
+			<span class="qa-choice-icon-setting-preview" aria-hidden="true">
+				<ObsidianIcon iconId={resolvedIcon} size={18} />
+			</span>
+			<input
+				type="text"
+				class="qa-choice-icon-input"
+				value={inputValue}
+				placeholder={defaultIcon}
+				aria-label="Choice icon"
+				oninput={onInput}
+				use:suggester={attachIconSuggester}
+			/>
+		</div>
+	{/snippet}
+</SettingItem>
+
+<style>
+	.qa-choice-icon-setting-control {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		min-width: min(18rem, 100%);
+	}
+
+	.qa-choice-icon-setting-preview {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 auto;
+		color: var(--text-muted);
+	}
+
+	.qa-choice-icon-input {
+		width: 100%;
+		min-width: 0;
+	}
+</style>

--- a/src/gui/ChoiceBuilder/components/choiceIconSetting.ts
+++ b/src/gui/ChoiceBuilder/components/choiceIconSetting.ts
@@ -1,0 +1,59 @@
+import { type App, Setting, setIcon } from "obsidian";
+import { ICON_LIST } from "../../../types/IconType";
+import type { ChoiceType } from "../../../types/choices/choiceType";
+import { defaultIconForChoiceType } from "../../../utils/choiceUtils";
+import { GenericTextSuggester } from "../../suggesters/genericTextSuggester";
+
+export interface ChoiceIconSettingState {
+	type: ChoiceType;
+	icon?: string | undefined;
+}
+
+function normalizeIcon(value: string): string | undefined {
+	const trimmed = value.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function resolveIcon(state: ChoiceIconSettingState): string {
+	const override = typeof state.icon === "string" ? state.icon.trim() : "";
+	return override || defaultIconForChoiceType(state.type);
+}
+
+export function addChoiceIconSetting(
+	app: App,
+	parent: HTMLElement,
+	state: ChoiceIconSettingState,
+	onChange: (icon: string | undefined) => void,
+): void {
+	const defaultIcon = defaultIconForChoiceType(state.type);
+	const setting = new Setting(parent)
+		.setName("Icon")
+		.setDesc(`Lucide/Obsidian icon id. Leave empty to use ${defaultIcon}.`);
+	setting.settingEl.addClass("qa-choice-icon-setting");
+
+	const preview = document.createElement("span");
+	preview.classList.add("qa-choice-icon-setting-preview");
+	preview.setAttribute("aria-hidden", "true");
+	setting.controlEl.appendChild(preview);
+
+	function renderPreview() {
+		preview.replaceChildren();
+		setIcon(preview, resolveIcon(state));
+	}
+
+	setting.addText((text) => {
+		text.setPlaceholder(defaultIcon);
+		text.setValue(typeof state.icon === "string" ? state.icon : "");
+		text.inputEl.addClass("qa-choice-icon-input");
+		text.inputEl.setAttribute("aria-label", "Choice icon");
+		new GenericTextSuggester(app, text.inputEl, ICON_LIST, 50);
+		text.onChange((value) => {
+			const icon = normalizeIcon(value);
+			state.icon = icon;
+			onChange(icon);
+			renderPreview();
+		});
+	});
+
+	renderPreview();
+}

--- a/src/gui/MacroGUIs/MacroBuilder.test.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+vi.mock("./CommandSequenceEditor", () => ({
+	CommandSequenceEditor: class {
+		render(parent: HTMLElement) {
+			const editor = document.createElement("div");
+			editor.className = "quickAddCommandEditor";
+			editor.textContent = "Mock command editor";
+			parent.appendChild(editor);
+		}
+
+		destroy() {}
+	},
+}));
+
+import { App } from "obsidian";
+import type QuickAdd from "../../main";
+import { MacroChoice } from "../../types/choices/MacroChoice";
+import { MacroBuilder } from "./MacroBuilder";
+
+describe("MacroBuilder", () => {
+	afterEach(() => {
+		document.body.replaceChildren();
+	});
+
+	it("keeps the optional icon override after macro behavior settings", () => {
+		const choice = new MacroChoice("Macro under test");
+		const modal = new MacroBuilder(
+			new App(),
+			{ settings: { choices: [] } } as unknown as QuickAdd,
+			choice,
+			[],
+		);
+		const children = Array.from(modal.contentEl.children);
+
+		expect(children.at(-2)?.textContent).toContain("Run on startup");
+		expect(children.at(-1)?.textContent).toContain("Icon");
+		expect(children.at(-1)?.textContent).toContain(
+			"Lucide/Obsidian icon id",
+		);
+	});
+});

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -13,6 +13,7 @@ import {
 import type { IConditionalCommand } from "../../types/macros/Conditional/IConditionalCommand";
 import { ConditionalCommandSettingsModal } from "./ConditionalCommandSettingsModal";
 import { ConditionalBranchEditorModal } from "./ConditionalBranchEditorModal";
+import { addChoiceIconSetting } from "../ChoiceBuilder/components/choiceIconSetting";
 
 function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 	const arr: IChoice[] = [];
@@ -69,6 +70,7 @@ export class MacroBuilder extends Modal {
 		this.containerEl.addClass("quickAddModal", "macroBuilder");
 		this.contentEl.empty();
 		this.addCenteredHeader(this.choice.name);
+		this.addIconSetting();
 		this.addCommandEditor();
 		this.addRunOnStartupSetting();
 	}
@@ -117,6 +119,12 @@ export class MacroBuilder extends Modal {
 					this.choice.runOnStartup = value;
 				})
 			);
+	}
+
+	private addIconSetting(): void {
+		addChoiceIconSetting(this.app, this.contentEl, this.choice, (icon) => {
+			this.choice.icon = icon;
+		});
 	}
 
 	private reload() {

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -70,9 +70,9 @@ export class MacroBuilder extends Modal {
 		this.containerEl.addClass("quickAddModal", "macroBuilder");
 		this.contentEl.empty();
 		this.addCenteredHeader(this.choice.name);
-		this.addIconSetting();
 		this.addCommandEditor();
 		this.addRunOnStartupSetting();
+		this.addIconSetting();
 	}
 
 	protected addCenteredHeader(header: string): void {

--- a/src/gui/MultiChoiceSettingsModal.test.ts
+++ b/src/gui/MultiChoiceSettingsModal.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { fireEvent } from "@testing-library/svelte";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+import { MultiChoiceSettingsModal } from "./MultiChoiceSettingsModal";
+
+function appWithSuggestSupport(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function multiChoice(icon?: string): IMultiChoice {
+	return {
+		id: "multi-1",
+		name: "Workflows",
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: [],
+		icon,
+	};
+}
+
+function getIconInput(modal: MultiChoiceSettingsModal): HTMLInputElement {
+	const input = modal.containerEl.querySelector<HTMLInputElement>(
+		'input[aria-label="Choice icon"]',
+	);
+	if (!input) throw new Error("Choice icon input not found");
+	return input;
+}
+
+function getSaveButton(modal: MultiChoiceSettingsModal): HTMLButtonElement {
+	const button = Array.from(
+		modal.containerEl.querySelectorAll<HTMLButtonElement>("button"),
+	).find((candidate) => candidate.textContent === "Save");
+	if (!button) throw new Error("Save button not found");
+	return button;
+}
+
+describe("MultiChoiceSettingsModal", () => {
+	beforeAll(() => {
+		const proto = HTMLElement.prototype as unknown as {
+			setText?: (text: string) => void;
+		};
+		proto.setText ??= function setText(this: HTMLElement, text: string) {
+			this.textContent = text;
+		};
+
+		const modalProto = Object.getPrototypeOf(
+			MultiChoiceSettingsModal.prototype,
+		) as { onClose?: () => void };
+		modalProto.onClose ??= function onClose() {};
+	});
+
+	it("edits and persists the choice icon", async () => {
+		const modal = new MultiChoiceSettingsModal(
+			appWithSuggestSupport(),
+			multiChoice(),
+		);
+		const input = getIconInput(modal);
+
+		expect(input.placeholder).toBe("folder");
+		expect(
+			modal.containerEl.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "folder");
+
+		await fireEvent.input(input, { target: { value: "folder-open" } });
+		expect(
+			modal.containerEl.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "folder-open");
+
+		const result = modal.waitForClose;
+		await fireEvent.click(getSaveButton(modal));
+
+		await expect(result).resolves.toMatchObject({
+			icon: "folder-open",
+		});
+	});
+
+	it("clears a blank icon override back to the default", async () => {
+		const modal = new MultiChoiceSettingsModal(
+			appWithSuggestSupport(),
+			multiChoice("star"),
+		);
+		const input = getIconInput(modal);
+
+		expect(input.value).toBe("star");
+
+		await fireEvent.input(input, { target: { value: "   " } });
+		expect(
+			modal.containerEl.querySelector(".qa-choice-icon-setting-preview svg"),
+		).toHaveAttribute("data-icon", "folder");
+
+		const result = modal.waitForClose;
+		await fireEvent.click(getSaveButton(modal));
+
+		await expect(result).resolves.toMatchObject({
+			icon: undefined,
+		});
+	});
+});

--- a/src/gui/MultiChoiceSettingsModal.ts
+++ b/src/gui/MultiChoiceSettingsModal.ts
@@ -1,6 +1,7 @@
 import type { App } from "obsidian";
 import { ButtonComponent, Modal, Setting } from "obsidian";
 import type IMultiChoice from "../types/choices/IMultiChoice";
+import { addChoiceIconSetting } from "./ChoiceBuilder/components/choiceIconSetting";
 
 export class MultiChoiceSettingsModal extends Modal {
 	public waitForClose: Promise<IMultiChoice | undefined>;
@@ -10,11 +11,13 @@ export class MultiChoiceSettingsModal extends Modal {
 
 	private name: string;
 	private placeholder: string;
+	private icon: string | undefined;
 
 	constructor(app: App, private choice: IMultiChoice) {
 		super(app);
 		this.name = choice.name;
 		this.placeholder = choice.placeholder ?? "";
+		this.icon = typeof choice.icon === "string" ? choice.icon : undefined;
 
 		this.waitForClose = new Promise<IMultiChoice | undefined>(
 			(resolve, reject) => {
@@ -52,6 +55,15 @@ export class MultiChoiceSettingsModal extends Modal {
 				});
 			});
 
+		addChoiceIconSetting(
+			this.app,
+			this.contentEl,
+			{ type: this.choice.type, icon: this.icon },
+			(icon) => {
+				this.icon = icon;
+			},
+		);
+
 		const buttonRow = this.contentEl.createDiv();
 		new ButtonComponent(buttonRow)
 			.setButtonText("Save")
@@ -85,6 +97,7 @@ export class MultiChoiceSettingsModal extends Modal {
 			...this.choice,
 			name: this.name.trim() || this.choice.name,
 			placeholder: trimmedPlaceholder ? trimmedPlaceholder : undefined,
+			icon: this.icon,
 		};
 		this.resolvePromise(updated);
 	}

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -521,6 +521,29 @@ describe("ChoiceSuggester", () => {
 			expect(el.textContent).toBe("Top note");
 		});
 
+		it("renders the default choice-type icon", async () => {
+			const suggester = makeSuggester(rootChoices);
+
+			const el = await render(suggester, topNote);
+
+			expect(el.querySelector(".quickadd-choice-icon svg")).toHaveAttribute(
+				"data-icon",
+				"file-text",
+			);
+		});
+
+		it("renders a per-choice icon override", async () => {
+			const starred = { ...choice("Starred"), icon: "star" };
+			const suggester = makeSuggester([starred]);
+
+			const el = await render(suggester, starred);
+
+			expect(el.querySelector(".quickadd-choice-icon svg")).toHaveAttribute(
+				"data-icon",
+				"star",
+			);
+		});
+
 		it("styles the sentinel back item but not a Multi named '← Back'", async () => {
 			const impostor = multi("← Back", []);
 			const back = makeBack(rootChoices);
@@ -537,6 +560,32 @@ describe("ChoiceSuggester", () => {
 			expect(
 				impostorEl.classList.contains("quickadd-choice-suggestion-back")
 			).toBe(false);
+		});
+
+		it("does not render an icon for the sentinel back item", async () => {
+			const back = makeBack(rootChoices);
+			const suggester = makeSuggester([back]);
+
+			const el = await render(suggester, back);
+
+			expect(el.querySelector(".quickadd-choice-icon")).toBeNull();
+		});
+
+		it("uses a create-file icon for the template-folder launcher row", async () => {
+			const row: IChoice = {
+				id: RUN_TEMPLATE_FROM_FOLDER_ID,
+				name: "New note from template…",
+				type: "Template",
+				command: false,
+			};
+			const suggester = makeSuggester([row]);
+
+			const el = await render(suggester, row);
+
+			expect(el.querySelector(".quickadd-choice-icon svg")).toHaveAttribute(
+				"data-icon",
+				"file-plus",
+			);
 		});
 	});
 });

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -4,6 +4,7 @@ import {
 	FuzzySuggestModal,
 	MarkdownRenderer,
 	prepareFuzzySearch,
+	setIcon,
 } from "obsidian";
 import type IChoice from "../../types/choices/IChoice";
 import { ChoiceExecutor } from "../../choiceExecutor";
@@ -18,6 +19,7 @@ import {
 	hasConfiguredTemplateFolders,
 	runTemplateFromFolder,
 } from "../../engine/runTemplateFromFolder";
+import { resolveChoiceIcon } from "../../utils/choiceUtils";
 
 const backLabel = "← Back";
 
@@ -216,12 +218,22 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		el.empty();
 		el.classList.remove("mod-complex");
 		const breadcrumb = this.breadcrumbById.get(item.item.id);
-		let nameEl: HTMLElement = el;
+
+		const row = el.createDiv({ cls: "quickadd-choice-suggestion-content" });
+		this.renderChoiceIcon(item.item, row);
+
+		let nameEl: HTMLElement;
 		if (breadcrumb) {
 			el.classList.add("mod-complex");
-			const content = el.createDiv({ cls: "suggestion-content" });
+			const content = row.createDiv({
+				cls: "suggestion-content quickadd-choice-suggestion-text",
+			});
 			nameEl = content.createDiv({ cls: "suggestion-title" });
 			content.createDiv({ cls: "suggestion-note", text: breadcrumb });
+		} else {
+			nameEl = row.createDiv({
+				cls: "quickadd-choice-suggestion-title quickadd-choice-suggestion-text",
+			});
 		}
 		void MarkdownRenderer.render(this.app, item.item.name, nameEl, "", this.markdownComponent)
 			.catch((error) => {
@@ -233,6 +245,23 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 			el.classList.add("quickadd-choice-suggestion-back");
 		if (item.item.id === RUN_TEMPLATE_FROM_FOLDER_ID)
 			el.classList.add("quickadd-choice-suggestion-run-template");
+	}
+
+	private renderChoiceIcon(choice: IChoice, parent: HTMLElement): void {
+		const iconId = this.getChoiceSuggestionIcon(choice);
+		if (!iconId) return;
+
+		const iconEl = document.createElement("span");
+		iconEl.classList.add("quickadd-choice-icon");
+		iconEl.setAttribute("aria-hidden", "true");
+		parent.appendChild(iconEl);
+		setIcon(iconEl, iconId);
+	}
+
+	private getChoiceSuggestionIcon(choice: IChoice): string | undefined {
+		if (choice.id === BACK_CHOICE_ID) return undefined;
+		if (choice.id === RUN_TEMPLATE_FROM_FOLDER_ID) return "file-plus";
+		return resolveChoiceIcon(choice);
 	}
 
 	getItemText(item: IChoice): string {

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -188,8 +188,10 @@ describe("choiceService", () => {
 			const original = createChoice("Capture", "Cap") as ITemplateChoice;
 			// Mutate a simple property to verify it is carried over.
 			(original as unknown as { command: boolean }).command = true;
+			original.icon = "inbox";
 			const copy = duplicateChoice(original);
 			expect(copy.command).toBe(true);
+			expect(copy.icon).toBe("inbox");
 			expect(copy.name).toBe("Cap (copy)");
 			expect(copy.id).not.toBe(original.id);
 		});
@@ -200,10 +202,12 @@ describe("choiceService", () => {
 			(original as unknown as { onePageInput: string }).onePageInput =
 				"always";
 			original.choices = [createChoice("Capture", "Child")];
+			original.icon = "folder-open";
 
 			const copy = duplicateChoice(original) as IMultiChoice;
 
 			expect(copy.command).toBe(true);
+			expect(copy.icon).toBe("folder-open");
 			expect(
 				(copy as unknown as { onePageInput?: string }).onePageInput,
 			).toBe("always");

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -225,6 +225,7 @@ describe("generateDefaultPackagePath", () => {
 describe("buildPackage", () => {
 	it("builds a package for a single template choice with its template asset", async () => {
 		const template = makeTemplateChoice("t1", "Daily", "Templates/daily.md");
+		template.icon = "star";
 		const { app } = makeFakeApp({
 			files: { "Templates/daily.md": "# Daily {{date}}" },
 		});
@@ -241,6 +242,7 @@ describe("buildPackage", () => {
 
 		expect(result.pkg.choices).toHaveLength(1);
 		expect(result.pkg.choices[0].choice.id).toBe("t1");
+		expect(result.pkg.choices[0].choice.icon).toBe("star");
 		expect(result.pkg.choices[0].parentChoiceId).toBeNull();
 		expect(result.pkg.choices[0].pathHint).toEqual(["Daily"]);
 

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -327,8 +327,10 @@ describe("analysePackage", () => {
 describe("applyPackageImport - root insertion", () => {
 	it("appends a brand-new root choice", async () => {
 		const { app } = createFakeApp();
+		const choice = makeChoice("new", "New", "Template");
+		choice.icon = "star";
 		const pkg = makePackage({
-			choices: [makePackageChoice(makeChoice("new", "New", "Template"))],
+			choices: [makePackageChoice(choice)],
 		});
 
 		const result = await applyPackageImport({
@@ -342,6 +344,7 @@ describe("applyPackageImport - root insertion", () => {
 		expect(result.addedChoiceIds).toEqual(["new"]);
 		expect(result.overwrittenChoiceIds).toEqual([]);
 		expect(result.updatedChoices.map((c) => c.id)).toEqual(["new"]);
+		expect(result.updatedChoices[0].icon).toBe("star");
 	});
 
 	it("overwrites an existing root choice in place", async () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -531,6 +531,23 @@
 	min-height: 10rem;
 }
 
+.qa-choice-icon-setting .setting-item-control {
+	gap: 8px;
+}
+
+.qa-choice-icon-setting-preview {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	color: var(--text-muted);
+}
+
+.qa-choice-icon-input {
+	min-width: 12rem;
+	max-width: 100%;
+}
+
 .quickadd-notice-link {
 	color: var(--interactive-accent);
 	text-decoration: underline;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1346,6 +1346,30 @@
 }
 
 /* ChoiceSuggester.ts */
+.quickadd-choice-suggestion-content {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.quickadd-choice-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	color: var(--text-muted);
+}
+
+.quickadd-choice-suggestion.is-selected .quickadd-choice-icon {
+	color: inherit;
+}
+
+.quickadd-choice-suggestion-text {
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
 .quickadd-choice-suggestion p {
 	margin: 0;
 }

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -8,9 +8,9 @@ export default interface IChoice {
 	/** Per-choice override for one-page flow. undefined = follow global setting */
 	onePageInput?: "always" | "never" | undefined;
 	/**
-	 * Optional per-choice icon id (lucide/Obsidian) for the registered command,
-	 * shown on the mobile toolbar and in the command palette. undefined = use the
-	 * per-type default (see resolveChoiceIcon). Never persisted as a default.
+	 * Optional per-choice icon id (lucide/Obsidian), shown in the choice picker
+	 * and on registered commands. undefined = use the per-type default (see
+	 * resolveChoiceIcon). Never persisted as a default.
 	 */
 	icon?: string;
 }

--- a/src/utils/choiceUtils.ts
+++ b/src/utils/choiceUtils.ts
@@ -7,10 +7,11 @@ function isMultiChoice(choice: IChoice): choice is IMultiChoice {
 }
 
 /**
- * Per-type default icon for a choice's registered command. Obsidian renders the
- * "question-mark-glyph" ("?") fallback for any command added without an `icon`,
- * which is what QuickAdd commands showed on the mobile editing toolbar (#766).
- * Each choice type maps to a semantically meaningful lucide id.
+ * Per-type default icon for choice display and registered commands. Obsidian
+ * renders the "question-mark-glyph" ("?") fallback for any command added
+ * without an `icon`, which is what QuickAdd commands showed on the mobile
+ * editing toolbar (#766). Each choice type maps to a semantically meaningful
+ * lucide id.
  *
  * The `default` arm is load-bearing, not decorative: `data.json` is not
  * runtime-validated before commands are registered, and the repo compiles with
@@ -34,11 +35,11 @@ export function defaultIconForChoiceType(type: ChoiceType): string {
 }
 
 /**
- * Resolve the icon id used when registering a choice's command. A non-empty
- * per-choice override wins; otherwise the per-type default. Resolved at
- * registration time only — defaults are never written to `data.json`, so the
- * settings payload stays clean and the defaults can evolve freely. `choice.icon`
- * is an optional override (absent for every choice unless explicitly set).
+ * Resolve the icon id used when displaying a choice or registering its command.
+ * A non-empty per-choice override wins; otherwise the per-type default. Defaults
+ * are never written to `data.json`, so the settings payload stays clean and the
+ * defaults can evolve freely. `choice.icon` is an optional override (absent for
+ * every choice unless explicitly set).
  *
  * The `typeof` guard (not just `?.`) is deliberate: `data.json` is not
  * runtime-validated, so a hand-edited or imported choice could carry a


### PR DESCRIPTION
Add native Obsidian/Lucide icons to QuickAdd choice picker rows and make the existing `choice.icon` metadata editable from the app.

The core design is intentionally small: `choice.icon` now drives both registered command icons and choice picker display. If a choice has no override, QuickAdd uses the existing type defaults (`file-text`, `pencil`, `terminal`, `folder`) without persisting those defaults into `data.json`.

This also adds Icon controls to Template, Capture, Macro, and Multi configuration, plus docs for the supported behavior. I intentionally did not add per-choice icon colors: Obsidian icons are theme-colored, command icons cannot carry per-choice color, and color settings would create a broader appearance system with accessibility and package-sharing tradeoffs.

Validation:
- `pnpm run build-with-lint`
- `pnpm run check` (0 errors)
- `pnpm test` (230 passed, 5 skipped)
- Isolated Obsidian vault: rebuilt, provisioned, reloaded QuickAdd, seeded choices, verified root picker rendered `lucide-star`, default Capture icon, and `lucide-rocket` after editing a Multi choice icon through the real ChoiceView/Multi settings UI
- Isolated Obsidian vault: verified nested Multi picker rendered `lucide-inbox` for a child Macro and no icon for the synthetic Back row
- `pnpm run obsidian:e2e -- dev:errors` returned no captured errors

Fixes #428


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Icon** picker to choice configuration (including Template/Capture/Multi and macro editing), letting users override the per-choice icon or clear it to fall back to the type default.
  * Icons render in the QuickAdd launcher, Multi choice pickers, and registered commands, using the active Obsidian theme color (monochrome).
* **Documentation**
  * Updated choice icon settings docs with the new **Icon** override behavior and supported icon source.
* **Tests**
  * Expanded test coverage for icon selection/preview, whitespace-to-default handling, and correct icon rendering in suggestion lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->