### PR TITLE
fix(preflight): skip multi capture filters as tag targets

### DIFF
--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -469,6 +469,25 @@ describe("collectChoiceRequirements - capture targets", () => {
 			]);
 		});
 
+	it("does not reinterpret multi-select capture target filters as tag targets", async () => {
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createCaptureChoice("#work|multi"),
+		);
+
+		expect(getMarkdownFilesMatchingFilterMock).not.toHaveBeenCalled();
+		expect(getMarkdownFilesWithTagMock).not.toHaveBeenCalled();
+		expect(getMarkdownFilesInFolderMock).not.toHaveBeenCalled();
+		expect(
+			requirements.some(
+				(requirement) =>
+					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			),
+		).toBe(false);
+	});
+
 	it("does not force the dropdown for a tokenized property value", async () => {
 		const requirements = await collectChoiceRequirements(
 			app,

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -281,7 +281,10 @@ async function collectForCaptureChoice(
 			? parseCaptureFileFilterTarget(normalizedTarget)
 			: null;
 	const isFilterTarget = !!fileFilterTarget && !fileFilterTarget.multiSelect;
-	const isTagTarget = !isPropertyTarget && !isFilterTarget && normalizedTarget.startsWith("#");
+	const isTagTarget =
+		!isPropertyTarget &&
+		!fileFilterTarget &&
+		normalizedTarget.startsWith("#");
 	const trimmedPath = normalizedTarget.replace(/\/$|\.md$/g, "");
 	const isFolderTarget =
 		!isTagTarget &&


### PR DESCRIPTION
Follow-up to #1398. Prevents multi-select capture target filters such as `#work|multi` from falling through to the legacy bare-tag preflight path.

The issue was valid against current `master`: `parseCaptureFileFilterTarget` succeeds for `#tag|multi`, but `isFilterTarget` intentionally excludes multi-select filters, so the old `isTagTarget` guard treated the same string as a bare tag and added the internal target-file dropdown. The fix makes tag handling require that no file-filter target parsed at all.

This keeps multi-select capture filters runtime-driven and leaves single-select filters, property targets, folders, and legacy bare `#tag` targets unchanged.

Validation:
- `pnpm test -- src/preflight/collectChoiceRequirements.test.ts`
- `pnpm run lint`
- `pnpm run check` (0 errors; existing 4 warnings in 1 file)
- `pnpm run build`
- Dev vault symlinked to this worktree, `obsidian vault=dev plugin:reload id=quickadd`
- Live dev-vault preflight check: temporary capture choice with `captureTo: "#work|multi"` returned `requiredInputCount: 0` via `obsidian vault=dev quickadd:check id=__qa_preflight_multi_filter_tag`
- `obsidian vault=dev dev:errors` reported no captured errors after cleanup

Release impact: bug fix only; no settings, docs, or migration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where multi-select style capture targets were incorrectly interpreted as tag targets, ensuring proper handling and classification of these input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->