### PR TITLE
fix: resolve Obsidian plugin review lint findings

### DIFF
--- a/src/ai/tokenEstimator.ts
+++ b/src/ai/tokenEstimator.ts
@@ -6,7 +6,13 @@ export function estimateTokenCount(text: string): number {
 	if (text.length === 0) return 0;
 
 	const bytes = new TextEncoder().encode(text).length;
-	const hasNonAscii = /[^\x00-\x7F]/.test(text);
+	let hasNonAscii = false;
+	for (let i = 0; i < text.length; i++) {
+		if (text.charCodeAt(i) > 127) {
+			hasNonAscii = true;
+			break;
+		}
+	}
 	const bytesPerToken = hasNonAscii
 		? MIXED_BYTES_PER_TOKEN_ESTIMATE
 		: ASCII_BYTES_PER_TOKEN_ESTIMATE;

--- a/src/ai/tools/Agent.ts
+++ b/src/ai/tools/Agent.ts
@@ -47,7 +47,6 @@ import type {
 	GenerateStep,
 	PublicToolCall,
 	PublicToolResult,
-	QATool,
 } from "./aiToolTypes";
 
 const TOOL_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
@@ -74,7 +73,7 @@ function toParsed(cr: CommonResponse): ParsedChatResult {
 }
 
 function toPublicToolChoice(
-	choice: AgentConfig["toolChoice"] | GenerateOptions["toolChoice"],
+	choice: AgentConfig["toolChoice"],
 ): NormalizedToolChoice | undefined {
 	if (!choice) return undefined;
 	if (typeof choice === "string") return choice;
@@ -316,7 +315,7 @@ export class Agent {
 					parameters: tool.inputSchema,
 					strict: tool.strict,
 				},
-				execute: (args, ctx) => (tool as QATool).execute(args, ctx),
+				execute: (args, ctx) => tool.execute(args, ctx),
 				readOnly: tool.readOnly,
 			});
 		}

