### PR TITLE
fix(core): command registration, multi-folder UX, URI/CLI guards, and update announcements

### DIFF
--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -1,4 +1,4 @@
-import type { App, WorkspaceLeaf } from "obsidian";
+import { Notice, type App, type WorkspaceLeaf } from "obsidian";
 import type QuickAdd from "./main";
 import type IChoice from "./types/choices/IChoice";
 import type ITemplateChoice from "./types/choices/ITemplateChoice";
@@ -266,10 +266,21 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	}
 
 	private onChooseMultiType(multiChoice: IMultiChoice) {
+		// An empty folder run via command/URI would otherwise open a dead, item-less
+		// picker (no Back row is appended on this path) that reads as a broken command.
+		// Surface a Notice instead so the user knows the folder simply has nothing in it.
+		if (multiChoice.choices.length === 0) {
+			new Notice(`Folder "${multiChoice.name}" is empty.`);
+			return;
+		}
+
 		ChoiceSuggester.Open(this.plugin, multiChoice.choices, {
 			choiceExecutor: this,
 			focusedProperty: this.focusedProperty,
-			placeholder: multiChoice.placeholder,
+			// Fall back to the folder name when no custom placeholder is set, matching the
+			// picker drill-down (choiceSuggester.onChooseMultiType) so both entry points to
+			// the same folder show the same search hint.
+			placeholder: multiChoice.placeholder?.trim() || multiChoice.name,
 		});
 	}
 }

--- a/src/cli/registerQuickAddCliHandlers.audit-cli-uri.test.ts
+++ b/src/cli/registerQuickAddCliHandlers.audit-cli-uri.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliData, CliFlags } from "obsidian";
+import { TFile } from "obsidian";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+import type QuickAdd from "../main";
+import { registerQuickAddCliHandlers } from "./registerQuickAddCliHandlers";
+import type IChoice from "../types/choices/IChoice";
+
+const {
+	ChoiceExecutorMock,
+	collectChoiceRequirementsMock,
+	getUnresolvedRequirementsMock,
+} = vi.hoisted(() => ({
+	ChoiceExecutorMock: vi.fn(),
+	collectChoiceRequirementsMock: vi.fn(),
+	getUnresolvedRequirementsMock: vi.fn(),
+}));
+
+vi.mock("../choiceExecutor", () => ({
+	ChoiceExecutor: ChoiceExecutorMock,
+}));
+
+vi.mock("../preflight/collectChoiceRequirements", () => ({
+	collectChoiceRequirements: collectChoiceRequirementsMock,
+	getUnresolvedRequirements: getUnresolvedRequirementsMock,
+}));
+
+interface RegisteredCliHandler {
+	command: string;
+	description: string;
+	flags: CliFlags | null;
+	handler: (params: CliData) => string | Promise<string>;
+}
+
+function createPlugin(choices: IChoice[]) {
+	const handlers: RegisteredCliHandler[] = [];
+	const byName = new Map<string, IChoice>();
+	for (const choice of choices) byName.set(choice.name, choice);
+
+	const plugin = {
+		app: {},
+		settings: { choices },
+		getChoiceByName: vi.fn((name: string) => {
+			const choice = byName.get(name);
+			if (!choice) throw new Error(`Choice ${name} not found`);
+			return choice;
+		}),
+		getChoiceById: vi.fn(),
+		registerCliHandler: vi.fn(
+			(
+				command: string,
+				description: string,
+				flags: CliFlags | null,
+				handler: (params: CliData) => string | Promise<string>,
+			) => {
+				handlers.push({ command, description, flags, handler });
+			},
+		),
+	} as unknown as QuickAdd & {
+		registerCliHandler: (
+			command: string,
+			description: string,
+			flags: CliFlags | null,
+			handler: (params: CliData) => string | Promise<string>,
+		) => void;
+	};
+
+	return { plugin, handlers };
+}
+
+describe("registerQuickAddCliHandlers (cli-uri audit: cli-run-choice honesty)", () => {
+	let executors: IChoiceExecutor[];
+
+	const templateChoice: IChoice = {
+		id: "template-id",
+		name: "Template Choice",
+		type: "Template",
+		command: true,
+	} as IChoice;
+
+	beforeEach(() => {
+		executors = [];
+		ChoiceExecutorMock.mockReset();
+		collectChoiceRequirementsMock.mockReset();
+		getUnresolvedRequirementsMock.mockReset();
+
+		ChoiceExecutorMock.mockImplementation(function ChoiceExecutorMock() {
+			const executor: IChoiceExecutor = {
+				execute: vi.fn().mockResolvedValue(undefined),
+				executeWithOutcome: vi.fn().mockResolvedValue({
+					status: "success",
+					file: { path: "Created Note.md" },
+				}),
+				variables: new Map<string, unknown>(),
+				consumeAbortSignal: vi.fn().mockReturnValue(null),
+			};
+			executors.push(executor);
+			return executor;
+		});
+
+		collectChoiceRequirementsMock.mockResolvedValue([]);
+		getUnresolvedRequirementsMock.mockReturnValue([]);
+	});
+
+	function getRunHandler(handlers: RegisteredCliHandler[]) {
+		const run = handlers.find((handler) => handler.command === "quickadd:run");
+		expect(run).toBeDefined();
+		return run!;
+	}
+
+	// The legacy void-execute() path can resolve even when the Template/Capture
+	// engine swallowed a runtime failure (no file created). The success envelope
+	// must mark itself unverified so a script keying off `ok` is not misled.
+	it("flags the legacy quickadd:run success envelope as verified:false", async () => {
+		const { plugin, handlers } = createPlugin([templateChoice]);
+		registerQuickAddCliHandlers(plugin);
+		const run = getRunHandler(handlers);
+
+		const payload = JSON.parse(
+			String(await run.handler({ choice: templateChoice.name })),
+		);
+
+		expect(payload.ok).toBe(true);
+		// Would be undefined before the fix; the field must distinguish the
+		// unverified legacy success from a confirmed-create.
+		expect(payload.verified).toBe(false);
+		// Still the legacy void path (not routed through executeWithOutcome).
+		expect(executors[0].execute).toHaveBeenCalledWith(templateChoice);
+	});
+
+	// run-template uses the honest outcome path, so its success is verified.
+	it("flags the verified run-template success envelope as verified:true", async () => {
+		const { plugin, handlers } = createPlugin([]);
+		(plugin as unknown as { app: unknown }).app = {
+			vault: {
+				getAbstractFileByPath: vi.fn((path: string) => {
+					if (path !== "Templates/Daily.md") return null;
+					const file = new TFile();
+					file.path = path;
+					return file;
+				}),
+			},
+		};
+		registerQuickAddCliHandlers(plugin);
+		const runTemplate = handlers.find(
+			(handler) => handler.command === "quickadd:run-template",
+		);
+		expect(runTemplate).toBeDefined();
+
+		const payload = JSON.parse(
+			String(
+				await runTemplate!.handler({
+					path: "Templates/Daily.md",
+					"value-value": "Note",
+				}),
+			),
+		);
+
+		expect(payload.ok).toBe(true);
+		expect(payload.verified).toBe(true);
+		expect(executors[0].executeWithOutcome).toHaveBeenCalledTimes(1);
+	});
+
+	// The caveat must be discoverable from the command description itself.
+	it("documents the ok:true caveat in the quickadd:run command descriptions", () => {
+		const { plugin, handlers } = createPlugin([templateChoice]);
+		registerQuickAddCliHandlers(plugin);
+
+		for (const command of ["quickadd", "quickadd:run"]) {
+			const handler = handlers.find((h) => h.command === command);
+			expect(handler).toBeDefined();
+			expect(handler!.description).toMatch(/verified/i);
+		}
+	});
+});

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -354,6 +354,9 @@ async function runResolvedChoice(
 					command,
 					choice: describeChoice(choice),
 					file: outcome.file?.path,
+					// The outcome path confirms the engine actually completed (a file
+					// was created / capture written), so this success is verified.
+					verified: true,
 					durationMs,
 				});
 			}
