### PR TITLE
fix(prompts): suggester crashes, input handling, preflight, and API robustness

### DIFF
--- a/src/gui/GenericCheckboxPrompt/genericCheckboxPrompt.audit-api-prompts.test.ts
+++ b/src/gui/GenericCheckboxPrompt/genericCheckboxPrompt.audit-api-prompts.test.ts
@@ -1,0 +1,185 @@
+import type { App } from "obsidian";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// Mock obsidian with a local Modal/ButtonComponent/ToggleComponent so
+// super.onClose() resolves (the shared stub's Modal omits onClose on the
+// prototype, which super.onClose() needs). Mirrors GenericYesNoPrompt.test.ts.
+vi.mock("obsidian", () => {
+	class Modal {
+		app: App;
+		containerEl: HTMLElement;
+		contentEl: HTMLElement;
+		titleEl: HTMLElement;
+
+		constructor(app: App) {
+			this.app = app;
+			this.containerEl = document.createElement("div");
+			this.contentEl = document.createElement("div");
+			this.titleEl = document.createElement("h1");
+			this.containerEl.append(this.titleEl, this.contentEl);
+			document.body.appendChild(this.containerEl);
+		}
+
+		open() {}
+
+		close() {
+			this.onClose();
+		}
+
+		onClose() {}
+	}
+
+	class ButtonComponent {
+		buttonEl: HTMLButtonElement;
+
+		constructor(containerEl: HTMLElement) {
+			this.buttonEl = document.createElement("button");
+			containerEl.appendChild(this.buttonEl);
+		}
+
+		setButtonText(text: string): this {
+			this.buttonEl.textContent = text;
+			return this;
+		}
+
+		setCta(): this {
+			return this;
+		}
+
+		onClick(callback: () => void): this {
+			this.buttonEl.addEventListener("click", callback);
+			return this;
+		}
+	}
+
+	class ToggleComponent {
+		toggleEl: HTMLInputElement;
+
+		constructor(containerEl: HTMLElement) {
+			this.toggleEl = document.createElement("input");
+			this.toggleEl.type = "checkbox";
+			containerEl.appendChild(this.toggleEl);
+		}
+
+		setValue(value: boolean): this {
+			this.toggleEl.checked = value;
+			return this;
+		}
+
+		setTooltip(): this {
+			return this;
+		}
+
+		onChange(callback: (value: boolean) => void): this {
+			this.toggleEl.addEventListener("change", () =>
+				callback(this.toggleEl.checked),
+			);
+			return this;
+		}
+	}
+
+	return { ButtonComponent, Modal, ToggleComponent };
+});
+
+const { default: GenericCheckboxPrompt } = await import("./genericCheckboxPrompt");
+
+function installObsidianElementHelpers(): void {
+	const proto = HTMLElement.prototype as unknown as {
+		addClass?: (this: HTMLElement, ...classes: string[]) => void;
+		createDiv?: (this: HTMLElement, cls?: string) => HTMLDivElement;
+		createEl?: (
+			this: HTMLElement,
+			tag: string,
+			options?: { text?: string },
+		) => HTMLElement;
+		empty?: (this: HTMLElement) => void;
+	};
+	proto.addClass ??= function (...classes: string[]) {
+		this.classList.add(...classes);
+	};
+	proto.createDiv ??= function (cls?: string) {
+		const div = document.createElement("div");
+		if (cls) div.className = cls;
+		this.appendChild(div);
+		return div;
+	};
+	proto.createEl ??= function (tag: string, options?: { text?: string }) {
+		const el = document.createElement(tag);
+		if (options?.text) el.textContent = options.text;
+		this.appendChild(el);
+		return el;
+	};
+	proto.empty ??= function () {
+		this.replaceChildren();
+	};
+}
+
+beforeAll(() => {
+	installObsidianElementHelpers();
+	// Obsidian augments Array.prototype.contains; jsdom does not.
+	const arrayProto = Array.prototype as unknown as {
+		contains?: <T>(item: T) => boolean;
+	};
+	if (typeof arrayProto.contains !== "function") {
+		arrayProto.contains = function contains<T>(this: T[], item: T): boolean {
+			return this.includes(item);
+		};
+	}
+});
+
+function buttonByText(
+	prompt: InstanceType<typeof GenericCheckboxPrompt>,
+	text: string,
+): HTMLButtonElement {
+	const contentEl = (prompt as unknown as { contentEl: HTMLElement }).contentEl;
+	const buttons = Array.from(
+		contentEl.querySelectorAll<HTMLButtonElement>("button"),
+	);
+	const target = buttons.find((b) => b.textContent === text);
+	if (!target) throw new Error(`button '${text}' not found`);
+	return target;
+}
+
+describe("GenericCheckboxPrompt header + cancel (audit: prompts-gui-checkbox-prompt)", () => {
+	const app = {} as App;
+
+	it("renders the optional header in titleEl", () => {
+		const prompt = new GenericCheckboxPrompt(app, ["a", "b"], [], "Pick options");
+		const titleEl = (prompt as unknown as { titleEl: HTMLElement }).titleEl;
+		expect(titleEl.textContent).toBe("Pick options");
+	});
+
+	it("leaves titleEl empty when no header is given", () => {
+		const prompt = new GenericCheckboxPrompt(app, ["a", "b"], []);
+		const titleEl = (prompt as unknown as { titleEl: HTMLElement }).titleEl;
+		expect(titleEl.textContent).toBe("");
+	});
+
+	it("renders an explicit Cancel button alongside Submit", () => {
+		const prompt = new GenericCheckboxPrompt(app, ["a"], []);
+		expect(() => buttonByText(prompt, "Submit")).not.toThrow();
+		expect(() => buttonByText(prompt, "Cancel")).not.toThrow();
+	});
+
+	it("Cancel rejects the promise (no input given)", async () => {
+		const prompt = new GenericCheckboxPrompt(app, ["a", "b"], ["a"]);
+		const promise = prompt.promise;
+
+		buttonByText(prompt, "Cancel").dispatchEvent(
+			new Event("click", { bubbles: true }),
+		);
+
+		await expect(promise).rejects.toBe("no input given.");
+	});
+
+	it("Submit resolves the selected items", async () => {
+		const prompt = new GenericCheckboxPrompt(app, ["a", "b"], ["a"]);
+		const promise = prompt.promise;
+
+		buttonByText(prompt, "Submit").dispatchEvent(
+			new Event("click", { bubbles: true }),
+		);
+
+		await expect(promise).resolves.toEqual(["a"]);
+	});
+});

