### PR TITLE
refactor: extract pure helpers from the capture+format god-classes

### DIFF
--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -50,9 +50,11 @@ import {
 	waitForTemplaterTriggerOnCreateToComplete,
 } from "../utilityObsidian";
 import { isCancellationError, reportError } from "../utils/errorUtils";
-import { parsePropertyTarget } from "../utils/propertyTarget";
-import { parseCaptureFileFilterTarget } from "../utils/captureFileFilterTarget";
 import type { FieldFilter } from "../utils/FieldSuggestionParser";
+import {
+	resolveCaptureTarget as resolveCaptureTargetFromString,
+	type CaptureTargetResolution,
+} from "./helpers/captureTargetResolution";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import {
 	appendFileLinkToDestinationFile,
@@ -857,97 +859,22 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		}
 	}
 
+	/**
+	 * Adapter: classifies the formatted "Capture to" string into a concrete
+	 * destination via the pure {@link resolveCaptureTargetFromString}, binding the
+	 * live vault probes. Kept as a method so the existing call site and tests stay
+	 * unchanged.
+	 */
 	private resolveCaptureTarget(
 		formattedCaptureTo: string,
-	):
-		| { kind: "vault" }
-		| { kind: "filter"; filter: FieldFilter }
-		| { kind: "property"; field: string; value?: string; filter: FieldFilter }
-		| { kind: "folder"; folder: string }
-		| { kind: "file"; path: string } {
-		// Resolution order:
-		// 1) empty => vault picker
-		// 2) #tag/tag:/folder: filters => filtered picker
-		// 3) property:<field>[=<value>] => frontmatter-property picker
-		// 4) trailing "/" => folder picker (explicit)
-		// 5) known file extension => file
-		// 6) ambiguous => folder if it exists and no same-name file exists; else file
-		const rawCaptureTo = this.stripLeadingSlash(
-			formattedCaptureTo.trim(),
-		);
-
-		if (rawCaptureTo === "") {
-			return { kind: "vault" };
-		}
-
-		// `property:<field>[=<value>]` pre-filters by a frontmatter field (issue #466).
-		// Checked before the `.base`/extension/folder branches so a property value
-		// containing `.md`/`/` (or a trailing `/`) can never misroute to a file/folder.
-		const propertyTarget = parsePropertyTarget(rawCaptureTo);
-		if (propertyTarget) {
-			if (!propertyTarget.field) {
-				throw new ChoiceAbortError(
-					"Property capture target needs a field name, e.g. property:type=draft",
-				);
-			}
-			return {
-				kind: "property",
-				field: propertyTarget.field,
-				value: propertyTarget.value,
-				filter: propertyTarget.filter,
-			};
-		}
-
-		const fileFilterTarget = parseCaptureFileFilterTarget(rawCaptureTo);
-		if (fileFilterTarget) {
-			if (fileFilterTarget.multiSelect) {
-				throw new ChoiceAbortError(
-					"Capture target filters select one destination file. Use {{FILE:...|multi}} in the capture format for multi-value metadata.",
-				);
-			}
-			return {
-				kind: "filter",
-				filter: fileFilterTarget.filter,
-			};
-		}
-
-		const normalizedCaptureTo = normalizeGeneratedFilePath(
-			rawCaptureTo,
-			"Capture target file path",
-		);
-
-		if (BASE_FILE_EXTENSION_REGEX.test(normalizedCaptureTo)) {
-			throw new ChoiceAbortError(
-				`Capture to '.base' files is not supported (${normalizedCaptureTo}). Use a Template choice instead.`,
-			);
-		}
-
-		const endsWithSlash = normalizedCaptureTo.endsWith("/");
-		const folderPath = normalizedCaptureTo.replace(/\/+$/, "");
-
-		if (endsWithSlash) {
-			return { kind: "folder", folder: folderPath };
-		}
-
-		if (
-			MARKDOWN_FILE_EXTENSION_REGEX.test(normalizedCaptureTo) ||
-			CANVAS_FILE_EXTENSION_REGEX.test(normalizedCaptureTo)
-		) {
-			return { kind: "file", path: normalizedCaptureTo };
-		}
-
-		// Guard against ambiguity where a folder and file share the same name.
-		const fileCandidatePath = this.normalizeMarkdownFilePath("", folderPath);
-		const fileCandidate = this.app.vault.getAbstractFileByPath(
-			fileCandidatePath,
-		);
-		const fileExists = !!fileCandidate;
-
-		if (isFolder(this.app, folderPath) && !fileExists) {
-			return { kind: "folder", folder: folderPath };
-		}
-
-		return { kind: "file", path: normalizedCaptureTo };
+	): CaptureTargetResolution {
+		return resolveCaptureTargetFromString(formattedCaptureTo, {
+			getAbstractFileByPath: (path) =>
+				this.app.vault.getAbstractFileByPath(path),
+			isFolder: (path) => isFolder(this.app, path),
+			normalizeMarkdownFilePath: (folderPath, fileName) =>
+				this.normalizeMarkdownFilePath(folderPath, fileName),
+		});
 	}
 
 	/**

--- a/src/engine/helpers/captureTargetResolution.test.ts
+++ b/src/engine/helpers/captureTargetResolution.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import type { TAbstractFile } from "obsidian";
+import {
+	resolveCaptureTarget,
+	type CaptureTargetDeps,
+} from "./captureTargetResolution";
+import { ChoiceAbortError } from "../../errors/ChoiceAbortError";
+
+function deps(opts: { isFolder?: boolean; fileExists?: boolean } = {}): CaptureTargetDeps {
+	return {
+		getAbstractFileByPath: () =>
+			opts.fileExists ? ({} as TAbstractFile) : null,
+		isFolder: () => !!opts.isFolder,
+		// Faithful to QuickAddEngine.normalizeMarkdownFilePath for the ""+folderPath call.
+		normalizeMarkdownFilePath: (folderPath, fileName) => {
+			const safe = folderPath.replace(/^\/+/, "");
+			const prefix = safe ? `${safe}/` : "";
+			const name = fileName.replace(/^\/+/, "").replace(/\.md$/i, "");
+			return `${prefix}${name}.md`;
+		},
+	};
+}
+
+describe("resolveCaptureTarget", () => {
+	it("routes empty input to the vault-wide picker", () => {
+		expect(resolveCaptureTarget("", deps())).toEqual({ kind: "vault" });
+		expect(resolveCaptureTarget("   ", deps())).toEqual({ kind: "vault" });
+		expect(resolveCaptureTarget("/", deps())).toEqual({ kind: "vault" });
+	});
+
+	it("routes an explicit trailing slash to a folder picker", () => {
+		expect(resolveCaptureTarget("journals/", deps())).toEqual({
+			kind: "folder",
+			folder: "journals",
+		});
+	});
+
+	it("routes a known markdown/canvas extension to a file", () => {
+		expect(resolveCaptureTarget("Inbox/note.md", deps())).toEqual({
+			kind: "file",
+			path: "Inbox/note.md",
+		});
+		expect(resolveCaptureTarget("Boards/board.canvas", deps())).toEqual({
+			kind: "file",
+			path: "Boards/board.canvas",
+		});
+	});
+
+	it("treats an ambiguous name as a folder only when the folder exists and no same-name file does", () => {
+		expect(
+			resolveCaptureTarget("journals", deps({ isFolder: true, fileExists: false })),
+		).toEqual({ kind: "folder", folder: "journals" });
+		// folder exists but a same-name note also exists -> file wins (disambiguation)
+		expect(
+			resolveCaptureTarget("journals", deps({ isFolder: true, fileExists: true })),
+		).toEqual({ kind: "file", path: "journals" });
+		// not a folder at all -> file
+		expect(
+			resolveCaptureTarget("journals", deps({ isFolder: false })),
+		).toEqual({ kind: "file", path: "journals" });
+	});
+
+	it("routes property:<field>[=<value>] to the property picker before any file/folder branch", () => {
+		const r = resolveCaptureTarget("property:type=draft", deps());
+		expect(r.kind).toBe("property");
+		if (r.kind === "property") {
+			expect(r.field).toBe("type");
+			expect(r.value).toBe("draft");
+		}
+	});
+
+	it("does not misroute a property value that looks like a file path", () => {
+		const r = resolveCaptureTarget("property:type=draft.md", deps());
+		expect(r.kind).toBe("property");
+		if (r.kind === "property") expect(r.value).toBe("draft.md");
+	});
+
+	it("throws when a property target has no field name", () => {
+		expect(() => resolveCaptureTarget("property:=x", deps())).toThrow(
+			ChoiceAbortError,
+		);
+	});
+
+	it("routes tag/folder filters to the filtered picker", () => {
+		expect(resolveCaptureTarget("#work|tag:project", deps()).kind).toBe(
+			"filter",
+		);
+	});
+
+	it("rejects a multi-select filter as a capture destination", () => {
+		expect(() => resolveCaptureTarget("tag:work|multi", deps())).toThrow(
+			ChoiceAbortError,
+		);
+	});
+
+	it("rejects .base file targets", () => {
+		expect(() => resolveCaptureTarget("Data/table.base", deps())).toThrow(
+			ChoiceAbortError,
+		);
+	});
+});

--- a/src/engine/helpers/captureTargetResolution.ts
+++ b/src/engine/helpers/captureTargetResolution.ts
@@ -1,0 +1,125 @@
+import type { TAbstractFile } from "obsidian";
+import {
+	BASE_FILE_EXTENSION_REGEX,
+	CANVAS_FILE_EXTENSION_REGEX,
+	MARKDOWN_FILE_EXTENSION_REGEX,
+} from "../../constants";
+import { ChoiceAbortError } from "../../errors/ChoiceAbortError";
+import type { FieldFilter } from "../../utils/FieldSuggestionParser";
+import { parsePropertyTarget } from "../../utils/propertyTarget";
+import { parseCaptureFileFilterTarget } from "../../utils/captureFileFilterTarget";
+import { normalizeGeneratedFilePath } from "../../utils/generatedFilePath";
+
+/**
+ * The concrete capture destination decision derived from a (formatted) "Capture
+ * to" string. Discriminated so each downstream branch (vault-wide picker,
+ * filtered picker, frontmatter-property picker, folder picker, or a definite
+ * file path) is selected without re-parsing the string.
+ */
+export type CaptureTargetResolution =
+	| { kind: "vault" }
+	| { kind: "filter"; filter: FieldFilter }
+	| { kind: "property"; field: string; value?: string; filter: FieldFilter }
+	| { kind: "folder"; folder: string }
+	| { kind: "file"; path: string };
+
+/**
+ * Vault probes the resolver needs, injected so the classification stays a pure
+ * function of (input, deps) — deterministic and unit-testable with stubs, with
+ * no direct Obsidian `App` dependency. The engine binds these to the live vault.
+ */
+export interface CaptureTargetDeps {
+	getAbstractFileByPath(path: string): TAbstractFile | null;
+	isFolder(path: string): boolean;
+	/** Mirrors QuickAddEngine.normalizeMarkdownFilePath (the single source of truth). */
+	normalizeMarkdownFilePath(folderPath: string, fileName: string): string;
+}
+
+/**
+ * Classifies a formatted "Capture to" string into a concrete destination.
+ *
+ * Resolution order:
+ * 1) empty => vault picker
+ * 2) #tag/tag:/folder: filters => filtered picker
+ * 3) property:<field>[=<value>] => frontmatter-property picker
+ * 4) trailing "/" => folder picker (explicit)
+ * 5) known file extension => file
+ * 6) ambiguous => folder if it exists and no same-name file exists; else file
+ */
+export function resolveCaptureTarget(
+	formattedCaptureTo: string,
+	deps: CaptureTargetDeps,
+): CaptureTargetResolution {
+	const rawCaptureTo = formattedCaptureTo.trim().replace(/^\/+/, "");
+
+	if (rawCaptureTo === "") {
+		return { kind: "vault" };
+	}
+
+	// `property:<field>[=<value>]` pre-filters by a frontmatter field (issue #466).
+	// Checked before the `.base`/extension/folder branches so a property value
+	// containing `.md`/`/` (or a trailing `/`) can never misroute to a file/folder.
+	const propertyTarget = parsePropertyTarget(rawCaptureTo);
+	if (propertyTarget) {
+		if (!propertyTarget.field) {
+			throw new ChoiceAbortError(
+				"Property capture target needs a field name, e.g. property:type=draft",
+			);
+		}
+		return {
+			kind: "property",
+			field: propertyTarget.field,
+			value: propertyTarget.value,
+			filter: propertyTarget.filter,
+		};
+	}
+
+	const fileFilterTarget = parseCaptureFileFilterTarget(rawCaptureTo);
+	if (fileFilterTarget) {
+		if (fileFilterTarget.multiSelect) {
+			throw new ChoiceAbortError(
+				"Capture target filters select one destination file. Use {{FILE:...|multi}} in the capture format for multi-value metadata.",
+			);
+		}
+		return {
+			kind: "filter",
+			filter: fileFilterTarget.filter,
+		};
+	}
+
+	const normalizedCaptureTo = normalizeGeneratedFilePath(
+		rawCaptureTo,
+		"Capture target file path",
+	);
+
+	if (BASE_FILE_EXTENSION_REGEX.test(normalizedCaptureTo)) {
+		throw new ChoiceAbortError(
+			`Capture to '.base' files is not supported (${normalizedCaptureTo}). Use a Template choice instead.`,
+		);
+	}
+
+	const endsWithSlash = normalizedCaptureTo.endsWith("/");
+	const folderPath = normalizedCaptureTo.replace(/\/+$/, "");
+
+	if (endsWithSlash) {
+		return { kind: "folder", folder: folderPath };
+	}
+
+	if (
+		MARKDOWN_FILE_EXTENSION_REGEX.test(normalizedCaptureTo) ||
+		CANVAS_FILE_EXTENSION_REGEX.test(normalizedCaptureTo)
+	) {
+		return { kind: "file", path: normalizedCaptureTo };
+	}
+
+	// Guard against ambiguity where a folder and file share the same name.
+	const fileCandidatePath = deps.normalizeMarkdownFilePath("", folderPath);
+	const fileCandidate = deps.getAbstractFileByPath(fileCandidatePath);
+	const fileExists = !!fileCandidate;
+
+	if (deps.isFolder(folderPath) && !fileExists) {
+		return { kind: "folder", folder: folderPath };
+	}
+
+	return { kind: "file", path: normalizedCaptureTo };
+}

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -7,7 +7,6 @@ import {
 	CREATE_IF_NOT_FOUND_TOP,
 } from "../constants";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
