### PR TITLE
fix(capture): allow empty scoped target creation

### DIFF
--- a/docs/docs/Advanced/CLI.md
+++ b/docs/docs/Advanced/CLI.md
@@ -91,6 +91,9 @@ By default, `quickadd` and `quickadd:run` are non-interactive. If QuickAdd
 detects missing inputs, it returns a JSON payload with `missing` fields and
 `missingFlags` suggestions instead of opening prompts.
 
+Pass a returned `missingFlags` entry back exactly as shown. Some generated flags
+fill internal runtime selections, such as a preselected capture target file.
+
 Use `ui` to allow interactive prompts:
 
 ```bash

--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -46,7 +46,8 @@ format_ value after applying format syntax:
 Folder pickers include Markdown files in the selected folder and its nested
 folders. The picker also accepts custom input, so you can type a new file name
 or path and let QuickAdd create it when **Create file if it doesn't exist** is
-enabled. The picker still needs at least one matching Markdown file to open.
+enabled. When creation is enabled, the picker still opens for an empty folder,
+tag, property, or filtered scope so you can type the first note name to create.
 
 The list is ordered like Obsidian's Quick Switcher: notes you opened most
 recently appear first (this session first, then your recent-files history), then

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -7,6 +7,7 @@ import type { IChoiceExecutor } from "../IChoiceExecutor";
 import {
 	getMarkdownFilesInFolder,
 	getMarkdownFilesMatchingFilter,
+	getMarkdownFilesWithProperty,
 	insertOnNewLineBelow,
 	insertFileLinkToActiveView,
 	isFolder,
@@ -106,6 +107,7 @@ vi.mock("../utilityObsidian", () => ({
 	appendToCurrentLine: vi.fn(() => true),
 	getMarkdownFilesInFolder: vi.fn(() => []),
 	getMarkdownFilesMatchingFilter: vi.fn(() => []),
+	getMarkdownFilesWithProperty: vi.fn(() => []),
 	getMarkdownFilesWithTag: vi.fn(() => []),
 	insertFileLinkToActiveView: vi.fn(),
 	insertOnNewLineAbove: vi.fn(() => true),
@@ -228,6 +230,8 @@ describe("CaptureChoiceEngine selection-as-value resolution", () => {
 		vi.mocked(openFile).mockClear();
 		vi.mocked(getMarkdownFilesMatchingFilter).mockReset();
 		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([]);
+		vi.mocked(getMarkdownFilesWithProperty).mockReset();
+		vi.mocked(getMarkdownFilesWithProperty).mockReturnValue([]);
 		vi.mocked(insertFileLinkToActiveView).mockReset();
 		vi.mocked(insertOnNewLineBelow).mockReturnValue(true);
 		vi.mocked(overwriteTemplaterOnce).mockClear();
@@ -820,31 +824,31 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		await (engine as any).selectFileInFolder("Inbox/", false);
 
 		expect(suggestSpy).toHaveBeenCalledTimes(1);
-			const [, displayItems, items, options] = suggestSpy.mock
-				.calls[0] as unknown as [
-				unknown,
-				string[],
-				string[],
-				{
-					allowCustomValue: boolean;
-					customValueLabel: (value: string) => string;
-					searchItems: string[];
-				},
-			];
+		const [, displayItems, items, options] = suggestSpy.mock
+			.calls[0] as unknown as [
+			unknown,
+			string[],
+			string[],
+			{
+				allowCustomValue: boolean;
+				customValueLabel: (value: string) => string;
+				searchItems: string[];
+			},
+		];
 
 		// Recently opened (Zebra) first, then the rest alphabetically.
 		expect(items).toEqual([
 			"Inbox/Zebra.md",
 			"Inbox/Apple.md",
 			"Inbox/Mango.md",
-			]);
-			expect(displayItems).toEqual(["Zebra", "Apple", "Mango"]);
-			expect(options.searchItems).toEqual([
-				"Zebra Inbox/Zebra.md",
-				"Apple Inbox/Apple.md",
-				"Mango Inbox/Mango.md",
-			]);
-			expect(options.allowCustomValue).toBe(true);
+		]);
+		expect(displayItems).toEqual(["Zebra", "Apple", "Mango"]);
+		expect(options.searchItems).toEqual([
+			"Zebra Inbox/Zebra.md",
+			"Apple Inbox/Apple.md",
+			"Mango Inbox/Mango.md",
+		]);
+		expect(options.allowCustomValue).toBe(true);
 		expect(options.customValueLabel("New")).toBe("Create new note: New");
 	});
 
@@ -919,6 +923,168 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 			allowCustomValue: boolean;
 		};
 		expect(options.allowCustomValue).toBe(false);
+	});
+
+	it("opens the folder picker for an empty folder when create-if-not-exists is on", async () => {
+		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([]);
+		const suggestSpy = vi.fn(async () => "New From Empty");
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "Inbox/",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			createExecutor(),
+		);
+
+		const resolved = await (engine as any).selectFileInFolder("Inbox", false);
+
+		expect(suggestSpy).toHaveBeenCalledTimes(1);
+		const [, displayItems, items, options] = suggestSpy.mock
+			.calls[0] as unknown as [
+			unknown,
+			string[],
+			string[],
+			{
+				allowCustomValue: boolean;
+				placeholder: string;
+				emptyStateText: string;
+				valueExists: (value: string) => boolean;
+			},
+		];
+		expect(displayItems).toEqual([]);
+		expect(items).toEqual([]);
+		expect(options.allowCustomValue).toBe(true);
+		expect(options.placeholder).toBe("Choose a note or type to create one");
+		expect(options.emptyStateText).toBe("Type a note name to create it");
+		expect(options.valueExists("New From Empty")).toBe(false);
+		expect(resolved).toBe("Inbox/New From Empty.md");
+	});
+
+	it("keeps empty folder captures as an error when create-if-not-exists is off", async () => {
+		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([]);
+		const suggestSpy = vi.fn();
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "Inbox/" }),
+			createExecutor(),
+		);
+
+		await expect(
+			(engine as any).selectFileInFolder("Inbox", false),
+		).rejects.toThrow("Folder Inbox/ is empty.");
+		expect(suggestSpy).not.toHaveBeenCalled();
+	});
+
+	it("opens scoped filter pickers with no matches when create-if-not-exists is on", async () => {
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([]);
+		const suggestSpy = vi.fn(async () => "New From Empty");
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "#empty",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			createExecutor(),
+		);
+
+		const resolved = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(getMarkdownFilesMatchingFilter).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ tags: ["empty"] }),
+		);
+		expect(suggestSpy).toHaveBeenCalledTimes(1);
+		const [, displayItems, items, options] = suggestSpy.mock
+			.calls[0] as unknown as [
+			unknown,
+			string[],
+			string[],
+			{
+				allowCustomValue: boolean;
+				placeholder: string;
+				emptyStateText: string;
+			},
+		];
+		expect(displayItems).toEqual([]);
+		expect(items).toEqual([]);
+		expect(options.allowCustomValue).toBe(true);
+		expect(options.placeholder).toBe("Choose a note or type to create one");
+		expect(options.emptyStateText).toBe("Type a note name to create it");
+		expect(resolved).toBe("New From Empty.md");
+	});
+
+	it("opens empty property pickers with vault-wide duplicate suppression when create-if-not-exists is on", async () => {
+		vi.mocked(getMarkdownFilesWithProperty).mockReturnValue([]);
+		const suggestSpy = vi.fn(async () => "Fresh Draft");
+		(InputSuggester as any).Suggest = suggestSpy;
+		const app = createApp() as any;
+		app.vault.getMarkdownFiles = vi.fn(() => [
+			{ path: "Archive/Existing.md", basename: "Existing" },
+		]);
+
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "property:type=draft",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			createExecutor(),
+		);
+
+		const resolved = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(getMarkdownFilesWithProperty).toHaveBeenCalledWith(
+			app,
+			"type",
+			"draft",
+			expect.any(Object),
+		);
+		const options = (suggestSpy.mock.calls[0] as unknown[])[3] as {
+			valueExists: (value: string) => boolean;
+		};
+		expect(options.valueExists("Existing")).toBe(true);
+		expect(options.valueExists("Fresh Draft")).toBe(false);
+		expect(resolved).toBe("Fresh Draft.md");
+	});
+
+	it("keeps empty scoped filter captures as an error when create-if-not-exists is off", async () => {
+		const suggestSpy = vi.fn();
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "#empty" }),
+			createExecutor(),
+		);
+
+		await expect(
+			(engine as any).getFormattedPathToCaptureTo(false),
+		).rejects.toThrow("No files matched the capture target filters.");
+		expect(suggestSpy).not.toHaveBeenCalled();
 	});
 
 	it("uses extensionless title for created .canvas capture files", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -35,7 +35,6 @@ import {
 	appendToCurrentLine,
 	getMarkdownFilesInFolder,
 	getMarkdownFilesMatchingFilter,
-	getMarkdownFilesWithTag,
 	getMarkdownFilesWithProperty,
 	insertFileLinkToActiveView,
 	insertOnNewLineAbove,
@@ -840,38 +839,35 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		);
 		const resolution = this.resolveCaptureTarget(formattedCaptureTo);
 
-			switch (resolution.kind) {
-				case "vault":
-					return this.selectFileInFolder("", true);
-				case "tag":
-					return this.selectFileWithTag(resolution.tag);
-				case "filter":
-					return this.selectFileWithFilter(resolution.filter);
-				case "property":
-					return this.selectFileWithProperty(
-						resolution.field,
-						resolution.value,
-						resolution.filter,
-					);
-				case "folder":
-					return this.selectFileInFolder(resolution.folder, false);
-				case "file":
-					return this.normalizeCaptureFilePath(resolution.path);
-			}
+		switch (resolution.kind) {
+			case "vault":
+				return this.selectFileInFolder("", true);
+			case "filter":
+				return this.selectFileWithFilter(resolution.filter);
+			case "property":
+				return this.selectFileWithProperty(
+					resolution.field,
+					resolution.value,
+					resolution.filter,
+				);
+			case "folder":
+				return this.selectFileInFolder(resolution.folder, false);
+			case "file":
+				return this.normalizeCaptureFilePath(resolution.path);
 		}
+	}
 
 	private resolveCaptureTarget(
 		formattedCaptureTo: string,
 	):
 		| { kind: "vault" }
-		| { kind: "tag"; tag: string }
 		| { kind: "filter"; filter: FieldFilter }
 		| { kind: "property"; field: string; value?: string; filter: FieldFilter }
 		| { kind: "folder"; folder: string }
 		| { kind: "file"; path: string } {
 		// Resolution order:
 		// 1) empty => vault picker
-		// 2) #tag => tag picker
+		// 2) #tag/tag:/folder: filters => filtered picker
 		// 3) property:<field>[=<value>] => frontmatter-property picker
 		// 4) trailing "/" => folder picker (explicit)
 		// 5) known file extension => file
@@ -1060,13 +1056,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			: `${folderPathSlash}${targetFilePath}`;
 
 		return await this.formatFilePath(filePath);
-	}
-
-	private async selectFileWithTag(tag: string): Promise<string> {
-		const tagWithHash = tag.startsWith("#") ? tag : `#${tag}`;
-		const filesWithTag = getMarkdownFilesWithTag(this.app, tagWithHash);
-
-		return this.selectFileFromSet(filesWithTag, `No files with tag ${tag}.`);
 	}
 
 	private async selectFileWithFilter(filter: FieldFilter): Promise<string> {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -995,8 +995,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				? folderPath
 				: `${folderPath}/`;
 		const filesInFolder = getMarkdownFilesInFolder(this.app, folderPathSlash);
+		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 
-		invariant(filesInFolder.length > 0, `Folder ${folderPathSlash} is empty.`);
+		invariant(
+			allowCreate || filesInFolder.length > 0,
+			`Folder ${folderPathSlash} is empty.`,
+		);
 
 		// Quick-Switcher-style ordering: recent first, excluded sunk, alphabetical tail.
 		const orderedFiles = orderFilesForPicker(
@@ -1014,7 +1018,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const existingLabels = new Set(
 			displayItems.map((label) => label.toLowerCase()),
 		);
-		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 		let targetFilePath: string;
 		try {
 			targetFilePath = await InputSuggester.Suggest(
@@ -1022,6 +1025,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				displayItems,
 				filePaths,
 				{
+					placeholder: allowCreate
+						? "Choose a note or type to create one"
+						: undefined,
+					emptyStateText: allowCreate
+						? "Type a note name to create it"
+						: undefined,
 					renderItem: (path, el) =>
 						renderNotePathSuggestion(el, path, this.app),
 					searchItems,
@@ -1137,7 +1146,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		files: TFile[],
 		notFoundMessage: string,
 	): Promise<string> {
-		invariant(files.length > 0, notFoundMessage);
+		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
+
+		invariant(allowCreate || files.length > 0, notFoundMessage);
 
 		// Quick-Switcher-style ordering; show note names (not raw paths).
 		const orderedFiles = orderFilesForPicker(
@@ -1152,7 +1163,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const searchItems = filePaths.map(
 			(path, index) => `${displayItems[index] ?? path} ${path}`,
 		);
-		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 		// Build once (not per keystroke): existing note basenames across the vault.
 		const vaultBasenames = new Set(
 			this.app.vault
@@ -1169,6 +1179,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				displayItems,
 				filePaths,
 				{
+					placeholder: allowCreate
+						? "Choose a note or type to create one"
+						: undefined,
+					emptyStateText: allowCreate
+						? "Type a note name to create it"
+						: undefined,
 					renderItem: (path, el) =>
 						renderNotePathSuggestion(el, path, this.app),
 					searchItems,

--- a/src/gui/InputSuggester/inputSuggester.test.ts
+++ b/src/gui/InputSuggester/inputSuggester.test.ts
@@ -54,6 +54,27 @@ describe("InputSuggester", () => {
 		).not.toThrow();
 	});
 
+	it("does not throw when tab-completing an empty suggestion list", () => {
+		const suggester = new InputSuggester(app, [], []);
+		(suggester as unknown as {
+			chooser: {
+				values: { item: string }[];
+				selectedItem: number;
+			};
+		}).chooser = {
+			values: [],
+			selectedItem: 0,
+		};
+		suggester.inputEl.value = "Draft";
+
+		expect(() =>
+			suggester.inputEl.dispatchEvent(
+				new KeyboardEvent("keydown", { code: "Tab" }),
+			),
+		).not.toThrow();
+		expect(suggester.inputEl.value).toBe("Draft");
+	});
+
 	it("omits the custom create row when allowCustomValue is false", () => {
 		const suggester = new InputSuggester(
 			app,

--- a/src/gui/InputSuggester/inputSuggester.ts
+++ b/src/gui/InputSuggester/inputSuggester.ts
@@ -115,7 +115,7 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 			};
 
 			const { value } = this.inputEl;
-			this.inputEl.value = values[selectedItem].item ?? value;
+			this.inputEl.value = values[selectedItem]?.item ?? value;
 		});
 
 		if (options.placeholder) this.setPlaceholder(options.placeholder);

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -7,7 +7,10 @@ import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { CommandType } from "src/types/macros/CommandType";
 import type { IUserScript } from "src/types/macros/IUserScript";
 import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "src/constants";
-import { collectChoiceRequirements } from "./collectChoiceRequirements";
+import {
+	collectChoiceRequirements,
+	getUnresolvedRequirements,
+} from "./collectChoiceRequirements";
 
 const {
 	getMarkdownFilesInFolderMock,
@@ -968,6 +971,26 @@ describe("collectChoiceRequirements - capture targets", () => {
 			displayOptions: [],
 			placeholder: "Type a new note name in the capture target picker",
 		});
+	});
+
+	it("allows a CLI-provided target path to satisfy an empty create-enabled scope", async () => {
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			enableCaptureTargetCreation(
+				createCaptureChoice("folder:Goals|tag:active"),
+			),
+		);
+		const variables = new Map<string, unknown>([
+			[QA_INTERNAL_CAPTURE_TARGET_FILE_PATH, "Goals/New target.md"],
+		]);
+
+		expect(getUnresolvedRequirements(requirements, variables)).not.toContainEqual(
+			expect.objectContaining({
+				id: QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			}),
+		);
 	});
 
 	it("keeps an empty disabled dropdown when target creation is off", async () => {

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -102,6 +102,17 @@ function createCaptureChoice(captureTo: string): ICaptureChoice {
 	};
 }
 
+function enableCaptureTargetCreation(choice: ICaptureChoice): ICaptureChoice {
+	return {
+		...choice,
+		createFileIfItDoesntExist: {
+			enabled: true,
+			createWithTemplate: false,
+			template: "",
+		},
+	};
+}
+
 describe("collectChoiceRequirements - template include scanning", () => {
 	const templateBodies = new Map<string, string>();
 	const cachedReadMock = vi.fn(
@@ -922,19 +933,63 @@ describe("collectChoiceRequirements - capture targets", () => {
 				tags: ["active"],
 			}),
 		);
-			const target = requirements.find(
-				(requirement) =>
-					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
-			);
-			expect(target?.options).toEqual([
-				"Goals/Alpha.md",
-				"Projects/Beta.md",
-			]);
-			expect(target?.displayOptions).toEqual([
-				"Alpha Goal (Alpha)",
-				"Beta Heading (Beta)",
-			]);
+		const target = requirements.find(
+			(requirement) =>
+				requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+		);
+		expect(target?.options).toEqual([
+			"Goals/Alpha.md",
+			"Projects/Beta.md",
+		]);
+		expect(target?.displayOptions).toEqual([
+			"Alpha Goal (Alpha)",
+			"Beta Heading (Beta)",
+		]);
+	});
+
+	it("leaves empty create-enabled capture target scopes to the runtime picker", async () => {
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			enableCaptureTargetCreation(
+				createCaptureChoice("folder:Goals|tag:active"),
+			),
+		);
+
+		const target = requirements.find(
+			(requirement) =>
+				requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+		);
+		expect(target).toMatchObject({
+			type: "file-picker",
+			runtimeOnly: true,
+			options: [],
+			displayOptions: [],
+			placeholder: "Type a new note name in the capture target picker",
 		});
+	});
+
+	it("keeps an empty disabled dropdown when target creation is off", async () => {
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createCaptureChoice("folder:Goals|tag:active"),
+		);
+
+		const target = requirements.find(
+			(requirement) =>
+				requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+		);
+		expect(target).toMatchObject({
+			type: "dropdown",
+			options: [],
+			displayOptions: [],
+			placeholder: "No files found in target scope",
+		});
+		expect(target?.runtimeOnly).toBeUndefined();
+	});
 
 	it("does not reinterpret multi-select capture target filters as tag targets", async () => {
 		const requirements = await collectChoiceRequirements(

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -393,16 +393,31 @@ async function collectForCaptureChoice(
 			orderedFiles,
 			(file) => app.metadataCache?.getFileCache(file) ?? null,
 		);
-		collector.requirements.set(QA_INTERNAL_CAPTURE_TARGET_FILE_PATH, {
-			id: QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
-			label: "Select capture target file",
-			type: "dropdown",
-			options,
-			displayOptions,
-			placeholder: options.length
-				? undefined
-				: "No files found in target scope",
-		});
+		const allowCreateTarget =
+			choice.createFileIfItDoesntExist?.enabled ?? false;
+		if (options.length === 0 && allowCreateTarget) {
+			collector.requirements.set(QA_INTERNAL_CAPTURE_TARGET_FILE_PATH, {
+				id: QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+				label: "Select capture target file",
+				type: "file-picker",
+				source: "collected",
+				options,
+				displayOptions,
+				runtimeOnly: true,
+				placeholder: "Type a new note name in the capture target picker",
+			});
+		} else {
+			collector.requirements.set(QA_INTERNAL_CAPTURE_TARGET_FILE_PATH, {
+				id: QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+				label: "Select capture target file",
+				type: "dropdown",
+				options,
+				displayOptions,
+				placeholder: options.length
+					? undefined
+					: "No files found in target scope",
+			});
+		}
 	}
 
 	if (seedCaptureSelectionAsValue) {


### PR DESCRIPTION
Allow Capture target pickers to create a new note even when the scoped file list starts empty.

The current runtime had the right shared primitive already: folder, tag/filter, and property capture targets all route through `InputSuggester` with a create row when **Create file if it doesn't exist** is enabled. The bug was that both capture picker helpers aborted before reaching that shared picker if the scoped list was empty. This moves the empty-list guard behind the create-enabled check, keeps create-disabled scopes as clear errors, and marks empty create-enabled one-page target requirements as runtime-only so the runtime picker keeps duplicate suppression and path normalization.

I also hardened `InputSuggester` tab completion for empty suggestion lists and updated the Capture docs to remove the old limitation that a matching Markdown file had to exist before the picker could open.

Verification evidence:
- Reproduced before the fix in the isolated vault: empty folder scope showed `Folder __qa_empty_scope/ is empty.` and created no file; empty tag scope showed `No files matched the capture target filters.` with no picker.
- Live after-fix folder proof: empty scoped folder opened a picker with `Choose a note or type to create one`, showed `Create new note: First Created`, created `__qa_live_empty_1782052468479/First Created.md`, and wrote `empty proof`.
- Live non-regression proof: non-empty folder picker still selected `Existing.md`, updated it to include `existing proof`, and did not create a duplicate.
- Live tag proof: empty tag scope showed the create row and created `Tag Created 1782052544480.md` with `tag proof`.
- Live property proof: empty property scope showed the create row and created `Property Created 1782052566480.md` with `property proof`.
- `pnpm exec tsc -noEmit -skipLibCheck`
- `pnpm run lint`
- `pnpm run check` (0 errors, existing warnings only)
- `pnpm test`
- `pnpm run build`
- `pnpm run obsidian:e2e -- dev:errors` returned no captured errors.

Release impact: no migration. Existing create-disabled empty scopes still abort instead of opening an unusable picker.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File picker now opens for empty destination scopes when **Create file if it doesn’t exist** is enabled, so you can type the first note name to create.
  * Capture-target selection now supports creating a target even when no existing matches are found.
* **Bug Fixes**
  * Improved keyboard/tab behavior in suggestion inputs to avoid crashes when no suggestions are available.
* **Documentation**
  * Updated capture-target documentation and clarified non-interactive CLI handling of `missingFlags`.
* **Tests**
  * Added coverage for empty-scope capture-target resolution and keyboard/suggestion edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->