--- a/src/ai/tools/aiToolTypes.ts
+++ b/src/ai/tools/aiToolTypes.ts
@@ -21,7 +21,7 @@ export interface ToolDefinitionInput {
 	execute: (
 		input: Record<string, unknown>,
 		ctx: ToolExecuteContext,
-	) => unknown | Promise<unknown>;
+	) => unknown;
 	/**
 	 * Per-tool human-in-the-loop gate (AI-SDK name). A tool resolving to true is
 	 * ALWAYS confirmed regardless of the global confirmToolCalls setting.

--- a/src/ai/tools/jsonSchemaValidator.ts
+++ b/src/ai/tools/jsonSchemaValidator.ts
@@ -89,7 +89,7 @@ export function assertRegisterableSchema(
 			throw new ToolSchemaError(`${where}.properties must be an object.`);
 		}
 		for (const [key, sub] of Object.entries(schema.properties)) {
-			assertRegisterableSchema(sub as JSONSchema, `${where}.properties.${key}`);
+			assertRegisterableSchema(sub, `${where}.properties.${key}`);
 		}
 	}
 
@@ -152,7 +152,7 @@ export function validateValue(
 	// type
 	if (schema.type !== undefined) {
 		const types = Array.isArray(schema.type) ? schema.type : [schema.type];
-		if (!types.some((t) => matchesType(value, t as JSONSchemaType))) {
+		if (!types.some((t) => matchesType(value, t))) {
 			return `${path}: expected ${types.join(" | ")}, got ${typeOfValue(value)}`;
 		}
 	}
@@ -182,7 +182,7 @@ export function validateValue(
 		if (schema.properties) {
 			for (const [key, sub] of Object.entries(schema.properties)) {
 				if (key in obj) {
-					const err = validateValue(obj[key], sub as JSONSchema, `${path}.${key}`);
+					const err = validateValue(obj[key], sub, `${path}.${key}`);
 					if (err) return err;
 				}
 			}
@@ -209,8 +209,8 @@ function deepEqual(a: unknown, b: unknown): boolean {
 		return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
 	}
 	if (typeof a === "object" && typeof b === "object") {
-		const ka = Object.keys(a as object);
-		const kb = Object.keys(b as object);
+		const ka = Object.keys(a);
+		const kb = Object.keys(b);
 		if (ka.length !== kb.length) return false;
 		return ka.every((k) =>
 			deepEqual(

--- a/src/ai/tools/providerToolMapping.ts
+++ b/src/ai/tools/providerToolMapping.ts
@@ -46,7 +46,7 @@ type Body = Record<string, unknown>;
 export function injectStrictObjectSchema(schema: JSONSchema): JSONSchema {
 	const out: JSONSchema = Array.isArray(schema)
 		? schema
-		: { ...(schema as JSONSchema) };
+		: { ...schema };
 
 	const isObject =
 		out.type === "object" ||

--- a/src/ai/tools/runToolLoop.ts
+++ b/src/ai/tools/runToolLoop.ts
@@ -25,7 +25,7 @@ export interface ToolEntry {
 	execute: (
 		args: Record<string, unknown>,
 		ctx: { toolCallId: string; toolName: string },
-	) => unknown | Promise<unknown>;
+	) => unknown;
 	readOnly?: boolean;
 }
 

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -173,6 +173,7 @@ const createApp = () =>
 		},
 		fileManager: {
 			getNewFileParent: vi.fn(() => ({ path: "" })),
+			trashFile: vi.fn(async () => {}),
 		},
 	} as unknown as App);
 
@@ -1193,7 +1194,7 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 
 		await engine.run();
 
-		expect(app.vault.delete).toHaveBeenCalledWith(attachmentFile);
+		expect(app.fileManager.trashFile).toHaveBeenCalledWith(attachmentFile);
 		expect(executor.recordExecutionResult).toHaveBeenCalledWith({
 			status: "error",
 		});
@@ -1692,7 +1693,7 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 
 		expect(setTextMock).toHaveBeenCalledWith("![[Clipboard image.png]]");
 		expect(insertFileLinkToActiveView).toHaveBeenCalled();
-		expect(app.vault.delete).not.toHaveBeenCalledWith(attachmentFile);
+		expect(app.fileManager.trashFile).not.toHaveBeenCalledWith(attachmentFile);
 	});
 
 	it("creates missing linked markdown file for configured canvas file-card targets", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -639,7 +639,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			try {
 				const file = this.app.vault.getAbstractFileByPath(path);
 				if (file instanceof TFile) {
-					await this.app.vault.delete(file);
+					await this.app.fileManager.trashFile(file);
 				}
 			} catch (error) {
 				log.logWarning(

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -231,7 +231,7 @@ export abstract class Formatter {
 		// Important: use a replacer function so `$` in user input is treated literally.
 		const regex = new RegExp(NAME_VALUE_REGEX.source, "gi");
 		output = output.replace(regex, (...args) => {
-			const token = args[0] as string;
+			const token = args[0];
 			const offset = args[args.length - 2] as number;
 			const source = args[args.length - 1] as string;
 			const inner = token.slice(2, -2);

--- a/src/formatters/helpers/sectionLink.ts
+++ b/src/formatters/helpers/sectionLink.ts
@@ -25,7 +25,7 @@ export interface SimpleHeading {
 // `#`/`^` subpath markers, and `{` `}` (so a heading literally containing a
 // QuickAdd token like `{{TITLE}}` can't have that token rewritten inside the
 // generated link). CR/LF are included for CRLF buffers.
-const OBSIDIAN_ANCHOR_STRIP = /[!"#$%&()*+,.:;<=>?@^`{|}~/\[\]\\\r\n]/g;
+const OBSIDIAN_ANCHOR_STRIP = /[!"#$%&()*+,.:;<=>?@^`{|}~/[\]\\\r\n]/g;
 
 /**
  * Normalizes heading text into the form Obsidian uses to resolve a `#heading`

--- a/src/gui/ChoiceBuilder/components/choiceIconSetting.ts
+++ b/src/gui/ChoiceBuilder/components/choiceIconSetting.ts
@@ -3,6 +3,7 @@ import { ICON_LIST } from "../../../types/IconType";
 import type { ChoiceType } from "../../../types/choices/choiceType";
 import { defaultIconForChoiceType } from "../../../utils/choiceUtils";
 import { GenericTextSuggester } from "../../suggesters/genericTextSuggester";
+import { createOwnedElement } from "../../../utils/activeWindow";
 
 export interface ChoiceIconSettingState {
 	type: ChoiceType;
@@ -31,7 +32,7 @@ export function addChoiceIconSetting(
 		.setDesc(`Lucide/Obsidian icon id. Leave empty to use ${defaultIcon}.`);
 	setting.settingEl.addClass("qa-choice-icon-setting");
 
-	const preview = document.createElement("span");
+	const preview = createOwnedElement(parent, "span");
 	preview.classList.add("qa-choice-icon-setting-preview");
 	preview.setAttribute("aria-hidden", "true");
 	setting.controlEl.appendChild(preview);

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -321,7 +321,6 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 1, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.temperature ??
 						DEFAULT_TEMPERATURE
@@ -340,7 +339,6 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 1, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.top_p ?? DEFAULT_TOP_P
 				);
@@ -358,7 +356,6 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 2, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.frequency_penalty ??
 						DEFAULT_FREQUENCY_PENALTY
@@ -377,7 +374,6 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 2, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.presence_penalty ??
 						DEFAULT_PRESENCE_PENALTY

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -219,7 +219,6 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 1, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.temperature ??
 						DEFAULT_TEMPERATURE
@@ -238,7 +237,6 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 1, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.top_p ?? DEFAULT_TOP_P
 				);
@@ -256,7 +254,6 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 2, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.frequency_penalty ??
 						DEFAULT_FREQUENCY_PENALTY
@@ -275,7 +272,6 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			)
 			.addSlider((slider) => {
 				slider.setLimits(0, 2, 0.1);
-				slider.setDynamicTooltip();
 				slider.setValue(
 					this.settings.modelParameters.presence_penalty ??
 						DEFAULT_PRESENCE_PENALTY
@@ -337,7 +333,6 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 						this.systemPromptTokenLength
 				);
 				slider.setLimits(1, sliderMax, 1);
-				slider.setDynamicTooltip();
 
 				slider.setValue(this.settings.maxChunkTokens);
 				slider.onChange((value) => {

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -22,6 +22,7 @@ import {
 	runTemplateFromFolder,
 } from "../../engine/runTemplateFromFolder";
 import { resolveChoiceIcon } from "../../utils/choiceUtils";
+import { createOwnedElement } from "../../utils/activeWindow";
 
 const backLabel = "← Back";
 
@@ -259,7 +260,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		const iconId = this.getChoiceSuggestionIcon(choice);
 		if (!iconId) return;
 
-		const iconEl = document.createElement("span");
+		const iconEl = createOwnedElement(parent, "span");
 		iconEl.classList.add("quickadd-choice-icon");
 		iconEl.setAttribute("aria-hidden", "true");
 		parent.appendChild(iconEl);

--- a/src/utils/dateModifiers.ts
+++ b/src/utils/dateModifiers.ts
@@ -1,5 +1,8 @@
-import type { Moment, unitOfTime } from "moment";
+import type { moment } from "obsidian";
 import { parsePipeKeyValue } from "./pipeSyntax";
+
+type Moment = ReturnType<typeof moment.unix>;
+type StartOf = NonNullable<Parameters<Moment["startOf"]>[0]>;
 
 /**
  * Shared "snap a date to the start/end of a period" support for {{DATE}} and
@@ -17,13 +20,13 @@ export type DateSnapBoundary = "start" | "end";
 export interface DateSnap {
 	boundary: DateSnapBoundary;
 	/** Canonical moment unit, e.g. "week", "isoWeek", "month". */