-import type { BlankLineAfterMatchMode } from "../types/choices/ICaptureChoice";
 import { templaterParseTemplate } from "../utilityObsidian";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { CompleteFormatter } from "./completeFormatter";
@@ -18,10 +17,8 @@ import {
 	type MomentLike,
 	type OrderedSlot,
 } from "./helpers/orderedSectionPlacement";
-import {
-	getBodyStartOffset,
-	insertAtNoteBodyStartWithResult,
-} from "../utils/noteContentInsertion";
+import * as positioning from "./helpers/insertionPositioning";
+import { insertAtNoteBodyStartWithResult } from "../utils/noteContentInsertion";
 import { parentFolderPath } from "../utils/pathUtils";
 
 /**
@@ -382,233 +379,6 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		return this.expandLinebreakEscapesOutsideTokens(withGlobals);
 	}
 
-	/**
-	 * Splits a fully-expanded insert target into the anchor lines used for
-	 * matching. `\n` escapes in the target have already been turned into real
-	 * newlines (symmetric with the create-if-not-found path, which writes the
-	 * same expansion to disk), so a multi-line target like `**Today**\n***`
-	 * becomes `["**Today**", "***"]`.
-	 *
-	 * Trailing blank lines come from a trailing `\n` escape and are not part of
-	 * the anchor, so they are dropped: `**Today**\n` and `**Today**\n\n` both
-	 * collapse to the single-line anchor `["**Today**"]`. Interior blank lines
-	 * are preserved so a `## D\n\n**Tasks**` anchor still requires the blank.
-	 */
-	private toTargetLines(expandedTarget: string): string[] {
-		const lines = expandedTarget.split("\n");
-		while (lines.length > 1 && lines[lines.length - 1].trim() === "") {
-			lines.pop();
-		}
-		return lines;
-	}
-
-	private isBlankTarget(targetLines: string[]): boolean {
-		return (
-			targetLines.length === 0 ||
-			(targetLines.length === 1 && targetLines[0].trim() === "")
-		);
-	}
-
-	/**
-	 * Locates the insert target in the file. Returns the inclusive line range
-	 * `{ start, end }` the target occupies, or `{ start: -1, end: -1 }` when not
-	 * found. For a single-line target `start === end`, preserving historical
-	 * single-line behavior exactly. Callers pick which boundary to anchor on:
-	 * insert-after-immediate uses `end`, insert-before uses `start`,
-	 * insert-after-at-end derives the section end from `start` (issue #742).
-	 */
-	private findInsertAfterRange(
-		lines: string[],
-		targetLines: string[],
-	): { start: number; end: number } {
-		if (targetLines.length <= 1) {
-			const start = this.findSingleLineIndex(lines, targetLines[0] ?? "");
-			return { start, end: start };
-		}
-		return this.findMultiLineRange(lines, targetLines);
-	}
-
-	private findSingleLineIndex(lines: string[], rawTarget: string): number {
-		// `\n` escapes are already expanded upstream, so no escape stripping
-		// happens here — stripping would desync search from the create path,
-		// which writes the unstripped string (issue #742).
-		const target = rawTarget.trimEnd();
-		let partialIndex = -1;
-
-		for (let i = 0; i < lines.length; i++) {
-			// Trim only left whitespace to preserve indentation alignment
-			const line = lines[i].trimStart();
-
-			// 1. Exact match wins immediately
-			if (line === target) return i;
-
-			// 2. Check for prefix match (target + only whitespace suffix)
-			// This matches old regex behavior for lines starting with the target
-			if (line.startsWith(target)) {
-				const suffix = line.slice(target.length);
-				// If suffix is only whitespace, this matches old regex behavior exactly
-				if (/^\s*$/.test(suffix)) return i;
-
-				// Remember first broader prefix match as fallback
-				if (partialIndex === -1) {
-					partialIndex = i;
-				}
-
-				continue;
-			}
-
-			// 3. Check for substring match (target appears anywhere in line with only whitespace after)
-			// This restores legacy behavior where selectors like "| ----- |" can match
-			// table separator rows where the target appears at the end
-			const targetIndex = line.indexOf(target);
-			if (targetIndex !== -1) {
-				const suffix = line.slice(targetIndex + target.length);
-				// If suffix is only whitespace, match this line
-				if (/^\s*$/.test(suffix)) return i;
-
-				// Remember first broader substring match as fallback
-				if (partialIndex === -1) {
-					partialIndex = i;
-				}
-			}
-		}
-
-		return partialIndex; // -1 if no match at all
-	}
-
-	/**
-	 * Matches a multi-line target as a consecutive run of file lines. Only
-	 * TRAILING whitespace is stripped before comparison (on both sides), which
-	 * normalizes CRLF carriage returns and trailing spaces while preserving
-	 * LEADING indentation — `  - Parent\n    - Child` must not match a flat
-	 * `- Parent\n- Child`. Because the create path writes the target verbatim,
-	 * an indented anchor still round-trips. No fuzzy/partial fallback: a
-	 * multi-line anchor must match verbatim to avoid false positives.
-	 */
-	private findMultiLineRange(
-		lines: string[],
-		targetLines: string[],
-	): { start: number; end: number } {
-		const n = targetLines.length;
-		const normalizedTargets = targetLines.map((line) =>
-			this.stripTrailingWhitespace(line),
-		);
-
-		for (let i = 0; i + n <= lines.length; i++) {
-			let matched = true;
-			for (let k = 0; k < n; k++) {
-				if (this.stripTrailingWhitespace(lines[i + k]) !== normalizedTargets[k]) {
-					matched = false;
-					break;
-				}
-			}
-			if (matched) return { start: i, end: i + n - 1 };
-		}
-
-		return { start: -1, end: -1 };
-	}
-
-	private stripTrailingWhitespace(line: string): string {
-		return line.replace(/\s+$/, "");
-	}
-
-	/**
-	 * `considerSubsections` only has meaning for a heading anchor — a non-heading
-	 * line has no section whose subsections could be included, and
-	 * getEndOfSection() throws if asked to consider subsections of a non-heading
-	 * line. Multi-line anchors made non-heading start lines newly matchable
-	 * (issue #742), so degrade to false when the anchor is not a heading
-	 * (using getEndOfSection's own heading definition) instead of throwing.
-	 */
-	private considerSubsectionsForAnchor(
-		lines: string[],
-		anchorLine: number,
-	): boolean {
-		if (!this.choice.insertAfter?.considerSubsections) return false;
-		return getMarkdownHeadings([lines[anchorLine] ?? ""]).length > 0;
-	}
-
-	private shouldSkipBlankLinesAfterMatch(
-		mode: BlankLineAfterMatchMode,
-		line: string,
-	): boolean {
-		if (mode === "skip") return true;
-		if (mode === "none") return false;
-		return this.isAtxHeading(line);
-	}
-
-	private isAtxHeading(line: string): boolean {
-		return /^\s{0,3}#{1,6}\s+\S/.test(line);
-	}
-
-	private findInsertAfterPositionWithBlankLines(
-		lines: string[],
-		matchIndex: number,
-		body: string,
-		mode: BlankLineAfterMatchMode,
-	): number {
-		if (matchIndex < 0) return matchIndex;
-
-		const matchLine = lines[matchIndex] ?? "";
-		const shouldSkip = this.shouldSkipBlankLinesAfterMatch(mode, matchLine);
-		if (!shouldSkip) return matchIndex;
-
-		// Ignore the trailing empty line that results from split("\n") when the
-		// file ends with a newline. This preserves existing EOF behavior.
-		const scanLimit = body.endsWith("\n")
-			? Math.max(lines.length - 1, 0)
-			: lines.length;
-		let position = matchIndex;
-
-		for (let i = matchIndex + 1; i < scanLimit; i++) {
-			if (lines[i].trim().length === 0) {
-				position = i;
-				continue;
-			}
-			break;
-		}
-
-		return position;
-	}
-
-	private findInsertAfterPositionAtSectionEnd(
-		lines: string[],
-		sectionEndIndex: number,
-		fileContent: string,
-		insertedText: string,
-	): number {
-		if (sectionEndIndex < 0) return sectionEndIndex;
-
-		let position = sectionEndIndex;
-		let i = sectionEndIndex + 1;
-
-		while (i < lines.length && lines[i].trim().length === 0) {
-			position = i;
-			i++;
-		}
-
-		// Preserve current behavior when there are no trailing blank lines or when
-		// blanks are followed by content (e.g. before a new heading).
-		if (position === sectionEndIndex || i !== lines.length) {
-			return sectionEndIndex;
-		}
-
-		// For entries without trailing newline, keep insertion anchored at the
-		// section end so repeated captures preserve order.
-		if (!insertedText.endsWith("\n")) {
-			return sectionEndIndex;
-		}
-
-		// split("\n") keeps a trailing empty string when content ends in "\n".
-		// We keep one trailing slot so the next insertion preserves capture spacing
-		// without introducing an extra blank line before the inserted text.
-		if (fileContent.endsWith("\n")) {
-			return Math.max(sectionEndIndex, position - 1);
-		}
-
-		return position;
-	}
-
 	private async insertAfterHandler(formatted: string) {
 		const override = this.insertAfterTargetOverride;
 
@@ -648,8 +418,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 				: null;
 		}
 