--- a/src/gui/GenericCheckboxPrompt/genericCheckboxPrompt.ts
+++ b/src/gui/GenericCheckboxPrompt/genericCheckboxPrompt.ts
@@ -8,11 +8,17 @@ export default class GenericCheckboxPrompt extends Modal {
 	private resolved: boolean;
 	private _selectedItems: string[];
 
-	public static Open(app: App, items: string[], selectedItems?: string[]) {
+	public static Open(
+		app: App,
+		items: string[],
+		selectedItems?: string[],
+		header?: string
+	) {
 		const newSuggester = new GenericCheckboxPrompt(
 			app,
 			items,
-			selectedItems
+			selectedItems,
+			header
 		);
 		return newSuggester.promise;
 	}
@@ -20,7 +26,8 @@ export default class GenericCheckboxPrompt extends Modal {
 	public constructor(
 		app: App,
 		private items: string[],
-		readonly selectedItems: string[] = []
+		readonly selectedItems: string[] = [],
+		private readonly header?: string
 	) {
 		super(app);
 		// This clones the item so that we don't get any unexpected modifications of the
@@ -39,6 +46,7 @@ export default class GenericCheckboxPrompt extends Modal {
 	private display() {
 		this.contentEl.empty();
 		this.containerEl.addClass("quickAddModal", "checkboxPrompt");
+		if (this.header) this.titleEl.textContent = this.header;
 		this.addCheckboxRows();
 		this.addSubmitButton();
 	}
@@ -94,5 +102,16 @@ export default class GenericCheckboxPrompt extends Modal {
 
 				this.close();
 			});
+
+		// Explicit Cancel affordance — without it, Esc was the only way to
+		// dismiss, which is undiscoverable. Cancelling rejects (like Esc) so
+		// the caller can distinguish it from an empty submission.
+		const cancelButton: ButtonComponent = new ButtonComponent(
+			submitButtonContainer
+		);
+
+		cancelButton.setButtonText("Cancel").onClick((evt) => {
+			this.close();
+		});
 	}
 }

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.audit-cleanup.test.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.audit-cleanup.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { isSkipPromptShortcut } from "./GenericInputPrompt";
+
+/**
+ * Optional text/number/slider/wide-input prompts gained a keyboard skip
+ * shortcut (ctrl/cmd+shift+Enter), mirroring the optional suggesters. This
+ * locks the shortcut's exact key combo and — critically — proves it does NOT
+ * collide with the wide prompt's ctrl/cmd+Enter submit (issue #1259).
+ */
+
+type KeyParts = Partial<{
+	key: string;
+	shiftKey: boolean;
+	ctrlKey: boolean;
+	metaKey: boolean;
+	isComposing: boolean;
+}>;
+
+function keyEvent(parts: KeyParts): KeyboardEvent {
+	return {
+		key: "Enter",
+		shiftKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		isComposing: false,
+		...parts,
+	} as KeyboardEvent;
+}
+
+describe("isSkipPromptShortcut", () => {
+	it("matches ctrl+shift+Enter", () => {
+		expect(
+			isSkipPromptShortcut(keyEvent({ ctrlKey: true, shiftKey: true })),
+		).toBe(true);
+	});
+
+	it("matches cmd+shift+Enter", () => {
+		expect(
+			isSkipPromptShortcut(keyEvent({ metaKey: true, shiftKey: true })),
+		).toBe(true);
+	});
+
+	it("does not match plain Enter (the normal submit gesture)", () => {
+		expect(isSkipPromptShortcut(keyEvent({}))).toBe(false);
+	});
+
+	it("does not match ctrl/cmd+Enter (the wide prompt submit gesture)", () => {
+		// This is the load-bearing case: without the shift requirement the
+		// shortcut would clobber the wide prompt's submit binding.
+		expect(isSkipPromptShortcut(keyEvent({ ctrlKey: true }))).toBe(false);
+		expect(isSkipPromptShortcut(keyEvent({ metaKey: true }))).toBe(false);
+	});
+
+	it("does not match shift+Enter alone (no modifier)", () => {
+		expect(isSkipPromptShortcut(keyEvent({ shiftKey: true }))).toBe(false);
+	});
+
+	it("requires the Enter key", () => {
+		expect(
+			isSkipPromptShortcut(
+				keyEvent({ key: "a", ctrlKey: true, shiftKey: true }),
+			),
+		).toBe(false);
+	});
+
+	it("ignores IME composition", () => {
+		expect(
+			isSkipPromptShortcut(
+				keyEvent({ ctrlKey: true, shiftKey: true, isComposing: true }),
+			),
+		).toBe(false);
+	});
+});
+
+/**
+ * Re-derive the exact branching of each prompt's `submitEnterCallback` to prove
+ * routing: skip fires before submit, and only on optional prompts. Keeping the
+ * predicate first is what makes ctrl/cmd+shift+Enter skip (not submit) in the
+ * wide prompt despite its ctrl/cmd+Enter submit binding.
+ */
+function route(
+	evt: KeyboardEvent,
+	isOptional: boolean,
+	submitMatches: (e: KeyboardEvent) => boolean,
+): "skip" | "submit" | "none" {
+	if (isOptional && isSkipPromptShortcut(evt)) return "skip";
+	if (submitMatches(evt)) return "submit";
+	return "none";
+}
+
+// GenericInputPrompt / Number / Slider submit on plain Enter.
+const genericSubmit = (e: KeyboardEvent) => !e.isComposing && e.key === "Enter";
+// Wide prompt submits on ctrl/cmd+Enter.
+const wideSubmit = (e: KeyboardEvent) =>
+	(e.ctrlKey || e.metaKey) && e.key === "Enter";
+
+describe("submitEnterCallback routing (generic/number/slider)", () => {
+	it("ctrl/cmd+shift+Enter skips on optional prompts", () => {
+		expect(
+			route(keyEvent({ ctrlKey: true, shiftKey: true }), true, genericSubmit),
+		).toBe("skip");
+	});
+
+	it("ctrl/cmd+shift+Enter does not skip on non-optional prompts", () => {
+		// Falls through to plain-Enter submit (behavior unchanged for required).
+		expect(
+			route(keyEvent({ ctrlKey: true, shiftKey: true }), false, genericSubmit),
+		).toBe("submit");
+	});
+
+	it("plain Enter still submits on optional prompts", () => {
+		expect(route(keyEvent({}), true, genericSubmit)).toBe("submit");
+	});
+});
+
+describe("submitEnterCallback routing (wide prompt, issue #1259 collision)", () => {
+	it("ctrl/cmd+shift+Enter skips instead of submitting on optional prompts", () => {
+		expect(
+			route(keyEvent({ ctrlKey: true, shiftKey: true }), true, wideSubmit),
+		).toBe("skip");
+		expect(
+			route(keyEvent({ metaKey: true, shiftKey: true }), true, wideSubmit),
+		).toBe("skip");
+	});
+
+	it("ctrl/cmd+Enter still submits (submit binding preserved)", () => {
+		expect(route(keyEvent({ ctrlKey: true }), true, wideSubmit)).toBe(
+			"submit",
+		);
+		expect(route(keyEvent({ metaKey: true }), true, wideSubmit)).toBe(
+			"submit",
+		);
+	});
+
+	it("ctrl/cmd+shift+Enter submits on non-optional wide prompts (unchanged)", () => {
+		expect(
+			route(keyEvent({ ctrlKey: true, shiftKey: true }), false, wideSubmit),
+		).toBe("submit");
+	});
+});

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -6,6 +6,21 @@ import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
 import type { InputPromptOptions } from "../../types/inputPrompt";
 import { positionInputPromptCursor } from "../inputPromptCursor";
 
+/**
+ * The keyboard gesture that skips an optional prompt: ctrl/cmd+shift+Enter.
+ * Mirrors the optional suggesters' `Mod+Shift+Enter` skip binding so all
+ * optional prompt surfaces share one shortcut. Checking shift here is what keeps
+ * it from colliding with the wide prompt's ctrl/cmd+Enter submit (issue #1259).
+ */
+export function isSkipPromptShortcut(evt: KeyboardEvent): boolean {
+	return (
+		!evt.isComposing &&
+		evt.key === "Enter" &&
+		evt.shiftKey &&
+		(evt.ctrlKey || evt.metaKey)
+	);
+}
+
 export default class GenericInputPrompt extends Modal {
 	public waitForClose: Promise<string>;
 
@@ -115,7 +130,7 @@ export default class GenericInputPrompt extends Modal {
 
 		if (this.isOptionalPrompt) {
 			const hintEl = this.contentEl.createDiv({
-				text: "Optional — leave empty or press Skip.",
+				text: "Optional — leave empty, press Skip, or ctrl/cmd+shift+↵.",
 				cls: "setting-item-description",
 			});
 			hintEl.setCssStyles({ marginBottom: "0.75rem" });
@@ -203,6 +218,13 @@ export default class GenericInputPrompt extends Modal {
 	private skipClickCallback = (evt: MouseEvent) => this.skip();
 
 	protected submitEnterCallback = (evt: KeyboardEvent) => {
+		// Skip is checked first so ctrl/cmd+shift+Enter leaves the field empty
+		// instead of submitting (only on optional prompts).
+		if (this.isOptionalPrompt && isSkipPromptShortcut(evt)) {
+			evt.preventDefault();
+			this.skip();
+			return;
+		}
 		if (!evt.isComposing && evt.key === "Enter") {
 			evt.preventDefault();
 			this.submit();

--- a/src/gui/GenericSuggester/genericSuggester.audit-api-prompts.test.ts
+++ b/src/gui/GenericSuggester/genericSuggester.audit-api-prompts.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { App } from "obsidian";
+import GenericSuggester from "./genericSuggester";
+
+// Drives the undocumented Tab autocomplete handler the same way Obsidian does:
+// a "Tab" keydown on inputEl while `chooser` holds the current suggestions.
+// jsdom swallows listener exceptions (routing them to window error events
+// instead of re-throwing), so capture any error the handler throws and surface
+// it to the caller for assertion.
+function pressTab(suggester: GenericSuggester<unknown>): void {
+	const inputEl = (suggester as unknown as { inputEl: HTMLInputElement })
+		.inputEl;
+	let captured: unknown;
+	const onError = (event: ErrorEvent) => {
+		captured = event.error ?? new Error(event.message);
+		event.preventDefault();
+	};
+	window.addEventListener("error", onError);
+	try {
+		inputEl.dispatchEvent(
+			new KeyboardEvent("keydown", { code: "Tab", bubbles: true }),
+		);
+	} finally {
+		window.removeEventListener("error", onError);
+	}
+	if (captured) throw captured;
+}
+
+describe("GenericSuggester Tab autocomplete (audit: api-suggester / prompts-gui-generic-suggester)", () => {
+	let app: App;
+
+	beforeEach(() => {
+		app = new App();
+	});
+
+	it("does not throw on Tab when the query matches nothing (empty chooser values)", () => {
+		const items = ["Alpha", "Beta"];
+		const suggester = new GenericSuggester(app, items, items);
+
+		const internal = suggester as unknown as {
+			inputEl: HTMLInputElement;
+			chooser: { values: unknown[]; selectedItem: number };
+		};
+		// Simulate a query that filtered out every suggestion.
+		internal.chooser.values = [];
+		internal.chooser.selectedItem = 0;
+		internal.inputEl.value = "no-match";
+
+		expect(() => pressTab(suggester)).not.toThrow();
+		// The typed query is kept untouched (the fallback `?? value`).
+		expect(internal.inputEl.value).toBe("no-match");
+	});
+
+	it("still completes to the selected suggestion's item when one exists", () => {
+		const items = ["Alpha", "Beta"];
+		const suggester = new GenericSuggester(app, items, items);
+
+		const internal = suggester as unknown as {
+			inputEl: HTMLInputElement;
+			chooser: { values: { item: string }[]; selectedItem: number };
+		};
+		internal.chooser.values = [{ item: "Alpha" }, { item: "Beta" }];
+		internal.chooser.selectedItem = 1;
+		internal.inputEl.value = "Be";
+
+		pressTab(suggester);
+		expect(internal.inputEl.value).toBe("Beta");
+	});
+});

--- a/src/gui/GenericSuggester/genericSuggester.ts
+++ b/src/gui/GenericSuggester/genericSuggester.ts
@@ -87,7 +87,7 @@ export default class GenericSuggester<T> extends FuzzySuggestModal<T> {
 			};
 
 			const { value } = this.inputEl;
-			this.inputEl.value = values[selectedItem].item ?? value;
+			this.inputEl.value = values[selectedItem]?.item ?? value;
 		});
 
 		if (this.displayItems.length !== this.items.length) {

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -6,6 +6,7 @@ import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
 import type { InputPromptOptions } from "../../types/inputPrompt";
 import { positionInputPromptCursor } from "../inputPromptCursor";
 import { attachTextareaIndent } from "../components/textareaIndent";
+import { isSkipPromptShortcut } from "../GenericInputPrompt/GenericInputPrompt";
 
 export default class GenericWideInputPrompt extends Modal {
 	public waitForClose: Promise<string>;
@@ -114,7 +115,7 @@ export default class GenericWideInputPrompt extends Modal {
 
 		if (this.isOptionalPrompt) {
 			const hintEl = this.contentEl.createDiv({
-				text: "Optional — leave empty or press Skip.",
+				text: "Optional — leave empty, press Skip, or ctrl/cmd+shift+↵.",
 				cls: "setting-item-description",
 			});
 			hintEl.setCssStyles({ marginBottom: "0.75rem" });
@@ -206,6 +207,14 @@ export default class GenericWideInputPrompt extends Modal {
 	private skipClickCallback = (evt: MouseEvent) => this.skip();
 
 	private submitEnterCallback = (evt: KeyboardEvent) => {
+		// Skip is checked first: ctrl/cmd+shift+Enter leaves the field empty on
+		// optional prompts. Without this guard it would fall through to the
+		// ctrl/cmd+Enter submit below, the collision noted in issue #1259.
+		if (this.isOptionalPrompt && isSkipPromptShortcut(evt)) {
+			evt.preventDefault();
+			this.skip();
+			return;
+		}
 		if ((evt.ctrlKey || evt.metaKey) && evt.key === "Enter") {
 			evt.preventDefault();
 			this.submit();

--- a/src/gui/MathModal.ts
+++ b/src/gui/MathModal.ts
@@ -20,7 +20,9 @@ export class MathModal extends Modal {
 	private didSubmit = false;
 
 	private keybindListener = (evt: KeyboardEvent) => {
-		if (evt.ctrlKey && evt.key === "Enter") {
+		// Accept Cmd+Enter on macOS as well as Ctrl+Enter, matching
+		// GenericWideInputPrompt; a bare Enter inserts a newline here.
+		if ((evt.ctrlKey || evt.metaKey) && evt.key === "Enter") {
 			this.submit();
 		}
 
@@ -71,6 +73,12 @@ export class MathModal extends Modal {
 		);
 
 		tc.inputEl.addEventListener("keydown", this.keybindListener);
+
+		const hintEl = this.contentEl.createDiv({
+			text: "Ctrl/Cmd+Enter to submit · Tab to jump to the cursor marker",
+			cls: "setting-item-description",
+		});
+		hintEl.setCssStyles({ marginTop: "0.5rem" });
 
 		this.createButtonBar(this.contentEl.createDiv());
 	}
@@ -144,7 +152,7 @@ export class MathModal extends Modal {
 
 	private resolveInput() {
 		const output = this.inputEl.value
-			.replace("\\n", `\\\\n`)
+			.replace(/\\n/g, `\\\\n`)
 			.replace(new RegExp(LATEX_CURSOR_MOVE_HERE, "g"), "");
 		if (!this.didSubmit) this.rejectPromise("No input given.");
 		else this.resolvePromise(output);

--- a/src/gui/VDateInputPrompt/VDateInputPrompt.audit-cleanup.test.ts
+++ b/src/gui/VDateInputPrompt/VDateInputPrompt.audit-cleanup.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Modal } from "obsidian";
+import type QuickAdd from "../../main";
+import { setQuickAddInstance } from "../../quickAddInstance";
+import { settingsStore } from "../../settingsStore";
+import { InputPromptDraftStore } from "../../utils/InputPromptDraftStore";
+import VDateInputPrompt from "./VDateInputPrompt";
+
+// The obsidian-stub Modal does not implement onOpen/onClose; GenericInputPrompt
+// calls super.onOpen() during open(). Provide a no-op base so construction (which
+// opens the modal) does not throw. Guarded so a richer stub still wins.
+const modalProto = Modal.prototype as unknown as { onOpen?: unknown };
+if (typeof modalProto.onOpen !== "function") modalProto.onOpen = () => {};
+
+// Obsidian augments HTMLElement at runtime; the shared vitest setup polyfills
+// addClass/createDiv/etc. but not toggleClass (preview renderer) or setAttr (the
+// date picker). Add them defensively (guarded) so constructing the modal under
+// jsdom does not throw. Mirrors the setup file's pattern.
+const htmlProto = HTMLElement.prototype as unknown as {
+	toggleClass?: unknown;
+	setAttr?: unknown;
+};
+if (typeof htmlProto.toggleClass !== "function") {
+	htmlProto.toggleClass = function toggleClass(
+		this: Element,
+		cls: string,
+		value: boolean,
+	) {
+		this.classList.toggle(cls, value);
+	};
+}
+if (typeof htmlProto.setAttr !== "function") {
+	htmlProto.setAttr = function setAttr(
+		this: Element,
+		name: string,
+		value: string | number | boolean | null,
+	) {
+		if (value === null || value === false) this.removeAttribute(name);
+		else this.setAttribute(name, String(value));
+	};
+}
+
+// Minimal fake app the prompt pulls in transitively via the FileSuggester/
+// TagSuggester created in the GenericInputPrompt constructor.
+function makeFakeApp() {
+	return {
+		workspace: { on: () => ({}) },
+		metadataCache: {
+			on: () => ({}),
+			getTags: () => ({}),
+			getFileCache: () => undefined,
+			isUserIgnored: () => false,
+		},
+		vault: {
+			on: () => ({}),
+			getMarkdownFiles: () => [],
+			getAllLoadedFiles: () => [],
+			getFiles: () => [],
+			getAbstractFileByPath: () => null,
+		},
+	};
+}
+
+interface PromptInternals {
+	currentInput: string;
+	previewEl: HTMLElement;
+	inputComponent: { inputEl: HTMLInputElement };
+}
+
+describe("VDateInputPrompt restored-draft preview", () => {
+	const draftStore = InputPromptDraftStore.getInstance();
+	const header = "Pick a date";
+	const placeholder = "";
+	const draftKey = draftStore.makeKey({
+		kind: "single",
+		header,
+		placeholder,
+		linkSourcePath: "",
+	});
+
+	let fakeApp: ReturnType<typeof makeFakeApp>;
+
+	beforeEach(() => {
+		fakeApp = makeFakeApp();
+		setQuickAddInstance({
+			app: fakeApp,
+			registerEvent: () => {},
+		} as unknown as QuickAdd);
+		settingsStore.setState({ persistInputPromptDrafts: true });
+		draftStore.clearAll();
+	});
+
+	afterEach(() => {
+		draftStore.clearAll();
+		// Remove modal DOM the construction appended to the document body.
+		for (const el of Array.from(document.body.children)) el.remove();
+	});
+
+	function construct(defaultValue: string): PromptInternals {
+		// Reach the protected constructor via a cast so we can inspect state
+		// (Prompt() only hands back the close promise).
+		const Ctor = VDateInputPrompt as unknown as new (
+			...args: unknown[]
+		) => VDateInputPrompt;
+		const prompt = new Ctor(
+			fakeApp,
+			header,
+			placeholder,
+			defaultValue,
+			"YYYY-MM-DD",
+			undefined,
+			false,
+		);
+		return prompt as unknown as PromptInternals;
+	}
+
+	it("seeds the preview from a restored draft, not the defaultValue", () => {
+		// Default parses cleanly; draft is unparseable garbage. With the bug the
+		// preview reflects the (parseable) default and shows no error; with the
+		// fix it reflects the (unparseable) draft and shows the error state.
+		draftStore.set(draftKey, "zzzz not a real date");
+
+		const state = construct("2025-01-15");
+
+		expect(state.inputComponent.inputEl.value).toBe("zzzz not a real date");
+		expect(state.currentInput).toBe("zzzz not a real date");
+		expect(state.previewEl.classList.contains("is-error")).toBe(true);
+	});
+
+	it("keeps the no-draft default path: preview reflects the defaultValue", () => {
+		// No draft stored: input + preview follow the parseable default.
+		const state = construct("2025-01-15");
+
+		expect(state.inputComponent.inputEl.value).toBe("2025-01-15");
+		expect(state.currentInput).toBe("2025-01-15");
+		expect(state.previewEl.classList.contains("is-error")).toBe(false);
+	});
+});

--- a/src/gui/VDateInputPrompt/VDateInputPrompt.ts
+++ b/src/gui/VDateInputPrompt/VDateInputPrompt.ts
@@ -1,5 +1,5 @@
 import type { App, Debouncer } from "obsidian";
-import { TextComponent, debounce } from "obsidian";
+import { Notice, TextComponent, debounce } from "obsidian";
 import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
 import type { InputPromptOptions } from "../../types/inputPrompt";
 import { createDatePicker, type DatePickerController } from "../date-picker/datePicker";
@@ -64,7 +64,12 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 		this.dateFormat =
 			dateFormat || (this.withTime ? "YYYY-MM-DD HH:mm" : "YYYY-MM-DD");
 		this.defaultValue = defaultValue;
-		this.currentInput = defaultValue ?? "";
+		// super() (via display() -> createInputField) already hydrated the input
+		// element + this.currentInput to the restored draft (or the defaultValue
+		// when there is no draft). Seed currentInput from the actual input value
+		// so the initial preview reflects a restored draft instead of being
+		// clobbered back to the defaultValue.
+		this.currentInput = this.inputComponent?.inputEl?.value ?? defaultValue ?? "";
 
 		// Mount the picker here (NOT in createInputField, which runs during the
 		// super() display() call before this.withTime is set), so the time
@@ -183,7 +188,15 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 			this.selectedIso = undefined;
 			this.lastPickerDisplayValue = undefined;
 			this.syncPickerSelection();
-			this.setPreviewText(VDateInputPrompt.PREVIEW_PLACEHOLDER, false);
+			// An optional blank is an intentional answer, so reassure the user it
+			// will be left empty (matching the one-page date field) rather than
+			// showing the neutral "Preview will appear here" placeholder.
+			this.setPreviewText(
+				this.isOptionalPrompt
+					? "Will be left empty"
+					: VDateInputPrompt.PREVIEW_PLACEHOLDER,
+				false,
+			);
 			return;
 		}
 
@@ -305,6 +318,13 @@ export default class VDateInputPrompt extends GenericInputPrompt {
 			if (parsed.isValid && parsed.isoString) {
 				return `@date:${parsed.isoString}`;
 			}
+			// The preview already shows this typed text is not a valid date; the
+			// raw value is handed back verbatim (so nothing is silently dropped),
+			// but surface a notice so the user/caller is not left without any
+			// signal that the date could not be parsed.
+			new Notice(
+				`QuickAdd: "${trimmed}" could not be parsed as a date; using it as-is.`,
+			);
 		}
 		return input;
 	}

--- a/src/gui/date-picker/datePicker.audit-api-prompts.test.ts
+++ b/src/gui/date-picker/datePicker.audit-api-prompts.test.ts
@@ -1,0 +1,98 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { createDatePicker } from "./datePicker";
+
+// createDatePicker renders into a real (jsdom) element and uses Obsidian's
+// HTMLElement augmentations. createDiv/createEl/addClass/empty are polyfilled in
+// the shared vitest setup; setAttr is not, so add a faithful local polyfill.
+beforeAll(() => {
+	const proto = HTMLElement.prototype as unknown as {
+		setAttr?: (name: string, value: string) => void;
+	};
+	if (typeof proto.setAttr !== "function") {
+		proto.setAttr = function setAttr(
+			this: Element,
+			name: string,
+			value: string,
+		) {
+			this.setAttribute(name, value);
+		};
+	}
+});
+
+function findTimeInput(container: HTMLElement): HTMLInputElement {
+	const input = container.querySelector<HTMLInputElement>(
+		"input.qa-date-picker__time-input",
+	);
+	if (!input) throw new Error("time input not found");
+	return input;
+}
+
+function clickDay(container: HTMLElement, day: string): void {
+	const buttons = Array.from(
+		container.querySelectorAll<HTMLButtonElement>(
+			"button.qa-date-picker__day:not(.is-outside)",
+		),
+	);
+	const target = buttons.find((b) => b.textContent === day);
+	if (!target) throw new Error(`day button '${day}' not found`);
+	target.dispatchEvent(new Event("click", { bubbles: true }));
+}
+
+describe("createDatePicker time-clearing (audit: prompts-gui-date-picker-time-control)", () => {
+	it("drops the merged time back to midnight when the time field is cleared", () => {
+		const container = document.createElement("div");
+		const emitted: Array<string | null> = [];
+
+		createDatePicker({
+			container,
+			initialIso: "2025-12-25T14:30:00",
+			withTime: true,
+			weekStartsOn: 0,
+			onSelect: (iso) => emitted.push(iso),
+		});
+
+		const timeInput = findTimeInput(container);
+		expect(timeInput.value).toBe("14:30");
+
+		// Pick a day so there is a selection carrying the 14:30 time.
+		clickDay(container, "10");
+		expect(emitted.at(-1)).toBe("2025-12-10T14:30:00");
+
+		// Clear the time field. Before the fix this returned early (NaN guard),
+		// leaving currentTime = 14:30 so the next day pick re-applied it.
+		timeInput.value = "";
+		timeInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+		// Clearing re-emits the current selection at midnight.
+		expect(emitted.at(-1)).toBe("2025-12-10T00:00:00");
+
+		// Subsequent day picks must NOT resurrect the old 14:30 time.
+		clickDay(container, "15");
+		expect(emitted.at(-1)).toBe("2025-12-15T00:00:00");
+	});
+
+	it("still merges a newly typed time after clearing", () => {
+		const container = document.createElement("div");
+		const emitted: Array<string | null> = [];
+
+		createDatePicker({
+			container,
+			initialIso: "2025-12-25T08:00:00",
+			withTime: true,
+			weekStartsOn: 0,
+			onSelect: (iso) => emitted.push(iso),
+		});
+
+		clickDay(container, "5");
+		expect(emitted.at(-1)).toBe("2025-12-05T08:00:00");
+
+		const timeInput = findTimeInput(container);
+		timeInput.value = "";
+		timeInput.dispatchEvent(new Event("change", { bubbles: true }));
+		expect(emitted.at(-1)).toBe("2025-12-05T00:00:00");
+
+		timeInput.value = "09:15";
+		timeInput.dispatchEvent(new Event("change", { bubbles: true }));
+		expect(emitted.at(-1)).toBe("2025-12-05T09:15:00");
+	});
+});

--- a/src/gui/date-picker/datePicker.ts
+++ b/src/gui/date-picker/datePicker.ts
@@ -226,9 +226,17 @@ export const createDatePicker = (
 
 	if (timeInput) {
 		timeInput.addEventListener("change", () => {
-			const [h, m] = timeInput.value.split(":").map((p) => Number.parseInt(p, 10));
-			if (Number.isNaN(h) || Number.isNaN(m)) return;
-			currentTime = { hour: h, minute: m };
+			// Clearing the field drops the time back to midnight instead of
+			// keeping the previously merged wall-clock time on later day picks.
+			if (timeInput.value.trim() === "") {
+				currentTime = { hour: 0, minute: 0 };
+			} else {
+				const [h, m] = timeInput.value
+					.split(":")
+					.map((p) => Number.parseInt(p, 10));
+				if (Number.isNaN(h) || Number.isNaN(m)) return;
+				currentTime = { hour: h, minute: m };
+			}
 			// Re-emit so editing the time after picking a day updates the value
 			// instead of being dropped.
 			if (selectedIso) {

--- a/src/gui/suggesters/SuggesterInputSuggest.audit-preflight-suggesters.test.ts
+++ b/src/gui/suggesters/SuggesterInputSuggest.audit-preflight-suggesters.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { SuggesterInputSuggest } from "./SuggesterInputSuggest";
+
+// Codex review follow-up: the ", "-joined multi-select text is ambiguous when an
+// option label equals the join of two other labels (options "a", "b", and
+// "a, b"). The per-pick onSelect event provides an UNAMBIGUOUS ordered selection
+// that distinguishes picking "a" then "b" from picking the single option "a, b".
+function makeSuggest(options: string[], onSelect: (item: string) => void) {
+	const input = document.createElement("input");
+	document.body.appendChild(input);
+	const suggest = new SuggesterInputSuggest(
+		new App(),
+		input,
+		options,
+		false,
+		true,
+		onSelect,
+	);
+	return { suggest, input };
+}
+
+describe("SuggesterInputSuggest multi-select onSelect (audit)", () => {
+	it("reports each picked item, distinguishing 'a' + 'b' from a literal 'a, b'", () => {
+		const picksTwo: string[] = [];
+		const two = makeSuggest(["a", "b", "a, b"], (item) => picksTwo.push(item));
+		two.suggest.selectSuggestion("a");
+		two.suggest.selectSuggestion("b");
+		// Two distinct picks -> unambiguous ["a", "b"], even though the joined
+		// input text "a, b" collides with the single option's label.
+		expect(picksTwo).toEqual(["a", "b"]);
+
+		const picksOne: string[] = [];
+		const one = makeSuggest(["a", "b", "a, b"], (item) => picksOne.push(item));
+		one.suggest.selectSuggestion("a, b");
+		// A single pick of the comma-bearing option -> ["a, b"].
+		expect(picksOne).toEqual(["a, b"]);
+	});
+
+	it("does not fire onSelect for single-select suggesters", () => {
+		const input = document.createElement("input");
+		const onSelect = vi.fn();
+		const suggest = new SuggesterInputSuggest(
+			new App(),
+			input,
+			["x", "y"],
+			false,
+			false,
+			onSelect,
+		);
+		suggest.selectSuggestion("x");
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+});

--- a/src/gui/suggesters/SuggesterInputSuggest.ts
+++ b/src/gui/suggesters/SuggesterInputSuggest.ts
@@ -11,6 +11,11 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	private options: string[];
 	private caseSensitive: boolean;
 	private multiSelect: boolean;
+	// Fires with the exact item picked on each multi-select selection. The
+	// resulting ", "-joined input text is ambiguous when an option's label equals
+	// the join of two other option labels (e.g. "a", "b", and "a, b"); the
+	// per-pick event lets callers record an unambiguous ordered selection.
+	private onSelect?: (item: string) => void;
 
 	constructor(
 		app: App,
@@ -18,11 +23,13 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 		options: string[],
 		caseSensitive = false,
 		multiSelect = false,
+		onSelect?: (item: string) => void,
 	) {
 		super(app, inputEl);
 		this.options = options.map((option) => normalizeDisplayItem(option));
 		this.caseSensitive = caseSensitive;
 		this.multiSelect = multiSelect;
+		this.onSelect = onSelect;
 
 		// Add accessibility attribute for multi-select mode
 		if (this.multiSelect) {
@@ -91,6 +98,11 @@ export class SuggesterInputSuggest extends TextInputSuggest<string> {
 	private selectMultipleItem(item: string): void {
 		const { alreadySelected } = this.parseMultiSelectInput(this.inputEl.value);
 		alreadySelected.push(item);
+
+		// Report the exact picked item so callers can keep an unambiguous ordered
+		// selection (the joined text alone can't distinguish picking "a" then "b"
+		// from picking a single option literally named "a, b").
+		this.onSelect?.(item);
 
 		const hasMoreItems = this.getRemainingOptions(alreadySelected).length > 0;
 

--- a/src/preflight/OnePageInputModal.audit-preflight-suggesters.test.ts
+++ b/src/preflight/OnePageInputModal.audit-preflight-suggesters.test.ts
@@ -1,0 +1,349 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type { FieldRequirement } from "./RequirementCollector";
+
+const { noticeMessages } = vi.hoisted(() => ({
+	noticeMessages: [] as string[],
+}));
+
+vi.mock("obsidian", () => {
+	class Scope {
+		private readonly handlers: Array<{
+			mods: string[];
+			key: string;
+			cb: () => boolean;
+		}> = [];
+
+		register(mods: string[], key: string, cb: () => boolean) {
+			this.handlers.push({ mods, key, cb });
+		}
+
+		trigger(mods: string[], key: string) {
+			this.handlers
+				.filter(
+					(h) =>
+						h.key === key &&
+						h.mods.length === mods.length &&
+						h.mods.every((m) => mods.includes(m)),
+				)
+				.forEach((h) => h.cb());
+		}
+	}
+
+	class Notice {
+		constructor(message: string) {
+			noticeMessages.push(message);
+		}
+	}
+
+	class Modal {
+		containerEl: HTMLElement;
+		contentEl: HTMLElement;
+		scope: Scope;
+
+		constructor(_app: App) {
+			this.containerEl = document.createElement("div");
+			this.contentEl = document.createElement("div");
+			this.containerEl.appendChild(this.contentEl);
+			this.scope = new Scope();
+		}
+
+		open() {
+			(this as unknown as { onOpen?: () => void }).onOpen?.();
+		}
+		close() {}
+	}
+
+	class DropdownComponent {
+		selectEl: HTMLSelectElement;
+		constructor(containerEl: HTMLElement) {
+			this.selectEl = document.createElement("select");
+			containerEl.appendChild(this.selectEl);
+		}
+		addOption(value: string, text: string): this {
+			const option = document.createElement("option");
+			option.value = value;
+			option.textContent = text;
+			this.selectEl.appendChild(option);
+			return this;
+		}
+		setValue(value: string): this {
+			this.selectEl.value = value;
+			return this;
+		}
+		setDisabled(): this {
+			return this;
+		}
+		onChange(cb: (value: string) => void): this {
+			this.selectEl.addEventListener("change", () => cb(this.selectEl.value));
+			return this;
+		}
+	}
+
+	class TextComponent {
+		inputEl: HTMLInputElement;
+		constructor(containerEl: HTMLElement) {
+			this.inputEl = document.createElement("input");
+			containerEl.appendChild(this.inputEl);
+		}
+		setPlaceholder(value: string): this {
+			this.inputEl.placeholder = value;
+			return this;
+		}
+		setValue(value: string): this {
+			this.inputEl.value = value;
+			return this;
+		}
+		onChange(cb: (value: string) => void): this {
+			this.inputEl.addEventListener("input", () => cb(this.inputEl.value));
+			return this;
+		}
+	}
+
+	class TextAreaComponent {
+		inputEl: HTMLTextAreaElement;
+		constructor(containerEl: HTMLElement) {
+			this.inputEl = document.createElement("textarea");
+			containerEl.appendChild(this.inputEl);
+		}
+		setPlaceholder(value: string): this {
+			this.inputEl.placeholder = value;
+			return this;
+		}
+		setValue(value: string): this {
+			this.inputEl.value = value;
+			return this;
+		}
+		onChange(cb: (value: string) => void): this {
+			this.inputEl.addEventListener("input", () => cb(this.inputEl.value));
+			return this;
+		}
+	}
+
+	class ButtonComponent {
+		buttonEl: HTMLButtonElement;
+		constructor(containerEl: HTMLElement) {
+			this.buttonEl = document.createElement("button");
+			containerEl.appendChild(this.buttonEl);
+		}
+		setButtonText(text: string): this {
+			this.buttonEl.textContent = text;
+			return this;
+		}
+		setCta(): this {
+			return this;
+		}
+		onClick(cb: () => void): this {
+			this.buttonEl.addEventListener("click", cb);
+			return this;
+		}
+	}
+
+	class Setting {
+		controlEl: HTMLElement;
+		private readonly infoEl: HTMLElement;
+		private readonly nameEl: HTMLElement;
+		private readonly descEl: HTMLElement;
+		constructor(containerEl: HTMLElement) {
+			const settingEl = document.createElement("div");
+			this.infoEl = document.createElement("div");
+			this.nameEl = document.createElement("div");
+			this.descEl = document.createElement("div");
+			this.controlEl = document.createElement("div");
+			settingEl.appendChild(this.infoEl);
+			settingEl.appendChild(this.controlEl);
+			containerEl.appendChild(settingEl);
+		}
+		setName(name: string | DocumentFragment): this {
+			if (typeof name === "string") this.nameEl.textContent = name;
+			else this.nameEl.replaceChildren(name);
+			this.infoEl.appendChild(this.nameEl);
+			return this;
+		}
+		setDesc(desc: string): this {
+			this.descEl.textContent = desc;
+			this.infoEl.appendChild(this.descEl);
+			return this;
+		}
+		addButton(cb: (component: ButtonComponent) => void): this {
+			cb(new ButtonComponent(this.controlEl));
+			return this;
+		}
+	}
+
+	return {
+		DropdownComponent,
+		Modal,
+		Notice,
+		Setting,
+		TextAreaComponent,
+		TextComponent,
+		Scope,
+		debounce: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn,
+	};
+});
+
+vi.mock("src/gui/date-picker/datePicker", () => ({
+	createDatePicker: () => ({ setSelectedIso: vi.fn() }),
+}));
+
+vi.mock("src/gui/suggesters/FieldValueInputSuggest", () => ({
+	FieldValueInputSuggest: class {},
+}));
+
+vi.mock("src/gui/suggesters/SuggesterInputSuggest", () => ({
+	SuggesterInputSuggest: class {},
+}));
+
+vi.mock("src/settingsStore", () => ({
+	settingsStore: { getState: () => ({ dateAliases: {} }) },
+}));
+
+import { OnePageInputModal } from "./OnePageInputModal";
+
+function ensureObsidianDomPolyfills(): void {
+	const proto = HTMLElement.prototype as any;
+	proto.empty ??= function () {
+		this.replaceChildren();
+		return this;
+	};
+	proto.addClass ??= function (...classes: string[]) {
+		this.classList.add(...classes);
+		return this;
+	};
+	proto.createEl ??= function (tag: string, options?: { text?: string }) {
+		const el = document.createElement(tag);
+		if (options?.text !== undefined) el.textContent = options.text;
+		this.appendChild(el);
+		return el;
+	};
+	proto.createDiv ??= function (options?: { cls?: string; text?: string }) {
+		const div = document.createElement("div");
+		if (options?.cls) div.className = options.cls;
+		if (options?.text !== undefined) div.textContent = options.text;
+		this.appendChild(div);
+		return div;
+	};
+	proto.setText ??= function (text: string) {
+		this.textContent = text;
+		return this;
+	};
+	proto.toggleClass ??= function (cls: string, on: boolean) {
+		this.classList.toggle(cls, on);
+		return this;
+	};
+}
+
+const findSubmit = (modal: OnePageInputModal): HTMLButtonElement =>
+	Array.from(
+		(modal as any).contentEl.querySelectorAll(
+			"button",
+		) as NodeListOf<HTMLButtonElement>,
+	).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+
+describe("OnePageInputModal preflight-suggesters audit", () => {
+	beforeEach(() => {
+		ensureObsidianDomPolyfills();
+		noticeMessages.length = 0;
+	});
+
+	// Finding: api-request-inputs — a required date with a typo would be silently
+	// dropped as "" instead of blocking Submit; ensure Submit is blocked with a
+	// notice and that fixing the value unblocks it.
+	describe("required date parse-error gating", () => {
+		it("blocks Submit and shows a notice while a required date fails to parse", async () => {
+			const requirements: FieldRequirement[] = [
+				{
+					id: "due",
+					label: "Due date",
+					type: "date",
+					dateFormat: "YYYY-MM-DD",
+				},
+			];
+			const modal = new OnePageInputModal({} as App, requirements, new Map());
+			const dateInput = (modal as any).contentEl.querySelector(
+				"input",
+			) as HTMLInputElement;
+			dateInput.value = "next fryday";
+			dateInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+			let settled = false;
+			void modal.waitForClose.then(() => (settled = true));
+
+			findSubmit(modal).click();
+			await Promise.resolve();
+
+			expect(settled).toBe(false);
+			expect(noticeMessages).toHaveLength(1);
+			expect(noticeMessages[0]).toContain("Due date");
+		});
+
+		it("submits once the parse error is cleared (blocking is specific to the error)", async () => {
+			const requirements: FieldRequirement[] = [
+				{
+					id: "due",
+					label: "Due date",
+					type: "date",
+					dateFormat: "YYYY-MM-DD",
+				},
+				{ id: "note", label: "Note", type: "text" },
+			];
+			const modal = new OnePageInputModal({} as App, requirements, new Map());
+			const dateInput = (modal as any).contentEl.querySelector(
+				"input",
+			) as HTMLInputElement;
+
+			// Typo -> parse error -> Submit blocked.
+			dateInput.value = "garbage";
+			dateInput.dispatchEvent(new Event("input", { bubbles: true }));
+			findSubmit(modal).click();
+			expect(noticeMessages).toHaveLength(1);
+
+			// Clearing the field removes the parse error; a required blank date is
+			// omitted (so the sequential prompt can fire) and Submit proceeds.
+			dateInput.value = "";
+			dateInput.dispatchEvent(new Event("input", { bubbles: true }));
+			findSubmit(modal).click();
+
+			await expect(modal.waitForClose).resolves.toEqual({ note: "" });
+		});
+	});
+
+	// Finding: prompts-gui-onepage-preflight-modal — the modal must auto-focus
+	// the first field and submit on Mod+Enter without the mouse.
+	describe("keyboard accessibility", () => {
+		it("auto-focuses the first field on open", () => {
+			const requirements: FieldRequirement[] = [
+				{ id: "title", label: "Title", type: "text" },
+				{ id: "body", label: "Body", type: "textarea" },
+			];
+			const modal = new OnePageInputModal({} as App, requirements, new Map());
+			// jsdom only updates activeElement for elements in the document.
+			document.body.appendChild((modal as any).containerEl);
+			(modal as any).open();
+
+			const firstInput = (modal as any).contentEl.querySelector(
+				"input",
+			) as HTMLInputElement;
+			expect(document.activeElement).toBe(firstInput);
+		});
+
+		it("submits on Mod+Enter via the modal scope", async () => {
+			const requirements: FieldRequirement[] = [
+				{ id: "title", label: "Title", type: "text" },
+			];
+			const modal = new OnePageInputModal({} as App, requirements, new Map());
+			(modal as any).open();
+
+			const input = (modal as any).contentEl.querySelector(
+				"input",
+			) as HTMLInputElement;
+			input.value = "Hello";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+
+			(modal as any).scope.trigger(["Mod"], "Enter");
+
+			await expect(modal.waitForClose).resolves.toEqual({ title: "Hello" });
+		});
+	});
+});

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -1,6 +1,7 @@
 import {
 	DropdownComponent,
 	Modal,
+	Notice,
 	Setting,
 	TextAreaComponent,
 	TextComponent,
@@ -114,6 +115,35 @@ export class OnePageInputModal extends Modal {
 			.addButton((btn) =>
 				btn.setButtonText("Cancel").onClick(() => this.cancel()),
 			);
+	}
+
+	onOpen() {
+		// Auto-focus the first field so keyboard-first users can start typing
+		// immediately, matching the single-field prompts.
+		const firstField = this.contentEl.querySelector<HTMLElement>(
+			"input, textarea, select",
+		);
+		firstField?.focus();
+
+		// Mod+Enter submits without reaching for the mouse. Guarded because the
+		// test mock's Modal has no scope.
+		const scope = (
+			this as unknown as {
+				scope?: {
+					register?: (
+						mods: string[],
+						key: string,
+						cb: () => boolean,
+					) => void;
+				};
+			}
+		).scope;
+		if (typeof scope?.register === "function") {
+			scope.register(["Mod"], "Enter", () => {
+				this.submit();
+				return false;
+			});
+		}
 	}
 
 	private renderField(req: FieldRequirement) {
@@ -555,6 +585,24 @@ export class OnePageInputModal extends Modal {
 		const requirementsById = new Map(
 			this.requirements.map((req) => [req.id, req]),
 		);
+
+		// A required date whose typed text failed to parse must not slip through:
+		// without a parse error the value would be silently dropped (and the
+		// script path has no sequential re-prompt to recover it). Block Submit and
+		// point the user at the offending field instead.
+		const erroredDate = this.requirements.find(
+			(req) =>
+				req.type === "date" &&
+				!req.optional &&
+				this.dateParseErrors.has(req.id),
+		);
+		if (erroredDate) {
+			new Notice(
+				`QuickAdd: "${erroredDate.label}" is not a valid date. Fix it or clear it before submitting.`,
+			);
+			return;
+		}
+
 		this.result.forEach((v, k) => {
 			const requirement = requirementsById.get(k);
 

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -40,6 +40,12 @@ export class OnePageInputModal extends Modal {
 	private readonly requirements: FieldRequirement[];
 	private readonly initialValues: Map<string, string>;
 	private readonly result = new Map<string, string>();
+	// Unambiguous ordered selections per multi-select field, recorded per-pick from
+	// the suggester (see SuggesterInputSuggest.onSelect). The ", "-joined input
+	// text alone can't distinguish picking "a" then "b" from picking a single
+	// option named "a, b"; consumers prefer this array when it still matches the
+	// final text (pure click flow), falling back to text parsing after manual edits.
+	public readonly multiSelections = new Map<string, string[]>();
 	// Date fields whose current (non-blank) text failed to parse.
 	private readonly dateParseErrors = new Set<string>();
 	private readonly computePreview?: PreviewComputer;
@@ -531,6 +537,13 @@ export class OnePageInputModal extends Modal {
 							displayOptions,
 							caseSensitive,
 							multiSelect,
+							multiSelect
+								? (item) => {
+										const arr = this.multiSelections.get(req.id) ?? [];
+										arr.push(item);
+										this.multiSelections.set(req.id, arr);
+									}
+								: undefined,
 						);
 					} catch {
 						// Non-fatal; falls back to plain text input
@@ -601,6 +614,15 @@ export class OnePageInputModal extends Modal {
 				`QuickAdd: "${erroredDate.label}" is not a valid date. Fix it or clear it before submitting.`,
 			);
 			return;
+		}
+
+		// Reconcile the per-pick multi-select arrays against the final text: if the
+		// user manually edited the field after picking (so the recorded picks no
+		// longer reproduce the text), drop the array and let the consumer fall back
+		// to text parsing. Otherwise the unambiguous picked order is authoritative.
+		for (const [id, picks] of this.multiSelections) {
+			const text = (this.result.get(id) ?? "").replace(/,\s*$/, "").trim();
+			if (picks.join(", ") !== text) this.multiSelections.delete(id);
 		}
 
 		this.result.forEach((v, k) => {

--- a/src/preflight/collectChoiceRequirements.audit-preflight-suggesters.test.ts
+++ b/src/preflight/collectChoiceRequirements.audit-preflight-suggesters.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FieldRequirement } from "./RequirementCollector";
+
+// collectChoiceRequirements imports utilityObsidian + the logger; mock them so
+// the pure getUnresolvedRequirements helper can be exercised in isolation.
+vi.mock("src/utilityObsidian", () => ({
+	getMarkdownFilesInFolder: vi.fn(() => []),
+	getMarkdownFilesMatchingFilter: vi.fn(() => []),
+	getMarkdownFilesWithTag: vi.fn(() => []),
+	getMarkdownFilesWithProperty: vi.fn(() => []),
+	getUserScript: vi.fn(),
+	getTemplateFile: vi.fn(() => null),
+	isFolder: vi.fn(() => false),
+}));
+
+vi.mock("src/logger/logManager", () => ({
+	log: { logWarning: vi.fn(), logMessage: vi.fn() },
+}));
+
+import { getUnresolvedRequirements } from "./collectChoiceRequirements";
+
+const req = (id: string): FieldRequirement => ({
+	id,
+	label: id,
+	type: "text",
+});
+
+// Finding: prompts-gui-onepage-orchestration — the documented rule is
+// "unresolved = variables missing or null", but the existence check only
+// rejected undefined, so a null-valued variable was wrongly treated as resolved
+// and silently skipped by the one-page modal.
+describe("getUnresolvedRequirements null handling", () => {
+	it("treats a null-valued variable as unresolved", () => {
+		const requirements = [req("value")];
+		const variables = new Map<string, unknown>([["value", null]]);
+
+		expect(getUnresolvedRequirements(requirements, variables)).toEqual(
+			requirements,
+		);
+	});
+
+	it("treats a missing variable as unresolved", () => {
+		const requirements = [req("value")];
+		const variables = new Map<string, unknown>();
+
+		expect(getUnresolvedRequirements(requirements, variables)).toEqual(
+			requirements,
+		);
+	});
+
+	it("treats a non-null value (including empty string) as resolved", () => {
+		const requirements = [req("value")];
+		const resolvedString = new Map<string, unknown>([["value", "x"]]);
+		const resolvedEmpty = new Map<string, unknown>([["value", ""]]);
+
+		expect(getUnresolvedRequirements(requirements, resolvedString)).toEqual(
+			[],
+		);
+		expect(getUnresolvedRequirements(requirements, resolvedEmpty)).toEqual(
+			[],
+		);
+	});
+});

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -525,7 +525,12 @@ export function getUnresolvedRequirements(
 	requirements: FieldRequirement[],
 	variables: Map<string, unknown>,
 ): FieldRequirement[] {
-	return requirements.filter(
-		(requirement) => !resolveExistingVariableKey(variables, requirement.id),
-	);
+	return requirements.filter((requirement) => {
+		const resolvedKey = resolveExistingVariableKey(variables, requirement.id);
+		// A variable explicitly set to null is unresolved (the documented rule is
+		// "missing or null"); resolveExistingVariableKey only rejects undefined,
+		// so re-check the resolved value here.
+		if (!resolvedKey) return true;
+		return variables.get(resolvedKey) == null;
+	});
 }

--- a/src/preflight/runOnePagePreflight.audit-preflight-suggesters.test.ts
+++ b/src/preflight/runOnePagePreflight.audit-preflight-suggesters.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+// runOnePagePreflight transitively imports src/main and obsidian-dataview; mock
+// the heavy deps so we can import the pure exported helper under test.
+vi.mock("src/quickAddSettingsTab", () => ({
+	QuickAddSettingsTab: class {},
+}));
+
+vi.mock("src/main", () => ({
+	__esModule: true,
+	default: class QuickAddMock {},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+
+import { splitMultiSelectLabels } from "./runOnePagePreflight";
+
+// Finding: prompts-gui-multi-suggester — the one-page |multi field stores a
+// ", "-joined string of DISPLAY labels. A naive split(",") loses options whose
+// value/label contains a literal comma (#239 quoted-comma option list). The
+// reconstruction must round-trip comma-bearing labels.
+describe("splitMultiSelectLabels", () => {
+	it("round-trips comma-bearing option labels (issue #239)", () => {
+		const displayToValue = new Map<string, string>([
+			["a, b", "a, b"],
+			["c, d", "c, d"],
+		]);
+
+		// Suggester joins the two picks with ", " -> "a, b, c, d".
+		expect(splitMultiSelectLabels("a, b, c, d", displayToValue)).toEqual([
+			"a, b",
+			"c, d",
+		]);
+	});
+
+	it("splits ordinary comma-free labels exactly like before", () => {
+		const displayToValue = new Map<string, string>([
+			["red", "red"],
+			["green", "green"],
+			["blue", "blue"],
+		]);
+
+		expect(
+			splitMultiSelectLabels("red, green, blue", displayToValue),
+		).toEqual(["red", "green", "blue"]);
+	});
+
+	it("falls back to a comma split for typed custom text not in the option map", () => {
+		const displayToValue = new Map<string, string>([["red", "red"]]);
+
+		// "red" is a known label; "custom" is typed text -> still captured.
+		expect(splitMultiSelectLabels("red, custom", displayToValue)).toEqual([
+			"red",
+			"custom",
+		]);
+	});
+
+	it("returns an empty array for a blank string", () => {
+		expect(splitMultiSelectLabels("", new Map())).toEqual([]);
+	});
+
+	it("prefers the longest matching label when labels share a prefix", () => {
+		const displayToValue = new Map<string, string>([
+			["a", "a"],
+			["a, b", "a, b"],
+		]);
+
+		// Greedy longest-first match keeps "a, b" intact instead of ["a","b"].
+		expect(splitMultiSelectLabels("a, b", displayToValue)).toEqual(["a, b"]);
+	});
+});

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -17,6 +17,51 @@ import {
 } from "./collectChoiceRequirements";
 import { shouldLeaveTemplateTitleForDiscovery } from "src/utils/templateNoteDiscoveryEligibility";
 
+/**
+ * Reconstruct the picked labels from the ", "-joined suggester string.
+ *
+ * A naive split on "," loses options whose value/label itself contains a comma
+ * (from a quoted-comma option list, #239): "a, b, c, d" must round-trip to
+ * ["a, b", "c, d"], not ["a","b","c","d"]. We greedily consume the longest known
+ * display label at each position so comma-bearing options survive; anything that
+ * doesn't match a known label (typed custom text) falls back to a "," split of
+ * the remainder so custom-allowed tokens keep working.
+ */
+export function splitMultiSelectLabels(
+	joined: string,
+	displayToValue: Map<string, string>,
+): string[] {
+	const text = joined.trim();
+	if (!text) return [];
+
+	// Longest-first so "a, b" wins over a hypothetical shorter "a" prefix.
+	const knownLabels = Array.from(displayToValue.keys()).sort(
+		(a, b) => b.length - a.length,
+	);
+
+	const out: string[] = [];
+	let rest = text;
+	while (rest.length > 0) {
+		const matched = knownLabels.find(
+			(label) => rest === label || rest.startsWith(`${label}, `),
+		);
+		if (!matched) break;
+		out.push(matched);
+		rest = rest === matched ? "" : rest.slice(matched.length + 2);
+	}
+
+	// Remainder is unrecognized (typed custom text or unmatched labels): fall back
+	// to a plain comma split so custom-allowed tokens still capture it.
+	if (rest.length > 0) {
+		for (const piece of rest.split(",")) {
+			const trimmed = piece.trim();
+			if (trimmed) out.push(trimmed);
+		}
+	}
+
+	return out;
+}
+
 function shouldPromptAtRuntimeForDiscovery(
 	choice: IChoice,
 	requirementId: string,
@@ -133,10 +178,10 @@ export async function runOnePagePreflight(
 		Object.entries(values).forEach(([k, v]) => {
 			const multiInfo = multiInfoByKey.get(k);
 			if (multiInfo !== undefined) {
-				const items = String(v)
-					.split(",")
-					.map((s) => s.trim())
-					.filter(Boolean)
+				const items = splitMultiSelectLabels(
+					String(v),
+					multiInfo.displayToValue,
+				)
 					// Drop typed entries that aren't options unless the token opted
 					// into custom input, matching the runtime MultiSuggester.
 					.filter(

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -178,9 +178,13 @@ export async function runOnePagePreflight(
 		Object.entries(values).forEach(([k, v]) => {
 			const multiInfo = multiInfoByKey.get(k);
 			if (multiInfo !== undefined) {
-				const items = splitMultiSelectLabels(
-					String(v),
-					multiInfo.displayToValue,
+				// Prefer the modal's unambiguous per-pick selection (survives the
+				// "a"+"b" vs literal "a, b" collision); fall back to parsing the
+				// ", "-joined text when the user manually edited the field.
+				const pickedLabels = modal.multiSelections.get(k);
+				const items = (
+					pickedLabels ??
+					splitMultiSelectLabels(String(v), multiInfo.displayToValue)
 				)
 					// Drop typed entries that aren't options unless the token opted
 					// into custom input, matching the runtime MultiSuggester.

--- a/src/quickAddApi.audit-api-prompts.test.ts
+++ b/src/quickAddApi.audit-api-prompts.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import type QuickAdd from "./main";
+import type { MacroAbortError } from "./errors/MacroAbortError";
+
+// ---------------------------------------------------------------------------
+// Minimal hoisted mocks. We keep the AI/format/settings subsystems stubbed out
+// so importing quickAddApi stays cheap; only reportError is spied so we can
+// assert the documented "report + continue" behaviour.
+// ---------------------------------------------------------------------------
+const mocks = vi.hoisted(() => ({
+	reportError: vi.fn(),
+}));
+
+vi.mock("./gui/GenericInputPrompt/GenericInputPrompt", () => ({
+	default: { Prompt: vi.fn() },
+}));
+vi.mock("./gui/GenericWideInputPrompt/GenericWideInputPrompt", () => ({
+	default: { Prompt: vi.fn() },
+}));
+vi.mock("./gui/GenericYesNoPrompt/GenericYesNoPrompt", () => ({
+	default: { Prompt: vi.fn() },
+}));
+vi.mock("./gui/GenericInfoDialog/GenericInfoDialog", () => ({
+	default: { Show: vi.fn() },
+}));
+vi.mock("./gui/GenericCheckboxPrompt/genericCheckboxPrompt", () => ({
+	default: { Open: vi.fn() },
+}));
+vi.mock("./gui/GenericSuggester/genericSuggester", () => ({
+	default: { Suggest: vi.fn() },
+}));
+vi.mock("./gui/InputSuggester/inputSuggester", () => ({
+	default: { Suggest: vi.fn() },
+}));
+vi.mock("./gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	default: { Prompt: vi.fn() },
+}));
+vi.mock("./preflight/OnePageInputModal", () => ({
+	OnePageInputModal: class {},
+}));
+vi.mock("./ai/AIAssistant", () => ({
+	Prompt: vi.fn(),
+	ChunkedPrompt: vi.fn(),
+	getAIRequestLogEntries: vi.fn(),
+	getAIRequestLogEntryById: vi.fn(),
+	getLastAIRequestLogEntry: vi.fn(),
+	clearAIRequestLogEntries: vi.fn(),
+}));
+vi.mock("./ai/tokenEstimator", () => ({ estimateTokenCount: vi.fn() }));
+vi.mock("./ai/aiHelpers", () => ({
+	getModelByName: vi.fn(),
+	getModelNames: vi.fn(),
+	getModelProvider: vi.fn(),
+}));
+vi.mock("./ai/providerSecrets", () => ({ resolveProviderApiKey: vi.fn() }));
+vi.mock("./formatters/completeFormatter", () => ({
+	CompleteFormatter: class {
+		formatFileContent = vi.fn();
+	},
+}));
+vi.mock("./settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({
+			disableOnlineFeatures: false,
+			ai: { defaultSystemPrompt: "DEFAULT SYS" },
+		}),
+	},
+}));
+vi.mock("./utilityObsidian", () => ({ getDate: vi.fn() }));
+vi.mock("./utils/errorUtils", async () => {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	const actual = await vi.importActual<typeof import("./utils/errorUtils")>(
+		"./utils/errorUtils",
+	);
+	return { ...actual, reportError: mocks.reportError };
+});
+
+const { QuickAddApi } = await import("./quickAddApi");
+
+type FakeFile = { path: string; basename?: string };
+
+function makeApp(overrides: Record<string, unknown> = {}) {
+	return {
+		workspace: { getActiveViewOfType: vi.fn(() => undefined) },
+		vault: {
+			getMarkdownFiles: vi.fn(() => [] as FakeFile[]),
+			read: vi.fn(async () => ""),
+		},
+		metadataCache: { getFileCache: vi.fn(() => undefined) },
+		...overrides,
+	} as unknown as App;
+}
+
+function makeChoiceExecutor() {
+	return {
+		variables: new Map<string, unknown>(),
+		execute: vi.fn(async () => {}),
+		consumeAbortSignal: vi.fn((): MacroAbortError | null => null),
+	};
+}
+
+function makePlugin(overrides: Record<string, unknown> = {}) {
+	return {
+		getChoiceByName: vi.fn(() => ({ name: "choice", id: "1" })),
+		...overrides,
+	} as unknown as QuickAdd;
+}
+
+function getApi(
+	app = makeApp(),
+	plugin = makePlugin(),
+	executor = makeChoiceExecutor(),
+) {
+	return {
+		api: QuickAddApi.GetApi(app, plugin, executor as never),
+		app,
+		plugin,
+		executor,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+// ===========================================================================
+// executeChoice — production getChoiceByName THROWS for an unknown name.
+// (audit: api-execute-choice)
+// ===========================================================================
+describe("executeChoice on an unknown choice (throwing getChoiceByName)", () => {
+	it("reports the error and returns instead of propagating the throw", async () => {
+		// Mirror production main.ts:getChoiceByName, which throws (never returns falsy).
+		const plugin = makePlugin({
+			getChoiceByName: vi.fn(() => {
+				throw new Error("Choice typo not found");
+			}),
+		});
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), plugin, executor);
+
+		await expect(api.executeChoice("typo")).resolves.toBeUndefined();
+		expect(mocks.reportError).toHaveBeenCalled();
+		// The macro is NOT aborted: execute() is never reached, no throw escapes.
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("still executes a found choice and clears variables", async () => {
+		const choice = { name: "MyChoice", id: "id1" };
+		const executor = makeChoiceExecutor();
+		const plugin = makePlugin({ getChoiceByName: vi.fn(() => choice) });
+		const { api } = getApi(makeApp(), plugin, executor);
+
+		await api.executeChoice("MyChoice", { foo: "bar" });
+
+		expect(executor.execute).toHaveBeenCalledWith(choice);
+		expect(executor.variables.size).toBe(0);
+		expect(mocks.reportError).not.toHaveBeenCalled();
+	});
+});
+
+// ===========================================================================
+// fieldSuggestions.getFieldValues — null/object array items + unreadable files.
+// (audit: api-field-suggestions-get-field-values / integrations-api-getfieldvalues)
+// ===========================================================================
+describe("getFieldValues frontmatter array safety", () => {
+	function fileCacheApp(
+		frontmatterByPath: Record<string, Record<string, unknown>>,
+		read?: (file: FakeFile) => Promise<string>,
+	) {
+		const files = Object.keys(frontmatterByPath).map((path) => ({ path }));
+		return makeApp({
+			vault: {
+				getMarkdownFiles: () => files,
+				read: read ?? (async () => ""),
+			},
+			metadataCache: {
+				getFileCache: (file: FakeFile) => ({
+					frontmatter: frontmatterByPath[file.path],
+				}),
+			},
+		});
+	}
+
+	it("skips null array items instead of throwing on .toString()", async () => {
+		// `tags:\n  - done\n  -\n  - pending` parses to ["done", null, "pending"].
+		const app = fileCacheApp({
+			"a.md": { tags: ["done", null, "pending"] },
+		});
+		const { api } = getApi(app);
+
+		const values = await api.fieldSuggestions.getFieldValues("tags");
+		expect(values).toEqual(["done", "pending"]);
+	});
+
+	it("ignores object array items instead of emitting [object Object]", async () => {
+		const app = fileCacheApp({
+			"a.md": { tags: ["ok", { nested: true }] },
+		});
+		const { api } = getApi(app);
+
+		const values = await api.fieldSuggestions.getFieldValues("tags");
+		expect(values).toEqual(["ok"]);
+		expect(values).not.toContain("[object Object]");
+	});
+
+	it("skips a file whose contents cannot be read for inline fields", async () => {
+		const app = fileCacheApp(
+			{ "a.md": {}, "b.md": {} },
+			async (file: FakeFile) => {
+				if (file.path === "a.md") throw new Error("EACCES");
+				return "priority:: high\n";
+			},
+		);
+		const { api } = getApi(app);
+
+		const values = await api.fieldSuggestions.getFieldValues("priority", {
+			includeInline: true,
+		});
+		// The unreadable a.md is skipped; b.md still contributes.
+		expect(values).toEqual(["high"]);
+	});
+});

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -329,19 +329,41 @@ export class QuickAddApi {
 					options,
 				);
 			},
-			checkboxPrompt: (items: string[], selectedItems?: string[]) => {
-				return QuickAddApi.checkboxPrompt(app, items, selectedItems);
+			checkboxPrompt: (
+				items: string[],
+				selectedItems?: string[],
+				header?: string,
+			) => {
+				return QuickAddApi.checkboxPrompt(
+					app,
+					items,
+					selectedItems,
+					header,
+				);
 			},
 			executeChoice: async (
 				choiceName: string,
 				variables?: Record<string, unknown>,
 			) => {
-				const choice: IChoice = plugin.getChoiceByName(choiceName);
-				if (!choice)
+				// getChoiceByName THROWS when the name doesn't match a choice, so
+				// look it up defensively: report + return (don't abort the macro)
+				// to honor the documented "reports an error, does not throw"
+				// contract. The `!choice` fallback also covers any non-throwing
+				// lookup that yields a falsy result.
+				let choice: IChoice | undefined;
+				try {
+					choice = plugin.getChoiceByName(choiceName);
+				} catch {
+					choice = undefined;
+				}
+
+				if (!choice) {
 					reportError(
 						new Error(`Choice named '${choiceName}' not found`),
 						"API executeChoice error",
 					);
+					return;
+				}
 
 				if (variables) {
 					Object.keys(variables).forEach((key) => {
@@ -805,27 +827,38 @@ export class QuickAddApi {
 						const value = cache?.frontmatter?.[fieldName];
 						if (value !== undefined && value !== null) {
 							if (Array.isArray(value)) {
+								// Skip null/undefined and nested objects before
+								// stringifying — String(null) is "null" and an
+								// object yields "[object Object]"; both are noise.
 								value.forEach((x) => {
-									const strValue = x.toString().trim();
+									if (x === undefined || x === null) return;
+									if (typeof x === "object") return;
+									const strValue = String(x).trim();
 									if (strValue) values.add(strValue);
 								});
 							} else if (typeof value !== "object") {
-								const strValue = value.toString().trim();
+								const strValue = String(value).trim();
 								if (strValue) values.add(strValue);
 							}
 						}
 
 						// Get values from inline fields if requested
 						if (filters.inline) {
-							const content = await app.vault.read(file);
-							const inlineValues = InlineFieldParser.getFieldValues(
-								content,
-								fieldName,
-								{
-									includeCodeBlocks: inlineCodeBlocks,
-								},
-							);
-							inlineValues.forEach((v) => values.add(v));
+							// One unreadable file must not abort the whole call;
+							// skip it (mirrors FieldValueCollector).
+							try {
+								const content = await app.vault.read(file);
+								const inlineValues = InlineFieldParser.getFieldValues(
+									content,
+									fieldName,
+									{
+										includeCodeBlocks: inlineCodeBlocks,
+									},
+								);
+								inlineValues.forEach((v) => values.add(v));
+							} catch {
+								// Ignore files whose contents cannot be read.
+							}
 						}
 					}
 
@@ -988,9 +1021,14 @@ export class QuickAddApi {
 		app: App,
 		items: string[],
 		selectedItems?: string[],
+		header?: string,
 	) {
 		try {
-			return await GenericCheckboxPrompt.Open(app, items, selectedItems);
+			// Only forward `header` when provided so existing 3-argument call
+			// sites stay byte-identical (no trailing `undefined`).
+			return await (header === undefined
+				? GenericCheckboxPrompt.Open(app, items, selectedItems)
+				: GenericCheckboxPrompt.Open(app, items, selectedItems, header));
 		} catch (error) {
 			throwIfPromptCancelled(error);
 			return undefined;


### PR DESCRIPTION
This PR bundles 18 fixes from a systematic feature audit (logic + UX), each adversarially verified and covered by regression tests.

- **[Minor]** executeChoice throws on unknown choice instead of reporting and continuing (dead error branch + misleading test)
- **[Minor]** getFieldValues throws on null array items and emits "[object Object]" for object array items
- **[Minor]** executeChoice throws raw 'Choice not found' instead of the friendly, non-throwing error it intends
- **[Minor]** Tab key crashes GenericSuggester when the query has no matches (api.suggester without custom input)
- **[Minor]** requestInputs silently drops unparseable/blank required date input as empty string (data loss)
- **[Minor]** datePrompt returns an unparseable typed value verbatim with no error
- **[Minor]** MathModal ignores Cmd+Enter on macOS (only Ctrl+Enter submits)
- **[Minor]** api.fieldSuggestions.getFieldValues throws on unreadable files and on null array elements
- **[Minor]** VDATE preview ignores a restored draft: box shows the draft but currentInput/preview reset to defaultValue
- **[Minor]** null-valued variables are treated as resolved, so the one-page modal skips them (contradicts 'missing/null' rule)
- **[Minor]** One-page |multi loses quoted-comma options: result is comma-split, breaking option values that contain commas
- **[Minor]** One-page modal does not auto-focus first field or submit on Enter
- **[Minor]** Tab autocomplete can throw when nothing is selected (missing null guard)
- **[Minor]** Checkbox prompt has no title/header and no Cancel button
- **[Minor]** MathJax modal doesn't submit on Cmd+Enter (macOS) and has no submit hint
- **[Trivial]** Clearing the date picker time field keeps the previously merged time (no way to drop it)
- **[Trivial]** Math output only escapes the first literal \n occurrence
- **[Trivial]** Optional VDATE blank shows generic placeholder instead of 'Will be left empty'

All tests/typecheck/lint/build green. Part of a 9-PR series splitting the audit by area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added optional headers to checkbox prompts.
  * Added **Ctrl/Cmd+Shift+Enter** to skip optional prompts (including correct behavior in wide prompts).
  * Improved multi-select handling with smarter label parsing and ordered selection tracking.
  * Math modal now supports **Cmd+Enter** submission and shows keyboard hints.
* **Bug Fixes**
  * Date/time handling fixes: clearing time resets to midnight; restored drafts/previews and parse warnings are more accurate.
  * Safer choice lookup and field suggestion handling (null/unreadable values), plus more resilient Tab completion.
* **Tests**
  * Expanded prompt/modal and input behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->