-	unit: unitOfTime.StartOf;
+	unit: StartOf;
 }
 
 // Lower-cased user input -> canonical moment unit. Plural/short aliases are
 // accepted for ergonomics; everything else throws so a typo can never silently
 // no-op (moment's startOf returns the date unchanged on an unknown unit).
-const UNIT_ALIASES: Record<string, unitOfTime.StartOf> = {
+const UNIT_ALIASES: Record<string, StartOf> = {
 	year: "year",
 	years: "year",
 	y: "year",
@@ -49,7 +52,7 @@ export const VALID_DATE_SNAP_UNITS = "year, quarter, month, week, isoweek, day";
  * Normalises a user-supplied unit to moment's canonical form, throwing a
  * self-correcting error on anything unrecognised.
  */
-export function normalizeDateUnit(raw: string): unitOfTime.StartOf {
+export function normalizeDateUnit(raw: string): StartOf {
 	const key = raw.trim().toLowerCase();
 	const unit = UNIT_ALIASES[key];
 	if (!unit) {

--- a/src/utils/fileLinks.ts
+++ b/src/utils/fileLinks.ts
@@ -90,7 +90,7 @@ export async function appendFileLinkToDestinationFile(
 export async function writeTextToClipboard(text: string): Promise<boolean> {
 	// Returns false without surfacing its own Notice so callers own the single
 	// user-facing failure message (avoids stacked duplicate notices).
-	const clipboard = globalThis.navigator?.clipboard;
+	const clipboard = window.navigator?.clipboard;
 	if (!clipboard?.writeText) {
 		log.logMessage("QuickAdd: Clipboard API is unavailable.");
 		return false;

--- a/src/utils/vaultQueries.ts
+++ b/src/utils/vaultQueries.ts
@@ -45,7 +45,7 @@ function getFrontmatterTags(fileCache: CachedMetadata): string[] {
 
 	const tags = tagPairs
 		.flatMap(([, value]) => normalizeFrontmatterTagValues(value))
-		.filter((v) => !!v) as string[]; // fair to cast after filtering out falsy values
+		.filter((v) => !!v);
 
 	return tags;
 }
@@ -162,7 +162,7 @@ export function getMarkdownFilesWithProperty(
 	if (hasFilter) {
 		files = EnhancedFieldSuggestionFileFilter.filterFiles(
 			files,
-			filter as FieldFilter,
+			filter,
 			(file) => app.metadataCache.getFileCache(file),
 		);
 	}


### PR DESCRIPTION
Resolves the mechanical, behavior-preserving findings from the Obsidian community plugin review dashboard (reviewed commit `dd5110e9`). No functional changes — these are lint/code-quality and API-preference fixes that keep the plugin aligned with Obsidian's reviewer guidance.

## Fixed (11 findings)

- **`tokenEstimator.ts`** — replace the `/[^\x00-\x7F]/` control-char regex with a `charCodeAt` scan (`no-control-regex`).
- **`Agent.ts`** — collapse the duplicated `toolChoice` union to `AgentConfig["toolChoice"]`; drop the now-unused `QATool` import left over from removing a redundant cast.
- **Unnecessary type assertions (10)** — removed across `jsonSchemaValidator.ts`, `providerToolMapping.ts`, `formatter.ts`, `vaultQueries.ts`, and `Agent.ts`.
- **`aiToolTypes.ts` / `runToolLoop.ts`** — simplify `unknown | Promise<unknown>` to `unknown`.
- **`CaptureChoiceEngine.ts`** — use `FileManager.trashFile()` instead of `Vault.delete()` so clipboard-attachment cleanup respects the user's file-deletion preference (affected tests + mock updated).
- **`sectionLink.ts`** — remove an unnecessary `\[` escape inside the anchor-strip character class.
- **`choiceIconSetting.ts` / `choiceSuggester.ts`** — create elements via the owning document (`createOwnedElement`) instead of the global `document` for popout-window compatibility.
- **`dateModifiers.ts`** — import `moment` from `obsidian` (bundled) instead of the `moment` package; types are derived via `ReturnType<typeof moment.unix>` because Obsidian's exported `moment` value strips the bare call signature.
- **`fileLinks.ts`** — use `window.navigator` instead of `globalThis.navigator`.
- **AI Assistant settings modals** — remove 9 deprecated `setDynamicTooltip()` calls.

## Intentionally not changed

These findings are deliberate design choices (or large refactors) and are left as-is:

- **`userScript.ts` — `new Function(...)` (the only Error + implied-eval warning):** this is how QuickAdd executes user-authored CommonJS scripts (same approach as Templater). Removing it breaks the entire user-script/macro feature; it's a manually-accepted exception for script-runner plugins.
- **`mountComponent.ts` — `Component<any, any>`:** Svelte's `Component` is contravariant in props, so a generic bound accepting any component cannot avoid `any` without rejecting concrete-prop call sites (documented inline).
- **`textareaIndent.ts` — `execCommand`:** the only way to mutate a textarea while preserving the native single-step undo stack and firing a trusted input event in Obsidian's Electron runtime (a non-`execCommand` fallback is already present).
- **`suggest.ts` — custom `TextInputSuggest`:** migrating to `AbstractInputSuggest` is a large, risky refactor of a core popper-based component extended throughout the plugin; deferred.
- **CSS `!important` (12):** several deliberately override Obsidian's higher-specificity mobile touch-target rules and the svelte-dnd drag-clone (documented inline); reworking risks manual-only visual regressions.

## Verification

- `pnpm run build` — passes (`tsc --noEmit` + esbuild)
- `pnpm run lint` — 0 problems
- `pnpm run test` — 3171 passed, 0 failures

## Reviewer notes

- Build artifacts (`main.js`, `styles.css`) are gitignored and excluded.
- The highest-attention change is `CaptureChoiceEngine.ts` (`Vault.delete()` → `FileManager.trashFile()`), since it changes deletion behavior to send files to the configured trash; the regression tests were updated accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clipboard attachments are now moved to Trash instead of being permanently deleted.

* **Changes**
  * Removed dynamic tooltips from AI model parameter adjustment sliders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->