### PR TITLE
fix(macro): correct conditional abort, deleted-choice handling, and command validation

### DIFF
--- a/src/engine/MacroChoiceEngine.audit-cleanup.test.ts
+++ b/src/engine/MacroChoiceEngine.audit-cleanup.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Finding: ai-assistant-disable-online-features — the AI Assistant guard in
+// MacroChoiceEngine.executeAIAssistant hardcoded "OpenAI" in its block message
+// regardless of the configured provider. This locks in the provider-neutral
+// wording (matching src/ai/AIAssistant.ts) and that the request never proceeds.
+
+const storeState = vi.hoisted(() => ({
+	ai: {} as Record<string, unknown>,
+	disableOnlineFeatures: false,
+	showInputCancellationNotification: false,
+}));
+
+vi.mock("../quickAddApi", () => ({
+	QuickAddApi: {
+		GetApi: vi.fn().mockReturnValue({}),
+	},
+}));
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: class GenericSuggesterMock {
+		static Suggest() {
+			return Promise.resolve(undefined);
+		}
+	},
+}));
+vi.mock("../main", () => ({
+	default: class QuickAddMock {},
+}));
+vi.mock("../gui/choiceList/ChoiceView.svelte", () => ({}));
+vi.mock("../quickAddSettingsTab", () => ({
+	DEFAULT_SETTINGS: {},
+	QuickAddSettingsTab: class {},
+}));
+vi.mock("../settingsStore", () => ({
+	settingsStore: {
+		getState: () => storeState,
+	},
+}));
+vi.mock("../formatters/completeFormatter", () => ({
+	CompleteFormatter: class CompleteFormatterMock {
+		constructor() {}
+	},
+}));
+vi.mock("../ai/AIAssistant", () => ({
+	runAIAssistant: vi.fn(),
+}));
+vi.mock("../ai/aiHelpers", () => ({
+	getModelByName: vi.fn(),
+	getModelNames: vi.fn().mockReturnValue([]),
+	getModelProvider: vi.fn().mockReturnValue({ apiKey: "" }),
+}));
+
+import type { App } from "obsidian";
+import { MacroChoiceEngine } from "./MacroChoiceEngine";
+import { CommandType } from "../types/macros/CommandType";
+import type { ICommand } from "../types/macros/ICommand";
+import type { IMacro } from "../types/macros/IMacro";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { runAIAssistant } from "../ai/AIAssistant";
+
+const runAIAssistantMock = runAIAssistant as unknown as ReturnType<typeof vi.fn>;
+
+function createEngine(commands: ICommand[]) {
+	const app = {
+		commands: {
+			commands: {},
+			executeCommandById: vi.fn(),
+		},
+	} as unknown as App;
+
+	const plugin = {
+		getChoiceById: vi.fn(),
+		getChoiceByName: vi.fn(),
+	} as unknown as never;
+
+	const choiceExecutor: IChoiceExecutor = {
+		variables: new Map<string, unknown>(),
+		execute: vi.fn(),
+		signalAbort: vi.fn(),
+		consumeAbortSignal: vi.fn(),
+	};
+
+	const macro: IMacro = { name: "Test macro", id: "macro-id", commands };
+	const choice: IMacroChoice = {
+		name: "Test choice",
+		id: "choice-id",
+		type: "Macro",
+		command: false,
+		macro,
+		runOnStartup: false,
+	};
+
+	return new MacroChoiceEngine(
+		app,
+		plugin,
+		choice,
+		choiceExecutor,
+		new Map<string, unknown>()
+	);
+}
+
+function makeAIAssistantCommand(): ICommand {
+	return {
+		id: "ai-cmd",
+		name: "AI Assistant",
+		type: CommandType.AIAssistant,
+		model: "Ask me",
+		systemPrompt: "",
+		outputVariableName: "output",
+		promptTemplate: { enable: false, name: "" },
+		modelParameters: {},
+	} as unknown as ICommand;
+}
+
+describe("MacroChoiceEngine executeAIAssistant disable-online-features guard", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		storeState.disableOnlineFeatures = false;
+		storeState.ai = {};
+	});
+
+	it("blocks with a provider-neutral message that does not name OpenAI", async () => {
+		storeState.disableOnlineFeatures = true;
+
+		const engine = createEngine([makeAIAssistantCommand()]);
+
+		await expect(engine.run()).rejects.toThrow(
+			"Blocking request: Online features are disabled in settings."
+		);
+		await expect(engine.run()).rejects.not.toThrow(/OpenAI/);
+		// The guard short-circuits before the assistant ever runs.
+		expect(runAIAssistantMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/engine/MacroChoiceEngine.audit-macro.test.ts
+++ b/src/engine/MacroChoiceEngine.audit-macro.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from "vitest";
+
+vi.mock("../quickAddApi", () => ({
+	QuickAddApi: {
+		GetApi: vi.fn(),
+	},
+}));
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: class GenericSuggesterMock {
+		static Suggest() {
+			return Promise.resolve(undefined);
+		}
+	},
+}));
+vi.mock("../main", () => ({
+	default: class QuickAddMock {},
+}));
+vi.mock("../gui/choiceList/ChoiceView.svelte", () => ({}));
+vi.mock("../quickAddSettingsTab", () => ({
+	DEFAULT_SETTINGS: {},
+	QuickAddSettingsTab: class {},
+}));
+vi.mock("../settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({
+			ai: {},
+			disableOnlineFeatures: false,
+			showInputCancellationNotification: false,
+		}),
+	},
+}));
+vi.mock("../formatters/completeFormatter", () => ({
+	CompleteFormatter: class CompleteFormatterMock {
+		constructor() {}
+	},
+}));
+vi.mock("../ai/AIAssistant", () => ({
+	runAIAssistant: vi.fn(),
+}));
+vi.mock("../ai/aiHelpers", () => ({
+	getModelByName: vi.fn(),
+	getModelNames: vi.fn().mockReturnValue([]),
+	getModelProvider: vi.fn().mockReturnValue({ apiKey: "" }),
+}));
+
+import type { App } from "obsidian";
+import { MacroChoiceEngine } from "./MacroChoiceEngine";
+import { ConditionalCommand } from "../types/macros/Conditional/ConditionalCommand";
+import { ObsidianCommand } from "../types/macros/ObsidianCommand";
+import { ChoiceCommand } from "../types/macros/ChoiceCommand";
+import type { ICommand } from "../types/macros/ICommand";
+import type { IMacro } from "../types/macros/IMacro";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { MacroAbortError } from "../errors/MacroAbortError";
+import { QuickAddApi } from "../quickAddApi";
+
+const getApiMock = QuickAddApi.GetApi as unknown as ReturnType<typeof vi.fn>;
+
+/**
+ * Minimal choice executor stub that mirrors the real ChoiceExecutor's
+ * pendingAbort handshake so the engine's abort propagation can be exercised.
+ */
+function createChoiceExecutorStub(
+	executeImpl: (executor: IChoiceExecutor) => void | Promise<void> = () => {}
+): IChoiceExecutor {
+	let pendingAbort: MacroAbortError | null = null;
+	const executor: IChoiceExecutor = {
+		variables: new Map<string, unknown>(),
+		execute: vi.fn(async () => {
+			await executeImpl(executor);
+		}),
+		signalAbort: (error: MacroAbortError) => {
+			pendingAbort = error;
+		},
+		consumeAbortSignal: () => {
+			const abort = pendingAbort;
+			pendingAbort = null;
+			return abort;
+		},
+	};
+	return executor;
+}
+
+interface CreateEngineOptions {
+	commands: ICommand[];
+	registeredCommandIds?: string[];
+	getChoiceById?: (id: string) => unknown;
+	choiceExecutor?: IChoiceExecutor;
+	variables?: Record<string, unknown>;
+}
+
+function createEngine({
+	commands,
+	registeredCommandIds = [],
+	getChoiceById = vi.fn(),
+	choiceExecutor = createChoiceExecutorStub(),
+	variables = {},
+}: CreateEngineOptions) {
+	const executeCommandById = vi.fn();
+	const commandRegistry: Record<string, { id: string; name: string }> = {};
+	for (const id of registeredCommandIds) {
+		commandRegistry[id] = { id, name: id };
+	}
+
+	const app = {
+		commands: {
+			commands: commandRegistry,
+			executeCommandById,
+		},
+	} as unknown as App;
+
+	const plugin = {
+		getChoiceById,
+		getChoiceByName: vi.fn(),
+	} as unknown as any;
+
+	const macro: IMacro = {
+		name: "Test macro",
+		id: "macro-id",
+		commands,
+	};
+
+	const choice: IMacroChoice = {
+		name: "Test choice",
+		id: "choice-id",
+		type: "Macro",
+		command: false,
+		macro,
+		runOnStartup: false,
+	};
+
+	const engine = new MacroChoiceEngine(
+		app,
+		plugin,
+		choice,
+		choiceExecutor,
+		new Map<string, unknown>(Object.entries(variables))
+	);
+
+	return { engine, executeCommandById, choiceExecutor };
+}
+
+describe("MacroChoiceEngine audit fixes", () => {
+	beforeEach(() => {
+		getApiMock.mockReturnValue({});
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		getApiMock.mockClear();
+	});
+
+	afterAll(() => {
+		getApiMock.mockReset();
+	});
+
+	describe("executeChoice with a deleted referenced choice", () => {
+		it("skips the choice and continues the macro instead of throwing", async () => {
+			const runMarker = new ObsidianCommand("After", "after-id");
+			runMarker.generateId();
+			const choiceCommand = new ChoiceCommand("Missing choice", "gone-id");
+
+			const { engine, executeCommandById } = createEngine({
+				commands: [choiceCommand, runMarker],
+				registeredCommandIds: ["after-id"],
+				getChoiceById: vi.fn(() => {
+					// Mirror plugin.getChoiceById, which THROWS when the choice was deleted.
+					throw new Error("Choice gone-id not found");
+				}),
+			});
+
+			// Must not reject: the deleted choice is skipped, not a hard crash.
+			await expect(engine.run()).resolves.toBeUndefined();
+			// The macro keeps running the commands after the missing choice.
+			expect(executeCommandById).toHaveBeenCalledWith("after-id");
+		});
+	});
+
+	describe("executeConditional abort propagation", () => {
+		it("halts the macro when a command inside the branch aborts", async () => {
+			const abortingChoice = new ChoiceCommand("Aborts", "abort-choice");
+			const afterBranch = new ObsidianCommand("After branch", "after-branch");
+			afterBranch.generateId();
+
+			const conditional = new ConditionalCommand({
+				condition: {
+					mode: "variable",
+					variableName: "flag",
+					operator: "isTruthy",
+					valueType: "boolean",
+				},
+				thenCommands: [abortingChoice, afterBranch],
+				elseCommands: [],
+			});
+
+			const afterConditional = new ObsidianCommand(
+				"After conditional",
+				"after-conditional"
+			);
+			afterConditional.generateId();
+
+			const choiceExecutor = createChoiceExecutorStub((executor) => {
+				// The aborting branch command signals an abort, like a cancelled prompt.
+				executor.signalAbort?.(new MacroAbortError("aborted in branch"));
+			});
+
+			const { engine, executeCommandById } = createEngine({
+				commands: [conditional, afterConditional],
+				registeredCommandIds: [
+					"after-branch",
+					"after-conditional",
+				],
+				getChoiceById: vi.fn(() => ({
+					id: "abort-choice",
+					name: "Aborts",
+				})),
+				choiceExecutor,
+				variables: { flag: true },
+			});
+
+			await engine.run();
+
+			// Neither the later branch command nor the command after the conditional
+			// should run once the branch aborted.
+			expect(executeCommandById).not.toHaveBeenCalledWith("after-branch");
+			expect(executeCommandById).not.toHaveBeenCalledWith(
+				"after-conditional"
+			);
+		});
+	});
+
+	describe("executeObsidianCommand for an uninstalled command", () => {
+		it("does not invoke executeCommandById when the command id is unregistered", async () => {
+			const missing = new ObsidianCommand("Gone plugin command", "gone:cmd");
+			missing.generateId();
+
+			const { engine, executeCommandById } = createEngine({
+				commands: [missing],
+				registeredCommandIds: [],
+			});
+
+			await engine.run();
+
+			expect(executeCommandById).not.toHaveBeenCalled();
+		});
+
+		it("invokes executeCommandById when the command id is still registered", async () => {
+			const present = new ObsidianCommand("Real command", "real:cmd");
+			present.generateId();
+
+			const { engine, executeCommandById } = createEngine({
+				commands: [present],
+				registeredCommandIds: ["real:cmd"],
+			});
+
+			await engine.run();
+
+			expect(executeCommandById).toHaveBeenCalledWith("real:cmd");
+		});
+	});
+});

