### PR TITLE
fix(ai-tools): tool-confirm safety, agent progress feedback, and step accounting

### DIFF
--- a/src/ai/tools/Agent.audit-ai-tools.test.ts
+++ b/src/ai/tools/Agent.audit-ai-tools.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CommonResponse } from "../OpenAIRequest";
+
+// Mirror Agent.test.ts harness: mock the Obsidian-coupled deps the Agent reaches for.
+const chatRequestMock = vi.fn<(...args: unknown[]) => Promise<CommonResponse>>();
+vi.mock("../OpenAIRequest", () => ({
+	chatRequest: (...args: unknown[]) => chatRequestMock(...args),
+	anthropicMaxTokens: () => 8192,
+}));
+
+const confirmMock = vi.fn<() => Promise<string>>(async () => "allow");
+vi.mock("../../gui/AIToolConfirmModal", () => ({
+	default: { Prompt: () => confirmMock() },
+}));
+
+vi.mock("../../formatters/completeFormatter", () => ({
+	CompleteFormatter: class {
+		async formatFileContent(input: string) {
+			return input;
+		}
+	},
+}));
+
+vi.mock("../aiHelpers", () => ({
+	getModelByName: (name: string) => ({ name, maxTokens: 128000 }),
+	getModelProvider: () => ({ name: "OpenAI", kind: "openai", endpoint: "https://x" }),
+}));
+
+vi.mock("../providerSecrets", () => ({ resolveProviderApiKey: async () => "key" }));
+vi.mock("../preventCursorChange", () => ({ preventCursorChange: () => () => {} }));
+
+let mockSettings: Record<string, unknown>;
+vi.mock("../../settingsStore", () => ({
+	settingsStore: { getState: () => mockSettings },
+}));
+
+import { Agent } from "./Agent";
+import type { AgentConfig } from "./aiToolTypes";
+
+function makeAgent(config: Partial<AgentConfig> = {}, vars = new Map<string, unknown>()) {
+	const choiceExecutor = { variables: vars } as never;
+	return new Agent({} as never, {} as never, choiceExecutor, {
+		model: "gpt-4o",
+		...config,
+	} as AgentConfig);
+}
+
+function turnResponse(p: Partial<CommonResponse>): CommonResponse {
+	return {
+		id: "r",
+		model: "gpt-4o",
+		content: p.content ?? "",
+		usage: p.usage ?? { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+		stopReason: p.stopReason ?? "",
+		stopSequence: null,
+		created: 0,
+		toolCalls: p.toolCalls,
+		normalizedStopReason: p.normalizedStopReason ?? (p.toolCalls?.length ? "tool_calls" : "stop"),
+	};
+}
+
+function tool(extra: Record<string, unknown> = {}) {
+	return {
+		__qaTool: true as const,
+		description: "writes a note",
+		inputSchema: {
+			type: "object" as const,
+			properties: { path: { type: "string" as const } },
+			required: ["path"],
+		},
+		execute: vi.fn(async () => "ok"),
+		...extra,
+	};
+}
+
+beforeEach(() => {
+	chatRequestMock.mockReset();
+	confirmMock.mockReset();
+	confirmMock.mockResolvedValue("allow");
+	mockSettings = {
+		disableOnlineFeatures: false,
+		// global 'never' so ONLY a per-tool needsApproval floor can trigger the modal.
+		ai: { confirmToolCalls: "never", defaultSystemPrompt: "" },
+	};
+});
+
+describe("ai-tools-tool-confirm-modal: approve-all does not bypass the per-tool needsApproval floor", () => {
+	it("re-confirms a needsApproval:true tool on every call even after 'Approve all this run'", async () => {
+		// First call: model invokes the writer; user clicks "Approve all this run".
+		// Second call: same needsApproval:true writer — must STILL be confirmed.
+		confirmMock.mockResolvedValueOnce("allow-all").mockResolvedValueOnce("allow");
+		const t = tool({ needsApproval: true });
+		chatRequestMock
+			.mockResolvedValueOnce(turnResponse({ toolCalls: [{ id: "c1", name: "write", args: { path: "a.md" } }] }))
+			.mockResolvedValueOnce(turnResponse({ toolCalls: [{ id: "c2", name: "write", args: { path: "b.md" } }] }))
+			.mockResolvedValueOnce(turnResponse({ content: "done", normalizedStopReason: "stop" }));
+
+		const agent = makeAgent({ tools: { write: t } });
+		await agent.generate({ prompt: "write two notes" });
+
+		// Before the fix the second call auto-ran (approveAllThisRun short-circuited
+		// before the per-tool floor) → confirm called once. After: called twice.
+		expect(confirmMock).toHaveBeenCalledTimes(2);
+		expect(t.execute).toHaveBeenCalledTimes(2);
+	});
+
+	it("approve-all DOES auto-run a tool whose approval came only from the global setting", async () => {
+		// 'destructive' global, non-readOnly tool with NO per-tool needsApproval.
+		mockSettings.ai = { confirmToolCalls: "destructive", defaultSystemPrompt: "" };
+		confirmMock.mockResolvedValueOnce("allow-all");
+		const t = tool({ readOnly: false });
+		chatRequestMock
+			.mockResolvedValueOnce(turnResponse({ toolCalls: [{ id: "c1", name: "write", args: { path: "a.md" } }] }))
+			.mockResolvedValueOnce(turnResponse({ toolCalls: [{ id: "c2", name: "write", args: { path: "b.md" } }] }))
+			.mockResolvedValueOnce(turnResponse({ content: "done", normalizedStopReason: "stop" }));
+
+		const agent = makeAgent({ tools: { write: t } });
+		await agent.generate({ prompt: "write two notes" });
+
+		// Only the first call prompts; allow-all then suppresses the global-only gate.
+		expect(confirmMock).toHaveBeenCalledTimes(1);
+		expect(t.execute).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/ai/tools/Agent.audit-cleanup.test.ts
+++ b/src/ai/tools/Agent.audit-cleanup.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CommonResponse } from "../OpenAIRequest";
+
+// ai-tools-agent-generate-text: a multi-step agent run must surface start/step/finish
+// status Notices through makeNoticeHandler — mirroring the legacy ai.prompt path —
+// and ONLY when the "Show assistant messages" (ai.showAssistant) setting is on.
+
+// --- Mirror Agent.test.ts harness: mock the Obsidian-coupled deps. ---
+const chatRequestMock = vi.fn<(...args: unknown[]) => Promise<CommonResponse>>();
+vi.mock("../OpenAIRequest", () => ({
+	chatRequest: (...args: unknown[]) => chatRequestMock(...args),
+	anthropicMaxTokens: () => 8192,
+}));
+
+const confirmMock = vi.fn<() => Promise<string>>(async () => "allow");
+vi.mock("../../gui/AIToolConfirmModal", () => ({
+	default: { Prompt: () => confirmMock() },
+}));
+
+vi.mock("../../formatters/completeFormatter", () => ({
+	CompleteFormatter: class {
+		async formatFileContent(input: string) {
+			return input;
+		}
+	},
+}));
+
+vi.mock("../aiHelpers", () => ({
+	getModelByName: (name: string) => ({ name, maxTokens: 128000 }),
+	getModelProvider: () => ({ name: "OpenAI", kind: "openai", endpoint: "https://x" }),
+}));
+
+vi.mock("../providerSecrets", () => ({ resolveProviderApiKey: async () => "key" }));
+vi.mock("../preventCursorChange", () => ({ preventCursorChange: () => () => {} }));
+
+// Capture every status emitted through the notice handler. Gated path: when
+// makeNoticeHandler is created with showMessages=false it returns a no-op handler,
+// so we record the showMessages flag the Agent passed too.
+const noticeCalls: Array<{ status: string; msg: string }> = [];
+const makeNoticeHandlerMock = vi.fn((showMessages: boolean) => {
+	if (!showMessages) {
+		return { setMessage: () => {}, hide: () => {} };
+	}
+	return {
+		setMessage: (status: string, msg: string) => noticeCalls.push({ status, msg }),
+		hide: () => {},
+	};
+});
+vi.mock("../makeNoticeHandler", () => ({
+	makeNoticeHandler: (showMessages: boolean) => makeNoticeHandlerMock(showMessages),
+}));
+
+let mockSettings: Record<string, unknown>;
+vi.mock("../../settingsStore", () => ({
+	settingsStore: { getState: () => mockSettings },
+}));
+
+import { Agent } from "./Agent";
+import type { AgentConfig } from "./aiToolTypes";
+
+function makeAgent(config: Partial<AgentConfig> = {}, vars = new Map<string, unknown>()) {
+	const choiceExecutor = { variables: vars } as never;
+	return new Agent({} as never, {} as never, choiceExecutor, {
+		model: "gpt-4o",
+		...config,
+	} as AgentConfig);
+}
+
+function turnResponse(p: Partial<CommonResponse>): CommonResponse {
+	return {
+		id: "r",
+		model: "gpt-4o",
+		content: p.content ?? "",
+		usage: p.usage ?? { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+		stopReason: p.stopReason ?? "",
+		stopSequence: null,
+		created: 0,
+		toolCalls: p.toolCalls,
+		normalizedStopReason: p.normalizedStopReason ?? (p.toolCalls?.length ? "tool_calls" : "stop"),
+	};
+}
+
+function tool(extra: Record<string, unknown> = {}) {
+	return {
+		__qaTool: true as const,
+		description: "create a note",
+		inputSchema: {
+			type: "object" as const,
+			properties: { path: { type: "string" as const } },
+			required: ["path"],
+		},
+		execute: vi.fn(async () => "created"),
+		...extra,
+	};
+}
+
+beforeEach(() => {
+	chatRequestMock.mockReset();
+	confirmMock.mockReset();
+	confirmMock.mockResolvedValue("allow");
+	makeNoticeHandlerMock.mockClear();
+	noticeCalls.length = 0;
+	mockSettings = {
+		disableOnlineFeatures: false,
+		ai: { confirmToolCalls: "never", defaultSystemPrompt: "", showAssistant: true },
+	};
+});
+
+describe("ai-tools-agent-generate-text: status notices follow ai.showAssistant", () => {
+	it("emits start, per-step, and finish status notices for a multi-step run when showAssistant is on", async () => {
+		const t = tool();
+		chatRequestMock
+			.mockResolvedValueOnce(
+				turnResponse({ toolCalls: [{ id: "c1", name: "create_note", args: { path: "a.md" } }] }),
+			)
+			.mockResolvedValueOnce(turnResponse({ content: "done", normalizedStopReason: "stop" }));
+
+		const agent = makeAgent({ tools: { create_note: t } });
+		await agent.generate({ prompt: "make a note" });
+
+		expect(makeNoticeHandlerMock).toHaveBeenCalledWith(true);
+		const statuses = noticeCalls.map((c) => c.status);
+		// start, one per step (tool step + final text step), finish.
+		expect(statuses[0]).toBe("starting");
+		expect(statuses[statuses.length - 1]).toBe("finished");
+		// At least one mid-run "thinking" step notice was emitted.
+		expect(statuses).toContain("thinking");
+		// A step that ran a tool names the tool; the wrap-up step mentions a response.
+		const stepMessages = noticeCalls.filter((c) => c.status === "thinking").map((c) => c.msg);
+		expect(stepMessages.some((m) => m.includes("create_note"))).toBe(true);
+		expect(stepMessages.some((m) => /generating a response/i.test(m))).toBe(true);
+	});
+
+	it("emits NO notices when showAssistant is off (no-op handler)", async () => {
+		mockSettings.ai = { confirmToolCalls: "never", defaultSystemPrompt: "", showAssistant: false };
+		chatRequestMock.mockResolvedValueOnce(turnResponse({ content: "done", normalizedStopReason: "stop" }));
+
+		const agent = makeAgent();
+		await agent.generate({ prompt: "hi" });
+
+		expect(makeNoticeHandlerMock).toHaveBeenCalledWith(false);
+		expect(noticeCalls).toHaveLength(0);
+	});
+
+	it("emits a 'dead' failure status when the run throws", async () => {
+		chatRequestMock.mockRejectedValueOnce(new Error("provider exploded"));
+		const agent = makeAgent();
+		await expect(agent.generate({ prompt: "boom" })).rejects.toThrow(/provider exploded/);
+
+		const statuses = noticeCalls.map((c) => c.status);
+		expect(statuses[0]).toBe("starting");
+		expect(statuses).toContain("dead");
+		const dead = noticeCalls.find((c) => c.status === "dead");
+		expect(dead?.msg).toMatch(/provider exploded/);
+	});
+});

--- a/src/ai/tools/Agent.ts
+++ b/src/ai/tools/Agent.ts
@@ -12,6 +12,7 @@ import type QuickAdd from "../../main";
 import type { IChoiceExecutor } from "../../IChoiceExecutor";
 import { settingsStore } from "../../settingsStore";
 import { CompleteFormatter } from "../../formatters/completeFormatter";
+import { makeNoticeHandler } from "../makeNoticeHandler";
 import { MacroAbortError } from "../../errors/MacroAbortError";
 import { getModelByName, getModelProvider } from "../aiHelpers";
 import type { Model } from "../Provider";
@@ -193,48 +194,83 @@ export class Agent {
 			Math.min(this.config.maxSteps ?? DEFAULT_MAX_STEPS, MAX_STEPS_CEILING),
 		);
 
-		const loop = await runToolLoop({
-			request,
-			maxSteps,
-			dispatch: async (req, ctx) => {
-				const turnReq = this.buildTurnRequest(req, ctx.isFinalStep, responseFormat);
-				const cr = await chatRequest(
-					this.app,
-					apiKey,
+		// Mirror the legacy ai.prompt status surface (makeNoticeHandler): a single
+		// persistent Notice updated through the multi-step run, only when the
+		// "Show assistant messages" setting is on. No-op handler otherwise.
+		const notice = makeNoticeHandler(pluginSettings.ai.showAssistant);
+		notice.setMessage("starting", "QuickAdd is running the AI agent.");
+
+		try {
+			const loop = await runToolLoop({
+				request,
+				maxSteps,
+				dispatch: async (req, ctx) => {
+					const turnReq = this.buildTurnRequest(req, ctx.isFinalStep, responseFormat);
+					const cr = await chatRequest(
+						this.app,
+						apiKey,
+						model,
+						turnReq,
+						restoreCursor,
+					);
+					return toParsed(cr);
+				},
+				getTool: (name) => registry.get(name),
+				confirm: (call, tool) => this.confirm(call, tool),
+				validateArgs: (tool, args) =>
+					validateValue(args, tool.definition.parameters),
+				isAbortError,
+				isContextOverflow: (e) => classifyProviderError(e) === "input_context",
+				isOnlineDisabled: () => settingsStore.getState().disableOnlineFeatures,
+				shouldStop: this.buildShouldStop(),
+				onStepFinish: (step) => this.reportStep(notice, step),
+			});
+
+			const result = this.toGenerateResult(loop);
+
+			if (options.schema) {
+				result.object = await this.resolveStructuredObject(
+					loop,
+					request,
 					model,
-					turnReq,
+					apiKey,
+					options.schema,
 					restoreCursor,
 				);
-				return toParsed(cr);
-			},
-			getTool: (name) => registry.get(name),
-			confirm: (call, tool) => this.confirm(call, tool),
-			validateArgs: (tool, args) =>
-				validateValue(args, tool.definition.parameters),
-			isAbortError,
-			isContextOverflow: (e) => classifyProviderError(e) === "input_context",
-			isOnlineDisabled: () => settingsStore.getState().disableOnlineFeatures,
-			shouldStop: this.buildShouldStop(),
-		});
+			}
 
-		const result = this.toGenerateResult(loop);
+			if (
+				typeof options.assignToVariable === "string" &&
+				options.assignToVariable
+			) {
+				this.assignVariable(options.assignToVariable, result.text);
+			}
 
-		if (options.schema) {
-			result.object = await this.resolveStructuredObject(
-				loop,
-				request,
-				model,
-				apiKey,
-				options.schema,
-				restoreCursor,
+			notice.setMessage(
+				"finished",
+				`Ran ${result.steps.length} step${result.steps.length === 1 ? "" : "s"}.`,
 			);
-		}
+			window.setTimeout(() => notice.hide(), 5000);
 
-		if (typeof options.assignToVariable === "string" && options.assignToVariable) {
-			this.assignVariable(options.assignToVariable, result.text);
+			return result;
+		} catch (error) {
+			notice.setMessage("dead", (error as { message?: string })?.message ?? "");
+			window.setTimeout(() => notice.hide(), 5000);
+			throw error;
 		}
+	}
 
-		return result;
+	/** Emit a per-step progress Notice mirroring the legacy ai.prompt status surface. */
+	private reportStep(
+		notice: { setMessage: (status: string, msg: string) => void },
+		step: LoopStep,
+	): void {
+		const toolNames = step.toolCalls.map((c) => c.name);
+		const msg =
+			toolNames.length > 0
+				? `Step ${step.stepNumber + 1}: running ${toolNames.join(", ")}.`
+				: `Step ${step.stepNumber + 1}: generating a response.`;
+		notice.setMessage("thinking", msg);
 	}
 
 	// --- request assembly -------------------------------------------------
@@ -338,9 +374,15 @@ export class Agent {
 		call: { id: string; name: string; args: Record<string, unknown> | null },
 		tool: ToolEntry,
 	): Promise<boolean> {
-		const needs = await this.needsConfirmation(tool, call.args ?? {});
+		const args = call.args ?? {};
+		// A tool's own needsApproval:true is the safety floor — it is "always ask"
+		// regardless of the global setting AND regardless of "Approve all this run",
+		// so we never let an allow-all click bypass it (a later destructive write tool
+		// the author marked needsApproval:true must still be re-confirmed).
+		const perToolFloor = await this.resolvePerToolApproval(tool, args);
+		const needs = perToolFloor || this.needsGlobalConfirmation(tool);
 		if (!needs) return true;
-		if (this.approveAllThisRun) return true;
+		if (this.approveAllThisRun && !perToolFloor) return true;
 
 		const outcome = await AIToolConfirmModal.Prompt(
 			this.app,
@@ -357,18 +399,22 @@ export class Agent {
 		return outcome === "allow";
 	}
 
-	private async needsConfirmation(
+	/**
+	 * Resolve a tool's OWN needsApproval gate (the "always ask" floor). True here
+	 * means the call must be confirmed even under "Approve all this run".
+	 */
+	private async resolvePerToolApproval(
 		tool: ToolEntry,
 		args: Record<string, unknown>,
 	): Promise<boolean> {
 		const declared = this.config.tools?.[tool.definition.name];
 		const perTool = declared?.needsApproval;
-		const resolved =
-			typeof perTool === "function"
-				? await perTool({ args })
-				: perTool === true;
-		if (resolved) return true; // a tool's own approval is the floor — always confirm
+		return typeof perTool === "function"
+			? await perTool({ args })
+			: perTool === true;
+	}
 
+	private needsGlobalConfirmation(tool: ToolEntry): boolean {
 		// Default to "destructive" when the persisted value is missing: main.ts
 		// shallow-merges loadedData, so an existing user's pre-`confirmToolCalls`
 		// `ai` object replaces DEFAULT_SETTINGS.ai wholesale and leaves this

--- a/src/ai/tools/builtins/shared.audit-ai-tools.test.ts
+++ b/src/ai/tools/builtins/shared.audit-ai-tools.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+import { applyGroupOptions, defineTool } from "./shared";
+import { createWorkspaceTools } from "./workspaceTools";
+import { log } from "src/logger/logManager";
+
+function makeApp(over: Record<string, unknown> = {}): App {
+	return {
+		vault: {
+			cachedRead: vi.fn(async () => "binary-bytes"),
+			...((over.vault as object) ?? {}),
+		},
+		workspace: {
+			getActiveFile: vi.fn(() => null),
+			getActiveViewOfType: vi.fn(() => null),
+			...((over.workspace as object) ?? {}),
+		},
+	} as unknown as App;
+}
+
+function fileLike(path: string, extension: string): TFile {
+	const f = Object.create(TFile.prototype) as TFile;
+	const basename = path.replace(/\.[^.]+$/, "");
+	Object.assign(f, { path, basename, extension });
+	return f;
+}
+
+describe("ai-tools-builtin-workspace: get_active_note markdown guard", () => {
+	it("returns active:null when the active file is NOT markdown (PDF/image/canvas)", async () => {
+		const pdf = fileLike("Docs/paper.pdf", "pdf");
+		const cachedRead = vi.fn(async () => "%PDF-1.7 binary…");
+		const app = makeApp({
+			vault: { cachedRead },
+			workspace: { getActiveFile: () => pdf },
+		});
+		const tools = createWorkspaceTools(app);
+		const res = await tools.get_active_note.execute(
+			{},
+			{ toolCallId: "c", toolName: "get_active_note" },
+		);
+		// Before the fix this read the PDF bytes back as active.content.
+		expect(res).toEqual({ active: null });
+		expect(cachedRead).not.toHaveBeenCalled();
+	});
+
+	it("still returns markdown content when a .md note is active", async () => {
+		const note = fileLike("Notes/Foo.md", "md");
+		const app = makeApp({
+			vault: { cachedRead: vi.fn(async () => "# hi") },
+			workspace: { getActiveFile: () => note },
+		});
+		const tools = createWorkspaceTools(app);
+		const res = (await tools.get_active_note.execute(
+			{},
+			{ toolCallId: "c", toolName: "get_active_note" },
+		)) as { active: { path: string; content: string } | null };
+		expect(res.active).toMatchObject({ path: "Notes/Foo.md", content: "# hi" });
+	});
+});
+
+describe("api-ai-builtin-tools-vault: only/exclude warn on unknown names", () => {
+	const set = {
+		read_note: defineTool({ description: "r", inputSchema: { type: "object" }, execute: async () => 1 }),
+		create_note: defineTool({ description: "c", inputSchema: { type: "object" }, execute: async () => 2 }),
+	};
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("warns naming the unknown tool and the valid names when `only` has a typo", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		// 'read_notes' is a typo for 'read_note' → empty map, silent before the fix.
+		const result = applyGroupOptions(set, { only: ["read_notes"] });
+		expect(Object.keys(result)).toEqual([]);
+		expect(warn).toHaveBeenCalledTimes(1);
+		const msg = warn.mock.calls[0][0] as string;
+		expect(msg).toContain("read_notes");
+		expect(msg).toContain("read_note");
+		expect(msg).toContain("create_note");
+	});
+
+	it("warns when `exclude` names a tool that is not in the group", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		const result = applyGroupOptions(set, { exclude: ["delete_note"] });
+		// exclude typo leaves the tool in (the silent failure the finding describes).
+		expect(Object.keys(result)).toEqual(["read_note", "create_note"]);
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0] as string).toContain("delete_note");
+	});
+
+	it("does NOT warn when only/exclude entries all match", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		applyGroupOptions(set, { only: ["read_note"], exclude: ["create_note"] });
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/src/ai/tools/builtins/shared.ts
+++ b/src/ai/tools/builtins/shared.ts
@@ -1,3 +1,4 @@
+import { log } from "src/logger/logManager";
 import type { QATool, ToolSet } from "../aiToolTypes";
 
 export type ToolSetMap = ToolSet;
@@ -23,6 +24,9 @@ export function applyGroupOptions(
 	options: BuiltinGroupOptions,
 ): ToolSetMap {
 	let entries = Object.entries(tools);
+	const known = new Set(entries.map(([name]) => name));
+	warnUnknownNames(options.only, known, "only");
+	warnUnknownNames(options.exclude, known, "exclude");
 	if (options.only) {
 		const allow = new Set(options.only);
 		entries = entries.filter(([name]) => allow.has(name));
@@ -39,4 +43,24 @@ export function applyGroupOptions(
 
 export function defineTool(def: Omit<QATool, "__qaTool">): QATool {
 	return { ...def, __qaTool: true };
+}
+
+/**
+ * Warn when an only/exclude entry matches no tool in the group — a typo such as
+ * only:['read_notes'] (correct: 'read_note') otherwise silently yields an empty (or
+ * unfiltered) tool map with no signal to debug against.
+ */
+function warnUnknownNames(
+	names: string[] | undefined,
+	known: Set<string>,
+	option: "only" | "exclude",
+): void {
+	if (!names) return;
+	const unknown = names.filter((name) => !known.has(name));
+	if (unknown.length === 0) return;
+	log.logWarning(
+		`AI tools: ${option} listed unknown tool name(s) ${unknown
+			.map((n) => `"${n}"`)
+			.join(", ")}. Valid names: ${[...known].join(", ")}.`,
+	);
 }

--- a/src/ai/tools/builtins/workspaceTools.ts
+++ b/src/ai/tools/builtins/workspaceTools.ts
@@ -18,7 +18,12 @@ export function createWorkspaceTools(
 			readOnly: true,
 			execute: async () => {
 				const file = app.workspace.getActiveFile();
-				if (!(file instanceof TFile)) return { active: null };
+				// Only markdown notes count as the "active note": getActiveFile()
+				// returns a TFile for ANY active file (PDF, image, canvas, …), and
+				// cachedRead-ing those would feed raw/binary bytes into the transcript.
+				if (!(file instanceof TFile) || file.extension !== "md") {
+					return { active: null };
+				}
 				const content = await app.vault.cachedRead(file);
 				return {
 					active: {

--- a/src/ai/tools/runToolLoop.audit-cleanup.test.ts
+++ b/src/ai/tools/runToolLoop.audit-cleanup.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+	runToolLoop,
+	type RunToolLoopDeps,
+	type ToolEntry,
+} from "./runToolLoop";
+import type { NormalizedToolCall } from "./NormalizedTools";
+import type { ParsedChatResult } from "./providerToolMapping";
+
+// ai-tools-cost-exfil-caps: 'max-steps' must be reachable when the step budget
+// forces the final turn — not derived from residual tool calls. The Agent strips
+// tools on the final step (tools:undefined / toolChoice:'none'), so a real run can
+// never present residual tool calls on the final turn. These tests pin the
+// budget-forced classification independent of any residual-toolCalls signal.
+
+function turn(p: Partial<ParsedChatResult>): ParsedChatResult {
+	return {
+		content: p.content ?? "",
+		toolCalls: p.toolCalls ?? [],
+		normalizedStopReason:
+			p.normalizedStopReason ?? (p.toolCalls?.length ? "tool_calls" : "stop"),
+		rawStopReason: p.rawStopReason ?? "",
+		usage: p.usage ?? { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+		providerRaw: p.providerRaw,
+	};
+}
+
+function call(name: string, args: Record<string, unknown> | null): NormalizedToolCall {
+	return { id: `c-${name}`, name, args };
+}
+
+function toolEntry(name: string, execute: ToolEntry["execute"]): ToolEntry {
+	return {
+		definition: { name, description: name, parameters: { type: "object", properties: {} } },
+		execute,
+	};
+}
+
+function makeDeps(
+	tools: Record<string, ToolEntry>,
+	overrides: Partial<RunToolLoopDeps>,
+): RunToolLoopDeps {
+	return {
+		request: {
+			messages: [{ role: "user", content: "go" }],
+			tools: Object.values(tools).map((t) => t.definition),
+		},
+		dispatch: vi.fn(async () => turn({ content: "done", normalizedStopReason: "stop" })),
+		getTool: (name) => tools[name],
+		confirm: async () => true,
+		validateArgs: () => null,
+		isAbortError: () => false,
+		maxSteps: 8,
+		...overrides,
+	};
+}
+
+describe("runToolLoop — budget-forced max-steps (audit cleanup)", () => {
+	it("reports 'max-steps' when the budget forces the final step, even with tools stripped (no residual tool calls)", async () => {
+		// Mirror the Agent: the final step sends NO tools, so the model returns plain
+		// text with a 'stop' reason. Without the budget-forced flag this would be
+		// reported as 'stop' (the old residual-toolCalls path is unreachable here).
+		const deps = makeDeps(
+			{ t: toolEntry("t", async () => "x") },
+			{
+				maxSteps: 2,
+				dispatch: vi.fn(async (_req, ctx) =>
+					ctx.isFinalStep
+						? turn({ content: "forced wrap-up", normalizedStopReason: "stop" })
+						: turn({ toolCalls: [call("t", {})] }),
+				),
+			},
+		);
+		const res = await runToolLoop(deps);
+		expect(res.finishReason).toBe("max-steps");
+		expect(res.text).toBe("forced wrap-up");
+	});
+
+	it("reports 'stop' (not 'max-steps') when a stopWhen condition forced the final step", async () => {
+		// stopWhen trips after the first tool step → forceFinal. Even if that final
+		// step coincides with the budget, a graceful stop must win over max-steps.
+		const deps = makeDeps(
+			{ t: toolEntry("t", async () => "x") },
+			{
+				maxSteps: 2,
+				shouldStop: ({ steps }) => steps.some((s) => s.toolResults.length > 0),
+				dispatch: vi.fn(async (_req, ctx) =>
+					ctx.isFinalStep
+						? turn({ content: "stopped early", normalizedStopReason: "stop" })
+						: turn({ toolCalls: [call("t", {})] }),
+				),
+			},
+		);
+		const res = await runToolLoop(deps);
+		expect(res.finishReason).toBe("stop");
+		expect(res.text).toBe("stopped early");
+	});
+
+	it("reports 'stop' (not 'max-steps') when the transcript-bytes ceiling forced the final step", async () => {
+		const big = "x".repeat(2000);
+		const deps = makeDeps(
+			{ t: toolEntry("t", async () => big) },
+			{
+				maxSteps: 8,
+				maxTranscriptBytes: 100,
+				dispatch: vi.fn(async (_req, ctx) =>
+					ctx.isFinalStep
+						? turn({ content: "wrapped up", normalizedStopReason: "stop" })
+						: turn({ toolCalls: [call("t", {})] }),
+				),
+			},
+		);
+		const res = await runToolLoop(deps);
+		expect(res.finishReason).toBe("stop");
+	});
+
+	it("reports 'stop' for a single-turn (maxSteps 1) run where the model just answers", async () => {
+		// A degenerate budget-forced-on-step-0 run is a one-shot answer, not an
+		// agentic budget exhaustion — must stay 'stop'.
+		const deps = makeDeps(
+			{ t: toolEntry("t", async () => "x") },
+			{
+				maxSteps: 1,
+				dispatch: vi.fn(async () => turn({ content: "single answer", normalizedStopReason: "stop" })),
+			},
+		);
+		const res = await runToolLoop(deps);
+		expect(res.finishReason).toBe("stop");
+		expect(res.text).toBe("single answer");
+	});
+
+	it("'length' still takes precedence over a budget-forced final step", async () => {
+		const deps = makeDeps(
+			{ t: toolEntry("t", async () => "x") },
+			{
+				maxSteps: 2,
+				dispatch: vi.fn(async (_req, ctx) =>
+					ctx.isFinalStep
+						? turn({ content: "cut", normalizedStopReason: "length" })
+						: turn({ toolCalls: [call("t", {})] }),
+				),
+			},
+		);
+		const res = await runToolLoop(deps);
+		expect(res.finishReason).toBe("length");
+	});
+});

--- a/src/ai/tools/runToolLoop.ts
+++ b/src/ai/tools/runToolLoop.ts
@@ -182,7 +182,13 @@ export async function runToolLoop(
 			return finish("aborted");
 		}
 
-		const isFinalStep = forceFinal || step === maxSteps - 1;
+		// A step is final because the budget ran out (step ceiling) OR because a
+		// prior step tripped stopWhen / the transcript-bytes ceiling (forceFinal).
+		// Track WHICH so the early-return branch can report 'max-steps' only when the
+		// budget forced it — the residual-toolCalls heuristic is unreachable via the
+		// Agent, which strips tools on the final step (tools:undefined/toolChoice:'none').
+		const budgetForcedFinal = step === maxSteps - 1;
+		const isFinalStep = forceFinal || budgetForcedFinal;
 		const turnReq: NormalizedChatRequest = {
 			...deps.request,
 			messages,
@@ -224,13 +230,23 @@ export async function runToolLoop(
 				usage: turn.usage,
 			});
 			await deps.onStepFinish?.(steps[steps.length - 1]);
-			// On the forced-final step the model can't actually run tools, so we land here.
+			// 'length' is a genuine provider output-cutoff signal and takes precedence.
+			// Otherwise report 'max-steps' only when the budget (step ceiling) forced
+			// this final step after at least one tool-using step — and no graceful stop
+			// (stopWhen / transcript-bytes) had already pre-empted it. Reaching a
+			// budget-forced final step at step > 0 means every prior step made tool
+			// calls (else the loop returns "stop" earlier), so the budget genuinely cut
+			// off an in-progress agentic run. A model that simply stopped, a single-turn
+			// (maxSteps 1) answer, or a stopWhen/transcript-forced wrap-up is 'stop'.
+			// (The Agent strips tools on the final step, so the model can no longer emit
+			// tool calls here; deriving max-steps from residual toolCalls was unreachable
+			// through the Agent.)
 			const reason: LoopFinishReason =
 				turn.normalizedStopReason === "length"
 					? "length"
-					: !isFinalStep || turn.toolCalls.length === 0
-						? "stop"
-						: "max-steps";
+					: budgetForcedFinal && !forceFinal && step > 0
+						? "max-steps"
+						: "stop";
 			return finish(reason);
 		}
 

--- a/src/gui/AIToolConfirmModal.audit-ai-tools.test.ts
+++ b/src/gui/AIToolConfirmModal.audit-ai-tools.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { summarizeToolCall } from "./AIToolConfirmModal";
+
+describe("ai-tools-tool-confirm-modal: summarizeToolCall surfaces the write target", () => {
+	it("surfaces the target path as a labeled line for a create/append call", () => {
+		expect(summarizeToolCall("create_note", { path: "Notes/Foo.md", content: "x" })).toBe(
+			"Target: Notes/Foo.md",
+		);
+	});
+
+	it("includes the heading when an insert_under_heading call has one", () => {
+		const summary = summarizeToolCall("insert_under_heading", {
+			path: "Notes/Bar.md",
+			heading: "Tasks",
+			content: "- [ ] x",
+		});
+		expect(summary).toContain("Target: Notes/Bar.md");
+		expect(summary).toContain("Heading: Tasks");
+	});
+
+	it("returns an empty summary when no recognizable target field is present", () => {
+		expect(summarizeToolCall("get_date", { format: "YYYY" })).toBe("");
+		expect(summarizeToolCall("noop", {})).toBe("");
+		expect(summarizeToolCall("noop", null)).toBe("");
+		expect(summarizeToolCall("noop", "not-an-object" as unknown)).toBe("");
+	});
+
+	it("ignores blank/whitespace-only path or heading values", () => {
+		expect(summarizeToolCall("create_note", { path: "   " })).toBe("");
+	});
+});

--- a/src/gui/AIToolConfirmModal.ts
+++ b/src/gui/AIToolConfirmModal.ts
@@ -11,7 +11,11 @@ export type ToolConfirmOutcome = "allow" | "allow-all" | "deny" | "abort";
  *  - deny       skip this call (the model gets an isError result and can adapt)
  *  - abort      cancel the whole AI run
  *
- * The safe option (Deny) is focused by default; Approve is destructive-styled.
+ * The safe option (Deny) is focused by default; Approve is NOT painted as the
+ * bright primary CTA, so visual emphasis matches the safe-by-default intent (the
+ * model — not the user — chose this action). The model-chosen target (path/heading)
+ * is surfaced as a labeled summary above the raw args so the dangerous detail is
+ * reviewable at a glance instead of buried in a JSON blob.
  * Dismissing (Esc / click-out) resolves to "deny" — declining THIS call, NOT
  * aborting the run (use the explicit Abort button for that).
  */
@@ -49,8 +53,28 @@ export default class AIToolConfirmModal extends Modal {
 		this.contentEl.createEl("p", {
 			text: "The AI requested this tool call with the arguments below.",
 		});
+
+		// Surface the model-chosen target (path/heading) as a labeled line so the
+		// safety-critical detail is reviewable without parsing the JSON.
+		const summary = summarizeToolCall(this.toolName, this.args);
+		if (summary) {
+			this.contentEl.createEl("p", {
+				cls: "qaAIToolSummary",
+				text: summary,
+			});
+		}
+
 		const pre = this.contentEl.createEl("pre", { cls: "qaAIToolArgs" });
-		pre.setText(safeStringify(this.args));
+		pre.textContent = safeStringify(this.args);
+		// No CSS ships for .qaAIToolArgs (the only styled `pre` is scoped to
+		// .quickadd-update-modal), so wrap + scroll inline — otherwise a long
+		// content string runs off the modal edge and can't be reviewed.
+		pre.setCssStyles({
+			whiteSpace: "pre-wrap",
+			wordBreak: "break-word",
+			maxHeight: "16rem",
+			overflowY: "auto",
+		});
 
 		const buttons = this.contentEl.createDiv({
 			cls: "yesNoPromptButtonContainer",
@@ -65,9 +89,10 @@ export default class AIToolConfirmModal extends Modal {
 		const allowAllBtn = new ButtonComponent(buttons)
 			.setButtonText("Approve all this run")
 			.onClick(() => this.submit("allow-all"));
+		// Deliberately NOT .setCta(): Approve runs a model-chosen action, so it must
+		// not be the bright primary button competing with the focused, safe Deny.
 		const allowBtn = new ButtonComponent(buttons)
 			.setButtonText("Approve")
-			.setCta()
 			.onClick(() => this.submit("allow"));
 
 		// Focus the safe option.
@@ -90,6 +115,23 @@ export default class AIToolConfirmModal extends Modal {
 		// Dismiss without an explicit choice = decline THIS call (not abort).
 		this.resolvePromise(this.outcome ?? "deny");
 	}
+}
+
+/**
+ * Build a one-line, plain-language summary of what a tool call will touch, from the
+ * model-chosen args. Pure (no DOM) so it is unit-testable. Returns "" when no
+ * recognizable target field is present (the raw args still render below it).
+ */
+export function summarizeToolCall(toolName: string, args: unknown): string {
+	if (!args || typeof args !== "object") return "";
+	const record = args as Record<string, unknown>;
+	const path = typeof record.path === "string" ? record.path.trim() : "";
+	const heading = typeof record.heading === "string" ? record.heading.trim() : "";
+	if (!path && !heading) return "";
+	const parts: string[] = [];
+	if (path) parts.push(`Target: ${path}`);
+	if (heading) parts.push(`Heading: ${heading}`);
+	return parts.join("  ·  ");
 }
 
 function safeStringify(value: unknown): string {


### PR DESCRIPTION
This PR bundles 7 fixes from a systematic feature audit (logic + UX), each adversarially verified and covered by regression tests.

- **[Minor]** get_active_note returns non-markdown file content instead of {active:null}
- **[Minor]** finishReason 'max-steps' is effectively unreachable through the Agent (hitting the step budget reports 'stop')
- **[Minor]** "Approve all this run" silently bypasses per-tool needsApproval floor
- **[Minor]** Confirm modal hides the safety-critical write path inside a raw JSON blob
- **[Minor]** Confirm-modal args <pre> has no wrapping/overflow styling
- **[Trivial]** Risky Approve button is styled as the primary CTA, contradicting safe-by-default intent
- **[Trivial]** Built-in tool group only/exclude silently ignore unknown tool names (no feedback on typos)

All tests/typecheck/lint/build green. Part of a 9-PR series splitting the audit by area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI assistant now displays status updates (starting, thinking, finished) when enabled
  * Tool confirmation modal now shows a plain-language summary of the tool's intended action
  * Improved tool approval: "Approve all this run" now respects per-tool approval requirements

* **Bug Fixes**
  * Fixed active note tool to properly skip non-Markdown files

* **Tests**
  * Added comprehensive test coverage for tool approval flows, status notifications, and built-in tool behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->