### PR TITLE
fix(preflight): scan template includes in capture preflight

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -486,6 +486,8 @@ If the capture format is long, put the full format in a template file and use a 
 
 QuickAdd replaces the token with the template file contents, then processes the result through the normal capture formatter. The referenced file can contain the same format syntax you would otherwise type inline, such as `{{VALUE}}`, `{{DATE}}`, `{{MACRO:...}}`, inline scripts, and additional `{{TEMPLATE:...}}` includes. Include the file extension in the token; template includes support `.md`, `.canvas`, and `.base` files.
 
+One-page input preflight and `quickadd:check` scan the referenced template files too, so prompts inside a file-backed capture format appear up front like inline capture format prompts.
+
 This is useful when you want to edit, version, or reuse a complete capture format as a normal note. You can also use `{{TEMPLATE:Templates/Partial.md}}` inside a larger inline capture format when only part of the format should come from a file.
 
 If you want to insert `.base` content into your current note, keep **Capture to active file** enabled and use a `.base` template token in the capture format. See [Capture: Insert a Related Notes Base into an MOC Note](/Examples/Capture_InsertBaseTemplateIntoActiveFile.md).

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -76,7 +76,7 @@ export interface TemplateInclusionState {
 	depth: number;
 }
 
-const MAX_TEMPLATE_INCLUSION_DEPTH = 10;
+export const MAX_TEMPLATE_INCLUSION_DEPTH = 10;
 
 export abstract class Formatter {
 	protected value: string;

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -102,6 +102,158 @@ function createCaptureChoice(captureTo: string): ICaptureChoice {
 	};
 }
 