@@ -398,6 +401,13 @@ async function runResolvedChoice(
 			ok: true,
 			command,
 			choice: describeChoice(choice),
+			// Legacy void-execute path: the Template/Capture engines swallow runtime
+			// failures (empty file name, failing inline script, write error) without
+			// signalling abort, so a resolving execute() does NOT guarantee a file was
+			// created. Flag the success as unverified so scripts keying retry/notify
+			// logic off `ok` can tell it apart from the verified outcome path (and use
+			// quickadd:check up front, or quickadd:run-template for a verified create).
+			verified: false,
 			durationMs,
 		});
 	} catch (error) {
@@ -669,14 +679,14 @@ export function registerQuickAddCliHandlers(plugin: QuickAdd): boolean {
 
 	register(
 		CLI_COMMANDS.runDefault,
-		"Run a QuickAdd choice",
+		"Run a QuickAdd choice (ok:true reports the choice ran without aborting; check the verified flag to know if a file was created)",
 		RUN_FLAGS,
 		(params: CliData) =>
 			runChoiceHandler(plugin, params, CLI_COMMANDS.runDefault),
 	);
 	register(
 		CLI_COMMANDS.run,
-		"Run a QuickAdd choice",
+		"Run a QuickAdd choice (ok:true reports the choice ran without aborting; check the verified flag to know if a file was created)",
 		RUN_FLAGS,
 		(params: CliData) => runChoiceHandler(plugin, params, CLI_COMMANDS.run),
 	);

--- a/src/gui/MultiChoiceSettingsModal.ts
+++ b/src/gui/MultiChoiceSettingsModal.ts
@@ -33,7 +33,7 @@ export class MultiChoiceSettingsModal extends Modal {
 
 	private display() {
 		this.contentEl.empty();
-		this.titleEl.setText("Edit Multi Choice");
+		this.titleEl.setText("Edit folder");
 
 		new Setting(this.contentEl)
 			.setName("Name")
@@ -46,10 +46,10 @@ export class MultiChoiceSettingsModal extends Modal {
 		new Setting(this.contentEl)
 			.setName("Placeholder")
 			.setDesc(
-				"Shown in the choice picker search box when this multi choice opens. Leave blank to use the multi name.",
+				"Shown in the choice picker search box when this folder opens. Leave blank to use the folder name.",
 			)
 			.addText((text) => {
-				text.setPlaceholder("Defaults to the multi name");
+				text.setPlaceholder("Defaults to the folder name");
 				text.setValue(this.placeholder).onChange((value) => {
 					this.placeholder = value;
 				});

--- a/src/gui/MultiSuggester/multiSuggester.audit-commands-choicelist.test.ts
+++ b/src/gui/MultiSuggester/multiSuggester.audit-commands-choicelist.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Modal, Notice } from "obsidian";
+
+// The Modal stub calls `this.titleEl.setText(...)`; jsdom HTMLElement has no
+// setText, so polyfill it before importing the suggester (mirrors how the real
+// Obsidian DOM API augments HTMLElement). Other DOM helpers are already added by
+// tests/vitest-setup.ts.
+(HTMLElement.prototype as unknown as { setText?: unknown }).setText ??= function (
+	this: HTMLElement,
+	text: string,
+) {
+	this.textContent = text;
+};
+
+// The real Obsidian Modal defines onClose() (a no-op base) that subclasses call
+// via super.onClose(); the stub omits it. Polyfill it so super.onClose() resolves.
+(Modal.prototype as unknown as { onClose?: unknown }).onClose ??= function () {};
+
+const MultiSuggester = (await import("./multiSuggester")).default;
+
+function typeCustom(suggester: { contentEl: HTMLElement }, value: string) {
+	const input = suggester.contentEl.querySelector<HTMLInputElement>(
+		".qa-multi-custom-input",
+	);
+	if (!input) throw new Error("custom value input not found");
+	input.value = value;
+	input.dispatchEvent(new Event("input"));
+	return input;
+}
+
+function clickButton(suggester: { contentEl: HTMLElement }, label: string) {
+	const button = Array.from(
+		suggester.contentEl.querySelectorAll("button"),
+	).find((b) => b.textContent === label);
+	if (!button) throw new Error(`button "${label}" not found`);
+	button.click();
+}
+
+describe("MultiSuggester audit (commands-choicelist)", () => {
+	beforeEach(() => {
+		(Notice as unknown as { instances: unknown[] }).instances.length = 0;
+	});
+
+	it("folds a typed-but-not-Added custom value into the result on Done (data-loss fix)", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["A", "B"],
+			["A", "B"],
+			{ allowCustomValue: true },
+		);
+
+		// User types a custom value but clicks Done WITHOUT clicking Add.
+		typeCustom(suggester, "Typed");
+		clickButton(suggester, "Done");
+
+		await expect(suggester.waitForClose).resolves.toEqual(["Typed"]);
+	});
+
+	it("commits a custom value on Enter in the custom field", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["A"],
+			["A"],
+			{ allowCustomValue: true },
+		);
+
+		const input = typeCustom(suggester, "ViaEnter");
+		input.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+		);
+		// After Enter the value is committed; Done should now resolve with it.
+		clickButton(suggester, "Done");
+
+		await expect(suggester.waitForClose).resolves.toEqual(["ViaEnter"]);
+	});
+
+	it("shows a Notice and does not add when the custom field is blank", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["A"],
+			["A"],
+			{ allowCustomValue: true },
+		);
+
+		typeCustom(suggester, "   ");
+		clickButton(suggester, "Add");
+
+		const messages = (
+			Notice as unknown as { instances: { message: string }[] }
+		).instances.map((n) => n.message);
+		expect(messages).toContain("Enter a value to add.");
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual([]);
+	});
+
+	it("warns on a duplicate add of an already-selected custom value", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			[],
+			[],
+			{ allowCustomValue: true },
+		);
+
+		typeCustom(suggester, "Dup");
+		clickButton(suggester, "Add");
+		// Type the same value again and Add — should warn, not duplicate.
+		typeCustom(suggester, "Dup");
+		clickButton(suggester, "Add");
+
+		const messages = (
+			Notice as unknown as { instances: { message: string }[] }
+		).instances.map((n) => n.message);
+		expect(messages).toContain('"Dup" is already added.');
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual(["Dup"]);
+	});
+});

