### PR TITLE
feat(template): add discovery-first note creation

### DIFF
--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -8,6 +8,11 @@ The template choice type is not meant to be a replacement for [Templater](https:
 If you just want to spin up a note from a template in your [template folder](/Settings.md#templates--properties) without maintaining a Template choice per file, use the **New note from template** command. It lists the templates in your configured folder, prompts for the new note's name, and creates it in Obsidian's default location. When a template folder is configured, the same entry also appears in **Run QuickAdd** — at the bottom by default, or move it to the top / hide it under [Settings → Choice Picker](/Settings.md#choice-picker) — and it's scriptable via [`quickadd:run-template`](/Advanced/CLI.md#quickaddrun-template). Make a Template choice (below) when you need a fixed location, file-name format, linking, or a hotkey.
 :::
 
+**New note from template** uses a discovery-first title picker. As you type the
+new note name, QuickAdd shows matching existing notes and unresolved wikilink
+targets first. Choose an existing note to open it unchanged, or choose the
+**Create new note** row to create the note from the selected template.
+
 The Template choice builder groups its settings into four sections: **Template** (template path and file name format), **Location** (where the file is created), **Linking** (whether and how to link to the created file), and **Behavior** (what happens when the file already exists, and how the file is opened).
 
 ![The QuickAdd Template builder, showing the Template, Location, Linking, and Behavior sections](/img/choices/template-builder.png)
@@ -33,6 +38,14 @@ Basically, this allows you to have dynamic file names. If you wrote `£ {{DATE}}
 If you disable **File Name Format**, QuickAdd uses `{{VALUE}}` as the file name format. This keeps the default behavior of prompting for a file name when you run the choice, with the same `{{VALUE}}` / `{{NAME}}` behavior described in the format syntax docs.
 
 If a value used in the file name contains a line break or another control character, QuickAdd folds it to a space in the created path and strips trailing spaces or periods from that path segment. The original value is still available unchanged in the template body, so multi-line prompts can create readable note content without making the note hard to link.
+
+**Search existing notes before creating**. For Template choices that use the
+default note-title prompt, this opens the same discovery-first picker used by
+**New note from template**. Matching notes and unresolved wikilink targets appear
+while you type, so you can open an existing note instead of creating a duplicate.
+Selecting an existing note opens it unchanged and does not apply the template,
+append template content, insert links, or copy links. Selecting the explicit
+**Create new note** row continues with normal Template creation.
 
 **New note location**. A dropdown that controls where the note is created. Pick one of four modes:
 - **Obsidian default** – use Obsidian's "Default location for new notes" setting.

--- a/src/engine/TemplateChoiceEngine.discovery.test.ts
+++ b/src/engine/TemplateChoiceEngine.discovery.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+	formatFileNameMock,
+	formatFileContentMock,
+	promptForTemplateNoteDiscoveryMock,
+	openExistingFileTabMock,
+	openFileMock,
+	insertFileLinkMock,
+	copyFileLinkMock,
+} = vi.hoisted(() => ({
+	formatFileNameMock: vi.fn<(format: string, prompt: string) => Promise<string>>(),
+	formatFileContentMock: vi.fn<() => Promise<string>>(),
+	promptForTemplateNoteDiscoveryMock: vi.fn(),
+	openExistingFileTabMock: vi.fn(),
+	openFileMock: vi.fn(),
+	insertFileLinkMock: vi.fn(),
+	copyFileLinkMock: vi.fn(),
+}));
+
+vi.mock("../formatters/completeFormatter", () => {
+	class CompleteFormatterMock {
+		setLinkToCurrentFileBehavior() {}
+		setTitle() {}
+		setTargetFolderPath() {}
+		async formatFileName(format: string, prompt: string) {
+			return formatFileNameMock(format, prompt);
+		}
+		async formatFileContent() {
+			return await formatFileContentMock();
+		}
+		async formatTemplateFilePath(input: string) {
+			return input;
+		}
+		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
+			return await work();
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map<string, unknown>();
+		}
+	}
+
+	return { CompleteFormatter: CompleteFormatterMock };
+});
+
+vi.mock("./templateNoteDiscovery", async () => {
+	const actual = await vi.importActual("./templateNoteDiscovery");
+	return {
+		...(actual as Record<string, unknown>),
+		promptForTemplateNoteDiscovery: promptForTemplateNoteDiscoveryMock,
+	};
+});
+
+vi.mock("../utilityObsidian", () => ({
+	getTemplater: vi.fn(() => ({})),
+	overwriteTemplaterOnce: vi.fn(),
+	getAllFolderPathsInVault: vi.fn(() => []),
+	insertFileLinkToActiveView: insertFileLinkMock,
+	openExistingFileTab: openExistingFileTabMock,
+	openFile: openFileMock,
+}));
+
+vi.mock("../utils/fileLinks", () => ({
+	copyFileLinkToClipboard: copyFileLinkMock,
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: {
+		Suggest: vi.fn(),
+	},
+}));
+
+vi.mock("../main", () => ({
+	default: class QuickAddMock {},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+import { TFile, type App } from "obsidian";
+import { TemplateChoiceEngine } from "./TemplateChoiceEngine";
+import type ITemplateChoice from "../types/choices/ITemplateChoice";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+
+function file(path: string): TFile {
+	const tfile = new TFile();
+	tfile.path = path;
+	tfile.name = path.split("/").pop() ?? path;
+	tfile.basename = tfile.name.replace(/\.(md|canvas|base)$/i, "");
+	tfile.extension = tfile.name.split(".").pop() ?? "md";
+	tfile.stat = { ctime: 0, mtime: 0, size: 0 };
+	return tfile;
+}
+
+function choice(overrides: Partial<ITemplateChoice> = {}): ITemplateChoice {
+	return {
+		id: "template",
+		name: "Project note",
+		type: "Template",
+		command: false,
+		templatePath: "Templates/Project.md",
+		folder: {
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		},
+		fileNameFormat: { enabled: false, format: "{{VALUE}}" },
+		appendLink: false,
+		copyLinkToClipboard: false,
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "source",
+			focus: false,
+		},
+		fileExistsBehavior: { kind: "prompt" },
+		discoverExistingNotesBeforeCreate: true,
+		...overrides,
+	};
+}
+
+function buildEngine(
+	templateChoice = choice(),
+	variables = new Map<string, unknown>(),
+) {
+	const created = file("Created.md");
+	const app = {
+		workspace: {
+			getActiveFile: vi.fn(() => null),
+		},
+		fileManager: {
+			getNewFileParent: vi.fn(() => ({ path: "" })),
+		},
+		vault: {
+			getRoot: vi.fn(() => ({ path: "" })),
+			adapter: {
+				exists: vi.fn(async () => false),
+			},
+			getAbstractFileByPath: vi.fn(() => null),
+			getFiles: vi.fn(() => []),
+			createFolder: vi.fn(),
+			create: vi.fn(async () => created),
+			modify: vi.fn(),
+		},
+	} as unknown as App;
+	const choiceExecutor: IChoiceExecutor = {
+		execute: vi.fn(),
+		variables,
+		recordExecutionResult: vi.fn(),
+		signalAbort: vi.fn(),
+		consumeAbortSignal: vi.fn(),
+	};
+	const plugin = { settings: { globalVariables: {} } } as never;
+	const engine = new TemplateChoiceEngine(
+		app,
+		plugin,
+		templateChoice,
+		choiceExecutor,
+	);
+	return { engine, app, choiceExecutor, created };
+}
+
+describe("TemplateChoiceEngine note discovery", () => {
+	beforeEach(() => {
+		formatFileNameMock.mockReset();
+		formatFileNameMock.mockResolvedValue("Created");
+		formatFileContentMock.mockReset();
+		formatFileContentMock.mockResolvedValue("");
+		promptForTemplateNoteDiscoveryMock.mockReset();
+		openExistingFileTabMock.mockReset();
+		openExistingFileTabMock.mockReturnValue(null);
+		openFileMock.mockReset();
+		insertFileLinkMock.mockReset();
+		copyFileLinkMock.mockReset();
+	});
+
+	it("opens an existing discovery result unchanged and skips template side effects", async () => {
+		const existing = file("People/Alice.md");
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({
+			kind: "openExisting",
+			file: existing,
+		});
+		const { engine, app, choiceExecutor } = buildEngine(
+			choice({
+				appendLink: true,
+				copyLinkToClipboard: true,
+				fileExistsBehavior: { kind: "apply", mode: "overwrite" },
+			}),
+		);
+		const createSpy = vi.spyOn(
+			engine as unknown as {
+				createFileWithTemplate: (path: string, template: string) => Promise<TFile | null>;
+			},
+			"createFileWithTemplate",
+		);
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+		await engine.run();
+
+		expect(formatFileNameMock).not.toHaveBeenCalled();
+		expect(createSpy).not.toHaveBeenCalled();
+		expect(insertFileLinkMock).not.toHaveBeenCalled();
+		expect(copyFileLinkMock).not.toHaveBeenCalled();
+		expect(openFileMock).toHaveBeenCalledWith(
+			expect.anything(),
+			existing,
+			expect.objectContaining({ focus: true }),
+		);
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: existing,
+		});
+	});
+
+	it("seeds VALUE and continues through normal template creation for create rows", async () => {
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({
+			kind: "create",
+			title: "Brand New Project",
+		});
+		formatFileNameMock.mockResolvedValue("Brand New Project");
+		const { engine, choiceExecutor, created } = buildEngine();
+		const createSpy = vi
+			.spyOn(
+				engine as unknown as {
+					createFileWithTemplate: (
+						path: string,
+						template: string,
+					) => Promise<TFile | null>;
+				},
+				"createFileWithTemplate",
+			)
+			.mockResolvedValue(created);
+
+		await engine.run();
+
+		expect(choiceExecutor.variables.get("value")).toBe("Brand New Project");
+		expect(formatFileNameMock).toHaveBeenCalledWith("{{value}}", "Project note");
+		expect(createSpy).toHaveBeenCalledWith(
+			"Brand New Project.md",
+			"Templates/Project.md",
+		);
+	});
+
+	it("skips discovery when VALUE was already supplied by CLI, URI, or preflight", async () => {
+		const { engine } = buildEngine(choice(), new Map([["value", "Seeded"]]));
+
+		await engine.run();
+
+		expect(promptForTemplateNoteDiscoveryMock).not.toHaveBeenCalled();
+		expect(formatFileNameMock).toHaveBeenCalled();
+	});
+
+	it("requires explicit opt-in for persisted Template choices", async () => {
+		const { engine } = buildEngine(
+			choice({ discoverExistingNotesBeforeCreate: false }),
+		);
+
+		await engine.run();
+
+		expect(promptForTemplateNoteDiscoveryMock).not.toHaveBeenCalled();
+	});
+
+	it("does not run for non-default file name formats", async () => {
+		const { engine } = buildEngine(
+			choice({
+				fileNameFormat: { enabled: true, format: "Project {{VALUE}}" },
+			}),
+		);
+
+		await engine.run();
+
+		expect(promptForTemplateNoteDiscoveryMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/engine/TemplateChoiceEngine.discovery.test.ts
+++ b/src/engine/TemplateChoiceEngine.discovery.test.ts
@@ -221,8 +221,11 @@ describe("TemplateChoiceEngine note discovery", () => {
 			kind: "create",
 			title: "Brand New Project",
 		});
-		formatFileNameMock.mockResolvedValue("Brand New Project");
 		const { engine, choiceExecutor, created } = buildEngine();
+		formatFileNameMock.mockImplementation(async () => {
+			expect(choiceExecutor.variables.get("value")).toBe("Brand New Project");
+			return "Brand New Project";
+		});
 		const createSpy = vi
 			.spyOn(
 				engine as unknown as {
@@ -237,7 +240,7 @@ describe("TemplateChoiceEngine note discovery", () => {
 
 		await engine.run();
 
-		expect(choiceExecutor.variables.get("value")).toBe("Brand New Project");
+		expect(choiceExecutor.variables.has("value")).toBe(false);
 		expect(formatFileNameMock).toHaveBeenCalledWith("{{value}}", "Project note");
 		expect(createSpy).toHaveBeenCalledWith(
 			"Brand New Project.md",

--- a/src/engine/TemplateChoiceEngine.discovery.test.ts
+++ b/src/engine/TemplateChoiceEngine.discovery.test.ts
@@ -248,6 +248,51 @@ describe("TemplateChoiceEngine note discovery", () => {
 		);
 	});
 
+	it("honors foldered unresolved-link targets as vault-relative paths", async () => {
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({
+			kind: "create",
+			title: "Projects/Missing Roadmap",
+			vaultRelativePath: "Projects/Missing Roadmap",
+		});
+		const { engine, choiceExecutor, created } = buildEngine(
+			choice({
+				folder: {
+					enabled: true,
+					folders: ["Inbox"],
+					chooseWhenCreatingNote: false,
+					createInSameFolderAsActiveFile: false,
+					chooseFromSubfolders: false,
+				},
+			}),
+		);
+		formatFileNameMock.mockImplementation(async () => {
+			expect(choiceExecutor.variables.get("value")).toBe(
+				"Projects/Missing Roadmap",
+			);
+			return "Projects/Missing Roadmap";
+		});
+		const createSpy = vi
+			.spyOn(
+				engine as unknown as {
+					createFileWithTemplate: (
+						path: string,
+						template: string,
+					) => Promise<TFile | null>;
+				},
+				"createFileWithTemplate",
+			)
+			.mockResolvedValue(created);
+
+		await engine.run();
+
+		expect(createSpy).toHaveBeenCalledWith(
+			"Projects/Missing Roadmap.md",
+			"Templates/Project.md",
+		);
+		expect(formatFileNameMock).not.toHaveBeenCalled();
+		expect(choiceExecutor.variables.has("value")).toBe(false);
+	});
+
 	it("skips discovery when VALUE was already supplied by CLI, URI, or preflight", async () => {
 		const { engine } = buildEngine(choice(), new Map([["value", "Seeded"]]));
 

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -37,6 +37,7 @@ import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { TemplateEngine } from "./TemplateEngine";
 import { UserCancelError } from "../errors/UserCancelError";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
+import { parentFolderPath } from "../utils/pathUtils";
 
 export class TemplateChoiceEngine extends TemplateEngine {
 	public choice: ITemplateChoice;
@@ -56,6 +57,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 
 	public async run(): Promise<void> {
 		let restoreDiscoveryValue: (() => void) | null = null;
+		let discoveryVaultRelativePath: string | null = null;
 
 		try {
 			invariant(this.choice.templatePath, () => {
@@ -97,6 +99,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				}
 
 				restoreDiscoveryValue = this.setTemporaryValueVariable(discovery.title);
+				discoveryVaultRelativePath = discovery.vaultRelativePath ?? null;
 			}
 
 			// Resolve format tokens in the template path ONCE, after discovery has
@@ -108,7 +111,9 @@ export class TemplateChoiceEngine extends TemplateEngine {
 
 			let folderPath = "";
 
-			if (this.choice.folder.enabled) {
+			if (discoveryVaultRelativePath) {
+				folderPath = parentFolderPath(discoveryVaultRelativePath);
+			} else if (this.choice.folder.enabled) {
 				folderPath = await this.getFolderPath();
 			} else {
 				// Respect Obsidian's "Default location for new notes" setting
@@ -121,15 +126,16 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			// Make the resolved folder available to {{FOLDER}} in the file name.
 			this.formatter.setTargetFolderPath(folderPath);
 
-			const formattedName = await this.formatter.formatFileName(
-				format,
-				this.choice.name,
-			);
+			const formattedName = discoveryVaultRelativePath
+				? discoveryVaultRelativePath
+				: await this.formatter.formatFileName(format, this.choice.name);
 			const routedName = normalizeGeneratedFilePath(formattedName, "File name");
-			const { fileName, strippedPrefix } = this.stripDuplicateFolderPrefix(
-				routedName,
-				folderPath,
-			);
+			const { fileName, strippedPrefix } = discoveryVaultRelativePath
+				? { fileName: routedName, strippedPrefix: false }
+				: this.stripDuplicateFolderPrefix(
+					routedName,
+					folderPath,
+				);
 			const treatAsVaultRelativePath =
 				this.shouldTreatFormattedNameAsVaultRelativePath(
 					routedName,
@@ -138,7 +144,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				);
 
 			const targetFilePath = this.normalizeTemplateFilePath(
-				treatAsVaultRelativePath ? "" : folderPath,
+				discoveryVaultRelativePath || treatAsVaultRelativePath ? "" : folderPath,
 				fileName,
 				templatePath,
 			);

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -55,6 +55,8 @@ export class TemplateChoiceEngine extends TemplateEngine {
 	}
 
 	public async run(): Promise<void> {
+		let restoreDiscoveryValue: (() => void) | null = null;
+
 		try {
 			invariant(this.choice.templatePath, () => {
 				return `Invalid template path for ${this.choice.name}. ${this.choice.templatePath.length === 0
@@ -94,7 +96,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					return;
 				}
 
-				this.choiceExecutor.variables.set("value", discovery.title);
+				restoreDiscoveryValue = this.setTemporaryValueVariable(discovery.title);
 			}
 
 			// Resolve format tokens in the template path ONCE, after discovery has
@@ -242,7 +244,25 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			}
 			InputPromptDraftStore.getInstance().markExecutionScopeFailed();
 			reportError(err, `Error running template choice "${this.choice.name}"`);