--- a/src/engine/MacroChoiceEngine.openFilePath.audit-macro.test.ts
+++ b/src/engine/MacroChoiceEngine.openFilePath.audit-macro.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from "vitest";
+
+const { formatFileNameMock, openFileMock } = vi.hoisted(() => ({
+	formatFileNameMock: vi.fn(async (path: string) => path),
+	openFileMock: vi.fn(
+		async (_app: unknown, _file: unknown, _options?: unknown) => {}
+	),
+}));
+
+vi.mock("../quickAddApi", () => ({
+	QuickAddApi: {
+		GetApi: vi.fn(),
+	},
+}));
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: class GenericSuggesterMock {
+		static Suggest() {
+			return Promise.resolve(undefined);
+		}
+	},
+}));
+vi.mock("../main", () => ({
+	default: class QuickAddMock {},
+}));
+vi.mock("../gui/choiceList/ChoiceView.svelte", () => ({}));
+vi.mock("../quickAddSettingsTab", () => ({
+	DEFAULT_SETTINGS: {},
+	QuickAddSettingsTab: class {},
+}));
+vi.mock("../settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({
+			ai: {},
+			disableOnlineFeatures: false,
+			showInputCancellationNotification: false,
+		}),
+	},
+}));
+vi.mock("../formatters/completeFormatter", () => ({
+	CompleteFormatter: class CompleteFormatterMock {
+		formatFileName = formatFileNameMock;
+	},
+}));
+vi.mock("../utilityObsidian", () => ({
+	getUserScript: vi.fn(),
+	openFile: openFileMock,
+}));
+vi.mock("../quickAddInstance", () => ({
+	getQuickAddInstance: vi.fn(() => ({})),
+}));
+vi.mock("../ai/AIAssistant", () => ({
+	runAIAssistant: vi.fn(),
+}));
+vi.mock("../ai/aiHelpers", () => ({
+	getModelByName: vi.fn(),
+	getModelNames: vi.fn().mockReturnValue([]),
+	getModelProvider: vi.fn().mockReturnValue({ apiKey: "" }),
+}));
+
+import type { App } from "obsidian";
+import { TFile } from "obsidian";
+import { MacroChoiceEngine } from "./MacroChoiceEngine";
+import { OpenFileCommand } from "../types/macros/QuickCommands/OpenFileCommand";
+import type { IMacro } from "../types/macros/IMacro";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { QuickAddApi } from "../quickAddApi";
+
+const getApiMock = QuickAddApi.GetApi as unknown as ReturnType<typeof vi.fn>;
+
+function makeFile(path: string): TFile {
+	const file = new TFile();
+	file.path = path;
+	return file;
+}
+
+function createEngine(filePath: string, existingPaths: Record<string, TFile>) {
+	const app = {
+		vault: {
+			getAbstractFileByPath: vi.fn(
+				(path: string) => existingPaths[path] ?? null
+			),
+		},
+	} as unknown as App;
+
+	const plugin = {
+		getChoiceById: vi.fn(),
+		getChoiceByName: vi.fn(),
+	} as unknown as any;
+
+	const command = new OpenFileCommand(filePath);
+
+	const macro: IMacro = {
+		name: "Test macro",
+		id: "macro-id",
+		commands: [command],
+	};
+
+	const choice: IMacroChoice = {
+		name: "Test choice",
+		id: "choice-id",
+		type: "Macro",
+		command: false,
+		macro,
+		runOnStartup: false,
+	};
+
+	const choiceExecutor: IChoiceExecutor = {
+		execute: vi.fn(),
+		variables: new Map<string, unknown>(),
+	};
+
+	const engine = new MacroChoiceEngine(
+		app,
+		plugin,
+		choice,
+		choiceExecutor,
+		new Map<string, unknown>()
+	);
+
+	return { engine };
+}
+
+describe("MacroChoiceEngine executeOpenFile path validation", () => {
+	beforeEach(() => {
+		getApiMock.mockReturnValue({});
+		formatFileNameMock.mockClear();
+		openFileMock.mockClear();
+	});
+
+	afterEach(() => {
+		getApiMock.mockClear();
+	});
+
+	afterAll(() => {
+		getApiMock.mockReset();
+	});
+
+	it("opens a legitimate file whose name contains '..'", async () => {
+		const file = makeFile("log..2024.md");
+		const { engine } = createEngine("log..2024.md", {
+			"log..2024.md": file,
+		});
+
+		await engine.run();
+
+		expect(openFileMock).toHaveBeenCalledTimes(1);
+		expect(openFileMock.mock.calls[0][1]).toBe(file);
+	});
+
+	it("still rejects an actual '..' traversal segment", async () => {
+		const file = makeFile("../secret.md");
+		const { engine } = createEngine("../secret.md", {
+			"../secret.md": file,
+		});
+
+		await engine.run();
+
+		expect(openFileMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -527,10 +527,14 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		let targetChoice: IChoice;
 		try {
 			targetChoice = this.plugin.getChoiceById(command.choiceId);
-		} catch {
-			// getChoiceById throws when the referenced choice was deleted; surface a
-			// friendly message naming the stored command and skip instead of aborting
-			// the whole macro.
+		} catch (error) {
+			// getChoiceById throws ONLY a "Choice <id> not found" error when the
+			// referenced choice was deleted; surface a friendly message naming the
+			// stored command and skip instead of aborting the whole macro. Rethrow
+			// anything else so a genuine fault isn't silently swallowed (which would
+			// let the macro continue in a corrupted state).
+			const message = error instanceof Error ? error.message : String(error);
+			if (!/not found/i.test(message)) throw error;
 			log.logError(
 				`choice '${command.name}' could not be found.`
 			);

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -508,16 +508,32 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 
 	protected executeObsidianCommand(command: IObsidianCommand) {
 		// @ts-ignore
-		 
+		const registry = this.app.commands.commands;
+		// When the command registry is available, a missing id means the source
+		// plugin was disabled/uninstalled; executeCommandById would silently no-op,
+		// so surface a clear error instead of letting the macro look successful.
+		if (registry && !registry[command.commandId]) {
+			log.logError(
+				`Obsidian command '${command.name}' is no longer available.`
+			);
+			return;
+		}
+
+		// @ts-ignore
 		this.app.commands.executeCommandById(command.commandId);
 	}
 
 	protected async executeChoice(command: IChoiceCommand) {
-		const targetChoice: IChoice = this.plugin.getChoiceById(
-			command.choiceId
-		);
-		if (!targetChoice) {
-			log.logError("choice could not be found.");
+		let targetChoice: IChoice;
+		try {
+			targetChoice = this.plugin.getChoiceById(command.choiceId);
+		} catch {
+			// getChoiceById throws when the referenced choice was deleted; surface a
+			// friendly message naming the stored command and skip instead of aborting
+			// the whole macro.
+			log.logError(
+				`choice '${command.name}' could not be found.`
+			);
 			return;
 		}
 
@@ -584,7 +600,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 	private async executeAIAssistant(command: IAIAssistantCommand) {
 		if (settingsStore.getState().disableOnlineFeatures) {
 			throw new Error(
-				"Blocking request to OpenAI: Online features are disabled in settings."
+				"Blocking request: Online features are disabled in settings."
 			);
 		}
 
@@ -665,6 +681,14 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		}
 
 		await this.executeCommands(branch);
+
+		// executeCommands swallows aborts (signals + returns) so the inner branch
+		// loop stops; re-throw the pending abort here so the outer macro loop halts
+		// too instead of running the commands after this conditional.
+		const abort = this.choiceExecutor.consumeAbortSignal?.();
+		if (abort) {
+			throw abort;
+		}
 	}
 
 	public async runSubset(commands: ICommand[]): Promise<void> {
@@ -765,9 +789,19 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 			const resolvedPath = await formatter.formatFileName(command.filePath, "");
 			const normalizedPath = resolvedPath.replace(/\\/g, "/");
 
-			// Validate path to prevent traversal attacks
-			const safePath = "/" + normalizedPath;
-			if (safePath.includes("..") || safePath.includes("//")) {
+			// Validate path segments to prevent traversal attacks. A substring check
+			// would wrongly reject legitimate filenames that merely contain ".." (e.g.
+			// 'log..2024.md') or "//"; only a literal '..' path segment or an empty
+			// segment (from '//') is an actual traversal/malformed path.
+			const segments = normalizedPath.split("/");
+			const hasTraversal = segments.some(
+				(segment, index) =>
+					segment === ".." ||
+					// An empty segment is a doubled slash; the leading slash of an
+					// absolute path is allowed (index 0), as is a single trailing slash.
+					(segment === "" && index !== 0 && index !== segments.length - 1)
+			);
+			if (hasTraversal) {
 				log.logError(`OpenFile: Path traversal not allowed in '${normalizedPath}'`);
 				return;
 			}

--- a/src/engine/StartupMacroEngine.audit-macro.test.ts
+++ b/src/engine/StartupMacroEngine.audit-macro.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const runMock = vi.fn();
+
+vi.mock("./MacroChoiceEngine", () => ({
+	MacroChoiceEngine: class MacroChoiceEngineMock {
+		private readonly choice: { name: string };
+		constructor(
+			_app: unknown,
+			_plugin: unknown,
+			choice: { name: string }
+		) {
+			this.choice = choice;
+		}
+		run() {
+			return runMock(this.choice.name);
+		}
+	},
+}));
+
+// log.logError shows a Notice via GuiLogger; keep it quiet/inspectable in tests.
+const logErrorMock = vi.fn();
+vi.mock("../logger/logManager", () => ({
+	log: {
+		logError: (...args: unknown[]) => logErrorMock(...args),
+		logWarning: vi.fn(),
+		logMessage: vi.fn(),
+	},
+}));
+
+import type { App } from "obsidian";
+import { StartupMacroEngine } from "./StartupMacroEngine";
+import type IChoice from "../types/choices/IChoice";
+import type IMacroChoice from "../types/choices/IMacroChoice";
+import type QuickAdd from "../main";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+
+function makeStartupMacro(name: string): IMacroChoice {
+	return {
+		name,
+		id: `${name}-id`,
+		type: "Macro",
+		command: false,
+		runOnStartup: true,
+		macro: { name, id: `${name}-macro`, commands: [] },
+	} as IMacroChoice;
+}
+
+describe("StartupMacroEngine error isolation", () => {
+	beforeEach(() => {
+		runMock.mockReset();
+		logErrorMock.mockReset();
+	});
+
+	it("continues running later startup macros after one throws", async () => {
+		runMock
+			.mockResolvedValueOnce(undefined) // first macro succeeds
+			.mockRejectedValueOnce(new Error("boom")) // second macro throws
+			.mockResolvedValueOnce(undefined); // third macro should still run
+
+		const choices: IChoice[] = [
+			makeStartupMacro("first"),
+			makeStartupMacro("second"),
+			makeStartupMacro("third"),
+		];
+
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+
+		const engine = new StartupMacroEngine(
+			{} as App,
+			{} as QuickAdd,
+			choices,
+			choiceExecutor
+		);
+
+		// Must not reject even though the second macro throws.
+		await expect(engine.run()).resolves.toBeUndefined();
+
+		expect(runMock).toHaveBeenCalledTimes(3);
+		expect(runMock).toHaveBeenNthCalledWith(1, "first");
+		expect(runMock).toHaveBeenNthCalledWith(2, "second");
+		expect(runMock).toHaveBeenNthCalledWith(3, "third");
+		// The failure is reported (Notice) naming the failing macro.
+		expect(logErrorMock).toHaveBeenCalledTimes(1);
+		const reported = String(logErrorMock.mock.calls[0][0]);
+		expect(reported).toContain("second");
+	});
+});

--- a/src/engine/StartupMacroEngine.ts
+++ b/src/engine/StartupMacroEngine.ts
@@ -5,6 +5,7 @@ import type { IChoiceExecutor } from "../IChoiceExecutor";
 import type IChoice from "../types/choices/IChoice";
 import type IMacroChoice from "../types/choices/IMacroChoice";
 import { flattenChoices } from "../utils/choiceUtils";
+import { reportError } from "../utils/errorUtils";
 
 export class StartupMacroEngine {
 	constructor(
@@ -19,13 +20,23 @@ export class StartupMacroEngine {
 			.filter((c): c is IMacroChoice => c.type === "Macro" && (c as IMacroChoice).runOnStartup);
 		
 		for (const choice of macroChoices) {
-			await new MacroChoiceEngine(
-				this.app,
-				this.plugin,
-				choice,
-				this.choiceExecutor,
-				new Map()
-			).run();
+			// Isolate each startup macro: one that throws (a script bug, missing
+			// dependency, etc.) must not stop the rest from running. Report the
+			// failure naming the macro and continue to the next one.
+			try {
+				await new MacroChoiceEngine(
+					this.app,
+					this.plugin,
+					choice,
+					this.choiceExecutor,
+					new Map()
+				).run();
+			} catch (error) {
+				reportError(
+					error,
+					`Startup macro '${choice.name}' failed`
+				);
+			}
 		}
 	}
 }

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-cleanup.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-cleanup.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+vi.mock("src/settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({
+			ai: { promptTemplatesFolderPath: "", showAssistant: false },
+			disableOnlineFeatures: false,
+		}),
+	},
+}));
+vi.mock("src/quickAddInstance", () => ({
+	getQuickAddInstance: vi.fn(() => ({})),
+}));
+vi.mock("src/ai/aiHelpers", () => ({
+	getModelNames: vi.fn(() => ["gpt-test"]),
+}));
+vi.mock("src/utilityObsidian", () => ({
+	getMarkdownFilesInFolder: vi.fn(() => []),
+}));
+vi.mock("src/ai/tokenEstimator", () => ({
+	estimateTokenCount: vi.fn(() => 0),
+}));
+vi.mock("./../suggesters/formatSyntaxSuggester", () => ({
+	FormatSyntaxSuggester: class {},
+}));
+vi.mock("../suggesters/genericTextSuggester", () => ({
+	GenericTextSuggester: class {},
+}));
+vi.mock("src/formatters/formatDisplayFormatter", () => ({
+	FormatDisplayFormatter: class {
+		async format(input: string) {
+			return input;
+		}
+	},
+}));
+
+import { App } from "obsidian";
+import type { IAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
+import { AIAssistantCommandSettingsModal } from "./AIAssistantCommandSettingsModal";
+
+function testApp(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function makeCommand(model: string): IAIAssistantCommand {
+	return {
+		id: "ai-1",
+		name: "AI Assistant",
+		type: "AIAssistant",
+		model,
+		systemPrompt: "original prompt",
+		outputVariableName: "output",
+		modelParameters: { temperature: 0.5 },
+		promptTemplate: { enable: false, name: "" },
+	} as IAIAssistantCommand;
+}
+
+// The Model dropdown is the only <select> rendered by the modal whose options
+// come from getModelNames() plus "Ask me".
+function getModelSelect(
+	modal: AIAssistantCommandSettingsModal
+): HTMLSelectElement {
+	const select = Array.from(
+		modal.contentEl.querySelectorAll<HTMLSelectElement>("select")
+	).find((candidate) =>
+		Array.from(candidate.options).some((opt) => opt.value === "Ask me")
+	);
+	if (!select) throw new Error("Model dropdown not found");
+	return select;
+}
+
+// Finding: ai-assistant-default-model-setting — the per-command Model dropdown
+// silently fell back to the first option (and persisted the wrong default) when
+// the pinned model had been deleted. It must now surface the stale value with a
+// "(missing)" option so the dropdown reflects the saved selection.
+describe("AIAssistantCommandSettingsModal Model dropdown missing-model handling", () => {
+	beforeAll(() => {
+		const modalProto = Object.getPrototypeOf(
+			AIAssistantCommandSettingsModal.prototype
+		) as { onClose?: () => void };
+		modalProto.onClose ??= function onClose() {};
+	});
+
+	it("adds a disabled (missing) option and selects it when the stored model is gone", () => {
+		const command = makeCommand("deleted-model");
+		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
+
+		const select = getModelSelect(modal);
+		const missing = Array.from(select.options).find(
+			(opt) => opt.value === "deleted-model"
+		);
+
+		expect(missing).toBeDefined();
+		expect(missing?.textContent).toBe("(missing) deleted-model");
+		// The dropdown reflects the stored value instead of silently defaulting.
+		expect(select.value).toBe("deleted-model");
+
+		modal.close();
+	});
+
+	it("does not add a (missing) option when the stored model still exists", () => {
+		const command = makeCommand("gpt-test");
+		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
+
+		const select = getModelSelect(modal);
+		const labels = Array.from(select.options).map((opt) => opt.textContent);
+
+		expect(labels).not.toContain("(missing) gpt-test");
+		expect(select.value).toBe("gpt-test");
+
+		modal.close();
+	});
+
+	it("does not add a (missing) option for the 'Ask me' sentinel", () => {
+		const command = makeCommand("Ask me");
+		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
+
+		const select = getModelSelect(modal);
+		const labels = Array.from(select.options).map((opt) => opt.textContent);
+
+		expect(labels.filter((label) => label === "Ask me")).toHaveLength(1);
+		expect(labels.some((label) => label?.startsWith("(missing)"))).toBe(
+			false
+		);
+		expect(select.value).toBe("Ask me");
+
+		modal.close();
+	});
+});

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-macro.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-macro.test.ts
@@ -1,0 +1,130 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+vi.mock("src/settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({
+			ai: { promptTemplatesFolderPath: "", showAssistant: false },
+			disableOnlineFeatures: false,
+		}),
+	},
+}));
+vi.mock("src/quickAddInstance", () => ({
+	getQuickAddInstance: vi.fn(() => ({})),
+}));
+vi.mock("src/ai/aiHelpers", () => ({
+	getModelNames: vi.fn(() => ["gpt-test"]),
+}));
+vi.mock("src/utilityObsidian", () => ({
+	getMarkdownFilesInFolder: vi.fn(() => []),
+}));
+vi.mock("src/ai/tokenEstimator", () => ({
+	estimateTokenCount: vi.fn(() => 0),
+}));
+vi.mock("./../suggesters/formatSyntaxSuggester", () => ({
+	FormatSyntaxSuggester: class {},
+}));
+vi.mock("../suggesters/genericTextSuggester", () => ({
+	GenericTextSuggester: class {},
+}));
+vi.mock("src/formatters/formatDisplayFormatter", () => ({
+	FormatDisplayFormatter: class {
+		async format(input: string) {
+			return input;
+		}
+	},
+}));
+
+import { App } from "obsidian";
+import { fireEvent } from "@testing-library/svelte";
+import type { IAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
+import { AIAssistantCommandSettingsModal } from "./AIAssistantCommandSettingsModal";
+
+function testApp(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function makeCommand(): IAIAssistantCommand {
+	return {
+		id: "ai-1",
+		name: "AI Assistant",
+		type: "AIAssistant",
+		model: "gpt-test",
+		systemPrompt: "original prompt",
+		outputVariableName: "output",
+		modelParameters: { temperature: 0.5 },
+		promptTemplate: { enable: false, name: "" },
+	} as IAIAssistantCommand;
+}
+
+function getButton(
+	modal: AIAssistantCommandSettingsModal,
+	text: string
+): HTMLButtonElement {
+	const button = Array.from(
+		modal.containerEl.querySelectorAll<HTMLButtonElement>("button")
+	).find((candidate) => candidate.textContent === text);
+	if (!button) throw new Error(`${text} button not found`);
+	return button;
+}
+
+describe("AIAssistantCommandSettingsModal cancel/discard semantics", () => {
+	beforeAll(() => {
+		const modalProto = Object.getPrototypeOf(
+			AIAssistantCommandSettingsModal.prototype
+		) as { onClose?: () => void };
+		modalProto.onClose ??= function onClose() {};
+	});
+
+	it("discards in-session edits and resolves null on Cancel", async () => {
+		const command = makeCommand();
+		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
+		const result = modal.waitForClose;
+
+		// Simulate edits made through the modal (it mutates the live command).
+		command.systemPrompt = "edited prompt";
+		command.modelParameters.temperature = 0.9;
+
+		await fireEvent.click(getButton(modal, "Cancel"));
+
+		await expect(result).resolves.toBeNull();
+		// The live command is restored to its opened state.
+		expect(command.systemPrompt).toBe("original prompt");
+		expect(command.modelParameters.temperature).toBe(0.5);
+	});
+
+	it("commits edits and resolves the command on Save", async () => {
+		const command = makeCommand();
+		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
+		const result = modal.waitForClose;
+
+		command.systemPrompt = "edited prompt";
+
+		await fireEvent.click(getButton(modal, "Save"));
+
+		const resolved = await result;
+		expect(resolved).not.toBeNull();
+		expect(command.systemPrompt).toBe("edited prompt");
+	});
+
+	it("discards edits and resolves null when dismissed without Save (Esc)", async () => {
+		const command = makeCommand();
+		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
+		const result = modal.waitForClose;
+
+		command.systemPrompt = "edited prompt";
+
+		modal.close();
+
+		await expect(result).resolves.toBeNull();
+		expect(command.systemPrompt).toBe("original prompt");
+	});
+});

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -1,5 +1,5 @@
 import type { App } from "obsidian";
-import { Modal, Setting, TextAreaComponent, debounce } from "obsidian";
+import { ButtonComponent, Modal, Setting, TextAreaComponent, debounce } from "obsidian";
 import { FormatSyntaxSuggester } from "./../suggesters/formatSyntaxSuggester";
 import { getQuickAddInstance } from "src/quickAddInstance";
 import { FormatDisplayFormatter } from "src/formatters/formatDisplayFormatter";
@@ -18,12 +18,16 @@ import { estimateTokenCount } from "src/ai/tokenEstimator";
 import { getModelNames } from "src/ai/aiHelpers";
 
 export class AIAssistantCommandSettingsModal extends Modal {
-	public waitForClose: Promise<IAIAssistantCommand>;
+	public waitForClose: Promise<IAIAssistantCommand | null>;
 
-	private resolvePromise: (settings: IAIAssistantCommand) => void;
+	private resolvePromise: (settings: IAIAssistantCommand | null) => void;
 	private rejectPromise: (reason?: unknown) => void;
 
 	private settings: IAIAssistantCommand;
+	// Snapshot of the command as it was opened, so Cancel/Esc can restore the live
+	// object (the same reference the caller persists) instead of committing edits.
+	private readonly originalSettings: IAIAssistantCommand;
+	private isResolved = false;
 	private showAdvancedSettings = false;
 
 	private get systemPromptTokenLength(): number {
@@ -35,8 +39,9 @@ export class AIAssistantCommandSettingsModal extends Modal {
 		super(app);
 
 		this.settings = settings;
+		this.originalSettings = this.cloneSettings(settings);
 
-		this.waitForClose = new Promise<IAIAssistantCommand>(
+		this.waitForClose = new Promise<IAIAssistantCommand | null>(
 			(resolve, reject) => {
 				this.rejectPromise = reject;
 				this.resolvePromise = resolve;
@@ -45,6 +50,32 @@ export class AIAssistantCommandSettingsModal extends Modal {
 
 		this.open();
 		this.display();
+	}
+
+	private resolve(value: IAIAssistantCommand | null) {
+		if (this.isResolved) return;
+		this.isResolved = true;
+		this.resolvePromise(value);
+	}
+
+	// Proxy-safe deep clone of the editable fields. Avoids structuredClone, which
+	// throws DataCloneError on a Svelte dev-mode $state proxy (the command passed in
+	// is one such proxy when edited from the macro command list).
+	private cloneSettings(settings: IAIAssistantCommand): IAIAssistantCommand {
+		return {
+			...settings,
+			promptTemplate: { ...settings.promptTemplate },
+			modelParameters: { ...settings.modelParameters },
+		};
+	}
+
+	// Restore the live command (same reference the caller persists) to its opened
+	// state so Cancel/Esc discards edits, including the nested objects.
+	private restoreOriginal(): void {
+		const snapshot = this.cloneSettings(this.originalSettings);
+		Object.assign(this.settings, snapshot);
+		this.settings.promptTemplate = snapshot.promptTemplate;
+		this.settings.modelParameters = snapshot.modelParameters;
 	}
 
 	private display(): void {
@@ -96,6 +127,31 @@ export class AIAssistantCommandSettingsModal extends Modal {
 		}
 
 		this.addSystemPromptSetting(this.contentEl);
+
+		this.addButtonBar(this.contentEl);
+	}
+
+	private addButtonBar(container: HTMLElement): void {
+		const buttonRow = container.createDiv({
+			cls: "qa-command-button-row",
+		});
+
+		new ButtonComponent(buttonRow)
+			.setButtonText("Cancel")
+			.onClick(() => {
+				// Dismissing via Cancel discards every edit made in this session.
+				this.restoreOriginal();
+				this.resolve(null);
+				this.close();
+			});
+
+		new ButtonComponent(buttonRow)
+			.setButtonText("Save")
+			.setCta()
+			.onClick(() => {
+				this.resolve(this.settings);
+				this.close();
+			});
 	}
 
 	private reload(): void {
@@ -150,7 +206,17 @@ export class AIAssistantCommandSettingsModal extends Modal {
 
 				dropdown.addOption("Ask me", "Ask me");
 
-				dropdown.setValue(this.settings.model);
+				// If the pinned model was deleted, the option no longer exists and
+				// setValue would silently fall back to the first option while the
+				// stored (now invalid) name persists. Surface the mismatch with a
+				// disabled "(missing)" entry so the dropdown reflects the saved value.
+				const stored = this.settings.model;
+				const isKnown = stored === "Ask me" || models.includes(stored);
+				if (stored && !isKnown) {
+					dropdown.addOption(stored, `(missing) ${stored}`);
+				}
+
+				dropdown.setValue(stored);
 				dropdown.onChange((value) => {
 					this.settings.model = value;
 
@@ -317,7 +383,12 @@ export class AIAssistantCommandSettingsModal extends Modal {
 	}
 
 	onClose(): void {
-		this.resolvePromise(this.settings);
+		// Dismissing via Esc / click-outside / X discards edits (matches the
+		// Conditional/Open File modals). Only the Save button commits the working copy.
+		if (!this.isResolved) {
+			this.restoreOriginal();
+			this.resolve(null);
+		}
 		super.onClose();
 	}
 }

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -214,6 +214,12 @@ export class AIAssistantCommandSettingsModal extends Modal {
 				const isKnown = stored === "Ask me" || models.includes(stored);
 				if (stored && !isKnown) {
 					dropdown.addOption(stored, `(missing) ${stored}`);
+					// Disable it so the stale value is shown but can't be re-selected
+					// and re-saved as a valid choice.
+					const missingOption = Array.from(
+						dropdown.selectEl.options,
+					).find((option) => option.value === stored);
+					if (missingOption) missingOption.disabled = true;
 				}
 
 				dropdown.setValue(stored);

--- a/src/gui/MacroGUIs/CommandSequenceEditor.audit-macro.test.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.audit-macro.test.ts
@@ -1,0 +1,157 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+import { App, Notice, TextComponent } from "obsidian";
+import { fireEvent } from "@testing-library/svelte";
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import { CommandSequenceEditor } from "./CommandSequenceEditor";
+
+type NoticeTestClass = typeof Notice & {
+	instances: Array<{ message: string }>;
+};
+const noticeClass = Notice as unknown as NoticeTestClass;
+
+function testApp(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function getInputByPlaceholder(
+	container: HTMLElement,
+	placeholder: string
+): HTMLInputElement {
+	const input = Array.from(
+		container.querySelectorAll<HTMLInputElement>("input")
+	).find((el) => el.placeholder === placeholder);
+	if (!input) throw new Error(`Input "${placeholder}" not found`);
+	return input;
+}
+
+/** Walk up from a control to the Setting wrapper that holds the "Add" button. */
+function getAddButtonFor(input: HTMLInputElement): HTMLButtonElement {
+	let node: HTMLElement | null = input.parentElement;
+	while (node) {
+		const button = Array.from(
+			node.querySelectorAll<HTMLButtonElement>("button")
+		).find((b) => b.textContent === "Add");
+		if (button) return button;
+		node = node.parentElement;
+	}
+	throw new Error("Add button not found");
+}
+
+describe("CommandSequenceEditor silent-add feedback", () => {
+	beforeAll(() => {
+		// The test obsidian stub's TextComponent lacks getValue(); back-fill it from
+		// the underlying input element (harness gap, not a code bug).
+		const textProto = TextComponent.prototype as unknown as {
+			getValue?: () => string;
+			inputEl: HTMLInputElement;
+		};
+		textProto.getValue ??= function getValue(this: {
+			inputEl: HTMLInputElement;
+		}) {
+			return this.inputEl.value;
+		};
+
+		// vitest-setup back-fills addClass/removeClass but not toggleClass, which the
+		// user-script row's onChange uses to show/hide the Add button.
+		const elProto = HTMLElement.prototype as unknown as {
+			toggleClass?: (classes: string | string[], value: boolean) => void;
+		};
+		elProto.toggleClass ??= function toggleClass(
+			this: HTMLElement,
+			classes: string | string[],
+			value: boolean
+		) {
+			const list = Array.isArray(classes) ? classes : [classes];
+			for (const cls of list) this.classList.toggle(cls, value);
+		};
+	});
+
+	beforeEach(() => {
+		noticeClass.instances.length = 0;
+	});
+
+	it("warns when adding a choice name that matches no existing choice", async () => {
+		const choices: IChoice[] = [
+			{
+				id: "c1",
+				name: "Real Choice",
+				type: "Template",
+				command: false,
+			} as IChoice,
+		];
+
+		const onCommandsChange = vi.fn();
+		const editor = new CommandSequenceEditor({
+			app: testApp(),
+			plugin: { settings: { choices } } as unknown as QuickAdd,
+			commands: [],
+			choices,
+			onCommandsChange,
+		});
+
+		const container = document.createElement("div");
+		document.body.appendChild(container);
+		editor.render(container);
+
+		const input = getInputByPlaceholder(container, "Choice");
+
+		await fireEvent.input(input, { target: { value: "Nonexistent" } });
+		await fireEvent.click(getAddButtonFor(input));
+
+		// No command added, and the user is told why.
+		expect(onCommandsChange).not.toHaveBeenCalled();
+		expect(
+			noticeClass.instances.some((n) => n.message.includes("Nonexistent"))
+		).toBe(true);
+
+		editor.destroy();
+	});
+
+	it("warns when adding a user-script name that resolves to nothing", async () => {
+		const onCommandsChange = vi.fn();
+		const editor = new CommandSequenceEditor({
+			app: testApp(),
+			plugin: { settings: { choices: [] } } as unknown as QuickAdd,
+			commands: [],
+			choices: [],
+			onCommandsChange,
+		});
+
+		const container = document.createElement("div");
+		document.body.appendChild(container);
+		editor.render(container);
+
+		const input = getInputByPlaceholder(
+			container,
+			"Start typing script name..."
+		);
+
+		await fireEvent.input(input, {
+			target: { value: "missingScript" },
+		});
+
+		await fireEvent.click(getAddButtonFor(input));
+		// addUserScriptFromInput is async; flush microtasks.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onCommandsChange).not.toHaveBeenCalled();
+		expect(
+			noticeClass.instances.some((n) => n.message.includes("missingScript"))
+		).toBe(true);
+
+		editor.destroy();
+	});
+});

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -364,7 +364,12 @@ export class CommandSequenceEditor {
 				this.scriptCandidates,
 				selector,
 			);
-			if (!resolved) return;
+			if (!resolved) {
+				new Notice(
+					`QuickAdd: No script or js-block note named "${value}" found.`
+				);
+				return;
+			}
 
 			if (resolved.isMarkdown) {
 				const reason = await noteScriptError(this.app, resolved.file);
@@ -440,7 +445,10 @@ export class CommandSequenceEditor {
 		const addChoiceFromInput = () => {
 			const value: string = input.getValue();
 			const choice = this.choices.find((c) => c.name === value);
-			if (!choice) return;
+			if (!choice) {
+				new Notice(`QuickAdd: No choice named "${value}".`);
+				return;
+			}
 
 			this.addCommand(new ChoiceCommand(choice.name, choice.id));
 

--- a/src/gui/MacroGUIs/Components/WaitCommand.audit-macro.test.ts
+++ b/src/gui/MacroGUIs/Components/WaitCommand.audit-macro.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import WaitCommand from "./WaitCommand.svelte";
+import { WaitCommand as WaitCommandModel } from "../../../types/macros/QuickCommands/WaitCommand";
+
+function makeProps(onUpdateCommand: (command: unknown) => void) {
+	const command = new WaitCommandModel(100);
+	command.id = "wait-1";
+	return {
+		command,
+		startDrag: () => {},
+		dragDisabled: true,
+		onDeleteCommand: () => {},
+		onUpdateCommand,
+		onMoveUp: () => {},
+		onMoveDown: () => {},
+	};
+}
+
+describe("WaitCommand duration input", () => {
+	it("exposes a non-negative minimum on the duration input", () => {
+		const { getByLabelText } = render(WaitCommand, {
+			props: makeProps(() => {}),
+		});
+
+		const input = getByLabelText(
+			"Wait duration in milliseconds"
+		) as HTMLInputElement;
+		expect(input.getAttribute("min")).toBe("0");
+	});
+
+	it("clamps a negative duration to 0", async () => {
+		const onUpdateCommand = vi.fn();
+		const { getByLabelText } = render(WaitCommand, {
+			props: makeProps(onUpdateCommand),
+		});
+
+		const input = getByLabelText(
+			"Wait duration in milliseconds"
+		) as HTMLInputElement;
+
+		await fireEvent.input(input, { target: { value: "-50" } });
+
+		expect(onUpdateCommand).toHaveBeenCalledTimes(1);
+		expect(onUpdateCommand.mock.calls[0][0]).toMatchObject({ time: 0 });
+	});
+
+	it("keeps a valid positive duration", async () => {
+		const onUpdateCommand = vi.fn();
+		const { getByLabelText } = render(WaitCommand, {
+			props: makeProps(onUpdateCommand),
+		});
+
+		const input = getByLabelText(
+			"Wait duration in milliseconds"
+		) as HTMLInputElement;
+
+		await fireEvent.input(input, { target: { value: "250" } });
+
+		expect(onUpdateCommand.mock.calls[0][0]).toMatchObject({ time: 250 });
+	});
+});

--- a/src/gui/MacroGUIs/Components/WaitCommand.svelte
+++ b/src/gui/MacroGUIs/Components/WaitCommand.svelte
@@ -37,7 +37,9 @@
 
     function onTimeInput(e: Event & { currentTarget: HTMLInputElement }) {
         const next = e.currentTarget.valueAsNumber;
-        time = Number.isNaN(next) ? 0 : next;
+        // Coerce NaN (empty/invalid) to 0 and clamp negatives: a negative wait is
+        // nonsensical (setTimeout treats it as 0) and the label would read "for -50 ms".
+        time = Number.isNaN(next) || next < 0 ? 0 : next;
         resizeInput();
         onUpdateCommand({ ...command, time });
     }
@@ -46,7 +48,7 @@
 </script>
 
 <li class="quickAddCommandListItem">
-    <span class="quickAddCommandLabel">{command.name} for <input bind:this={inputEl} oninput={onTimeInput} type="number" placeholder="   " value={time} class="dotInput" aria-label="Wait duration in milliseconds">ms</span>
+    <span class="quickAddCommandLabel">{command.name} for <input bind:this={inputEl} oninput={onTimeInput} type="number" min="0" placeholder="   " value={time} class="dotInput" aria-label="Wait duration in milliseconds">ms</span>
     <div class="quickAddCommandControls">
         <IconButton
             iconId="trash-2"

--- a/src/gui/MacroGUIs/ConditionalCommandSettingsModal.audit-macro.test.ts
+++ b/src/gui/MacroGUIs/ConditionalCommandSettingsModal.audit-macro.test.ts
@@ -1,0 +1,109 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { App, DropdownComponent, Notice } from "obsidian";
+import { fireEvent } from "@testing-library/svelte";
+import { ConditionalCommand } from "../../types/macros/Conditional/ConditionalCommand";
+import { ConditionalCommandSettingsModal } from "./ConditionalCommandSettingsModal";
+
+type NoticeTestClass = typeof Notice & {
+	instances: Array<{ message: string }>;
+};
+const noticeClass = Notice as unknown as NoticeTestClass;
+
+function testApp(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function getButton(
+	modal: ConditionalCommandSettingsModal,
+	text: string
+): HTMLButtonElement {
+	const button = Array.from(
+		modal.containerEl.querySelectorAll<HTMLButtonElement>("button")
+	).find((candidate) => candidate.textContent === text);
+	if (!button) throw new Error(`${text} button not found`);
+	return button;
+}
+
+describe("ConditionalCommandSettingsModal save validation", () => {
+	beforeAll(() => {
+		const modalProto = Object.getPrototypeOf(
+			ConditionalCommandSettingsModal.prototype
+		) as { onClose?: () => void };
+		modalProto.onClose ??= function onClose() {};
+
+		// The test obsidian stub's DropdownComponent lacks addOptions; back-fill it
+		// so the modal's operator dropdown can render (harness gap, not a code bug).
+		const dropdownProto = DropdownComponent.prototype as unknown as {
+			addOptions?: (options: Record<string, string>) => unknown;
+			addOption: (value: string, text: string) => unknown;
+		};
+		dropdownProto.addOptions ??= function addOptions(
+			this: { addOption: (value: string, text: string) => unknown },
+			options: Record<string, string>
+		) {
+			for (const [value, text] of Object.entries(options)) {
+				this.addOption(value, text);
+			}
+			return this;
+		};
+	});
+
+	beforeEach(() => {
+		noticeClass.instances.length = 0;
+	});
+
+	it("blocks Save and warns when the variable name is empty", async () => {
+		const command = new ConditionalCommand({
+			condition: {
+				mode: "variable",
+				variableName: "",
+				operator: "isTruthy",
+				valueType: "boolean",
+			},
+		});
+
+		const modal = new ConditionalCommandSettingsModal(testApp(), command);
+
+		let resolved = false;
+		void modal.waitForClose.then(() => {
+			resolved = true;
+		});
+
+		await fireEvent.click(getButton(modal, "Save"));
+		// Let any microtasks flush.
+		await Promise.resolve();
+
+		// Save must not resolve the modal while the variable name is empty.
+		expect(resolved).toBe(false);
+		// The command name must NOT have been rewritten to a "missing variable" label.
+		expect(command.name).toBe("If condition");
+		expect(
+			noticeClass.instances.some((n) => /variable name/i.test(n.message))
+		).toBe(true);
+	});
+
+	it("allows Save once the variable name is filled in", async () => {
+		const command = new ConditionalCommand({
+			condition: {
+				mode: "variable",
+				variableName: "status",
+				operator: "isTruthy",
+				valueType: "boolean",
+			},
+		});
+
+		const modal = new ConditionalCommandSettingsModal(testApp(), command);
+		const result = modal.waitForClose;
+
+		await fireEvent.click(getButton(modal, "Save"));
+
+		await expect(result).resolves.not.toBeNull();
+		expect(command.name).toContain("status");
+	});
+});

--- a/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/ConditionalCommandSettingsModal.ts
@@ -334,10 +334,28 @@ export class ConditionalCommandSettingsModal extends Modal {
 			.setCta()
 			.setButtonText("Save")
 			.onClick(() => {
+				if (!this.validateCondition()) return;
 				this.applyChanges();
 				this.resolve(this.originalCommand);
 				this.close();
 			});
+	}
+
+	private validateCondition(): boolean {
+		const condition = this.workingCommand.condition;
+		if (condition.mode === "variable") {
+			if (!condition.variableName.trim()) {
+				new Notice("QuickAdd: Enter a variable name before saving.");
+				return false;
+			}
+			return true;
+		}
+
+		if (!condition.scriptPath.trim()) {
+			new Notice("QuickAdd: Enter a script path before saving.");
+			return false;
+		}
+		return true;
 	}
 
 	private applyChanges() {

--- a/src/gui/MacroGUIs/OpenFileCommandSettingsModal.audit-macro.test.ts
+++ b/src/gui/MacroGUIs/OpenFileCommandSettingsModal.audit-macro.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { fireEvent } from "@testing-library/svelte";
+import { OpenFileCommand } from "../../types/macros/QuickCommands/OpenFileCommand";
+import { OpenFileCommandSettingsModal } from "./OpenFileCommandSettingsModal";
+
+function testApp(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function getButton(
+	modal: OpenFileCommandSettingsModal,
+	text: string
+): HTMLButtonElement {
+	const button = Array.from(
+		modal.containerEl.querySelectorAll<HTMLButtonElement>("button")
+	).find((candidate) => candidate.textContent === text);
+	if (!button) throw new Error(`${text} button not found`);
+	return button;
+}
+
+describe("OpenFileCommandSettingsModal dismissal semantics", () => {
+	beforeAll(() => {
+		const modalProto = Object.getPrototypeOf(
+			OpenFileCommandSettingsModal.prototype
+		) as { onClose?: () => void };
+		modalProto.onClose ??= function onClose() {};
+	});
+
+	it("discards edits (resolves null) when dismissed without Save (Esc/click-outside)", async () => {
+		const command = new OpenFileCommand("original.md");
+		const modal = new OpenFileCommandSettingsModal(testApp(), command);
+		const result = modal.waitForClose;
+
+		// Simulate Esc / click-outside / X: Obsidian calls close() which fires onClose().
+		modal.close();
+
+		await expect(result).resolves.toBeNull();
+	});
+
+	it("commits the working copy when Save is clicked", async () => {
+		const command = new OpenFileCommand("original.md");
+		const modal = new OpenFileCommandSettingsModal(testApp(), command);
+		const result = modal.waitForClose;
+
+		await fireEvent.click(getButton(modal, "Save"));
+
+		const resolved = await result;
+		expect(resolved).not.toBeNull();
+		expect(resolved?.filePath).toBe("original.md");
+	});
+});

--- a/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/OpenFileCommandSettingsModal.ts
@@ -32,8 +32,11 @@ export class OpenFileCommandSettingsModal extends Modal {
 
 	onClose() {
 		super.onClose();
+		// Dismissing via Esc / click-outside / X discards edits (resolve null),
+		// matching the sibling Conditional/Branch modals. Only the Save button
+		// commits the working copy (it resolves before close()).
 		if (!this.isResolved) {
-			this.resolvePromise(this.command);
+			this.resolvePromise(null);
 			this.isResolved = true;
 		}
 	}


### PR DESCRIPTION
This PR bundles 14 fixes from a systematic feature audit (logic + UX), each adversarially verified and covered by regression tests.

- **[Major]** Deleted referenced choice crashes the macro instead of being skipped
- **[Major]** Abort inside a conditional branch does not halt the macro
- **[Minor]** Esc / click-outside saves the OpenFile settings modal instead of cancelling
- **[Minor]** Typing an unmatched user-script name and pressing Add/Enter silently does nothing
- **[Minor]** Open File modal saves on Esc/X but Conditional modals discard — inconsistent close semantics
- **[Minor]** AI Assistant settings modal has no Cancel/discard and always persists, even on Esc
- **[Minor]** Conditional Save accepts empty variable name / script path with no validation
- **[Minor]** Obsidian command referencing an uninstalled/removed command fails silently at runtime
- **[Minor]** Dead null-check hides intended friendly message for a deleted referenced choice
- **[Minor]** One throwing startup macro skips all later startup macros (and leaks an unhandled rejection)
- **[Minor]** One throwing startup macro aborts all remaining startup macros with no user notice
- **[Trivial]** Path-traversal guard rejects legitimate file paths containing '..'
- **[Trivial]** Typing an unmatched choice name and pressing Add silently does nothing
- **[Trivial]** Wait duration input accepts negative values with no minimum or validation

All tests/typecheck/lint/build green. Part of a 9-PR series splitting the audit by area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in macro execution and command registration validation
  * Fixed modal dismiss behavior to properly discard unsaved edits
  * Added input validation for conditional commands
  * Negative wait durations now clamp to 0
  * Startup macros continue executing even if one fails

* **UI Improvements**
  * Added user feedback when adding commands fails to find a match
  * Model dropdown displays missing/stale models instead of silently hiding them

<!-- end of auto-generated comment: release notes by coderabbit.ai -->