### PR TITLE
fix(settings): global-variable data loss, package overwrite guard, and settings UX

### DIFF
--- a/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
+++ b/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
@@ -79,8 +79,12 @@ describe("GlobalVariablesView mid-edit persistence (audit)", () => {
 		const valueTextareas = getValueTextareas(container);
 		expect(valueTextareas).toHaveLength(1);
 		expect(valueTextareas[0].value).toBe("snippet-data");
-		// The store may hold {} now, but the user has not lost their snippet.
-		expect(settingsStore.getState().globalVariables).toEqual({});
+		// And the store is NOT corrupted with a lossy record: an empty (unkeyable)
+		// name is never written, so the previously-persisted value is preserved
+		// until the name is valid again (Codex review follow-up).
+		expect(settingsStore.getState().globalVariables).toEqual({
+			foo: "snippet-data",
+		});
 	});
 
 	it("does not collapse a second row when its name transiently duplicates another", async () => {
@@ -106,5 +110,11 @@ describe("GlobalVariablesView mid-edit persistence (audit)", () => {
 		const valueTextareas = getValueTextareas(container);
 		expect(valueTextareas).toHaveLength(2);
 		expect(valueTextareas.map((t) => t.value)).toContain("second-value");
+		// The duplicate name is never persisted (no last-wins collapse): the
+		// store keeps the prior valid record until the names are unique again.
+		expect(settingsStore.getState().globalVariables).toEqual({
+			foo: "first-value",
+			bar: "second-value",
+		});
 	});
 });

--- a/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
+++ b/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import { App } from "obsidian";
+import GlobalVariablesView from "./GlobalVariablesView.svelte";
+import { settingsStore } from "../../settingsStore";
+import { DEFAULT_SETTINGS } from "../../settings";
+import { deepClone } from "../../utils/deepClone";
+
+// Regression coverage for the Global Variables mid-edit data-loss footgun:
+// persistToSettings drops empty-name rows and the store subscriber reloaded
+// `items` on EVERY store change — including the component's own debounced
+// persist. Clearing a Name field (to retype it) therefore made the row, and
+// the snippet value the user wrote, vanish. The fix suppresses the reload that
+// the component's own setState triggers, so in-memory rows survive editing.
+
+function appWithSuggestSupport(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function fakePlugin() {
+	return {
+		settings: { choices: [] },
+		getTemplateFiles: () => [],
+	} as never;
+}
+
+function getNameInputs(container: HTMLElement): HTMLInputElement[] {
+	return Array.from(
+		container.querySelectorAll<HTMLInputElement>(".qa-gv__name input"),
+	);
+}
+
+function getValueTextareas(container: HTMLElement): HTMLTextAreaElement[] {
+	return Array.from(
+		container.querySelectorAll<HTMLTextAreaElement>(".qa-gv__value textarea"),
+	);
+}
+
+describe("GlobalVariablesView mid-edit persistence (audit)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	afterEach(() => {
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	it("keeps the row and its value when the Name field is cleared mid-edit", async () => {
+		settingsStore.setState({ globalVariables: { foo: "snippet-data" } });
+
+		const { container } = render(GlobalVariablesView, {
+			props: { app: appWithSuggestSupport(), plugin: fakePlugin() },
+		});
+
+		expect(getNameInputs(container)).toHaveLength(1);
+		expect(getValueTextareas(container)[0].value).toBe("snippet-data");
+
+		// User selects-all + deletes the Name to retype it.
+		const nameInput = getNameInputs(container)[0];
+		nameInput.value = "";
+		await fireEvent.input(nameInput);
+
+		// Pause past the 200ms debounce -> persistToSettings runs and writes an
+		// empty record (empty name is unkeyable). Pre-fix the subscriber reloaded
+		// items to [] and the row + value disappeared.
+		vi.advanceTimersByTime(250);
+		flushSync();
+
+		const valueTextareas = getValueTextareas(container);
+		expect(valueTextareas).toHaveLength(1);
+		expect(valueTextareas[0].value).toBe("snippet-data");
+		// The store may hold {} now, but the user has not lost their snippet.
+		expect(settingsStore.getState().globalVariables).toEqual({});
+	});
+
+	it("does not collapse a second row when its name transiently duplicates another", async () => {
+		settingsStore.setState({
+			globalVariables: { foo: "first-value", bar: "second-value" },
+		});
+
+		const { container } = render(GlobalVariablesView, {
+			props: { app: appWithSuggestSupport(), plugin: fakePlugin() },
+		});
+
+		expect(getNameInputs(container)).toHaveLength(2);
+
+		// User renames the second row to collide with the first.
+		const secondName = getNameInputs(container)[1];
+		secondName.value = "foo";
+		await fireEvent.input(secondName);
+		vi.advanceTimersByTime(250);
+		flushSync();
+
+		// Both rows (and their values) remain on screen mid-edit; the snippet the
+		// user wrote into the second row is not silently destroyed.
+		const valueTextareas = getValueTextareas(container);
+		expect(valueTextareas).toHaveLength(2);
+		expect(valueTextareas.map((t) => t.value)).toContain("second-value");
+	});
+});