--- a/src/gui/MultiSuggester/multiSuggester.ts
+++ b/src/gui/MultiSuggester/multiSuggester.ts
@@ -1,5 +1,5 @@
 import type { App } from "obsidian";
-import { Modal, Setting } from "obsidian";
+import { Modal, Notice, Setting } from "obsidian";
 import { normalizeDisplayItem } from "../suggesters/utils";
 
 export interface MultiSuggesterOptions {
@@ -30,6 +30,10 @@ export default class MultiSuggester extends Modal {
 	private readonly opts: MultiSuggesterOptions;
 	private readonly selected = new Set<string>();
 	private readonly customValues: string[] = [];
+	// The in-progress custom-value text. Held on the instance (not a render-scoped
+	// local) so submit() can fold an un-"Add"ed draft into the result instead of
+	// silently dropping it.
+	private draft = "";
 
 	public static Suggest(
 		app: App,
@@ -83,27 +87,26 @@ export default class MultiSuggester extends Modal {
 		}
 
 		if (this.opts.allowCustomValue) {
-			let draft = "";
 			new Setting(contentEl)
 				.setName("Add a custom value")
-				.addText((text) =>
+				.addText((text) => {
 					text
 						.setPlaceholder("Not in the list…")
-						.onChange((v) => (draft = v)),
-				)
-				.addButton((btn) =>
-					btn.setButtonText("Add").onClick(() => {
-						const trimmed = draft.trim();
-						if (!trimmed) return;
-						if (
-							!this.items.includes(trimmed) &&
-							!this.customValues.includes(trimmed)
-						) {
-							this.customValues.push(trimmed);
+						.setValue(this.draft)
+						.onChange((v) => (this.draft = v));
+					text.inputEl.addClass("qa-multi-custom-input");
+					// Enter is the natural "commit this value" gesture; without it the
+					// typed value is only added by the explicit "Add" button and is
+					// otherwise silently lost.
+					text.inputEl.addEventListener("keydown", (evt) => {
+						if (evt.key === "Enter") {
+							evt.preventDefault();
+							this.commitDraft();
 						}
-						this.selected.add(trimmed);
-						this.render();
-					}),
+					});
+				})
+				.addButton((btn) =>
+					btn.setButtonText("Add").onClick(() => this.commitDraft()),
 				);
 		}
 
@@ -128,7 +131,61 @@ export default class MultiSuggester extends Modal {
 		}
 	}
 
+	/**
+	 * Commit the current custom-value draft into the selection. Returns `false`
+	 * (with a Notice) for blank or duplicate input so the user gets feedback instead
+	 * of a silent no-op; on success the draft is cleared and the list re-rendered with
+	 * focus restored to the custom-value field for rapid multi-add.
+	 */
+	private commitDraft(): boolean {
+		const trimmed = this.draft.trim();
+		if (!trimmed) {
+			new Notice("Enter a value to add.");
+			return false;
+		}
+		const alreadySelected =
+			(this.items.includes(trimmed) || this.customValues.includes(trimmed)) &&
+			this.selected.has(trimmed);
+		if (alreadySelected) {
+			new Notice(`"${trimmed}" is already added.`);
+			return false;
+		}
+		if (
+			!this.items.includes(trimmed) &&
+			!this.customValues.includes(trimmed)
+		) {
+			this.customValues.push(trimmed);
+		}
+		this.selected.add(trimmed);
+		this.draft = "";
+		this.render();
+		// render() rebuilds contentEl, dropping focus from the (now-recreated) custom
+		// input; restore it so adding several values in a row stays fluid.
+		this.focusCustomInput();
+		return true;
+	}
+
+	private focusCustomInput(): void {
+		const input = this.contentEl.querySelector<HTMLInputElement>(
+			".qa-multi-custom-input",
+		);
+		input?.focus();
+	}
+
 	private submit() {
+		// Fold any non-empty, un-"Add"ed draft into the selection so a user who typed a
+		// value and pressed Done (the common submit gesture) doesn't silently lose it.
+		if (this.opts.allowCustomValue && this.draft.trim()) {
+			const trimmed = this.draft.trim();
+			if (
+				!this.items.includes(trimmed) &&
+				!this.customValues.includes(trimmed)
+			) {
+				this.customValues.push(trimmed);
+			}
+			this.selected.add(trimmed);
+			this.draft = "";
+		}
 		this.didSubmit = true;
 		this.close();
 	}

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -203,7 +203,10 @@
 		// Deleting removes the whole subtree, so recursively unregister the
 		// commands of any command-enabled descendants too (toggling a folder's
 		// own command off, by contrast, must leave its children registered).
-		commandRegistry.disableCommand(choice, { recursive: true });
+		// Use the resolved live `target`, not `choice`: with an active filter the
+		// passed `choice` can be a truncated clone (only matching children), which
+		// would otherwise leave hidden command-enabled descendants orphaned.
+		commandRegistry.disableCommand(target, { recursive: true });
 		save();
 	}
 

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { App } from "obsidian";
-	import { Platform, prepareFuzzySearch } from "obsidian";
+	import { Notice, Platform, prepareFuzzySearch } from "obsidian";
 	import { settingsStore } from "src/settingsStore";
 	import { log } from "src/logger/logManager";
 	import { tick, untrack } from "svelte";
@@ -14,11 +14,14 @@
 		deleteChoiceWithConfirmation,
 		duplicateChoiceWithUserScriptSecretSanitization,
 		addChoiceToTree,
+		insertChoiceAfter,
 		moveChoice as moveChoiceService,
+		moveChoiceToRoot,
 		removeChoiceById,
 		setFolderChildrenById,
 		setMultiCollapsedById,
 	} from "../../services/choiceService";
+	import { MOVE_TO_ROOT_TARGET_ID } from "./contextMenu";
 	import type { ChoiceType } from "../../types/choices/choiceType";
 	import type IChoice from "../../types/choices/IChoice";
 	import type IMultiChoice from "../../types/choices/IMultiChoice";
@@ -176,6 +179,18 @@
 		return findChoiceById(choices, choice.id) ?? choice;
 	}
 
+	// True when `choice` or any descendant is command-enabled. Gates command
+	// registration when duplicating so a command-less folder never reaches the
+	// registry (and so a folder with command-enabled children DOES get them
+	// registered via the recursive addCommandForChoice).
+	function subtreeHasCommand(choice: IChoice): boolean {
+		if (choice.command) return true;
+		if (isMultiChoice(choice)) {
+			return (choice.choices ?? []).some(subtreeHasCommand);
+		}
+		return false;
+	}
+
 	async function deleteChoice(choice: IChoice) {
 		const target = liveChoice(choice);
 		const userConfirmed = await deleteChoiceWithConfirmation(target, app);
@@ -185,7 +200,10 @@
 		// $state array without relying on the top-array reassignment to heal an
 		// in-place nested mutation (which would silently fail for a nested-only delete).
 		choices = removeChoiceById(choices, choice.id).updated;
-		commandRegistry.disableCommand(choice);
+		// Deleting removes the whole subtree, so recursively unregister the
+		// commands of any command-enabled descendants too (toggling a folder's
+		// own command off, by contrast, must leave its children registered).
+		commandRegistry.disableCommand(choice, { recursive: true });
 		save();
 	}
 
@@ -243,12 +261,35 @@
 			liveChoice(sourceChoice),
 			app,
 		);
