### PR TITLE
fix(deps): bump undici to 6.27.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3174,8 +3174,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   undici@7.28.0:
@@ -3465,7 +3465,7 @@ snapshots:
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -6172,7 +6172,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.26.0: {}
+  undici@6.27.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
Bump the remaining root-lockfile `undici` 6.x resolution from 6.26.0 to 6.27.0 to clear the new Dependabot security advisories.

Alerts addressed:
- Dependabot alert #121: low, `undici < 6.27.0`, fixed by 6.27.0, manifest `pnpm-lock.yaml`
- Dependabot alert #123: medium, `undici < 6.27.0`, fixed by 6.27.0, manifest `pnpm-lock.yaml`
- Dependabot alert #124: low, `undici < 6.27.0`, fixed by 6.27.0, manifest `pnpm-lock.yaml`

Dependency path and exposure:
- Before: `@actions/http-client@4.0.1 -> undici@6.26.0`
- After: `@actions/http-client@4.0.1 -> undici@6.27.0`
- Parent path: `@actions/http-client -> @actions/core -> @semantic-release/npm -> semantic-release`, reached from root devDependencies/release tooling.
- `@actions/http-client@4.0.1` already allows `undici` via `^6.23.0`, so no package.json override was needed.
- `pnpm why --prod undici` is empty, and the production bundle has no package import markers for `undici`, `@actions/http-client`, or `semantic-release`. Real exposure is dev/release tooling only, not shipped QuickAdd plugin code in `main.js`.
- Existing `pnpm.overrides` entries for `@semantic-release/github>undici` and `jsdom>undici` remain at 7.28.0.

Scope checks:
- Only root `pnpm-lock.yaml` changed.
- `docs/` lockfile/package files were not touched.
- No Svelte pin drift; `svelte@5.56.3` remains intact.

Verification:
- Confirmed no root lockfile `undici` below 6.27.0 remains; root lockfile contains `undici@6.27.0` and `undici@7.28.0`.
- `pnpm install --frozen-lockfile`
- `pnpm run build-with-lint`
- `pnpm test` (240 files passed, 2957 tests passed)
- `pnpm run obsidian:e2e -- quickadd:list`
- `pnpm run obsidian:e2e -- dev:errors`