+		} finally {
+			restoreDiscoveryValue?.();
 		}
+	}
+
+	private setTemporaryValueVariable(value: string): () => void {
+		const variables = this.choiceExecutor.variables;
+		const hadPreviousValue = variables.has("value");
+		const previousValue = variables.get("value");
+
+		variables.set("value", value);
+
+		return () => {
+			if (hadPreviousValue) {
+				variables.set("value", previousValue);
+				return;
+			}
+			variables.delete("value");
+		};
 	}
 
 	private async getSelectedFileExistsMode(): Promise<FileExistsModeId> {

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -12,6 +12,10 @@ import {
 	resolveCreateNewCollisionFilePath,
 	type FileExistsModeId,
 } from "../template/fileExistsPolicy";
+import {
+	promptForTemplateNoteDiscovery,
+	shouldRunTemplateNoteDiscovery,
+} from "./templateNoteDiscovery";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { normalizeAppendLinkOptions } from "../types/linkPlacement";
 import {
@@ -66,12 +70,36 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					: "required",
 			);
 
-			// Resolve format tokens in the template path ONCE, up front (issue
-			// #620). Doing it before folder/file-name resolution means a cancelled
-			// path prompt aborts the run before any folder is created, and the
-			// resolved path feeds BOTH the target extension/name (below) and the
-			// content read — so the file that's read and the file that's created
-			// can never disagree.
+			const format = this.choice.fileNameFormat.enabled
+				? this.choice.fileNameFormat.format
+				: VALUE_SYNTAX;
+
+			if (
+				shouldRunTemplateNoteDiscovery(
+					this.choice,
+					format,
+					this.choiceExecutor.variables.get("value"),
+				)
+			) {
+				const discovery = await promptForTemplateNoteDiscovery(
+					this.app,
+					this.choice,
+				);
+				if (discovery.kind === "openExisting") {
+					await this.openDiscoveredExistingNote(discovery.file);
+					this.choiceExecutor.recordExecutionResult?.({
+						status: "success",
+						file: discovery.file,
+					});
+					return;
+				}
+
+				this.choiceExecutor.variables.set("value", discovery.title);
+			}
+
+			// Resolve format tokens in the template path ONCE, after discovery has
+			// either selected "create" or been skipped. Existing-note discovery exits
+			// before any template-path prompt, folder creation, or template side effect.
 			const templatePath = await this.resolveTemplateSourcePath(
 				this.choice.templatePath,
 			);
@@ -91,9 +119,6 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			// Make the resolved folder available to {{FOLDER}} in the file name.
 			this.formatter.setTargetFolderPath(folderPath);
 
-			const format = this.choice.fileNameFormat.enabled
-				? this.choice.fileNameFormat.format
-				: VALUE_SYNTAX;
 			const formattedName = await this.formatter.formatFileName(
 				format,
 				this.choice.name,
@@ -283,6 +308,19 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					createdFile: existingFile,
 					shouldAutoOpen: true,
 				};
+		}
+	}
+
+	private async openDiscoveredExistingNote(file: TFile): Promise<void> {
+		const fileOpening = normalizeFileOpening(this.choice.fileOpening);
+		const openExistingTab = openExistingFileTab(this.app, file, true);
+
+		if (!openExistingTab) {
+			await openFile(this.app, file, {
+				...fileOpening,
+				focus: true,
+				originLeaf: this.originLeaf,
+			});
 		}
 	}
 

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -40,6 +40,7 @@ export function createFolderTemplateChoice(templatePath: string): ITemplateChoic
 	// Creating a brand-new note from a template — land in it, like the user expects.
 	choice.openFile = true;
 	choice.fileNameFormat = { enabled: true, format: VALUE_SYNTAX };
