### PR TITLE
feat(capture): copy captured note links to clipboard

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -185,6 +185,12 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
 
     For the **Specified note** destination, choose an existing Markdown file. QuickAdd appends a normal link at the bottom of that file after each successful capture. It does not create the index file, insert under a heading, update properties, or remove duplicate links.
 
+-   _Copy link to clipboard_ copies a link to the captured file after the Capture
+    choice runs. This works separately from _Link to captured file_, so you can
+    copy the link without inserting it into the current note, or do both. The
+    copied link is a vault-path wikilink, which makes it suitable for pasting
+    into another note.
+
 ### Opening the captured file
 
 When _Capture to active file_ is disabled, the **Behavior** section shows an _Open_ toggle (described as "Open the captured file."). Enabling it reveals the shared file-opening controls:

--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -45,9 +45,11 @@ vi.mock("../quickAddSettingsTab", () => {
 
 const {
 	appendFileLinkToDestinationFileMock,
+	copyFileLinkToClipboardMock,
 	getAppendLinkDestinationFileMock,
 } = vi.hoisted(() => ({
 	appendFileLinkToDestinationFileMock: vi.fn(),
+	copyFileLinkToClipboardMock: vi.fn(),
 	getAppendLinkDestinationFileMock: vi.fn(),
 }));
 
@@ -85,6 +87,7 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 
 vi.mock("../utils/fileLinks", () => ({
 	appendFileLinkToDestinationFile: appendFileLinkToDestinationFileMock,
+	copyFileLinkToClipboard: copyFileLinkToClipboardMock,
 	getAppendLinkDestinationFile: getAppendLinkDestinationFileMock,
 }));
 
@@ -227,6 +230,7 @@ describe("CaptureChoiceEngine cancellation notices", () => {
 		settingsStore.setState(structuredClone(defaultSettingsState));
 		noticeClass.instances.length = 0;
 		appendFileLinkToDestinationFileMock.mockReset();
+		copyFileLinkToClipboardMock.mockReset();
 		getAppendLinkDestinationFileMock.mockReset();
 	});
 
@@ -343,6 +347,8 @@ describe("CaptureChoiceEngine append-link destination", () => {
 		noticeClass.instances.length = 0;
 		appendFileLinkToDestinationFileMock.mockReset();
 		appendFileLinkToDestinationFileMock.mockResolvedValue(true);
+		copyFileLinkToClipboardMock.mockReset();
+		copyFileLinkToClipboardMock.mockResolvedValue(true);
 		getAppendLinkDestinationFileMock.mockReset();
 	});
 
@@ -393,11 +399,48 @@ describe("CaptureChoiceEngine append-link destination", () => {
 		return {
 			app,
 			captureFile,
+			choice,
 			destinationFile,
 			choiceExecutor,
 			engine: new CaptureChoiceEngine(app, plugin, choice, choiceExecutor),
 		};
 	}
+
+	it("copies the captured file link after committing without append-link insertion", async () => {
+		const { app, captureFile, choice, choiceExecutor, engine } =
+			createAppendLinkHarness();
+		choice.appendLink = false;
+		choice.copyLinkToClipboard = true;
+
+		await engine.run();
+
+		expect(app.vault.modify).toHaveBeenCalledWith(captureFile, "");
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: captureFile,
+		});
+		expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(captureFile);
+		expect(appendFileLinkToDestinationFileMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps capture execution successful when clipboard copying throws", async () => {
+		const { app, captureFile, choice, choiceExecutor, engine } =
+			createAppendLinkHarness();
+		choice.appendLink = false;
+		choice.copyLinkToClipboard = true;
+		copyFileLinkToClipboardMock.mockRejectedValueOnce(
+			new Error("clipboard denied"),
+		);
+
+		await engine.run();
+
+		expect(app.vault.modify).toHaveBeenCalledWith(captureFile, "");
+		expect(copyFileLinkToClipboardMock).toHaveBeenCalledWith(captureFile);
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({
+			status: "success",
+			file: captureFile,
+		});
+	});
 
 	it("appends the captured file link to a specified destination without an active editor", async () => {
 		const { app, captureFile, destinationFile, choiceExecutor, engine } =
@@ -422,7 +465,8 @@ describe("CaptureChoiceEngine append-link destination", () => {
 	});
 
 	it("does not write the capture when a specified append-link destination is missing", async () => {
-		const { app, engine, choiceExecutor } = createAppendLinkHarness();
+		const { app, choice, engine, choiceExecutor } = createAppendLinkHarness();
+		choice.copyLinkToClipboard = true;
 		getAppendLinkDestinationFileMock.mockReturnValue(null);
 
 		await engine.run();
@@ -431,5 +475,6 @@ describe("CaptureChoiceEngine append-link destination", () => {
 		expect(app.vault.modify).not.toHaveBeenCalled();
 		expect(choiceExecutor.recordExecutionResult).not.toHaveBeenCalled();
 		expect(appendFileLinkToDestinationFileMock).not.toHaveBeenCalled();
+		expect(copyFileLinkToClipboardMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -57,6 +57,7 @@ import type { FieldFilter } from "../utils/FieldSuggestionParser";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import {
 	appendFileLinkToDestinationFile,
+	copyFileLinkToClipboard,
 	getAppendLinkDestinationFile,
 } from "../utils/fileLinks";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
@@ -262,6 +263,22 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		}
 
 		await insertFileLinkToActiveView(this.app, file, linkOptions);
+	}
+
+	private async copyCapturedFileLinkToClipboard(file: TFile): Promise<void> {
+		if (!this.choice.copyLinkToClipboard) {
+			return;
+		}
+
+		try {
+			await copyFileLinkToClipboard(file);
+		} catch (error) {
+			log.logWarning(
+				`Could not copy link to clipboard for '${file.path}': ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
 	}
 
 	private validateAppendLinkDestination(
@@ -506,6 +523,8 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				});
 			}
 
+			await this.copyCapturedFileLinkToClipboard(file);
+
 			await this.insertCaptureLink(file, linkOptions, {
 				isCanvasTriggered: !!canvasTarget,
 			});
@@ -642,6 +661,8 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				action,
 			});
 		}
+
+		await this.copyCapturedFileLinkToClipboard(file);
 
 		await this.insertCaptureLink(file, linkOptions, {
 			isCanvasTriggered: true,

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -127,6 +127,17 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 
 <SettingItem name="Linking" heading />
 <AppendLinkSetting bind:appendLink={choice.appendLink} fileLabel="captured" {app} />
+<SettingItem
+	name="Copy link to clipboard"
+	desc="Copy a link to the captured file after the Capture choice runs."
+>
+	{#snippet control()}
+		<Toggle
+			checked={choice.copyLinkToClipboard ?? false}
+			onchange={(value) => (choice.copyLinkToClipboard = value)}
+		/>
+	{/snippet}
+</SettingItem>
 
 <SettingItem name="Content" heading />
 <SettingItem name="Task" desc="Formats the value as a task.">

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -76,6 +76,15 @@ function selectUnderSetting(
 	return item?.querySelector("select") as HTMLSelectElement;
 }
 
+function settingItem(container: HTMLElement, name: string): HTMLElement {
+	const item = Array.from(container.querySelectorAll(".setting-item")).find(
+		(el) =>
+			el.querySelector(".setting-item-name")?.textContent?.trim() === name,
+	);
+	if (!item) throw new Error(`Setting item not found: ${name}`);
+	return item as HTMLElement;
+}
+
 function choiceIconInput(container: HTMLElement): HTMLInputElement {
 	const el = container.querySelector<HTMLInputElement>(
 		'input[aria-label="Choice icon"]',
@@ -202,6 +211,20 @@ describe("CaptureChoiceForm", () => {
 		const { container } = mountForm();
 
 		expect(settingNames(container).at(-1)).toBe("Icon");
+	});
+
+	it("persists the copy-link-to-clipboard toggle", async () => {
+		const { container, props } = mountForm();
+		expect(props.choice.copyLinkToClipboard).toBeUndefined();
+
+		const toggle = settingItem(container, "Copy link to clipboard").querySelector(
+			".checkbox-container",
+		) as HTMLElement;
+		await fireEvent.click(toggle);
+		flushSync();
+
+		expect(props.choice.copyLinkToClipboard).toBe(true);
+		expect(toggle.classList.contains("is-enabled")).toBe(true);
 	});
 
 	it("shows recognized feedback and hides the path preview for picker filter targets", async () => {

--- a/src/types/choices/CaptureChoice.ts
+++ b/src/types/choices/CaptureChoice.ts
@@ -11,6 +11,7 @@ import { normalizeFileOpening } from "../../utils/fileOpeningDefaults";
 
 export class CaptureChoice extends Choice implements ICaptureChoice {
 	appendLink: boolean | AppendLinkOptions;
+	copyLinkToClipboard: boolean;
 	captureTo: string;
 	captureToActiveFile: boolean;
 	captureToCanvasNodeId: string;
@@ -62,6 +63,7 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 		super(name, "Capture");
 
 		this.appendLink = false;
+		this.copyLinkToClipboard = false;
 		this.captureTo = "";
 		this.captureToActiveFile = false;
 		this.captureToCanvasNodeId = "";

--- a/src/types/choices/ICaptureChoice.ts
+++ b/src/types/choices/ICaptureChoice.ts
@@ -51,6 +51,8 @@ export default interface ICaptureChoice extends IChoice {
 		* - AppendLinkOptions: New format with configurable placement options
 		*/
 	appendLink: boolean | AppendLinkOptions;
+	/** Copy a link to the captured file after the capture runs. */
+	copyLinkToClipboard?: boolean;
 	task: boolean;
 	insertAfter: {
 		enabled: boolean;


### PR DESCRIPTION
Add Capture parity for copying the captured file link to the clipboard.

Templates already had a separate `copyLinkToClipboard` post-commit option. Capture shared the append-link insertion UI, but had no equivalent persisted setting or runtime side effect, so a Capture choice could create the target note while leaving the clipboard unchanged. This adds the same choice-level option to Capture and runs the existing `copyFileLinkToClipboard` helper only after the capture content is committed and success is recorded.

I kept this outside `AppendLinkOptions` because append-link placement models writing into a note/editor or specified destination. Clipboard copy is an independent post-commit side effect, so Capture now mirrors Template's separate option instead of overloading link insertion settings.

Live isolated-vault evidence:
- Pre-change Template choice with `copyLinkToClipboard: true`: created `__qa_clipboard_parity_prechange/template-created.md`, active note stayed `ACTIVE BEFORE`, clipboard became `[[__qa_clipboard_parity_prechange/template-created]]`.
- Pre-change Capture choice with the same seeded field: created `__qa_clipboard_parity_prechange/capture-created.md`, active note stayed `ACTIVE BEFORE`, clipboard stayed `CAPTURE_SENTINEL_CONFIRMED`.
- Post-change Template choice: created `__qa_clipboard_parity_postchange/template-created.md`, active note stayed `ACTIVE POSTCHANGE BEFORE`, clipboard became `[[__qa_clipboard_parity_postchange/template-created]]`.
- Post-change Capture choice: created `__qa_clipboard_parity_postchange/capture-created.md`, active note stayed `ACTIVE POSTCHANGE BEFORE`, clipboard became `[[__qa_clipboard_parity_postchange/capture-created]]`.
- `pnpm run obsidian:e2e -- dev:errors`: no errors captured.

Verification:
- `pnpm run build`
- `pnpm run provision:e2e-vault`
- `pnpm exec vitest run --config vitest.config.mts src/engine/CaptureChoiceEngine.notice.test.ts src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts`
- `pnpm exec tsc -noEmit -skipLibCheck`
- `pnpm run lint`
- `pnpm run check` (0 errors, 4 warnings in existing file)
- `pnpm test`
- `pnpm run build-with-lint`

Refs audit item #3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy link to clipboard" option in capture settings that automatically copies a wikilink to the captured file to your clipboard after capture, independent of the "Link to captured file" setting.

* **Documentation**
  * Updated capture options documentation to describe the new clipboard copy feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->