### PR TITLE
fix(template): merge frontmatter when appending templates

### DIFF
--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -134,6 +134,13 @@ These options modify the existing markdown, canvas, or base file:
 - **Append to top**: Adds the template content to the beginning of the existing file
 - **Overwrite file**: Replaces the existing file content with the template
 
+For markdown files, **Append to bottom** and **Append to top** handle template
+frontmatter the same way as [Apply Template to Note](/ApplyTemplateToNote.md):
+the template's frontmatter properties are merged into the existing note instead
+of inserting a second `---` block. Existing note values win, and missing or
+empty properties are filled from the template. Canvas and base files receive the
+template content as-is.
+
 ### Create Another File
 
 These options keep the existing file untouched and create a new file instead:

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -43,8 +43,14 @@ vi.mock("../quickAddSettingsTab", () => {
 	};
 });
 
-const { formatFileNameMock, formatFileContentMock, formatTemplatePathMock } =
-	vi.hoisted(() => {
+const {
+	formatFileNameMock,
+	formatFileContentMock,
+	formatTemplatePathMock,
+	templateInsertApplyMock,
+	templateInsertConstructorMock,
+	templateInsertSetLinkToCurrentFileBehaviorMock,
+} = vi.hoisted(() => {
 		const formatName =
 			vi.fn<(format: string, prompt: string) => Promise<string>>();
 		const formatContent = vi
@@ -60,6 +66,9 @@ const { formatFileNameMock, formatFileContentMock, formatTemplatePathMock } =
 			formatFileNameMock: formatName,
 			formatFileContentMock: formatContent,
 			formatTemplatePathMock: formatPath,
+			templateInsertApplyMock: vi.fn(),
+			templateInsertConstructorMock: vi.fn(),
+			templateInsertSetLinkToCurrentFileBehaviorMock: vi.fn(),
 		};
 	});
 
@@ -110,6 +119,24 @@ vi.mock("../main", () => ({
 	default: class QuickAddMock {},
 }));
 
+vi.mock("./TemplateInsertEngine", () => {
+	class TemplateInsertEngineMock {
+		constructor(...args: unknown[]) {
+			templateInsertConstructorMock(...args);
+		}
+
+		setLinkToCurrentFileBehavior(behavior: "required" | "optional") {
+			templateInsertSetLinkToCurrentFileBehaviorMock(behavior);
+		}
+
+		async apply() {
+			return await templateInsertApplyMock();
+		}
+	}
+
+	return { TemplateInsertEngine: TemplateInsertEngineMock };
+});
+
 vi.mock("obsidian-dataview", () => ({
 	getAPI: vi.fn(),
 }));
@@ -149,12 +176,12 @@ const createTemplateChoice = (): ITemplateChoice => ({
 	fileExistsBehavior: { kind: "prompt" },
 });
 
-const createExistingFile = (path: string) => {
+const createExistingFile = (path: string, extension = "md") => {
 	const file = new TFile();
 	file.path = path;
 	file.name = path.split("/").pop() ?? path;
-	file.extension = "md";
-	file.basename = file.name.replace(/\.md$/, "");
+	file.extension = extension;
+	file.basename = file.name.replace(new RegExp(`\\.${extension}$`), "");
 	return file;
 };
 
@@ -193,9 +220,10 @@ const createEngine = () => {
 		consumeAbortSignal: vi.fn(),
 	};
 
+	const plugin = { settings: settingsStore.getState() } as any;
 	const engine = new TemplateChoiceEngine(
 		app,
-		{ settings: settingsStore.getState() } as any,
+		plugin,
 		createTemplateChoice(),
 		choiceExecutor,
 	);
@@ -203,7 +231,7 @@ const createEngine = () => {
 	formatFileNameMock.mockResolvedValue("Test Template");
 	formatFileContentMock.mockResolvedValue("");
 
-	return { app, engine };
+	return { app, engine, choiceExecutor, plugin };
 };
 
 describe("TemplateChoiceEngine collision behavior", () => {
@@ -213,6 +241,9 @@ describe("TemplateChoiceEngine collision behavior", () => {
 		formatFileContentMock.mockReset();
 		formatTemplatePathMock.mockReset();
 		formatTemplatePathMock.mockImplementation(async (input: string) => input);
+		templateInsertApplyMock.mockReset();
+		templateInsertConstructorMock.mockReset();
+		templateInsertSetLinkToCurrentFileBehaviorMock.mockReset();
 		vi.mocked(GenericSuggester.Suggest).mockReset();
 	});
 
@@ -512,6 +543,112 @@ describe("TemplateChoiceEngine collision behavior", () => {
 		expect(createSpy).toHaveBeenCalledWith(
 			"Test Template (1).md",
 			engine.choice.templatePath,
+		);
+	});
+
+	it.each([
+		["appendTop", "top"],
+		["appendBottom", "bottom"],
+	] as const)(
+		"delegates markdown %s collisions to TemplateInsertEngine",
+		async (mode, position) => {
+			const { app, choiceExecutor, engine, plugin } = createEngine();
+			const existingFile = createExistingFile("Test Template.md");
+			engine.choice.fileExistsBehavior = { kind: "apply", mode };
+
+			(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(
+				true,
+			);
+			(app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(
+				existingFile,
+			);
+			templateInsertApplyMock.mockResolvedValue(existingFile);
+
+			const rawAppendSpy = vi.spyOn(
+				engine as unknown as {
+					appendToFileWithTemplate: () => Promise<TFile | null>;
+				},
+				"appendToFileWithTemplate",
+			);
+
+			await engine.run();
+
+			expect(rawAppendSpy).not.toHaveBeenCalled();
+			expect(templateInsertConstructorMock).toHaveBeenCalledWith(
+				app,
+				plugin,
+				existingFile,
+				engine.choice.templatePath,
+				position,
+				choiceExecutor,
+				engine.choice.templatePath,
+			);
+			expect(templateInsertSetLinkToCurrentFileBehaviorMock).toHaveBeenCalledWith(
+				"required",
+			);
+			expect(templateInsertApplyMock).toHaveBeenCalledTimes(1);
+		},
+	);
+
+	it("preserves optional LINKCURRENT behavior when append-link does not require an active file", async () => {
+		const { app, engine } = createEngine();
+		const existingFile = createExistingFile("Test Template.md");
+		engine.choice.fileExistsBehavior = { kind: "apply", mode: "appendBottom" };
+		engine.choice.appendLink = {
+			enabled: true,
+			requireActiveFile: false,
+			placement: "newLine",
+			destination: { type: "activeFile" },
+		};
+
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(
+			true,
+		);
+		(app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(
+			existingFile,
+		);
+		templateInsertApplyMock.mockResolvedValue(existingFile);
+
+		await engine.run();
+
+		expect(templateInsertSetLinkToCurrentFileBehaviorMock).toHaveBeenCalledWith(
+			"optional",
+		);
+	});
+
+	it("keeps non-markdown append collisions on the raw append path", async () => {
+		const { app, engine } = createEngine();
+		const existingFile = createExistingFile("Test Board.canvas", "canvas");
+		engine.choice.fileExistsBehavior = { kind: "apply", mode: "appendTop" };
+
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(
+			true,
+		);
+		(app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(
+			existingFile,
+		);
+
+		const rawAppendSpy = vi
+			.spyOn(
+				engine as unknown as {
+					appendToFileWithTemplate: (
+						file: TFile,
+						templatePath: string,
+						position: "top" | "bottom",
+					) => Promise<TFile | null>;
+				},
+				"appendToFileWithTemplate",
+			)
+			.mockResolvedValue(existingFile);
+
+		await engine.run();
+
+		expect(templateInsertConstructorMock).not.toHaveBeenCalled();
+		expect(templateInsertSetLinkToCurrentFileBehaviorMock).not.toHaveBeenCalled();
+		expect(rawAppendSpy).toHaveBeenCalledWith(
+			existingFile,
+			engine.choice.templatePath,
+			"top",
 		);
 	});
 

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -47,6 +47,7 @@ const {
 	formatFileNameMock,
 	formatFileContentMock,
 	formatTemplatePathMock,
+	getAnonymousValueMock,
 	templateInsertApplyMock,
 	templateInsertConstructorMock,
 	templateInsertSetLinkToCurrentFileBehaviorMock,
@@ -66,6 +67,7 @@ const {
 			formatFileNameMock: formatName,
 			formatFileContentMock: formatContent,
 			formatTemplatePathMock: formatPath,
+			getAnonymousValueMock: vi.fn<() => string | undefined>(),
 			templateInsertApplyMock: vi.fn(),
 			templateInsertConstructorMock: vi.fn(),
 			templateInsertSetLinkToCurrentFileBehaviorMock: vi.fn(),
@@ -86,6 +88,9 @@ vi.mock("../formatters/completeFormatter", () => {
 		}
 		async formatTemplateFilePath(input: string) {
 			return formatTemplatePathMock(input);
+		}
+		getAnonymousValue() {
+			return getAnonymousValueMock();
 		}
 		getAndClearTemplatePropertyVars() {
 			return new Map<string, unknown>();
@@ -241,6 +246,7 @@ describe("TemplateChoiceEngine collision behavior", () => {
 		formatFileContentMock.mockReset();
 		formatTemplatePathMock.mockReset();
 		formatTemplatePathMock.mockImplementation(async (input: string) => input);
+		getAnonymousValueMock.mockReset();
 		templateInsertApplyMock.mockReset();
 		templateInsertConstructorMock.mockReset();
 		templateInsertSetLinkToCurrentFileBehaviorMock.mockReset();
@@ -589,6 +595,29 @@ describe("TemplateChoiceEngine collision behavior", () => {
 			expect(templateInsertApplyMock).toHaveBeenCalledTimes(1);
 		},
 	);
+
+	it("carries the resolved anonymous VALUE into markdown append collisions", async () => {
+		const { app, choiceExecutor, engine } = createEngine();
+		const existingFile = createExistingFile("Test Template.md");
+		engine.choice.fileExistsBehavior = { kind: "apply", mode: "appendBottom" };
+		getAnonymousValueMock.mockReturnValue("Prompted file name");
+
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(
+			true,
+		);
+		(app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(
+			existingFile,
+		);
+		templateInsertApplyMock.mockImplementation(async () => {
+			expect(choiceExecutor.variables.get("value")).toBe("Prompted file name");
+			return existingFile;
+		});
+
+		await engine.run();
+
+		expect(choiceExecutor.variables.has("value")).toBe(false);
+		expect(templateInsertApplyMock).toHaveBeenCalledTimes(1);
+	});
 
 	it("preserves optional LINKCURRENT behavior when append-link does not require an active file", async () => {
 		const { app, engine } = createEngine();

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -43,6 +43,7 @@ import {
 import { appendLinkToFrontmatterProperty } from "../utils/frontmatterPropertyLinks";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { TemplateEngine } from "./TemplateEngine";
+import { TemplateInsertEngine } from "./TemplateInsertEngine";
 import { UserCancelError } from "../errors/UserCancelError";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { parentFolderPath } from "../utils/pathUtils";
@@ -188,6 +189,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					targetFilePath,
 					existingFile,
 					templatePath,
+					linkOptions,
 				));
 				if (!createdFile) {
 					InputPromptDraftStore.getInstance().markExecutionScopeFailed();
@@ -352,6 +354,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		targetFilePath: string,
 		existingFile: TFile | null,
 		templatePath: string,
+		linkOptions: NormalizedAppendLinkOptions,
 	): Promise<{ createdFile: TFile | null; shouldAutoOpen: boolean }> {
 		const mode = getFileExistsMode(modeId);
 
@@ -362,6 +365,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 						mode.id,
 						existingFile!,
 						templatePath,
+						linkOptions,
 					),
 					shouldAutoOpen: false,
 				};
@@ -406,19 +410,22 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		modeId: "appendTop" | "appendBottom" | "overwrite",
 		existingFile: TFile,
 		templatePath: string,
+		linkOptions: NormalizedAppendLinkOptions,
 	): Promise<TFile | null> {
 		switch (modeId) {
 			case "appendTop":
-				return await this.appendToFileWithTemplate(
+				return await this.appendToExistingFileWithTemplate(
 					existingFile,
 					templatePath,
 					"top",
+					linkOptions,
 				);
 			case "appendBottom":
-				return await this.appendToFileWithTemplate(
+				return await this.appendToExistingFileWithTemplate(
 					existingFile,
 					templatePath,
 					"bottom",
+					linkOptions,
 				);
 			case "overwrite":
 				return await this.overwriteFileWithTemplate(
@@ -426,6 +433,38 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					templatePath,
 				);
 		}
+	}
+
+	private async appendToExistingFileWithTemplate(
+		existingFile: TFile,
+		resolvedTemplatePath: string,
+		position: "top" | "bottom",
+		linkOptions: NormalizedAppendLinkOptions,
+	): Promise<TFile | null> {
+		if (existingFile.extension !== "md") {
+			return await this.appendToFileWithTemplate(
+				existingFile,
+				resolvedTemplatePath,
+				position,
+			);
+		}
+
+		const insertEngine = new TemplateInsertEngine(
+			this.app,
+			this.plugin,
+			existingFile,
+			resolvedTemplatePath,
+			position,
+			this.choiceExecutor,
+			resolvedTemplatePath,
+		);
+		insertEngine.setLinkToCurrentFileBehavior(
+			linkOptions.enabled && !linkOptions.requireActiveFile
+				? "optional"
+				: "required",
+		);
+
+		return await insertEngine.apply();
 	}
 
 	/**

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -464,7 +464,29 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				: "required",
 		);
 
-		return await insertEngine.apply();
+		return await this.withAnonymousValueForInsertEngine(() =>
+			insertEngine.apply()
+		);
+	}
+
+	private async withAnonymousValueForInsertEngine<T>(
+		work: () => Promise<T>,
+	): Promise<T> {
+		const anonymousValue = this.formatter.getAnonymousValue();
+		const variables = this.choiceExecutor.variables;
+		const shouldSeedValue =
+			anonymousValue !== undefined && !variables.has("value");
+
+		if (!shouldSeedValue) {
+			return await work();
+		}
+
+		variables.set("value", anonymousValue);
+		try {
+			return await work();
+		} finally {
+			variables.delete("value");
+		}
 	}
 
 	/**

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -104,11 +104,13 @@ export class TemplateInsertEngine extends TemplateEngine {
 		private readonly templatePath: string,
 		private readonly mode: TemplateInsertModeId,
 		choiceExecutor?: IChoiceExecutor,
+		resolvedTemplatePath?: string,
 	) {
 		super(app, plugin, choiceExecutor);
+		this.resolvedTemplatePath = resolvedTemplatePath ?? null;
 	}
 
-	private resolvedTemplatePath: string | null = null;
+	private resolvedTemplatePath: string | null;
 
 	public async run(): Promise<void> {
 		await this.apply();

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -127,6 +127,10 @@ export abstract class Formatter {
 		}
 	}
 
+	public getAnonymousValue(): string | undefined {
+		return this.value;
+	}
+
 	protected replacer(str: string, reg: RegExp, replaceValue: string) {
 		return str.replace(reg, function () {
 			return replaceValue;

--- a/tests/e2e/file-exists-behavior.test.ts
+++ b/tests/e2e/file-exists-behavior.test.ts
@@ -16,6 +16,7 @@ import {
 
 const PLUGIN_ID = "quickadd";
 const TPL_CONTENT = "QA_TEMPLATE_CONTENT";
+const TPL_FM = "---\nstatus: draft\npriority: high\n---\nQA_TEMPLATE_BODY";
 const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
 
 let obsidian: ObsidianClient;
@@ -46,13 +47,14 @@ function templateChoice(
 	id: string,
 	format: string,
 	fileExistsBehavior?: Record<string, unknown>,
+	templatePath = sandbox.path("tpl.md"),
 ) {
 	return {
 		id,
 		name: id,
 		type: "Template",
 		command: false,
-		templatePath: sandbox.path("tpl.md"),
+		templatePath,
 		fileNameFormat: { enabled: true, format },
 		folder: {
 			enabled: false,
@@ -76,6 +78,12 @@ function templateChoice(
 /** Write a file into the sandbox and wait for Obsidian to index it. */
 async function seedFile(name: string, content = "EXISTING") {
 	await sandbox.write(name, content, { waitForContent: true, waitOptions: WAIT_OPTS });
+	const path = sandbox.path(name);
+	await obsidian.waitFor(async () => {
+		return await obsidian.dev.evalJson<boolean>(
+			`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(path)}))`,
+		);
+	}, WAIT_OPTS);
 }
 
 /** Run a QuickAdd choice. */
@@ -94,6 +102,13 @@ function expectOrderedSubstrings(
 	expect(firstIndex).toBeGreaterThanOrEqual(0);
 	expect(secondIndex).toBeGreaterThanOrEqual(0);
 	expect(firstIndex).toBeLessThan(secondIndex);
+}
+
+function expectSingleFrontmatterBlock(content: string) {
+	expect(content.match(/^---$/gm)).toHaveLength(2);
+	expect(content).toContain("status: done");
+	expect(content).toContain("priority: high");
+	expect(content).not.toContain("status: draft");
 }
 
 /** Run a QuickAdd choice and wait for a new file to appear. */
@@ -137,6 +152,7 @@ beforeAll(async () => {
 	});
 
 	await seedFile("tpl.md", TPL_CONTENT);
+	await seedFile("tpl-fm.md", TPL_FM);
 }, 30_000);
 
 afterAll(async () => {
@@ -184,6 +200,8 @@ describe("functional: file collision behaviors", () => {
 				templateChoice("__qa-test-t13-alldigit", `${root}/0001`, behavior.increment),
 				templateChoice("__qa-test-t14-nodigit", `${root}/qa-t14-hello`, behavior.increment),
 				templateChoice("__qa-test-t15-dupid", `${root}/tt0780504`, behavior.duplicateSuffix),
+				templateChoice("__qa-test-t16-atop-fm", `${root}/qa-t16-append-top-fm`, behavior.appendTop, sandbox.path("tpl-fm.md")),
+				templateChoice("__qa-test-t17-abot-fm", `${root}/qa-t17-append-bottom-fm`, behavior.appendBottom, sandbox.path("tpl-fm.md")),
 			);
 		});
 
@@ -250,6 +268,34 @@ describe("functional: file collision behaviors", () => {
 		await seedFile("qa-t10-append-top.md", "ORIGINAL_TOP_TEST");
 		const content = await runChoiceAndWaitForContent("__qa-test-t10-atop", "qa-t10-append-top.md", TPL_CONTENT);
 		expectOrderedSubstrings(content, TPL_CONTENT, "ORIGINAL_TOP_TEST");
+	});
+
+	it("T10a: append to top with frontmatter merges properties", async () => {
+		await seedFile(
+			"qa-t16-append-top-fm.md",
+			"---\nstatus: done\n---\nEXISTING_CONTENT",
+		);
+		const content = await runChoiceAndWaitForContent(
+			"__qa-test-t16-atop-fm",
+			"qa-t16-append-top-fm.md",
+			"priority: high",
+		);
+		expectSingleFrontmatterBlock(content);
+		expectOrderedSubstrings(content, "QA_TEMPLATE_BODY", "EXISTING_CONTENT");
+	});
+
+	it("T10b: append to bottom with frontmatter merges properties", async () => {
+		await seedFile(
+			"qa-t17-append-bottom-fm.md",
+			"---\nstatus: done\n---\nEXISTING_CONTENT",
+		);
+		const content = await runChoiceAndWaitForContent(
+			"__qa-test-t17-abot-fm",
+			"qa-t17-append-bottom-fm.md",
+			"priority: high",
+		);
+		expectSingleFrontmatterBlock(content);
+		expectOrderedSubstrings(content, "EXISTING_CONTENT", "QA_TEMPLATE_BODY");
 	});
 
 	it("T11: overwrite", async () => {


### PR DESCRIPTION
## Context

QuickAdd Template choices create a new file from a configured template. If the target file already exists, the choice can update that existing file instead of creating another one. The update actions include **Append to top** and **Append to bottom**.

Markdown templates can contain YAML frontmatter:

```md
---
status: draft
priority: high
---
TPL_BODY
```

When that template is appended to an existing markdown note, users expect the YAML properties to remain note frontmatter, not become literal body text. QuickAdd already did this correctly in **Apply Template to Note**, but the Template Choice existing-file append path had drifted and still raw-appended the full template text.

## Problem

Before this PR, Template Choice append-top could turn this existing note:

```md
---
status: done
---
EXISTING_CONTENT
```

into this:

```md
---
status: draft
priority: high
---
TPL_BODY
---
status: done
---
EXISTING_CONTENT
```

That creates two YAML fence blocks. Obsidian only treats the first one as note frontmatter, so the original note properties are displaced into the body and the result differs from Apply Template to Note.

Apply Template to Note already produced the intended result:

```md
---
status: done
priority: high
---
TPL_BODY
EXISTING_CONTENT
```

The existing note's `status: done` wins, the missing `priority: high` is filled from the template, and only the template body is inserted into the note body.

## What This Changes

This PR makes Template Choice **Append to top** and **Append to bottom** use the same frontmatter-aware markdown insertion behavior as Apply Template to Note.

For markdown target files:

- Split the formatted template into frontmatter and body.
- Insert only the template body at the requested position.
- Merge template frontmatter into the existing note frontmatter.
- Preserve existing note values; only missing, `null`, or empty-string properties are filled from the template.
- Keep frontmatter-only templates as metadata-only updates without inserting an empty body block.

The change is intentionally scoped:

- New-file creation is unchanged.
- Overwrite behavior is unchanged and still replaces the whole file with the template.
- Canvas and base append behavior stays raw because those files are not markdown notes with Obsidian YAML frontmatter semantics.

## Implementation Notes

Template Choice append collisions now delegate markdown updates to `TemplateInsertEngine`, the same engine used by Apply Template to Note.

The delegation preserves Template Choice behavior that would otherwise be easy to lose:

- The already-resolved template source path is passed through, so dynamic template paths are not formatted twice.
- `{{LINKCURRENT}}` strict vs skip-if-unavailable behavior is copied onto the insert engine.
- The cached anonymous `{{VALUE}}` from the filename prompt is carried into the insert engine, so append collisions do not prompt a second time or render a different value in the template body.

## Verification

- Reproduced the original Template Choice duplicate-frontmatter symptom in this worktree's isolated Obsidian vault before changing code.
- Verified live after the fix that Template Choice append top and append bottom both produce a single YAML block with `status: done`, `priority: high`, and only `TPL_BODY` inserted.
- Verified live that Apply Template to Note top and bottom still produce the same frontmatter-aware result.
- Addressed and resolved the Codex review finding about preserving anonymous `{{VALUE}}` across the delegated append path.

Commands run:

- `pnpm run build-with-lint`
- `pnpm run check`
- `pnpm test`
- `eval "$(pnpm run start:e2e-obsidian -- --print-env | sed -n '/^export QUICKADD_E2E_/p')" && pnpm exec vitest run --config vitest.e2e.config.mts tests/e2e/file-exists-behavior.test.ts -t 'frontmatter merges'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how append-to-top/bottom handle template frontmatter for markdown: frontmatter is merged (not duplicated), existing values take precedence, and missing properties are filled from the template.

* **Bug Fixes**
  * Improved template insertion when modifying existing files so link-current options are consistently applied, including correct behavior for markdown vs non-markdown targets.

* **Tests**
  * Expanded collision and append-mode coverage with new e2e frontmatter merge assertions and additional template collision scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->