### PR TITLE
feat: improve file and note suggesters

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -76,6 +76,24 @@ Similarly, you can type a **tag name** in the _Capture To_ field, and QuickAdd w
 
 If you have a tag called `#people`, and you type `#people` in the _Capture To_ field, QuickAdd will ask you which file to capture to, assuming the file has the `#people` tag.
 
+### Capturing to filtered files
+
+You can combine folder and tag filters in the _Capture To_ field with `|`.
+This is useful when the destination could live in several folders, or when it
+must match several tags.
+
+- `folder:Goals|folder:Projects` - notes inside either folder
+- `tag:active|tag:work` - notes that have both tags
+- `folder:Goals|folder:Projects|tag:active|tag:work` - active work notes in either folder
+- `folder:Goals|exclude-folder:Archive|exclude-tag:done` - goals that are not archived or done
+
+Repeated `folder:` filters are OR filters. Repeated `tag:` filters are AND
+filters. Exclusions remove any matching file.
+
+Capture still writes to one destination per run. If you want to select multiple
+related files for metadata, use the `{{FILE:<folder>|multi}}` format syntax in
+the capture format instead of the _Capture To_ field.
+
 ### Capturing to a property
 
 You can pre-filter the picker by an arbitrary **frontmatter property** by typing
@@ -111,6 +129,13 @@ Notes:
 - As with the tag picker, typing a new note name (with **Create file if it
   doesn't exist** enabled) creates that note — it will not automatically receive
   the property.
+
+### File picker labels
+
+When QuickAdd asks you to choose a note, it shows the note's frontmatter `title`
+when available, then its first level-1 heading, then its file basename. The
+selected destination remains the real vault path, so captures still write to the
+same file even when the displayed label is friendlier than the filename.
 
 ## Capture Options
 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -456,7 +456,7 @@ research-topics:
 
 - `{{FILE:<folder>|optional}}` — allow skipping the pick (resolves to nothing).
 - `{{FILE:<folder>|custom}}` — also allow typing a value that isn't in the folder.
-- `{{FILE:<folder>|multi}}` — select multiple files. In frontmatter/property positions, QuickAdd writes a YAML list. In note bodies, file names, and other text positions, it writes comma-separated text. Combine with `|link` or `|path` to write links or paths for every selected file.
+- `{{FILE:<folder>|multi}}` — select multiple files. In frontmatter/property positions where QuickAdd collects structured properties, QuickAdd writes a YAML list. In note bodies, file names, existing-note captures, and other text positions, it writes comma-separated text. Combine with `|link` or `|path` to write links or paths for every selected file.
 - `{{FILE:<folder>|label:Pick a person}}` — set the picker's placeholder text.
 - `{{FILE:<folder>|name:<id>}}` — give the pick a shared **id**. Like `{{VALUE}}` and `{{FIELD}}`, FILE tokens are cached by identity: tokens that differ (by folder, filters, mode, or `|label:`) prompt independently, while *identical* tokens reuse one pick. So to choose **two different** files from the same folder, give them distinct labels — e.g. `{{FILE:People|label:Author}}` and `{{FILE:People|label:Reviewer}}` prompt separately. To reuse the *same* pick across tokens — for example to insert both the name and a link to one chosen file — give them the same `|name:`. Tokens that share an id should target the same folder/filters; the shared pick is required if *any* occurrence omits `|optional`.
 - Filtering reuses the `{{FIELD}}` grammar: `|tag:`, `|exclude-folder:`, `|exclude-tag:`, `|exclude-file:` (each repeatable).

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -408,8 +408,10 @@ the FIELD value.
 
 **Enhanced Filtering Options:**
 
-- `{{FIELD:fieldname|folder:path/to/folder}}` - Only suggest values from files in specific folder
-- `{{FIELD:fieldname|tag:tagname}}` - Only suggest values from files with specific tag
+- `{{FIELD:fieldname|folder:path/to/folder}}` - Only suggest values from files in a specific folder
+- `{{FIELD:fieldname|folder:goals|folder:projects}}` - Suggest values from either folder
+- `{{FIELD:fieldname|tag:tagname}}` - Only suggest values from files with a specific tag
+- `{{FIELD:fieldname|tag:active|tag:project}}` - Only suggest values from files that have both tags
 - `{{FIELD:fieldname|inline:true}}` - Include Dataview inline fields (fieldname:: value)
 - `{{FIELD:fieldname|inline:true|inline-code-blocks:ad-note}}` - Include inline fields inside specific fenced code blocks (opt-in)
 - `{{FIELD:fieldname|exclude-folder:templates}}` - Exclude values from files in specific folder
@@ -418,8 +420,11 @@ the FIELD value.
 - `{{FIELD:fieldname|default:Status - To Do}}` - Prepend a default suggestion; the modal placeholder shows it and pressing Enter accepts it.
 - `{{FIELD:fieldname|default:Draft|default-empty:true}}` - Only add the default when no matching values are found.
 - `{{FIELD:fieldname|default:Draft|default-always:true}}` - Keep the default first even if other suggestions exist.
-- Combine filters: `{{FIELD:fieldname|folder:daily|tag:work|exclude-folder:templates|inline:true|inline-code-blocks:ad-note}}`
+- Combine filters: `{{FIELD:fieldname|folder:goals|folder:projects|tag:work|tag:active|exclude-folder:templates|inline:true|inline-code-blocks:ad-note}}`
 - Multiple exclusions: `{{FIELD:fieldname|exclude-folder:templates|exclude-folder:archive}}`
+
+Repeated `folder:` filters are OR filters. Repeated `tag:` filters are AND
+filters. Exclusions remove any matching file.
 
 Examples: `status: {{FIELD:status|default:Draft|default-always:true}}` or `id: {{FIELD:Id|inline:true|inline-code-blocks:ad-note}}`.
 
@@ -429,11 +434,16 @@ This is currently in beta, and the syntax can change—leave your thoughts [here
 
 Prompts you to pick a markdown **file** from `<folder>` and inserts the choice. Unlike `{{FIELD:...}}` (which suggests the *values* of a YAML field), this suggests the files themselves — handy for "metadata folders" such as a `People/` or `Research Topics/` folder where each note is an option. Because the options are real files, the list always reflects what currently exists, which keeps your links consistent.
 
+The picker shows a note's frontmatter `title` when available, then its first
+level-1 heading, then its file basename. QuickAdd still stores the selected file
+path internally, so friendly labels do not change which file is inserted.
+
 By default the **basename** (just the file name, no folder or extension) is inserted. Output modes:
 
 - `{{FILE:People}}` — inserts the basename, e.g. `Tom`.
 - `{{FILE:People|link}}` — inserts a resolved wikilink, e.g. `[[Tom]]`, using your link settings (wikilink vs. Markdown, shortest path, etc.). In a capture it resolves relative to the capture target; in a template it resolves like `{{LINKCURRENT}}`. Do **not** wrap this in `[[ ]]` yourself — you'd get `[[[[Tom]]]]`.
 - `{{FILE:People|path}}` — inserts the vault-relative path, e.g. `People/Tom.md`.
+- `{{FILE:People|multi}}` — lets you pick several files.
 
 Example — add a wikilink to a `research-topics` frontmatter list (quote it so the YAML stays a valid list item):
 
@@ -446,6 +456,7 @@ research-topics:
 
 - `{{FILE:<folder>|optional}}` — allow skipping the pick (resolves to nothing).
 - `{{FILE:<folder>|custom}}` — also allow typing a value that isn't in the folder.
+- `{{FILE:<folder>|multi}}` — select multiple files. In frontmatter/property positions, QuickAdd writes a YAML list. In note bodies, file names, and other text positions, it writes comma-separated text. Combine with `|link` or `|path` to write links or paths for every selected file.
 - `{{FILE:<folder>|label:Pick a person}}` — set the picker's placeholder text.
 - `{{FILE:<folder>|name:<id>}}` — give the pick a shared **id**. Like `{{VALUE}}` and `{{FIELD}}`, FILE tokens are cached by identity: tokens that differ (by folder, filters, mode, or `|label:`) prompt independently, while *identical* tokens reuse one pick. So to choose **two different** files from the same folder, give them distinct labels — e.g. `{{FILE:People|label:Author}}` and `{{FILE:People|label:Reviewer}}` prompt separately. To reuse the *same* pick across tokens — for example to insert both the name and a link to one chosen file — give them the same `|name:`. Tokens that share an id should target the same folder/filters; the shared pick is required if *any* occurrence omits `|optional`.
 - Filtering reuses the `{{FIELD}}` grammar: `|tag:`, `|exclude-folder:`, `|exclude-tag:`, `|exclude-file:` (each repeatable).
@@ -454,8 +465,10 @@ Notes:
 
 - The folder is the first part of the token; a `|folder:` option is **not** used here (that's `{{FIELD}}` syntax) and is ignored.
 - The folder is matched **recursively** (its subfolders are included). Point at the leaf folder (e.g. `{{FILE:fields/people}}`) to scope tightly.
+- Repeated `|tag:` filters are AND filters. Exclusions remove any matching file.
 - Markdown files only.
 - `|link` and `|path` insert characters that aren't valid in file names; in the **file name** field, use the default basename mode.
+- One-page input forms collect other inputs first, then open the runtime FILE multi-select, because file names and title labels can contain commas.
 
 ## `{{selected}}` {#selected}
 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -941,8 +941,9 @@ Retrieves all unique values for a specific field across your vault.
 **Parameters:**
 - `fieldName`: The name of the field to search for
 - `options`: (Optional) Filtering options:
-  - `folder`: Only search in specific folder (e.g., "daily/notes")
-  - `tags`: Only search in files with specific tags (array)
+  - `folder`: Only search in a specific folder (e.g., "daily/notes")
+  - `folders`: Only search in any of these folders (OR filter)
+  - `tags`: Only search in files with all of these tags (AND filter)
   - `includeInline`: Include Dataview inline fields (default: false)
   - `includeInlineCodeBlocks`: Include inline fields inside specific fenced code block types when `includeInline` is true (e.g., `["ad-note"]`)
 
@@ -966,9 +967,18 @@ const projectTypes = await quickAddApi.fieldSuggestions.getFieldValues(
 );
 ```
 
+With multiple folder filters:
+```javascript
+// Get relation types from either goals or projects
+const relationTypes = await quickAddApi.fieldSuggestions.getFieldValues(
+    "type",
+    { folders: ["goals", "projects"] }
+);
+```
+
 With tag filter:
 ```javascript
-// Get priorities from work-tagged files
+// Get priorities from files tagged with both #work and #important
 const priorities = await quickAddApi.fieldSuggestions.getFieldValues(
     "priority",
     { tags: ["work", "important"] }

--- a/docs/docs/SuggesterSystem.md
+++ b/docs/docs/SuggesterSystem.md
@@ -16,6 +16,10 @@ Type `#` to search through all tags in your vault.
 ### File Search
 Type `[[` to start searching through all files in your vault.
 
+QuickAdd file pickers show a note's frontmatter `title` when available, then its
+first level-1 heading, then its file basename. The selected item is still the
+real vault path.
+
 ### Heading Search
 Type `[[#` to start searching through all headings in your vault.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const VARIABLE_TRIM_SYNTAX = "{{value:<variable name>|trim}}";
 export const FIELD_VAR_SYNTAX = "{{field:<field name>}}";
 export const FIELD_VAR_MULTI_SYNTAX = "{{field:<field name>|multi}}";
 export const FILE_SYNTAX = "{{file:<folder>}}";
+export const FILE_MULTI_SYNTAX = "{{file:<folder>|multi}}";
 export const FILE_LINK_SYNTAX = "{{file:<folder>|link}}";
 export const FILE_PATH_SYNTAX = "{{file:<folder>|path}}";
 export const MATH_VALUE_SYNTAX = "{{mvalue}}";
@@ -66,6 +67,7 @@ export const FORMAT_SYNTAX: string[] = [
 	"{{field:<fieldname>|inline:true}}",
 	"{{field:<fieldname>|inline:true|inline-code-blocks:ad-note}}",
 	FILE_SYNTAX,
+	FILE_MULTI_SYNTAX,
 	FILE_LINK_SYNTAX,
 	FILE_PATH_SYNTAX,
 	LINKCURRENT_SYNTAX,

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -6,6 +6,7 @@ import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import {
 	getMarkdownFilesInFolder,
+	getMarkdownFilesMatchingFilter,
 	insertOnNewLineBelow,
 	insertFileLinkToActiveView,
 	isFolder,
@@ -103,6 +104,7 @@ vi.mock("../utilityObsidian", () => ({
 	// to "inserted" so capture-to-active-file paths proceed to the cosmetic/openFile steps.
 	appendToCurrentLine: vi.fn(() => true),
 	getMarkdownFilesInFolder: vi.fn(() => []),
+	getMarkdownFilesMatchingFilter: vi.fn(() => []),
 	getMarkdownFilesWithTag: vi.fn(() => []),
 	insertFileLinkToActiveView: vi.fn(),
 	insertOnNewLineAbove: vi.fn(() => true),
@@ -219,6 +221,8 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 		createdClipboardAttachmentPaths.length = 0;
 		InputPromptDraftStore.getInstance().clearAll();
 		vi.mocked(openFile).mockClear();
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReset();
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([]);
 		vi.mocked(insertFileLinkToActiveView).mockReset();
 		vi.mocked(insertOnNewLineBelow).mockReturnValue(true);
 		vi.mocked(overwriteTemplaterOnce).mockClear();
@@ -567,8 +571,62 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 			kind: "property",
 			field: "type",
 			value: "draft",
-			filter: { folder: "Notes" },
+			filter: { folder: "Notes", folders: ["Notes"] },
 		});
+	});
+
+	it("resolves a hashtag target with extra pipe filters", () => {
+		const app = createApp();
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "#work|tag:project" }),
+			createExecutor(),
+		);
+
+		expect(
+			(engine as any).resolveCaptureTarget("#work|tag:project"),
+		).toEqual({
+			kind: "filter",
+			filter: { tags: ["work", "project"] },
+		});
+	});
+
+	it("resolves repeated folder filters as a filtered target", () => {
+		const app = createApp();
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "folder:Goals|folder:Projects|tag:active" }),
+			createExecutor(),
+		);
+
+		expect(
+			(engine as any).resolveCaptureTarget(
+				"folder:Goals|folder:Projects|tag:active",
+			),
+		).toEqual({
+			kind: "filter",
+			filter: {
+				folder: "Goals",
+				folders: ["Goals", "Projects"],
+				tags: ["active"],
+			},
+		});
+	});
+
+	it("rejects multi-select on capture target filters", () => {
+		const app = createApp();
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "tag:work|multi" }),
+			createExecutor(),
+		);
+
+		expect(() =>
+			(engine as any).resolveCaptureTarget("tag:work|multi"),
+		).toThrow(ChoiceAbortError);
 	});
 
 	it("throws on a property target with no field name", () => {

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -159,6 +159,10 @@ const createApp = () =>
 			delete: vi.fn(async () => {}),
 			modify: vi.fn(async () => {}),
 			read: vi.fn(async () => ""),
+			getMarkdownFiles: vi.fn(() => []),
+		},
+		metadataCache: {
+			getFileCache: vi.fn(() => null),
 		},
 		workspace: {
 			getActiveFile: vi.fn(() => null),
@@ -793,7 +797,7 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 			"Inbox/Apple.md",
 			"Inbox/Mango.md",
 		]);
-		expect(displayItems).toEqual(["Zebra.md", "Apple.md", "Mango.md"]);
+		expect(displayItems).toEqual(["Zebra", "Apple", "Mango"]);
 		expect(options.allowCustomValue).toBe(true);
 		expect(options.customValueLabel("New")).toBe("Create new note: New");
 	});

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -20,6 +20,7 @@ import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { InputPromptDraftHandler } from "../utils/InputPromptDraftHandler";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
+import { log } from "../logger/logManager";
 
 const {
 	setUseSelectionAsCaptureValueMock,
@@ -446,6 +447,45 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 		expect(overwriteTemplaterOnce).toHaveBeenCalled();
 		expect(setMarkdownCursorAtOffset).not.toHaveBeenCalled();
 	});