-		choices = [...choices, newChoice];
+		// Insert the copy right after its source (same parent folder), not at the
+		// bottom of the root list — so duplicating a nested row produces a visible,
+		// adjacent copy. Fall back to a root append if the source can't be located.
+		choices =
+			insertChoiceAfter(choices, sourceChoice.id, newChoice) ?? [
+				...choices,
+				newChoice,
+			];
+		// A duplicate carries command:true when its source did; register its command so
+		// the copy is immediately usable from the palette instead of only appearing
+		// command-enabled until the next plugin reload. enableCommand -> addCommandForChoice
+		// recurses into a folder's children, so registering once covers any command-enabled
+		// descendants too. Gate on the subtree actually containing a command so we never
+		// touch the registry for a command-less folder.
+		if (subtreeHasCommand(newChoice)) {
+			commandRegistry.enableCommand(newChoice);
+		}
 		save();
+		new Notice(`Duplicated "${sourceChoice.name}".`);
+		await revealChoice(newChoice.id);
 	}
 
 	function handleMoveChoice(choice: IChoice, targetId: string) {
-		choices = moveChoiceService(choices, choice.id, targetId);
+		// The "Move to: (root)" menu item routes through onMove with a sentinel id
+		// (no real folder target exists for root), so re-append at the top level.
+		choices =
+			targetId === MOVE_TO_ROOT_TARGET_ID
+				? moveChoiceToRoot(choices, choice.id)
+				: moveChoiceService(choices, choice.id, targetId);
 		save();
 	}
 

--- a/src/gui/choiceList/contextMenu.audit-commands-choicelist.test.ts
+++ b/src/gui/choiceList/contextMenu.audit-commands-choicelist.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { Menu, type App } from "obsidian";
+import type IChoice from "../../types/choices/IChoice";
+import type IMultiChoice from "../../types/choices/IMultiChoice";
+import {
+	isChoiceNested,
+	MOVE_TO_ROOT_TARGET_ID,
+	showChoiceContextMenu,
+} from "./contextMenu";
+
+let nextId = 0;
+const leaf = (name: string): IChoice =>
+	({ id: `id-${nextId++}`, name, type: "Template", command: false }) as IChoice;
+const folder = (name: string, children: IChoice[] = []): IMultiChoice =>
+	({
+		id: `id-${nextId++}`,
+		name,
+		type: "Multi",
+		command: false,
+		choices: children,
+	}) as IMultiChoice;
+
+const fakeApp = {} as unknown as App;
+
+const noopActions = {
+	onRename: vi.fn(),
+	onToggle: vi.fn(),
+	onConfigure: vi.fn(),
+	onDuplicate: vi.fn(),
+	onDelete: vi.fn(),
+	onMove: vi.fn(),
+};
+
+describe("contextMenu audit (commands-choicelist)", () => {
+	describe("isChoiceNested", () => {
+		it("returns false for a top-level choice", () => {
+			const a = leaf("A");
+			expect(isChoiceNested(a, [a, folder("F")])).toBe(false);
+		});
+
+		it("returns true for a choice inside a folder", () => {
+			const child = leaf("Child");
+			const f = folder("F", [child]);
+			expect(isChoiceNested(child, [f])).toBe(true);
+		});
+
+		it("returns true for a deeply nested choice", () => {
+			const deep = leaf("Deep");
+			const inner = folder("Inner", [deep]);
+			const outer = folder("Outer", [inner]);
+			expect(isChoiceNested(deep, [outer])).toBe(true);
+		});
+
+		it("returns false when roots is undefined", () => {
+			expect(isChoiceNested(leaf("X"), undefined)).toBe(false);
+		});
+	});
+
+	describe('"Move to: (root)" menu item', () => {
+		const lastShownItems = () =>
+			((Menu as unknown as {
+				lastShown: {
+					items: { title: string; clickHandler: (() => void) | null }[];
+				};
+			}).lastShown.items);
+
+		it("is offered (wired to the root sentinel) for a nested choice", () => {
+			const child = leaf("Child");
+			const f = folder("F", [child]);
+			const evt = { preventDefault: vi.fn() } as unknown as MouseEvent;
+			const onMove = vi.fn();
+
+			showChoiceContextMenu(fakeApp, evt, child, [f], {
+				...noopActions,
+				onMove,
+			});
+
+			const moveToRoot = lastShownItems().find(
+				(i) => i.title === "Move to: (root)",
+			);
+			expect(moveToRoot).toBeDefined();
+
+			moveToRoot?.clickHandler?.();
+			expect(onMove).toHaveBeenCalledWith(MOVE_TO_ROOT_TARGET_ID);
+		});
+
+		it("is NOT offered for a top-level choice", () => {
+			const a = leaf("A");
+			const evt = { preventDefault: vi.fn() } as unknown as MouseEvent;
+
+			showChoiceContextMenu(fakeApp, evt, a, [a, folder("F")], {
+				...noopActions,
+			});
+
+			const moveToRoot = lastShownItems().find(
+				(i) => i.title === "Move to: (root)",
+			);
+			expect(moveToRoot).toBeUndefined();
+		});
+	});
+});

