### PR TITLE
fix(cli): abort non-interactive runs instead of hanging on engine prompts

### DIFF
--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -29,6 +29,17 @@ export interface IChoiceExecutor {
 	): Promise<ChoiceOutcome>;
 	variables: Map<string, unknown>;
 	/**
+	 * Whether this execution may open blocking interactive UI (suggesters/modals)
+	 * for inputs the requirement collector cannot pre-satisfy — e.g. the
+	 * "file already exists" prompt, the folder chooser, or the heading picker.
+	 * Defaults to interactive (`true`/`undefined`) so GUI runs are unchanged.
+	 * Non-interactive callers (the `quickadd:run`/`run-template` CLI without the
+	 * `ui` flag, and any headless automation) set this to `false`; engines then
+	 * abort such a prompt with a clear, actionable error instead of hanging forever
+	 * on an unanswerable modal.
+	 */
+	interactive?: boolean;
+	/**
 	 * Frontmatter property value focused when the outermost choice execution began.
 	 * Append Link uses this to avoid the stale CodeMirror cursor Obsidian reports
 	 * while a Properties field owns focus.

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -1,6 +1,7 @@
 import type { App } from "obsidian";
 import { TFile } from "obsidian";
 import { UserCancelError } from "src/errors/UserCancelError";
+import { ChoiceAbortError } from "src/errors/ChoiceAbortError";
 import GenericSuggester from "src/gui/GenericSuggester/genericSuggester";
 import { settingsStore } from "src/settingsStore";
 import { getMarkdownFilesInFolder } from "src/utilityObsidian";
@@ -176,7 +177,8 @@ function toError(reason: unknown): Error {
 async function getTargetPromptTemplate(
 	app: App,
 	userDefinedPromptTemplate: Params["promptTemplate"],
-	promptTemplates: TFile[]
+	promptTemplates: TFile[],
+	interactive = true
 ): Promise<[string, string]> {
 	let targetFile;
 
@@ -185,6 +187,15 @@ async function getTargetPromptTemplate(
 			item.path.endsWith(userDefinedPromptTemplate.name)
 		);
 	} else {
+		// Non-interactive run (CLI without `ui`): the prompt-template picker has no
+		// one to answer it, so opening it would hang. Abort with an actionable error.
+		if (!interactive) {
+			throw new ChoiceAbortError(
+				"This AI command asks which prompt template to use, but this run is non-interactive. " +
+					"Enable a specific prompt template in the command, or re-run with the ui flag."
+			);
+		}
+
 		const basenames = promptTemplates.map((f) => f.basename);
 
 		targetFile = await GenericSuggester.Suggest(
@@ -217,6 +228,13 @@ interface Params {
 	promptTemplateFolder: string;
 	showAssistantMessages: boolean;
 	modelOptions: Partial<OpenAIModelParameters>;
+	/**
+	 * Whether the run may open a blocking picker (the prompt-template suggester).
+	 * Defaults to interactive; the non-interactive CLI sets it false so the picker
+	 * aborts with a clear error instead of hanging. Optional so existing callers
+	 * (api.ai) are unaffected.
+	 */
+	interactive?: boolean;
 }
 
 export async function runAIAssistant(
@@ -247,7 +265,8 @@ export async function runAIAssistant(
 		const [targetKey, targetPrompt] = await getTargetPromptTemplate(
 			app,
 			promptTemplate,
-			promptTemplates
+			promptTemplates,
+			settings.interactive ?? true
 		);
 
 		notice.setMessage(

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -25,6 +25,10 @@ import {
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
+	// Default to interactive so every GUI entry point (command palette, ribbon,
+	// suggester) keeps its current prompt behaviour. Non-interactive callers (CLI
+	// without `ui`) flip this to false so engine prompts abort instead of hanging.
+	public interactive = true;
 	public focusedProperty: FrontmatterPropertyTarget | null = null;
 	private pendingAbort: MacroAbortError | null = null;
 	private pendingResult: ChoiceOutcome | null = null;
@@ -164,9 +168,14 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			if (this.pendingAbort) {
 				promptDraftStore.rollbackExecutionScope();
 				const abort = this.consumeAbortSignal();
+				const isUser = abort instanceof UserCancelError;
 				return {
 					status: "cancelled",
-					cancelKind: abort instanceof UserCancelError ? "user" : "aborted",
+					cancelKind: isUser ? "user" : "aborted",
+					// Only surface the message for an involuntary abort (e.g. the
+					// non-interactive prompt guards). A user dismissal keeps its stable
+					// "cancelled by user" text and leaks no internals.
+					reason: isUser ? undefined : abort?.message,
 				};
 			}
 
@@ -178,10 +187,11 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		} catch (error) {
 			promptDraftStore.rollbackExecutionScope();
 			if (error instanceof UserCancelError) {
+				// Stable user-facing text; no internal message surfaced.
 				return { status: "cancelled", cancelKind: "user" };
 			}
 			if (error instanceof MacroAbortError) {
-				return { status: "cancelled", cancelKind: "aborted" };
+				return { status: "cancelled", cancelKind: "aborted", reason: error.message };
 			}
 			reportError(error, "Error executing choice from URI");
 			return { status: "error" };

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -313,6 +313,11 @@ async function runResolvedChoice(
 		setExecutorVariables(choiceExecutor, variables);
 
 		const interactiveMode = isTruthy(params.ui);
+		// Without `ui`, engine prompts the requirement collector can't pre-satisfy
+		// (the "file already exists" prompt, folder chooser, heading picker) would
+		// hang forever on an unanswerable modal. Mark the run non-interactive so the
+		// engines abort those with a clear error instead. `ui` keeps full prompting.
+		choiceExecutor.interactive = interactiveMode;
 		if (!interactiveMode) {
 			const requirements = await collectChoiceRequirements(
 				plugin.app,
@@ -364,10 +369,14 @@ async function runResolvedChoice(
 				return serialize({
 					ok: false,
 					command,
+					// Surface the engine's actionable abort reason (e.g. the non-interactive
+					// "file already exists" / folder-chooser guard) when present, so a
+					// headless caller learns how to fix it instead of a bare "aborted".
 					error:
-						outcome.cancelKind === "user"
+						outcome.reason ||
+						(outcome.cancelKind === "user"
 							? "Execution cancelled by user"
-							: "Execution aborted",
+							: "Execution aborted"),
 					aborted: true,
 					choice: describeChoice(choice),
 					durationMs,

--- a/src/engine/CaptureChoiceEngine.heading-picker.test.ts
+++ b/src/engine/CaptureChoiceEngine.heading-picker.test.ts
@@ -5,6 +5,7 @@ import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { UserCancelError } from "../errors/UserCancelError";
+import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 
 // Capture the override the engine pushes into the formatter for the "Under heading…" path.
 const { setInsertAfterTargetOverrideMock } = vi.hoisted(() => ({
@@ -211,6 +212,29 @@ describe("CaptureChoiceEngine 'Under heading…' runtime picker (#738)", () => {
 		expect(setInsertAfterTargetOverrideMock).toHaveBeenCalledWith("## New Heading");
 		// Custom value isn't a known heading line → notice falls back to the raw value.
 		expect((engine as any).resolvedInsertAfterHeading).toBe("## New Heading");
+	});
+
+	it("aborts (without opening the picker) on a non-interactive run", async () => {
+		const suggestSpy = vi.fn(async () => "## Tasks");
+		(InputSuggester as any).Suggest = suggestSpy;
+		// Non-interactive (CLI without `ui`): the heading picker has no one to answer.
+		const executor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+			interactive: false,
+		};
+		const engine = new CaptureChoiceEngine(
+			createApp(),
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice(),
+			executor,
+		);
+
+		await expect(
+			(engine as any).maybeResolveInsertAfterHeading(HEADING_NOTE),
+		).rejects.toBeInstanceOf(ChoiceAbortError);
+		expect(suggestSpy).not.toHaveBeenCalled();
+		expect(setInsertAfterTargetOverrideMock).not.toHaveBeenCalled();
 	});
 
 	it("aborts cleanly (UserCancelError) when the picker is dismissed", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -786,9 +786,33 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	 * the choice is in heading mode. Cancelling aborts the capture cleanly (UserCancelError),
 	 * before any write.
 	 */
+	/**
+	 * Abort a runtime capture-target file picker on a non-interactive run (CLI
+	 * without `ui`) instead of hanging on an unanswerable suggester. Reached when a
+	 * format-syntax "Capture to" resolves to a folder/tag/property scope the
+	 * requirement collector could not pre-collect.
+	 */
+	private assertInteractiveCaptureTarget(): void {
+		if (this.choiceExecutor.interactive === false) {
+			throw new ChoiceAbortError(
+				`'${this.choice.name}' needs to ask which note to capture into, but this run is non-interactive. ` +
+					`Point "Capture to" at a specific file, or re-run with the ui flag.`,
+			);
+		}
+	}
+
 	private async maybeResolveInsertAfterHeading(content: string): Promise<void> {
 		const insertAfter = this.choice.insertAfter;
 		if (!insertAfter?.enabled || !insertAfter.promptHeading) return;
+
+		// Non-interactive run (CLI without `ui`): the heading picker has no one to
+		// answer it, so opening it would hang. Abort with an actionable error.
+		if (this.choiceExecutor.interactive === false) {
+			throw new ChoiceAbortError(
+				`'${this.choice.name}' needs to ask which heading to capture under, but this run is non-interactive. ` +
+					`Turn off "Choose heading when capturing" and set a fixed heading, or re-run with the ui flag.`,
+			);
+		}
 
 		const allowCreate = !!insertAfter.createIfNotFound;
 
@@ -992,6 +1016,13 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			`Folder ${folderPathSlash} is empty.`,
 		);
 
+		// Non-interactive run (CLI without `ui`): a format-syntax "Capture to" target
+		// resolves to a folder/vault scope at runtime (the requirement collector
+		// cannot pre-collect it), so this picker would hang. Abort with a clear error.
+		// Placed after the empty-folder check so a genuinely empty scope surfaces its
+		// own accurate error rather than the prompt message.
+		this.assertInteractiveCaptureTarget();
+
 		// Quick-Switcher-style ordering: recent first, excluded sunk, alphabetical tail.
 		const orderedFiles = orderFilesForPicker(
 			filesInFolder,
@@ -1132,6 +1163,11 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const allowCreate = this.choice.createFileIfItDoesntExist?.enabled ?? false;
 
 		invariant(allowCreate || files.length > 0, notFoundMessage);
+
+		// See selectFileInFolder: a format-syntax tag/property capture target resolves
+		// to a runtime file picker the requirement collector can't pre-collect. Placed
+		// after the no-match check so an empty result surfaces its own accurate error.
+		this.assertInteractiveCaptureTarget();
 
 		// Quick-Switcher-style ordering; show note names (not raw paths).
 		const orderedFiles = orderFilesForPicker(

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -48,6 +48,7 @@ import { openFile } from "../utilityObsidian";
 import { TFile } from "obsidian";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { UserCancelError } from "../errors/UserCancelError";
+import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { initializeUserScriptSettings } from "../utils/userScriptSettings";
 import {
 	migrateUserScriptSecretSettings,
@@ -485,6 +486,22 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 			return;
 		}
 
+		// Non-interactive run (CLI without `ui`): a user script that exports an object
+		// of MULTIPLE named members opens a picker to choose which to run, which has
+		// no one to answer it headlessly. A single-member export is unambiguous, so
+		// run it directly (the interactive path keeps its existing picker behaviour).
+		if (this.choiceExecutor.interactive === false) {
+			const keys = Object.keys(obj);
+			if (keys.length === 1) {
+				await this.userScriptDelegator(obj[keys[0]]);
+				return;
+			}
+			throw new ChoiceAbortError(
+				"This macro's user script exports multiple members and needs to ask which one to run, but this run is non-interactive. " +
+					"Reference a single member (e.g. myScript::start), or re-run with the ui flag.",
+			);
+		}
+
 		try {
 			const keys = Object.keys(obj);
 			const selected: string = await GenericSuggester.Suggest(
@@ -613,6 +630,14 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		const options = getModelNames();
 		let modelName: string;
 		if (command.model === "Ask me") {
+			// Non-interactive run (CLI without `ui`): the "Ask me" model picker has no
+			// one to answer it. Abort with an actionable error instead of hanging.
+			if (this.choiceExecutor.interactive === false) {
+				throw new ChoiceAbortError(
+					"This AI command is set to \"Ask me\" for the model, but this run is non-interactive. " +
+						"Pick a specific model in the command, or re-run with the ui flag.",
+				);
+			}
 			try {
 				modelName = await GenericSuggester.Suggest(this.app, options, options);
 			} catch (error) {
@@ -658,6 +683,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 				systemPrompt: command.systemPrompt,
 				showAssistantMessages: aiSettings.showAssistant,
 				modelOptions: command.modelParameters,
+				interactive: this.choiceExecutor.interactive,
 			},
 			async (input: string) => {
 				return formatter.formatFileContent(input);

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -390,6 +390,61 @@ describe("TemplateChoiceEngine collision behavior", () => {
 		expect(app.vault.adapter.exists).toHaveBeenCalledWith("Test Template.md");
 	});
 
+	it("aborts (does not open the file-exists prompt) on a non-interactive run when the target exists", async () => {
+		const { app, engine, choiceExecutor } = createEngine();
+		// Non-interactive (CLI without `ui`): no one can answer the prompt.
+		choiceExecutor.interactive = false;
+		engine.choice.fileExistsBehavior = { kind: "prompt" };
+
+		(app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+		(app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(
+			createExistingFile("Test Template.md"),
+		);
+		const createSpy = vi.spyOn(
+			engine as unknown as {
+				createFileWithTemplate: (
+					filePath: string,
+					templatePath: string,
+				) => Promise<TFile | null>;
+			},
+			"createFileWithTemplate",
+		);
+
+		await engine.run();
+
+		// The unanswerable prompt is never opened; instead the run aborts cleanly.
+		expect(GenericSuggester.Suggest).not.toHaveBeenCalled();
+		expect(createSpy).not.toHaveBeenCalled();
+		expect(choiceExecutor.signalAbort).toHaveBeenCalledTimes(1);
+		const abortArg = vi.mocked(choiceExecutor.signalAbort!).mock.calls[0][0];
+		expect(abortArg.message).toMatch(/non-interactive/i);
+		expect(abortArg.message).toMatch(/already exists/i);
+	});
+
+	it("aborts the folder chooser on a non-interactive run instead of hanging", async () => {
+		const { engine, choiceExecutor } = createEngine();
+		choiceExecutor.interactive = false;
+		// chooseWhenCreatingNote => the folder chooser would prompt across the vault.
+		engine.choice.folder = {
+			enabled: true,
+			folders: [],
+			chooseWhenCreatingNote: true,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		};
+
+		await engine.run();
+
+		// The run aborts before the folder chooser opens (it would be an
+		// InputSuggester here); the abort signal with an actionable message is the
+		// proof. GenericSuggester is the file-exists prompt and must also stay closed.
+		expect(GenericSuggester.Suggest).not.toHaveBeenCalled();
+		expect(choiceExecutor.signalAbort).toHaveBeenCalledTimes(1);
+		const abortArg = vi.mocked(choiceExecutor.signalAbort!).mock.calls[0][0];
+		expect(abortArg.message).toMatch(/non-interactive/i);
+		expect(abortArg.message).toMatch(/folder/i);
+	});
+
 	it("creates an incremented file from the original target after prompting", async () => {
 		const { app, engine } = createEngine();
 		const createdFile = createExistingFile("Test Template1.md");

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -46,6 +46,7 @@ import { TemplateEngine } from "./TemplateEngine";
 import { TemplateInsertEngine } from "./TemplateInsertEngine";
 import { UserCancelError } from "../errors/UserCancelError";
 import { MacroAbortError } from "../errors/MacroAbortError";
+import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { parentFolderPath } from "../utils/pathUtils";
 
@@ -363,6 +364,17 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			return this.choice.fileExistsBehavior.mode;
 		}
 
+		// Non-interactive run (CLI without `ui`): there is no one to answer the
+		// "file already exists" prompt, so opening it would hang forever. Abort with
+		// an actionable error instead. This is the default behaviour for new Template
+		// choices, so it is the most common non-interactive hang.
+		if (this.choiceExecutor.interactive === false) {
+			throw new ChoiceAbortError(
+				`'${this.choice.name}' needs to ask what to do because a note with that name already exists, but this run is non-interactive. ` +
+					`Set the choice's "If the file already exists" behaviour to a specific action (e.g. Increment, Overwrite), or re-run with the ui flag.`,
+			);
+		}
+
 		const promptModes = getPromptModes();
 
 		try {
@@ -598,6 +610,9 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		]);
 		const currentFolder = this.getCurrentFolderSuggestion();
 		const topItems = currentFolder ? [currentFolder] : [];
+		// Propagate non-interactivity so a folder chooser aborts (instead of hanging)
+		// in a headless CLI run; a single configured folder never prompts regardless.
+		const interactive = this.choiceExecutor.interactive;
 
 		if (
 			this.choice.folder?.chooseFromSubfolders &&
@@ -619,6 +634,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				allowCreate: true,
 				allowedRoots: folders,
 				topItems,
+				interactive,
 			});
 		}
 
@@ -629,6 +645,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			return await this.getOrCreateFolder(allFoldersInVault, {
 				allowCreate: true,
 				topItems,
+				interactive,
 			});
 		}
 
@@ -645,6 +662,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			return await this.getOrCreateFolder([activeFile.parent.path], {
 				allowCreate: true,
 				topItems,
+				interactive,
 			});
 		}
 
@@ -652,6 +670,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			allowCreate: true,
 			allowedRoots: folders,
 			topItems,
+			interactive,
 		});
 	}
 

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -35,6 +35,7 @@ import {
 } from "../utils/pathValidation";
 import { MacroAbortError } from "../errors/MacroAbortError";
 import { UserCancelError } from "../errors/UserCancelError";
+import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { isCancellationError } from "../utils/errorUtils";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
@@ -44,6 +45,13 @@ type FolderChoiceOptions = {
 	placeholder?: string;
 	allowedRoots?: string[];
 	topItems?: Array<{ path: string; label: string }>;
+	/**
+	 * When `false`, refuse to open the folder-chooser suggester (no one can answer
+	 * it in a non-interactive CLI run) and abort with a clear error instead of
+	 * hanging. Defaults to interactive. A single configured folder never prompts,
+	 * so it is unaffected regardless of this flag.
+	 */
+	interactive?: boolean;
 };
 
 type FolderSelectionContext = {
@@ -115,6 +123,15 @@ export abstract class TemplateEngine extends QuickAddEngine {
 
 		if (!this.shouldPromptForFolder(context)) {
 			return await this.handleSingleSelection(context);
+		}
+
+		// Non-interactive run (CLI without `ui`): the folder chooser has no one to
+		// answer it, so opening it would hang. Abort with an actionable error.
+		if (options.interactive === false) {
+			throw new ChoiceAbortError(
+				"This choice needs to ask which folder to create the note in, but this run is non-interactive. " +
+					"Configure a single target folder, or re-run with the ui flag.",
+			);
 		}
 
 		const selection = await this.promptUntilAllowed(context);

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -161,6 +161,7 @@ vi.mock("../logger/logManager", () => ({
 
 const { CompleteFormatter } = await import("./completeFormatter");
 const { MacroAbortError } = await import("../errors/MacroAbortError");
+const { ChoiceAbortError } = await import("../errors/ChoiceAbortError");
 
 // --- Test helpers --------------------------------------------------------
 
@@ -747,6 +748,50 @@ describe("CompleteFormatter - {{VALUE}} prompting", () => {
 		mocks.inputPromptPrompt.mockRejectedValue(realError);
 		const f = defaultFormatter();
 		await expect(f.formatFolderPath("{{VALUE}}")).rejects.toBe(realError);
+	});
+});
+
+describe("CompleteFormatter - non-interactive guard (CLI without ui)", () => {
+	// A non-interactive ChoiceExecutor: the formatter must abort any token prompt
+	// (instead of hanging on an unanswerable modal) when a value wasn't provided.
+	const nonInteractiveFormatter = () => {
+		const app = makeApp({ activeFile: null, selection: null, generatedLink: "" });
+		const plugin = makePlugin({});
+		return new CompleteFormatter(app as any, plugin as any, {
+			variables: new Map<string, unknown>(),
+			interactive: false,
+			execute: vi.fn(),
+		} as any);
+	};
+
+	it("aborts on an unresolved anonymous {{VALUE}} without opening the prompt", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("typed");
+		const f = nonInteractiveFormatter();
+		await expect(f.formatFolderPath("{{VALUE}}")).rejects.toBeInstanceOf(
+			ChoiceAbortError,
+		);
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
+	});
+
+	it("aborts on an unresolved {{VALUE:opts}} suggester without opening it", async () => {
+		mocks.genericSuggesterSuggest.mockResolvedValue("a");
+		const f = nonInteractiveFormatter();
+		await expect(
+			f.formatFolderPath("{{VALUE:a,b,c}}"),
+		).rejects.toBeInstanceOf(ChoiceAbortError);
+		expect(mocks.genericSuggesterSuggest).not.toHaveBeenCalled();
+	});
+
+	it("does NOT abort when the value is provided up front", async () => {
+		const app = makeApp({ activeFile: null, selection: null, generatedLink: "" });
+		const plugin = makePlugin({});
+		const f = new CompleteFormatter(app as any, plugin as any, {
+			variables: new Map<string, unknown>([["value", "Given"]]),
+			interactive: false,
+			execute: vi.fn(),
+		} as any);
+		await expect(f.formatFolderPath("{{VALUE}}")).resolves.toBe("Given");
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -37,6 +37,7 @@ import {
 	extractHeadingsFromLines,
 } from "./helpers/sectionLink";
 import { UserCancelError } from "../errors/UserCancelError";
+import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { isCancellationError } from "../utils/errorUtils";
 
 export class CompleteFormatter extends Formatter {
@@ -354,6 +355,24 @@ export class CompleteFormatter extends Formatter {
 		return await this.getSelectedText();
 	}
 
+	/**
+	 * Central guard for every token prompt this formatter can open. The requirement
+	 * collector pre-collects the inputs it can see, but tokens hidden behind a
+	 * format-syntax template path or capture target (which it cannot resolve up
+	 * front) still reach the formatter at runtime. On a non-interactive run (the CLI
+	 * without `ui`) there is no one to answer such a prompt, so opening it would hang
+	 * forever — abort with an actionable error instead. GUI runs leave `interactive`
+	 * at its default (true/undefined) and are unaffected.
+	 */
+	private assertInteractivePrompt(what: string): void {
+		if (this.choiceExecutor?.interactive === false) {
+			throw new ChoiceAbortError(
+				`This run is non-interactive but a value for ${what} was not provided up front. ` +
+					`Pass it (e.g. a value- flag) or re-run with the ui flag.`,
+			);
+		}
+	}
+
 	protected async promptForValue(header?: string): Promise<string> {
 		if (this.value === undefined) {
 			if (this.shouldUseSelectionForValue()) {
@@ -367,6 +386,8 @@ export class CompleteFormatter extends Formatter {
 					}
 				}
 			}
+			// No selection resolved the value; any path below opens a prompt.
+			this.assertInteractivePrompt("{{VALUE}}");
 			// Anonymous {{VALUE|type:checkbox}} gets the same forced true/false
 			// picker as the named form (resolved before the InputPrompt factory).
 			if (this.valuePromptContext?.inputTypeOverride === "checkbox") {
@@ -478,6 +499,9 @@ export class CompleteFormatter extends Formatter {
 		header?: string,
 		context?: PromptContext,
 	): Promise<string> {
+		this.assertInteractivePrompt(
+			header ? `{{VALUE:${header}}}` : "a template variable",
+		);
 		try {
 			// Use VDateInputPrompt for VDATE variables
 			if (context?.type === "VDATE") {
@@ -528,6 +552,7 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async promptForMathValue(): Promise<string> {
+		this.assertInteractivePrompt("a {{MATH}} expression");
 		try {
 			return await MathModal.Prompt();
 		} catch (error) {
@@ -548,6 +573,9 @@ export class CompleteFormatter extends Formatter {
 			optional?: boolean;
 		},
 	) {
+		this.assertInteractivePrompt(
+			context?.variableKey ? `{{VALUE:${context.variableKey}}}` : "a value choice",
+		);
 		try {
 			const displayValues = context?.displayValues ?? suggestedValues;
 			if (allowCustomInput) {
@@ -589,6 +617,11 @@ export class CompleteFormatter extends Formatter {
 			optional?: boolean;
 		},
 	): Promise<string[]> {
+		this.assertInteractivePrompt(
+			context?.variableKey
+				? `{{VALUE:${context.variableKey}}}`
+				: "a multi-select value",
+		);
 		try {
 			const displayValues = context?.displayValues ?? suggestedValues;
 			return await MultiSuggester.Suggest(
@@ -612,6 +645,7 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async suggestForField(fieldInput: string): Promise<string | string[]> {
+		this.assertInteractivePrompt(`{{FIELD:${fieldInput}}}`);
 		try {
 			// Parse the field input to extract field name and filters. Do NOT warn
 			// on unknown keys here: the field replacer in formatter.ts already parses
@@ -694,6 +728,9 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async suggestForFile(parsed: ParsedFileToken): Promise<string | string[]> {
+		this.assertInteractivePrompt(
+			`{{FILE}} (pick a file from ${parsed.folderPath})`,
+		);
 		try {
 			const files = EnhancedFieldSuggestionFileFilter.filterFiles(
 				this.app.vault.getMarkdownFiles(),

--- a/src/types/ChoiceOutcome.ts
+++ b/src/types/ChoiceOutcome.ts
@@ -10,8 +10,13 @@ import type { TFile } from "obsidian";
  * `cancelled` distinguishes a genuine user prompt-dismissal (`"user"`) from an
  * involuntary script/config abort (`"aborted"`). `error` means the choice failed
  * (the detailed message is kept in the internal log, never surfaced externally).
+ *
+ * `reason` carries the abort message for a local, trusted caller (the CLI) to
+ * surface — e.g. "needs to ask … re-run with the ui flag". The URI x-callback
+ * handler deliberately ignores it, reporting only `cancelKind`, so no vault detail
+ * leaks to an external callback URL.
  */
 export type ChoiceOutcome =
 	| { status: "success"; file?: TFile }
 	| { status: "error" }
-	| { status: "cancelled"; cancelKind: "user" | "aborted" };
+	| { status: "cancelled"; cancelKind: "user" | "aborted"; reason?: string };


### PR DESCRIPTION
## Summary

Found via a live end-to-end audit of QuickAdd in an isolated Obsidian instance: a **non-interactive CLI run** (`quickadd:run` / `quickadd:run-template` without the `ui` flag, and any headless automation) **hangs forever** when an engine opens a blocking prompt the requirement collector cannot pre-satisfy.

### Reproduction (before this PR)
```
# 1st run creates the note
obsidian vault=… quickadd:run-template path=Templates/T.md value-value=Daily
# 2nd run — target now exists, default "Ask every time" file-exists behaviour:
obsidian vault=… quickadd:run-template path=Templates/T.md value-value=Daily
# → no output, no error envelope, hangs 2+ minutes (stuck on an unanswerable
#   "file already exists" suggester). Same for quickadd:run of any Template
#   choice whose fileExistsBehavior is "prompt".
```

The non-interactive CLI contract is "succeed, or return an `{ok:false}` envelope" — never hang. The requirement collector pre-collects the inputs it can *see*, but prompts opened at **runtime** (after token resolution) escape it and block indefinitely.

## Reproduced hang sites (all fixed + verified live)
| Site | Trigger |
|------|---------|
| Template file-exists prompt | target note exists + `fileExistsBehavior: prompt` (the default) |
| Template folder chooser | `chooseWhenCreatingNote` / multiple folders |
| Capture target file picker | format-syntax `Capture to` (e.g. `{{VALUE:folder}}`) |
| Capture heading picker | `Choose heading when capturing` |
| Formatter token prompts | `{{VALUE}}` / `{{VDATE}}` / … hidden behind a tokenized template path or capture target |
| Macro member picker | a user script that exports an object of named members |
| AI model / prompt-template pickers | `Ask me` model, or prompt-template selection |

## Fix
- Add `interactive?: boolean` to `IChoiceExecutor` (default `true` → **every GUI entry point is byte-identical**). `ChoiceExecutor` defaults it `true`; the CLI sets it `false` when `ui` is absent.
- Each **config-driven** prompt the collector cannot pre-satisfy now throws an actionable `ChoiceAbortError` → a clean `ok:false` envelope in ~1–30 ms instead of hanging:
  - `TemplateChoiceEngine`: file-exists prompt + folder chooser (`getOrCreateFolder`)
  - `CaptureChoiceEngine`: capture target file picker + heading picker
  - `CompleteFormatter`: a single `assertInteractivePrompt` guard covering all 7 token-prompt methods (the central source of token prompts). `RequirementCollector` overrides `promptForValue` separately, so **input collection is unaffected**.
  - `MacroChoiceEngine` / `AIAssistant`: member picker, AI `Ask me` model picker, AI prompt-template picker
- The abort reason is threaded through `ChoiceOutcome.cancelled.reason` so `quickadd:run-template` surfaces the actionable message; the **URI x-callback handler still reports only `cancelKind`**, so no vault detail leaks to an external callback URL. A user dismissal keeps its stable "cancelled by user" text.

### Boundary (intentional, not a bug)
A macro user-script that **explicitly** calls an interactive api method (`api.inputPrompt`/`suggester`/`yesNoPrompt`/`checkboxPrompt`) is inherently interactive and still needs `ui`. That's the script author's choice, not a config-driven prompt, so the public api contract is left unchanged.

## Verification
- **Live** (this worktree's isolated Obsidian instance): every site above now returns a clear `{ok:false, error, aborted:true}` envelope in ~1–30 ms; new-note create / normal capture / normal macro are unaffected; no leaked modals.
  - e.g. `run-template` on existing target → `'T' needs to ask what to do because a note with that name already exists … Set the choice's "If the file already exists" behaviour … or re-run with the ui flag.`
- **Gates**: `tsc` ✓, `eslint` ✓, `svelte-check` 0 errors ✓, `pnpm test` 3169 passed (+ regression tests for the file-exists, folder, heading, and formatter guards).
- Two rounds of adversarial review (opposite model); the first round caught that an earlier version only guarded 3 sites — this PR extends the fix to the full reproduced surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-interactive mode that prevents prompt/picker/template selection UI from blocking headless runs.
  * Exposed an `interactive` setting to control whether interactive selection is allowed (including AI assistant template selection).

* **Bug Fixes**
  * Improved cancellation results: user cancels are distinguished from aborts, and aborted/cancelled responses can include a clearer reason when available.
  * CLI behavior now maps interactivity to whether the `ui` option is enabled.

* **Tests**
  * Added/extended coverage for non-interactive abort behavior across capture, template collisions, and formatting/assistant flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->