-		const targetLines = this.toTargetLines(targetString);
-		if (this.isBlankTarget(targetLines)) {
+		const targetLines = positioning.toTargetLines(targetString);
+		if (positioning.isBlankTarget(targetLines)) {
 			throw new ChoiceAbortError(
 				"Insert-after target is empty after formatting.",
 			);
@@ -664,9 +434,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		// so the found-path position math below stays valid. Non-ordered captures keep
 		// their existing (unmasked) search behaviour.
 		const searchLines = this.isOrderedCreate()
-			? this.maskNonBodyHeadingsForSearch(fileContentLines)
+			? positioning.maskNonBodyHeadingsForSearch(fileContentLines, this.fileContent)
 			: fileContentLines;
-		const { start, end } = this.findInsertAfterRange(searchLines, targetLines);
+		const { start, end } = positioning.findInsertAfterRange(searchLines, targetLines);
 		const targetNotFound = start === -1;
 		if (targetNotFound) {
 			if (this.choice.insertAfter?.createIfNotFound) {
@@ -695,7 +465,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 				end,
 			);
 
-			targetPosition = this.findInsertAfterPositionAtSectionEnd(
+			targetPosition = positioning.findInsertAfterPositionAtSectionEnd(
 				fileContentLines,
 				sectionEnd,
 				this.fileContent,
@@ -705,7 +475,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			const blankLineMode =
 				this.choice.insertAfter?.blankLineAfterMatchMode ?? "auto";
 			// Insert after the block's last line; blank-line skipping keys off it.
-			targetPosition = this.findInsertAfterPositionWithBlankLines(
+			targetPosition = positioning.findInsertAfterPositionWithBlankLines(
 				fileContentLines,
 				end,
 				this.fileContent,
@@ -732,8 +502,8 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			await this.expandFormatTemplateEscapes(insertBefore.before),
 		);
 
-		const targetLines = this.toTargetLines(targetString);
-		if (this.isBlankTarget(targetLines)) {
+		const targetLines = positioning.toTargetLines(targetString);
+		if (positioning.isBlankTarget(targetLines)) {
 			throw new ChoiceAbortError(
 				"Insert-before target is empty after formatting.",
 			);
@@ -742,7 +512,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		const fileContentLines: string[] = getLinesInString(this.fileContent);
 		// Insert-before anchors on the block's FIRST line so the capture lands
 		// before the whole multi-line anchor (never inside it — issue #742).
-		const { start } = this.findInsertAfterRange(fileContentLines, targetLines);
+		const { start } = positioning.findInsertAfterRange(fileContentLines, targetLines);
 		const targetNotFound = start === -1;
 		if (targetNotFound) {
 			if (insertBefore.createIfNotFound) {
@@ -761,24 +531,11 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		);
 	}
 
-	private hasInlineTargetLinebreak(target: string): boolean {
-		return target.includes("\n") || target.includes("\r");
-	}
-
-	private getInlineEndOfLine(startIndex: number): number {
-		const newlineIndex = this.fileContent.indexOf("\n", startIndex);
-		if (newlineIndex === -1) return this.fileContent.length;
-		if (newlineIndex > 0 && this.fileContent[newlineIndex - 1] === "\r") {
-			return newlineIndex - 1;
-		}
-		return newlineIndex;
-	}
-
 	private async insertAfterInlineHandler(
 		formatted: string,
 		targetString: string,
 	): Promise<string> {
-		if (this.hasInlineTargetLinebreak(targetString)) {
+		if (positioning.hasInlineTargetLinebreak(targetString)) {
 			// Inline insertion lands mid-line after a matched substring, so a
 			// multi-line target can never match. Abort cleanly with a clear message
 			// (parity with the block path's not-found abort) instead of searching for
@@ -805,7 +562,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		const matchEnd = matchIndex + targetString.length;
 		this.setCaptureInsertionEndOffset(matchEnd + formatted.length);
 		if (this.choice.insertAfter?.replaceExisting) {
-			const endOfLine = this.getInlineEndOfLine(matchEnd);
+			const endOfLine = positioning.getInlineEndOfLine(this.fileContent, matchEnd);
 			return (
 				this.fileContent.slice(0, matchEnd) +
 				formatted +
@@ -873,7 +630,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 						this.considerSubsectionsForAnchor(fileContentLines, targetPosition),
 					);
 
-					targetPosition = this.findInsertAfterPositionAtSectionEnd(
+					targetPosition = positioning.findInsertAfterPositionAtSectionEnd(
 						fileContentLines,
 						endOfSectionIndex ?? fileContentLines.length - 1,
 						this.fileContent,
@@ -925,30 +682,20 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	/**
-	 * Index of the first body line after any YAML frontmatter (0 when none).
-	 * Mirrors insertAtNoteBodyStart's frontmatter detection (getBodyStartOffset).
+	 * Adapter: binds this run's `considerSubsections` choice flag to the pure
+	 * helper. Kept (unlike the single-use file-content passthroughs, which are
+	 * inlined at their call site) because it dedupes the flag binding across the
+	 * three insert-after positioning call sites.
 	 */
-	private getBodyStartLine(): number {
-		const bodyStartOffset = getBodyStartOffset(this.fileContent);
-		return bodyStartOffset > 0
-			? this.fileContent.slice(0, bodyStartOffset).split("\n").length - 1
-			: 0;
-	}
-
-	/**
-	 * Returns CRLF-stripped lines with frontmatter lines blanked and fenced-code
-	 * headings neutralized, so the ordered target search never matches a heading
-	 * that isn't a real body section. Line indices are preserved.
-	 */
-	private maskNonBodyHeadingsForSearch(lines: string[]): string[] {
-		const bodyStartLine = this.getBodyStartLine();
-		const masked = maskFencedHeadings(lines).map((line) =>
-			line.replace(/\r$/, ""),
+	private considerSubsectionsForAnchor(
+		lines: string[],
+		anchorLine: number,
+	): boolean {
+		return positioning.anchorAllowsSubsections(
+			!!this.choice.insertAfter?.considerSubsections,
+			lines,
+			anchorLine,
 		);
-		for (let i = 0; i < bodyStartLine && i < masked.length; i++) {
-			masked[i] = "";
-		}
-		return masked;
 	}
 
 	private createInsertAfterOrdered(
@@ -981,7 +728,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		// Exclude any YAML frontmatter so a `#`-prefixed YAML line is never treated
 		// as a sibling/ancestor and the new section can never be spliced into the
 		// frontmatter block (frontmatter detection mirrors insertAtNoteBodyStart).
-		const bodyStartLine = this.getBodyStartLine();
+		const bodyStartLine = positioning.getBodyStartLine(this.fileContent);
 
 		// Idempotency guard for multi-line anchors: the block search (findInsertAfterRange)
 		// matches the WHOLE multi-line target, so a target like "## 2026-06-16\n**Tasks**"
@@ -998,7 +745,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		);
 		if (existingHeadingLine !== -1) {
 			const position = this.choice.insertAfter?.insertAtEnd
-				? this.findInsertAfterPositionAtSectionEnd(
+				? positioning.findInsertAfterPositionAtSectionEnd(
 						maskedLines,
 						getEndOfSection(
 							maskedLines,
@@ -1011,7 +758,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 						this.fileContent,
 						formatted,
 					)
-				: this.findInsertAfterPositionWithBlankLines(
+				: positioning.findInsertAfterPositionWithBlankLines(
 						maskedLines,
 						existingHeadingLine,
 						this.fileContent,
@@ -1045,69 +792,23 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	/**
-	 * Splice a created section at the resolved slot, padding it with a single blank
-	 * line above the heading (when the preceding line is non-blank) and below the
-	 * block (when the following line is non-blank) so the heading is never glued to
-	 * neighbouring content (the helpers QuickAdd ships do not pad headings —
-	 * verified — so this is the dedicated separation path for ordered creation).
-	 *
-	 * Byte-preserving: the original `fileContent` is sliced at the insertion offset
-	 * and the existing text on both sides is kept VERBATIM (so a mixed-EOL note is
-	 * never wholesale-normalized — an ordered capture produces a minimal diff). Only
-	 * the inserted block and its two seams use the file's dominant EOL. The offset
-	 * is derived from `rawLines` (which `getLinesInString` produced by splitting on
-	 * "\n", so each prior line consumed its own length + 1 for the "\n"). `\r` is
-	 * stripped only for the blank-line trim checks.
+	 * Adapter: splices a created ordered section into this run's file content and
+	 * records the cursor end offset. Positioning logic lives in
+	 * {@link positioning.spliceOrderedSection}.
 	 */
 	private spliceOrderedSection(
 		rawLines: string[],
 		slot: Exclude<OrderedSlot, { mode: "bodyStart" }>,
 		payload: string,
 	): string {
-		const content = this.fileContent;
-		const eol = content.includes("\r\n") ? "\r\n" : "\n";
-		const insertIdx = slot.mode === "before" ? slot.line : slot.line + 1;
-
-		// Character offset of the start of line `insertIdx` in the original content.
-		let offset = 0;
-		for (let i = 0; i < insertIdx && i < rawLines.length; i++) {
-			offset += rawLines[i].length + 1; // +1 for the consumed "\n"
-		}
-		if (offset > content.length) offset = content.length;
-		const before = content.slice(0, offset);
-		const after = content.slice(offset);
-
-		const prev =
-			insertIdx > 0 ? (rawLines[insertIdx - 1] ?? "").replace(/\r$/, "") : "";
-		const next =
-			insertIdx < rawLines.length
-				? (rawLines[insertIdx] ?? "").replace(/\r$/, "")
-				: "";
-
-		const payloadLines = payload.split("\n").map((line) => line.replace(/\r$/, ""));
-		// Drop a single trailing empty line that a format ending in "\n" produces, so
-		// separation is controlled solely by the padding below.
-		if (payloadLines.length > 1 && payloadLines[payloadLines.length - 1] === "") {
-			payloadLines.pop();
-		}
-
-		const blockLines: string[] = [];
-		if (insertIdx > 0 && prev.trim() !== "") blockLines.push(""); // blank above heading
-		blockLines.push(...payloadLines);
-		if (insertIdx < rawLines.length && next.trim() !== "") blockLines.push(""); // blank below block
-
-		const blockText = blockLines.join(eol);
-		// Terminate the preceding line when `before` doesn't already end with a
-		// newline (the EOF-without-trailing-newline case), and terminate the block
-		// when content follows it OR when the file already ended with a newline (so
-		// appending at EOF preserves the file's trailing newline). Existing bytes in
-		// before/after stay verbatim.
-		const lead = before.length > 0 && !/\n$/.test(before) ? eol : "";
-		const trail =
-			after.length > 0 || /\n$/.test(content) ? eol : "";
-		const insertedStartOffset = before.length + lead.length;
-		this.setCaptureInsertionEndOffset(insertedStartOffset + blockText.length);
-		return `${before}${lead}${blockText}${trail}${after}`;
+		const { content, insertedEndOffset } = positioning.spliceOrderedSection(
+			rawLines,
+			slot,
+			payload,
+			this.fileContent,
+		);
+		this.setCaptureInsertionEndOffset(insertedEndOffset);
+		return content;
 	}
 
 	private async createInsertBeforeIfNotFound(
@@ -1251,74 +952,38 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		return result.content;
 	}
 
+	/** Adapter: binds this run's task flag, records the cursor end offset. */
 	private insertTextAfterPositionInBody(
 		rawText: string,
 		body: string,
 		pos: number,
 	): string {
-		// Line-matched insertAfter callers always pass a real line index (>= 0); the
-		// frontmatter-aware "top" insertion lives in insertAtNoteBodyStart instead.
-		// Shared by every "after" path: the line-matched handler, insert-at-end-of-
-		// section, and the create-if-not-found cursor paths.
-		const splitContent = body.split("\n");
-		const pre = splitContent.slice(0, pos + 1).join("\n");
-		const post = splitContent.slice(pos + 1).join("\n");
-
-		// "Format as task" injects a trailing newline onto the capture content
-		// (getCaptureContent in CaptureChoiceEngine) so a bare task is always a
-		// complete line. When the line directly below the insertion point is already
-		// blank, that injected newline stacks on top of the existing blank line and
-		// renders a spurious blank line AFTER the task (issue #312) — an asymmetry
-		// the user does not see without the task option. Drop the redundant injected
-		// newline in that case; the existing blank line still separates the task from
-		// the following content. A user-typed trailing newline in the format string
-		// is intentional content and is left untouched (gated on choice.task, this
-		// only collapses QuickAdd's own injected task newline).
-		//
-		// Detect the blank line via the split index, not `post.startsWith("\n")`, so
-		// whitespace-only and CRLF blanks (where the line is "\r" or "   ", not "")
-		// are recognised too. When `body` ends in a newline, split() appends a
-		// trailing empty slot that is the EOF artifact, not a real blank line, so it
-		// must not trigger the drop; a body WITHOUT a trailing newline has no such
-		// artifact, so its final slot is a genuine (possibly blank) last line.
-		const lineBelow = splitContent[pos + 1];
-		const isTrailingNewlineArtifact =
-			body.endsWith("\n") && pos + 1 === splitContent.length - 1;
-		const blankLineDirectlyBelow =
-			pos + 1 < splitContent.length &&
-			!isTrailingNewlineArtifact &&
-			(lineBelow ?? "").trim() === "";
-		const text =
-			this.choice.task && rawText.endsWith("\n") && blankLineDirectlyBelow
-				? rawText.slice(0, -1)
-				: rawText;
-
-		this.setCaptureInsertionEndOffset(pre.length + 1 + text.length);
-		return `${pre}\n${text}${post}`;
+		const { content, insertedEndOffset } =
+			positioning.insertTextAfterPositionInBody(
+				rawText,
+				body,
+				pos,
+				!!this.choice.task,
+			);
+		this.setCaptureInsertionEndOffset(insertedEndOffset);
+		return content;
 	}
 
+	/** Adapter: records the cursor end offset around the pure helper. */
 	private insertTextBeforePositionInBody(
 		text: string,
 		body: string,
 		pos: number,
 		cursorOffsetInText = text.length,
 	): string {
-		const separator = body.length > 0 && !text.endsWith("\n") ? "\n" : "";
-		const clampedOffset = Math.max(
-			0,
-			Math.min(cursorOffsetInText, text.length),
-		);
-
-		if (pos <= 0) {
-			this.setCaptureInsertionEndOffset(clampedOffset);
-			return `${text}${separator}${body}`;
-		}
-
-		const splitContent = body.split("\n");
-		const pre = splitContent.slice(0, pos).join("\n");
-		const post = splitContent.slice(pos).join("\n");
-
-		this.setCaptureInsertionEndOffset(pre.length + 1 + clampedOffset);
-		return `${pre}\n${text}${separator}${post}`;
+		const { content, insertedEndOffset } =
+			positioning.insertTextBeforePositionInBody(
+				text,
+				body,
+				pos,
+				cursorOffsetInText,
+			);
+		this.setCaptureInsertionEndOffset(insertedEndOffset);
+		return content;
 	}
 }

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -25,10 +25,10 @@ import {
 import {
 	decodeFileValue,
 	fileBasenameFromPath,
-	type FileMode,
 	type ParsedFileToken,
 	parseFileToken,
 } from "../utils/fileSyntax";
+import { renderStoredFileValue } from "./helpers/fileTokenRendering";
 import { getDate } from "../utilityObsidian";
 import type { IDateParser } from "../parsers/IDateParser";
 import { log } from "../logger/logManager";
@@ -994,9 +994,10 @@ export abstract class Formatter {
 				this.variables.set(key, await this.suggestForFile(parsed));
 			}
 
-			const renderedValue = this.renderFileValue(
+			const renderedValue = renderStoredFileValue(
 				this.variables.get(key),
 				parsed.mode,
+				(stored) => this.getFileLinkForStoredValue(stored),
 			);
 			if (Array.isArray(renderedValue)) {
 				const structuredYamlValue = this.propertyCollector.maybeCollect({
@@ -1016,33 +1017,6 @@ export abstract class Formatter {
 		}
 
 		return output + input.slice(lastIndex);
-	}
-
-	private renderFileValue(stored: unknown, mode: FileMode): string | string[] {
-		if (Array.isArray(stored)) {
-			return stored.map((value) => this.renderSingleFileValue(value, mode));
-		}
-		return this.renderSingleFileValue(stored, mode);
-	}
-
-	private renderSingleFileValue(stored: unknown, mode: FileMode): string {
-		if (mode === "link") return this.getFileLinkForStoredValue(stored);
-
-		const decoded = decodeFileValue(stored);
-		switch (decoded.kind) {
-			case "empty":
-				return "";
-			case "file":
-				return mode === "path"
-					? decoded.path
-					: fileBasenameFromPath(decoded.path);
-			case "custom":
-			case "raw":
-				// Literal, user-provided text (a |custom type-in, a one-page typed
-				// value, or a script-seeded string). It is NEVER resolved to a real
-				// file — only a `@file:` pick from the filtered list is.
-				return decoded.kind === "custom" ? decoded.text : decoded.value;
-		}
 	}
 
 	/**

--- a/src/formatters/helpers/fileTokenRendering.test.ts
+++ b/src/formatters/helpers/fileTokenRendering.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderStoredFileValue } from "./fileTokenRendering";
+
+// decodeFileValue contract: a real pick is "@file:<path>" (kind file), typed
+// text is "@filecustom:<text>" (kind custom), "" is empty, and any other bare
+// string is kind raw (passed through verbatim, never resolved to a file).
+describe("renderStoredFileValue", () => {
+	const link = (stored: unknown) => `[[${String(stored)}]]`;
+
+	it("renders a picked file's basename in name mode", () => {
+		expect(renderStoredFileValue("@file:Notes/Idea.md", "name", link)).toBe(
+			"Idea",
+		);
+	});
+
+	it("renders the full path in path mode", () => {
+		expect(renderStoredFileValue("@file:Notes/Idea.md", "path", link)).toBe(
+			"Notes/Idea.md",
+		);
+	});
+
+	it("delegates link mode to the injected resolver (verbatim stored value)", () => {
+		const resolve = vi.fn(() => "[[Notes/Idea|Idea]]");
+		expect(renderStoredFileValue("@file:Notes/Idea.md", "link", resolve)).toBe(
+			"[[Notes/Idea|Idea]]",
+		);
+		expect(resolve).toHaveBeenCalledWith("@file:Notes/Idea.md");
+	});
+
+	it("renders empty for an empty stored value", () => {
+		expect(renderStoredFileValue("", "name", link)).toBe("");
+		expect(renderStoredFileValue("", "path", link)).toBe("");
+	});
+
+	it("passes literal custom text through verbatim, never resolving it", () => {
+		const resolve = vi.fn(() => "SHOULD-NOT-BE-CALLED");
+		expect(
+			renderStoredFileValue("@filecustom:My typed value", "name", resolve),
+		).toBe("My typed value");
+		expect(resolve).not.toHaveBeenCalled();
+	});
+
+	it("passes a bare (unprefixed) raw string through verbatim", () => {
+		expect(renderStoredFileValue("just text", "name", link)).toBe("just text");
+		expect(renderStoredFileValue("just text", "path", link)).toBe("just text");
+	});
+
+	it("maps array stored values element-wise", () => {
+		expect(
+			renderStoredFileValue(["@file:A/one.md", "@file:B/two.md"], "name", link),
+		).toEqual(["one", "two"]);
+	});
+
+	it("applies link mode element-wise for arrays", () => {
+		expect(
+			renderStoredFileValue(["@file:one.md", "@file:two.md"], "link", link),
+		).toEqual(["[[@file:one.md]]", "[[@file:two.md]]"]);
+	});
+});

--- a/src/formatters/helpers/fileTokenRendering.ts
+++ b/src/formatters/helpers/fileTokenRendering.ts
@@ -1,0 +1,52 @@
+import {
+	decodeFileValue,
+	fileBasenameFromPath,
+	type FileMode,
+} from "../../utils/fileSyntax";
+
+/**
+ * Renders a stored `{{FILE:...}}` token value to the string(s) that replace the
+ * token, by render mode (basename / wikilink / path).
+ *
+ * Pure: the only effectful concern — turning a real picked file into a wikilink
+ * (which needs the vault + the caller's link settings/source path) — is injected
+ * as `resolveLink`. Everything else (decode, basename, path, literal/custom
+ * passthrough) is a deterministic transform of the stored value, so this stays
+ * App-free and unit-testable. An array stored value (a `|multi` pick or a script
+ * array) maps element-wise, mirroring how the token is later collected as a YAML
+ * list.
+ */
+export function renderStoredFileValue(
+	stored: unknown,
+	mode: FileMode,
+	resolveLink: (stored: unknown) => string,
+): string | string[] {
+	if (Array.isArray(stored)) {
+		return stored.map((value) => renderSingleFileValue(value, mode, resolveLink));
+	}
+	return renderSingleFileValue(stored, mode, resolveLink);
+}
+
+function renderSingleFileValue(
+	stored: unknown,
+	mode: FileMode,
+	resolveLink: (stored: unknown) => string,
+): string {
+	if (mode === "link") return resolveLink(stored);
+
+	const decoded = decodeFileValue(stored);
+	switch (decoded.kind) {
+		case "empty":
+			return "";
+		case "file":
+			return mode === "path"
+				? decoded.path
+				: fileBasenameFromPath(decoded.path);
+		case "custom":
+		case "raw":
+			// Literal, user-provided text (a |custom type-in, a one-page typed
+			// value, or a script-seeded string). It is NEVER resolved to a real
+			// file — only a `@file:` pick from the filtered list is.
+			return decoded.kind === "custom" ? decoded.text : decoded.value;
+	}
+}

--- a/src/formatters/helpers/insertionPositioning.test.ts
+++ b/src/formatters/helpers/insertionPositioning.test.ts
@@ -174,6 +174,17 @@ describe("maskNonBodyHeadingsForSearch", () => {
 		expect(masked[3]).toBe("## Real"); // real heading kept
 		expect(masked[5]).not.toBe("## Fake"); // fenced heading neutralized
 	});
+
+	it("does not mask a real body heading when frontmatter holds an unclosed code fence (CodeRabbit #1404)", () => {
+		// A YAML block scalar containing an indented code fence: maskFencedHeadings
+		// must run on body-scoped lines, otherwise the unclosed frontmatter fence
+		// leaks into the body and neutralizes the real heading.
+		const file = "---\nnote: |\n  ```js\n  example\n---\n## Real\n- x";
+		const lines = file.split("\n");
+		const realIdx = lines.indexOf("## Real");
+		const masked = maskNonBodyHeadingsForSearch(lines, file);
+		expect(masked[realIdx]).toBe("## Real");
+	});
 });
 
 describe("anchorAllowsSubsections", () => {

--- a/src/formatters/helpers/insertionPositioning.test.ts
+++ b/src/formatters/helpers/insertionPositioning.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "vitest";
+import {
+	toTargetLines,
+	isBlankTarget,
+	findSingleLineIndex,
+	findMultiLineRange,
+	findInsertAfterRange,
+	isAtxHeading,
+	shouldSkipBlankLinesAfterMatch,
+	findInsertAfterPositionWithBlankLines,
+	findInsertAfterPositionAtSectionEnd,
+	hasInlineTargetLinebreak,
+	getInlineEndOfLine,
+	getBodyStartLine,
+	maskNonBodyHeadingsForSearch,
+	anchorAllowsSubsections,
+	insertTextAfterPositionInBody,
+	insertTextBeforePositionInBody,
+	spliceOrderedSection,
+} from "./insertionPositioning";
+
+describe("toTargetLines", () => {
+	it("drops trailing blank lines from a trailing \\n escape", () => {
+		expect(toTargetLines("**Today**\n")).toEqual(["**Today**"]);
+		expect(toTargetLines("**Today**\n\n")).toEqual(["**Today**"]);
+	});
+	it("preserves interior blank lines", () => {
+		expect(toTargetLines("## D\n\n**Tasks**")).toEqual(["## D", "", "**Tasks**"]);
+	});
+	it("returns a single-element array for a plain target", () => {
+		expect(toTargetLines("## Log")).toEqual(["## Log"]);
+	});
+});
+
+describe("isBlankTarget", () => {
+	it("is true for empty / single-blank targets", () => {
+		expect(isBlankTarget([])).toBe(true);
+		expect(isBlankTarget([""])).toBe(true);
+		expect(isBlankTarget(["   "])).toBe(true);
+	});
+	it("is false for real content", () => {
+		expect(isBlankTarget(["## Log"])).toBe(false);
+		expect(isBlankTarget(["", "x"])).toBe(false);
+	});
+});
+
+describe("findSingleLineIndex", () => {
+	const lines = ["# Title", "  ## Log", "- a", "before | ----- |"];
+	it("matches exact (ignoring leading whitespace)", () => {
+		expect(findSingleLineIndex(lines, "## Log")).toBe(1);
+	});
+	it("matches a substring with only-whitespace suffix", () => {
+		expect(findSingleLineIndex(["text TARGET   "], "TARGET")).toBe(0);
+	});
+	it("returns -1 when no match", () => {
+		expect(findSingleLineIndex(lines, "## Missing")).toBe(-1);
+	});
+});
+
+describe("findMultiLineRange", () => {
+	it("matches a consecutive run, normalizing trailing whitespace/CR", () => {
+		const lines = ["a", "## D\r", "**Tasks**  ", "b"];
+		expect(findMultiLineRange(lines, ["## D", "**Tasks**"])).toEqual({
+			start: 1,
+			end: 2,
+		});
+	});
+	it("does not match when leading indentation differs", () => {
+		const lines = ["- Parent", "- Child"];
+		expect(findMultiLineRange(lines, ["  - Parent", "    - Child"])).toEqual({
+			start: -1,
+			end: -1,
+		});
+	});
+});
+
+describe("findInsertAfterRange", () => {
+	it("delegates to single-line search for a one-line target", () => {
+		expect(findInsertAfterRange(["x", "## Log"], ["## Log"])).toEqual({
+			start: 1,
+			end: 1,
+		});
+	});
+	it("delegates to multi-line search for a multi-line target", () => {
+		expect(
+			findInsertAfterRange(["## D", "**Tasks**", "y"], ["## D", "**Tasks**"]),
+		).toEqual({ start: 0, end: 1 });
+	});
+});
+
+describe("isAtxHeading / shouldSkipBlankLinesAfterMatch", () => {
+	it("recognizes ATX headings", () => {
+		expect(isAtxHeading("## Log")).toBe(true);
+		expect(isAtxHeading("not a heading")).toBe(false);
+	});
+	it("auto mode only skips after a heading", () => {
+		expect(shouldSkipBlankLinesAfterMatch("auto", "## Log")).toBe(true);
+		expect(shouldSkipBlankLinesAfterMatch("auto", "- item")).toBe(false);
+		expect(shouldSkipBlankLinesAfterMatch("skip", "- item")).toBe(true);
+		expect(shouldSkipBlankLinesAfterMatch("none", "## Log")).toBe(false);
+	});
+});
+
+describe("findInsertAfterPositionWithBlankLines", () => {
+	it("skips trailing blank lines after a heading in auto mode", () => {
+		const body = "## Log\n\n\n- existing";
+		const lines = body.split("\n");
+		// matchIndex 0 (the heading), should advance past the two blanks to line 2
+		expect(findInsertAfterPositionWithBlankLines(lines, 0, body, "auto")).toBe(2);
+	});
+	it("returns the match index when not a heading (auto)", () => {
+		const body = "- item\n\n- next";
+		expect(
+			findInsertAfterPositionWithBlankLines(body.split("\n"), 0, body, "auto"),
+		).toBe(0);
+	});
+});
+
+describe("findInsertAfterPositionAtSectionEnd", () => {
+	it("advances past trailing blanks but keeps one slot when content ends with a newline", () => {
+		const file = "## A\n- x\n\n";
+		const lines = file.split("\n"); // ["## A","- x","",""]
+		// sectionEnd at 1, two trailing blank slots, inserted text ends with \n:
+		// advance to the last blank (3) then keep one slot back -> 2.
+		expect(
+			findInsertAfterPositionAtSectionEnd(lines, 1, file, "- new\n"),
+		).toBe(2);
+	});
+	it("stays at the section end when there are no trailing blanks", () => {
+		const file = "## A\n- x\n## B\n";
+		const lines = file.split("\n");
+		expect(findInsertAfterPositionAtSectionEnd(lines, 1, file, "- new\n")).toBe(1);
+	});
+});
+
+describe("hasInlineTargetLinebreak", () => {
+	it("detects LF and CR in a target", () => {
+		expect(hasInlineTargetLinebreak("a\nb")).toBe(true);
+		expect(hasInlineTargetLinebreak("a\rb")).toBe(true);
+		expect(hasInlineTargetLinebreak("single line")).toBe(false);
+	});
+});
+
+describe("getInlineEndOfLine", () => {
+	it("returns the LF index", () => {
+		expect(getInlineEndOfLine("abc\ndef", 0)).toBe(3);
+	});
+	it("returns before the CR for CRLF", () => {
+		expect(getInlineEndOfLine("abc\r\ndef", 0)).toBe(3);
+	});
+	it("returns content length when no newline", () => {
+		expect(getInlineEndOfLine("abc", 0)).toBe(3);
+	});
+});
+
+describe("getBodyStartLine", () => {
+	it("is 0 when there is no frontmatter", () => {
+		expect(getBodyStartLine("# Title\nbody")).toBe(0);
+	});
+	it("points past a YAML frontmatter block", () => {
+		const file = "---\ntitle: x\n---\n## Log";
+		// line 3 is the first body line after the closing ---
+		expect(getBodyStartLine(file)).toBe(3);
+	});
+});
+
+describe("maskNonBodyHeadingsForSearch", () => {
+	it("blanks frontmatter lines and masks fenced-code headings, preserving indices", () => {
+		const file = "---\na: 1\n---\n## Real\n```\n## Fake\n```";
+		const lines = file.split("\n");
+		const masked = maskNonBodyHeadingsForSearch(lines, file);
+		expect(masked.length).toBe(lines.length);
+		expect(masked[0]).toBe(""); // frontmatter blanked
+		expect(masked[3]).toBe("## Real"); // real heading kept
+		expect(masked[5]).not.toBe("## Fake"); // fenced heading neutralized
+	});
+});
+
+describe("anchorAllowsSubsections", () => {
+	it("is false when the flag is off", () => {
+		expect(anchorAllowsSubsections(false, ["## H"], 0)).toBe(false);
+	});
+	it("is true only for a heading anchor when the flag is on", () => {
+		expect(anchorAllowsSubsections(true, ["## H"], 0)).toBe(true);
+		expect(anchorAllowsSubsections(true, ["- item"], 0)).toBe(false);
+	});
+});
+
+describe("insertTextAfterPositionInBody", () => {
+	it("splices after the given line and reports the end offset", () => {
+		const body = "a\nb\nc";
+		const r = insertTextAfterPositionInBody("X\n", body, 0, false);
+		expect(r.content).toBe("a\nX\nb\nc");
+		expect(r.insertedEndOffset).toBe("a\n".length + "X\n".length);
+	});
+	it("drops QuickAdd's injected task newline when a blank line is directly below (#312)", () => {
+		const body = "## Log\n\n- after";
+		// insert after heading (pos 0); line below (1) is blank -> the injected
+		// task newline is dropped, collapsing the doubled blank.
+		const r = insertTextAfterPositionInBody("- task\n", body, 0, true);
+		expect(r.content).toBe("## Log\n- task\n- after");
+	});
+	it("keeps the trailing newline when not a task (one blank preserved)", () => {
+		const body = "## Log\n\n- after";
+		const r = insertTextAfterPositionInBody("- x\n", body, 0, false);
+		expect(r.content).toBe("## Log\n- x\n\n- after");
+	});
+});
+
+describe("insertTextBeforePositionInBody", () => {
+	it("prepends when pos <= 0", () => {
+		const r = insertTextBeforePositionInBody("X", "body", 0);
+		expect(r.content).toBe("X\nbody");
+	});
+	it("splices before a mid-file line", () => {
+		const r = insertTextBeforePositionInBody("X", "a\nb\nc", 1);
+		expect(r.content).toBe("a\nX\nb\nc");
+	});
+});
+
+describe("spliceOrderedSection", () => {
+	it("inserts before a slot line with blank-line padding", () => {
+		const file = "## 2026-06-16\n- a\n## 2026-06-14\n- c\n";
+		const rawLines = file.split("\n");
+		const r = spliceOrderedSection(
+			rawLines,
+			{ mode: "before", line: 2 },
+			"## 2026-06-15\n- b",
+			file,
+		);
+		expect(r.content).toBe(
+			"## 2026-06-16\n- a\n\n## 2026-06-15\n- b\n\n## 2026-06-14\n- c\n",
+		);
+		expect(r.insertedEndOffset).toBeGreaterThan(0);
+	});
+	it("preserves CRLF as the dominant EOL", () => {
+		const file = "## A\r\n- a\r\n";
+		const rawLines = file.split("\n"); // ["## A\r","- a\r",""]
+		const r = spliceOrderedSection(
+			rawLines,
+			{ mode: "after", line: 1 },
+			"## B\n- b",
+			file,
+		);
+		expect(r.content).toContain("\r\n## B\r\n- b");
+	});
+});

--- a/src/formatters/helpers/insertionPositioning.ts
+++ b/src/formatters/helpers/insertionPositioning.ts
@@ -1,0 +1,449 @@
+import type { BlankLineAfterMatchMode } from "../../types/choices/ICaptureChoice";
+import { getMarkdownHeadings } from "./getEndOfSection";
+import { maskFencedHeadings, type OrderedSlot } from "./orderedSectionPlacement";
+import { getBodyStartOffset } from "../../utils/noteContentInsertion";
+
+/**
+ * Pure document-positioning algorithms for the capture insert-after / insert-before
+ * flows. Given a note's lines (or raw content) and a resolved target, these compute
+ * WHERE captured content should land — the line range a target occupies, the line
+ * after which to splice, and the resulting spliced string. They never touch the
+ * Obsidian app, the formatter's prompt state, or any instance: every input arrives
+ * as a parameter and the result is returned, which keeps the gnarly edge-case logic
+ * (CRLF, frontmatter, fenced code, blank-line spacing, EOF newlines, #312 task
+ * spacing, #742 multi-line anchors) independently unit-testable and out of the
+ * CaptureChoiceFormatter token-substitution path.
+ */
+
+/** Inclusive line range a target occupies; `{ -1, -1 }` means "not found". */
+export interface LineRange {
+	start: number;
+	end: number;
+}
+
+/**
+ * Result of a splice: the new file content, plus the byte offset just past the
+ * inserted text (or `null` when no trackable insertion happened). The caller
+ * records the offset for cursor placement.
+ */
+export interface SpliceResult {
+	content: string;
+	insertedEndOffset: number | null;
+}
+
+/**
+ * Splits a fully-expanded insert target into the anchor lines used for
+ * matching. `\n` escapes in the target have already been turned into real
+ * newlines (symmetric with the create-if-not-found path, which writes the
+ * same expansion to disk), so a multi-line target like `**Today**\n***`
+ * becomes `["**Today**", "***"]`.
+ *
+ * Trailing blank lines come from a trailing `\n` escape and are not part of
+ * the anchor, so they are dropped: `**Today**\n` and `**Today**\n\n` both
+ * collapse to the single-line anchor `["**Today**"]`. Interior blank lines
+ * are preserved so a `## D\n\n**Tasks**` anchor still requires the blank.
+ */
+export function toTargetLines(expandedTarget: string): string[] {
+	const lines = expandedTarget.split("\n");
+	while (lines.length > 1 && lines[lines.length - 1].trim() === "") {
+		lines.pop();
+	}
+	return lines;
+}
+
+export function isBlankTarget(targetLines: string[]): boolean {
+	return (
+		targetLines.length === 0 ||
+		(targetLines.length === 1 && targetLines[0].trim() === "")
+	);
+}
+
+/**
+ * Locates the insert target in the file. Returns the inclusive line range
+ * `{ start, end }` the target occupies, or `{ start: -1, end: -1 }` when not
+ * found. For a single-line target `start === end`, preserving historical
+ * single-line behavior exactly. Callers pick which boundary to anchor on:
+ * insert-after-immediate uses `end`, insert-before uses `start`,
+ * insert-after-at-end derives the section end from `start` (issue #742).
+ */
+export function findInsertAfterRange(
+	lines: string[],
+	targetLines: string[],
+): LineRange {
+	if (targetLines.length <= 1) {
+		const start = findSingleLineIndex(lines, targetLines[0] ?? "");
+		return { start, end: start };
+	}
+	return findMultiLineRange(lines, targetLines);
+}
+
+export function findSingleLineIndex(lines: string[], rawTarget: string): number {
+	// `\n` escapes are already expanded upstream, so no escape stripping
+	// happens here — stripping would desync search from the create path,
+	// which writes the unstripped string (issue #742).
+	const target = rawTarget.trimEnd();
+	let partialIndex = -1;
+
+	for (let i = 0; i < lines.length; i++) {
+		// Trim only left whitespace to preserve indentation alignment
+		const line = lines[i].trimStart();
+
+		// 1. Exact match wins immediately
+		if (line === target) return i;
+
+		// 2. Check for prefix match (target + only whitespace suffix)
+		// This matches old regex behavior for lines starting with the target
+		if (line.startsWith(target)) {
+			const suffix = line.slice(target.length);
+			// If suffix is only whitespace, this matches old regex behavior exactly
+			if (/^\s*$/.test(suffix)) return i;
+
+			// Remember first broader prefix match as fallback
+			if (partialIndex === -1) {
+				partialIndex = i;
+			}
+
+			continue;
+		}
+
+		// 3. Check for substring match (target appears anywhere in line with only whitespace after)
+		// This restores legacy behavior where selectors like "| ----- |" can match
+		// table separator rows where the target appears at the end
+		const targetIndex = line.indexOf(target);
+		if (targetIndex !== -1) {
+			const suffix = line.slice(targetIndex + target.length);
+			// If suffix is only whitespace, match this line
+			if (/^\s*$/.test(suffix)) return i;
+
+			// Remember first broader substring match as fallback
+			if (partialIndex === -1) {
+				partialIndex = i;
+			}
+		}
+	}
+
+	return partialIndex; // -1 if no match at all
+}
+
+/**
+ * Matches a multi-line target as a consecutive run of file lines. Only
+ * TRAILING whitespace is stripped before comparison (on both sides), which
+ * normalizes CRLF carriage returns and trailing spaces while preserving
+ * LEADING indentation — `  - Parent\n    - Child` must not match a flat
+ * `- Parent\n- Child`. Because the create path writes the target verbatim,
+ * an indented anchor still round-trips. No fuzzy/partial fallback: a
+ * multi-line anchor must match verbatim to avoid false positives.
+ */
+export function findMultiLineRange(
+	lines: string[],
+	targetLines: string[],
+): LineRange {
+	const n = targetLines.length;
+	const normalizedTargets = targetLines.map((line) =>
+		stripTrailingWhitespace(line),
+	);
+
+	for (let i = 0; i + n <= lines.length; i++) {
+		let matched = true;
+		for (let k = 0; k < n; k++) {
+			if (stripTrailingWhitespace(lines[i + k]) !== normalizedTargets[k]) {
+				matched = false;
+				break;
+			}
+		}
+		if (matched) return { start: i, end: i + n - 1 };
+	}
+
+	return { start: -1, end: -1 };
+}
+
+function stripTrailingWhitespace(line: string): string {
+	return line.replace(/\s+$/, "");
+}
+
+/**
+ * `considerSubsections` only has meaning for a heading anchor — a non-heading
+ * line has no section whose subsections could be included, and
+ * getEndOfSection() throws if asked to consider subsections of a non-heading
+ * line. Multi-line anchors made non-heading start lines newly matchable
+ * (issue #742), so degrade to false when the anchor is not a heading
+ * (using getEndOfSection's own heading definition) instead of throwing.
+ */
+export function anchorAllowsSubsections(
+	considerSubsections: boolean,
+	lines: string[],
+	anchorLine: number,
+): boolean {
+	if (!considerSubsections) return false;
+	return getMarkdownHeadings([lines[anchorLine] ?? ""]).length > 0;
+}
+
+export function shouldSkipBlankLinesAfterMatch(
+	mode: BlankLineAfterMatchMode,
+	line: string,
+): boolean {
+	if (mode === "skip") return true;
+	if (mode === "none") return false;
+	return isAtxHeading(line);
+}
+
+export function isAtxHeading(line: string): boolean {
+	return /^\s{0,3}#{1,6}\s+\S/.test(line);
+}
+
+export function findInsertAfterPositionWithBlankLines(
+	lines: string[],
+	matchIndex: number,
+	body: string,
+	mode: BlankLineAfterMatchMode,
+): number {
+	if (matchIndex < 0) return matchIndex;
+
+	const matchLine = lines[matchIndex] ?? "";
+	const shouldSkip = shouldSkipBlankLinesAfterMatch(mode, matchLine);
+	if (!shouldSkip) return matchIndex;
+
+	// Ignore the trailing empty line that results from split("\n") when the
+	// file ends with a newline. This preserves existing EOF behavior.
+	const scanLimit = body.endsWith("\n")
+		? Math.max(lines.length - 1, 0)
+		: lines.length;
+	let position = matchIndex;
+
+	for (let i = matchIndex + 1; i < scanLimit; i++) {
+		if (lines[i].trim().length === 0) {
+			position = i;
+			continue;
+		}
+		break;
+	}
+
+	return position;
+}
+
+export function findInsertAfterPositionAtSectionEnd(
+	lines: string[],
+	sectionEndIndex: number,
+	fileContent: string,
+	insertedText: string,
+): number {
+	if (sectionEndIndex < 0) return sectionEndIndex;
+
+	let position = sectionEndIndex;
+	let i = sectionEndIndex + 1;
+
+	while (i < lines.length && lines[i].trim().length === 0) {
+		position = i;
+		i++;
+	}
+
+	// Preserve current behavior when there are no trailing blank lines or when
+	// blanks are followed by content (e.g. before a new heading).
+	if (position === sectionEndIndex || i !== lines.length) {
+		return sectionEndIndex;
+	}
+
+	// For entries without trailing newline, keep insertion anchored at the
+	// section end so repeated captures preserve order.
+	if (!insertedText.endsWith("\n")) {
+		return sectionEndIndex;
+	}
+
+	// split("\n") keeps a trailing empty string when content ends in "\n".
+	// We keep one trailing slot so the next insertion preserves capture spacing
+	// without introducing an extra blank line before the inserted text.
+	if (fileContent.endsWith("\n")) {
+		return Math.max(sectionEndIndex, position - 1);
+	}
+
+	return position;
+}
+
+export function hasInlineTargetLinebreak(target: string): boolean {
+	return target.includes("\n") || target.includes("\r");
+}
+
+export function getInlineEndOfLine(
+	fileContent: string,
+	startIndex: number,
+): number {
+	const newlineIndex = fileContent.indexOf("\n", startIndex);
+	if (newlineIndex === -1) return fileContent.length;
+	if (newlineIndex > 0 && fileContent[newlineIndex - 1] === "\r") {
+		return newlineIndex - 1;
+	}
+	return newlineIndex;
+}
+
+/**
+ * Index of the first body line after any YAML frontmatter (0 when none).
+ * Mirrors insertAtNoteBodyStart's frontmatter detection (getBodyStartOffset).
+ */
+export function getBodyStartLine(fileContent: string): number {
+	const bodyStartOffset = getBodyStartOffset(fileContent);
+	return bodyStartOffset > 0
+		? fileContent.slice(0, bodyStartOffset).split("\n").length - 1
+		: 0;
+}
+
+/**
+ * Returns CRLF-stripped lines with frontmatter lines blanked and fenced-code
+ * headings neutralized, so the ordered target search never matches a heading
+ * that isn't a real body section. Line indices are preserved.
+ */
+export function maskNonBodyHeadingsForSearch(
+	lines: string[],
+	fileContent: string,
+): string[] {
+	const bodyStartLine = getBodyStartLine(fileContent);
+	const masked = maskFencedHeadings(lines).map((line) =>
+		line.replace(/\r$/, ""),
+	);
+	for (let i = 0; i < bodyStartLine && i < masked.length; i++) {
+		masked[i] = "";
+	}
+	return masked;
+}
+
+export function insertTextAfterPositionInBody(
+	rawText: string,
+	body: string,
+	pos: number,
+	isTask: boolean,
+): SpliceResult {
+	// Line-matched insertAfter callers always pass a real line index (>= 0); the
+	// frontmatter-aware "top" insertion lives in insertAtNoteBodyStart instead.
+	// Shared by every "after" path: the line-matched handler, insert-at-end-of-
+	// section, and the create-if-not-found cursor paths.
+	const splitContent = body.split("\n");
+	const pre = splitContent.slice(0, pos + 1).join("\n");
+	const post = splitContent.slice(pos + 1).join("\n");
+
+	// "Format as task" injects a trailing newline onto the capture content
+	// (getCaptureContent in CaptureChoiceEngine) so a bare task is always a
+	// complete line. When the line directly below the insertion point is already
+	// blank, that injected newline stacks on top of the existing blank line and
+	// renders a spurious blank line AFTER the task (issue #312) — an asymmetry
+	// the user does not see without the task option. Drop the redundant injected
+	// newline in that case; the existing blank line still separates the task from
+	// the following content. A user-typed trailing newline in the format string
+	// is intentional content and is left untouched (gated on choice.task, this
+	// only collapses QuickAdd's own injected task newline).
+	//
+	// Detect the blank line via the split index, not `post.startsWith("\n")`, so
+	// whitespace-only and CRLF blanks (where the line is "\r" or "   ", not "")
+	// are recognised too. When `body` ends in a newline, split() appends a
+	// trailing empty slot that is the EOF artifact, not a real blank line, so it
+	// must not trigger the drop; a body WITHOUT a trailing newline has no such
+	// artifact, so its final slot is a genuine (possibly blank) last line.
+	const lineBelow = splitContent[pos + 1];
+	const isTrailingNewlineArtifact =
+		body.endsWith("\n") && pos + 1 === splitContent.length - 1;
+	const blankLineDirectlyBelow =
+		pos + 1 < splitContent.length &&
+		!isTrailingNewlineArtifact &&
+		(lineBelow ?? "").trim() === "";
+	const text =
+		isTask && rawText.endsWith("\n") && blankLineDirectlyBelow
+			? rawText.slice(0, -1)
+			: rawText;
+
+	return {
+		content: `${pre}\n${text}${post}`,
+		insertedEndOffset: pre.length + 1 + text.length,
+	};
+}
+
+export function insertTextBeforePositionInBody(
+	text: string,
+	body: string,
+	pos: number,
+	cursorOffsetInText = text.length,
+): SpliceResult {
+	const separator = body.length > 0 && !text.endsWith("\n") ? "\n" : "";
+	const clampedOffset = Math.max(0, Math.min(cursorOffsetInText, text.length));
+
+	if (pos <= 0) {
+		return {
+			content: `${text}${separator}${body}`,
+			insertedEndOffset: clampedOffset,
+		};
+	}
+
+	const splitContent = body.split("\n");
+	const pre = splitContent.slice(0, pos).join("\n");
+	const post = splitContent.slice(pos).join("\n");
+
+	return {
+		content: `${pre}\n${text}${separator}${post}`,
+		insertedEndOffset: pre.length + 1 + clampedOffset,
+	};
+}
+
+/**
+ * Splice a created section at the resolved slot, padding it with a single blank
+ * line above the heading (when the preceding line is non-blank) and below the
+ * block (when the following line is non-blank) so the heading is never glued to
+ * neighbouring content (the helpers QuickAdd ships do not pad headings —
+ * verified — so this is the dedicated separation path for ordered creation).
+ *
+ * Byte-preserving: the original `fileContent` is sliced at the insertion offset
+ * and the existing text on both sides is kept VERBATIM (so a mixed-EOL note is
+ * never wholesale-normalized — an ordered capture produces a minimal diff). Only
+ * the inserted block and its two seams use the file's dominant EOL. The offset
+ * is derived from `rawLines` (which `getLinesInString` produced by splitting on
+ * "\n", so each prior line consumed its own length + 1 for the "\n"). `\r` is
+ * stripped only for the blank-line trim checks.
+ */
+export function spliceOrderedSection(
+	rawLines: string[],
+	slot: Exclude<OrderedSlot, { mode: "bodyStart" }>,
+	payload: string,
+	fileContent: string,
+): SpliceResult {
+	const content = fileContent;
+	const eol = content.includes("\r\n") ? "\r\n" : "\n";
+	const insertIdx = slot.mode === "before" ? slot.line : slot.line + 1;
+
+	// Character offset of the start of line `insertIdx` in the original content.
+	let offset = 0;
+	for (let i = 0; i < insertIdx && i < rawLines.length; i++) {
+		offset += rawLines[i].length + 1; // +1 for the consumed "\n"
+	}
+	if (offset > content.length) offset = content.length;
+	const before = content.slice(0, offset);
+	const after = content.slice(offset);
+
+	const prev =
+		insertIdx > 0 ? (rawLines[insertIdx - 1] ?? "").replace(/\r$/, "") : "";
+	const next =
+		insertIdx < rawLines.length
+			? (rawLines[insertIdx] ?? "").replace(/\r$/, "")
+			: "";
+
+	const payloadLines = payload.split("\n").map((line) => line.replace(/\r$/, ""));
+	// Drop a single trailing empty line that a format ending in "\n" produces, so
+	// separation is controlled solely by the padding below.
+	if (payloadLines.length > 1 && payloadLines[payloadLines.length - 1] === "") {
+		payloadLines.pop();
+	}
+
+	const blockLines: string[] = [];
+	if (insertIdx > 0 && prev.trim() !== "") blockLines.push(""); // blank above heading
+	blockLines.push(...payloadLines);
+	if (insertIdx < rawLines.length && next.trim() !== "") blockLines.push(""); // blank below block
+
+	const blockText = blockLines.join(eol);
+	// Terminate the preceding line when `before` doesn't already end with a
+	// newline (the EOF-without-trailing-newline case), and terminate the block
+	// when content follows it OR when the file already ended with a newline (so
+	// appending at EOF preserves the file's trailing newline). Existing bytes in
+	// before/after stay verbatim.
+	const lead = before.length > 0 && !/\n$/.test(before) ? eol : "";
+	const trail = after.length > 0 || /\n$/.test(content) ? eol : "";
+	const insertedStartOffset = before.length + lead.length;
+	return {
+		content: `${before}${lead}${blockText}${trail}${after}`,
+		insertedEndOffset: insertedStartOffset + blockText.length,
+	};
+}

--- a/src/formatters/helpers/insertionPositioning.ts
+++ b/src/formatters/helpers/insertionPositioning.ts
@@ -295,14 +295,19 @@ export function maskNonBodyHeadingsForSearch(
 	lines: string[],
 	fileContent: string,
 ): string[] {
+	// Blank the frontmatter lines BEFORE fence masking, not after: maskFencedHeadings
+	// scans every line it is given, so an unclosed ```/~~~ marker inside the YAML
+	// frontmatter (e.g. a block scalar holding a code-fence example) would otherwise
+	// leave the scanner "in a fence" at the body boundary and neutralize a real body
+	// heading. Scoping the masking to the body avoids that leak. For frontmatter
+	// without fence markers this is identical to masking first then blanking.
 	const bodyStartLine = getBodyStartLine(fileContent);
-	const masked = maskFencedHeadings(lines).map((line) =>
+	const bodyScopedLines = lines.map((line, index) =>
+		index < bodyStartLine ? "" : line,
+	);
+	return maskFencedHeadings(bodyScopedLines).map((line) =>
 		line.replace(/\r$/, ""),
 	);
-	for (let i = 0; i < bodyStartLine && i < masked.length; i++) {
-		masked[i] = "";
-	}
-	return masked;
 }
 
 export function insertTextAfterPositionInBody(


### PR DESCRIPTION
## Summary

Behavior-preserving architecture pass on the three biggest / most-central files of the capture + format pipeline. One pattern throughout — **functional core, injected effects**: pure logic moves into independently-testable helper modules; the classes stay thin stateful adapters that bind instance state / vault probes and route side-effects.

No user-facing behavior changes. No new repo docs. Commits are `refactor(...)` so semantic-release does not cut a release.

## Changes

| Commit | What | Effect |
|---|---|---|
| `refactor(capture): extract document-positioning…` | `captureChoiceFormatter.ts` → new `formatters/helpers/insertionPositioning.ts` (17 pure fns: target matching, splice, blank-line spacing, ordered splice, fence/frontmatter masking) | **1324 → 989 lines** (−25%). Splice fns return `{ content, insertedEndOffset }`; the class routes the offset through its validating `setCaptureInsertionEndOffset` so the cursor side-effect is preserved. |
| `refactor(capture): extract capture-target classifier…` | `CaptureChoiceEngine.ts` → new `engine/helpers/captureTargetResolution.ts` (pure `resolveCaptureTarget` with injected vault probes) | Removes the `(engine as any).resolveCaptureTarget` test smell; the classifier is now a first-class testable unit. UI-coupled selection stays in the engine. |
| `refactor(format): extract FILE-token value rendering…` | base `Formatter` (`formatter.ts`) → new `formatters/helpers/fileTokenRendering.ts` (`renderStoredFileValue`, link generation injected) | The vault-coupled `getFileLinkForStoredValue` stays in the class and is injected as `resolveLink`. |

## Verification

- `pnpm run build` + `pnpm run lint` green.
- `pnpm run test`: **2956 passing** (+52 new tests across the 3 helper modules; 0 regressions vs the 2904 baseline).
- **Live-tested in the real app** (isolated worktree e2e vault) after each phase and again on the final reloaded build:
  - ordered-insert capture → `## 2026-06-15` lands correctly between `16`/`14`, frontmatter intact;
  - `{{FILE:..|name/path/link}}` → `name=MyNote path=Inbox/MyNote.md link=[[MyNote]]`;
  - `dev:errors` clean throughout.
- Adversarial-reviewed (opposite-model): Phase 1 Skeptic PASS + Architect (one real finding — leftover dead methods — fixed); Phase 2 Skeptic PASS; Phase 3's reviewer hung and was terminated, so it was verified via self-review + the two identical prior passes + the test/live evidence.

## Not in scope (deferred, documented)

Higher-risk deeper surgery / polish, intentionally left out to avoid regressing a stable plugin: breaking up the 270-line `CaptureChoiceEngine.run()`; restructuring the formatter inheritance and the `RequirementCollector extends Formatter` prompt-interception coupling; unifying `SpliceResult` with `noteContentInsertion`'s `InsertionResult`; a shared markdown-heading primitive.

## Release / migration impact

None. Pure refactor, no settings/data shape changes, `main.js`/`manifest`/`versions` unaffected by behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved reliability of capture destination parsing for “Capture to” inputs (vault, folders, files, properties, and filters), including clearer handling of ambiguous names and invalid targets.
  * Refined capture insertion positioning (insert-after/before, ordered creation, and inline anchors) for more consistent placement.
  * Improved rendering behavior for `{{FILE:...}}` tokens via a dedicated renderer.

* **Tests**
  * Added coverage for capture-target resolution, insertion positioning, and file-token rendering to validate edge cases and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->