+describe("collectChoiceRequirements - template include scanning", () => {
+	const templateBodies = new Map<string, string>();
+	const cachedReadMock = vi.fn(
+		async (file: { path: string }) => templateBodies.get(file.path) ?? "",
+	);
+	const app = {
+		vault: {
+			cachedRead: cachedReadMock,
+		},
+		metadataCache: {
+			getFileCache: vi.fn(() => null),
+		},
+	} as unknown as App;
+	const plugin = {
+		settings: {
+			inputPrompt: "single-line",
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any;
+
+	function createTemplateChoice(templatePath: string): ITemplateChoice {
+		return {
+			id: "template-choice",
+			name: "Template Choice",
+			type: "Template",
+			command: false,
+			templatePath,
+			fileNameFormat: { enabled: false, format: "" },
+			folder: {
+				enabled: false,
+				folders: [],
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			},
+			appendLink: false,
+			openFile: false,
+			fileOpening: {
+				location: "tab",
+				direction: "vertical",
+				mode: "default",
+				focus: true,
+			},
+			fileExistsBehavior: { kind: "prompt" },
+		} as ITemplateChoice;
+	}
+
+	beforeEach(() => {
+		templateBodies.clear();
+		cachedReadMock.mockClear();
+		getTemplateFileMock.mockReset();
+		getTemplateFileMock.mockImplementation((_app: App, path: string) =>
+			templateBodies.has(path) ? ({ path } as never) : null,
+		);
+	});
+
+	it("collects requirements from TEMPLATE includes in Capture formats", async () => {
+		templateBodies.set(
+			"Templates/Capture Format.md",
+			"Included value: {{VALUE:includedValue}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:Templates/Capture Format.md}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "includedValue" }),
+			]),
+		);
+		expect(cachedReadMock).toHaveBeenCalledWith(
+			expect.objectContaining({ path: "Templates/Capture Format.md" }),
+		);
+	});
+
+	it("recursively collects nested TEMPLATE includes in Capture formats", async () => {
+		templateBodies.set(
+			"Templates/Capture Outer.md",
+			"Outer {{TEMPLATE:Templates/Capture Inner.md}}",
+		);
+		templateBodies.set(
+			"Templates/Capture Inner.md",
+			"Inner {{VALUE:nestedIncludedValue}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:Templates/Capture Outer.md}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "nestedIncludedValue" }),
+			]),
+		);
+	});
+
+	it("keeps recursive TEMPLATE scanning for Template choices", async () => {
+		templateBodies.set(
+			"Templates/Outer.md",
+			"Outer {{TEMPLATE:Templates/Inner.md}}",
+		);
+		templateBodies.set("Templates/Inner.md", "Inner {{VALUE:templateValue}}");
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createTemplateChoice("Templates/Outer.md"),
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "templateValue" }),
+			]),
+		);
+	});
+});
+
 describe("collectChoiceRequirements - macro script metadata", () => {
 	const app = {} as App;
 	const plugin = {} as any;

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -25,7 +25,7 @@ const {
 	getMarkdownFilesWithTagMock: vi.fn(() => []),
 	getMarkdownFilesWithPropertyMock: vi.fn(() => []),
 	getUserScriptMock: vi.fn(),
-	getTemplateFileMock: vi.fn(() => null),
+	getTemplateFileMock: vi.fn((_app?: unknown, _path?: string) => null),
 	isFolderMock: vi.fn(() => false),
 	logWarningMock: vi.fn(),
 	logMessageMock: vi.fn(),

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -228,6 +228,82 @@ describe("collectChoiceRequirements - template include scanning", () => {
 		);
 	});
 
+	it("does not collect requirements beyond the runtime TEMPLATE inclusion depth", async () => {
+		for (let index = 0; index < 9; index++) {
+			templateBodies.set(
+				`Templates/T${index}.md`,
+				`{{TEMPLATE:Templates/T${index + 1}.md}}`,
+			);
+		}
+		templateBodies.set(
+			"Templates/T9.md",
+			"{{VALUE:atRuntimeLimit}} {{TEMPLATE:Templates/T10.md}}",
+		);
+		templateBodies.set("Templates/T10.md", "{{VALUE:tooDeep}}");
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:Templates/T0.md}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "atRuntimeLimit" }),
+			]),
+		);
+		expect(requirements).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: "tooDeep" })]),
+		);
+		expect(cachedReadMock).not.toHaveBeenCalledWith(
+			expect.objectContaining({ path: "Templates/T10.md" }),
+		);
+	});
+
+	it("collects requirements from Capture create-with-template literal bodies", async () => {
+		templateBodies.set(
+			"Templates/Create Body.md",
+			"Created with {{VALUE:createBodyValue}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			createFileIfItDoesntExist: {
+				enabled: true,
+				createWithTemplate: true,
+				template: "Templates/Create Body.md",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "createBodyValue" }),
+			]),
+		);
+	});
+
 	it("keeps recursive TEMPLATE scanning for Template choices", async () => {
 		templateBodies.set(
 			"Templates/Outer.md",

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -193,6 +193,62 @@ describe("collectChoiceRequirements - template include scanning", () => {
 		);
 	});
 
+	it("collects requirements from TEMPLATE includes in Capture targets", async () => {
+		templateBodies.set(
+			"Templates/Capture Target.md",
+			"Inbox/{{VALUE:captureTargetName}}.md",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createCaptureChoice("{{TEMPLATE:Templates/Capture Target.md}}"),
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "captureTargetName" }),
+			]),
+		);
+	});
+
+	it("collects requirements from TEMPLATE includes in Template file names", async () => {
+		templateBodies.set("Templates/Source.md", "Body");
+		templateBodies.set(
+			"Templates/File Name.md",
+			"{{VALUE:templateFileName}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const templateChoice = {
+			...createTemplateChoice("Templates/Source.md"),
+			fileNameFormat: {
+				enabled: true,
+				format: "{{TEMPLATE:Templates/File Name.md}}",
+			},
+		} as ITemplateChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			templateChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "templateFileName" }),
+			]),
+		);
+	});
+
 	it("recursively collects nested TEMPLATE includes in Capture formats", async () => {
 		templateBodies.set(
 			"Templates/Capture Outer.md",

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -217,6 +217,71 @@ describe("collectChoiceRequirements - template include scanning", () => {
 		);
 	});
 
+	it("collects requirements from TEMPLATE includes in Capture insert-after targets", async () => {
+		templateBodies.set(
+			"Templates/Heading.md",
+			"## {{VALUE:insertAfterHeading}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			insertAfter: {
+				...createCaptureChoice("Inbox.md").insertAfter,
+				enabled: true,
+				after: "{{TEMPLATE:Templates/Heading.md}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "insertAfterHeading" }),
+			]),
+		);
+	});
+
+	it("collects requirements from TEMPLATE includes in Capture insert-before targets", async () => {
+		templateBodies.set(
+			"Templates/Before.md",
+			"## {{VALUE:insertBeforeHeading}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			insertBefore: {
+				enabled: true,
+				before: "{{TEMPLATE:Templates/Before.md}}",
+				createIfNotFound: false,
+				createIfNotFoundLocation: "top",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "insertBeforeHeading" }),
+			]),
+		);
+	});
+
 	it("collects requirements from TEMPLATE includes in Template file names", async () => {
 		templateBodies.set("Templates/Source.md", "Body");
 		templateBodies.set(
@@ -325,6 +390,49 @@ describe("collectChoiceRequirements - template include scanning", () => {
 		);
 		expect(cachedReadMock).not.toHaveBeenCalledWith(
 			expect.objectContaining({ path: "Templates/T10.md" }),
+		);
+	});
+
+	it("allows a template reached at max depth to be scanned again after the stack unwinds", async () => {
+		templateBodies.set(
+			"Templates/Root Deep.md",
+			"{{TEMPLATE:Templates/Deep0.md}} {{TEMPLATE:Templates/Shared.md}}",
+		);
+		for (let index = 0; index < 8; index++) {
+			templateBodies.set(
+				`Templates/Deep${index}.md`,
+				`{{TEMPLATE:Templates/Deep${index + 1}.md}}`,
+			);
+		}
+		templateBodies.set("Templates/Deep8.md", "{{TEMPLATE:Templates/Shared.md}}");
+		templateBodies.set("Templates/Shared.md", "{{TEMPLATE:Templates/Nested.md}}");
+		templateBodies.set("Templates/Nested.md", "{{VALUE:sharedNestedValue}}");
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:Templates/Root Deep.md}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "sharedNestedValue" }),
+			]),
+		);
+		expect(cachedReadMock).toHaveBeenCalledWith(
+			expect.objectContaining({ path: "Templates/Nested.md" }),
 		);
 	});
 

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -193,6 +193,81 @@ describe("collectChoiceRequirements - template include scanning", () => {
 		);
 	});
 