+	choice.discoverExistingNotesBeforeCreate = true;
 	return choice;
 }
 

--- a/src/engine/templateNoteDiscovery.test.ts
+++ b/src/engine/templateNoteDiscovery.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { inputSuggestMock } = vi.hoisted(() => ({
+	inputSuggestMock: vi.fn(),
+}));
+
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
+	default: {
+		Suggest: inputSuggestMock,
+	},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+import { TFile, type App } from "obsidian";
+import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+import {
+	promptForTemplateNoteDiscovery,
+	shouldRunTemplateNoteDiscovery,
+	testExports,
+} from "./templateNoteDiscovery";
+
+function file(path: string): TFile {
+	const tfile = new TFile();
+	tfile.path = path;
+	tfile.name = path.split("/").pop() ?? path;
+	tfile.basename = tfile.name.replace(/\.md$/i, "");
+	tfile.extension = "md";
+	tfile.stat = { ctime: 0, mtime: 0, size: 0 };
+	tfile.parent = {
+		path: path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "",
+	} as never;
+	return tfile;
+}
+
+function choice(
+	overrides: Partial<ITemplateChoice> = {},
+): ITemplateChoice {
+	return {
+		id: "template",
+		name: "Project note",
+		type: "Template",
+		command: false,
+		templatePath: "Templates/Project.md",
+		folder: {
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		},
+		fileNameFormat: { enabled: false, format: "{{VALUE}}" },
+		appendLink: false,
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "source",
+			focus: false,
+		},
+		fileExistsBehavior: { kind: "prompt" },
+		discoverExistingNotesBeforeCreate: true,
+		...overrides,
+	};
+}
+
+function app(files: TFile[] = []): App {
+	return {
+		vault: {
+			getMarkdownFiles: vi.fn(() => files),
+			getAbstractFileByPath: vi.fn((path: string) =>
+				files.find((entry) => entry.path === path) ?? null,
+			),
+		},
+		workspace: {
+			getLastOpenFiles: vi.fn(() => []),
+		},
+		metadataCache: {
+			getFileCache: vi.fn((entry: TFile) =>
+				entry.basename === "Alice"
+					? { frontmatter: { aliases: ["A. Example"] } }
+					: { frontmatter: {} },
+			),
+			unresolvedLinks: {
+				"Source.md": {
+					"Missing Project": 1,
+					"Projects/Missing Roadmap": 1,
+					"Existing/Alice": 1,
+				},
+			},
+			isUserIgnored: vi.fn(() => false),
+		},
+	} as unknown as App;
+}
+
+describe("template note discovery", () => {
+	beforeEach(() => {
+		inputSuggestMock.mockReset();
+	});
+
+	it("only runs for opted-in default title prompts with no seeded value", () => {
+		expect(
+			shouldRunTemplateNoteDiscovery(choice(), "{{VALUE}}", undefined),
+		).toBe(true);
+		expect(
+			shouldRunTemplateNoteDiscovery(
+				choice({ fileNameFormat: { enabled: true, format: "{{VALUE}}" } }),
+				"{{VALUE}}",
+				undefined,
+			),
+		).toBe(true);
+		expect(
+			shouldRunTemplateNoteDiscovery(
+				choice({ fileNameFormat: { enabled: true, format: "{{NAME}}" } }),
+				"{{NAME}}",
+				undefined,
+			),
+		).toBe(true);
+		expect(
+			shouldRunTemplateNoteDiscovery(choice(), "{{VALUE}}", "Seeded"),
+		).toBe(false);
+		expect(
+			shouldRunTemplateNoteDiscovery(
+				choice({ discoverExistingNotesBeforeCreate: false }),
+				"{{VALUE}}",
+				undefined,
+			),
+		).toBe(false);
+		expect(
+			shouldRunTemplateNoteDiscovery(
+				choice({ fileNameFormat: { enabled: true, format: "Project {{VALUE}}" } }),
+				"Project {{VALUE}}",
+				undefined,
+			),
+		).toBe(false);
+	});
+
+	it("builds existing-note and unresolved-link candidates for the picker", () => {
+		const alice = file("Existing/Alice.md");
+		const built = testExports.buildDiscoveryCandidates(app([alice]));
+
+		expect(built.candidates.map((candidate) => candidate.display)).toContain(
+			"Alice Existing/Alice.md A. Example",
+		);
+		expect(built.candidates.map((candidate) => candidate.unresolvedTitle)).toEqual(
+			expect.arrayContaining(["Missing Project", "Projects/Missing Roadmap"]),
+		);
+		expect(built.candidates.map((candidate) => candidate.unresolvedTitle)).not.toContain(
+			"Existing/Alice",
+		);
+	});
+
+	it("returns a tagged existing-file result when an existing row is selected", async () => {
+		const alice = file("People/Alice.md");
+		inputSuggestMock.mockImplementation(async (_app, _display, items) => items[0]);
+
+		const result = await promptForTemplateNoteDiscovery(app([alice]), choice());
+
+		expect(result).toEqual({ kind: "openExisting", file: alice });
+	});
+
+	it("returns a create result for unresolved-link rows", async () => {
+		const alice = file("People/Alice.md");
+		inputSuggestMock.mockImplementation(async (_app, _display, items) =>
+			items.find((item: string) => item.includes("Missing Project")),
+		);
+
+		const result = await promptForTemplateNoteDiscovery(app([alice]), choice());
+
+		expect(result).toEqual({ kind: "create", title: "Missing Project" });
+	});
+
+	it("suppresses the generic create row for exact existing or unresolved names", async () => {
+		const alice = file("People/Alice.md");
+		inputSuggestMock.mockResolvedValue("Fresh Idea");
+
+		await promptForTemplateNoteDiscovery(app([alice]), choice());
+
+		const options = inputSuggestMock.mock.calls[0]?.[3];
+		expect(options.valueExists("Alice")).toBe(true);
+		expect(options.valueExists("People/Alice")).toBe(true);
+		expect(options.valueExists("Missing Project")).toBe(true);
+		expect(options.valueExists("Fresh Idea")).toBe(false);
+	});
+});