+
+	it("warns when FILE multi cannot become a YAML list in Capture", async () => {
+		const warningSpy = vi
+			.spyOn(log, "logWarning")
+			.mockImplementation(() => {});
+		const choice = createChoice({
+			format: {
+				enabled: true,
+				format: "---\nrelated: {{FILE:People|multi}}\n---\n",
+			},
+		});
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			choice,
+			createExecutor(),
+		);
+		const file = { path: "Test.md", basename: "Test", extension: "md" } as any;
+
+		(engine as any).getFormattedPathToCaptureTo = vi
+			.fn()
+			.mockResolvedValue("Test.md");
+		(engine as any).fileExists = vi.fn().mockResolvedValue(true);
+		(engine as any).onFileExists = vi.fn().mockResolvedValue({
+			file,
+			newFileContent: "content",
+			captureContent: "content",
+		});
+
+		try {
+			await engine.run();
+
+			expect(warningSpy).toHaveBeenCalledWith(
+				expect.stringContaining("{{FILE:…|multi}}"),
+			);
+		} finally {
+			warningSpy.mockRestore();
+		}
+	});
 });
 
 describe("CaptureChoiceEngine capture target resolution", () => {
@@ -780,25 +820,31 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		await (engine as any).selectFileInFolder("Inbox/", false);
 
 		expect(suggestSpy).toHaveBeenCalledTimes(1);
-		const [, displayItems, items, options] = suggestSpy.mock
-			.calls[0] as unknown as [
-			unknown,
-			string[],
-			string[],
-			{
-				allowCustomValue: boolean;
-				customValueLabel: (value: string) => string;
-			},
-		];
+			const [, displayItems, items, options] = suggestSpy.mock
+				.calls[0] as unknown as [
+				unknown,
+				string[],
+				string[],
+				{
+					allowCustomValue: boolean;
+					customValueLabel: (value: string) => string;
+					searchItems: string[];
+				},
+			];
 
 		// Recently opened (Zebra) first, then the rest alphabetically.
 		expect(items).toEqual([
 			"Inbox/Zebra.md",
 			"Inbox/Apple.md",
 			"Inbox/Mango.md",
-		]);
-		expect(displayItems).toEqual(["Zebra", "Apple", "Mango"]);
-		expect(options.allowCustomValue).toBe(true);
+			]);
+			expect(displayItems).toEqual(["Zebra", "Apple", "Mango"]);
+			expect(options.searchItems).toEqual([
+				"Zebra Inbox/Zebra.md",
+				"Apple Inbox/Apple.md",
+				"Mango Inbox/Mango.md",
+			]);
+			expect(options.allowCustomValue).toBe(true);
 		expect(options.customValueLabel("New")).toBe("Create new note: New");
 	});
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -30,6 +30,7 @@ import { normalizeAppendLinkOptions, type AppendLinkOptions } from "../types/lin
 import {
 	appendToCurrentLine,
 	getMarkdownFilesInFolder,
+	getMarkdownFilesMatchingFilter,
 	getMarkdownFilesWithTag,
 	getMarkdownFilesWithProperty,
 	insertFileLinkToActiveView,
@@ -47,6 +48,7 @@ import {
 } from "../utilityObsidian";
 import { isCancellationError, reportError } from "../utils/errorUtils";
 import { parsePropertyTarget } from "../utils/propertyTarget";
+import { parseCaptureFileFilterTarget } from "../utils/captureFileFilterTarget";
 import type { FieldFilter } from "../utils/FieldSuggestionParser";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
@@ -772,6 +774,8 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					return this.selectFileInFolder("", true);
 				case "tag":
 					return this.selectFileWithTag(resolution.tag);
+				case "filter":
+					return this.selectFileWithFilter(resolution.filter);
 				case "property":
 					return this.selectFileWithProperty(
 						resolution.field,
@@ -790,6 +794,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	):
 		| { kind: "vault" }
 		| { kind: "tag"; tag: string }
+		| { kind: "filter"; filter: FieldFilter }
 		| { kind: "property"; field: string; value?: string; filter: FieldFilter }
 		| { kind: "folder"; folder: string }
 		| { kind: "file"; path: string } {
@@ -808,13 +813,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			return { kind: "vault" };
 		}
 
-		if (rawCaptureTo.startsWith("#")) {
-			return {
-				kind: "tag",
-				tag: rawCaptureTo.replace(/\.md$/, ""),
-			};
-		}
-
 		// `property:<field>[=<value>]` pre-filters by a frontmatter field (issue #466).
 		// Checked before the `.base`/extension/folder branches so a property value
 		// containing `.md`/`/` (or a trailing `/`) can never misroute to a file/folder.
@@ -830,6 +828,19 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				field: propertyTarget.field,
 				value: propertyTarget.value,
 				filter: propertyTarget.filter,
+			};
+		}
+
+		const fileFilterTarget = parseCaptureFileFilterTarget(rawCaptureTo);
+		if (fileFilterTarget) {
+			if (fileFilterTarget.multiSelect) {
+				throw new ChoiceAbortError(
+					"Capture target filters select one destination file. Use {{FILE:...|multi}} in the capture format for multi-value metadata.",
+				);
+			}
+			return {
+				kind: "filter",
+				filter: fileFilterTarget.filter,
 			};
 		}
 
@@ -961,6 +972,14 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const filesWithTag = getMarkdownFilesWithTag(this.app, tagWithHash);
 
 		return this.selectFileFromSet(filesWithTag, `No files with tag ${tag}.`);
