### PR TITLE
fix(deps): patch vulnerable undici and js-yaml

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,7 +2,6 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 const {themes} = require('prism-react-renderer');
-const yaml = require('js-yaml');
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
@@ -16,36 +15,6 @@ try {
 
 const latestStableVersion = docsVersions[0];
 
-function parseFrontMatterWithJsYaml({fileContent}) {
-  const contentWithoutBom = fileContent.replace(/^\uFEFF/, '');
-  const opener = /^---[ \t]*(?:\r?\n|$)/.exec(contentWithoutBom);
-  if (!opener) {
-    return {
-      frontMatter: {},
-      content: contentWithoutBom.trim(),
-    };
-  }
-
-  const afterOpener = contentWithoutBom.slice(opener[0].length);
-  const closer = /(?:^|\r?\n)---[ \t]*(?:\r?\n|$)/.exec(afterOpener);
-  if (!closer) {
-    throw new Error('Invalid YAML front matter fence');
-  }
-
-  const frontMatter = yaml.load(afterOpener.slice(0, closer.index)) ?? {};
-  if (
-    typeof frontMatter !== 'object' ||
-    Array.isArray(frontMatter)
-  ) {
-    throw new Error('Markdown front matter must be a YAML mapping');
-  }
-
-  return {
-    frontMatter,
-    content: afterOpener.slice(closer.index + closer[0].length).trim(),
-  };
-}
-
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'QuickAdd',
@@ -55,9 +24,6 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
-  markdown: {
-    parseFrontMatter: async (params) => parseFrontMatterWithJsYaml(params),
-  },
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,6 +2,7 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 const {themes} = require('prism-react-renderer');
+const yaml = require('js-yaml');
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
@@ -15,6 +16,36 @@ try {
 
 const latestStableVersion = docsVersions[0];
 
+function parseFrontMatterWithJsYaml({fileContent}) {
+  const contentWithoutBom = fileContent.replace(/^\uFEFF/, '');
+  const opener = /^---[ \t]*(?:\r?\n|$)/.exec(contentWithoutBom);
+  if (!opener) {
+    return {
+      frontMatter: {},
+      content: contentWithoutBom.trim(),
+    };
+  }
+
+  const afterOpener = contentWithoutBom.slice(opener[0].length);
+  const closer = /(?:^|\r?\n)---[ \t]*(?:\r?\n|$)/.exec(afterOpener);
+  if (!closer) {
+    throw new Error('Invalid YAML front matter fence');
+  }
+
+  const frontMatter = yaml.load(afterOpener.slice(0, closer.index)) ?? {};
+  if (
+    typeof frontMatter !== 'object' ||
+    Array.isArray(frontMatter)
+  ) {
+    throw new Error('Markdown front matter must be a YAML mapping');
+  }
+
+  return {
+    frontMatter,
+    content: afterOpener.slice(closer.index + closer[0].length).trim(),
+  };
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'QuickAdd',
@@ -24,6 +55,9 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
+  markdown: {
+    parseFrontMatter: async (params) => parseFrontMatterWithJsYaml(params),
+  },
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,6 @@
     "@easyops-cn/docusaurus-search-local": "^0.55.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
-    "js-yaml": "4.2.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
@@ -39,6 +38,9 @@
       "uuid": "^11.1.1",
       "cheerio>undici": "7.28.0",
       "gray-matter>js-yaml": "4.2.0"
+    },
+    "patchedDependencies": {
+      "gray-matter@4.0.3": "patches/gray-matter@4.0.3.patch"
     }
   },
   "browserslist": {
@@ -54,6 +56,6 @@
     ]
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.18.1"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
     "@easyops-cn/docusaurus-search-local": "^0.55.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
+    "js-yaml": "4.2.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
@@ -35,7 +36,9 @@
       "webpackbar": "^7.0.0",
       "serialize-javascript": "^7.0.3",
       "joi": "^17.13.4",
-      "uuid": "^11.1.1"
+      "uuid": "^11.1.1",
+      "cheerio>undici": "7.28.0",
+      "gray-matter>js-yaml": "4.2.0"
     }
   },
   "browserslist": {

--- a/docs/patches/gray-matter@4.0.3.patch
+++ b/docs/patches/gray-matter@4.0.3.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/engines.js b/lib/engines.js
+index 38f993db06cf364191ac635a6590c2d29303297d..1dfec8d9527653ad9ccfaacfa59732246fdb1e32 100644
+--- a/lib/engines.js
++++ b/lib/engines.js
+@@ -13,8 +13,8 @@ const engines = exports = module.exports;
+  */
+ 
+ engines.yaml = {
+-  parse: yaml.safeLoad.bind(yaml),
+-  stringify: yaml.safeDump.bind(yaml)
++  parse: yaml.load.bind(yaml),
++  stringify: yaml.dump.bind(yaml)
+ };
+ 
+ /**

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   serialize-javascript: ^7.0.3
   joi: ^17.13.4
   uuid: ^11.1.1
+  cheerio>undici: 7.28.0
+  gray-matter>js-yaml: 4.2.0
 
 importers:
 
@@ -29,6 +31,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      js-yaml:
+        specifier: 4.2.0
+        version: 4.2.0
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.7)
@@ -1980,9 +1985,6 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2709,11 +2711,6 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -3325,10 +3322,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -4768,9 +4761,6 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   srcset@4.0.0:
     resolution: {integrity: sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==}
     engines: {node: '>=12'}
@@ -4991,8 +4981,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8329,10 +8319,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
@@ -8584,7 +8570,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.27.2
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -9091,8 +9077,6 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
-  esprima@4.0.1: {}
-
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
@@ -9385,7 +9369,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -9806,11 +9790,6 @@ snapshots:
       '@sideway/pinpoint': 2.0.0
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -11685,8 +11664,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  sprintf-js@1.0.3: {}
-
   srcset@4.0.0: {}
 
   statuses@1.5.0: {}
@@ -11853,7 +11830,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   cheerio>undici: 7.28.0
   gray-matter>js-yaml: 4.2.0
 
+patchedDependencies:
+  gray-matter@4.0.3:
+    hash: 82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f
+    path: patches/gray-matter@4.0.3.patch
+
 importers:
 
   .:
@@ -31,9 +36,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.7)
@@ -7351,7 +7353,7 @@ snapshots:
       fs-extra: 11.3.5
       github-slugger: 1.5.0
       globby: 11.1.0
-      gray-matter: 4.0.3
+      gray-matter: 4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f)
       jiti: 1.21.7
       js-yaml: 4.2.0
       lodash: 4.18.1
@@ -9367,7 +9369,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gray-matter@4.0.3:
+  gray-matter@4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f):
     dependencies:
       js-yaml: 4.2.0
       kind-of: 6.0.3

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "type": "git",
     "url": "https://github.com/chhoumann/quickadd.git"
   },
+  "engines": {
+    "node": ">=20.18.1"
+  },
   "packageManager": "pnpm@10.32.1",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
       "esbuild"
     ],
     "overrides": {
-      "obsidian-calendar-ui>svelte": "^5.56.3"
+      "obsidian-calendar-ui>svelte": "^5.56.3",
+      "@semantic-release/github>undici": "7.28.0",
+      "jsdom>undici": "7.28.0"
     }
   },
   "release": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   obsidian-calendar-ui>svelte: ^5.56.3
+  '@semantic-release/github>undici': 7.28.0
+  jsdom>undici: 7.28.0
 
 importers:
 
@@ -3176,8 +3178,8 @@ packages:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
     engines: {node: '>=18.17'}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -4083,7 +4085,7 @@ snapshots:
       p-filter: 4.1.0
       semantic-release: 25.0.5(typescript@6.0.3)
       tinyglobby: 0.2.17
-      undici: 7.27.2
+      undici: 7.28.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - kerberos
@@ -5207,7 +5209,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6172,7 +6174,7 @@ snapshots:
 
   undici@6.26.0: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
Patches the open Dependabot security advisories for `undici` and `js-yaml` by pinning the vulnerable transitive paths with pnpm overrides and regenerating both lockfiles.

Advisories covered:

- Dependabot alert 115, high, `pnpm-lock.yaml`: `undici` `>=7.23.0 <7.28.0`, fixed by moving the root vulnerable `undici@7.27.2` paths to `7.28.0`.
- Dependabot alert 117, moderate, `pnpm-lock.yaml`: `undici` `>=7.0.0 <7.28.0`, fixed by the same root `undici@7.28.0` resolution.
- Dependabot alert 116, high, `docs/pnpm-lock.yaml`: `undici` `>=7.23.0 <7.28.0`, fixed by moving the docs `cheerio` path from `undici@7.27.2` to `7.28.0`.
- Dependabot alert 118, moderate, `docs/pnpm-lock.yaml`: `undici` `>=7.0.0 <7.28.0`, fixed by the same docs `undici@7.28.0` resolution.
- Dependabot alert 114, moderate, `docs/pnpm-lock.yaml`: `js-yaml` `<=4.1.1`, fixed by moving the docs `gray-matter` path from `js-yaml@3.14.2` to `4.2.0`.

Exposure assessment:

- Root `undici@7.27.2` was pulled through `@semantic-release/github` release tooling and `jsdom` test/e2e tooling. These are development/release-time dependencies and are not shipped in the Obsidian plugin bundle. The remaining root `undici@6.26.0` path is outside the vulnerable `>=7` advisory ranges.
- Root `js-yaml` was already resolved to the patched `4.2.0`; the root lockfile remains free of vulnerable `js-yaml` entries.
- Docs `undici@7.27.2` was pulled through `@easyops-cn/docusaurus-search-local -> cheerio`; this is docs build/search-index tooling and is not shipped in `main.js`.
- Docs `js-yaml@3.14.2` was pulled through `@docusaurus/utils -> gray-matter`; this is docs front-matter parsing during Docusaurus builds and is not shipped in `main.js`.

Implementation notes:

- Overrides are under `pnpm.overrides`, not the npm-style top-level `overrides` key.
- The existing `obsidian-calendar-ui>svelte` override is preserved and still resolves to `svelte@5.56.3`.
- `gray-matter@4.0.3` is patched through `pnpm.patchedDependencies` so its YAML engine uses `js-yaml` 4's `load`/`dump` APIs instead of removed `safeLoad`/`safeDump` APIs.
- Root and docs package engines now declare `node >=20.18.1`, matching the patched `undici@7.28.0` engine requirement and the existing GitHub Actions Node 24 runtime.

Verification:

- `pnpm install --frozen-lockfile`
- `pnpm run build-with-lint`
- `pnpm test`
- `cd docs && pnpm install --frozen-lockfile && pnpm build`
- `pnpm run obsidian:e2e -- quickadd:list`
- `pnpm run obsidian:e2e -- dev:errors`
- Direct `gray-matter` smoke check confirmed front matter parses with the patched `js-yaml@4.2.0` path.
- Lockfile checks confirmed no `undici@7.27.2` or `js-yaml@3.14.2` remains in root/docs lockfiles.
- `pnpm why svelte obsidian-calendar-ui` confirmed the Svelte pin remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated minimum Node.js requirement to version 20.18.1 or higher.
  * Pinned transitive dependency versions for improved stability and consistent builds.
  * Updated YAML processing configuration in dependencies for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->