### PR TITLE
fix(integrations): field-value suggestion filters and defaults

### DIFF
--- a/src/utils/DataviewIntegration.ts
+++ b/src/utils/DataviewIntegration.ts
@@ -180,11 +180,28 @@ export class DataviewIntegration {
 			const query = `TABLE ${safe} WHERE ${whereClause}`;
 			const result = await dv.query(query);
 			
+			// Dataview's query builder can't express exclude-file, so apply it by
+			// dropping excluded files' rows here — keeping Dataview's richer value
+			// parsing (comma-splitting, link/file-object handling) instead of
+			// bypassing Dataview to the manual collector. Matches the manual
+			// filter's semantics: exact file name (with extension) OR full path.
+			const excludeFiles = filters.excludeFiles ?? [];
+			const isExcludedRowFile = (row: unknown[]): boolean => {
+				if (excludeFiles.length === 0) return false;
+				const fileCol = row[0] as { path?: unknown } | null;
+				const filePath =
+					fileCol && typeof fileCol.path === "string" ? fileCol.path : null;
+				if (!filePath) return false;
+				const baseName = filePath.split("/").pop() ?? filePath;
+				return excludeFiles.some((e) => e === filePath || e === baseName);
+			};
+
 			if (result.successful && result.value.values) {
 				// Process results same as above
 				for (const row of result.value.values) {
+					if (isExcludedRowFile(row)) continue;
 					const fieldValue = row[1];
-					
+
 					if (Array.isArray(fieldValue)) {
 						fieldValue.forEach(v => {
 							if (v && typeof v === 'string') {

--- a/src/utils/FieldValueCollector.audit-integrations.test.ts
+++ b/src/utils/FieldValueCollector.audit-integrations.test.ts
@@ -3,12 +3,19 @@ import { App, TFile } from "obsidian";
 import { FieldSuggestionCache } from "./FieldSuggestionCache";
 import { collectFieldValuesProcessed } from "./FieldValueCollector";
 
-// Dataview IS installed in these tests. The query API returns a sentinel value
-// that would only ever come from the Dataview branch, so we can prove whether
-// that branch ran.
+// Dataview IS installed in these tests. The query API returns TABLE rows shaped
+// [fileLink, fieldValue]; the first column carries the file (with .path), which
+// the collector uses to honor exclude-file WITHOUT abandoning Dataview's richer
+// value parsing (comma-splitting, link/file-object handling).
 const dataviewQuery = vi.fn(async () => ({
 	successful: true,
-	value: { values: [[null, "from-dataview"]] },
+	value: {
+		values: [
+			[{ path: "Template.md" }, "TemplateValue"],
+			[{ path: "notes/Real.md" }, "RealValue"],
+			[{ path: "notes/Multi.md" }, "A, B"], // comma value -> Dataview splits it
+		],
+	},
 }));
 
 vi.mock("obsidian-dataview", () => ({
@@ -30,28 +37,38 @@ describe("FieldValueCollector - exclude-file with Dataview installed (integratio
 		dataviewQuery.mockClear();
 	});
 
-	it("honors exclude-file even when Dataview is available by bypassing Dataview", async () => {
+	it("honors exclude-file via the Dataview path, dropping the excluded file's row while keeping Dataview's parsing", async () => {
 		const app = new App();
-
-		const templateFile = makeFile("Template.md");
-		const realFile = makeFile("notes/Real.md");
-		app.vault.getMarkdownFiles = () => [templateFile, realFile];
-		app.metadataCache.getFileCache = (file: TFile) => {
-			if (file.path === "Template.md") {
-				return { frontmatter: { project: "TemplateValue" } } as any;
-			}
-			return { frontmatter: { project: "RealValue" } } as any;
-		};
+		// No markdown files, so any value can only come from the Dataview branch.
+		app.vault.getMarkdownFiles = () => [];
 
 		const values = await collectFieldValuesProcessed(app, "project", {
 			excludeFiles: ["Template.md"],
 		});
 
-		// Dataview must NOT have been consulted (its sentinel would otherwise win).
-		expect(values).not.toContain("from-dataview");
-		// The excluded file's value is dropped, the other file's value remains.
+		// Dataview IS used now (not bypassed), so its row handling is preserved.
+		expect(dataviewQuery).toHaveBeenCalled();
+		// The excluded file's row is dropped...
 		expect(values).not.toContain("TemplateValue");
+		// ...while a non-excluded file's value remains...
 		expect(values).toContain("RealValue");
+		// ...and Dataview's comma-splitting still yields separate values
+		// (manual fallback would have returned a single "A, B" suggestion).
+		expect(values).toContain("A");
+		expect(values).toContain("B");
+		expect(values).not.toContain("A, B");
+	});
+
+	it("matches exclude-file by basename when given a full path target, too", async () => {
+		const app = new App();
+		app.vault.getMarkdownFiles = () => [];
+
+		const values = await collectFieldValuesProcessed(app, "project", {
+			excludeFiles: ["notes/Real.md"],
+		});
+
+		expect(values).not.toContain("RealValue");
+		expect(values).toContain("TemplateValue");
 	});
 
 	it("still uses Dataview when no exclude-file filter is present", async () => {
@@ -60,7 +77,8 @@ describe("FieldValueCollector - exclude-file with Dataview installed (integratio
 
 		const values = await collectFieldValuesProcessed(app, "project", {});
 
-		expect(values).toContain("from-dataview");
 		expect(dataviewQuery).toHaveBeenCalled();
+		expect(values).toContain("TemplateValue");
+		expect(values).toContain("RealValue");
 	});
 });

--- a/src/utils/FieldValueCollector.audit-integrations.test.ts
+++ b/src/utils/FieldValueCollector.audit-integrations.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App, TFile } from "obsidian";
+import { FieldSuggestionCache } from "./FieldSuggestionCache";
+import { collectFieldValuesProcessed } from "./FieldValueCollector";
+
+// Dataview IS installed in these tests. The query API returns a sentinel value
+// that would only ever come from the Dataview branch, so we can prove whether
+// that branch ran.
+const dataviewQuery = vi.fn(async () => ({
+	successful: true,
+	value: { values: [[null, "from-dataview"]] },
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: () => ({ query: dataviewQuery }),
+}));
+
+function makeFile(path: string): TFile {
+	const file = new TFile();
+	file.path = path;
+	file.name = path.split("/").pop() ?? path;
+	file.basename = file.name.replace(/\.md$/, "");
+	file.extension = "md";
+	return file;
+}
+
+describe("FieldValueCollector - exclude-file with Dataview installed (integrations audit)", () => {
+	beforeEach(() => {
+		FieldSuggestionCache.getInstance().clear();
+		dataviewQuery.mockClear();
+	});
+
+	it("honors exclude-file even when Dataview is available by bypassing Dataview", async () => {
+		const app = new App();
+
+		const templateFile = makeFile("Template.md");
+		const realFile = makeFile("notes/Real.md");
+		app.vault.getMarkdownFiles = () => [templateFile, realFile];
+		app.metadataCache.getFileCache = (file: TFile) => {
+			if (file.path === "Template.md") {
+				return { frontmatter: { project: "TemplateValue" } } as any;
+			}
+			return { frontmatter: { project: "RealValue" } } as any;
+		};
+
+		const values = await collectFieldValuesProcessed(app, "project", {
+			excludeFiles: ["Template.md"],
+		});
+
+		// Dataview must NOT have been consulted (its sentinel would otherwise win).
+		expect(values).not.toContain("from-dataview");
+		// The excluded file's value is dropped, the other file's value remains.
+		expect(values).not.toContain("TemplateValue");
+		expect(values).toContain("RealValue");
+	});
+
+	it("still uses Dataview when no exclude-file filter is present", async () => {
+		const app = new App();
+		app.vault.getMarkdownFiles = () => [];
+
+		const values = await collectFieldValuesProcessed(app, "project", {});
+
+		expect(values).toContain("from-dataview");
+		expect(dataviewQuery).toHaveBeenCalled();
+	});
+});

--- a/src/utils/FieldValueCollector.audit-integrations.test.ts
+++ b/src/utils/FieldValueCollector.audit-integrations.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { App, TFile } from "obsidian";
+import { App } from "obsidian";
 import { FieldSuggestionCache } from "./FieldSuggestionCache";
 import { collectFieldValuesProcessed } from "./FieldValueCollector";
 
@@ -21,15 +21,6 @@ const dataviewQuery = vi.fn(async () => ({
 vi.mock("obsidian-dataview", () => ({
 	getAPI: () => ({ query: dataviewQuery }),
 }));
-
-function makeFile(path: string): TFile {
-	const file = new TFile();
-	file.path = path;
-	file.name = path.split("/").pop() ?? path;
-	file.basename = file.name.replace(/\.md$/, "");
-	file.extension = "md";
-	return file;
-}
 
 describe("FieldValueCollector - exclude-file with Dataview installed (integrations audit)", () => {
 	beforeEach(() => {

--- a/src/utils/FieldValueCollector.ts
+++ b/src/utils/FieldValueCollector.ts
@@ -78,9 +78,17 @@ export async function collectFieldValuesRaw(
 		if (tagValues.size > 0) return tagValues;
 	}
 
-	// Try Dataview when allowed; fall back to manual collection
+	// Try Dataview when allowed; fall back to manual collection.
+	// Dataview's query builder translates exclude-folder/exclude-tag but NOT
+	// exclude-file, so bypass it (like the inline path) when an exclude-file
+	// filter is present and let the manual collector honor it via
+	// EnhancedFieldSuggestionFileFilter. Otherwise the exclusion is dropped.
 	try {
-		if (!filters.inline && DataviewIntegration.isAvailable(app)) {
+		if (
+			!filters.inline &&
+			!filters.excludeFiles?.length &&
+			DataviewIntegration.isAvailable(app)
+		) {
 			const dvValues = await DataviewIntegration.getFieldValuesWithFilter(
 				app,
 				fieldName,

--- a/src/utils/FieldValueCollector.ts
+++ b/src/utils/FieldValueCollector.ts
@@ -78,17 +78,14 @@ export async function collectFieldValuesRaw(
 		if (tagValues.size > 0) return tagValues;
 	}
 
-	// Try Dataview when allowed; fall back to manual collection.
-	// Dataview's query builder translates exclude-folder/exclude-tag but NOT
-	// exclude-file, so bypass it (like the inline path) when an exclude-file
-	// filter is present and let the manual collector honor it via
-	// EnhancedFieldSuggestionFileFilter. Otherwise the exclusion is dropped.
+	// Try Dataview when allowed; fall back to manual collection. Dataview's query
+	// builder can't express exclude-file, but getFieldValuesWithFilter now applies
+	// it by dropping excluded files' rows, so the Dataview path is kept (with its
+	// richer value parsing — comma-splitting, link/file objects) even when an
+	// exclude-file filter is present. Only the inline path still bypasses Dataview
+	// (inline fields aren't in Dataview's metadata).
 	try {
-		if (
-			!filters.inline &&
-			!filters.excludeFiles?.length &&
-			DataviewIntegration.isAvailable(app)
-		) {
+		if (!filters.inline && DataviewIntegration.isAvailable(app)) {
 			const dvValues = await DataviewIntegration.getFieldValuesWithFilter(
 				app,
 				fieldName,

--- a/src/utils/FieldValueProcessor.audit-integrations.test.ts
+++ b/src/utils/FieldValueProcessor.audit-integrations.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { FieldValueProcessor } from "./FieldValueProcessor";
+import type { FieldFilter } from "./FieldSuggestionParser";
+
+describe("FieldValueProcessor - default value case-folding (integrations audit)", () => {
+	it("does not add a default that differs only by case from an existing value (default-always, case-insensitive)", () => {
+		const rawValues = new Set(["Done", "Active"]);
+		const filters: FieldFilter = {
+			defaultValue: "done",
+			defaultAlways: true,
+		};
+
+		const result = FieldValueProcessor.processValues(rawValues, filters);
+
+		// Only one "done"-ish entry should exist, not both "done" and "Done".
+		const doneVariants = result.values.filter(
+			(v) => v.toLowerCase() === "done",
+		);
+		expect(doneVariants).toHaveLength(1);
+		// The default replaces the existing variant and sits first.
+		expect(result.values[0]).toBe("done");
+		expect(result.values).toContain("Active");
+		expect(result.hasDefaultValue).toBe(true);
+	});
+
+	it("does not prepend a default that differs only by case from an existing value (plain default, case-insensitive)", () => {
+		const rawValues = new Set(["Done", "Active"]);
+		const filters: FieldFilter = {
+			defaultValue: "done",
+		};
+
+		const result = FieldValueProcessor.processValues(rawValues, filters);
+
+		const doneVariants = result.values.filter(
+			(v) => v.toLowerCase() === "done",
+		);
+		expect(doneVariants).toHaveLength(1);
+		// Existing value is preserved, default is NOT added as a duplicate.
+		expect(result.values).toContain("Done");
+		expect(result.values).not.toContain("done");
+		expect(result.hasDefaultValue).toBe(false);
+	});
+
+	it("folds accents when matching the default (case-insensitive)", () => {
+		const rawValues = new Set(["Café"]);
+		const filters: FieldFilter = {
+			defaultValue: "cafe",
+			defaultAlways: true,
+		};
+
+		const result = FieldValueProcessor.processValues(rawValues, filters);
+
+		expect(result.values).toEqual(["cafe"]);
+		expect(result.hasDefaultValue).toBe(true);
+	});
+
+	it("treats case-different default as distinct when case-sensitive is set", () => {
+		const rawValues = new Set(["Done", "Active"]);
+		const filters: FieldFilter = {
+			defaultValue: "done",
+			caseSensitive: true,
+		};
+
+		const result = FieldValueProcessor.processValues(rawValues, filters);
+
+		// case-sensitive: "done" and "Done" are legitimately distinct entries.
+		expect(result.values).toContain("done");
+		expect(result.values).toContain("Done");
+		expect(result.hasDefaultValue).toBe(true);
+	});
+});

--- a/src/utils/FieldValueProcessor.ts
+++ b/src/utils/FieldValueProcessor.ts
@@ -68,9 +68,19 @@ export class FieldValueProcessor {
 		let processedValues = [...values];
 		let hasDefault = false;
 
+		// Existing values are deduplicated case-insensitively by default, so the
+		// default must be compared with the same fold; otherwise a default that
+		// differs only by case from an existing value (e.g. default:done vs a
+		// collected "Done") is added as a separate, near-identical entry.
+		const isPresent = (value: string): boolean =>
+			filters.caseSensitive
+				? value === defaultValue
+				: this.normalizeForComparison(value) ===
+					this.normalizeForComparison(defaultValue);
+
 		if (filters.defaultAlways) {
 			// Always include default at the beginning, remove if already present
-			processedValues = processedValues.filter(v => v !== defaultValue);
+			processedValues = processedValues.filter((v) => !isPresent(v));
 			processedValues.unshift(defaultValue);
 			hasDefault = true;
 		} else if (filters.defaultEmpty && values.length === 0) {
@@ -79,13 +89,25 @@ export class FieldValueProcessor {
 			hasDefault = true;
 		} else if (!filters.defaultEmpty && !filters.defaultAlways) {
 			// Default behavior: include if not already present and prepend
-			if (!processedValues.includes(defaultValue)) {
+			if (!processedValues.some(isPresent)) {
 				processedValues.unshift(defaultValue);
 				hasDefault = true;
 			}
 		}
 
 		return { processedValues, hasDefault };
+	}
+
+	/**
+	 * Normalize a value for case-insensitive comparison, mirroring
+	 * FieldValueDeduplicator's fold (Unicode NFD + diacritic strip + lowercase)
+	 * so default-value matching is consistent with case-insensitive dedup.
+	 */
+	private static normalizeForComparison(value: string): string {
+		return value
+			.normalize("NFD")
+			.replace(/[\u0300-\u036f]/g, "")
+			.toLowerCase();
 	}
 
 	/**


### PR DESCRIPTION
This PR bundles 2 fixes from a systematic feature audit (logic + UX), each adversarially verified and covered by regression tests.

- **[Minor]** exclude-file is silently ignored when Dataview is installed
- **[Minor]** Default value not case-folded against existing values, producing duplicate-looking entries

All tests/typecheck/lint/build green. Part of a 9-PR series splitting the audit by area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File exclusion now correctly applies to Dataview-derived results.
  * Default values no longer duplicate when they differ only by letter case or by accents/diacritics.
* **Tests**
  * Added integration coverage for Dataview file exclusion behavior.
  * Added integration coverage for default value insertion and case/accent matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->