--- a/src/gui/choiceList/contextMenu.ts
+++ b/src/gui/choiceList/contextMenu.ts
@@ -6,6 +6,40 @@ import type IMultiChoice from "src/types/choices/IMultiChoice";
 export type MoveTarget = { id: string; path: string };
 
 /**
+ * Sentinel target id for "Move to: (root)". Passed through the existing `onMove`
+ * action (so no new wiring is needed in the row components); the ChoiceView handler
+ * recognises it and re-appends the choice at the top level. The constant prefix
+ * cannot collide with a real uuid-keyed choice.
+ */
+export const MOVE_TO_ROOT_TARGET_ID = "quickadd:move-to-root";
+
+/**
+ * True when `choice` lives inside a Multi (folder) rather than at the top level of
+ * `roots`. Drives whether the "Move to: (root)" affordance is offered — there is
+ * nowhere to move a choice that is already at root.
+ */
+export function isChoiceNested(
+  choice: IChoice,
+  roots: IChoice[] | undefined,
+): boolean {
+  const source: IChoice[] = Array.isArray(roots) ? roots : [];
+  if (source.some((c) => c.id === choice.id)) return false;
+
+  const walk = (list: IChoice[]): boolean => {
+    for (const c of list) {
+      if (c.type === "Multi") {
+        const children = (c as IMultiChoice).choices ?? [];
+        if (children.some((child) => child.id === choice.id)) return true;
+        if (walk(children)) return true;
+      }
+    }
+    return false;
+  };
+
+  return walk(source);
+}
+
+/**
  * Compute eligible Multi targets for moving `moving` into, excluding self and descendants.
  * Returns label paths as "Parent / Child".
  */