+	}
+
+	private async selectFileWithFilter(filter: FieldFilter): Promise<string> {
+		const files = getMarkdownFilesMatchingFilter(this.app, filter);
+		return this.selectFileFromSet(
+			files,
+			"No files matched the capture target filters.",
+		);
 	}
 
 	private async selectFileWithProperty(

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -54,6 +54,7 @@ import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
+import { buildFileDisplayLabels } from "../utils/fileSyntax";
 import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
 import {
 	postProcessFrontMatter,
@@ -928,21 +929,32 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		invariant(filesInFolder.length > 0, `Folder ${folderPathSlash} is empty.`);
 
 		// Quick-Switcher-style ordering: recent first, excluded sunk, alphabetical tail.
-		const filePaths = orderFilesForPicker(
+		const orderedFiles = orderFilesForPicker(
 			filesInFolder,
 			buildPickerOrderingDeps(this.app),
-		).map((f) => f.path);
+		);
+		const filePaths = orderedFiles.map((f) => f.path);
+		const displayItems = buildFileDisplayLabels(
+			orderedFiles,
+			(file) => this.app.metadataCache.getFileCache(file),
+		);
+		const existingLabels = new Set(
+			displayItems.map((label) => label.toLowerCase()),
+		);
 		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 		let targetFilePath: string;
 		try {
 			targetFilePath = await InputSuggester.Suggest(
 				this.app,
-				filePaths.map((item) => item.replace(folderPathSlash, "")),
+				displayItems,
 				filePaths,
 				{
+					renderItem: (path, el) =>
+						renderNotePathSuggestion(el, path, this.app),
 					allowCustomValue: allowCreate,
 					customValueLabel: (value) => `Create new note: ${value}`,
 					valueExists: (value) =>
+						existingLabels.has(value.toLowerCase()) ||
 						this.captureTargetExists(folderPathSlash, value),
 				},
 			);
@@ -1054,10 +1066,15 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		invariant(files.length > 0, notFoundMessage);
 
 		// Quick-Switcher-style ordering; show note names (not raw paths).
-		const filePaths = orderFilesForPicker(
+		const orderedFiles = orderFilesForPicker(
 			files,
 			buildPickerOrderingDeps(this.app),
-		).map((f) => f.path);
+		);
+		const filePaths = orderedFiles.map((f) => f.path);
+		const displayItems = buildFileDisplayLabels(
+			orderedFiles,
+			(file) => this.app.metadataCache.getFileCache(file),
+		);
 		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 		// Build once (not per keystroke): existing note basenames across the vault.
 		const vaultBasenames = new Set(
@@ -1065,17 +1082,22 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				.getMarkdownFiles()
 				.map((f) => f.basename.toLowerCase()),
 		);
+		const existingLabels = new Set(
+			displayItems.map((label) => label.toLowerCase()),
+		);
 		let targetFilePath: string;
 		try {
 			targetFilePath = await InputSuggester.Suggest(
 				this.app,
-				filePaths,
+				displayItems,
 				filePaths,
 				{
-					renderItem: (path, el) => renderNotePathSuggestion(el, path),
+					renderItem: (path, el) =>
+						renderNotePathSuggestion(el, path, this.app),
 					allowCustomValue: allowCreate,
 					customValueLabel: (value) => `Create new note: ${value}`,
 					valueExists: (value) =>
+						existingLabels.has(value.toLowerCase()) ||
 						this.captureTargetAlreadyExists(value, vaultBasenames),
 				},
 			);

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -358,12 +358,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				// Match the `|multi` flag specifically: a pipe, then `multi`
 				// terminated by `:`/`|`/`}` or end — excluding `|type:multiline`,
 				// `|multi1`, `|multi-select`, etc.
-				/\{\{VALUE:[^}]*\|\s*multi(?=[:}|]|$)/i.test(
+				/\{\{(?:VALUE|FILE):[^}]*\|\s*multi(?=[:}|]|$)/i.test(
 					this.choice?.format?.format ?? "",
 				)
 			) {
 				log.logWarning(
-					"QuickAdd: {{VALUE:…|multi}} in this capture writes a comma-separated string, not a YAML list. Multi-select produces a real list only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template).",
+					"QuickAdd: {{VALUE:…|multi}} and {{FILE:…|multi}} in this capture write comma-separated strings, not YAML lists. Multi-select produces a real list only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template).",
 				);
 			}
 
@@ -938,6 +938,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			orderedFiles,
 			(file) => this.app.metadataCache.getFileCache(file),
 		);
+		const searchItems = filePaths.map(
+			(path, index) => `${displayItems[index] ?? path} ${path}`,
+		);
 		const existingLabels = new Set(
 			displayItems.map((label) => label.toLowerCase()),
 		);
@@ -951,6 +954,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				{
 					renderItem: (path, el) =>
 						renderNotePathSuggestion(el, path, this.app),
+					searchItems,
 					allowCustomValue: allowCreate,
 					customValueLabel: (value) => `Create new note: ${value}`,
 					valueExists: (value) =>
@@ -1075,6 +1079,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			orderedFiles,
 			(file) => this.app.metadataCache.getFileCache(file),
 		);
+		const searchItems = filePaths.map(
+			(path, index) => `${displayItems[index] ?? path} ${path}`,
+		);
 		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 		// Build once (not per keystroke): existing note basenames across the vault.
 		const vaultBasenames = new Set(
@@ -1094,6 +1101,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				{
 					renderItem: (path, el) =>
 						renderNotePathSuggestion(el, path, this.app),
+					searchItems,
 					allowCustomValue: allowCreate,
 					customValueLabel: (value) => `Create new note: ${value}`,
 					valueExists: (value) =>

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -642,7 +642,7 @@ export class CompleteFormatter extends Formatter {
 		return generateFieldCacheKey(filters);
 	}
 
-	protected async suggestForFile(parsed: ParsedFileToken): Promise<string> {
+	protected async suggestForFile(parsed: ParsedFileToken): Promise<string | string[]> {
 		try {
 			const files = EnhancedFieldSuggestionFileFilter.filterFiles(
 				this.app.vault.getMarkdownFiles(),
@@ -665,15 +665,40 @@ export class CompleteFormatter extends Formatter {
 					undefined,
 					parsed.optional ? { optional: true } : undefined,
 				);
+				if (parsed.multiSelect) {
+					return typed ? [`${FILE_CUSTOM_PREFIX}${typed}`] : [];
+				}
 				return typed ? `${FILE_CUSTOM_PREFIX}${typed}` : "";
 			}
 
-			const displayItems = buildFileDisplayLabels(files);
+			const displayItems = buildFileDisplayLabels(
+				files,
+				(file) => this.app.metadataCache.getFileCache(file),
+			);
 			const items = files.map((file) => `${FILE_PICK_PREFIX}${file.path}`);
+
+			if (parsed.multiSelect) {
+				const result = await MultiSuggester.Suggest(
+					this.app,
+					displayItems,
+					items,
+					{
+						placeholder,
+						allowCustomValue: parsed.allowCustomInput,
+						...(parsed.optional ? { skippable: true } : {}),
+					},
+				);
+				return result.map((item) =>
+					items.includes(item) ? item : `${FILE_CUSTOM_PREFIX}${item}`,
+				);
+			}
 
 			if (parsed.allowCustomInput) {
 				const basenames = new Set(
 					files.map((file) => file.basename.toLowerCase()),
+				);
+				const displayLabels = new Set(
+					displayItems.map((label) => label.toLowerCase()),
 				);
 				const result = await InputSuggester.Suggest(
 					this.app,
@@ -683,7 +708,9 @@ export class CompleteFormatter extends Formatter {
 						placeholder,
 						// Typing a real basename (e.g. "Tom", or "tom") should pick that
 						// file, not add a separate, indistinguishable custom row.
-						valueExists: (typed) => basenames.has(typed.toLowerCase()),
+						valueExists: (typed) =>
+							basenames.has(typed.toLowerCase()) ||
+							displayLabels.has(typed.toLowerCase()),
 						...(parsed.optional ? { skippable: true } : {}),
 					},
 				);

--- a/src/formatters/formatter-file.test.ts
+++ b/src/formatters/formatter-file.test.ts
@@ -44,7 +44,7 @@ class FileTestFormatter extends Formatter {
 
 	constructor(
 		app: unknown,
-		private responder: (parsed: ParsedFileToken) => string,
+		private responder: (parsed: ParsedFileToken) => string | string[],
 		linkSource: string | null = null,
 	) {
 		super(app as App);
@@ -55,13 +55,19 @@ class FileTestFormatter extends Formatter {
 		return this.linkSource;
 	}
 
-	protected suggestForFile(parsed: ParsedFileToken): string {
+	protected suggestForFile(parsed: ParsedFileToken): string | string[] {
 		this.calls += 1;
 		return this.responder(parsed);
 	}
 
 	public run(input: string): Promise<string> {
 		return this.replaceFileInString(input);
+	}
+
+	public runWithPropertyCollection(input: string): Promise<string> {
+		return this.withTemplatePropertyCollection(() =>
+			this.replaceFileInString(input),
+		);
 	}
 
 	/** Test seam: pre-seed a stored FILE value to exercise rendering directly. */
@@ -240,5 +246,36 @@ describe("Formatter {{FILE:...}} token", () => {
 		});
 		expect(await f.run("a {{FILE:}} b")).toBe("a {{FILE:}} b");
 		expect(f.calls).toBe(0);
+	});
+
+	it("joins FILE multi-select arrays outside frontmatter property positions", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md", "People/Jack.md"]),
+			() => [
+				`${FILE_PICK_PREFIX}People/Tom.md`,
+				`${FILE_PICK_PREFIX}People/Jack.md`,
+			],
+		);
+		expect(await f.run("People: {{FILE:People|multi}}")).toBe(
+			"People: Tom,Jack",
+		);
+	});
+
+	it("collects FILE multi-select arrays as YAML list properties", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md", "People/Jack.md"]),
+			() => [
+				`${FILE_PICK_PREFIX}People/Tom.md`,
+				`${FILE_PICK_PREFIX}People/Jack.md`,
+			],
+		);
+
+		const output = await f.runWithPropertyCollection(
+			"---\npeople: {{FILE:People|multi|link}}\n---\n",
+		);
+		const vars = f.getAndClearTemplatePropertyVars();
+
+		expect(output).toBe("---\npeople: []\n---\n");
+		expect(vars.get("people")).toEqual(["[[Tom@]]", "[[Jack@]]"]);
 	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -990,14 +990,38 @@ export abstract class Formatter {
 				this.variables.set(key, await this.suggestForFile(parsed));
 			}
 
-			output += this.renderFileValue(this.variables.get(key), parsed.mode);
+			const renderedValue = this.renderFileValue(
+				this.variables.get(key),
+				parsed.mode,
+			);
+			if (Array.isArray(renderedValue)) {
+				const structuredYamlValue = this.propertyCollector.maybeCollect({
+					input,
+					matchStart: match.index,
+					matchEnd: match.index + match[0].length,
+					rawValue: renderedValue,
+					fallbackKey: parsed.aliasName ?? parsed.folderPath,
+					collectionActive: this.templatePropertyCollectionDepth > 0,
+					heuristicEnabled: false,
+				});
+				output += getYamlPlaceholder(structuredYamlValue) ?? renderedValue.join(",");
+			} else {
+				output += renderedValue;
+			}
 			lastIndex = regex.lastIndex;
 		}
 
 		return output + input.slice(lastIndex);
 	}
 
-	private renderFileValue(stored: unknown, mode: FileMode): string {
+	private renderFileValue(stored: unknown, mode: FileMode): string | string[] {
+		if (Array.isArray(stored)) {
+			return stored.map((value) => this.renderSingleFileValue(value, mode));
+		}
+		return this.renderSingleFileValue(stored, mode);
+	}
+
+	private renderSingleFileValue(stored: unknown, mode: FileMode): string {
 		if (mode === "link") return this.getFileLinkForStoredValue(stored);
 
 		const decoded = decodeFileValue(stored);
@@ -1064,7 +1088,7 @@ export abstract class Formatter {
 	 */
 	protected abstract suggestForFile(
 		parsed: ParsedFileToken,
-	): Promise<string> | string;
+	): Promise<string | string[]> | string | string[];
 
 	protected abstract promptForMathValue(): Promise<string>;
 

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -4,7 +4,7 @@ vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
 
 import { App } from "obsidian";
 import { fireEvent, render } from "@testing-library/svelte";
-import { flushSync } from "svelte";
+import { flushSync, tick } from "svelte";
 import type QuickAdd from "../../main";
 import type ICaptureChoice from "../../types/choices/ICaptureChoice";
 import CaptureChoiceForm from "./CaptureChoiceForm.svelte";
@@ -96,6 +96,23 @@ function mountForm() {
 	return { ...result, props };
 }
 
+async function settleValidation() {
+	await tick();
+	await tick();
+}
+
+function describedHint(
+	container: HTMLElement,
+	input: HTMLInputElement,
+): HTMLElement {
+	const hintId = input.getAttribute("aria-describedby");
+	return container.querySelector(`#${hintId}`) as HTMLElement;
+}
+
+function previewRows(container: HTMLElement): HTMLElement[] {
+	return Array.from(container.querySelectorAll(".qa-preview-row"));
+}
+
 describe("CaptureChoiceForm", () => {
 	it("reveals insert-after / insert-before fields by write position, mutually exclusive, without remounting", async () => {
 		const { container } = mountForm();
@@ -185,5 +202,56 @@ describe("CaptureChoiceForm", () => {
 		const { container } = mountForm();
 
 		expect(settingNames(container).at(-1)).toBe("Icon");
+	});
+
+	it("shows recognized feedback and hides the path preview for picker filter targets", async () => {
+		const { container, getByLabelText } = mountForm();
+		const input = getByLabelText("File path / format") as HTMLInputElement;
+		expect(previewRows(container)).toHaveLength(2);
+
+		input.value = "folder:Goals|folder:Projects|tag:active";
+		await fireEvent.input(input);
+		await settleValidation();
+
+		const hint = describedHint(container, input);
+		expect(previewRows(container)).toHaveLength(1);
+		expect(hint.textContent).toContain("Recognized filtered picker");
+		expect(hint.textContent).toContain("folders Goals or Projects");
+		expect(hint.textContent).toContain("tag active");
+		expect(hint.classList.contains("qa-field-hint--success")).toBe(true);
+		expect(input.classList.contains("is-valid")).toBe(true);
+		expect(input.getAttribute("aria-invalid")).toBe("false");
+	});
+
+	it("rejects multi-select capture target filters before runtime", async () => {
+		const { container, getByLabelText } = mountForm();
+		const input = getByLabelText("File path / format") as HTMLInputElement;
+		expect(previewRows(container)).toHaveLength(2);
+
+		input.value = "tag:work|multi";
+		await fireEvent.input(input);
+		await settleValidation();
+
+		const hint = describedHint(container, input);
+		expect(previewRows(container)).toHaveLength(1);
+		expect(hint.textContent).toBe(
+			"Capture target filters select one destination file. Use {{FILE:...|multi}} in the capture format for multi-value metadata.",
+		);
+		expect(input.classList.contains("is-invalid")).toBe(true);
+		expect(input.getAttribute("aria-invalid")).toBe("true");
+	});
+
+	it("does not show the canvas node picker for filter syntax that ends in .canvas", async () => {
+		const { container, getByLabelText } = mountForm();
+		const input = getByLabelText("File path / format") as HTMLInputElement;
+
+		input.value = "folder:Boards.canvas";
+		await fireEvent.input(input);
+		await settleValidation();
+
+		expect(settingNames(container)).not.toContain("Target canvas node");
+		expect(describedHint(container, input).textContent).toContain(
+			"Recognized filtered picker",
+		);
 	});
 });

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -242,14 +242,16 @@ describe("CaptureChoiceForm", () => {
 	});
 
 	it("does not show the canvas node picker for filter syntax that ends in .canvas", async () => {
-		const { container, getByLabelText } = mountForm();
+		const { container, getByLabelText, props } = mountForm();
 		const input = getByLabelText("File path / format") as HTMLInputElement;
+		props.choice.captureToCanvasNodeId = "stale-node-id";
 
 		input.value = "folder:Boards.canvas";
 		await fireEvent.input(input);
 		await settleValidation();
 
 		expect(settingNames(container)).not.toContain("Target canvas node");
+		expect(props.choice.captureToCanvasNodeId).toBe("");
 		expect(describedHint(container, input).textContent).toContain(
 			"Recognized filtered picker",
 		);

--- a/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
@@ -83,6 +83,7 @@ function onCaptureToActiveFileChange(value: boolean) {
 function onCaptureToChange(value: string) {
 	const previousCanvasPath = normalizeVaultPath(choice.captureTo);
 	const wasCanvasTarget = isCanvasTargetPath(choice.captureTo);
+	const nextUsesPickerTargetSyntax = getCaptureTargetFeedback(value) !== null;
 	choice.captureTo = value;
 	const nextCanvasPath = normalizeVaultPath(value);
 	const nextIsCanvasTarget = isCanvasTargetPath(value);
@@ -91,7 +92,7 @@ function onCaptureToChange(value: string) {
 		nextIsCanvasTarget &&
 		previousCanvasPath !== nextCanvasPath;
 
-	if (!nextIsCanvasTarget || canvasPathChanged) {
+	if (nextUsesPickerTargetSyntax || !nextIsCanvasTarget || canvasPathChanged) {
 		choice.captureToCanvasNodeId = "";
 	}
 }

--- a/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
@@ -7,12 +7,12 @@ import { getAllFolderPathsInVault } from "../../../utilityObsidian";
 import { sortFolderPathsByTree } from "../../../utils/folder-sorting";
 import { FormatSyntaxSuggester } from "../../suggesters/formatSyntaxSuggester";
 import { isCanvasTargetPath, normalizeVaultPath } from "../canvasNodes";
-import { isPropertyTarget, parsePropertyTarget } from "../../../utils/propertyTarget";
 import SettingItem from "../../components/SettingItem.svelte";
 import Toggle from "../../components/Toggle.svelte";
 import ValidatedInput from "./ValidatedInput.svelte";
 import FormatPreviewField from "./FormatPreviewField.svelte";
 import CanvasNodePicker from "./CanvasNodePicker.svelte";
+import { getCaptureTargetFeedback } from "./captureTargetFeedback";
 
 /** Reactive port of captureChoiceBuilder.addCapturedToSetting. */
 let {
@@ -51,23 +51,17 @@ const suggesters = [
 		new FormatSyntaxSuggester(app, el, plugin),
 ];
 
-// A `property:` target filters notes by a frontmatter field — it is NOT a path,
-// so showing the file-name format preview would render a misleading fake path.
-const isProperty = $derived(isPropertyTarget(choice.captureTo ?? ""));
-// Exclude property targets from canvas detection so a contrived value like
+const captureTargetFeedback = $derived.by(() =>
+	getCaptureTargetFeedback(choice.captureTo ?? ""),
+);
+// Filter/property targets are not paths, so showing the file-name format preview
+// would render a misleading fake path.
+const usesPickerTargetSyntax = $derived(captureTargetFeedback !== null);
+// Exclude picker syntax from canvas detection so a contrived value like
 // `property:type=foo.canvas` never offers the (meaningless) canvas-node picker.
 const isCanvasTarget = $derived(
-	!isProperty && isCanvasTargetPath(choice.captureTo),
+	!usesPickerTargetSyntax && isCanvasTargetPath(choice.captureTo),
 );
-const propertyHint = $derived.by(() => {
-	const parsed = parsePropertyTarget(choice.captureTo ?? "");
-	if (!parsed || !parsed.field) {
-		return "Add a field name, e.g. property:type=draft";
-	}
-	return parsed.value !== undefined
-		? `Filters notes whose frontmatter ${parsed.field} = ${parsed.value}`
-		: `Filters notes that have the frontmatter field ${parsed.field}`;
-});
 
 function onCaptureToActiveFileChange(value: boolean) {
 	// Read the prior state BEFORE mutating (one-way toggle, not bind).
@@ -101,6 +95,17 @@ function onCaptureToChange(value: string) {
 		choice.captureToCanvasNodeId = "";
 	}
 }
+
+function validateCaptureTo(value: string) {
+	const feedback = getCaptureTargetFeedback(value);
+	if (!feedback) return true;
+
+	return {
+		valid: feedback.valid,
+		message: feedback.message,
+		variant: feedback.valid ? ("success" as const) : undefined,
+	};
+}
 </script>
 
 <SettingItem
@@ -122,9 +127,7 @@ function onCaptureToChange(value: string) {
 		name="File path / format"
 		desc={"Choose a file, folder, #tag, property:field=value, or format syntax (e.g., {{DATE}})"}
 	/>
-	{#if isProperty}
-		<div class="qa-field-hint qa-field-hint--neutral">{propertyHint}</div>
-	{:else}
+	{#if !usesPickerTargetSyntax}
 		<FormatPreviewField value={choice.captureTo} formatterKind="fileName" {app} {plugin} />
 	{/if}
 	<ValidatedInput
@@ -134,6 +137,7 @@ function onCaptureToChange(value: string) {
 		suggestions={captureTargetSuggestions}
 		maxSuggestions={50}
 		makeSuggesters={suggesters}
+		validator={validateCaptureTo}
 		ariaLabel="File path / format"
 		onChange={onCaptureToChange}
 	/>

--- a/src/gui/ChoiceBuilder/components/ValidatedInput.svelte
+++ b/src/gui/ChoiceBuilder/components/ValidatedInput.svelte
@@ -5,10 +5,11 @@ import type { TextInputSuggest } from "../../suggesters/suggest";
 import { suggester } from "./suggesterAction";
 
 type AnySuggest = Pick<TextInputSuggest<unknown>, "destroy">;
+type HintVariant = "neutral" | "success";
 type ValidatorResult =
 	| boolean
 	| string
-	| { valid: boolean; message?: string };
+	| { valid: boolean; message?: string; variant?: HintVariant };
 type Validator = (
 	value: string,
 ) => ValidatorResult | Promise<ValidatorResult>;
@@ -57,6 +58,7 @@ let {
 
 let invalid = $state(false);
 let hintMessage = $state("");
+let hintVariant = $state<HintVariant>("neutral");
 let validateToken = 0;
 let disposed = false;
 const hintId = `qa-hint-${Math.random().toString(36).slice(2)}`;
@@ -66,9 +68,14 @@ const normalize = (raw: string) => (trim ? raw.trim() : raw);
 // Shows the hint message; marks the field invalid only when isInvalid. A valid
 // result that still carries a message renders as a neutral hint (not an error),
 // e.g. a template path with format syntax that "resolves at run time".
-function setHint(message?: string, isInvalid = false) {
+function setHint(
+	message?: string,
+	isInvalid = false,
+	variant: HintVariant = "neutral",
+) {
 	invalid = isInvalid;
 	hintMessage = message ?? "";
+	hintVariant = isInvalid ? "neutral" : variant;
 }
 
 async function runValidator(candidate: string): Promise<boolean> {
@@ -92,7 +99,11 @@ async function runValidator(candidate: string): Promise<boolean> {
 		setHint(res, true);
 		return false;
 	}
-	setHint(res.message ?? (res.valid ? undefined : "Invalid value"), !res.valid);
+	setHint(
+		res.message ?? (res.valid ? undefined : "Invalid value"),
+		!res.valid,
+		res.valid ? (res.variant ?? "neutral") : "neutral",
+	);
 	return res.valid;
 }
 
@@ -132,6 +143,7 @@ function attach(el: HTMLInputElement | HTMLTextAreaElement): AnySuggest[] {
 	<textarea
 		class="qa-validated-input-full-width qa-validated-input-margin-8 qa-validated-input-textarea"
 		class:is-invalid={invalid}
+		class:is-valid={!invalid && hintVariant === "success" && hintMessage.length > 0}
 		{placeholder}
 		{disabled}
 		aria-label={ariaLabel}
@@ -146,6 +158,7 @@ function attach(el: HTMLInputElement | HTMLTextAreaElement): AnySuggest[] {
 		type="text"
 		class="qa-validated-input-full-width qa-validated-input-margin-8"
 		class:is-invalid={invalid}
+		class:is-valid={!invalid && hintVariant === "success" && hintMessage.length > 0}
 		{placeholder}
 		{disabled}
 		aria-label={ariaLabel}
@@ -158,7 +171,8 @@ function attach(el: HTMLInputElement | HTMLTextAreaElement): AnySuggest[] {
 {/if}
 <div
 	class="qa-field-hint"
-	class:qa-field-hint--neutral={!invalid}
+	class:qa-field-hint--neutral={!invalid && hintVariant === "neutral"}
+	class:qa-field-hint--success={!invalid && hintVariant === "success"}
 	id={hintId}
 	aria-live="polite"
 >{hintMessage}</div>

--- a/src/gui/ChoiceBuilder/components/captureTargetFeedback.test.ts
+++ b/src/gui/ChoiceBuilder/components/captureTargetFeedback.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { getCaptureTargetFeedback } from "./captureTargetFeedback";
+
+describe("getCaptureTargetFeedback", () => {
+	it("returns null for ordinary capture paths", () => {
+		expect(getCaptureTargetFeedback("Inbox.md")).toBeNull();
+		expect(getCaptureTargetFeedback("Projects/{{DATE}}.md")).toBeNull();
+	});
+
+	it("recognizes repeated folder and tag filters", () => {
+		const feedback = getCaptureTargetFeedback(
+			"folder:Goals|folder:Projects|tag:active|tag:work",
+		);
+
+		expect(feedback).toMatchObject({
+			recognized: true,
+			valid: true,
+			variant: "success",
+		});
+		expect(feedback?.message).toContain("Recognized filtered picker");
+		expect(feedback?.message).toContain("folders Goals or Projects");
+		expect(feedback?.message).toContain("tags active + work");
+	});
+
+	it("recognizes hashtag targets with additional tag filters", () => {
+		const feedback = getCaptureTargetFeedback("#work|tag:#project");
+
+		expect(feedback).toMatchObject({
+			recognized: true,
+			valid: true,
+			variant: "success",
+		});
+		expect(feedback?.message).toContain("tags work + project");
+	});
+
+	it("normalizes leading vault slashes before classifying targets", () => {
+		expect(getCaptureTargetFeedback("/property:type=draft")).toMatchObject({
+			recognized: true,
+			valid: true,
+			variant: "success",
+			message: expect.stringContaining("frontmatter type = draft"),
+		});
+	});
+
+	it("rejects capture-target multi-select filters with runtime-aligned guidance", () => {
+		expect(getCaptureTargetFeedback("tag:work|multi")).toMatchObject({
+			recognized: true,
+			valid: false,
+			variant: "error",
+			message:
+				"Capture target filters select one destination file. Use {{FILE:...|multi}} in the capture format for multi-value metadata.",
+		});
+	});
+
+	it("accepts false multi flags because runtime treats them as single-select", () => {
+		expect(getCaptureTargetFeedback("tag:work|multi:false")).toMatchObject({
+			recognized: true,
+			valid: true,
+			variant: "success",
+		});
+		expect(getCaptureTargetFeedback("tag:work|multi:off")).toMatchObject({
+			recognized: true,
+			valid: true,
+			variant: "success",
+		});
+	});
+
+	it("summarizes property targets and honored pipe filters", () => {
+		const feedback = getCaptureTargetFeedback(
+			"property:type=draft|folder:Notes|exclude-tag:done",
+		);
+
+		expect(feedback).toMatchObject({
+			recognized: true,
+			valid: true,
+			variant: "success",
+		});
+		expect(feedback?.message).toContain("Recognized property target");
+		expect(feedback?.message).toContain("frontmatter type = draft");
+		expect(feedback?.message).toContain("folder Notes");
+		expect(feedback?.message).toContain("excluding tag done");
+	});
+
+	it("rejects property targets without a field name", () => {
+		expect(getCaptureTargetFeedback("property:")).toMatchObject({
+			recognized: true,
+			valid: false,
+			variant: "error",
+			message:
+				"Property capture target needs a field name, e.g. property:type=draft.",
+		});
+		expect(getCaptureTargetFeedback("property:=draft")).toMatchObject({
+			recognized: true,
+			valid: false,
+			variant: "error",
+		});
+	});
+});

--- a/src/gui/ChoiceBuilder/components/captureTargetFeedback.test.ts
+++ b/src/gui/ChoiceBuilder/components/captureTargetFeedback.test.ts
@@ -22,6 +22,15 @@ describe("getCaptureTargetFeedback", () => {
 		expect(feedback?.message).toContain("tags active + work");
 	});
 
+	it("formats three or more tag filters as an AND-style list", () => {
+		const feedback = getCaptureTargetFeedback(
+			"tag:active|tag:work|tag:urgent",
+		);
+
+		expect(feedback?.message).toContain("tags active + work + urgent");
+		expect(feedback?.message).not.toContain(", +");
+	});
+
 	it("recognizes hashtag targets with additional tag filters", () => {
 		const feedback = getCaptureTargetFeedback("#work|tag:#project");
 

--- a/src/gui/ChoiceBuilder/components/captureTargetFeedback.ts
+++ b/src/gui/ChoiceBuilder/components/captureTargetFeedback.ts
@@ -19,6 +19,7 @@ function compact(values: readonly string[] | undefined): string[] {
 
 function formatList(values: readonly string[], finalJoiner = "or"): string {
 	if (values.length <= 1) return values[0] ?? "";
+	if (finalJoiner === "+") return values.join(" + ");
 	if (values.length === 2) return `${values[0]} ${finalJoiner} ${values[1]}`;
 	return `${values.slice(0, -1).join(", ")}, ${finalJoiner} ${values[values.length - 1]}`;
 }

--- a/src/gui/ChoiceBuilder/components/captureTargetFeedback.ts
+++ b/src/gui/ChoiceBuilder/components/captureTargetFeedback.ts
@@ -1,0 +1,110 @@
+import type { FieldFilter } from "../../../utils/FieldSuggestionParser";
+import { parseCaptureFileFilterTarget } from "../../../utils/captureFileFilterTarget";
+import { parsePropertyTarget } from "../../../utils/propertyTarget";
+
+export type CaptureTargetFeedback = {
+	recognized: true;
+	valid: boolean;
+	variant: "success" | "error";
+	message: string;
+};
+
+function normalizeCaptureTarget(raw: string): string {
+	return raw.trim().replace(/^\/+/, "");
+}
+
+function compact(values: readonly string[] | undefined): string[] {
+	return [...new Set((values ?? []).map((value) => value.trim()).filter(Boolean))];
+}
+
+function formatList(values: readonly string[], finalJoiner = "or"): string {
+	if (values.length <= 1) return values[0] ?? "";
+	if (values.length === 2) return `${values[0]} ${finalJoiner} ${values[1]}`;
+	return `${values.slice(0, -1).join(", ")}, ${finalJoiner} ${values[values.length - 1]}`;
+}
+
+function summarizeFilter(filter: FieldFilter): string {
+	const folders = compact(filter.folders ?? (filter.folder ? [filter.folder] : []));
+	const tags = compact(filter.tags);
+	const excludedFolders = compact(filter.excludeFolders);
+	const excludedTags = compact(filter.excludeTags);
+	const excludedFiles = compact(filter.excludeFiles);
+	const parts: string[] = [];
+
+	if (folders.length > 0) {
+		parts.push(
+			`${folders.length === 1 ? "folder" : "folders"} ${formatList(folders)}`,
+		);
+	}
+	if (tags.length > 0) {
+		parts.push(`${tags.length === 1 ? "tag" : "tags"} ${formatList(tags, "+")}`);
+	}
+	if (excludedFolders.length > 0) {
+		parts.push(
+			`excluding ${excludedFolders.length === 1 ? "folder" : "folders"} ${formatList(excludedFolders)}`,
+		);
+	}
+	if (excludedTags.length > 0) {
+		parts.push(
+			`excluding ${excludedTags.length === 1 ? "tag" : "tags"} ${formatList(excludedTags, "+")}`,
+		);
+	}
+	if (excludedFiles.length > 0) {
+		parts.push(
+			`excluding ${excludedFiles.length === 1 ? "file" : "files"} ${formatList(excludedFiles)}`,
+		);
+	}
+
+	return parts.length > 0 ? parts.join("; ") : "all notes";
+}
+
+export function getCaptureTargetFeedback(
+	raw: string,
+): CaptureTargetFeedback | null {
+	const normalized = normalizeCaptureTarget(raw);
+	const propertyTarget = parsePropertyTarget(normalized);
+	if (propertyTarget) {
+		if (!propertyTarget.field) {
+			return {
+				recognized: true,
+				valid: false,
+				variant: "error",
+				message:
+					"Property capture target needs a field name, e.g. property:type=draft.",
+			};
+		}
+
+		const propertySummary = propertyTarget.value
+			? `frontmatter ${propertyTarget.field} = ${propertyTarget.value}`
+			: `frontmatter field ${propertyTarget.field}`;
+		const filterSummary = summarizeFilter(propertyTarget.filter);
+		const suffix = filterSummary === "all notes" ? "" : `; ${filterSummary}`;
+
+		return {
+			recognized: true,
+			valid: true,
+			variant: "success",
+			message: `Recognized property target: ${propertySummary}${suffix}.`,
+		};
+	}
+
+	const fileFilterTarget = parseCaptureFileFilterTarget(normalized);
+	if (!fileFilterTarget) return null;
+
+	if (fileFilterTarget.multiSelect) {
+		return {
+			recognized: true,
+			valid: false,
+			variant: "error",
+			message:
+				"Capture target filters select one destination file. Use {{FILE:...|multi}} in the capture format for multi-value metadata.",
+		};
+	}
+
+	return {
+		recognized: true,
+		valid: true,
+		variant: "success",
+		message: `Recognized filtered picker: ${summarizeFilter(fileFilterTarget.filter)}.`,
+	};
+}

--- a/src/gui/InputSuggester/inputSuggester.test.ts
+++ b/src/gui/InputSuggester/inputSuggester.test.ts
@@ -115,6 +115,21 @@ describe("InputSuggester", () => {
 		expect(suggestions[suggestions.length - 1]?.item).toBe("Brand new");
 	});
 
+	it("matches custom search text while returning the underlying item", () => {
+		const suggester = new InputSuggester(
+			app,
+			["Project Display Title"],
+			["Projects/uuid-project.md"],
+			{ searchItems: ["Project Display Title Projects/uuid-project.md"] },
+		);
+
+		suggester.inputEl.value = "uuid-project";
+
+		const suggestions = suggester.getSuggestions("uuid-project");
+
+		expect(suggestions[0]?.item).toBe("Projects/uuid-project.md");
+	});
+
 	it("aligns displayItems length with items length", () => {
 		const shortDisplay = ["Alpha"];
 		const shortItems = ["Alpha", "Beta", "Gamma"];

--- a/src/gui/InputSuggester/inputSuggester.ts
+++ b/src/gui/InputSuggester/inputSuggester.ts
@@ -35,6 +35,12 @@ type Options = {
 	 * target the caller recognises (e.g. an existing file reached by basename).
 	 */
 	valueExists: (value: string) => boolean;
+	/**
+	 * Optional text used for fuzzy matching. Visual rendering still comes from
+	 * displayItems/renderItem; this lets file pickers search both title labels and
+	 * vault paths.
+	 */
+	searchItems: string[];
 };
 
 /**
@@ -48,6 +54,7 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 
 	private renderItem?: SuggestRender<string>;
 	private displayItems: string[];
+	private searchItems: string[];
 	private items: string[];
 	private warnedOnEmptyDisplay = false;
 	private allowCustomValue = true;
@@ -79,6 +86,8 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 
 		this.items = items;
 		this.displayItems = displayItems.map((value) => normalizeDisplayItem(value));
+		this.searchItems =
+			options.searchItems?.map((value) => normalizeDisplayItem(value)) ?? [];
 
 		this.promise = new Promise<string>((resolve, reject) => {
 			this.resolvePromise = resolve;
@@ -122,6 +131,13 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 				return normalizeDisplayItem(displayItem ?? item);
 			});
 		}
+		if (this.searchItems.length !== this.items.length) {
+			this.searchItems = this.items.map((item, index) => {
+				return normalizeDisplayItem(
+					this.searchItems[index] ?? this.displayItems[index] ?? item,
+				);
+			});
+		}
 
 		if (options.skippable) {
 			installSkipAffordance(this, () => this.skip());
@@ -135,8 +151,8 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 		if (item === this.inputEl.value) return item;
 
 		const index = this.items.indexOf(item);
-		const displayItem = index >= 0 ? this.displayItems[index] : undefined;
-		return normalizeDisplayItem(displayItem ?? item);
+		const searchItem = index >= 0 ? this.searchItems[index] : undefined;
+		return normalizeDisplayItem(searchItem ?? item);
 	}
 
 	getItems(): string[] {

--- a/src/gui/InputSuggester/renderNotePathSuggestion.ts
+++ b/src/gui/InputSuggester/renderNotePathSuggestion.ts
@@ -1,3 +1,5 @@
+import { TFile, type App } from "obsidian";
+import { buildFileDisplayInfos } from "src/utils/fileSyntax";
 import { stripMdExtensionForDisplay } from "../suggesters/utils";
 
 /**
@@ -6,17 +8,30 @@ import { stripMdExtensionForDisplay } from "../suggesters/utils";
  * (never invoked in unit tests). Used by the tag-scoped capture picker so it shows
  * note names instead of raw `Some/Deep/Folder/Note.md` paths (issue #745).
  */
-export function renderNotePathSuggestion(el: HTMLElement, path: string): void {
+export function renderNotePathSuggestion(
+	el: HTMLElement,
+	path: string,
+	app?: App,
+): void {
 	const lastSlash = path.lastIndexOf("/");
 	const parent = lastSlash >= 0 ? path.slice(0, lastSlash) : "";
 	const basename = stripMdExtensionForDisplay(
 		lastSlash >= 0 ? path.slice(lastSlash + 1) : path,
 	);
+	const file = app?.vault.getAbstractFileByPath(path);
+	const info = app && file instanceof TFile
+		? buildFileDisplayInfos(
+				[file],
+				(candidate) => app.metadataCache.getFileCache(candidate),
+			)[0]
+		: null;
+	const title = info?.primary ?? basename;
+	const note = info?.secondary ?? parent;
 
 	el.addClass("mod-complex");
 	const content = el.createDiv({ cls: "suggestion-content" });
-	content.createDiv({ cls: "suggestion-title", text: basename });
-	if (parent) {
-		content.createDiv({ cls: "suggestion-note", text: parent });
+	content.createDiv({ cls: "suggestion-title", text: title });
+	if (note) {
+		content.createDiv({ cls: "suggestion-note", text: note });
 	}
 }

--- a/src/preflight/RequirementCollector.file.test.ts
+++ b/src/preflight/RequirementCollector.file.test.ts
@@ -14,7 +14,10 @@ function makeFile(path: string) {
 	return { path, name: segment, basename, parent: { path: parentPath } };
 }
 
-const makeApp = (paths: string[]) =>
+const makeApp = (
+	paths: string[],
+	metadata: Record<string, unknown> = {},
+) =>
 	({
 		workspace: { getActiveFile: () => null },
 		vault: {
@@ -22,7 +25,10 @@ const makeApp = (paths: string[]) =>
 			cachedRead: async () => "",
 			getMarkdownFiles: () => paths.map(makeFile),
 		},
-		metadataCache: { getFileCache: () => null },
+		metadataCache: {
+			getFileCache: (file: { path: string }) =>
+				(metadata[file.path] as never) ?? null,
+		},
 	}) as never;
 
 const makePlugin = () =>
@@ -53,6 +59,18 @@ describe("RequirementCollector — {{FILE:...}}", () => {
 		expect(req?.displayOptions).toEqual(["Alpha", "Beta"]);
 	});
 
+	it("uses title metadata for FILE option display labels", async () => {
+		const app = makeApp(["People/01HX.md"], {
+			"People/01HX.md": { frontmatter: { title: "Ada Lovelace" } },
+		});
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString("{{FILE:People|link}}");
+
+		const key = parseFileToken("People|link")!.variableKey;
+		const req = rc.requirements.get(key);
+		expect(req?.displayOptions).toEqual(["Ada Lovelace (01HX)"]);
+	});
+
 	it("records a suggester (free text) only when |custom, with the flags set", async () => {
 		const app = makeApp(["People/Tom.md"]);
 		const rc = new RequirementCollector(app, makePlugin());
@@ -74,6 +92,18 @@ describe("RequirementCollector — {{FILE:...}}", () => {
 		const req = rc.requirements.get(key);
 		expect(req?.type).toBe("suggester");
 		expect(req?.options).toEqual([]);
+	});
+
+	it("marks FILE multi-select requirements as runtime-only", async () => {
+		const app = makeApp(["People/Tom.md", "People/Jack.md"]);
+		const rc = new RequirementCollector(app, makePlugin());
+		await rc.scanString("{{FILE:People|multi|link}}");
+
+		const key = parseFileToken("People|multi|link")!.variableKey;
+		const req = rc.requirements.get(key);
+		expect(req?.runtimeOnly).toBe(true);
+		expect(req?.type).toBe("suggester");
+		expect(req?.suggesterConfig?.multiSelect).toBe(true);
 	});
 
 	it("records ONE requirement for two |name:-shared tokens across modes", async () => {

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -526,7 +526,18 @@ export class RequirementCollector extends Formatter {
 				existing.suggesterConfig = {
 					allowCustomInput: true,
 					caseSensitive: false,
-					multiSelect: false,
+					multiSelect: parsed.multiSelect,
+				};
+			}
+			if (parsed.multiSelect) {
+				existing.type = "suggester";
+				existing.runtimeOnly = true;
+				existing.suggesterConfig = {
+					allowCustomInput:
+						existing.suggesterConfig?.allowCustomInput ??
+						parsed.allowCustomInput,
+					caseSensitive: false,
+					multiSelect: true,
 				};
 			}
 			return;
@@ -541,14 +552,18 @@ export class RequirementCollector extends Formatter {
 			(file) => this.app.metadataCache.getFileCache(file),
 		);
 		const options = files.map((file) => `${FILE_PICK_PREFIX}${file.path}`);
-		const displayOptions = buildFileDisplayLabels(files);
+		const displayOptions = buildFileDisplayLabels(
+			files,
+			(file) => this.app.metadataCache.getFileCache(file),
+		);
 		// A non-custom FILE is a FORCED choice: render it as a dropdown so the
 		// one-page form can't store a raw typed value (a free-text suggester would
 		// let "type name + Enter" bypass the option list, mirroring the runtime
 		// GenericSuggester vs InputSuggester split). Fall back to a suggester (free
 		// text) when |custom, or when the folder is empty so the field isn't a
 		// dead, disabled dropdown.
-		const useSuggester = parsed.allowCustomInput || options.length === 0;
+		const useSuggester =
+			parsed.allowCustomInput || parsed.multiSelect || options.length === 0;
 		// Disambiguate same-scope tokens that differ only by mode (e.g. a basename
 		// and a link to the same folder) when no explicit |label.
 		const autoLabel =
@@ -563,12 +578,13 @@ export class RequirementCollector extends Formatter {
 			options,
 			displayOptions,
 			optional: parsed.optional,
+			runtimeOnly: parsed.multiSelect,
 			...(useSuggester
 				? {
 						suggesterConfig: {
 							allowCustomInput: parsed.allowCustomInput,
 							caseSensitive: false,
-							multiSelect: false,
+							multiSelect: parsed.multiSelect,
 						},
 					}
 				: {}),

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -421,8 +421,8 @@ describe("collectChoiceRequirements - capture targets", () => {
 
 	it("forces the capture target dropdown for file filter targets", async () => {
 		getMarkdownFilesMatchingFilterMock.mockReturnValue([
-			{ path: "Goals/Alpha.md" },
-			{ path: "Projects/Beta.md" },
+			{ path: "Goals/Alpha.md" } as never,
+			{ path: "Projects/Beta.md" } as never,
 		]);
 
 		const requirements = await collectChoiceRequirements(

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -302,7 +302,12 @@ describe("collectChoiceRequirements - macro script metadata", () => {
 });
 
 describe("collectChoiceRequirements - capture targets", () => {
-	const app = {} as App;
+	const getFileCacheMock = vi.fn();
+	const app = {
+		metadataCache: {
+			getFileCache: getFileCacheMock,
+		},
+	} as unknown as App;
 	const plugin = {
 		settings: {
 			inputPrompt: "single-line",
@@ -326,6 +331,16 @@ describe("collectChoiceRequirements - capture targets", () => {
 		getMarkdownFilesMatchingFilterMock.mockReturnValue([]);
 		getMarkdownFilesWithTagMock.mockReturnValue([]);
 		getMarkdownFilesWithPropertyMock.mockReturnValue([]);
+		getFileCacheMock.mockReset();
+		getFileCacheMock.mockImplementation((file: { path: string }) => {
+			if (file.path === "Goals/Alpha.md") {
+				return { frontmatter: { title: "Alpha Goal" } };
+			}
+			if (file.path === "Projects/Beta.md") {
+				return { headings: [{ level: 1, heading: "Beta Heading" }] };
+			}
+			return null;
+		});
 	});
 
 	it("normalizes capture folder paths ending in .md", async () => {
@@ -440,15 +455,19 @@ describe("collectChoiceRequirements - capture targets", () => {
 				tags: ["active"],
 			}),
 		);
-		const target = requirements.find(
-			(requirement) =>
-				requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
-		);
-		expect(target?.options).toEqual([
-			"Goals/Alpha.md",
-			"Projects/Beta.md",
-		]);
-	});
+			const target = requirements.find(
+				(requirement) =>
+					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			);
+			expect(target?.options).toEqual([
+				"Goals/Alpha.md",
+				"Projects/Beta.md",
+			]);
+			expect(target?.displayOptions).toEqual([
+				"Alpha Goal (Alpha)",
+				"Beta Heading (Beta)",
+			]);
+		});
 
 	it("does not force the dropdown for a tokenized property value", async () => {
 		const requirements = await collectChoiceRequirements(

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -11,6 +11,7 @@ import { collectChoiceRequirements } from "./collectChoiceRequirements";
 
 const {
 	getMarkdownFilesInFolderMock,
+	getMarkdownFilesMatchingFilterMock,
 	getMarkdownFilesWithTagMock,
 	getMarkdownFilesWithPropertyMock,
 	getUserScriptMock,
@@ -20,6 +21,7 @@ const {
 	logMessageMock,
 } = vi.hoisted(() => ({
 	getMarkdownFilesInFolderMock: vi.fn(() => []),
+	getMarkdownFilesMatchingFilterMock: vi.fn(() => []),
 	getMarkdownFilesWithTagMock: vi.fn(() => []),
 	getMarkdownFilesWithPropertyMock: vi.fn(() => []),
 	getUserScriptMock: vi.fn(),
@@ -31,6 +33,7 @@ const {
 
 vi.mock("src/utilityObsidian", () => ({
 	getMarkdownFilesInFolder: getMarkdownFilesInFolderMock,
+	getMarkdownFilesMatchingFilter: getMarkdownFilesMatchingFilterMock,
 	getMarkdownFilesWithTag: getMarkdownFilesWithTagMock,
 	getMarkdownFilesWithProperty: getMarkdownFilesWithPropertyMock,
 	getUserScript: getUserScriptMock,
@@ -117,6 +120,7 @@ describe("collectChoiceRequirements - macro script metadata", () => {
 
 	beforeEach(() => {
 		getMarkdownFilesInFolderMock.mockReset();
+		getMarkdownFilesMatchingFilterMock.mockReset();
 		getMarkdownFilesWithTagMock.mockReset();
 		getUserScriptMock.mockReset();
 		isFolderMock.mockReset();
@@ -313,11 +317,13 @@ describe("collectChoiceRequirements - capture targets", () => {
 
 	beforeEach(() => {
 		getMarkdownFilesInFolderMock.mockReset();
+		getMarkdownFilesMatchingFilterMock.mockReset();
 		getMarkdownFilesWithTagMock.mockReset();
 		getMarkdownFilesWithPropertyMock.mockReset();
 		isFolderMock.mockReset();
 		logWarningMock.mockReset();
 		getMarkdownFilesInFolderMock.mockReturnValue([]);
+		getMarkdownFilesMatchingFilterMock.mockReturnValue([]);
 		getMarkdownFilesWithTagMock.mockReturnValue([]);
 		getMarkdownFilesWithPropertyMock.mockReturnValue([]);
 	});
@@ -411,6 +417,37 @@ describe("collectChoiceRequirements - capture targets", () => {
 			"draft",
 			expect.objectContaining({ folder: "Notes" }),
 		);
+	});
+
+	it("forces the capture target dropdown for file filter targets", async () => {
+		getMarkdownFilesMatchingFilterMock.mockReturnValue([
+			{ path: "Goals/Alpha.md" },
+			{ path: "Projects/Beta.md" },
+		]);
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createCaptureChoice("folder:Goals|folder:Projects|tag:active"),
+		);
+
+		expect(getMarkdownFilesMatchingFilterMock).toHaveBeenCalledWith(
+			app,
+			expect.objectContaining({
+				folder: "Goals",
+				folders: ["Goals", "Projects"],
+				tags: ["active"],
+			}),
+		);
+		const target = requirements.find(
+			(requirement) =>
+				requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+		);
+		expect(target?.options).toEqual([
+			"Goals/Alpha.md",
+			"Projects/Beta.md",
+		]);
 	});
 
 	it("does not force the dropdown for a tokenized property value", async () => {

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -24,6 +24,7 @@ import { hasTemplatePathSyntax } from "src/utils/templatePathSyntax";
 import { parsePropertyTarget } from "src/utils/propertyTarget";
 import { parseCaptureFileFilterTarget } from "src/utils/captureFileFilterTarget";
 import { orderFilesForPicker } from "src/utils/fileOrdering";
+import { buildFileDisplayLabels } from "src/utils/fileSyntax";
 import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
 import { resolveExistingVariableKey } from "src/utils/valueSyntax";
 import {
@@ -317,15 +318,21 @@ async function collectForCaptureChoice(
 			files = getMarkdownFilesInFolder(app, base);
 		}
 
-		const options = orderFilesForPicker(
+		const orderedFiles = orderFilesForPicker(
 			files,
 			buildPickerOrderingDeps(app),
-		).map((file) => file.path);
+		);
+		const options = orderedFiles.map((file) => file.path);
+		const displayOptions = buildFileDisplayLabels(
+			orderedFiles,
+			(file) => app.metadataCache?.getFileCache(file) ?? null,
+		);
 		collector.requirements.set(QA_INTERNAL_CAPTURE_TARGET_FILE_PATH, {
 			id: QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
 			label: "Select capture target file",
 			type: "dropdown",
 			options,
+			displayOptions,
 			placeholder: options.length
 				? undefined
 				: "No files found in target scope",

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -12,6 +12,7 @@ import type { ICommand } from "src/types/macros/ICommand";
 import type { IUserScript } from "src/types/macros/IUserScript";
 import {
 	getMarkdownFilesInFolder,
+	getMarkdownFilesMatchingFilter,
 	getMarkdownFilesWithTag,
 	getMarkdownFilesWithProperty,
 	getTemplateFile,
@@ -21,6 +22,7 @@ import {
 import { log } from "src/logger/logManager";
 import { hasTemplatePathSyntax } from "src/utils/templatePathSyntax";
 import { parsePropertyTarget } from "src/utils/propertyTarget";
+import { parseCaptureFileFilterTarget } from "src/utils/captureFileFilterTarget";
 import { orderFilesForPicker } from "src/utils/fileOrdering";
 import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
 import { resolveExistingVariableKey } from "src/utils/valueSyntax";
@@ -273,18 +275,25 @@ async function collectForCaptureChoice(
 			? parsePropertyTarget(normalizedTarget)
 			: null;
 	const isPropertyTarget = !!propertyTarget && !!propertyTarget.field;
-	const isTagTarget = !isPropertyTarget && normalizedTarget.startsWith("#");
+	const fileFilterTarget =
+		!isPropertyTarget && !hasTemplatePathSyntax(normalizedTarget)
+			? parseCaptureFileFilterTarget(normalizedTarget)
+			: null;
+	const isFilterTarget = !!fileFilterTarget && !fileFilterTarget.multiSelect;
+	const isTagTarget = !isPropertyTarget && !isFilterTarget && normalizedTarget.startsWith("#");
 	const trimmedPath = normalizedTarget.replace(/\/$|\.md$/g, "");
 	const isFolderTarget =
 		!isTagTarget &&
 		!isPropertyTarget &&
+		!isFilterTarget &&
 		(normalizedTarget === "" || isFolder(app, trimmedPath));
 	const looksLikeFolderBySuffix =
-		!isPropertyTarget && normalizedTarget.endsWith("/");
+		!isPropertyTarget && !isFilterTarget && normalizedTarget.endsWith("/");
 
 	if (
 		!choice.captureToActiveFile &&
 		(isPropertyTarget ||
+			isFilterTarget ||
 			isTagTarget ||
 			isFolderTarget ||
 			looksLikeFolderBySuffix)
@@ -297,6 +306,8 @@ async function collectForCaptureChoice(
 				propertyTarget.value,
 				propertyTarget.filter,
 			);
+		} else if (isFilterTarget && fileFilterTarget) {
+			files = getMarkdownFilesMatchingFilter(app, fileFilterTarget.filter);
 		} else if (isTagTarget) {
 			files = getMarkdownFilesWithTag(app, normalizedTarget);
 		} else {

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -770,6 +770,7 @@ export class QuickAddApi {
 					fieldName: string,
 					options?: {
 						folder?: string;
+						folders?: string[];
 						tags?: string[];
 						includeInline?: boolean;
 						includeInlineCodeBlocks?: string[];
@@ -780,6 +781,7 @@ export class QuickAddApi {
 						.filter((value) => value.length > 0);
 					const filters = {
 						folder: options?.folder,
+						folders: options?.folders,
 						tags: options?.tags,
 						inline: options?.includeInline ?? false,
 						inlineCodeBlocks,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1473,9 +1473,18 @@
 	color: var(--text-muted);
 }
 
+.qa-field-hint--success {
+	color: var(--text-success, var(--color-green, #0aa344));
+}
+
 input.is-invalid,
 textarea.is-invalid {
 	box-shadow: 0 0 0 1px var(--text-error);
+}
+
+input.is-valid,
+textarea.is-valid {
+	box-shadow: 0 0 0 1px var(--text-success, var(--color-green, #0aa344));
 }
 
 /* Suggestion highlighting */

--- a/src/utilityObsidian.ts
+++ b/src/utilityObsidian.ts
@@ -66,6 +66,7 @@ export {
 	isFolder,
 	getMarkdownFilesInFolder,
 	getMarkdownFilesWithTag,
+	getMarkdownFilesMatchingFilter,
 	getMarkdownFilesWithProperty,
 } from "./utils/vaultQueries";
 

--- a/src/utils/DataviewIntegration.ts
+++ b/src/utils/DataviewIntegration.ts
@@ -1,6 +1,7 @@
 import type { App } from "obsidian";
 import { getAPI } from "obsidian-dataview";
 import { log } from "src/logger/logManager";
+import type { FieldFilter } from "./FieldSuggestionParser";
 
 type DataviewFileLike = { path: string };
 
@@ -14,6 +15,14 @@ type DataviewQueryApi = {
 		value: { values: unknown[][] };
 	}>;
 };
+
+function escapeDataviewString(value: string): string {
+	return value.replace(/[\\"]/g, "\\$&");
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function isDataviewFileLike(value: unknown): value is DataviewFileLike {
 	return (
@@ -52,7 +61,7 @@ export class DataviewIntegration {
 		try {
 			// Query for all pages that have this field
 			// Properly escape field name to prevent injection
-			const escapedFieldName = fieldName.replace(/[\\"]/g, '\\$&');
+			const escapedFieldName = escapeDataviewString(fieldName);
 			const safe = `field("${escapedFieldName}")`;
 			const query = `TABLE ${safe} WHERE ${safe}`;
 			const result = await dv.query(query);
@@ -113,10 +122,7 @@ export class DataviewIntegration {
 	static async getFieldValuesWithFilter(
 		app: App, 
 		fieldName: string, 
-		folder?: string, 
-		tags?: string[],
-		excludeFolders?: string[],
-		excludeTags?: string[]
+		filters: FieldFilter = {},
 	): Promise<Set<string>> {
 		const values = new Set<string>();
 		const dv = this.getDataviewAPI(app);
@@ -128,36 +134,45 @@ export class DataviewIntegration {
 		try {
 			// Build the WHERE clause
 			// Properly escape field name to prevent injection
-			const escapedFieldName = fieldName.replace(/[\\"]/g, '\\$&');
+			const escapedFieldName = escapeDataviewString(fieldName);
 			const safe = `field("${escapedFieldName}")`;
 			const conditions: string[] = [safe]; // Field must exist
-			
-			if (folder) {
-				// Normalize folder path
-				const normalizedFolder = folder.replace(/^\/+|\/+$/g, '');
-				conditions.push(`regexmatch("^${normalizedFolder}/", file.path)`);
+
+			const includeFolders = (filters.folders?.length
+				? filters.folders
+				: filters.folder
+					? [filters.folder]
+					: [])
+				.map(folder => folder.replace(/^\/+|\/+$/g, ""))
+				.filter(Boolean);
+			if (includeFolders.length > 0) {
+				const folderConditions = includeFolders.map(folder => {
+					const escapedFolder = escapeRegex(folder);
+					return `regexmatch("^${escapedFolder}/", file.path)`;
+				});
+				conditions.push(`(${folderConditions.join(" OR ")})`);
 			}
 			
-			if (tags && tags.length > 0) {
+			if (filters.tags && filters.tags.length > 0) {
 				// Add tag conditions (file must have all specified tags)
-				tags.forEach(tag => {
+				filters.tags.forEach(tag => {
 					const tagName = tag.startsWith('#') ? tag : `#${tag}`;
-					conditions.push(`contains(file.tags, "${tagName}")`);
+					conditions.push(`contains(file.tags, "${escapeDataviewString(tagName)}")`);
 				});
 			}
 			
 			// Add exclusion conditions
-			if (excludeFolders && excludeFolders.length > 0) {
-				excludeFolders.forEach(excludeFolder => {
+			if (filters.excludeFolders && filters.excludeFolders.length > 0) {
+				filters.excludeFolders.forEach(excludeFolder => {
 					const normalizedFolder = excludeFolder.replace(/^\/+|\/+$/g, '');
-					conditions.push(`!regexmatch("^${normalizedFolder}/", file.path)`);
+					conditions.push(`!regexmatch("^${escapeRegex(normalizedFolder)}/", file.path)`);
 				});
 			}
 			
-			if (excludeTags && excludeTags.length > 0) {
-				excludeTags.forEach(excludeTag => {
+			if (filters.excludeTags && filters.excludeTags.length > 0) {
+				filters.excludeTags.forEach(excludeTag => {
 					const tagName = excludeTag.startsWith('#') ? excludeTag : `#${excludeTag}`;
-					conditions.push(`!contains(file.tags, "${tagName}")`);
+					conditions.push(`!contains(file.tags, "${escapeDataviewString(tagName)}")`);
 				});
 			}
 			

--- a/src/utils/EnhancedFieldSuggestionFileFilter.test.ts
+++ b/src/utils/EnhancedFieldSuggestionFileFilter.test.ts
@@ -78,6 +78,24 @@ describe("EnhancedFieldSuggestionFileFilter", () => {
 			]);
 		});
 
+		it("should include files from any repeated folder filter", () => {
+			const filters: FieldFilter = {
+				folder: "folder1",
+				folders: ["folder1", "folder2"],
+			};
+			const result = EnhancedFieldSuggestionFileFilter.filterFiles(
+				mockFiles,
+				filters,
+				mockMetadataCache,
+			);
+			expect(result.map(f => f.path)).toEqual([
+				"folder1/file1.md",
+				"folder1/subfolder/file2.md",
+				"folder2/file3.md",
+				"folder2/file4.md",
+			]);
+		});
+
 		it("should filter by tag inclusion", () => {
 			const filters: FieldFilter = { tags: ["todo"] };
 			const result = EnhancedFieldSuggestionFileFilter.filterFiles(
@@ -89,6 +107,16 @@ describe("EnhancedFieldSuggestionFileFilter", () => {
 			expect(result.map(f => f.path)).toContain("folder1/file1.md");
 			expect(result.map(f => f.path)).toContain("folder2/file4.md");
 			expect(result.map(f => f.path)).toContain("root-file.md");
+		});
+
+		it("should require all inclusion tags", () => {
+			const filters: FieldFilter = { tags: ["project", "todo"] };
+			const result = EnhancedFieldSuggestionFileFilter.filterFiles(
+				mockFiles,
+				filters,
+				mockMetadataCache,
+			);
+			expect(result.map(f => f.path)).toEqual(["folder1/file1.md"]);
 		});
 
 		it("should exclude folders", () => {
@@ -238,6 +266,16 @@ describe("EnhancedFieldSuggestionFileFilter", () => {
 			);
 			expect(result).toHaveLength(1);
 			expect(result[0].path).toBe("folder1/subfolder/file2.md");
+		});
+
+		it("should normalize leading # in frontmatter tags", () => {
+			const files = [createMockFile("note.md")];
+			const result = EnhancedFieldSuggestionFileFilter.filterFiles(
+				files,
+				{ tags: ["topic"] },
+				() => createMockMetadata(undefined, ["#topic"]),
+			);
+			expect(result.map(f => f.path)).toEqual(["note.md"]);
 		});
 
 		it("should handle frontmatter tags for exclusion", () => {

--- a/src/utils/EnhancedFieldSuggestionFileFilter.test.ts
+++ b/src/utils/EnhancedFieldSuggestionFileFilter.test.ts
@@ -17,7 +17,7 @@ const createMockFile = (path: string): TFile => {
 };
 
 // Mock CachedMetadata
-const createMockMetadata = (tags?: string[], frontmatterTags?: string[]): CachedMetadata => {
+const createMockMetadata = (tags?: string[], frontmatterTags?: unknown): CachedMetadata => {
 	const metadata: any = {};
 	
 	if (tags) {
@@ -274,6 +274,38 @@ describe("EnhancedFieldSuggestionFileFilter", () => {
 				files,
 				{ tags: ["topic"] },
 				() => createMockMetadata(undefined, ["#topic"]),
+			);
+			expect(result.map(f => f.path)).toEqual(["note.md"]);
+		});
+
+		it("should split comma-separated scalar frontmatter tags", () => {
+			const files = [createMockFile("note.md")];
+			const result = EnhancedFieldSuggestionFileFilter.filterFiles(
+				files,
+				{ tags: ["work", "project"] },
+				() => createMockMetadata(undefined, "work, project"),
+			);
+			expect(result.map(f => f.path)).toEqual(["note.md"]);
+		});
+
+		it("should split whitespace-separated scalar frontmatter tags", () => {
+			const files = [createMockFile("note.md")];
+			const result = EnhancedFieldSuggestionFileFilter.filterFiles(
+				files,
+				{ tags: ["work", "project"] },
+				() => createMockMetadata(undefined, "work project"),
+			);
+			expect(result.map(f => f.path)).toEqual(["note.md"]);
+		});
+
+		it("should split scalar singular frontmatter tag values", () => {
+			const files = [createMockFile("note.md")];
+			const result = EnhancedFieldSuggestionFileFilter.filterFiles(
+				files,
+				{ tags: ["work", "project"] },
+				() => ({
+					frontmatter: { tag: "#work, project" },
+				} as CachedMetadata),
 			);
 			expect(result.map(f => f.path)).toEqual(["note.md"]);
 		});

--- a/src/utils/EnhancedFieldSuggestionFileFilter.ts
+++ b/src/utils/EnhancedFieldSuggestionFileFilter.ts
@@ -1,5 +1,9 @@
 import type { TFile, CachedMetadata } from "obsidian";
 import type { FieldFilter } from "./FieldSuggestionParser";
+import {
+	normalizeFrontmatterTagValues,
+	normalizeTag,
+} from "./tagNormalizer";
 
 export class EnhancedFieldSuggestionFileFilter {
 	/**
@@ -157,33 +161,23 @@ export class EnhancedFieldSuggestionFileFilter {
 
 		// Get tags from frontmatter
 		if (metadata.frontmatter?.tags) {
-			const frontmatterTags = Array.isArray(metadata.frontmatter.tags)
-				? metadata.frontmatter.tags
-				: [metadata.frontmatter.tags];
-			
-			tags.push(...frontmatterTags.map(tag => this.normalizeTag(tag)));
+			tags.push(...normalizeFrontmatterTagValues(metadata.frontmatter.tags));
 		}
 
 		if (metadata.frontmatter?.tag) {
-			const frontmatterTag = Array.isArray(metadata.frontmatter.tag)
-				? metadata.frontmatter.tag
-				: [metadata.frontmatter.tag];
-			
-			tags.push(...frontmatterTag.map(tag => this.normalizeTag(tag)));
+			tags.push(...normalizeFrontmatterTagValues(metadata.frontmatter.tag));
 		}
 
 		// Get inline tags
 		if (metadata.tags) {
-			tags.push(...metadata.tags.map(tag => this.normalizeTag(tag.tag)));
+			tags.push(...metadata.tags.map(tag => normalizeTag(tag.tag)));
 		}
 
 		return tags.filter(Boolean);
 	}
 
 	private static normalizeTag(tag: unknown): string {
-		const tagString = typeof tag === "string" ? tag : String(tag);
-		const trimmed = tagString.trim();
-		return trimmed.startsWith("#") ? trimmed.substring(1).trim() : trimmed;
+		return normalizeTag(tag);
 	}
 
 	private static normalizePath(path: string): string {

--- a/src/utils/EnhancedFieldSuggestionFileFilter.ts
+++ b/src/utils/EnhancedFieldSuggestionFileFilter.ts
@@ -27,30 +27,21 @@ export class EnhancedFieldSuggestionFileFilter {
 		metadataCache: (file: TFile) => CachedMetadata | null,
 	): TFile[] {
 		let hasInclusionFilters = false;
-		let includedFiles: TFile[] = [];
+		let includedFiles = files;
 
-		// Folder filter
-		if (filters.folder) {
+		const folders = this.getIncludeFolders(filters);
+		if (folders.length > 0) {
 			hasInclusionFilters = true;
-			const folder = filters.folder;
-			const folderFiles = files.filter(file => this.matchesFolder(file, folder));
-			includedFiles.push(...folderFiles);
+			includedFiles = includedFiles.filter(file =>
+				folders.some(folder => this.matchesFolder(file, folder))
+			);
 		}
 
-		// Tag filter
 		if (filters.tags && filters.tags.length > 0) {
 			hasInclusionFilters = true;
-			const tags = filters.tags;
-			const tagFiles = files.filter(file => 
-				this.matchesTags(file, tags, metadataCache)
+			includedFiles = includedFiles.filter(file =>
+				this.matchesAllTags(file, filters.tags ?? [], metadataCache)
 			);
-			
-			if (filters.folder) {
-				// If we already have folder filtering, intersect the results
-				includedFiles = includedFiles.filter(file => tagFiles.includes(file));
-			} else {
-				includedFiles.push(...tagFiles);
-			}
 		}
 
 		// If no inclusion filters were specified, include all files
@@ -72,7 +63,7 @@ export class EnhancedFieldSuggestionFileFilter {
 
 			// Exclude by tag
 			if (filters.excludeTags && filters.excludeTags.length > 0) {
-				if (this.matchesTags(file, filters.excludeTags, metadataCache)) {
+				if (this.matchesAnyTag(file, filters.excludeTags, metadataCache)) {
 					return false;
 				}
 			}
@@ -86,6 +77,16 @@ export class EnhancedFieldSuggestionFileFilter {
 
 			return true;
 		});
+	}
+
+	private static getIncludeFolders(filters: FieldFilter): string[] {
+		const folders = filters.folders?.length
+			? filters.folders
+			: filters.folder
+				? [filters.folder]
+				: [];
+
+		return [...new Set(folders.map(folder => this.normalizePath(folder)).filter(Boolean))];
 	}
 
 	private static matchesFolder(file: TFile, folder: string): boolean {
@@ -103,10 +104,27 @@ export class EnhancedFieldSuggestionFileFilter {
 		);
 	}
 
+	private static matchesAllTags(
+		file: TFile,
+		requiredTags: string[],
+		metadataCache: (file: TFile) => CachedMetadata | null,
+	): boolean {
+		return this.matchesTags(file, requiredTags, metadataCache, "all");
+	}
+
+	private static matchesAnyTag(
+		file: TFile,
+		requiredTags: string[],
+		metadataCache: (file: TFile) => CachedMetadata | null,
+	): boolean {
+		return this.matchesTags(file, requiredTags, metadataCache, "any");
+	}
+
 	private static matchesTags(
 		file: TFile,
 		requiredTags: string[],
 		metadataCache: (file: TFile) => CachedMetadata | null,
+		mode: "all" | "any",
 	): boolean {
 		const metadata = metadataCache(file);
 		if (!metadata) {
@@ -115,13 +133,18 @@ export class EnhancedFieldSuggestionFileFilter {
 
 		// Get all tags from the file (both frontmatter and inline)
 		const fileTags = this.getAllTags(metadata);
+		const normalizedRequiredTags = requiredTags
+			.map(tag => this.normalizeTag(tag))
+			.filter(Boolean);
 
-		// Check if file has any of the required tags (OR logic for inclusion, AND logic for exclusion)
-		return requiredTags.some(requiredTag =>
-			fileTags.some(fileTag => 
+		const matchesRequiredTag = (requiredTag: string) =>
+			fileTags.some(fileTag =>
 				fileTag === requiredTag || fileTag.startsWith(requiredTag + "/")
-			)
-		);
+			);
+
+		return mode === "all"
+			? normalizedRequiredTags.every(matchesRequiredTag)
+			: normalizedRequiredTags.some(matchesRequiredTag);
 	}
 
 	private static matchesFile(file: TFile, targetFile: string): boolean {
@@ -138,9 +161,7 @@ export class EnhancedFieldSuggestionFileFilter {
 				? metadata.frontmatter.tags
 				: [metadata.frontmatter.tags];
 			
-			tags.push(...frontmatterTags.map(tag => 
-				typeof tag === 'string' ? tag : String(tag)
-			));
+			tags.push(...frontmatterTags.map(tag => this.normalizeTag(tag)));
 		}
 
 		if (metadata.frontmatter?.tag) {
@@ -148,19 +169,21 @@ export class EnhancedFieldSuggestionFileFilter {
 				? metadata.frontmatter.tag
 				: [metadata.frontmatter.tag];
 			
-			tags.push(...frontmatterTag.map(tag => 
-				typeof tag === 'string' ? tag : String(tag)
-			));
+			tags.push(...frontmatterTag.map(tag => this.normalizeTag(tag)));
 		}
 
 		// Get inline tags
 		if (metadata.tags) {
-			tags.push(...metadata.tags.map(tag => 
-				tag.tag.startsWith("#") ? tag.tag.substring(1) : tag.tag
-			));
+			tags.push(...metadata.tags.map(tag => this.normalizeTag(tag.tag)));
 		}
 
-		return tags;
+		return tags.filter(Boolean);
+	}
+
+	private static normalizeTag(tag: unknown): string {
+		const tagString = typeof tag === "string" ? tag : String(tag);
+		const trimmed = tagString.trim();
+		return trimmed.startsWith("#") ? trimmed.substring(1).trim() : trimmed;
 	}
 
 	private static normalizePath(path: string): string {

--- a/src/utils/FieldSuggestionFileFilter.test.ts
+++ b/src/utils/FieldSuggestionFileFilter.test.ts
@@ -198,6 +198,93 @@ describe("FieldSuggestionFileFilter", () => {
 			expect(result[0].path).toBe("note1.md");
 		});
 
+		it("should split comma-separated scalar frontmatter tags", () => {
+			const filesWithFrontmatter = [
+				{ path: "note1.md" } as TFile,
+				{ path: "note2.md" } as TFile,
+			];
+
+			const metadataWithFrontmatter = (file: TFile) => {
+				if (file.path === "note1.md") {
+					return {
+						frontmatter: { tags: "Test, Work" },
+					} as CachedMetadata;
+				}
+				if (file.path === "note2.md") {
+					return {
+						frontmatter: { tags: "Test" },
+					} as CachedMetadata;
+				}
+				return null;
+			};
+
+			const result = FieldSuggestionFileFilter.filterFiles(
+				filesWithFrontmatter,
+				{ tags: ["Test", "Work"] },
+				metadataWithFrontmatter,
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0].path).toBe("note1.md");
+		});
+
+		it("should split whitespace-separated scalar frontmatter tags", () => {
+			const filesWithFrontmatter = [
+				{ path: "note1.md" } as TFile,
+				{ path: "note2.md" } as TFile,
+			];
+
+			const metadataWithFrontmatter = (file: TFile) => {
+				if (file.path === "note1.md") {
+					return {
+						frontmatter: { tags: "#Test Work" },
+					} as CachedMetadata;
+				}
+				if (file.path === "note2.md") {
+					return {
+						frontmatter: { tags: "Test" },
+					} as CachedMetadata;
+				}
+				return null;
+			};
+
+			const result = FieldSuggestionFileFilter.filterFiles(
+				filesWithFrontmatter,
+				{ tags: ["Test", "Work"] },
+				metadataWithFrontmatter,
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0].path).toBe("note1.md");
+		});
+
+		it("should split scalar singular frontmatter tag values", () => {
+			const filesWithFrontmatter = [
+				{ path: "note1.md" } as TFile,
+				{ path: "note2.md" } as TFile,
+			];
+
+			const metadataWithFrontmatter = (file: TFile) => {
+				if (file.path === "note1.md") {
+					return {
+						frontmatter: { tag: "#Test, Work" },
+					} as CachedMetadata;
+				}
+				if (file.path === "note2.md") {
+					return {
+						frontmatter: { tag: "Test" },
+					} as CachedMetadata;
+				}
+				return null;
+			};
+
+			const result = FieldSuggestionFileFilter.filterFiles(
+				filesWithFrontmatter,
+				{ tags: ["Test", "Work"] },
+				metadataWithFrontmatter,
+			);
+			expect(result).toHaveLength(1);
+			expect(result[0].path).toBe("note1.md");
+		});
+
 		it("should filter files by frontmatter tags (array)", () => {
 			const filesWithFrontmatter = [
 				{ path: "note1.md" } as TFile,

--- a/src/utils/FieldSuggestionFileFilter.test.ts
+++ b/src/utils/FieldSuggestionFileFilter.test.ts
@@ -80,6 +80,20 @@ describe("FieldSuggestionFileFilter", () => {
 			]);
 		});
 
+		it("should filter files by multiple folders (OR logic)", () => {
+			const result = FieldSuggestionFileFilter.filterFiles(
+				mockFiles,
+				{ folder: "daily", folders: ["daily", "projects"] },
+				mockMetadataCache,
+			);
+			expect(result.map((f) => f.path)).toEqual([
+				"daily/2024-01-01.md",
+				"daily/2024-01-02.md",
+				"projects/project1.md",
+				"projects/work/task1.md",
+			]);
+		});
+
 		it("should filter files by nested folder", () => {
 			const result = FieldSuggestionFileFilter.filterFiles(
 				mockFiles,

--- a/src/utils/FieldSuggestionFileFilter.ts
+++ b/src/utils/FieldSuggestionFileFilter.ts
@@ -1,5 +1,9 @@
 import type { TFile, CachedMetadata } from "obsidian";
 import type { FieldFilter } from "./FieldSuggestionParser";
+import {
+	normalizeFrontmatterTagValues,
+	normalizeTag,
+} from "./tagNormalizer";
 
 export class FieldSuggestionFileFilter {
 	/**
@@ -74,9 +78,7 @@ export class FieldSuggestionFileFilter {
 		const fileTags = this.getAllTags(metadata);
 
 		// Normalize required tags (remove leading # and trim)
-		const normalizedRequiredTags = requiredTags.map((tag) =>
-			tag.startsWith("#") ? tag.substring(1).trim() : tag.trim(),
-		);
+		const normalizedRequiredTags = requiredTags.map(normalizeTag).filter(Boolean);
 
 		// Check if file has all required tags (AND logic)
 		return normalizedRequiredTags.every((requiredTag) =>
@@ -90,35 +92,19 @@ export class FieldSuggestionFileFilter {
 		const tags: string[] = [];
 
 		if (metadata.frontmatter?.tags) {
-			const frontmatterTags = Array.isArray(metadata.frontmatter.tags)
-				? metadata.frontmatter.tags
-				: [metadata.frontmatter.tags];
-			
-			tags.push(...frontmatterTags.map(tag => {
-				const tagStr = typeof tag === 'string' ? tag : String(tag);
-				return tagStr.startsWith("#") ? tagStr.substring(1).trim() : tagStr.trim();
-			}));
+			tags.push(...normalizeFrontmatterTagValues(metadata.frontmatter.tags));
 		}
 
 		if (metadata.frontmatter?.tag) {
-			const frontmatterTag = Array.isArray(metadata.frontmatter.tag)
-				? metadata.frontmatter.tag
-				: [metadata.frontmatter.tag];
-			
-			tags.push(...frontmatterTag.map(tag => {
-				const tagStr = typeof tag === 'string' ? tag : String(tag);
-				return tagStr.startsWith("#") ? tagStr.substring(1).trim() : tagStr.trim();
-			}));
+			tags.push(...normalizeFrontmatterTagValues(metadata.frontmatter.tag));
 		}
 
 		// Get inline tags
 		if (metadata.tags) {
-			tags.push(...metadata.tags.map(tag => 
-				tag.tag.startsWith("#") ? tag.tag.substring(1).trim() : tag.tag.trim()
-			));
+			tags.push(...metadata.tags.map(tag => normalizeTag(tag.tag)));
 		}
 
-		return tags;
+		return tags.filter(Boolean);
 	}
 
 	private static normalizePath(path: string): string {

--- a/src/utils/FieldSuggestionFileFilter.ts
+++ b/src/utils/FieldSuggestionFileFilter.ts
@@ -15,8 +15,11 @@ export class FieldSuggestionFileFilter {
 		}
 
 		return files.filter((file) => {
-			// Check folder filter
-			if (filters.folder && !this.matchesFolder(file, filters.folder)) {
+			const folders = this.getIncludeFolders(filters);
+			if (
+				folders.length > 0 &&
+				!folders.some((folder) => this.matchesFolder(file, folder))
+			) {
 				return false;
 			}
 
@@ -31,6 +34,15 @@ export class FieldSuggestionFileFilter {
 
 			return true;
 		});
+	}
+
+	private static getIncludeFolders(filters: FieldFilter): string[] {
+		const folders = filters.folders?.length
+			? filters.folders
+			: filters.folder
+				? [filters.folder]
+				: [];
+		return [...new Set(folders.map((folder) => this.normalizePath(folder)).filter(Boolean))];
 	}
 
 	private static matchesFolder(file: TFile, folderPath: string): boolean {
@@ -68,7 +80,9 @@ export class FieldSuggestionFileFilter {
 
 		// Check if file has all required tags (AND logic)
 		return normalizedRequiredTags.every((requiredTag) =>
-			fileTags.includes(requiredTag),
+			fileTags.some((fileTag) =>
+				fileTag === requiredTag || fileTag.startsWith(requiredTag + "/"),
+			),
 		);
 	}
 

--- a/src/utils/FieldSuggestionParser.test.ts
+++ b/src/utils/FieldSuggestionParser.test.ts
@@ -17,7 +17,20 @@ describe("FieldSuggestionParser", () => {
 			);
 			expect(result).toEqual({
 				fieldName: "fieldname",
-				filters: { folder: "daily" },
+				filters: { folder: "daily", folders: ["daily"] },
+			});
+		});
+
+		it("parses repeated folder filters as an include list", () => {
+			const result = FieldSuggestionParser.parse(
+				"fieldname|folder:daily|folder:projects",
+			);
+			expect(result).toEqual({
+				fieldName: "fieldname",
+				filters: {
+					folder: "daily",
+					folders: ["daily", "projects"],
+				},
 			});
 		});
 
@@ -70,6 +83,7 @@ describe("FieldSuggestionParser", () => {
 				fieldName: "fieldname",
 				filters: {
 					folder: "daily",
+					folders: ["daily"],
 					tags: ["work"],
 					inline: true,
 				},
@@ -84,6 +98,7 @@ describe("FieldSuggestionParser", () => {
 				fieldName: "fieldname",
 				filters: {
 					folder: "daily",
+					folders: ["daily"],
 					tags: ["work"],
 				},
 				multiSelect: true,
@@ -124,6 +139,7 @@ describe("FieldSuggestionParser", () => {
 				fieldName: "fieldname",
 				filters: {
 					folder: "daily",
+					folders: ["daily"],
 					tags: ["work"],
 				},
 			});
@@ -135,7 +151,10 @@ describe("FieldSuggestionParser", () => {
 			);
 			expect(result).toEqual({
 				fieldName: "fieldname",
-				filters: { folder: "daily/notes/work" },
+				filters: {
+					folder: "daily/notes/work",
+					folders: ["daily/notes/work"],
+				},
 			});
 		});
 
@@ -195,6 +214,7 @@ describe("FieldSuggestionParser", () => {
 				fieldName: "fieldname",
 				filters: {
 					folder: "active",
+					folders: ["active"],
 					tags: ["project"],
 					excludeFolders: ["archive"],
 					defaultValue: "Planning",

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -5,7 +5,13 @@ import {
 } from "./pipeSyntax";
 
 export interface FieldFilter {
+	/**
+	 * Legacy single-folder include. Kept for compatibility with existing callers.
+	 * New code should read both this and `folders`; repeated `folder:` filters
+	 * populate `folders` and mean "any of these folders".
+	 */
 	folder?: string;
+	folders?: string[];
 	tags?: string[];
 	inline?: boolean;
 	inlineCodeBlocks?: string[];
@@ -54,7 +60,13 @@ export class FieldSuggestionParser {
 					multiSelect = parseBooleanFlag(filterValue);
 					break;
 				case "folder":
-					filters.folder = filterValue;
+					if (!filters.folders) {
+						filters.folders = [];
+					}
+					filters.folders.push(filterValue);
+					if (!filters.folder) {
+						filters.folder = filterValue;
+					}
 					break;
 				case "tag": {
 					if (!filters.tags) {

--- a/src/utils/FieldValueCollector.ts
+++ b/src/utils/FieldValueCollector.ts
@@ -9,6 +9,9 @@ import { InlineFieldParser } from "./InlineFieldParser";
 export function generateFieldCacheKey(filters: FieldFilter): string {
 	const parts: string[] = [];
 	if (filters.folder) parts.push(`folder:${filters.folder}`);
+	if (filters.folders?.length) {
+		parts.push(`folders:${filters.folders.join(",")}`);
+	}
 	if (filters.tags) parts.push(`tags:${filters.tags.join(",")}`);
 	if (filters.inline) parts.push("inline:true");
 	if (filters.inlineCodeBlocks?.length) {
@@ -81,10 +84,7 @@ export async function collectFieldValuesRaw(
 			const dvValues = await DataviewIntegration.getFieldValuesWithFilter(
 				app,
 				fieldName,
-				filters.folder,
-				filters.tags,
-				filters.excludeFolders,
-				filters.excludeTags,
+				filters,
 			);
 			if (dvValues.size > 0) return dvValues;
 		}
@@ -98,6 +98,7 @@ export async function collectFieldValuesRaw(
 async function collectTagValues(app: App, filters: FieldFilter): Promise<Set<string>> {
 	const hasFileFilters =
 		Boolean(filters.folder) ||
+		Boolean(filters.folders?.length) ||
 		Boolean(filters.tags?.length) ||
 		Boolean(filters.excludeFolders?.length) ||
 		Boolean(filters.excludeTags?.length) ||

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -53,7 +53,7 @@ export class TemplatePropertyCollector {
     const propertyKeyMatch = lineContent.match(/^\s*([^:]+):/);
     const fallbackPathKey = propertyKeyMatch ? propertyKeyMatch[1].trim() : fallbackKey;
 
-	const listItemPattern = /^-\s*['"]?\{\{(?:VALUE|FIELD):[^}]+\}\}['"]?\s*$/i;
+	const listItemPattern = /^-\s*['"]?\{\{(?:VALUE|FIELD|FILE):[^}]+\}\}['"]?\s*$/i;
     let propertyPath: string[] | null = null;
 
     if (context.isKeyValuePosition) {

--- a/src/utils/captureFileFilterTarget.test.ts
+++ b/src/utils/captureFileFilterTarget.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { parseCaptureFileFilterTarget } from "./captureFileFilterTarget";
+
+describe("parseCaptureFileFilterTarget", () => {
+	it("parses a hashtag target with additional tag filters", () => {
+		expect(parseCaptureFileFilterTarget("#work|tag:project")).toEqual({
+			filter: { tags: ["work", "project"] },
+			multiSelect: false,
+		});
+	});
+
+	it("parses tag: filters without requiring a leading #", () => {
+		expect(parseCaptureFileFilterTarget("tag:work|tag:#project")).toEqual({
+			filter: { tags: ["work", "project"] },
+			multiSelect: false,
+		});
+	});
+
+	it("parses repeated folders as an include union", () => {
+		expect(
+			parseCaptureFileFilterTarget(
+				"folder:Goals|folder:Projects|tag:active",
+			),
+		).toEqual({
+			filter: {
+				folder: "Goals",
+				folders: ["Goals", "Projects"],
+				tags: ["active"],
+			},
+			multiSelect: false,
+		});
+	});
+
+	it("does not parse literal paths", () => {
+		expect(parseCaptureFileFilterTarget("Projects/Alpha.md")).toBeNull();
+	});
+
+	it("reports but does not apply multi-select semantics", () => {
+		expect(parseCaptureFileFilterTarget("tag:work|multi")).toEqual({
+			filter: { tags: ["work"] },
+			multiSelect: true,
+		});
+	});
+});

--- a/src/utils/captureFileFilterTarget.ts
+++ b/src/utils/captureFileFilterTarget.ts
@@ -1,0 +1,90 @@
+import {
+	FieldSuggestionParser,
+	type FieldFilter,
+} from "./FieldSuggestionParser";
+import { parsePipeKeyValue, splitPipeParts } from "./pipeSyntax";
+
+export interface CaptureFileFilterTarget {
+	filter: FieldFilter;
+	multiSelect: boolean;
+}
+
+const FILTER_KEYS = new Set([
+	"folder",
+	"tag",
+	"exclude-folder",
+	"exclude-tag",
+	"exclude-file",
+]);
+
+function mergeTags(first: string | undefined, rest: string[] | undefined): string[] | undefined {
+	const tags = [first, ...(rest ?? [])]
+		.filter((tag): tag is string => typeof tag === "string")
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+	return tags.length > 0 ? tags : undefined;
+}
+
+function parsePipeFilters(input: string): CaptureFileFilterTarget {
+	const parsed = FieldSuggestionParser.parse(`__capture_scope|${input}`);
+	return {
+		filter: parsed.filters,
+		multiSelect: parsed.multiSelect ?? false,
+	};
+}
+
+function hasFileFilter(filter: FieldFilter): boolean {
+	return Boolean(
+		filter.folder ||
+			filter.folders?.length ||
+			filter.tags?.length ||
+			filter.excludeFolders?.length ||
+			filter.excludeTags?.length ||
+			filter.excludeFiles?.length,
+	);
+}
+
+/**
+ * Parses Capture "Capture to" file-filter targets:
+ *
+ * - `#work|tag:project`
+ * - `tag:work|tag:project`
+ * - `folder:Goals|folder:Projects|tag:active`
+ *
+ * `property:` targets are intentionally parsed elsewhere before this helper.
+ */
+export function parseCaptureFileFilterTarget(
+	raw: string,
+): CaptureFileFilterTarget | null {
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+
+	if (trimmed.startsWith("#")) {
+		const parts = splitPipeParts(trimmed);
+		const tag = (parts.shift() ?? "")
+			.replace(/^#/, "")
+			.replace(/\.md$/i, "")
+			.trim();
+		if (!tag) return null;
+
+		const parsed = parts.length > 0
+			? parsePipeFilters(parts.join("|"))
+			: { filter: {}, multiSelect: false };
+		return {
+			filter: {
+				...parsed.filter,
+				tags: mergeTags(tag, parsed.filter.tags),
+			},
+			multiSelect: parsed.multiSelect,
+		};
+	}
+
+	const firstPart = splitPipeParts(trimmed)[0] ?? "";
+	const parsedFirstPart = parsePipeKeyValue(firstPart);
+	if (!parsedFirstPart || !FILTER_KEYS.has(parsedFirstPart.key)) {
+		return null;
+	}
+
+	const parsed = parsePipeFilters(trimmed);
+	return hasFileFilter(parsed.filter) ? parsed : null;
+}

--- a/src/utils/fileSyntax.test.ts
+++ b/src/utils/fileSyntax.test.ts
@@ -39,6 +39,12 @@ describe("parseFileToken", () => {
 		expect(parsed?.allowCustomInput).toBe(true);
 	});
 
+	it("parses multi-select as FILE behavior", () => {
+		const parsed = parseFileToken("People|multi");
+		expect(parsed?.multiSelect).toBe(true);
+		expect(parsed?.variableKey).toContain("|multi");
+	});
+
 	it("parses label and the |name: alias", () => {
 		const parsed = parseFileToken("People|link|label:Pick a person|name:reviewer");
 		expect(parsed?.label).toBe("Pick a person");
@@ -199,11 +205,27 @@ describe("buildFileDisplayLabels", () => {
 		expect(labels).toEqual(["Tom", "Jack"]);
 	});
 
-	it("disambiguates duplicate basenames with the parent folder", () => {
+	it("disambiguates duplicate labels with the parent folder", () => {
 		const labels = buildFileDisplayLabels([
 			makeFile("Companies/Apple.md"),
 			makeFile("Fruits/Apple.md"),
 		]);
-		expect(labels).toEqual(["Apple (Companies)", "Apple (Fruits)"]);
+		expect(labels).toEqual(["Apple - Companies", "Apple - Fruits"]);
+	});
+
+	it("prefers frontmatter title and keeps basename searchable", () => {
+		const file = makeFile("People/01HX.md");
+		const labels = buildFileDisplayLabels([file], () => ({
+			frontmatter: { title: "Ada Lovelace" },
+		} as never));
+		expect(labels).toEqual(["Ada Lovelace (01HX)"]);
+	});
+
+	it("falls back to the first H1 when no title property exists", () => {
+		const file = makeFile("People/01HX.md");
+		const labels = buildFileDisplayLabels([file], () => ({
+			headings: [{ heading: "Ada Lovelace", level: 1 }],
+		} as never));
+		expect(labels).toEqual(["Ada Lovelace (01HX)"]);
 	});
 });

--- a/src/utils/fileSyntax.ts
+++ b/src/utils/fileSyntax.ts
@@ -54,6 +54,13 @@ function normalizeFolder(path: string): string {
  */
 function buildFileScopeSignature(folderPath: string, filter: FieldFilter): string {
 	const parts = [`folder=${normalizeFolder(folderPath)}`];
+	if (filter.folders?.length)
+		parts.push(
+			`folders=${[...filter.folders]
+				.map(normalizeFolder)
+				.sort()
+				.join(",")}`,
+		);
 	if (filter.tags?.length)
 		parts.push(`tags=${[...filter.tags].sort().join(",")}`);
 	if (filter.excludeFolders?.length)

--- a/src/utils/fileSyntax.ts
+++ b/src/utils/fileSyntax.ts
@@ -1,4 +1,4 @@
-import type { TFile } from "obsidian";
+import type { CachedMetadata, TFile } from "obsidian";
 import {
 	FieldSuggestionParser,
 	type FieldFilter,
@@ -36,6 +36,8 @@ export type ParsedFileToken = {
 	allowCustomInput: boolean;
 	/** Reuses the FIELD file filter so folder/tag/exclude-* behave identically. */
 	filter: FieldFilter;
+	/** Pick several files and store/render them as a list. */
+	multiSelect: boolean;
 	/** Variables-map key. Full token identity by default; `|name:` shares it. */
 	variableKey: string;
 };
@@ -89,9 +91,10 @@ function buildFileSignature(parsed: {
 	label?: string;
 	optional: boolean;
 	allowCustomInput: boolean;
+	multiSelect: boolean;
 	filter: FieldFilter;
 }): string {
-	const { folderPath, mode, label, optional, allowCustomInput, filter } =
+	const { folderPath, mode, label, optional, allowCustomInput, multiSelect, filter } =
 		parsed;
 	const parts = [
 		buildFileScopeSignature(folderPath, filter),
@@ -100,6 +103,7 @@ function buildFileSignature(parsed: {
 	if (label) parts.push(`label=${label}`);
 	if (optional) parts.push("optional");
 	if (allowCustomInput) parts.push("custom");
+	if (multiSelect) parts.push("multi");
 	return parts.join("|");
 }
 
@@ -132,6 +136,10 @@ export function parseFileToken(raw: string): ParsedFileToken | null {
 	remaining = customResult.remaining;
 	const allowCustomInput = customResult.found;
 
+	const multiResult = extractBareFlagPart(remaining, "multi");
+	remaining = multiResult.remaining;
+	const bareMultiSelect = multiResult.found;
+
 	let mode: FileMode = "name";
 	const afterMode: string[] = [];
 	for (const part of remaining) {
@@ -159,6 +167,7 @@ export function parseFileToken(raw: string): ParsedFileToken | null {
 	// segment is the folder, so any `|folder:` sub-option the parser picks up is
 	// intentionally discarded below (the positional folder always wins).
 	const fieldParsed = FieldSuggestionParser.parse(raw);
+	const multiSelect = bareMultiSelect || (fieldParsed.multiSelect ?? false);
 	const filter: FieldFilter = {
 		folder: folderPath,
 		tags: fieldParsed.filters.tags,
@@ -173,13 +182,14 @@ export function parseFileToken(raw: string): ParsedFileToken | null {
 	// must not silently reuse each other's pick. Mode/label/optional/custom are
 	// intentionally NOT in the alias key, so one pick renders across modes.
 	const variableKey = aliasName
-		? `${FILE_VARIABLE_PREFIX}name=${aliasName}|${buildFileScopeSignature(folderPath, filter)}`
+		? `${FILE_VARIABLE_PREFIX}name=${aliasName}|${buildFileScopeSignature(folderPath, filter)}${multiSelect ? "|multi" : ""}`
 		: `${FILE_VARIABLE_PREFIX}${buildFileSignature({
 				folderPath,
 				mode,
 				label,
 				optional,
 				allowCustomInput,
+				multiSelect,
 				filter,
 			})}`;
 
@@ -192,6 +202,7 @@ export function parseFileToken(raw: string): ParsedFileToken | null {
 		optional,
 		allowCustomInput,
 		filter,
+		multiSelect,
 		variableKey,
 	};
 }
@@ -238,20 +249,85 @@ export function fileBasenameFromPath(value: string): string {
 	return segment.replace(/\.(md|canvas|base)$/i, "");
 }
 
-/**
- * Display labels for a folder's files: basenames, with the parent folder
- * appended when a basename is ambiguous within the list so duplicate-named files
- * are still distinguishable in the picker.
- */
-export function buildFileDisplayLabels(files: TFile[]): string[] {
-	const counts = new Map<string, number>();
-	for (const file of files) {
-		counts.set(file.basename, (counts.get(file.basename) ?? 0) + 1);
-	}
-	return files.map((file) => {
-		if ((counts.get(file.basename) ?? 0) <= 1) return file.basename;
-		const parent = file.parent?.path;
-		const where = parent && parent !== "/" ? parent : "vault root";
-		return `${file.basename} (${where})`;
+function scalarTitleValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function frontmatterTitle(frontmatter?: Record<string, unknown>): string | undefined {
+	if (!frontmatter) return undefined;
+	const entry = Object.entries(frontmatter).find(
+		([key]) => key.toLowerCase() === "title",
+	);
+	return entry ? scalarTitleValue(entry[1]) : undefined;
+}
+
+function firstLevelHeading(metadata?: CachedMetadata | null): string | undefined {
+	const heading = metadata?.headings?.find((entry) => entry.level === 1);
+	return scalarTitleValue(heading?.heading);
+}
+
+function parentLabel(file: TFile): string {
+	const parent = file.parent?.path;
+	if (parent && parent !== "/") return parent;
+	if (file.path.includes("/")) return file.path.slice(0, file.path.lastIndexOf("/"));
+	return "vault root";
+}
+
+function basenameFor(file: TFile): string {
+	if (file.basename) return file.basename;
+	return fileBasenameFromPath(file.path);
+}
+
+export interface FileDisplayInfo {
+	primary: string;
+	secondary: string;
+	label: string;
+}
+
+export function buildFileDisplayInfos(
+	files: TFile[],
+	metadataCache?: (file: TFile) => CachedMetadata | null,
+): FileDisplayInfo[] {
+	const baseLabels = files.map((file) => {
+		const metadata = metadataCache?.(file) ?? null;
+		const basename = basenameFor(file);
+		const primary =
+			frontmatterTitle(metadata?.frontmatter as Record<string, unknown> | undefined) ??
+			firstLevelHeading(metadata) ??
+			basename;
+		const label = primary === basename
+			? basename
+			: `${primary} (${basename})`;
+		return { file, primary, label };
 	});
+
+	const counts = new Map<string, number>();
+	for (const { label } of baseLabels) {
+		counts.set(label, (counts.get(label) ?? 0) + 1);
+	}
+
+	return baseLabels.map(({ file, primary, label }) => {
+		const uniqueLabel = (counts.get(label) ?? 0) <= 1
+			? label
+			: `${label} - ${parentLabel(file)}`;
+		return {
+			primary,
+			secondary: file.path,
+			label: uniqueLabel,
+		};
+	});
+}
+
+/**
+ * Display labels for a folder's files: readable title/H1 labels first, with the
+ * basename and parent folder folded in when needed so duplicate labels stay
+ * distinguishable in plain-text suggesters.
+ */
+export function buildFileDisplayLabels(
+	files: TFile[],
+	metadataCache?: (file: TFile) => CachedMetadata | null,
+): string[] {
+	return buildFileDisplayInfos(files, metadataCache).map((info) => info.label);
 }

--- a/src/utils/propertyTarget.test.ts
+++ b/src/utils/propertyTarget.test.ts
@@ -75,7 +75,7 @@ describe("parsePropertyTarget", () => {
 		expect(parsePropertyTarget("property:type=draft|folder:Notes")).toEqual({
 			field: "type",
 			value: "draft",
-			filter: { folder: "Notes" },
+			filter: { folder: "Notes", folders: ["Notes"] },
 		});
 		const parsed = parsePropertyTarget(
 			"property:type=draft|exclude-folder:Archive|exclude-tag:done",

--- a/src/utils/tagNormalizer.test.ts
+++ b/src/utils/tagNormalizer.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+	normalizeFrontmatterTagValues,
+	normalizeTag,
+} from "./tagNormalizer";
+
+describe("tagNormalizer", () => {
+	it("normalizes single tags", () => {
+		expect(normalizeTag("#work")).toBe("work");
+		expect(normalizeTag(" work ")).toBe("work");
+		expect(normalizeTag(1)).toBe("1");
+		expect(normalizeTag(false)).toBe("false");
+	});
+
+	it("ignores null and object-valued tags", () => {
+		expect(normalizeTag(null)).toBe("");
+		expect(normalizeTag(undefined)).toBe("");
+		expect(normalizeTag({ tag: "work" })).toBe("");
+	});
+
+	it("splits scalar frontmatter tags on commas and whitespace", () => {
+		expect(normalizeFrontmatterTagValues("work, project urgent")).toEqual([
+			"work",
+			"project",
+			"urgent",
+		]);
+	});
+
+	it("normalizes arrays without splitting array entries", () => {
+		expect(normalizeFrontmatterTagValues(["#work", "project"])).toEqual([
+			"work",
+			"project",
+		]);
+	});
+
+	it("drops empty and nested object frontmatter tag values", () => {
+		expect(
+			normalizeFrontmatterTagValues(["", "  ", null, { tag: "work" }, "#ok"]),
+		).toEqual(["ok"]);
+	});
+});

--- a/src/utils/tagNormalizer.ts
+++ b/src/utils/tagNormalizer.ts
@@ -1,0 +1,25 @@
+export function normalizeTag(tag: unknown): string {
+	if (tag === null || tag === undefined) return "";
+	if (
+		typeof tag !== "string" &&
+		typeof tag !== "number" &&
+		typeof tag !== "boolean"
+	) {
+		return "";
+	}
+
+	const trimmed = String(tag).trim();
+	return trimmed.startsWith("#") ? trimmed.substring(1).trim() : trimmed;
+}
+
+export function normalizeFrontmatterTagValues(value: unknown): string[] {
+	if (value === null || value === undefined) return [];
+
+	const values = Array.isArray(value)
+		? value
+		: typeof value === "string"
+			? value.split(/,|\s+/)
+			: [value];
+
+	return values.map(normalizeTag).filter(Boolean);
+}

--- a/src/utils/vaultQueries.test.ts
+++ b/src/utils/vaultQueries.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { App, TFile } from "obsidian";
 import {
 	frontmatterValueMatches,
+	getMarkdownFilesMatchingFilter,
 	getMarkdownFilesWithProperty,
+	getMarkdownFilesWithTag,
 } from "./vaultQueries";
 
 describe("frontmatterValueMatches", () => {
@@ -108,5 +110,82 @@ describe("getMarkdownFilesWithProperty", () => {
 			.map((f) => f.path)
 			.sort();
 		expect(paths).toEqual(["Arr D.md", "Draft A.md", "Draft B.md"].sort());
+	});
+
+	it("applies tag pipe filters to scalar frontmatter tags", () => {
+		const tagApp = makeApp([
+			{
+				path: "Draft A.md",
+				basename: "Draft A",
+				frontmatter: { type: "draft", tags: "work, project" },
+			},
+			{
+				path: "Draft B.md",
+				basename: "Draft B",
+				frontmatter: { type: "draft", tags: "work" },
+			},
+			{
+				path: "Note C.md",
+				basename: "Note C",
+				frontmatter: { type: "note", tags: "work, project" },
+			},
+		]);
+
+		const paths = getMarkdownFilesWithProperty(tagApp, "type", "draft", {
+			tags: ["work", "project"],
+		}).map((f) => f.path);
+
+		expect(paths).toEqual(["Draft A.md"]);
+	});
+});
+
+describe("tag-based vault queries", () => {
+	const app = makeApp([
+		{
+			path: "Comma.md",
+			basename: "Comma",
+			frontmatter: { tags: "work, project" },
+		},
+		{
+			path: "Space.md",
+			basename: "Space",
+			frontmatter: { tags: "#work project" },
+		},
+		{
+			path: "Singular.md",
+			basename: "Singular",
+			frontmatter: { tag: "#work, project" },
+		},
+		{
+			path: "Object.md",
+			basename: "Object",
+			frontmatter: { tags: { tag: "work" } },
+		},
+	]);
+
+	it("finds bare tag targets with scalar frontmatter tags", () => {
+		const paths = getMarkdownFilesWithTag(app, "#work").map((f) => f.path);
+
+		expect(paths.sort()).toEqual(
+			["Comma.md", "Singular.md", "Space.md"].sort(),
+		);
+	});
+
+	it("matches compound filters against scalar frontmatter tags", () => {
+		const paths = getMarkdownFilesMatchingFilter(app, {
+			tags: ["work", "project"],
+		}).map((f) => f.path);
+
+		expect(paths.sort()).toEqual(
+			["Comma.md", "Singular.md", "Space.md"].sort(),
+		);
+	});
+
+	it("excludes scalar frontmatter tags", () => {
+		const paths = getMarkdownFilesMatchingFilter(app, {
+			excludeTags: ["project"],
+		}).map((f) => f.path);
+
+		expect(paths).toEqual(["Object.md"]);
 	});
 });

--- a/src/utils/vaultQueries.ts
+++ b/src/utils/vaultQueries.ts
@@ -79,6 +79,17 @@ export function getMarkdownFilesWithTag(app: App, tag: string): TFile[] {
 	});
 }
 
+export function getMarkdownFilesMatchingFilter(
+	app: App,
+	filter: FieldFilter,
+): TFile[] {
+	return EnhancedFieldSuggestionFileFilter.filterFiles(
+		app.vault.getMarkdownFiles(),
+		filter,
+		(file) => app.metadataCache.getFileCache(file),
+	);
+}
+
 /**
  * Whether a frontmatter value equals a (case-insensitive, trimmed) target string.
  * Pure and Obsidian-free so it can be unit-tested directly.

--- a/src/utils/vaultQueries.ts
+++ b/src/utils/vaultQueries.ts
@@ -2,6 +2,10 @@ import type { App, CachedMetadata, TFile } from "obsidian";
 import { TFolder } from "obsidian";
 import { EnhancedFieldSuggestionFileFilter } from "./EnhancedFieldSuggestionFileFilter";
 import type { FieldFilter } from "./FieldSuggestionParser";
+import {
+	normalizeFrontmatterTagValues,
+	normalizeTag,
+} from "./tagNormalizer";
 
 export function getAllFolderPathsInVault(app: App): string[] {
 	return app.vault
@@ -40,14 +44,7 @@ function getFrontmatterTags(fileCache: CachedMetadata): string[] {
 	if (!tagPairs) return [];
 
 	const tags = tagPairs
-		.flatMap(([key, value]) => {
-			if (typeof value === "string") {
-				// separator can either be comma or space separated
-				return value.split(/,|\s+/).map((v) => v.trim());
-			} else if (Array.isArray(value)) {
-				return value as string[];
-			}
-		})
+		.flatMap(([, value]) => normalizeFrontmatterTagValues(value))
 		.filter((v) => !!v) as string[]; // fair to cast after filtering out falsy values
 
 	return tags;
@@ -63,7 +60,7 @@ function getFileTags(app: App, file: TFile): string[] {
 	}
 
 	if (fileCache.tags && Array.isArray(fileCache.tags)) {
-		tagsInFile.push(...fileCache.tags.map((v) => v.tag.replace(/^#/, "")));
+		tagsInFile.push(...fileCache.tags.map((v) => normalizeTag(v.tag)));
 	}
 
 	return tagsInFile;


### PR DESCRIPTION
## Summary

Fixes #528
Fixes #491
Fixes #467

This ships one cohesive file/note suggester improvement instead of three separate surfaces:

- Adds shared compound file filters for Capture targets and field/value collection: repeated `folder:` filters are OR, repeated `tag:` filters are AND, exclusions remove matching files.
- Adds `{{FILE:<folder>|multi}}` for selecting several related files and writing them as structured frontmatter lists where QuickAdd can collect property values.
- Makes file pickers readable for UUID-style note names by showing frontmatter `title`, then first H1, then basename, while storing and writing the real vault path.
- Preserves path/UUID search even when the visible label is a title or heading.
- Adds live Capture To feedback for recognized filter/property target syntax, including a success state for accepted picker syntax and an error state for unsupported capture-target `|multi`.

## Design / tradeoffs

- Capture target selection intentionally remains single-destination. Multi-write capture would change the core Capture invariant and create unclear partial-write/failure behavior. Multi-file selection belongs in the capture/template format via `{{FILE:...|multi}}` for metadata relations.
- Repeated folders are OR because users are describing alternate locations. Repeated tags are AND because users are narrowing to notes that match all requested concepts. This now applies consistently across the shared filter path.
- Friendly display labels are presentation-only. The selected value remains the vault path/encoded file pick, so existing `name`/`link`/`path` output behavior stays backward compatible.
- Existing-note Capture flows still write body text. `{{FILE:...|multi}}` can only become a YAML list when QuickAdd is collecting structured frontmatter/property values; otherwise QuickAdd warns and writes comma-separated text, matching existing multi-select constraints.
- Capture To feedback confirms that QuickAdd recognizes the target syntax; it does not promise matching notes exist, because format syntax and vault metadata can resolve at runtime.
- Ordinary file paths and file-name format syntax keep the existing preview row. Recognized picker syntax hides that preview because rendering it as a path is misleading.

## Validation

- `pnpm run build`
- `pnpm run provision:e2e-vault`
- Isolated Obsidian live validation via `pnpm run obsidian:e2e -- ...`:
  - seeded UUID-named goal/project/person notes in this worktree's isolated vault
  - verified `folder:Goals|folder:Projects|tag:active|tag:work` only suggested matching files
  - verified picker labels used frontmatter title and H1 fallback
  - verified typing a UUID/path segment still found the friendly-labeled note
  - verified capture wrote only to the selected note and not to excluded/unselected notes
  - verified `{{FILE:People|multi|path}}` wrote a YAML frontmatter list
  - verified capture-target `|multi` aborts with guidance to use `{{FILE:...|multi}}`
  - verified the real Capture builder shows a green recognized hint for `folder:QA Suggester/Goals|folder:QA Suggester/Projects|tag:active|tag:work`, hides the target path preview, and does not show the canvas picker
  - verified the real Capture builder shows the runtime-aligned red error for `tag:work|multi`
  - verified `/property:type=draft|folder:QA Suggester/Goals` is recognized in the real Capture builder after leading-slash normalization
  - verified ordinary `Inbox.md` still shows the normal target preview and no success hint
- `pnpm run obsidian:e2e -- dev:errors` -> no errors captured
- `pnpm exec tsc -noEmit -skipLibCheck --pretty false`
- Focused Vitest suites for parsers, filters, FILE formatting, preflight, Capture selection, and Capture To feedback
- `pnpm run check`
- `pnpm test`
- `pnpm run build-with-lint`

## Release / migration impact

No data migration. New syntax is additive. Existing `{{FILE:<folder>}}` output defaults and Capture target behavior remain compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `{{FILE:<folder>|multi}}` multi-select and enhanced **Capture To** support for file-filter destinations using combined `folder:` / `tag:` / `exclude-*:` rules.
  * File pickers now use metadata-aware labels (frontmatter title → first H1 → filename) with better disambiguation.
  * Field suggestions filtering now supports `folders` (OR) for multi-folder selection.
  * QuickAdd API `getFieldValues` now accepts `folders?: string[]` (replacing `folder`).

* **Bug Fixes**
  * Improved filter semantics (folder OR, tag AND, hierarchical tag matching) plus clearer validation/runtime behavior for multi-select.

* **Documentation**
  * Updated format syntax, picker-label behavior, capture-to filtering, and API docs for the new `|multi` and filter combinations.

* **Style**
  * Improved success hint styling for recognized/valid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