--- a/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
+++ b/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
@@ -159,9 +159,10 @@ describe("GlobalVariablesView mid-edit persistence (audit)", () => {
 		vi.advanceTimersByTime(250);
 		flushSync();
 
-		// Stored under the trimmed key so {{GLOBAL_VAR:spaced}} resolves it.
-		expect(
-			Object.keys(settingsStore.getState().globalVariables),
-		).toContain("spaced");
+		// Stored under the trimmed key so {{GLOBAL_VAR:spaced}} resolves it, and
+		// NOT under the raw untrimmed key (which would be unreferenceable).
+		const keys = Object.keys(settingsStore.getState().globalVariables);
+		expect(keys).toContain("spaced");
+		expect(keys).not.toContain("  spaced  ");
 	});
 });

--- a/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
+++ b/src/gui/GlobalVariables/GlobalVariablesView.audit-settings-pkg.test.ts
@@ -117,4 +117,51 @@ describe("GlobalVariablesView mid-edit persistence (audit)", () => {
 			bar: "second-value",
 		});
 	});
+
+	it("treats a whitespace-only name as empty (does not persist a ' ' key)", async () => {
+		settingsStore.setState({ globalVariables: { foo: "snippet-data" } });
+
+		const { container } = render(GlobalVariablesView, {
+			props: { app: appWithSuggestSupport(), plugin: fakePlugin() },
+		});
+
+		// User replaces the name with only spaces while editing.
+		const nameInput = getNameInputs(container)[0];
+		nameInput.value = "   ";
+		await fireEvent.input(nameInput);
+		vi.advanceTimersByTime(250);
+		flushSync();
+
+		// A whitespace-only name is effectively empty ({{GLOBAL_VAR}} trims before
+		// lookup), so it is NOT written — the prior value is preserved.
+		expect(settingsStore.getState().globalVariables).toEqual({
+			foo: "snippet-data",
+		});
+	});
+
+	it("persists a trimmed, referenceable key when the name has stray whitespace", async () => {
+		settingsStore.setState({ globalVariables: {} });
+
+		const { container } = render(GlobalVariablesView, {
+			props: { app: appWithSuggestSupport(), plugin: fakePlugin() },
+		});
+
+		const addButton = Array.from(
+			container.querySelectorAll<HTMLButtonElement>("button"),
+		).find((b) => b.textContent === "Add variable");
+		expect(addButton).toBeDefined();
+		await fireEvent.click(addButton!);
+		flushSync();
+
+		const nameInput = getNameInputs(container)[0];
+		nameInput.value = "  spaced  ";
+		await fireEvent.input(nameInput);
+		vi.advanceTimersByTime(250);
+		flushSync();
+
+		// Stored under the trimmed key so {{GLOBAL_VAR:spaced}} resolves it.
+		expect(
+			Object.keys(settingsStore.getState().globalVariables),
+		).toContain("spaced");
+	});
 });

--- a/src/gui/GlobalVariables/GlobalVariablesView.svelte
+++ b/src/gui/GlobalVariables/GlobalVariablesView.svelte
@@ -23,13 +23,26 @@
     items = Object.keys(globals).map((k) => ({ name: k, value: globals[k] ?? "" }));
   }
 