@@ -83,6 +117,17 @@ function buildChoiceMenu(
     .addItem((item) => item.setTitle("Duplicate").setIcon("copy").onClick(actions.onDuplicate))
     .addItem((item) => item.setTitle("Delete").setIcon("trash-2").onClick(actions.onDelete))
     .addSeparator();
+
+  // Offer a way back OUT of a folder for keyboard/menu users (cross-zone drag is
+  // pointer-only). Only meaningful when the choice is currently nested.
+  if (isChoiceNested(choice, roots)) {
+    menu.addItem((item) =>
+      item
+        .setTitle("Move to: (root)")
+        .setIcon("folder-up")
+        .onClick(() => actions.onMove(MOVE_TO_ROOT_TARGET_ID)),
+    );
+  }
 
   const targets = computeEligibleMultiTargets(choice, roots);
   if (targets.length === 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import { UpdateModal } from "./gui/UpdateModal/UpdateModal";
 import { CommandType } from "./types/macros/CommandType";
 import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
-import { isMajorUpdate } from "./utils/semver";
+import { parseSemver } from "./utils/semver";
 import { resolveChoiceIcon } from "./utils/choiceUtils";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
@@ -142,7 +142,11 @@ export default class QuickAdd extends Plugin {
 
 				menu.addItem((item) =>
 					item
-						.setTitle("Apply QuickAdd template")
+						// Aligns with the command-palette label
+						// (QUICK_ADD_COMMAND_LABELS.applyTemplate) so the same action reads
+						// consistently across both surfaces. Obsidian prefixes commands with
+						// "QuickAdd:"; the file menu is unprefixed, so add it here.
+						.setTitle(`QuickAdd: ${QUICK_ADD_COMMAND_LABELS.applyTemplate}`)
 						.setIcon("file-plus")
 						.onClick(() => {
 							void applyTemplateToNote(this.app, this, {
@@ -253,9 +257,14 @@ export default class QuickAdd extends Plugin {
 				return;
 			}
 
+			// Names are not unique; getChoice returns the FIRST match. Warn so an
+			// ambiguous target is diagnosable rather than silently running the wrong one.
+			this.warnIfChoiceNameAmbiguous(parameters.choice);
+
 			if (choice.type !== "Template" && choice.type !== "Capture") {
 				log.logWarning(
-					`QuickAdd URI x-callback supports Template and Capture choices only ('${choice.name}' is ${choice.type}).`,
+					`QuickAdd URI x-callback supports Template and Capture choices only ('${choice.name}' is ${choice.type}). ` +
+						`A URI with x-* callback params cannot run a ${choice.type} choice while "Enable URI callbacks" is on; remove the x-* params to run it on the legacy path.`,
 				);
 				this.fireUriError(targets, "unsupported-choice-type");
 				return;
@@ -345,6 +354,10 @@ export default class QuickAdd extends Plugin {
 			);
 			return;
 		}
+		// Choice names are not unique; getChoice returns the FIRST match. Warn the user
+		// (via Notice) when the name is ambiguous so an automation that silently ran the
+		// wrong choice is at least diagnosable.
+		this.warnIfChoiceNameAmbiguous(parameters.choice);
 		const choiceExecutor = new ChoiceExecutor(this.app, this);
 		this.applyUriValueParameters(choiceExecutor, parameters);
 		try {
@@ -361,8 +374,9 @@ export default class QuickAdd extends Plugin {
 		Object.entries(parameters)
 			.filter(([key]) => key.startsWith("value-"))
 			.forEach(([key, value]) => {
-				if (typeof value === "string") {
-					choiceExecutor.variables.set(key.slice(6), value);
+				const variableName = key.slice(6);
+				if (variableName && typeof value === "string") {
+					choiceExecutor.variables.set(variableName, value);
 				}
 			});
 	}
@@ -514,7 +528,53 @@ export default class QuickAdd extends Plugin {
 		return null;
 	}
 
-	public removeCommandForChoice(choice: IChoice) {
+	/** Count how many choices anywhere in the tree carry `name` (names aren't unique). */
+	private countChoicesByName(
+		name: string,
+		choices: IChoice[] = this.settings.choices,
+	): number {
+		let count = 0;
+		for (const choice of choices) {
+			if (choice.name === name) count++;
+			if (choice.type === "Multi") {
+				count += this.countChoicesByName(
+					name,
+					(choice as IMultiChoice).choices,
+				);
+			}
+		}
+		return count;
+	}
+
+	/** Surface a Notice when a URI's `choice=<name>` is ambiguous, so an automation
+	 * that ran the wrong (first-matching) choice is at least diagnosable. */
+	private warnIfChoiceNameAmbiguous(name: string): void {
+		const matches = this.countChoicesByName(name);
+		if (matches > 1) {
+			log.logWarning(
+				`QuickAdd URI: ${matches} choices are named '${name}'. Ran the first match — rename choices to keep names unique so URIs target the right one.`,
+			);
+		}
+	}
+
+	public removeCommandForChoice(
+		choice: IChoice,
+		options?: { recursive?: boolean },
+	) {
+		// Recurse ONLY when the whole subtree is going away (a folder DELETE):
+		// a Multi (folder) registers commands for its command-enabled descendants,
+		// so tearing it down must remove theirs too, or deleting a folder leaves
+		// orphaned palette entries that throw "Choice <id> not found" when invoked.
+		//
+		// Do NOT recurse when only the folder's OWN command is being removed (e.g.
+		// toggling the folder's command off, or the remove half of an update): the
+		// children remain and their still-enabled commands must stay registered.
+		if (options?.recursive && choice.type === "Multi") {
+			for (const child of (<IMultiChoice>choice).choices) {
+				this.removeCommandForChoice(child, options);
+			}
+		}
+
 		deleteObsidianCommand(this.app, `quickadd:choice:${choice.id}`);
 	}
 
@@ -531,6 +591,25 @@ export default class QuickAdd extends Plugin {
 	}
 
 	private announceUpdate() {
+		// `isFeatureUpdate`: the "major" announce tier promises "new features, breaking
+		// changes". QuickAdd ships features as semantic-release feat: commits, which become
+		// MINOR bumps (e.g. 2.13.x -> 2.14.0), never MAJOR — so gating purely on the major
+		// digit (isMajorUpdate) would suppress the modal for every feature release. Treat a
+		// major OR minor increase as a feature update so feature releases are announced as
+		// documented, while patch-only bumps stay quiet. Unparseable versions fall back to
+		// showing the update (mirrors isMajorUpdate's err-on-the-side-of-showing default).
+		const isFeatureUpdate = (
+			currentVersion: string,
+			previousVersion: string,
+		): boolean => {
+			const current = parseSemver(currentVersion);
+			const previous = parseSemver(previousVersion);
+			if (!current || !previous) return true;
+			if (current.major !== previous.major)
+				return current.major > previous.major;
+			return current.minor > previous.minor;
+		};
+
 		const currentVersion = this.manifest.version;
 		const knownVersion = this.settings.version;
 
@@ -541,7 +620,10 @@ export default class QuickAdd extends Plugin {
 
 		if (preference === "none") {
 			shouldAnnounce = false;
-		} else if (preference === "major" && !isMajorUpdate(currentVersion, knownVersion)) {
+		} else if (
+			preference === "major" &&
+			!isFeatureUpdate(currentVersion, knownVersion)
+		) {
 			shouldAnnounce = false;
 		}
 

--- a/src/services/choiceService.audit-commands-choicelist.test.ts
+++ b/src/services/choiceService.audit-commands-choicelist.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Notice, type App } from "obsidian";
+import type IChoice from "../types/choices/IChoice";
+import type IMultiChoice from "../types/choices/IMultiChoice";
+
+// --- Hoisted mock state -----------------------------------------------------
+// Mirrors choiceService.test.ts: stub the GUI builders so importing the module
+// does not pull in the full Obsidian/Svelte stack.
+
+const mocks = vi.hoisted(() => ({
+	yesNoPrompt: vi.fn(),
+}));
+
+vi.mock("../gui/ChoiceBuilder/templateChoiceBuilder", () => ({
+	TemplateChoiceBuilder: class {},
+}));
+vi.mock("../gui/ChoiceBuilder/captureChoiceBuilder", () => ({
+	CaptureChoiceBuilder: class {},
+}));
+vi.mock("../gui/MacroGUIs/MacroBuilder", () => ({ MacroBuilder: class {} }));
+vi.mock("../gui/MultiChoiceSettingsModal", () => ({
+	MultiChoiceSettingsModal: class {},
+}));
+vi.mock("../gui/GenericYesNoPrompt/GenericYesNoPrompt", () => ({
+	default: {
+		Prompt: (...args: unknown[]) => mocks.yesNoPrompt(...args),
+	},
+}));
+vi.mock("../settingsStore", () => ({
+	settingsStore: { getState: () => ({ choices: [] }) },
+}));
+
+const {
+	createChoice,
+	insertChoiceAfter,
+	moveChoiceToRoot,
+	deleteChoiceWithConfirmation,
+} = await import("./choiceService");
+
+const fakeApp = { name: "fake-app" } as unknown as App;
+
+const makeMulti = (name: string, children: IChoice[] = []) => {
+	const m = createChoice("Multi", name) as IMultiChoice;
+	m.choices = children;
+	return m;
+};
+
+describe("choiceService audit (commands-choicelist)", () => {
+	beforeEach(() => {
+		mocks.yesNoPrompt.mockReset();
+		(Notice as unknown as { instances: unknown[] }).instances.length = 0;
+	});
+
+	describe("insertChoiceAfter (settings-choice-duplicate)", () => {
+		it("inserts immediately after a top-level sibling, not at the end", () => {
+			const a = createChoice("Template", "A");
+			const b = createChoice("Template", "B");
+			const c = createChoice("Template", "C");
+			const copy = createChoice("Template", "A (copy)");
+
+			const result = insertChoiceAfter([a, b, c], a.id, copy);
+
+			expect(result).toBeDefined();
+			expect((result as IChoice[]).map((x) => x.id)).toEqual([
+				a.id,
+				copy.id,
+				b.id,
+				c.id,
+			]);
+		});
+
+		it("inserts next to a nested sibling inside its folder", () => {
+			const inner = createChoice("Template", "Inner");
+			const folder = makeMulti("Folder", [inner]);
+			const copy = createChoice("Template", "Inner (copy)");
+
+			const result = insertChoiceAfter([folder], inner.id, copy) as IChoice[];
+
+			const newFolder = result[0] as IMultiChoice;
+			expect(newFolder.choices.map((x) => x.id)).toEqual([inner.id, copy.id]);
+			// The copy lands in the SAME folder as its source, not at root.
+			expect(result).toHaveLength(1);
+		});
+
+		it("returns undefined when the sibling id is not found (caller falls back to root)", () => {
+			const a = createChoice("Template", "A");
+			const copy = createChoice("Template", "A (copy)");
+			expect(insertChoiceAfter([a], "missing", copy)).toBeUndefined();
+		});
+	});
+
+	describe("moveChoiceToRoot (settings-choice-move-to-folder)", () => {
+		it("moves a nested choice back to the top level", () => {
+			const child = createChoice("Template", "Child");
+			const folder = makeMulti("Folder", [child]);
+
+			const result = moveChoiceToRoot([folder], child.id);
+
+			const newFolder = result.find((c) => c.id === folder.id) as IMultiChoice;
+			expect(newFolder.choices).toHaveLength(0);
+			expect(result.some((c) => c.id === child.id)).toBe(true);
+			// Appended at root.
+			expect(result[result.length - 1].id).toBe(child.id);
+		});
+
+		it("is a no-op for a choice already at the top level", () => {
+			const a = createChoice("Template", "A");
+			const root = [a];
+			expect(moveChoiceToRoot(root, a.id)).toBe(root);
+		});
+
+		it("is a no-op for a missing id", () => {
+			const root = [createChoice("Template", "A")];
+			expect(moveChoiceToRoot(root, "nope")).toBe(root);
+		});
+	});
+
+	describe("deleteChoiceWithConfirmation count (multi-delete-recursive)", () => {
+		it("counts the FULL nested subtree, not just direct children", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			// Outer folder has 1 direct child (a subfolder) holding 3 leaves.
+			const subfolder = makeMulti("Sub", [
+				createChoice("Template", "a"),
+				createChoice("Template", "b"),
+				createChoice("Template", "c"),
+			]);
+			const outer = makeMulti("Outer", [subfolder]);
+
+			await deleteChoiceWithConfirmation(outer, fakeApp);
+
+			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
+			// 1 subfolder + 3 leaves = 4 descendants (NOT "(1)").
+			expect(message).toContain("(4)");
+			expect(message).not.toContain("(1)");
+			expect(message).toContain("including nested folders");
+		});
+
+		it("omits the scary warning for an empty folder", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const empty = makeMulti("Empty");
+
+			await deleteChoiceWithConfirmation(empty, fakeApp);
+
+			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
+			expect(message).not.toContain("(0)");
+			expect(message).not.toContain("choices inside it");
+			expect(message).toContain("Empty");
+		});
+
+		it("uses singular 'choice' for a folder with exactly one descendant", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const one = makeMulti("One", [createChoice("Template", "only")]);
+
+			await deleteChoiceWithConfirmation(one, fakeApp);
+
+			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
+			expect(message).toContain("(1) choice inside it");
+			expect(message).not.toContain("(1) choices inside it");
+		});
+	});
+});

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -571,8 +571,27 @@ describe("choiceService", () => {
 			const registry = new CommandRegistry(plugin);
 			const choice = createChoice("Template", "T");
 			registry.disableCommand(choice);
+			// Toggle-off path: no recursive flag, so a folder's children keep
+			// their still-enabled commands.
 			expect(removeCommandForChoice).toHaveBeenCalledWith(choice);
 			expect(addCommandForChoice).not.toHaveBeenCalled();
+		});
+
+		it("disableCommand forwards { recursive: true } for a folder delete", () => {
+			const addCommandForChoice = vi.fn();
+			const removeCommandForChoice = vi.fn();
+			const plugin = {
+				addCommandForChoice,
+				removeCommandForChoice,
+			} as unknown as QuickAdd;
+			const registry = new CommandRegistry(plugin);
+			const folder = createChoice("Multi", "Folder");
+			registry.disableCommand(folder, { recursive: true });
+			// Delete path: the whole subtree is gone, so recurse to unregister
+			// command-enabled descendants too.
+			expect(removeCommandForChoice).toHaveBeenCalledWith(folder, {
+				recursive: true,
+			});
 		});
 
 		it("updateCommand removes the old choice then adds the new one in order", () => {

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -17,6 +17,7 @@ import { MacroChoice } from "../types/choices/MacroChoice";
 import { MultiChoice } from "../types/choices/MultiChoice";
 import { TemplateChoice } from "../types/choices/TemplateChoice";
 import { regenerateIds } from "../utils/macroUtils";
+import { flattenChoices } from "../utils/choiceUtils";
 import { excludeKeys } from "../utils/excludeKeys";
 import { deepClone } from "../utils/deepClone";
 import {
@@ -215,16 +216,21 @@ export async function deleteChoiceWithConfirmation(
 	const isMulti = choice.type === "Multi";
 	const isMacro = choice.type === "Macro";
 
+	// Count the FULL subtree (flattenChoices includes the folder itself, so drop it),
+	// not just direct children — a recursive delete removes everything nested. Special-
+	// case 0 (no scary "delete all (0) choices") and pluralize correctly.
+	const buildMultiWarning = (multi: IMultiChoice): string => {
+		const descendantCount = flattenChoices(multi.choices).length;
+		if (descendantCount === 0) return "";
+		const noun = descendantCount === 1 ? "choice" : "choices";
+		return `Deleting this choice will delete all (${descendantCount}) ${noun} inside it (including nested folders)!`;
+	};
+
 	const userConfirmed: boolean = await GenericYesNoPrompt.Prompt(
 		app,
 		`Confirm deletion of choice`,
 		`Please confirm that you wish to delete '${choice.name}'.
-            ${isMulti
-			? "Deleting this choice will delete all (" +
-			(choice as IMultiChoice).choices.length +
-			") choices inside it!"
-			: ""
-		}
+            ${isMulti ? buildMultiWarning(choice as IMultiChoice) : ""}
             ${isMacro
 			? "Deleting this choice will delete its macro commands!"
 			: ""
@@ -292,11 +298,19 @@ export class CommandRegistry {
 		this.plugin.addCommandForChoice(choice);
 	}
 
-	disableCommand(choice: IChoice): void {
-		this.plugin.removeCommandForChoice(choice);
+	disableCommand(choice: IChoice, options?: { recursive?: boolean }): void {
+		// Pass `recursive` through only when supplied (a folder DELETE) so the
+		// common, non-recursive case keeps its single-argument call shape.
+		if (options) {
+			this.plugin.removeCommandForChoice(choice, options);
+		} else {
+			this.plugin.removeCommandForChoice(choice);
+		}
 	}
 
 	updateCommand(oldChoice: IChoice, newChoice: IChoice): void {
+		// Non-recursive remove: the children remain and addCommandForChoice below
+		// re-registers any command-enabled descendants of newChoice.
 		this.plugin.removeCommandForChoice(oldChoice);
 		this.plugin.addCommandForChoice(newChoice);
 	}
@@ -334,6 +348,30 @@ export function moveChoice(
 	// Insert at end of the target multi
 	const inserted = insertIntoMulti(withoutMoving, targetMultiId, removed);
 	return inserted ?? rootChoices;
+}
+
+/**
+ * Move a choice OUT of its folder back to the top level (appended at root).
+ * Immutable; returns a new roots array. No-op when the choice is missing or is
+ * already at the top level. The counterpart to `moveChoice` (which only moves INTO
+ * folders) — gives keyboard/menu users a way out that drag offers only via pointer.
+ */
+export function moveChoiceToRoot(
+	rootChoices: IChoice[],
+	movingId: string,
+): IChoice[] {
+	if (!movingId) return rootChoices;
+
+	// Already at root: nothing to do.
+	if (rootChoices.some((c) => c.id === movingId)) return rootChoices;
+
+	const { updated: withoutMoving, removed } = removeChoiceById(
+		rootChoices,
+		movingId,
+	);
+	if (!removed) return rootChoices;
+
+	return [...withoutMoving, removed];
 }
 
 /**
@@ -410,6 +448,44 @@ export function insertIntoMulti(
 		}
 		if (c.type !== "Multi") return c;
 		const inner = insertIntoMulti((c as IMultiChoice).choices, targetId, child);
+		if (inner) {
+			changed = true;
+			return { ...(c as IMultiChoice), choices: inner } as IChoice;
+		}
+		return c;
+	});
+
+	return changed ? updated : undefined;
+}
+
+/**
+ * Immutably insert `newChoice` immediately after the choice with id `afterId`,
+ * keeping it in the SAME parent (root or folder) as its sibling. Only the touched
+ * branch is recreated (siblings keep their identity). Returns `undefined` when no
+ * such sibling exists, so callers can fall back to a root append. Used by the
+ * duplicate action so the copy lands next to its source instead of at the bottom
+ * of the root list.
+ */
+export function insertChoiceAfter(
+	choices: IChoice[],
+	afterId: string,
+	newChoice: IChoice,
+): IChoice[] | undefined {
+	const index = choices.findIndex((c) => c.id === afterId);
+	if (index !== -1) {
+		const updated = [...choices];
+		updated.splice(index + 1, 0, newChoice);
+		return updated;
+	}
+
+	let changed = false;
+	const updated = choices.map((c) => {
+		if (c.type !== "Multi") return c;
+		const inner = insertChoiceAfter(
+			(c as IMultiChoice).choices,
+			afterId,
+			newChoice,
+		);
 		if (inner) {
 			changed = true;
 			return { ...(c as IMultiChoice), choices: inner } as IChoice;


### PR DESCRIPTION
This PR bundles 19 fixes from a systematic feature audit (logic + UX), each adversarially verified and covered by regression tests.

- **[Minor]** URI runs a choice by name only — duplicate names silently run the wrong choice
- **[Minor]** quickadd:run can report ok:true when no file was actually created
- **[Minor]** Multi/Macro accepted on legacy URI path but rejected on callback path — inconsistent
- **[Minor]** MultiSuggester silently drops a typed custom value if user clicks Done without 'Add'
- **[Minor]** Duplicating a command-enabled choice/folder never registers its Obsidian command
- **[Minor]** Deleting a folder orphans its descendants' registered commands (removeCommandForChoice is non-recursive)
- **[Minor]** Delete confirmation undercounts nested choices (direct children only)
- **[Minor]** Running a command-enabled folder opens a picker with no folder-name placeholder (inconsistent with drill-down)
- **[Minor]** Running an empty command-enabled folder opens a dead, item-less picker with no feedback
- **[Minor]** No way to move a choice OUT of a folder back to root via the menu
- **[Minor]** Custom-value add: no Enter support, no feedback on blank/duplicate, focus lost on add
- **[Minor]** Default "major" Announce Updates never shows feature releases (minor bumps)
- **[Minor]** Deleting a folder leaves orphaned Command Palette entries for its command-enabled children
- **[Minor]** No keyboard/menu way to move a choice OUT of a folder (only INTO)
- **[Minor]** Duplicated choice lands at root with no feedback and no scroll-into-view
- **[Trivial]** Empty value- name handled inconsistently between URI and CLI
- **[Trivial]** File-menu item 'Apply QuickAdd template' uses different wording than the command 'Apply template to active note'
- **[Trivial]** Delete prompt grammar/empty-folder wording ("all (1) choices", "all (0) choices")
- **[Trivial]** Multi modal titled 'Edit Multi Choice' uses internal jargon instead of the user-facing 'folder' term

All tests/typecheck/lint/build green. Part of a 9-PR series splitting the audit by area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `verified` to CLI success envelopes to indicate whether a file was actually created
  * Added “Move to: (root)” for nested choices via the context menu

* **Bug Fixes**
  * Empty folders now show a notice instead of opening an empty picker
  * Custom folder input no longer gets lost mid-edit; Enter now commits typed values
  * Duplicate choices now insert immediately after the source

* **Improvements**
  * Updated nested choice command registration/removal to avoid missing or orphaned commands
  * Improved URI handling with ambiguity warnings and better placeholder/parameter handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->