### PR TITLE
fix(format): token previews, value-syntax warnings, and field-token parsing

### DIFF
--- a/src/formatters/completeFormatter.audit-formatter-core.test.ts
+++ b/src/formatters/completeFormatter.audit-formatter-core.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression tests for the formatter-core audit fixes that live in
+ * src/formatters/completeFormatter.ts:
+ *  - format-core-title-token / format-file-title-token: a {{title}} injected by a
+ *    global snippet or a {{VALUE}} value must throw post-format() in
+ *    formatFileName / formatFolderPath (not leak the literal token into a path).
+ *  - value-syntax-type-checkbox: an active selection must NOT bypass the forced
+ *    true/false picker for an anonymous {{VALUE|type:checkbox}} unless the
+ *    selection is itself "true"/"false".
+ *  - integrations-field-filter-default: a multi-select FIELD with no vault values
+ *    seeds the picker with smart defaults.
+ *
+ * The heavy collaborators are mocked, mirroring completeFormatter.test.ts.
+ */
+
+const mocks = vi.hoisted(() => ({
+	macroRunAndGetOutput: vi.fn(),
+	macroGetVariables: vi.fn(() => new Map()),
+	templateRun: vi.fn(),
+	inlineRunAndGetOutput: vi.fn(),
+	inlineParamsVariables: {} as Record<string, unknown>,
+	inputPromptPrompt: vi.fn(),
+	inputPromptPromptWithContext: vi.fn(),
+	inputPromptFactory: vi.fn(),
+	genericInputPromptWithContext: vi.fn(),
+	inputSuggesterSuggest: vi.fn(),
+	genericSuggesterSuggest: vi.fn(),
+	multiSuggesterSuggest: vi.fn(),
+	vdatePrompt: vi.fn(),
+	mathPrompt: vi.fn(),
+	fieldParse: vi.fn(),
+	collectProcessedDetailed: vi.fn(),
+	collectRaw: vi.fn(),
+	getSmartDefaults: vi.fn(() => [] as string[]),
+	dateAliases: {} as Record<string, string>,
+}));
+
+vi.mock("obsidian", () => {
+	class MarkdownView {}
+	return { MarkdownView };
+});
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+	SingleMacroEngine: class {
+		runAndGetOutput = mocks.macroRunAndGetOutput;
+		getVariables = mocks.macroGetVariables;
+	},
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		run() {
+			return mocks.templateRun.call(this);
+		}
+		setTargetFolderPath() {}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+	},
+}));
+
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	SingleInlineScriptEngine: class {
+		params = { variables: mocks.inlineParamsVariables };
+		runAndGetOutput = mocks.inlineRunAndGetOutput;
+	},
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+	default: class {
+		factory(inputTypeOverride?: string) {
+			mocks.inputPromptFactory(inputTypeOverride);
+			return {
+				Prompt: mocks.inputPromptPrompt,
+				PromptWithContext: mocks.inputPromptPromptWithContext,
+			};
+		}
+	},
+}));
+
+vi.mock("src/gui/GenericInputPrompt/GenericInputPrompt", () => ({
+	default: { PromptWithContext: mocks.genericInputPromptWithContext },
+}));
+
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
+	default: { Suggest: mocks.inputSuggesterSuggest },
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: { Suggest: mocks.genericSuggesterSuggest },
+}));
+
+vi.mock("src/gui/MultiSuggester/multiSuggester", () => ({
+	default: { Suggest: mocks.multiSuggesterSuggest },
+}));
+
+vi.mock("src/gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	default: { Prompt: mocks.vdatePrompt },
+}));
+
+vi.mock("../gui/MathModal", () => ({
+	MathModal: { Prompt: mocks.mathPrompt },
+}));
+
+vi.mock("../parsers/NLDParser", () => ({
+	NLDParser: { parseDate: () => null },
+}));
+
+vi.mock("../utils/FieldSuggestionParser", () => ({
+	FieldSuggestionParser: { parse: mocks.fieldParse },
+}));
+
+vi.mock("../utils/FieldValueCollector", () => ({
+	collectFieldValuesProcessedDetailed: mocks.collectProcessedDetailed,
+	collectFieldValuesRaw: mocks.collectRaw,
+	generateFieldCacheKey: (f: unknown) => JSON.stringify(f),
+}));
+
+vi.mock("../utils/FieldValueProcessor", () => ({
+	FieldValueProcessor: { getSmartDefaults: mocks.getSmartDefaults },
+}));
+
+vi.mock("../settingsStore", () => ({
+	settingsStore: { getState: () => ({ dateAliases: mocks.dateAliases }) },
+}));
+
+vi.mock("../logger/logManager", () => ({
+	log: {
+		logError: vi.fn(),
+		logWarning: vi.fn(),
+		logMessage: vi.fn(),
+	},
+}));
+
+const { CompleteFormatter } = await import("./completeFormatter");
+
+type FakeFile = { basename: string } | null;
+
+function makeApp(state: {
+	activeFile: FakeFile;
+	selection: string | null;
+	generatedLink?: string;
+}) {
+	return {
+		workspace: {
+			getActiveFile: () => state.activeFile,
+			getActiveViewOfType: () =>
+				state.selection === null
+					? undefined
+					: { editor: { getSelection: () => state.selection } },
+		},
+		fileManager: {
+			generateMarkdownLink: () => state.generatedLink ?? "",
+		},
+	};
+}
+
+function makePlugin(globalVariables: Record<string, string> = {}) {
+	return {
+		settings: {
+			globalVariables,
+			enableTemplatePropertyTypes: false,
+			choices: [],
+			inputPrompt: "single-line",
+		},
+	};
+}
+
+function formatter(
+	globalVariables: Record<string, string> = {},
+	app: Partial<{ activeFile: FakeFile; selection: string | null }> = {},
+) {
+	return new CompleteFormatter(
+		makeApp({
+			activeFile: app.activeFile ?? null,
+			selection: app.selection ?? null,
+		}) as any,
+		makePlugin(globalVariables) as any,
+	);
+}
+
+beforeEach(() => {
+	mocks.dateAliases = {};
+	vi.clearAllMocks();
+	mocks.macroGetVariables.mockReturnValue(new Map());
+	mocks.getSmartDefaults.mockReturnValue([]);
+	(globalThis as any).navigator = {
+		clipboard: { readText: vi.fn().mockResolvedValue("") },
+	};
+});
+
+describe("circular {{title}} re-check after format() (format-file-title-token)", () => {
+	it("formatFileName throws when a global snippet expands to {{title}}", async () => {
+		const f = formatter({ snip: "{{title}}" });
+		await expect(
+			f.formatFileName("{{GLOBAL_VAR:snip}}-note", "Value"),
+		).rejects.toThrow("circular dependency");
+	});
+
+	it("formatFolderPath throws when a global snippet expands to {{title}}", async () => {
+		const f = formatter({ snip: "{{title}}" });
+		await expect(
+			f.formatFolderPath("folder/{{GLOBAL_VAR:snip}}"),
+		).rejects.toThrow("circular dependency");
+	});
+
+	it("formatFileName still throws on a raw {{title}} (unchanged)", async () => {
+		const f = formatter();
+		await expect(f.formatFileName("{{title}}-x", "V")).rejects.toThrow(
+			"circular dependency",
+		);
+	});
+
+	it("formatFileName does not false-positive on a global with no {{title}}", async () => {
+		const f = formatter({ greeting: "hello" });
+		await expect(
+			f.formatFileName("{{GLOBAL_VAR:greeting}}-note", "V"),
+		).resolves.toBe("hello-note");
+	});
+});
+
+describe("anonymous {{VALUE|type:checkbox}} vs active selection (value-syntax-type-checkbox)", () => {
+	it("does NOT use a non-boolean selection; falls through to the forced picker", async () => {
+		mocks.genericSuggesterSuggest.mockResolvedValue("true");
+		const f = formatter({}, { selection: "hello world" });
+
+		const out = await f.formatFileContent("[{{VALUE|type:checkbox}}]");
+
+		expect(out).toBe("[true]");
+		// The forced true/false picker ran (not the raw selection).
+		expect(mocks.genericSuggesterSuggest).toHaveBeenCalledTimes(1);
+		const call = mocks.genericSuggesterSuggest.mock.calls[0];
+		expect(call[1]).toEqual(["true", "false"]);
+	});
+
+	it("accepts a boolean selection without showing the picker", async () => {
+		const f = formatter({}, { selection: "  TRUE  " });
+
+		const out = await f.formatFileContent("[{{VALUE|type:checkbox}}]");
+
+		expect(out).toBe("[true]");
+		expect(mocks.genericSuggesterSuggest).not.toHaveBeenCalled();
+	});
+});
+
+describe("multi-select FIELD seeds smart defaults when vault is empty (integrations-field-filter-default)", () => {
+	it("passes smart defaults to MultiSuggester when no values exist", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "status",
+			filters: {},
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: [],
+			hasDefaultValue: false,
+		});
+		mocks.getSmartDefaults.mockReturnValue(["To Do", "In Progress", "Done"]);
+		mocks.multiSuggesterSuggest.mockResolvedValue(["To Do"]);
+
+		const f = formatter();
+		await f.formatFileContent("{{FIELD:status|multi}}");
+
+		expect(mocks.multiSuggesterSuggest).toHaveBeenCalledTimes(1);
+		const call = mocks.multiSuggesterSuggest.mock.calls[0];
+		// displayValues + values both seeded with the smart defaults.
+		expect(call[1]).toEqual(["To Do", "In Progress", "Done"]);
+		expect(call[2]).toEqual(["To Do", "In Progress", "Done"]);
+	});
+
+	it("still opens an empty picker when there are no smart defaults", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "weird",
+			filters: {},
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: [],
+			hasDefaultValue: false,
+		});
+		mocks.getSmartDefaults.mockReturnValue([]);
+		mocks.multiSuggesterSuggest.mockResolvedValue([]);
+
+		const f = formatter();
+		await f.formatFileContent("{{FIELD:weird|multi}}");
+
+		const call = mocks.multiSuggesterSuggest.mock.calls[0];
+		expect(call[1]).toEqual([]);
+	});
+});

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -105,6 +105,17 @@ export class CompleteFormatter extends Formatter {
 
 		this.valueHeader = valueHeader;
 		let output = await this.format(input);
+		// A {{title}} produced AFTER the raw-input check — by an expanded global
+		// snippet ({{GLOBAL_VAR:x}} -> {{title}}) or a {{VALUE}} that resolved to
+		// the literal text "{{title}}" — would otherwise survive into the file name
+		// (the token pass below omits `title`, leaving it verbatim). Re-check post
+		// format() so it throws the same circular-dependency error, mirroring
+		// formatTemplateFilePath's post-global-expansion guard.
+		if (/\{\{title\}\}/i.test(output)) {
+			throw new Error(
+				"{{title}} cannot be used in file names as it would create a circular dependency. The title is derived from the filename itself.",
+			);
+		}
 		// {{filenamecurrent}} + {{folder}} in one pass (links stay literal in a
 		// file name; {{title}} threw above). One pass so no token re-scans
 		// another's output (#1358).
@@ -141,10 +152,21 @@ export class CompleteFormatter extends Formatter {
 			);
 		}
 