+  // True while this component is writing its own edits to the store, so the
+  // store subscriber does not reload (and collapse/drop) the rows the user is
+  // actively editing. Empty-name rows are dropped on persist (they cannot be
+  // keyed), and duplicate names overwrite each other in the persisted record;
+  // suppressing the self-triggered reload keeps those in-memory rows (and their
+  // values) on screen mid-edit instead of making them vanish.
+  let suppressReload = false;
+
   function persistToSettings() {
     const next: Record<string, string> = {};
     for (const it of items) {
       if (!it.name) continue;
       next[it.name] = it.value ?? "";
     }
-    settingsStore.setState({ globalVariables: next });
+    suppressReload = true;
+    try {
+      settingsStore.setState({ globalVariables: next });
+    } finally {
+      suppressReload = false;
+    }
   }
 
   function addVariable() {
@@ -66,7 +79,12 @@
   }
 
   $effect(() => {
-    const unsubscribe = settingsStore.subscribe(() => loadFromSettings());
+    const unsubscribe = settingsStore.subscribe(() => {
+      // Ignore the store change this component just produced, so our own
+      // debounced persist does not reload over the rows being edited.
+      if (suppressReload) return;
+      loadFromSettings();
+    });
     loadFromSettings();
     return () => {
       if (debounceTimer !== undefined) window.clearTimeout(debounceTimer);

--- a/src/gui/GlobalVariables/GlobalVariablesView.svelte
+++ b/src/gui/GlobalVariables/GlobalVariablesView.svelte
@@ -23,18 +23,25 @@
     items = Object.keys(globals).map((k) => ({ name: k, value: globals[k] ?? "" }));
   }
 
-  // True while this component is writing its own edits to the store, so the
-  // store subscriber does not reload (and collapse/drop) the rows the user is
-  // actively editing. Empty-name rows are dropped on persist (they cannot be
-  // keyed), and duplicate names overwrite each other in the persisted record;
-  // suppressing the self-triggered reload keeps those in-memory rows (and their
-  // values) on screen mid-edit instead of making them vanish.
+  // True while this component is writing its own (valid) edits to the store, so
+  // the store subscriber does not reload (and collapse) the rows the user is
+  // actively editing. Invalid states (empty or duplicate names) are never
+  // written at all (see persistToSettings), so they can't corrupt the store.
   let suppressReload = false;
 
   function persistToSettings() {
+    // Never publish a lossy record. An empty name can't be keyed (it would be
+    // dropped) and duplicate names collapse last-wins — writing either to the
+    // store (and the debounced data.json save) is the data-loss footgun. While
+    // any name is empty or duplicated, keep the edit local and leave the
+    // previously-persisted values intact until the names are valid again.
+    const names = items.map((it) => it.name);
+    const hasEmpty = names.some((n) => !n);
+    const hasDuplicate = new Set(names).size !== names.length;
+    if (hasEmpty || hasDuplicate) return;
+
     const next: Record<string, string> = {};
     for (const it of items) {
-      if (!it.name) continue;
       next[it.name] = it.value ?? "";
     }
     suppressReload = true;

--- a/src/gui/GlobalVariables/GlobalVariablesView.svelte
+++ b/src/gui/GlobalVariables/GlobalVariablesView.svelte
@@ -35,14 +35,19 @@
     // store (and the debounced data.json save) is the data-loss footgun. While
     // any name is empty or duplicated, keep the edit local and leave the
     // previously-persisted values intact until the names are valid again.
-    const names = items.map((it) => it.name);
+    // Validate and persist on TRIMMED names: the {{GLOBAL_VAR:<name>}} token
+    // trims the name before lookup, so a whitespace-only name ("   ") is
+    // effectively empty and "foo " collides with "foo". Treat both as
+    // invalid/duplicate (keep the edit local) and write trimmed, referenceable
+    // keys when valid.
+    const names = items.map((it) => it.name.trim());
     const hasEmpty = names.some((n) => !n);
     const hasDuplicate = new Set(names).size !== names.length;
     if (hasEmpty || hasDuplicate) return;
 
     const next: Record<string, string> = {};
     for (const it of items) {
-      next[it.name] = it.value ?? "";
+      next[it.name.trim()] = it.value ?? "";
     }
     suppressReload = true;
     try {

--- a/src/gui/PackageManager/ExportPackageModal.audit-cleanup.test.ts
+++ b/src/gui/PackageManager/ExportPackageModal.audit-cleanup.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@testing-library/svelte";
+import { Notice } from "obsidian";
+import type { App } from "obsidian";
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import ExportPackageModal from "./ExportPackageModal.svelte";
+import type * as PackageExportService from "../../services/packageExportService";
+import { QUICKADD_PACKAGE_SCHEMA_VERSION } from "../../types/packages/QuickAddPackage";
+import type { QuickAddPackage } from "../../types/packages/QuickAddPackage";
+
+// Audit cleanup for settings-package-export: the save handler must (a) reflect
+// overwrite-vs-new in the success Notice using writePackageToVault's
+// {overwritten} return value, and (b) surface a neutral "Save cancelled." no-op
+// (not "Save failed: Save cancelled: …") when the user declines the overwrite
+// confirmation.
+
+const writePackageToVault = vi.hoisted(() => vi.fn());
+
+function makePkg(): QuickAddPackage {
+	return {
+		schemaVersion: QUICKADD_PACKAGE_SCHEMA_VERSION,
+		quickAddVersion: "1.0.0",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		rootChoiceIds: ["root"],
+		choices: [
+			{
+				choice: { id: "root", name: "Root", type: "Template" } as never,
+				pathHint: ["Root"],
+				parentChoiceId: null,
+			},
+		],
+		assets: [],
+	};
+}
+
+vi.mock("../../services/packageExportService", async (importOriginal) => {
+	const actual = await importOriginal<typeof PackageExportService>();
+	return {
+		...actual,
+		// Deterministic default path so the save input is pre-filled.
+		generateDefaultPackagePath: () => "QuickAdd Packages/test.quickadd.json",
+		buildPackage: vi.fn(async () => ({
+			pkg: makePkg(),
+			missingChoiceIds: [],
+			missingAssets: [],
+		})),
+		writePackageToVault,
+	};
+});
+
+const ROOT_CHOICE: IChoice = {
+	id: "root",
+	name: "Root",
+	type: "Template",
+} as unknown as IChoice;
+
+function fakeApp(): App {
+	return {
+		vault: {
+			adapter: {
+				exists: vi.fn(async () => true),
+				read: vi.fn(async () => ""),
+				write: vi.fn(async () => {}),
+			},
+		},
+	} as unknown as App;
+}
+
+function fakePlugin(): QuickAdd {
+	return { manifest: { version: "1.0.0" } } as unknown as QuickAdd;
+}
+
+async function selectRootAndSave(): Promise<{ close: ReturnType<typeof vi.fn> }> {
+	const close = vi.fn();
+	const { container } = render(ExportPackageModal, {
+		props: {
+			app: fakeApp(),
+			plugin: fakePlugin(),
+			allChoices: [ROOT_CHOICE],
+			close,
+		},
+	});
+
+	// Select the single root choice so rootChoiceIds is non-empty.
+	const checkbox = container.querySelector(
+		'input[type="checkbox"]',
+	) as HTMLInputElement;
+	await fireEvent.change(checkbox, { target: { checked: true } });
+
+	const saveButton = container.querySelector(
+		".saveRow button",
+	) as HTMLButtonElement;
+	await fireEvent.click(saveButton);
+
+	return { close };
+}
+
+// The obsidian test stub records every constructed Notice; the public type does
+// not expose `instances`, so cast through the shape other audit tests use.
+function noticeStore(): { instances: { message: string }[] } {
+	return Notice as unknown as { instances: { message: string }[] };
+}
+
+function noticeMessages(): string[] {
+	return noticeStore().instances.map((n) => n.message);
+}
+
+beforeEach(() => {
+	noticeStore().instances.length = 0;
+	writePackageToVault.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("ExportPackageModal save notices (audit)", () => {
+	it("says 'Saved package … to' when the file is new (overwritten=false)", async () => {
+		writePackageToVault.mockResolvedValue({ overwritten: false });
+
+		await selectRootAndSave();
+
+		await waitFor(() => {
+			expect(
+				noticeMessages().some((m) => m.startsWith("Saved package")),
+			).toBe(true);
+		});
+		expect(
+			noticeMessages().some((m) => m.startsWith("Overwrote package")),
+		).toBe(false);
+	});
+
+	it("says 'Overwrote package … at' when overwritten=true", async () => {
+		writePackageToVault.mockResolvedValue({ overwritten: true });
+
+		await selectRootAndSave();
+
+		await waitFor(() => {
+			expect(
+				noticeMessages().some((m) => m.startsWith("Overwrote package")),
+			).toBe(true);
+		});
+		expect(
+			noticeMessages().some((m) => m.startsWith("Saved package")),
+		).toBe(false);
+	});
+
+	it("surfaces a neutral 'Save cancelled.' (not 'Save failed: …') when the overwrite is declined", async () => {
+		writePackageToVault.mockRejectedValue(
+			new Error(
+				"Save cancelled: 'QuickAdd Packages/test.quickadd.json' already exists.",
+			),
+		);
+
+		const { close } = await selectRootAndSave();
+
+		await waitFor(() => {
+			expect(noticeMessages()).toContain("Save cancelled.");
+		});
+		// No contradictory failure notice, and the modal stays open.
+		expect(
+			noticeMessages().some((m) => m.startsWith("Save failed")),
+		).toBe(false);
+		expect(close).not.toHaveBeenCalled();
+	});
+
+	it("still reports genuine write errors as 'Save failed: …'", async () => {
+		writePackageToVault.mockRejectedValue(new Error("disk full"));
+
+		await selectRootAndSave();
+
+		await waitFor(() => {
+			expect(noticeMessages()).toContain("Save failed: disk full");
+		});
+	});
+});

--- a/src/gui/PackageManager/ExportPackageModal.svelte
+++ b/src/gui/PackageManager/ExportPackageModal.svelte
@@ -278,11 +278,17 @@
 			const buildResult = await preparePackage();
 			if (!buildResult) return;
 
-			await writePackageToVault(app, buildResult.pkg, trimmedPath);
+			const { overwritten } = await writePackageToVault(
+				app,
+				buildResult.pkg,
+				trimmedPath,
+			);
+			const choiceCount = buildResult.pkg.choices.length;
+			const choiceLabel = `${choiceCount} choice${choiceCount === 1 ? "" : "s"}`;
 			new Notice(
-				`Saved package (${buildResult.pkg.choices.length} choice${
-					buildResult.pkg.choices.length === 1 ? "" : "s"
-				}) to '${trimmedPath}'.`,
+				overwritten
+					? `Overwrote package (${choiceLabel}) at '${trimmedPath}'.`
+					: `Saved package (${choiceLabel}) to '${trimmedPath}'.`,
 			);
 
 			if (exportWarnings) {
@@ -291,8 +297,15 @@
 				close();
 			}
 		} catch (error) {
+			const message = (error as Error)?.message ?? String(error);
+			// Declining the overwrite confirmation is a deliberate no-op, not a
+			// failure: surface it neutrally instead of "Save failed: Save cancelled: …".
+			if (message.startsWith("Save cancelled:")) {
+				new Notice("Save cancelled.");
+				return;
+			}
 			console.error(error);
-			new Notice(`Save failed: ${(error as Error)?.message ?? String(error)}`);
+			new Notice(`Save failed: ${message}`);
 		} finally {
 			actionInProgress = null;
 		}

--- a/src/quickAddSettingsTab.audit-cleanup.test.ts
+++ b/src/quickAddSettingsTab.audit-cleanup.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { App } from "obsidian";
+import { QuickAddSettingsTab } from "./quickAddSettingsTab";
+import type QuickAdd from "./main";
+
+// Importing the settings tab transitively pulls in ChoiceView -> the Dataview
+// integration, whose compiled CJS does a bare `require('obsidian')` that the
+// vitest alias can't intercept. Mock it as the sibling settings tests do.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+function makeTab(): QuickAddSettingsTab {
+	const app = new App();
+	const plugin = { app } as unknown as QuickAdd;
+	return new QuickAddSettingsTab(app, plugin);
+}
+
+function findUriToggleDesc(tab: QuickAddSettingsTab): string {
+	const groups = tab.getSettingDefinitions() as unknown as Array<{
+		items?: Array<{ desc?: unknown; control?: { key?: string } }>;
+	}>;
+
+	for (const group of groups) {
+		for (const item of group.items ?? []) {
+			if (item.control?.key === "enableUriCallbacks") {
+				expect(typeof item.desc).toBe("string");
+				return item.desc as string;
+			}
+		}
+	}
+
+	throw new Error("Could not find the enableUriCallbacks toggle definition");
+}
+
+describe("URI x-callback toggle description", () => {
+	it("notes that x-* callbacks restrict a URI to Template/Capture choices", () => {
+		const desc = findUriToggleDesc(makeTab());
+
+		// The runtime warning half (main.ts) skips non-Template/Capture choices
+		// when x-* params are present; the toggle copy must surface that limit.
+		expect(desc).toContain("Template");
+		expect(desc).toContain("Capture");
+		expect(desc.toLowerCase()).toContain("x-*");
+		expect(desc.toLowerCase()).toMatch(/restrict/);
+	});
+});

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -300,7 +300,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 				},
 				{
 					name: "Allow URI x-callback-url",
-					desc: "When on, an obsidian://quickadd URI may open a callback URL (x-success / x-error / x-cancel) after a Template or Capture choice finishes — sending the outcome and the affected note's vault path and URL to that callback. Off by default because the callback URL is set by whoever creates the obsidian:// link. Only shortcuts: and obsidian: callback URLs are permitted.",
+					desc: "When on, an obsidian://quickadd URI may open a callback URL (x-success / x-error / x-cancel) after a Template or Capture choice finishes — sending the outcome and the affected note's vault path and URL to that callback. While on, a URI that carries x-* callback params is restricted to Template and Capture choices (other choice types are warned and skipped). Off by default because the callback URL is set by whoever creates the obsidian:// link. Only shortcuts: and obsidian: callback URLs are permitted.",
 					control: { type: "toggle", key: "enableUriCallbacks" },
 				},
 			],

--- a/src/services/packageExportService.audit-settings-pkg.test.ts
+++ b/src/services/packageExportService.audit-settings-pkg.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { writePackageToVault } from "./packageExportService";
+import { QUICKADD_PACKAGE_SCHEMA_VERSION } from "../types/packages/QuickAddPackage";
+import type { QuickAddPackage } from "../types/packages/QuickAddPackage";
+
+// Regression coverage for the settings-package-export overwrite footgun:
+// writePackageToVault previously called adapter.write unconditionally, silently
+// clobbering any existing file at the chosen (freely editable) path. It must now
+// confirm before overwriting an existing file and abort if the user declines.
+
+function makePackage(): QuickAddPackage {
+	return {
+		schemaVersion: QUICKADD_PACKAGE_SCHEMA_VERSION,
+		quickAddVersion: "1.0.0",
+		createdAt: "2026-01-01T00:00:00.000Z",
+		rootChoiceIds: [],
+		choices: [],
+		assets: [],
+	};
+}
+
+function makeFakeApp(existing: boolean) {
+	const writes: Array<{ path: string; content: string }> = [];
+	const adapter = {
+		exists: vi.fn(async (_path: string) => existing),
+		write: vi.fn(async (path: string, content: string) => {
+			writes.push({ path, content });
+		}),
+	};
+	const app = {
+		vault: {
+			adapter,
+			createFolder: vi.fn(async () => {}),
+		},
+	};
+	return { app, adapter, writes };
+}
+
+describe("writePackageToVault overwrite confirmation (audit)", () => {
+	it("does NOT prompt and writes directly when the target does not exist", async () => {
+		const { app, writes } = makeFakeApp(false);
+		const confirmOverwrite = vi.fn(async () => true);
+
+		const result = await writePackageToVault(
+			app as never,
+			makePackage(),
+			"QuickAdd Packages/new.quickadd.json",
+			{ confirmOverwrite },
+		);
+
+		expect(confirmOverwrite).not.toHaveBeenCalled();
+		expect(writes).toHaveLength(1);
+		expect(result.overwritten).toBe(false);
+	});
+
+	it("confirms before overwriting an existing file and writes when confirmed", async () => {
+		const { app, writes } = makeFakeApp(true);
+		const confirmOverwrite = vi.fn(async () => true);
+
+		const result = await writePackageToVault(
+			app as never,
+			makePackage(),
+			"Existing/note.md",
+			{ confirmOverwrite },
+		);
+
+		expect(confirmOverwrite).toHaveBeenCalledWith("Existing/note.md");
+		expect(writes).toHaveLength(1);
+		expect(result.overwritten).toBe(true);
+	});
+
+	it("aborts the write (throws, no adapter.write) when the user declines the overwrite", async () => {
+		const { app, adapter, writes } = makeFakeApp(true);
+		const confirmOverwrite = vi.fn(async () => false);
+
+		await expect(
+			writePackageToVault(app as never, makePackage(), "Existing/note.md", {
+				confirmOverwrite,
+			}),
+		).rejects.toThrow("already exists");
+
+		expect(confirmOverwrite).toHaveBeenCalledOnce();
+		expect(adapter.write).not.toHaveBeenCalled();
+		expect(writes).toEqual([]);
+	});
+});

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -610,6 +610,7 @@ describe("writePackageToVault", () => {
 			app as never,
 			pkg,
 			"QuickAdd Packages/out.quickadd.json",
+			{ confirmOverwrite: async () => true },
 		);
 
 		expect(writes).toHaveLength(1);
@@ -627,6 +628,7 @@ describe("writePackageToVault", () => {
 			app as never,
 			pkg,
 			"  QuickAdd Packages\\nested\\out.json  ",
+			{ confirmOverwrite: async () => true },
 		);
 
 		expect(writes[0].path).toBe("QuickAdd Packages/nested/out.json");
@@ -662,7 +664,9 @@ describe("writePackageToVault", () => {
 			existsImpl: () => true,
 		});
 
-		await writePackageToVault(app as never, pkg, "Existing/file.json");
+		await writePackageToVault(app as never, pkg, "Existing/file.json", {
+			confirmOverwrite: async () => true,
+		});
 
 		expect(createdFolders).toEqual([]);
 		expect(app.vault.createFolder).not.toHaveBeenCalled();

--- a/src/services/packageExportService.ts
+++ b/src/services/packageExportService.ts
@@ -15,6 +15,7 @@ import {
 	collectFileDependencies,
 } from "../utils/packageTraversal";
 import { log } from "../logger/logManager";
+import GenericYesNoPrompt from "../gui/GenericYesNoPrompt/GenericYesNoPrompt";
 import { decodeFromBase64, encodeToBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
 import { ensureParentFolders } from "../utils/ensureParentFolders";
@@ -238,17 +239,61 @@ function pruneChoiceTree(
 		});
 }
 
+export interface WritePackageOptions {
+	/**
+	 * Invoked when the target path already exists, so the caller can confirm the
+	 * overwrite before any data is replaced. Returning false aborts the write
+	 * (writePackageToVault throws so the caller can report a clean cancellation).
+	 * Defaults to a Yes/No prompt. Injectable for tests / non-interactive callers.
+	 */
+	confirmOverwrite?: (normalizedPath: string) => Promise<boolean>;
+}
+
+export interface WritePackageResult {
+	overwritten: boolean;
+}
+
+async function defaultConfirmOverwrite(
+	app: App,
+	normalizedPath: string,
+): Promise<boolean> {
+	try {
+		return await GenericYesNoPrompt.Prompt(
+			app,
+			"Overwrite existing file?",
+			`A file already exists at '${normalizedPath}'. Saving the package will overwrite it. Continue?`,
+		);
+	} catch {
+		// Dismissing the prompt (Esc) is treated as "do not overwrite".
+		return false;
+	}
+}
+
 export async function writePackageToVault(
 	app: App,
 	pkg: QuickAddPackage,
 	outputPath: string,
-): Promise<void> {
+	options: WritePackageOptions = {},
+): Promise<WritePackageResult> {
 	const normalizedPath = normalizePath(outputPath.trim());
 	if (!normalizedPath) {
 		throw new Error("Output path cannot be empty.");
 	}
 
+	const overwriting = await app.vault.adapter.exists(normalizedPath);
+	if (overwriting) {
+		const confirm =
+			options.confirmOverwrite ??
+			((path: string) => defaultConfirmOverwrite(app, path));
+		const confirmed = await confirm(normalizedPath);
+		if (!confirmed) {
+			throw new Error(`Save cancelled: '${normalizedPath}' already exists.`);
+		}
+	}
+
 	await ensureParentFolders(app, normalizedPath);
 	const serialized = JSON.stringify(pkg, null, 2);
 	await app.vault.adapter.write(normalizedPath, serialized);
+
+	return { overwritten: overwriting };
 }


### PR DESCRIPTION
This PR bundles 3 fixes from a systematic feature audit (logic + UX), each adversarially verified and covered by regression tests.

- **[Major]** Clearing a Global Variable's name mid-edit drops the row and loses its value
- **[Minor]** Duplicate or empty global-variable names silently delete data
- **[Minor]** Save package silently overwrites an existing file at the chosen path

All tests/typecheck/lint/build green. Part of a 9-PR series splitting the audit by area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Global Variables editing persistence: names are trimmed, whitespace-only/duplicate names are rejected (no invalid overwrites), and auto-reloads are suppressed while saving mid-edit.
  * Refined package export UI feedback: success messaging now distinguishes save vs overwrite, and “Save cancelled.” is shown neutrally while keeping the modal open.
* **New Features**
  * Package exports now support overwrite confirmation and return whether an overwrite occurred.
* **Documentation**
  * Updated Quick Add “enable URI callbacks” description to clarify restrictions for `x-*` callbacks (Template/Capture).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->