+	it("does not recurse into TEMPLATE includes introduced by global variables", async () => {
+		templateBodies.set(
+			"Templates/From Global.md",
+			"{{VALUE:fromGlobalTemplate}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{GLOBAL_VAR:TemplateRef}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			{
+				settings: {
+					...plugin.settings,
+					globalVariables: {
+						TemplateRef: "{{TEMPLATE:Templates/From Global.md}}",
+					},
+				},
+			} as any,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "fromGlobalTemplate" }),
+			]),
+		);
+		expect(cachedReadMock).not.toHaveBeenCalledWith(
+			expect.objectContaining({ path: "Templates/From Global.md" }),
+		);
+	});
+
+	it("still collects ordinary requirements introduced by global variables", async () => {
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+		const captureChoice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{GLOBAL_VAR:ValueRef}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			{
+				settings: {
+					...plugin.settings,
+					globalVariables: {
+						ValueRef: "{{VALUE:fromGlobalValue}}",
+					},
+				},
+			} as any,
+			choiceExecutor,
+			captureChoice,
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "fromGlobalValue" }),
+			]),
+		);
+	});
+
 	it("collects requirements from TEMPLATE includes in Capture targets", async () => {
 		templateBodies.set(
 			"Templates/Capture Target.md",

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -168,7 +168,7 @@ async function scanContentWithTemplateIncludes(
 	app: App,
 	collector: RequirementCollector,
 	content: string,
-	visitedTemplates = new Set<string>(),
+	templateStack = new Set<string>(),
 	depth = 0,
 ): Promise<void> {
 	// templatesToScan is a queue for this content scan. Clear it before and
@@ -181,15 +181,19 @@ async function scanContentWithTemplateIncludes(
 	if (depth >= MAX_TEMPLATE_INCLUSION_DEPTH) return;
 
 	for (const ref of nested) {
-		if (visitedTemplates.has(ref)) continue;
-		visitedTemplates.add(ref);
-		await scanContentWithTemplateIncludes(
-			app,
-			collector,
-			await readTemplate(app, ref),
-			visitedTemplates,
-			depth + 1,
-		);
+		if (templateStack.has(ref)) continue;
+		templateStack.add(ref);
+		try {
+			await scanContentWithTemplateIncludes(
+				app,
+				collector,
+				await readTemplate(app, ref),
+				templateStack,
+				depth + 1,
+			);
+		} finally {
+			templateStack.delete(ref);
+		}
 	}
 }
 
@@ -277,6 +281,22 @@ async function collectForCaptureChoice(
 			app,
 			collector,
 			choice.format.format,
+		);
+	}
+
+	if (choice.insertAfter?.enabled && !choice.insertAfter.promptHeading) {
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			choice.insertAfter.after,
+		);
+	}
+
+	if (choice.insertBefore?.enabled) {
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			choice.insertBefore.before,
 		);
 	}
 

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -2,7 +2,10 @@ import type { App, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
 import { MAX_TEMPLATE_INCLUSION_DEPTH } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
-import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "src/constants";
+import {
+	QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+	TEMPLATE_REGEX,
+} from "src/constants";
 import type QuickAdd from "src/main";
 import type ICaptureChoice from "src/types/choices/ICaptureChoice";
 import type IChoice from "src/types/choices/IChoice";
@@ -164,6 +167,16 @@ async function readTemplate(app: App, path: string): Promise<string> {
 	return file ? await app.vault.cachedRead(file) : "";
 }
 
+function getRawTemplateRefs(content: string): Set<string> {
+	const refs = new Set<string>();
+	const re = new RegExp(TEMPLATE_REGEX.source, "gi");
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(content)) !== null) {
+		if (match[1]) refs.add(match[1]);
+	}
+	return refs;
+}
+
 async function scanContentWithTemplateIncludes(
 	app: App,
 	collector: RequirementCollector,
@@ -173,9 +186,12 @@ async function scanContentWithTemplateIncludes(
 ): Promise<void> {
 	// templatesToScan is a queue for this content scan. Clear it before and
 	// after scanning so refs from unrelated strings are not drained together.
+	const rawTemplateRefs = getRawTemplateRefs(content);
 	collector.templatesToScan.clear();
 	await collector.scanString(content);
-	const nested = [...collector.templatesToScan];
+	const nested = [...collector.templatesToScan].filter((ref) =>
+		rawTemplateRefs.has(ref),
+	);
 	collector.templatesToScan.clear();
 
 	if (depth >= MAX_TEMPLATE_INCLUSION_DEPTH) return;

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -163,6 +163,31 @@ async function readTemplate(app: App, path: string): Promise<string> {
 	return file ? await app.vault.cachedRead(file) : "";
 }
 
+async function scanContentWithTemplateIncludes(
+	app: App,
+	collector: RequirementCollector,
+	content: string,
+	visitedTemplates = new Set<string>(),
+): Promise<void> {
+	// templatesToScan is a queue for this content scan. Clear it before and
+	// after scanning so refs from unrelated strings are not drained together.
+	collector.templatesToScan.clear();
+	await collector.scanString(content);
+	const nested = [...collector.templatesToScan];
+	collector.templatesToScan.clear();
+
+	for (const ref of nested) {
+		if (visitedTemplates.has(ref)) continue;
+		visitedTemplates.add(ref);
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			await readTemplate(app, ref),
+			visitedTemplates,
+		);
+	}
+}
+
 /**
  * Collects requirements from a template *source* path and (when resolvable) its
  * body. Shared by Template choices and Capture "create with template" so both
@@ -188,23 +213,12 @@ async function scanTemplateSource(
 		return;
 	}
 
-	const visited = new Set<string>();
-	const walk = async (path: string) => {
-		if (visited.has(path)) return;
-		visited.add(path);
-		const content = await readTemplate(app, path);
-		await collector.scanString(content);
-		// Snapshot and clear the shared discovery set BEFORE recursing: a nested
-		// walk() runs scanString again, which would otherwise mutate (and then
-		// clear) the very set we're iterating, dropping sibling/grandchild
-		// templates from the scan.
-		const nested = [...collector.templatesToScan];
-		collector.templatesToScan.clear();
-		for (const ref of nested) {
-			if (!visited.has(ref)) await walk(ref);
-		}
-	};
-	await walk(templatePath);
+	await scanContentWithTemplateIncludes(
+		app,
+		collector,
+		await readTemplate(app, templatePath),
+		new Set([templatePath]),
+	);
 }
 
 async function collectForTemplateChoice(
@@ -250,7 +264,11 @@ async function collectForCaptureChoice(
 	await collector.scanString(choice.captureTo);
 
 	if (choice.format?.enabled) {
-		await collector.scanString(choice.format.format);
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			choice.format.format,
+		);
 	}
 
 	// Capture's "create file if it doesn't exist → with template" runs through

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -235,12 +235,16 @@ async function collectForTemplateChoice(
 	const collector = new RequirementCollector(app, plugin, choiceExecutor);
 
 	if (choice.fileNameFormat?.enabled) {
-		await collector.scanString(choice.fileNameFormat.format);
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			choice.fileNameFormat.format,
+		);
 	}
 
 	if (choice.folder?.enabled) {
 		for (const folder of choice.folder.folders ?? []) {
-			await collector.scanString(folder);
+			await scanContentWithTemplateIncludes(app, collector, folder);
 		}
 	}
 
@@ -266,7 +270,7 @@ async function collectForCaptureChoice(
 ): Promise<RequirementCollector> {
 	const collector = new RequirementCollector(app, plugin, choiceExecutor);
 
-	await collector.scanString(choice.captureTo);
+	await scanContentWithTemplateIncludes(app, collector, choice.captureTo);
 
 	if (choice.format?.enabled) {
 		await scanContentWithTemplateIncludes(

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -1,5 +1,6 @@
 import type { App, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
+import { MAX_TEMPLATE_INCLUSION_DEPTH } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "src/constants";
 import type QuickAdd from "src/main";
@@ -168,6 +169,7 @@ async function scanContentWithTemplateIncludes(
 	collector: RequirementCollector,
 	content: string,
 	visitedTemplates = new Set<string>(),
+	depth = 0,
 ): Promise<void> {
 	// templatesToScan is a queue for this content scan. Clear it before and
 	// after scanning so refs from unrelated strings are not drained together.
@@ -175,6 +177,8 @@ async function scanContentWithTemplateIncludes(
 	await collector.scanString(content);
 	const nested = [...collector.templatesToScan];
 	collector.templatesToScan.clear();
+
+	if (depth >= MAX_TEMPLATE_INCLUSION_DEPTH) return;
 
 	for (const ref of nested) {
 		if (visitedTemplates.has(ref)) continue;
@@ -184,6 +188,7 @@ async function scanContentWithTemplateIncludes(
 			collector,
 			await readTemplate(app, ref),
 			visitedTemplates,
+			depth + 1,
 		);
 	}
 }


### PR DESCRIPTION
Fixes a preflight/runtime divergence for template-backed capture formats from audit item #25.

Capture runtime already expands `{{TEMPLATE:...}}` includes before resolving prompts, but `quickadd:check` and one-page preflight only scanned the raw capture format. A capture format like `{{TEMPLATE:QA25/CaptureFormat.md}}` could therefore report no missing inputs even when the included file contained `{{VALUE:includedValue}}`.

This extracts one shared inert scanner for content plus queued template includes and uses it for the preflight strings that runtime sends through the full formatter: Template filenames/folders/bodies, Capture targets/formats/insert targets, and Capture create-with-template bodies. Template source paths keep the existing path-safe behavior: scan path tokens, skip body reads for dynamic paths, and only scan literal source bodies. The scanner also mirrors runtime template inclusion stack, max-depth behavior, and formatter ordering by not following `{{TEMPLATE:...}}` refs introduced by global-variable expansion.

Docs now clarify that `quickadd:check` and one-page preflight scan file-backed capture formats.

Review feedback:
- Addressed and resolved the Codex review thread about globals that expand to `{{TEMPLATE:...}}`; added regressions for ignored global-injected template includes and still-collected ordinary global-injected values.

Verification:
- Before fix in isolated vault: `quickadd:check id=qa25-capture-template-preflight` returned `requiredInputCount:0` even though runtime expanded the included template.
- After fix in isolated vault: `quickadd:check id=qa25-capture-template-preflight` returns missing `includedValue`; supplying `value-includedValue=...` returns OK.
- Template parity in isolated vault: `quickadd:check id=qa25-template-parity` still returns missing `templateIncludedValue`; supplying it returns OK.
- Runtime proof: Capture wrote `Captured included value: FinalCaptureRuntime`; Template created `QA25/TemplateOutput1.md` with `FinalTemplateRuntime` after correcting the test fixture to the current `{ kind: "apply", mode: "increment" }` policy shape.
- `pnpm run build-with-lint`
- `pnpm run check` (0 errors, existing 4 warnings)
- `pnpm test` (237 files, 2887 tests)
- `pnpm --dir docs run build` (passes with existing Docusaurus deprecation/localStorage warnings)
- `pnpm run obsidian:e2e -- dev:errors` -> no errors captured

Risk notes:
- The shared scanner remains inert: it reads template files through `getTemplateFile`/`cachedRead` and uses `RequirementCollector`; it does not run macros, inline JavaScript, or template engines during preflight.
- A malformed imported Capture choice with both insert-after and insert-before enabled may collect both static target inputs, while runtime prioritizes insert-after. The UI keeps those modes mutually exclusive.