--- a/src/engine/templateNoteDiscovery.test.ts
+++ b/src/engine/templateNoteDiscovery.test.ts
@@ -139,7 +139,7 @@ describe("template note discovery", () => {
 
 	it("builds existing-note and unresolved-link candidates for the picker", () => {
 		const alice = file("Existing/Alice.md");
-		const built = testExports.buildDiscoveryCandidates(app([alice]));
+		const built = testExports.buildDiscoveryCandidates(app([alice]), choice());
 
 		expect(built.candidates.map((candidate) => candidate.display)).toContain(
 			"Alice Existing/Alice.md A. Example",
@@ -149,6 +149,22 @@ describe("template note discovery", () => {
 		);
 		expect(built.candidates.map((candidate) => candidate.unresolvedTitle)).not.toContain(
 			"Existing/Alice",
+		);
+	});
+
+	it("excludes the selected literal template file from existing-note candidates", () => {
+		const template = file("Templates/Project.md");
+		const alice = file("Existing/Alice.md");
+		const built = testExports.buildDiscoveryCandidates(
+			app([template, alice]),
+			choice({ templatePath: "Templates/Project.md" }),
+		);
+
+		expect(built.candidates.map((candidate) => candidate.renderPath)).toContain(
+			"Existing/Alice.md",
+		);
+		expect(built.candidates.map((candidate) => candidate.renderPath)).not.toContain(
+			"Templates/Project.md",
 		);
 	});
 
@@ -170,6 +186,33 @@ describe("template note discovery", () => {
 		const result = await promptForTemplateNoteDiscovery(app([alice]), choice());
 
 		expect(result).toEqual({ kind: "create", title: "Missing Project" });
+	});
+
+	it("tags foldered unresolved-link rows with a vault-relative target path", async () => {
+		const alice = file("People/Alice.md");
+		inputSuggestMock.mockImplementation(async (_app, _display, items) =>
+			items.find((item: string) => item.includes("Projects/Missing Roadmap")),
+		);
+
+		const result = await promptForTemplateNoteDiscovery(app([alice]), choice());
+
+		expect(result).toEqual({
+			kind: "create",
+			title: "Projects/Missing Roadmap",
+			vaultRelativePath: "Projects/Missing Roadmap",
+		});
+	});
+
+	it("aborts instead of creating a sentinel-named note when a selected existing row is stale", async () => {
+		const alice = file("People/Alice.md");
+		const staleApp = app([alice]);
+		(staleApp.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>)
+			.mockReturnValueOnce(null);
+		inputSuggestMock.mockImplementation(async (_app, _display, items) => items[0]);
+
+		await expect(
+			promptForTemplateNoteDiscovery(staleApp, choice()),
+		).rejects.toThrow("Selected note no longer exists");
 	});
 
 	it("suppresses the generic create row for exact existing or unresolved names", async () => {

--- a/src/engine/templateNoteDiscovery.ts
+++ b/src/engine/templateNoteDiscovery.ts
@@ -17,7 +17,7 @@ const EXISTING_PREFIX = "@quickadd-existing-note:";
 const UNRESOLVED_PREFIX = "@quickadd-unresolved-note:";
 
 export type TemplateNoteDiscoveryResult =
-	| { kind: "create"; title: string }
+	| { kind: "create"; title: string; vaultRelativePath?: string }
 	| { kind: "openExisting"; file: TFile };
 
 type DiscoveryCandidate = {
@@ -54,6 +54,22 @@ function decodeUnresolvedTitle(item: string): string {
 
 function normalizedKey(value: string): string {
 	return value.trim().replace(/\.md$/i, "").toLowerCase();
+}
+
+function normalizeVaultPath(value: string): string {
+	return value.trim().replace(/^\/+/, "");
+}
+
+function isLiteralMarkdownPath(path: string): boolean {
+	return path.trim().length > 0 && !path.includes("{{");
+}
+
+function templatePathExclusions(choice: ITemplateChoice): Set<string> {
+	if (!isLiteralMarkdownPath(choice.templatePath)) return new Set();
+
+	const normalized = normalizeVaultPath(choice.templatePath);
+	const markdownPath = /\.md$/i.test(normalized) ? normalized : `${normalized}.md`;
+	return new Set([markdownPath.toLowerCase()]);
 }
 
 function addPathKeys(keys: Set<string>, path: string, basename: string): void {
@@ -118,11 +134,12 @@ function collectUnresolvedTargets(app: App): string[] {
 	return [...targets.values()].sort((a, b) => a.localeCompare(b));
 }
 
-function buildDiscoveryCandidates(app: App): {
+function buildDiscoveryCandidates(app: App, choice: ITemplateChoice): {
 	candidates: DiscoveryCandidate[];
 	existingKeys: Set<string>;
 } {
 	const existingKeys = new Set<string>();
+	const excludedPaths = templatePathExclusions(choice);
 	const markdownFiles = orderFilesForPicker(
 		app.vault.getMarkdownFiles(),
 		buildPickerOrderingDeps(app),
@@ -130,6 +147,9 @@ function buildDiscoveryCandidates(app: App): {
 
 	const candidates: DiscoveryCandidate[] = [];
 	for (const file of markdownFiles) {
+		if (excludedPaths.has(normalizeVaultPath(file.path).toLowerCase())) {
+			continue;
+		}
 		addPathKeys(existingKeys, file.path, file.basename);
 		const aliases = readAliases(app, file);
 		const searchable = [file.basename, file.path, ...aliases].join(" ");
@@ -177,7 +197,7 @@ export async function promptForTemplateNoteDiscovery(
 	app: App,
 	choice: ITemplateChoice,
 ): Promise<TemplateNoteDiscoveryResult> {
-	const { candidates, existingKeys } = buildDiscoveryCandidates(app);
+	const { candidates, existingKeys } = buildDiscoveryCandidates(app, choice);
 	const candidateByItem = new Map(
 		candidates.map((candidate) => [candidate.item, candidate]),
 	);
@@ -225,15 +245,24 @@ export async function promptForTemplateNoteDiscovery(
 			if (file instanceof TFile) {
 				return { kind: "openExisting", file };
 			}
+			throw new Error("Selected note no longer exists. Please run QuickAdd again.");
 		}
 
-		const title = isUnresolvedItem(selected)
-			? decodeUnresolvedTitle(selected)
-			: selected;
+		if (isUnresolvedItem(selected)) {
+			const title = normalizeGeneratedFilePath(
+				decodeUnresolvedTitle(selected),
+				"Note title",
+			);
+			return {
+				kind: "create",
+				title,
+				...(title.includes("/") ? { vaultRelativePath: title } : {}),
+			};
+		}
 
 		return {
 			kind: "create",
-			title: normalizeGeneratedFilePath(title, "Note title"),
+			title: normalizeGeneratedFilePath(selected, "Note title"),
 		};
 	} catch (error) {
 		if (isCancellationError(error)) {
@@ -247,4 +276,5 @@ export const testExports = {
 	buildDiscoveryCandidates,
 	collectUnresolvedTargets,
 	normalizeUnresolvedTarget,
+	templatePathExclusions,
 };

--- a/src/engine/templateNoteDiscovery.ts
+++ b/src/engine/templateNoteDiscovery.ts
@@ -1,0 +1,268 @@
+import { TFile, type App } from "obsidian";
+import InputSuggester from "src/gui/InputSuggester/inputSuggester";
+import { renderNotePathSuggestion } from "src/gui/InputSuggester/renderNotePathSuggestion";
+import { orderFilesForPicker } from "src/utils/fileOrdering";
+import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
+import { isCancellationError } from "src/utils/errorUtils";
+import { UserCancelError } from "src/errors/UserCancelError";
+import { normalizeGeneratedFilePath } from "src/utils/generatedFilePath";
+import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+import { NAME_SYNTAX, VALUE_SYNTAX } from "src/constants";
+
+const EXISTING_PREFIX = "@quickadd-existing-note:";
+const UNRESOLVED_PREFIX = "@quickadd-unresolved-note:";
+
+export type TemplateNoteDiscoveryResult =
+	| { kind: "create"; title: string }
+	| { kind: "openExisting"; file: TFile };
+
+type DiscoveryCandidate = {
+	item: string;
+	display: string;
+	renderPath?: string;
+	renderAlias?: string;
+	unresolvedTitle?: string;
+};
+
+function encodeExisting(path: string): string {
+	return `${EXISTING_PREFIX}${path}`;
+}
+
+function encodeUnresolved(title: string): string {
+	return `${UNRESOLVED_PREFIX}${title}`;
+}
+
+function isExistingItem(item: string): boolean {
+	return item.startsWith(EXISTING_PREFIX);
+}
+
+function isUnresolvedItem(item: string): boolean {
+	return item.startsWith(UNRESOLVED_PREFIX);
+}
+
+function decodeExistingPath(item: string): string {
+	return item.slice(EXISTING_PREFIX.length);
+}
+
+function decodeUnresolvedTitle(item: string): string {
+	return item.slice(UNRESOLVED_PREFIX.length);
+}
+
+function normalizedKey(value: string): string {
+	return value.trim().replace(/\.md$/i, "").toLowerCase();
+}
+
+function addPathKeys(keys: Set<string>, path: string, basename: string): void {
+	const withoutExtension = path.replace(/\.md$/i, "");
+	keys.add(normalizedKey(path));
+	keys.add(normalizedKey(withoutExtension));
+	keys.add(normalizedKey(basename));
+}
+
+function readAliases(app: App, file: TFile): string[] {
+	const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+	if (!frontmatter) return [];
+
+	const aliases: string[] = [];
+	for (const [key, value] of Object.entries(frontmatter)) {
+		const lowerKey = key.toLowerCase();
+		if (lowerKey !== "alias" && lowerKey !== "aliases") continue;
+
+		if (typeof value === "string") {
+			aliases.push(
+				...value
+					.split(",")
+					.map((alias) => alias.trim())
+					.filter(Boolean),
+			);
+		} else if (Array.isArray(value)) {
+			aliases.push(
+				...value
+					.filter((alias): alias is string => typeof alias === "string")
+					.map((alias) => alias.trim())
+					.filter(Boolean),
+			);
+		}
+	}
+
+	return aliases;
+}
+
+function normalizeUnresolvedTarget(raw: string): string | null {
+	const withoutAlias = raw.split("|")[0]?.trim() ?? "";
+	const withoutSubpath = withoutAlias.split("#")[0]?.trim() ?? "";
+	const withoutExtension = withoutSubpath.replace(/\.md$/i, "").trim();
+	if (!withoutExtension || withoutExtension === "/") return null;
+	return withoutExtension;
+}
+
+function collectUnresolvedTargets(app: App): string[] {
+	const unresolvedLinks =
+		(app.metadataCache as { unresolvedLinks?: Record<string, Record<string, number>> })
+			.unresolvedLinks ?? {};
+	const targets = new Map<string, string>();
+
+	for (const links of Object.values(unresolvedLinks)) {
+		for (const raw of Object.keys(links)) {
+			const target = normalizeUnresolvedTarget(raw);
+			if (!target) continue;
+			const key = normalizedKey(target);
+			if (!targets.has(key)) targets.set(key, target);
+		}
+	}
+
+	return [...targets.values()].sort((a, b) => a.localeCompare(b));
+}
+
+function buildDiscoveryCandidates(app: App): {
+	candidates: DiscoveryCandidate[];
+	existingKeys: Set<string>;
+} {
+	const existingKeys = new Set<string>();
+	const markdownFiles = orderFilesForPicker(
+		app.vault.getMarkdownFiles(),
+		buildPickerOrderingDeps(app),
+	);
+
+	const candidates: DiscoveryCandidate[] = [];
+	for (const file of markdownFiles) {
+		addPathKeys(existingKeys, file.path, file.basename);
+		const aliases = readAliases(app, file);
+		const searchable = [file.basename, file.path, ...aliases].join(" ");
+		candidates.push({
+			item: encodeExisting(file.path),
+			display: searchable,
+			renderPath: file.path,
+			renderAlias: aliases[0],
+		});
+	}
+
+	for (const target of collectUnresolvedTargets(app)) {
+		const key = normalizedKey(target);
+		if (existingKeys.has(key)) continue;
+		candidates.push({
+			item: encodeUnresolved(target),
+			display: target,
+			unresolvedTitle: target,
+		});
+	}
+
+	return { candidates, existingKeys };
+}
+
+function renderUnresolvedSuggestion(el: HTMLElement, title: string): void {
+	el.addClass("mod-complex");
+	const content = el.createDiv({ cls: "suggestion-content" });
+	content.createDiv({ cls: "suggestion-title", text: title });
+	content.createDiv({ cls: "suggestion-note", text: "Unresolved link" });
+}
+
+function renderExistingSuggestion(
+	el: HTMLElement,
+	path: string,
+	alias?: string,
+): void {
+	renderNotePathSuggestion(el, path);
+	if (!alias) return;
+
+	const content = el.querySelector(".suggestion-content");
+	content?.createDiv({ cls: "suggestion-note", text: `Alias: ${alias}` });
+}
+
+export function usesDefaultTemplateTitlePrompt(
+	choice: ITemplateChoice,
+	format: string,
+): boolean {
+	if (!choice.fileNameFormat?.enabled) return true;
+	const normalized = format.trim().toLowerCase();
+	return (
+		normalized === VALUE_SYNTAX.toLowerCase() ||
+		normalized === NAME_SYNTAX.toLowerCase()
+	);
+}
+
+export function shouldRunTemplateNoteDiscovery(
+	choice: ITemplateChoice,
+	format: string,
+	seededValue: unknown,
+): boolean {
+	if (!choice.discoverExistingNotesBeforeCreate) return false;
+	if (seededValue !== undefined && seededValue !== null) return false;
+	return usesDefaultTemplateTitlePrompt(choice, format);
+}
+
+export async function promptForTemplateNoteDiscovery(
+	app: App,
+	choice: ITemplateChoice,
+): Promise<TemplateNoteDiscoveryResult> {
+	const { candidates, existingKeys } = buildDiscoveryCandidates(app);
+	const candidateByItem = new Map(
+		candidates.map((candidate) => [candidate.item, candidate]),
+	);
+
+	try {
+		const selected = await InputSuggester.Suggest(
+			app,
+			candidates.map((candidate) => candidate.display),
+			candidates.map((candidate) => candidate.item),
+			{
+				placeholder: `Search notes or create ${choice.name}`,
+				allowCustomValue: true,
+				customValueLabel: (value) => `Create new note: ${value}`,
+				valueExists: (value) => {
+					const key = normalizedKey(value);
+					return (
+						existingKeys.has(key) ||
+						candidates.some(
+							(candidate) =>
+								candidate.unresolvedTitle &&
+								normalizedKey(candidate.unresolvedTitle) === key,
+						)
+					);
+				},
+				renderItem: (item, el) => {
+					const candidate = candidateByItem.get(item);
+					if (!candidate) return;
+					if (candidate.renderPath) {
+						renderExistingSuggestion(
+							el,
+							candidate.renderPath,
+							candidate.renderAlias,
+						);
+						return;
+					}
+					if (candidate.unresolvedTitle) {
+						renderUnresolvedSuggestion(el, candidate.unresolvedTitle);
+					}
+				},
+			},
+		);
+
+		if (isExistingItem(selected)) {
+			const file = app.vault.getAbstractFileByPath(decodeExistingPath(selected));
+			if (file instanceof TFile) {
+				return { kind: "openExisting", file };
+			}
+		}
+
+		const title = isUnresolvedItem(selected)
+			? decodeUnresolvedTitle(selected)
+			: selected;
+
+		return {
+			kind: "create",
+			title: normalizeGeneratedFilePath(title, "Note title"),
+		};
+	} catch (error) {
+		if (isCancellationError(error)) {
+			throw new UserCancelError("Input cancelled by user");
+		}
+		throw error;
+	}
+}
+
+export const testExports = {
+	buildDiscoveryCandidates,
+	collectUnresolvedTargets,
+	normalizeUnresolvedTarget,
+};

--- a/src/engine/templateNoteDiscovery.ts
+++ b/src/engine/templateNoteDiscovery.ts
@@ -7,7 +7,11 @@ import { isCancellationError } from "src/utils/errorUtils";
 import { UserCancelError } from "src/errors/UserCancelError";
 import { normalizeGeneratedFilePath } from "src/utils/generatedFilePath";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
-import { NAME_SYNTAX, VALUE_SYNTAX } from "src/constants";
+
+export {
+	shouldRunTemplateNoteDiscovery,
+	usesDefaultTemplateTitlePrompt,
+} from "src/utils/templateNoteDiscoveryEligibility";
 
 const EXISTING_PREFIX = "@quickadd-existing-note:";
 const UNRESOLVED_PREFIX = "@quickadd-unresolved-note:";
@@ -167,28 +171,6 @@ function renderExistingSuggestion(
 
 	const content = el.querySelector(".suggestion-content");
 	content?.createDiv({ cls: "suggestion-note", text: `Alias: ${alias}` });
-}
-
-export function usesDefaultTemplateTitlePrompt(
-	choice: ITemplateChoice,
-	format: string,
-): boolean {
-	if (!choice.fileNameFormat?.enabled) return true;
-	const normalized = format.trim().toLowerCase();
-	return (
-		normalized === VALUE_SYNTAX.toLowerCase() ||
-		normalized === NAME_SYNTAX.toLowerCase()
-	);
-}
-
-export function shouldRunTemplateNoteDiscovery(
-	choice: ITemplateChoice,
-	format: string,
-	seededValue: unknown,
-): boolean {
-	if (!choice.discoverExistingNotesBeforeCreate) return false;
-	if (seededValue !== undefined && seededValue !== null) return false;
-	return usesDefaultTemplateTitlePrompt(choice, format);
 }
 
 export async function promptForTemplateNoteDiscovery(

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -38,6 +38,8 @@ import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
 import OnePageOverrideSetting from "./components/OnePageOverrideSetting.svelte";
 import { suggester } from "./components/suggesterAction";
+import { VALUE_SYNTAX } from "../../constants";
+import { usesDefaultTemplateTitlePrompt } from "../../utils/templateNoteDiscoveryEligibility";
 
 /**
  * Reactive replacement for TemplateChoiceBuilder.display(). Conditional rows are
@@ -82,6 +84,19 @@ const fileNameSuggesters = [
 	(el: HTMLInputElement | HTMLTextAreaElement) =>
 		new FormatSyntaxSuggester(app, el, plugin, true),
 ];
+const discoverySupported = $derived(
+	usesDefaultTemplateTitlePrompt(
+		choice,
+		choice.fileNameFormat.enabled
+			? choice.fileNameFormat.format
+			: VALUE_SYNTAX,
+	),
+);
+const discoveryDescription = $derived(
+	discoverySupported
+		? "For the default note-title prompt, show matching notes first. Choosing one opens it unchanged; choosing the create row continues with this template."
+		: "Only available when the file name prompt is the default note title: no custom format, {{VALUE}}, or {{NAME}}.",
+);
 
 // --- Folder selector -----------------------------------------------------
 // The four persisted folder booleans encode mutually-exclusive destination
@@ -269,11 +284,12 @@ function onModeChange(value: string) {
 
 <SettingItem
 	name="Search existing notes before creating"
-	desc="For the default note-title prompt, show matching notes first. Choosing one opens it unchanged; choosing the create row continues with this template."
+	desc={discoveryDescription}
 >
 	{#snippet control()}
 		<Toggle
 			checked={choice.discoverExistingNotesBeforeCreate ?? false}
+			disabled={!discoverySupported}
 			onchange={(value) => (choice.discoverExistingNotesBeforeCreate = value)}
 		/>
 	{/snippet}

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -268,6 +268,18 @@ function onModeChange(value: string) {
 <SettingItem name="Behavior" heading />
 
 <SettingItem
+	name="Search existing notes before creating"
+	desc="For the default note-title prompt, show matching notes first. Choosing one opens it unchanged; choosing the create row continues with this template."
+>
+	{#snippet control()}
+		<Toggle
+			checked={choice.discoverExistingNotesBeforeCreate ?? false}
+			onchange={(value) => (choice.discoverExistingNotesBeforeCreate = value)}
+		/>
+	{/snippet}
+</SettingItem>
+
+<SettingItem
 	name="If the target file already exists"
 	desc="Choose whether QuickAdd should ask what to do, update the existing file, create another file, or keep the existing file."
 >

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -27,6 +27,7 @@ function templateChoice(): ITemplateChoice {
 			chooseFromSubfolders: false,
 		},
 		fileNameFormat: { enabled: false, format: "" },
+		discoverExistingNotesBeforeCreate: false,
 		appendLink: false,
 		openFile: false,
 		fileOpening: {
@@ -114,6 +115,21 @@ describe("TemplateChoiceForm", () => {
 			"active-file",
 			"prompt",
 		]);
+	});
+
+	it("persists the discovery-before-create toggle", async () => {
+		const { container, props } = mountForm();
+		const toggle = settingItem(
+			container,
+			"Search existing notes before creating",
+		).querySelector<HTMLInputElement>('input[type="checkbox"]');
+
+		expect(toggle).not.toBeNull();
+		expect(props.choice.discoverExistingNotesBeforeCreate).toBe(false);
+
+		await fireEvent.click(toggle!);
+
+		expect(props.choice.discoverExistingNotesBeforeCreate).toBe(true);
 	});
 
 	it("opens a legacy choice on its derived mode", () => {

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -132,6 +132,32 @@ describe("TemplateChoiceForm", () => {
 		expect(props.choice.discoverExistingNotesBeforeCreate).toBe(true);
 	});
 
+	it("disables discovery when file name format is not the default title prompt", async () => {
+		const { container, props } = mountForm();
+		props.choice.fileNameFormat = {
+			enabled: true,
+			format: "Project {{VALUE}}",
+		};
+		flushSync();
+
+		const item = settingItem(container, "Search existing notes before creating");
+		const toggle = item.querySelector<HTMLElement>(".checkbox-container");
+
+		expect(toggle?.classList.contains("is-disabled")).toBe(true);
+		expect(item.textContent).toContain(
+			"Only available when the file name prompt is the default note title",
+		);
+
+		await fireEvent.click(toggle!);
+
+		expect(props.choice.discoverExistingNotesBeforeCreate).toBe(false);
+
+		props.choice.fileNameFormat.format = "{{VALUE}}";
+		flushSync();
+
+		expect(toggle?.classList.contains("is-disabled")).toBe(false);
+	});
+
 	it("opens a legacy choice on its derived mode", () => {
 		const props = createTemplateChoiceFormProps({
 			choice: {

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -284,4 +284,90 @@ describe("runOnePagePreflight template extension handling", () => {
 		expect(modalOpenMock).not.toHaveBeenCalled();
 		expect(executor.variables.has("FIELD:topic|multi")).toBe(false);
 	});
+
+	it("leaves the default Template note title for discovery instead of the one-page modal", async () => {
+		const templateFile = new TFile();
+		templateFile.path = "Templates/Daily.md";
+		templateFile.name = "Daily.md";
+		templateFile.basename = "Daily";
+		templateFile.extension = "md";
+
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn().mockReturnValue(null),
+			},
+			vault: {
+				getAbstractFileByPath: vi.fn((path: string) =>
+					path === "Templates/Daily.md" ? templateFile : null,
+				),
+				cachedRead: vi.fn(async () => ""),
+			},
+		} as unknown as App;
+
+		const plugin = {
+			settings: {
+				inputPrompt: "single-line",
+				globalVariables: {},
+				useSelectionAsCaptureValue: true,
+			},
+		} as any;
+
+		const choice = createTemplateChoice("Templates/Daily.md");
+		choice.discoverExistingNotesBeforeCreate = true;
+		choice.fileNameFormat = { enabled: true, format: "{{VALUE}}" };
+
+		const executor = createExecutor();
+
+		const result = await runOnePagePreflight(app, plugin, executor, choice);
+
+		expect(result).toBe(false);
+		expect(modalOpenMock).not.toHaveBeenCalled();
+		expect(executor.variables.has("value")).toBe(false);
+	});
+
+	it("still collects other Template prompts while leaving the note title for discovery", async () => {
+		const templateFile = new TFile();
+		templateFile.path = "Templates/Project.md";
+		templateFile.name = "Project.md";
+		templateFile.basename = "Project";
+		templateFile.extension = "md";
+
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn().mockReturnValue(null),
+			},
+			vault: {
+				getAbstractFileByPath: vi.fn((path: string) =>
+					path === "Templates/Project.md" ? templateFile : null,
+				),
+				cachedRead: vi.fn(async () => "Project: {{VALUE:project}}"),
+			},
+		} as unknown as App;
+
+		const plugin = {
+			settings: {
+				inputPrompt: "single-line",
+				globalVariables: {},
+				useSelectionAsCaptureValue: true,
+			},
+		} as any;
+
+		const choice = createTemplateChoice("Templates/Project.md");
+		choice.discoverExistingNotesBeforeCreate = true;
+		choice.fileNameFormat = { enabled: true, format: "{{VALUE}}" };
+
+		const executor = createExecutor();
+		modalResult = { project: "Atlas" };
+
+		const result = await runOnePagePreflight(app, plugin, executor, choice);
+
+		expect(result).toBe(true);
+		expect(executor.variables.has("value")).toBe(false);
+		expect(executor.variables.get("project")).toBe("Atlas");
+		expect(modalOpenMock).toHaveBeenCalledTimes(1);
+		const requirements = modalOpenMock.mock.calls[0][1] as Array<{ id: string }>;
+		expect(requirements.map((requirement) => requirement.id)).toEqual([
+			"project",
+		]);
+	});
 });

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -4,6 +4,7 @@ import { FormatDisplayFormatter } from "src/formatters/formatDisplayFormatter";
 import type QuickAdd from "src/main";
 import type IChoice from "src/types/choices/IChoice";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+import { VALUE_SYNTAX } from "src/constants";
 import { OnePageInputModal } from "./OnePageInputModal";
 import {
 	canonicalizeOnePageFileValue,
@@ -14,6 +15,20 @@ import {
 	collectChoiceRequirements,
 	getUnresolvedRequirements,
 } from "./collectChoiceRequirements";
+import { shouldLeaveTemplateTitleForDiscovery } from "src/utils/templateNoteDiscoveryEligibility";
+
+function shouldPromptAtRuntimeForDiscovery(
+	choice: IChoice,
+	requirementId: string,
+): boolean {
+	if (choice.type !== "Template" || requirementId !== "value") return false;
+
+	const templateChoice = choice as ITemplateChoice;
+	const format = templateChoice.fileNameFormat?.enabled
+		? templateChoice.fileNameFormat.format
+		: VALUE_SYNTAX;
+	return shouldLeaveTemplateTitleForDiscovery(templateChoice, format);
+}
 
 export async function runOnePagePreflight(
 	app: App,
@@ -40,7 +55,9 @@ export async function runOnePagePreflight(
 		if (unresolved.length === 0) return false; // Everything prefilled, skip modal
 
 		const modalRequirements = unresolved.filter(
-			(requirement) => !requirement.runtimeOnly,
+			(requirement) =>
+				!requirement.runtimeOnly &&
+				!shouldPromptAtRuntimeForDiscovery(choice, requirement.id),
 		);
 		if (modalRequirements.length === 0) return false;
 

--- a/src/types/choices/ITemplateChoice.ts
+++ b/src/types/choices/ITemplateChoice.ts
@@ -21,6 +21,11 @@ export default interface ITemplateChoice extends IChoice {
 	templatePath: string;
 	folder: TemplateFolderConfig;
 	fileNameFormat: { enabled: boolean; format: string };
+	/**
+	 * When enabled for the default note-title prompt, QuickAdd shows existing notes
+	 * before committing to creating a new one.
+	 */
+	discoverExistingNotesBeforeCreate?: boolean;
 	/** 
 	 * Configure link appending behavior. 
 	 * - boolean: Legacy format for backward compatibility (true = enabled with default placement)

--- a/src/types/choices/TemplateChoice.ts
+++ b/src/types/choices/TemplateChoice.ts
@@ -9,6 +9,7 @@ import type { TemplateFileExistsBehavior } from "../../template/fileExistsPolicy
 export class TemplateChoice extends Choice implements ITemplateChoice {
 	appendLink: boolean | AppendLinkOptions;
 	copyLinkToClipboard: boolean;
+	discoverExistingNotesBeforeCreate: boolean;
 	fileNameFormat: { enabled: boolean; format: string };
 	folder: TemplateFolderConfig;
 	openFile: boolean;
@@ -26,6 +27,7 @@ export class TemplateChoice extends Choice implements ITemplateChoice {
 
 		this.templatePath = "";
 		this.fileNameFormat = { enabled: false, format: "" };
+		this.discoverExistingNotesBeforeCreate = false;
 		this.folder = {
 			enabled: false,
 			folders: [],

--- a/src/utils/templateNoteDiscoveryEligibility.ts
+++ b/src/utils/templateNoteDiscoveryEligibility.ts
@@ -1,0 +1,34 @@
+import { NAME_SYNTAX, VALUE_SYNTAX } from "src/constants";
+import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+
+export function usesDefaultTemplateTitlePrompt(
+	choice: ITemplateChoice,
+	format: string,
+): boolean {
+	if (!choice.fileNameFormat?.enabled) return true;
+	const normalized = format.trim().toLowerCase();
+	return (
+		normalized === VALUE_SYNTAX.toLowerCase() ||
+		normalized === NAME_SYNTAX.toLowerCase()
+	);
+}
+
+export function shouldLeaveTemplateTitleForDiscovery(
+	choice: ITemplateChoice,
+	format: string,
+): boolean {
+	return (
+		choice.discoverExistingNotesBeforeCreate === true &&
+		usesDefaultTemplateTitlePrompt(choice, format)
+	);
+}
+
+export function shouldRunTemplateNoteDiscovery(
+	choice: ITemplateChoice,
+	format: string,
+	seededValue: unknown,
+): boolean {
+	if (!shouldLeaveTemplateTitleForDiscovery(choice, format)) return false;
+	if (seededValue !== undefined && seededValue !== null) return false;
+	return true;
+}


### PR DESCRIPTION
Add a discovery-first picker before Template choices commit to note creation, so the user can see existing related notes and open them instead of accidentally creating a duplicate.

The underlying problem in #184 is not that QuickAdd should clone the whole Quick Switcher. It is that note-creation flows hide the memory-sparking search step users rely on when deciding whether a note should be new at all. This PR keeps the scope to that decision point:

- New note from template gets discovery automatically.
- Saved Template choices get an explicit setting, Search existing notes before creating.
- Discovery only runs for default note-title prompts, `{{VALUE}}` or `{{NAME}}`, so custom filename formats keep their existing behavior.
- Existing-note selection opens the note unchanged and bypasses template rendering, folder creation, collision handling, append-link, copy-link, and Templater side effects.
- Create rows continue through the normal Template flow.
- Unresolved wikilinks are offered as creation targets. Foldered unresolved links such as `[[Projects/Missing Roadmap]]` create the exact vault-relative target so the original wikilink resolves.

Design tradeoffs:

- I did not change Capture, Macro, or arbitrary formatted Template flows. Those need separate design because their prompts can mean more than the new note title.
- I made persisted Template choices opt-in instead of changing all existing choices. That avoids surprising users whose Template choice is intentionally deterministic.
- I filtered the selected source template out of discovery results, but did not globally hide every file in template folders. Quick Switcher itself searches broadly, and users may have notes in folders named Templates.

Validation:

- `pnpm exec vitest run src/engine/templateNoteDiscovery.test.ts src/engine/TemplateChoiceEngine.discovery.test.ts src/preflight/runOnePagePreflight.selection.test.ts`
- `pnpm run lint`
- `pnpm run check` reports 0 errors and 4 existing warnings in 1 file
- `pnpm run test` reports 231 passed, 5 skipped test files, 2755 passed, 37 skipped tests
- `pnpm run build-with-lint`
- Live Obsidian validation in this worktree's isolated vault with `pnpm run obsidian:e2e`:
  - Existing selection opened `Existing/Alice.md` and left its sentinel content unchanged.
  - Create row produced `Created/Brand New Live Note.md` with template content.
  - Unresolved `[[Missing Project]]` produced `Created/Missing Project.md` through the configured Template folder.
  - Foldered unresolved `[[Projects/Missing Roadmap]]` produced `Projects/Missing Roadmap.md`, not `Created/Projects/Missing Roadmap.md`.
  - One-page input collected the additional `project` prompt while leaving the note title to discovery.
  - `dev:errors` reported no captured runtime errors after the live run.

Fixes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added “Search existing notes before creating” for template choices, enabling discovery while typing.
  * Selecting an existing note opens it unchanged; choosing “Create new note” continues with normal template creation, including support for unresolved link targets and correct routing.

* **Documentation**
  * Expanded Template choice docs for “New note from template” to explain the discovery-first picker behavior.

* **Tests**
  * Added unit coverage for template discovery flows and one-page preflight handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->