+		const formatted = await this.format(folderName);
+		// As in formatFileName: a {{title}} injected by a global snippet or a
+		// {{VALUE}} resolving to "{{title}}" slips past the raw-input check above,
+		// then the folder-only token pass would leave it literal in the path.
+		// Re-check post format() so it throws the circular-dependency error.
+		if (/\{\{title\}\}/i.test(formatted)) {
+			throw new Error(
+				"{{title}} cannot be used in folder paths as it would create a circular dependency. The title is derived from the filename itself.",
+			);
+		}
+
 		// {{FOLDER}} in a folder definition is self-referential: the target
 		// folder isn't known while folders are being resolved, so it collapses
 		// to an empty string rather than leaking the literal token into a path.
-		return this.replaceCurrentFileTokensInString(await this.format(folderName), {
+		return this.replaceCurrentFileTokensInString(formatted, {
 			folder: true,
 		});
 	}
@@ -414,6 +436,19 @@ export class CompleteFormatter extends Formatter {
 		selectedText: string,
 	): string | undefined {
 		const context = this.valuePromptContext;
+
+		// |type:checkbox forces a true/false picker (no free text). An active editor
+		// selection must not short-circuit that contract: only accept the selection
+		// when it is itself a boolean ("true"/"false", case/space-insensitive),
+		// otherwise return undefined so promptForValue falls through to the forced
+		// true/false picker instead of storing arbitrary selected text.
+		if (context?.inputTypeOverride === "checkbox") {
+			const boolText = selectedText.trim().toLowerCase();
+			return boolText === "true" || boolText === "false"
+				? boolText
+				: undefined;
+		}
+
 		if (
 			context?.inputTypeOverride !== "number" &&
 			context?.inputTypeOverride !== "slider"
@@ -580,7 +615,7 @@ export class CompleteFormatter extends Formatter {
 		try {
 			// Parse the field input to extract field name and filters
 			const { fieldName, filters, multiSelect } =
-				FieldSuggestionParser.parse(fieldInput);
+				FieldSuggestionParser.parse(fieldInput, { warnUnknown: true });
 
 			// Collect and process via shared collector
 			const { values, hasDefaultValue } =
@@ -597,7 +632,20 @@ export class CompleteFormatter extends Formatter {
 			}
 
 			if (multiSelect) {
-				return await MultiSuggester.Suggest(this.app, values, values, {
+				// When the vault has no existing values yet, seed the picker with the
+				// same smart defaults the single-select no-values fallback surfaces
+				// (e.g. To Do / In Progress / Done), so a brand-new {{FIELD:x|multi}}
+				// offers starting hints instead of an empty list. Custom values stay
+				// enabled so the user can still type anything.
+				let multiValues = values;
+				if (values.length === 0 && !filters.defaultValue) {
+					const smartDefaults = FieldValueProcessor.getSmartDefaults(
+						fieldName,
+						[],
+					);
+					if (smartDefaults.length > 0) multiValues = smartDefaults;
+				}
+				return await MultiSuggester.Suggest(this.app, multiValues, multiValues, {
 					placeholder,
 					allowCustomValue: true,
 				});

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -613,9 +613,12 @@ export class CompleteFormatter extends Formatter {
 
 	protected async suggestForField(fieldInput: string): Promise<string | string[]> {
 		try {
-			// Parse the field input to extract field name and filters
+			// Parse the field input to extract field name and filters. Do NOT warn
+			// on unknown keys here: the field replacer in formatter.ts already parses
+			// the same token with { warnUnknown: true } before calling this, so
+			// warning again would emit a duplicate notice per malformed FIELD token.
 			const { fieldName, filters, multiSelect } =
-				FieldSuggestionParser.parse(fieldInput, { warnUnknown: true });
+				FieldSuggestionParser.parse(fieldInput);
 
 			// Collect and process via shared collector
 			const { values, hasDefaultValue } =

--- a/src/formatters/fileNameDisplayFormatter.audit-cleanup.test.ts
+++ b/src/formatters/fileNameDisplayFormatter.audit-cleanup.test.ts
@@ -1,0 +1,96 @@
+import realMoment from "moment";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileNameDisplayFormatter } from "./fileNameDisplayFormatter";
+import type { App } from "obsidian";
+
+/**
+ * Regression for the audit-cleanup fix (bucket cu-filename-preview, task
+ * format-core-format-preview): FileNameDisplayFormatter.replaceDateVariableInString
+ * used to stop at (match, variableName, dateFormat) and ignore the third capture
+ * group, so the file-name VDATE preview dropped the "(default: X)" / "(optional)"
+ * hints and the |startof:/|endof: period-snap that FormatDisplayFormatter's body
+ * preview shows. It now mirrors that behaviour.
+ *
+ * Snap rendering needs real moment + a frozen clock (the obsidian-stub moment has
+ * no startOf/endOf), mirroring formatter-datesnap.test.ts. en locale =
+ * Sunday-first week.
+ */
+const originalMoment = (window as unknown as { moment?: unknown }).moment;
+const previousLocale = realMoment.locale();
+
+beforeAll(() => {
+	realMoment.locale("en");
+	(window as unknown as { moment: unknown }).moment = realMoment;
+});
+afterAll(() => {
+	(window as unknown as { moment?: unknown }).moment = originalMoment;
+	realMoment.locale(previousLocale);
+	vi.useRealTimers();
+});
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date("2023-06-01T12:00:00")); // Thursday
+});
+
+// Minimal App: the VDATE preview path never touches the workspace/vault.
+const mockApp = {
+	workspace: { getActiveFile: () => null },
+	vault: { getMarkdownFiles: () => [] },
+	metadataCache: { getFileCache: () => null },
+} as unknown as App;
+
+function makeFormatter(): FileNameDisplayFormatter {
+	return new FileNameDisplayFormatter(mockApp);
+}
+
+describe("FileNameDisplayFormatter VDATE preview (audit-cleanup)", () => {
+	it("appends the (default: X) hint", async () => {
+		const out = await makeFormatter().format(
+			"{{VDATE:due,YYYY-MM-DD|tomorrow}}",
+		);
+		expect(out).toBe("2023-06-01 (default: tomorrow)");
+	});
+
+	it("appends the (optional) hint", async () => {
+		const out = await makeFormatter().format(
+			"{{VDATE:due,YYYY-MM-DD|optional}}",
+		);
+		expect(out).toBe("2023-06-01 (optional)");
+	});
+
+	it("appends both hints together (default + optional, order-insensitive)", async () => {
+		const out = await makeFormatter().format(
+			"{{VDATE:due,YYYY-MM-DD|optional|tomorrow}}",
+		);
+		expect(out).toBe("2023-06-01 (default: tomorrow) (optional)");
+	});
+
+	it("does NOT apply |startof: snap to the preview (matches body preview)", async () => {
+		const out = await makeFormatter().format(
+			"{{VDATE:wk,gggg.MM.[Wk]w|startof:week}}",
+		);
+		// Snap is only resolved in the real CompleteFormatter pass; the preview
+		// renders the current date (2023-06-01) like the body preview does, so
+		// the two previews stay consistent. (DateFormatPreviewGenerator leaves
+		// gggg / [Wk] literal — that's its existing simplified-preview behavior.)
+		expect(out).toBe("gggg.06.[Wk]22");
+	});
+
+	it("ignores snap but still appends a default hint", async () => {
+		const out = await makeFormatter().format(
+			"{{VDATE:eom,YYYY-MM-DD|endof:month|tomorrow}}",
+		);
+		// No snap applied to the preview; current date + default hint.
+		expect(out).toBe("2023-06-01 (default: tomorrow)");
+	});
+
+	it("leaves a snap-free VDATE preview unchanged (no spurious hints)", async () => {
+		const out = await makeFormatter().format("{{VDATE:plain,YYYY-MM-DD}}");
+		expect(out).toBe("2023-06-01");
+	});
+
+	it("returns the token literally when the format is missing", async () => {
+		const out = await makeFormatter().format("{{VDATE:noformat}}");
+		expect(out).toBe("{{VDATE:noformat}}");
+	});
+});

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -13,6 +13,7 @@ import {
 	DateFormatPreviewGenerator
 } from "./helpers/previewHelpers";
 import { getValueVariableBaseName } from "../utils/valueSyntax";
+import { parseVDateOptions } from "../utils/vdateSyntax";
 import { EnhancedFieldSuggestionFileFilter } from "../utils/EnhancedFieldSuggestionFileFilter";
 import { FILE_CUSTOM_PREFIX, FILE_PICK_PREFIX, type ParsedFileToken } from "../utils/fileSyntax";
 
@@ -155,29 +156,44 @@ export class FileNameDisplayFormatter extends Formatter {
 
 	protected async replaceDateVariableInString(input: string): Promise<string> {
 		let output: string = input;
-		
-		// Enhanced date variable preview with realistic examples
-		output = output.replace(new RegExp(DATE_VARIABLE_REGEX.source, 'gi'), (match, variableName, dateFormat) => {
+
+		// Mirror FormatDisplayFormatter's VDATE preview so the file-name preview
+		// shows the same default/optional hints (issue #511). Like the body
+		// preview, this renders the current date WITHOUT applying |startof:/
+		// |endof: snap — snap is only resolved in the real CompleteFormatter
+		// pass, and snapping only the file-name preview would diverge from the
+		// body preview.
+		output = output.replace(new RegExp(DATE_VARIABLE_REGEX.source, 'gi'), (match, variableName, dateFormat, rawOptions) => {
 			const cleanVariableName = variableName?.trim();
 			const cleanDateFormat = dateFormat?.trim();
-			
+			const { defaultValue: cleanDefaultValue, optional } =
+				parseVDateOptions(rawOptions);
+
 			if (!cleanVariableName || !cleanDateFormat) {
 				return match; // Return original if incomplete
 			}
 
-			// Generate a realistic preview using current date
+			// Generate a realistic preview using the current date.
 			const previewDate = new Date();
 			let formattedExample: string;
-			
+
 			try {
 				formattedExample = DateFormatPreviewGenerator.generate(cleanDateFormat, previewDate);
 			} catch {
 				formattedExample = `[${cleanDateFormat}]`;
 			}
-			
+
+			// If there's a default value, indicate it in the preview
+			if (cleanDefaultValue) {
+				formattedExample += ` (default: ${cleanDefaultValue})`;
+			}
+			if (optional) {
+				formattedExample += ` (optional)`;
+			}
+
 			return formattedExample;
 		});
-		
+
 		return output;
 	}
 

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -166,8 +166,19 @@ export class FileNameDisplayFormatter extends Formatter {
 		output = output.replace(new RegExp(DATE_VARIABLE_REGEX.source, 'gi'), (match, variableName, dateFormat, rawOptions) => {
 			const cleanVariableName = variableName?.trim();
 			const cleanDateFormat = dateFormat?.trim();
-			const { defaultValue: cleanDefaultValue, optional } =
-				parseVDateOptions(rawOptions);
+			// Parse defensively: a malformed |startof:/|endof: option can throw, and
+			// since format() catches and returns the whole raw input on any error, an
+			// unparseable VDATE option would otherwise blank out EVERY other preview
+			// substitution. Treat a parse failure as "no options".
+			let cleanDefaultValue: string | undefined;
+			let optional = false;
+			try {
+				({ defaultValue: cleanDefaultValue, optional } =
+					parseVDateOptions(rawOptions));
+			} catch {
+				cleanDefaultValue = undefined;
+				optional = false;
+			}
 
 			if (!cleanVariableName || !cleanDateFormat) {
 				return match; // Return original if incomplete

--- a/src/formatters/formatter.audit-formatter-core.test.ts
+++ b/src/formatters/formatter.audit-formatter-core.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Formatter, type PromptContext } from "./formatter";
+import { log } from "../logger/logManager";
+
+/**
+ * Regression tests for the formatter-core audit fixes that live in
+ * src/formatters/formatter.ts. Only the abstract UI/IO hooks are stubbed so the
+ * REAL replacer methods run.
+ */
+class TestFormatter extends Formatter {
+	public selectedText = "";
+	public vdatePrompts: string[] = [];
+	private vdateResponse = "";
+
+	constructor() {
+		super(undefined);
+		//@ts-ignore minimal date parser stub
+		this.dateParser = {
+			parseDate: (input: string) =>
+				input
+					? {
+							moment: {
+								format: () => "2025-06-21",
+								toISOString: () => "2025-06-21T00:00:00.000Z",
+								isValid: () => true,
+							},
+						}
+					: null,
+		};
+	}
+
+	public setVDateResponse(value: string): void {
+		this.vdateResponse = value;
+	}
+
+	public runSelected(input: string): Promise<string> {
+		return this.replaceSelectedInString(input);
+	}
+
+	public runDateVariable(input: string): Promise<string> {
+		return this.replaceDateVariableInString(input);
+	}
+
+	public runVariable(input: string): Promise<string> {
+		return this.replaceVariableInString(input);
+	}
+
+	public runValue(input: string): Promise<string> {
+		return this.replaceValueInString(input);
+	}
+
+	public setValue(value: string | undefined): void {
+		//@ts-ignore protected
+		this.value = value;
+	}
+
+	protected async format(input: string): Promise<string> {
+		return input;
+	}
+	protected async promptForValue(): Promise<string> {
+		return "";
+	}
+	protected async promptForVariable(
+		variableName: string,
+		context?: PromptContext,
+	): Promise<string> {
+		if (context?.type === "VDATE") {
+			this.vdatePrompts.push(variableName);
+			return this.vdateResponse;
+		}
+		return `typed(${variableName})`;
+	}
+	protected async suggestForValue(
+		suggestedValues: string[],
+	): Promise<string> {
+		return suggestedValues[0] ?? "";
+	}
+	protected suggestForFile(): string {
+		return "";
+	}
+	protected async suggestForField(): Promise<string> {
+		return "";
+	}
+	protected async getMacroValue(): Promise<string> {
+		return "";
+	}
+	protected async getTemplateContent(): Promise<string> {
+		return "";
+	}
+	protected async getSelectedText(): Promise<string> {
+		return this.selectedText;
+	}
+	protected async getClipboardContent(): Promise<string> {
+		return "";
+	}
+	protected getCurrentFileLink(): string | null {
+		return null;
+	}
+	protected getCurrentFileName(): string | null {
+		return null;
+	}
+	protected getVariableValue(variableName: string): string {
+		return String(this.variables.get(variableName) ?? "");
+	}
+	protected async promptForMathValue(): Promise<string> {
+		return "";
+	}
+	protected isTemplatePropertyTypesEnabled(): boolean {
+		return false;
+	}
+}
+
+beforeEach(() => {
+	(globalThis as any).window ??= globalThis;
+	(globalThis as any).window.moment = (_iso?: unknown) => ({
+		isValid: () => true,
+		format: (fmt?: string) => `[${fmt}]`,
+	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("{{SELECTED}} self-reference (format-core-selected-token)", () => {
+	it("does not loop when the selection literally contains {{SELECTED}}", async () => {
+		const f = new TestFormatter();
+		// A selection that re-contains the token would loop forever with the old
+		// re-scanning while-loop; the single-pass replacer inserts it literally.
+		f.selectedText = "before {{SELECTED}} after";
+
+		const out = await f.runSelected("[{{SELECTED}}]");
+
+		expect(out).toBe("[before {{SELECTED}} after]");
+	});
+
+	it("replaces every occurrence in one pass", async () => {
+		const f = new TestFormatter();
+		f.selectedText = "X";
+		expect(await f.runSelected("{{SELECTED}}-{{SELECTED}}")).toBe("X-X");
+	});
+
+	it("returns the input unchanged when no token is present", async () => {
+		const f = new TestFormatter();
+		f.selectedText = "X";
+		expect(await f.runSelected("no token here")).toBe("no token here");
+	});
+});
+
+describe("{{VDATE}} malformed-token skip (value-syntax-vdate-prompt)", () => {
+	it("a leading empty-name {{VDATE:}} does not block a later valid {{VDATE}}", async () => {
+		const f = new TestFormatter();
+		f.setVDateResponse("2025-06-21");
+
+		const out = await f.runDateVariable(
+			"{{VDATE:,YYYY}} and {{VDATE:due,YYYY-MM-DD}}",
+		);
+
+		// The malformed token is left literal; the valid one still prompts + renders.
+		expect(out).toBe("{{VDATE:,YYYY}} and [YYYY-MM-DD]");
+		expect(f.vdatePrompts).toEqual(["due"]);
+	});
+
+	it("a malformed {{VDATE:,fmt}} after a valid one still leaves the valid one resolved", async () => {
+		const f = new TestFormatter();
+		f.setVDateResponse("2025-06-21");
+
+		const out = await f.runDateVariable(
+			"{{VDATE:due,YYYY-MM-DD}} then {{VDATE:,YYYY}}",
+		);
+
+		expect(out).toBe("[YYYY-MM-DD] then {{VDATE:,YYYY}}");
+		expect(f.vdatePrompts).toEqual(["due"]);
+	});
+});
+
+describe("anonymous {{VALUE|default:X}} on empty submission (value-syntax-anonymous-value)", () => {
+	it("applies the default when the submission is empty and not optional", async () => {
+		const f = new TestFormatter();
+		f.setValue(""); // user cleared the pre-filled box
+
+		expect(await f.runValue("[{{VALUE|default:Hi}}]")).toBe("[Hi]");
+	});
+
+	it("does NOT apply the default for an |optional empty submission", async () => {
+		const f = new TestFormatter();
+		f.setValue("");
+
+		expect(await f.runValue("[{{VALUE|default:Hi|optional}}]")).toBe("[]");
+	});
+
+	it("a provided value still wins over the default", async () => {
+		const f = new TestFormatter();
+		f.setValue("typed");
+
+		expect(await f.runValue("[{{VALUE|default:Hi}}]")).toBe("[typed]");
+	});
+});
+
+describe("named-value option-list conflict surfaces a Notice (format-core-value-named-alias)", () => {
+	it("routes the conflict warning through log.logWarning (on-screen Notice)", async () => {
+		const warnSpy = vi
+			.spyOn(log, "logWarning")
+			.mockImplementation(() => {});
+		const f = new TestFormatter();
+
+		await f.runVariable(
+			"a={{VALUE:bug,feature|name:type}} b={{VALUE:book,movie|name:type}}",
+		);
+
+		expect(
+			warnSpy.mock.calls.some((c) =>
+				String(c[0]).includes("different option lists"),
+			),
+		).toBe(true);
+	});
+});

--- a/src/formatters/formatter.audit-formatter-core.test.ts
+++ b/src/formatters/formatter.audit-formatter-core.test.ts
@@ -110,8 +110,11 @@ class TestFormatter extends Formatter {
 	}
 }
 
+let previousMoment: unknown;
+
 beforeEach(() => {
 	(globalThis as any).window ??= globalThis;
+	previousMoment = (globalThis as any).window.moment;
 	(globalThis as any).window.moment = (_iso?: unknown) => ({
 		isValid: () => true,
 		format: (fmt?: string) => `[${fmt}]`,
@@ -119,6 +122,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	// Restore the prior global so this stub doesn't bleed into later suites.
+	(globalThis as any).window.moment = previousMoment;
 	vi.restoreAllMocks();
 });
 

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -239,7 +239,15 @@ export abstract class Formatter {
 			if (optionsIndex === -1) return this.value;
 			const rawOptions = inner.slice(optionsIndex);
 			const parsed = parseAnonymousValueOptions(rawOptions);
-			const transformed = this.applyValueTextOptions(this.value, parsed);
+			// Apply |default on an empty submission, mirroring the named path
+			// (ensureValueVariableResolved): the |default pre-fills the prompt, but
+			// a user who clears the box should still get the default unless the
+			// token is |optional (an optional empty is taken at face value).
+			const effectiveValue =
+				this.value === "" && parsed.defaultValue && !parsed.optional
+					? parsed.defaultValue
+					: this.value;
+			const transformed = this.applyValueTextOptions(effectiveValue, parsed);
 			// |type:text on the anonymous {{VALUE|...}} form quotes the same way
 			// as the named form (see replaceVariableInString).
 			if (
@@ -293,7 +301,10 @@ export abstract class Formatter {
 			if (optionsIndex === -1) continue;
 			const rawOptions = inner.slice(optionsIndex);
 
-			const parsed = parseAnonymousValueOptions(rawOptions);
+			// Quiet: this is the prompt-context pre-pass; the actual replacer
+			// pass (replaceValueInString) emits any |case warning so it fires
+			// once, not twice.
+			const parsed = parseAnonymousValueOptions(rawOptions, { quiet: true });
 			if (!context) context = {};
 
 			if (!context.description && parsed.label) {
@@ -320,15 +331,16 @@ export abstract class Formatter {
 	}
 
 	protected async replaceSelectedInString(input: string): Promise<string> {
-		let output: string = input;
+		if (!SELECTED_REGEX.test(input)) return input;
 
 		const selectedText = await this.getSelectedText();
-
-		while (SELECTED_REGEX.test(output)) {
-			output = this.replacer(output, SELECTED_REGEX, selectedText);
-		}
-
-		return output;
+		// Single global function-replacer pass (mirrors replaceClipboardInString):
+		// the inserted selection is arbitrary user text and may itself contain the
+		// literal "{{SELECTED}}" token, so a re-scanning while-loop would re-match
+		// it every iteration and grow without bound, hanging Obsidian (#1358-class).
+		// A function replacer inserts it literally and is never re-scanned.
+		const regex = new RegExp(SELECTED_REGEX.source, "gi");
+		return input.replace(regex, () => selectedText);
 	}
 
 	protected async replaceClipboardInString(input: string): Promise<string> {
@@ -662,9 +674,14 @@ export abstract class Formatter {
 		}
 		if (previous !== signature && !this.namedSuggesterConflictsWarned.has(nameKey)) {
 			this.namedSuggesterConflictsWarned.add(nameKey);
-			console.warn(
-				`QuickAdd: named value "${parsed.variableKey}" is defined with different option lists; the first definition's value is reused.`,
-			);
+			const message = `QuickAdd: named value "${parsed.variableKey}" is defined with different option lists; the first definition's value is reused.`;
+			// Surface as a Notice (consistent with the other |name: warnings, which
+			// all use log.logWarning) — the conflict silently drops the second
+			// option list, so the user needs to see it on-screen, not only in
+			// devtools. Warn-once dedupe is kept by the guard above. The console.warn
+			// is retained for the diagnostic log/trail.
+			log.logWarning(message);
+			console.warn(message);
 		}
 	}
 
@@ -920,7 +937,9 @@ export abstract class Formatter {
 
 			if (fullMatch) {
 				const fieldVariableKey = this.getFieldVariableKey(fullMatch);
-				const parsed = FieldSuggestionParser.parse(fullMatch);
+				const parsed = FieldSuggestionParser.parse(fullMatch, {
+					warnUnknown: true,
+				});
 
 				if (!this.hasConcreteVariable(fieldVariableKey)) {
 					this.variables.set(
@@ -1162,141 +1181,143 @@ export abstract class Formatter {
 	): Promise<string | string[]>;
 
 	protected async replaceDateVariableInString(input: string) {
-		let output: string = input;
+		// Scan with a GLOBAL regex + accumulator (mirrors replaceFieldVarInString)
+		// so a malformed/empty-name {{VDATE:}} token is skipped (left literal) and
+		// every LATER valid {{VDATE}} is still prompted. The previous in-place
+		// while-loop `break`ed the entire scan on the first empty-name match, which
+		// silently dropped all subsequent date prompts. The accumulator also never
+		// re-scans a replacement, so a stored value re-containing the token can't
+		// loop.
+		const regex = new RegExp(DATE_VARIABLE_REGEX.source, "gi");
+		let output = "";
+		let lastIndex = 0;
+		let match: RegExpExecArray | null;
 
-		while (DATE_VARIABLE_REGEX.test(output)) {
-			const match = DATE_VARIABLE_REGEX.exec(output);
-			if (!match || !match[1]) break;
+		while ((match = regex.exec(input)) !== null) {
+			output += input.slice(lastIndex, match.index);
+			lastIndex = match.index + match[0].length;
 
-			const variableName = match[1].trim();
+			const variableName = match[1]?.trim();
+			// Empty/incomplete token (e.g. {{VDATE:}} or {{VDATE:,YYYY}}): leave it
+			// literal and keep scanning so a later valid token still resolves.
+			if (!variableName) {
+				output += match[0];
+				continue;
+			}
+
 			const { defaultValue, optional, withTime, snap } = parseVDateOptions(match[3]);
 			// A |time/|datetime token with no explicit format gets a datetime
 			// default so the rendered value carries the picked time.
 			const dateFormat =
 				match[2]?.trim() || (withTime ? "YYYY-MM-DD HH:mm" : "YYYY-MM-DD");
 
-			// Skip processing if variable name or format is empty
-			// This prevents crashes when typing incomplete patterns like {{VDATE:,
-			if (!variableName) {
-				break;
-			}
+			const existingValue = this.variables.get(variableName);
 
-			if (variableName) {
-				const existingValue = this.variables.get(variableName);
+			// Check if we already have this date variable stored.
+			// Only `undefined` counts as unset — null and "" are intentional
+			// values (same contract as VALUE variables, see #872), so a
+			// script-set "" renders empty instead of re-prompting.
+			if (existingValue === undefined) {
+				// Prompt for date input with VDATE context
+				const dateInput = await this.promptForVariable(
+					variableName,
+					{ type: "VDATE", dateFormat, defaultValue, optional, withTime }
+				);
+				if (optional && !dateInput?.trim()) {
+					// Optional date left blank or skipped: answered-empty.
+					this.variables.set(variableName, "");
+				} else if (dateInput?.startsWith("@date:")) {
+					this.variables.set(variableName, dateInput);
+				} else {
+					if (!this.dateParser)
+						throw new Error("Date parser is not available");
 
-				// Check if we already have this date variable stored.
-				// Only `undefined` counts as unset — null and "" are intentional
-				// values (same contract as VALUE variables, see #872), so a
-				// script-set "" renders empty instead of re-prompting.
-				if (existingValue === undefined) {
-					// Prompt for date input with VDATE context
-					const dateInput = await this.promptForVariable(
-						variableName,
-						{ type: "VDATE", dateFormat, defaultValue, optional, withTime }
+					const aliasMap = settingsStore.getState().dateAliases;
+					const normalizedInput = normalizeDateInput(
+						dateInput,
+						aliasMap,
 					);
-					if (optional && !dateInput?.trim()) {
-						// Optional date left blank or skipped: answered-empty.
-						this.variables.set(variableName, "");
-					} else if (dateInput?.startsWith("@date:")) {
-						this.variables.set(variableName, dateInput);
-					} else {
-						if (!this.dateParser)
-							throw new Error("Date parser is not available");
+					const parseAttempt = this.dateParser.parseDate(normalizedInput);
 
-						const aliasMap = settingsStore.getState().dateAliases;
-						const normalizedInput = normalizeDateInput(
-							dateInput,
-							aliasMap,
+					if (parseAttempt) {
+						// Store the ISO string with a special prefix
+						this.variables.set(
+							variableName,
+							`@date:${parseAttempt.moment.toISOString()}`,
 						);
-						const parseAttempt = this.dateParser.parseDate(normalizedInput);
-
-						if (parseAttempt) {
-							// Store the ISO string with a special prefix
-							this.variables.set(
-								variableName,
-								`@date:${parseAttempt.moment.toISOString()}`,
-							);
-						} else {
-							throw new Error(
-								`unable to parse date variable ${dateInput}${
-									optional
-										? ""
-										: ". Tip: add |optional inside the {{VDATE}} token to allow leaving this date empty"
-								}`,
-							);
-						}
+					} else {
+						throw new Error(
+							`unable to parse date variable ${dateInput}${
+								optional
+									? ""
+									: ". Tip: add |optional inside the {{VDATE}} token to allow leaving this date empty"
+							}`,
+						);
 					}
 				}
+			}
 
-				// Format the date based on what's stored
-				let formattedDate = "";
-				let storedValue = this.variables.get(variableName);
+			// Format the date based on what's stored
+			let formattedDate = "";
+			let storedValue = this.variables.get(variableName);
 
-				// If a VDATE variable was pre-seeded (e.g., via API/URL) as a plain string,
-				// attempt to coerce it into the internal @date:ISO form so formatting works.
-				if (
-					typeof storedValue === "string" &&
-					storedValue &&
-					!storedValue.startsWith("@date:")
-				) {
-					if (this.dateParser) {
-						const aliasMap = settingsStore.getState().dateAliases;
-						const normalizedInput = normalizeDateInput(storedValue, aliasMap);
-						const parseAttempt = this.dateParser.parseDate(normalizedInput);
+			// If a VDATE variable was pre-seeded (e.g., via API/URL) as a plain string,
+			// attempt to coerce it into the internal @date:ISO form so formatting works.
+			if (
+				typeof storedValue === "string" &&
+				storedValue &&
+				!storedValue.startsWith("@date:")
+			) {
+				if (this.dateParser) {
+					const aliasMap = settingsStore.getState().dateAliases;
+					const normalizedInput = normalizeDateInput(storedValue, aliasMap);
+					const parseAttempt = this.dateParser.parseDate(normalizedInput);
 
-						// Keep backwards compatibility: only coerce if we can parse it.
-						if (parseAttempt) {
-							const iso = parseAttempt.moment.toISOString();
-							const coerced = `@date:${iso}`;
-							this.variables.set(variableName, coerced);
-							storedValue = coerced;
-						}
-					}
-				} else if (storedValue instanceof Date) {
-					// Some callers may pass actual Date objects through the JS API.
-					if (!Number.isNaN(storedValue.getTime())) {
-						const coerced = `@date:${storedValue.toISOString()}`;
+					// Keep backwards compatibility: only coerce if we can parse it.
+					if (parseAttempt) {
+						const iso = parseAttempt.moment.toISOString();
+						const coerced = `@date:${iso}`;
 						this.variables.set(variableName, coerced);
 						storedValue = coerced;
 					}
 				}
-
-				if (typeof storedValue === "string" && storedValue.startsWith("@date:")) {
-					// It's a date variable, extract and format it
-					const isoString = storedValue.substring(6);
-
-					if (this.dateParser && window.moment) {
-						const moment = window.moment(isoString);
-						if (moment && moment.isValid()) {
-							// Snap is per-occurrence (issue #511): the stored
-							// @date:ISO stays raw, so {{VDATE:d,F1|startof:week}}
-							// and {{VDATE:d,F2}} share one picked date but only one
-							// snaps. A fresh moment per iteration prevents leaks.
-							formattedDate = applyDateSnap(moment, snap).format(
-								dateFormat,
-							);
-						}
-					}
-				} else if (typeof storedValue === "string" && storedValue) {
-					// Backward compatibility: use the stored value as-is
-					formattedDate = storedValue;
-				} else if (storedValue != null) {
-					// Fallback: avoid throwing if a non-string value is stored.
-					formattedDate = formatUnknownValue(storedValue);
+			} else if (storedValue instanceof Date) {
+				// Some callers may pass actual Date objects through the JS API.
+				if (!Number.isNaN(storedValue.getTime())) {
+					const coerced = `@date:${storedValue.toISOString()}`;
+					this.variables.set(variableName, coerced);
+					storedValue = coerced;
 				}
-
-				// Replace the specific match rather than using regex again
-				// to handle multiple VDATE variables with same name but different formats.
-				// Replacer function so `$` patterns in stored values are literal —
-				// a raw string replacement would re-expand `$&` into the token and
-				// loop forever.
-				output = output.replace(match[0], () => formattedDate);
-			} else {
-				break;
 			}
+
+			if (typeof storedValue === "string" && storedValue.startsWith("@date:")) {
+				// It's a date variable, extract and format it
+				const isoString = storedValue.substring(6);
+
+				if (this.dateParser && window.moment) {
+					const moment = window.moment(isoString);
+					if (moment && moment.isValid()) {
+						// Snap is per-occurrence (issue #511): the stored
+						// @date:ISO stays raw, so {{VDATE:d,F1|startof:week}}
+						// and {{VDATE:d,F2}} share one picked date but only one
+						// snaps. A fresh moment per iteration prevents leaks.
+						formattedDate = applyDateSnap(moment, snap).format(
+							dateFormat,
+						);
+					}
+				}
+			} else if (typeof storedValue === "string" && storedValue) {
+				// Backward compatibility: use the stored value as-is
+				formattedDate = storedValue;
+			} else if (storedValue != null) {
+				// Fallback: avoid throwing if a non-string value is stored.
+				formattedDate = formatUnknownValue(storedValue);
+			}
+
+			output += formattedDate;
 		}
 
-		return output;
+		return output + input.slice(lastIndex);
 	}
 
 	protected async replaceTemplateInString(input: string): Promise<string> {

--- a/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
+++ b/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
@@ -15,11 +15,19 @@ let {
 	formatterKind = "format",
 	app,
 	plugin,
+	targetFolderPath,
 }: {
 	value: string;
 	formatterKind?: "format" | "fileName";
 	app: App;
 	plugin: QuickAdd;
+	/**
+	 * The choice's configured target folder, so {{FOLDER}} / {{FOLDER|name}}
+	 * preview meaningfully. When unknown we fall back to a "Folder/Name"
+	 * placeholder rather than an empty string (no caller wires the real path in
+	 * yet, but the placeholder keeps the FOLDER token from previewing blank).
+	 */
+	targetFolderPath?: string;
 } = $props();
 
 let preview = $state("Loading preview…");
@@ -37,6 +45,12 @@ const formatter = $derived(
 
 $effect(() => {
 	const current = value;
+	// Resolve {{FOLDER}} / {{FOLDER|name}} against the configured target folder,
+	// or a "Folder/Name" placeholder so the token never previews blank when no
+	// caller wires the real path in (issue: FOLDER preview always empty).
+	formatter.setTargetFolderPath(
+		targetFolderPath?.trim() ? targetFolderPath : "Folder/Name",
+	);
 	const token = ++previewToken;
 	void (async () => {
 		try {

--- a/src/gui/suggesters/formatSyntaxSuggester.audit-preflight-suggesters.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.audit-preflight-suggesters.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { FormatSyntaxSuggester } from "./formatSyntaxSuggester";
+
+function ensureObsidianDomPolyfills(): void {
+	(globalThis as any).createDiv ??= (cls?: string) => {
+		const div = document.createElement("div");
+		if (cls) div.className = cls;
+		return div;
+	};
+
+	const proto = HTMLElement.prototype as any;
+
+	proto.createDiv ??= function (arg?: string | { cls?: string }) {
+		const div = document.createElement("div");
+		if (typeof arg === "string") div.className = arg;
+		else if (arg && typeof arg === "object" && typeof arg.cls === "string")
+			div.className = arg.cls;
+		this.appendChild(div);
+		return div;
+	};
+
+	proto.empty ??= function () {
+		this.replaceChildren();
+		return this;
+	};
+
+	proto.on ??= function () {
+		return this;
+	};
+
+	proto.detach ??= function () {
+		this.remove();
+	};
+
+	proto.addClass ??= function (...classes: string[]) {
+		this.classList.add(...classes);
+		return this;
+	};
+
+	proto.removeClass ??= function (...classes: string[]) {
+		this.classList.remove(...classes);
+		return this;
+	};
+
+	proto.setAttr ??= function (name: string, value: string) {
+		this.setAttribute(name, value);
+		return this;
+	};
+}
+
+const makeApp = () =>
+	({
+		dom: { appContainerEl: document.body },
+		keymap: { pushScope: () => {}, popScope: () => {} },
+	}) as any;
+
+const makePlugin = () =>
+	({
+		settings: { choices: [], globalVariables: {} },
+		getTemplateFiles: () => [],
+	}) as any;
+
+async function suggestForFile(value: string, suggestForFileNames: boolean) {
+	const inputEl = document.createElement("input");
+	inputEl.value = value;
+	inputEl.selectionStart = value.length;
+	inputEl.selectionEnd = value.length;
+
+	const suggester = new FormatSyntaxSuggester(
+		makeApp(),
+		inputEl,
+		makePlugin(),
+		suggestForFileNames,
+	);
+	const suggestions = await suggester.getSuggestions(value);
+	suggester.destroy();
+	return suggestions;
+}
+
+describe("FormatSyntaxSuggester file-name token gating", () => {
+	beforeEach(() => {
+		ensureObsidianDomPolyfills();
+	});
+
+	// Finding: format-core-file-options
+	it("does NOT offer {{FILE:<folder>|optional}} in the file-name field", async () => {
+		const suggestions = await suggestForFile("{{FILE", true);
+		expect(suggestions).toContain("{{FILE:<folder>}}");
+		expect(suggestions).not.toContain("{{FILE:<folder>|optional}}");
+		// |link / |path stay gated too
+		expect(suggestions).not.toContain("{{FILE:<folder>|link}}");
+		expect(suggestions).not.toContain("{{FILE:<folder>|path}}");
+	});
+
+	it("still offers {{FILE:<folder>|optional}} outside the file-name field", async () => {
+		const suggestions = await suggestForFile("{{FILE", false);
+		expect(suggestions).toContain("{{FILE:<folder>|optional}}");
+		expect(suggestions).toContain("{{FILE:<folder>|link}}");
+		expect(suggestions).toContain("{{FILE:<folder>|path}}");
+	});
+
+	// Finding: format-file-filenamecurrent-token
+	it("offers {{filenamecurrent}} in the file-name field", async () => {
+		const suggestions = await suggestForFile("{{FILENAME", true);
+		expect(suggestions).toContain("{{filenamecurrent}}");
+	});
+});

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -196,6 +196,14 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 			token: FormatSyntaxToken.FolderTarget,
 			suggestion: "{{folder|name}}",
 		},
+		// formatFileName resolves {{FILENAMECURRENT}} (the source note's
+		// basename), so it is valid here; {{title}} is deliberately excluded
+		// because it throws in file names.
+		{
+			regex: FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
+			token: FormatSyntaxToken.FilenameCurrent,
+			suggestion: FILENAMECURRENT_SYNTAX,
+		},
 	];
 
 	constructor(
@@ -331,18 +339,18 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 			} else if (tokenDef.token === FormatSyntaxToken.File) {
 				// Pick a file from a folder; default inserts the basename.
 				suggestions.push("{{FILE:<folder>}}");
-				// |link / |path insert characters invalid in a file name, so only
-				// offer them outside the file-name field.
+				// |link / |path insert characters invalid in a file name, and
+				// |optional permits an all-optional name that resolves empty
+				// (rejected at creation time), so only offer them outside the
+				// file-name field.
 				if (!this.suggestForFileNames) {
 					suggestions.push(
 						"{{FILE:<folder>|link}}",
 						"{{FILE:<folder>|path}}",
+						"{{FILE:<folder>|optional}}",
 					);
 				}
-				suggestions.push(
-					"{{FILE:<folder>|optional}}",
-					"{{FILE:<folder>|custom}}",
-				);
+				suggestions.push("{{FILE:<folder>|custom}}");
 			}
 		}
 

--- a/src/gui/suggesters/utils.audit-preflight-suggesters.test.ts
+++ b/src/gui/suggesters/utils.audit-preflight-suggesters.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { installSkipAffordance } from "./utils";
+
+function ensureObsidianDomPolyfills(): void {
+	const proto = HTMLElement.prototype as any;
+	proto.createDiv ??= function (options?: { cls?: string; text?: string }) {
+		const div = document.createElement("div");
+		if (options?.cls) div.className = options.cls;
+		if (options?.text !== undefined) div.textContent = options.text;
+		this.appendChild(div);
+		return div;
+	};
+	proto.createEl ??= function (
+		tag: string,
+		options?: { cls?: string; text?: string },
+	) {
+		const el = document.createElement(tag);
+		if (options?.cls) el.className = options.cls;
+		if (options?.text !== undefined) el.textContent = options.text;
+		this.appendChild(el);
+		return el;
+	};
+}
+
+// Finding: value-syntax-optional — optional option-list suggesters only had a
+// keyboard Mod+Shift+Enter skip; mobile/pointer users had no Skip control.
+// installSkipAffordance must render a visible, clickable Skip button when the
+// modal exposes a modalEl.
+describe("installSkipAffordance Skip button", () => {
+	beforeEach(() => {
+		ensureObsidianDomPolyfills();
+	});
+
+	it("renders a touch/mouse Skip button that invokes onSkip", () => {
+		const modalEl = document.createElement("div");
+		const onSkip = vi.fn();
+
+		installSkipAffordance({ modalEl }, onSkip);
+
+		const button = modalEl.querySelector(
+			"button.qa-suggester-skip-button",
+		) as HTMLButtonElement | null;
+		expect(button).not.toBeNull();
+		expect(button?.textContent).toBe("Skip (leave empty)");
+
+		button?.click();
+		expect(onSkip).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not throw when the modal has no modalEl (stub suggester)", () => {
+		const onSkip = vi.fn();
+		expect(() => installSkipAffordance({}, onSkip)).not.toThrow();
+		expect(onSkip).not.toHaveBeenCalled();
+	});
+});

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -18,13 +18,17 @@ export function normalizeDisplayItem(value: unknown): string {
 type SkipCapableModal = {
 	scope?: Scope;
 	setInstructions?: (instructions: Instruction[]) => void;
+	// SuggestModal exposes modalEl; used to mount a touch/mouse-friendly Skip
+	// button. Optional because the test stub's FuzzySuggestModal lacks it.
+	modalEl?: HTMLElement;
 };
 
 /**
  * Wires the skip affordance for optional tokens onto a suggester modal: an
- * instructions footer plus a Mod+Shift+Enter scope binding that invokes the
- * modal's skip resolution. Both hooks are runtime-guarded because the test
- * stub's FuzzySuggestModal provides neither scope nor setInstructions.
+ * instructions footer, a Mod+Shift+Enter scope binding, and a touch/mouse Skip
+ * button — all invoking the modal's skip resolution. Every hook is
+ * runtime-guarded because the test stub's FuzzySuggestModal provides none of
+ * scope, setInstructions, or modalEl.
  */
 export function installSkipAffordance(
 	modal: SkipCapableModal,
@@ -42,6 +46,26 @@ export function installSkipAffordance(
 			{ command: "ctrl/cmd+shift+↵", purpose: "to skip (leave empty)" },
 			{ command: "esc", purpose: "to cancel" },
 		]);
+	}
+
+	// Mod+Shift+Enter is keyboard-only; mobile/pointer users get no modifier
+	// keys, so add a visible Skip button (matching the text prompt and
+	// MultiSuggester) that resolves the same "leave empty" answer.
+	const modalEl = modal.modalEl;
+	if (modalEl && typeof modalEl.createDiv === "function") {
+		const skipBar = modalEl.createDiv({
+			cls: "qa-suggester-skip-bar",
+		});
+		const skipButton = skipBar.createEl("button", {
+			text: "Skip (leave empty)",
+			cls: "qa-suggester-skip-button",
+		});
+		skipButton.type = "button";
+		skipButton.setAttribute("aria-label", "Skip and leave empty");
+		skipButton.addEventListener("click", (evt) => {
+			evt.preventDefault();
+			onSkip();
+		});
 	}
 }
 

--- a/src/utils/FieldSuggestionParser.audit-integrations.test.ts
+++ b/src/utils/FieldSuggestionParser.audit-integrations.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { logWarningMock } = vi.hoisted(() => ({
+	logWarningMock: vi.fn(),
+}));
+
+vi.mock("../logger/logManager", () => ({
+	log: {
+		logWarning: logWarningMock,
+		logError: vi.fn(),
+		logMessage: vi.fn(),
+	},
+}));
+
+import { FieldSuggestionParser } from "./FieldSuggestionParser";
+
+describe("FieldSuggestionParser - unknown filter feedback (integrations audit)", () => {
+	beforeEach(() => {
+		logWarningMock.mockReset();
+	});
+
+	it("warns when a pipe key is misspelled / unrecognized (FIELD grammar opts in)", () => {
+		const result = FieldSuggestionParser.parse("status|exclud-tag:draft", {
+			warnUnknown: true,
+		});
+
+		// The typo is still dropped (no filter applied)...
+		expect(result.filters.excludeTags).toBeUndefined();
+		// ...but the {{FIELD}} caller now gets a warning instead of silent nothing.
+		expect(logWarningMock).toHaveBeenCalledTimes(1);
+		expect(logWarningMock.mock.calls[0][0]).toContain("exclud-tag");
+	});
+
+	it("stays SILENT for shared callers (FILE/property/capture) on unknown keys", () => {
+		// The parser is shared by the {{FILE:...|label:/name:}}, property:, and
+		// capture-scope grammars, which legitimately carry keys this parser does
+		// not recognize. Without warnUnknown it must not emit a false
+		// "Unknown FIELD filter" notice or leak internal sentinels.
+		FieldSuggestionParser.parse("People|link|label:Pick a person|name:reviewer");
+		FieldSuggestionParser.parse("__capture_scope|folder:Work|fodler:Other");
+
+		expect(logWarningMock).not.toHaveBeenCalled();
+	});
+
+	it("does not warn for recognized filters", () => {
+		FieldSuggestionParser.parse(
+			"status|folder:Work|tag:project|exclude-folder:Archive|default:Todo|case-sensitive:true|multi",
+		);
+
+		expect(logWarningMock).not.toHaveBeenCalled();
+	});
+
+	it("does not warn for colon-less invalid parts (existing skip behavior)", () => {
+		const result = FieldSuggestionParser.parse("status|invalidfilter");
+
+		expect(result.filters).toEqual({});
+		expect(logWarningMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -1,3 +1,4 @@
+import { log } from "../logger/logManager";
 import {
 	parseBooleanFlag,
 	parsePipeKeyValue,
@@ -32,7 +33,10 @@ export class FieldSuggestionParser {
 	 * - "fieldname|folder:daily" -> { fieldName: "fieldname", filters: { folder: "daily" } }
 	 * - "fieldname|folder:daily|tag:work|tag:project" -> { fieldName: "fieldname", filters: { folder: "daily", tags: ["work", "project"] } }
 	 */
-	static parse(input: string): {
+	static parse(
+		input: string,
+		options?: { warnUnknown?: boolean },
+	): {
 		fieldName: string;
 		filters: FieldFilter;
 		multiSelect?: boolean;
@@ -127,6 +131,24 @@ export class FieldSuggestionParser {
 						filters.excludeFiles = [];
 					}
 					filters.excludeFiles.push(filterValue);
+					break;
+				default:
+					// An unrecognized pipe key (typically a typo like
+					// `exclud-tag` or `fodler`) would otherwise be dropped
+					// silently, leaving the user with unfiltered suggestions and
+					// no indication the filter did nothing. Surface a warning so
+					// the mistake is discoverable — but ONLY for the {{FIELD}}
+					// grammar (warnUnknown). This parser is also shared by the
+					// {{FILE:...|label:/name:}}, property:, and capture-scope
+					// grammars, which legitimately carry keys this switch does
+					// not know and peel off elsewhere; warning there would emit
+					// false "Unknown FIELD filter" notices and leak internal
+					// sentinels like __capture_scope.
+					if (options?.warnUnknown) {
+						log.logWarning(
+							`Unknown FIELD filter "${filterType}" in "{{FIELD:${input}}}" was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-empty, default-always, case-sensitive, multi.`,
+						);
+					}
 					break;
 			}
 		}

--- a/src/utils/caseTransform.ts
+++ b/src/utils/caseTransform.ts
@@ -28,6 +28,25 @@ function normalizeStyle(style?: string): CaseStyle | null {
 	}
 }
 
+/** The case styles {@link transformCase} understands, in the order shown to the
+ *  user when an unrecognized |case: style is rejected. */
+export const SUPPORTED_CASE_STYLES: readonly CaseStyle[] = [
+	"kebab",
+	"snake",
+	"camel",
+	"pascal",
+	"title",
+	"lower",
+	"upper",
+	"slug",
+];
+
+/** Returns true when `style` resolves to a known case style; false (with a
+ *  non-empty input) means the author typo'd it and it will be ignored. */
+export function isSupportedCaseStyle(style?: string): boolean {
+	return normalizeStyle(style) !== null;
+}
+
 function upperFirstLowerRest(word: string): string {
 	if (!word) return word;
 	const lower = word.toLowerCase();

--- a/src/utils/valueSyntax.audit-formatter-core.test.ts
+++ b/src/utils/valueSyntax.audit-formatter-core.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseAnonymousValueOptions, parseValueToken } from "./valueSyntax";
+import { log } from "../logger/logManager";
+
+describe("valueSyntax audit (formatter-core)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("invalid |case style warns (value-syntax-case-transform / format-core-value-case)", () => {
+		it("warns and drops an unrecognized |case style on a named/single token", () => {
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			const parsed = parseValueToken("title|case:keb");
+
+			expect(parsed?.caseStyle).toBeUndefined();
+			expect(
+				warnSpy.mock.calls.some((c) =>
+					String(c[0]).includes("Unsupported |case style"),
+				),
+			).toBe(true);
+		});
+
+		it("warns for a common typo like case:uppercase", () => {
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			parseValueToken("x|case:uppercase");
+
+			expect(warnSpy).toHaveBeenCalled();
+		});
+
+		it("does NOT warn for a valid |case style", () => {
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			const parsed = parseValueToken("title|case:kebab");
+
+			expect(parsed?.caseStyle).toBe("kebab");
+			expect(
+				warnSpy.mock.calls.some((c) =>
+					String(c[0]).includes("Unsupported |case style"),
+				),
+			).toBe(false);
+		});
+
+		it("stays silent in quiet mode (preflight pre-pass)", () => {
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			parseValueToken("title|case:keb", { quiet: true });
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it("warns for an invalid |case on the anonymous form", () => {
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			const parsed = parseAnonymousValueOptions("|case:keb");
+
+			expect(parsed.caseStyle).toBeUndefined();
+			expect(
+				warnSpy.mock.calls.some((c) =>
+					String(c[0]).includes("Unsupported |case style"),
+				),
+			).toBe(true);
+		});
+
+		it("stays silent on the anonymous form in quiet mode (prompt-context pre-pass)", () => {
+			// The formatter calls parseAnonymousValueOptions twice per token (a
+			// quiet prompt-context pre-pass + the real replacer). Only the
+			// replacer warns, so the |case typo notice fires once, not twice.
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			const parsed = parseAnonymousValueOptions("|case:keb", { quiet: true });
+
+			expect(parsed.caseStyle).toBeUndefined();
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("bare |custom on a single value (value-syntax-custom-input)", () => {
+		it("warns and does not pre-fill the prompt with the literal word 'custom'", () => {
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			const parsed = parseValueToken("notes|custom");
+
+			// Before the fix, defaultValue was the literal "custom".
+			expect(parsed?.defaultValue).toBe("");
+			expect(parsed?.allowCustomInput).toBe(false);
+			expect(
+				warnSpy.mock.calls.some((c) =>
+					String(c[0]).includes("|custom needs an option list"),
+				),
+			).toBe(true);
+		});
+
+		it("still honors |custom on an option-list token (no warning)", () => {
+			const warnSpy = vi
+				.spyOn(log, "logWarning")
+				.mockImplementation(() => {});
+
+			const parsed = parseValueToken("a,b|custom");
+
+			expect(parsed?.allowCustomInput).toBe(true);
+			expect(
+				warnSpy.mock.calls.some((c) =>
+					String(c[0]).includes("|custom needs an option list"),
+				),
+			).toBe(false);
+		});
+	});
+});

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -6,6 +6,7 @@ import {
 	stripLeadingPipe,
 } from "./pipeSyntax";
 import { log } from "../logger/logManager";
+import { isSupportedCaseStyle, SUPPORTED_CASE_STYLES } from "./caseTransform";
 
 // Internal-only delimiter for scoping labeled VALUE lists. Unlikely to appear in user input.
 export const VALUE_LABEL_KEY_DELIMITER = "\u001F";
@@ -786,6 +787,18 @@ export function parseValueToken(
 		);
 	}
 
+	// An unrecognized |case: style (e.g. a typo like "keb" or "uppercase") is
+	// silently passed through unchanged by transformCase at render time, so warn
+	// here — mirroring the |type: unsupported-value warning — so the author sees
+	// their mistake instead of debugging an untransformed value.
+	if (caseStyle && !isSupportedCaseStyle(caseStyle)) {
+		if (!quiet)
+			log.logWarning(
+				`QuickAdd: Unsupported |case style "${caseStyle}" in token "${tokenDisplay}". Supported styles: ${SUPPORTED_CASE_STYLES.join(", ")}.`,
+			);
+		caseStyle = undefined;
+	}
+
 	// |multi needs an option list and is incompatible with |case (a list is not
 	// case-transformed, and routing an array through transformCase would throw).
 	if (multiSelect && !hasOptions) {
@@ -801,6 +814,23 @@ export function parseValueToken(
 				`QuickAdd: |case is ignored with |multi in "${tokenDisplay}" — a list is not case-transformed.`,
 			);
 		caseStyle = undefined;
+	}
+
+	// A bare `|custom` only enables free-text-with-autocomplete on an option-list
+	// token (2+ values). On a single value it falls through to being parsed as the
+	// literal default text "custom", silently pre-filling the prompt with that
+	// word. Warn (mirroring "|multi needs an option list") so the author isn't
+	// surprised, and drop the bogus default so the prompt opens empty.
+	if (
+		!hasOptions &&
+		!options.usesOptions &&
+		optionParts.some((part) => part.trim().toLowerCase() === "custom")
+	) {
+		if (!quiet)
+			log.logWarning(
+				`QuickAdd: |custom needs an option list (2+ comma-separated values) in "${tokenDisplay}"; ignoring.`,
+			);
+		if (defaultValue.toLowerCase() === "custom") defaultValue = "";
 	}
 
 	const variableKey = aliasName
@@ -831,6 +861,7 @@ export function parseValueToken(
 
 export function parseAnonymousValueOptions(
 	rawOptions: string,
+	opts?: { quiet?: boolean },
 ): {
 	label?: string;
 	caseStyle?: string;
@@ -841,6 +872,7 @@ export function parseAnonymousValueOptions(
 	optional: boolean;
 	trim: boolean;
 } {
+	const quiet = opts?.quiet ?? false;
 	const normalized = stripLeadingPipe(rawOptions);
 	const allParts = splitPipeParts(normalized)
 		.map((part) => part.trim())
@@ -866,6 +898,18 @@ export function parseAnonymousValueOptions(
 	let { label, caseStyle, defaultValue } = options;
 	if (!options.usesOptions) {
 		defaultValue = defaultValue.trim();
+	}
+
+	// Warn on an unrecognized |case style (typo) so the anonymous form gets the
+	// same feedback as the named/single form (parseValueToken). Gated on quiet
+	// so the prompt-context pre-pass (which also calls this) does not double the
+	// notice — mirroring parseValueToken's quiet handling.
+	if (caseStyle && !isSupportedCaseStyle(caseStyle)) {
+		if (!quiet)
+			log.logWarning(
+				`QuickAdd: Unsupported |case style "${caseStyle}" in token "${tokenDisplay}". Supported styles: ${SUPPORTED_CASE_STYLES.join(", ")}.`,
+			);
+		caseStyle = undefined;
 	}
 
 	const inputTypeOverride = resolveInputType(options.inputTypeOverride, {


### PR DESCRIPTION
This PR bundles 17 fixes from a systematic feature audit (logic + UX), each adversarially verified and covered by regression tests.

- **[Minor]** {{SELECTED}} infinite-loops (hangs Obsidian) when the selection contains the literal text "{{SELECTED}}"
- **[Minor]** Injected {{title}} in a file name is left literal instead of throwing the circular-title error
- **[Minor]** Invalid {{VALUE|case:<style>}} value silently does nothing (no warning)
- **[Minor]** Named-value option-list conflict warning goes only to the console, not a Notice
- **[Minor]** Circular-{{title}} guard in file names / folder paths is bypassed by a global variable that expands to {{title}}
- **[Minor]** Unknown / misspelled FIELD filter keys are silently ignored with no feedback
- **[Minor]** Multi-select FIELD ignores the smart-default / no-values fallback that single-select provides
- **[Minor]** A leading empty-name {{VDATE}} token silently blocks ALL later {{VDATE}} prompts
- **[Minor]** Anonymous {{VALUE|default:X}} ignores the default on an empty submission (named form applies it)
- **[Minor]** Anonymous {{VALUE|type:checkbox}} is bypassed by an active editor selection (stores free text, not true/false)
- **[Minor]** Conflicting |name: definitions warn only to console, not as a Notice
- **[Minor]** Optional option-list tokens have no touch/mouse Skip control (keyboard-only)
- **[Minor]** Invalid |case:<style> is silently ignored with no feedback
- **[Minor]** |custom on a single value (no option list) silently becomes a literal default
- **[Trivial]** Format-syntax suggester offers {{FILE:...|optional}} in the file-name field where it is invalid
- **[Trivial]** {{FILENAMECURRENT}} is not offered by the file-name token suggester despite being valid there
- **[Trivial]** No keyboard shortcut to Skip on text/number/slider/wide prompts (only suggesters have one)

All tests/typecheck/lint/build green. Part of a 9-PR series splitting the audit by area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added a visual “Skip (leave empty)” button to suggesters.
  * Improved file-name token suggestions with `{{FILENAMECURRENT...}}` support and better optional/link/path gating.
* **Bug Fixes**
  * Fixed circular dependency handling for `{{title}}` expansion (including indirect cases).
  * Corrected anonymous `{{VALUE|...}}` defaulting rules and tightened checkbox handling for boolean-like selections.
  * Refined `{{SELECTED}}` replacement to avoid re-scanning issues.
  * Improved VDATE handling for malformed tokens and enhanced VDATE preview hints.
* **Improvements**
  * Added warnings for unknown `{{FIELD:...}}` filter keys and improved `|case:` validation behavior.
  * Better `{{FOLDER}}` previews with an accurate target folder path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->