### PR TITLE
feat(field): default {{FIELD}} from the active note's property (default-from:active)

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -406,6 +406,57 @@ commas as separators. When a format contains `{{FIELD:...|multi}}`, QuickAdd
 collects other one-page inputs first, then opens the runtime multi-select for
 the FIELD value.
 
+### `{{FIELD:<FIELDNAME>|default-from:active}}` {#field-default-from-active}
+
+Defaults the FIELD prompt to the value the same property already has on the
+**active note** - the note that was focused when you triggered QuickAdd. This is
+useful for metadata inheritance: from an active project/person/area note, trigger
+a capture or template and carry a property such as `project`, `type`, or `area`
+over to the new content as the default. You can still accept it, pick another
+suggestion, or type a different value.
+
+Active note:
+
+```yaml
+---
+project: The Great Endeavor
+---
+```
+
+Format:
+
+```md
+project: {{FIELD:project|default-from:active}}
+```
+
+The `project` prompt defaults to `The Great Endeavor`. The active note is captured
+when the run starts, before any QuickAdd modal can move focus, so the default
+reflects the note you triggered from.
+
+Behavior:
+
+- The normal FIELD suggestion list still comes from your vault (and honors
+  `folder:`/`tag:`/`exclude-*`/`inline` filters); the active value is just
+  promoted to the top as the default and pre-filled in the one-page form. It is
+  promoted even if it already exists in the suggestions.
+- If no Markdown note is active, the note doesn't have the property, or the value
+  is empty, it falls back to a normal `{{FIELD:<field>}}` prompt with no default.
+- Scalar string/number/boolean values are used as-is. A YAML **list** value
+  applies only to `|multi` FIELD prompts, where each list item is pre-checked in
+  the multi-select picker; for a single-select prompt a list value is skipped (no
+  default). Object/map and null values are never used as defaults.
+- The property name is matched case-insensitively against the active note's
+  properties, so `{{FIELD:Project|default-from:active}}` still reads a `project`
+  property.
+- This is different from `|default:` (a literal default value) and intentionally
+  not `|default:current` (which would clash with `current` as a real field value).
+
+Combine it with `|multi` to inherit a list property:
+
+```md
+topics: {{FIELD:topics|multi|default-from:active}}
+```
+
 **Enhanced Filtering Options:**
 
 - `{{FIELD:fieldname|folder:path/to/folder}}` - Only suggest values from files in a specific folder
@@ -420,6 +471,7 @@ the FIELD value.
 - `{{FIELD:fieldname|default:Status - To Do}}` - Prepend a default suggestion; the modal placeholder shows it and pressing Enter accepts it.
 - `{{FIELD:fieldname|default:Draft|default-empty:true}}` - Only add the default when no matching values are found.
 - `{{FIELD:fieldname|default:Draft|default-always:true}}` - Keep the default first even if other suggestions exist.
+- `{{FIELD:fieldname|default-from:active}}` - Default to the active note's current value of this property (see [above](#field-default-from-active)).
 - Combine filters: `{{FIELD:fieldname|folder:goals|folder:projects|tag:work|tag:active|exclude-folder:templates|inline:true|inline-code-blocks:ad-note}}`
 - Multiple exclusions: `{{FIELD:fieldname|exclude-folder:templates|exclude-folder:archive}}`
 
@@ -428,7 +480,7 @@ filters. Exclusions remove any matching file.
 
 Examples: `status: {{FIELD:status|default:Draft|default-always:true}}` or `id: {{FIELD:Id|inline:true|inline-code-blocks:ad-note}}`.
 
-This is currently in beta, and the syntax can change—leave your thoughts [here](https://github.com/chhoumann/quickadd/issues/337).
+This is currently in beta, and the syntax can change—leave your thoughts [here](https://github.com/chhoumann/quickadd/issues/1429).
 
 ## `{{FILE:<folder>}}` {#file}
 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -480,7 +480,7 @@ filters. Exclusions remove any matching file.
 
 Examples: `status: {{FIELD:status|default:Draft|default-always:true}}` or `id: {{FIELD:Id|inline:true|inline-code-blocks:ad-note}}`.
 
-This is currently in beta, and the syntax can change—leave your thoughts [here](https://github.com/chhoumann/quickadd/issues/1429).
+This is currently in beta, and the syntax can change—leave your thoughts [on issue #1429](https://github.com/chhoumann/quickadd/issues/1429).
 
 ## `{{FILE:<folder>}}` {#file}
 

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -9,13 +9,19 @@ import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
 	/**
-	 * Executes a choice while reusing a frontmatter property target captured before
-	 * an intermediate UI layer, such as a Multi-choice suggester, stole focus.
-	 * Optional so existing stubs can fall back to {@link execute}.
+	 * Executes a choice while reusing context captured before an intermediate UI
+	 * layer, such as a Multi-choice suggester, ran: the frontmatter property target
+	 * (DOM focus is stolen by the suggester) and the trigger-time
+	 * {@link QuickAddTriggerContext} (cleared when the outer Multi execute()
+	 * returns). Both are re-injected so the eventual leaf run uses the original
+	 * trigger note for `{{...|default-from:active}}`. Optional so existing stubs can
+	 * fall back to {@link execute}; `triggerContext` is optional so callers that only
+	 * carry a focused property need not pass it (the executor then reads it live).
 	 */
 	executeWithFocusedProperty?(
 		choice: IChoice,
 		focusedProperty: FrontmatterPropertyTarget | null,
+		triggerContext?: QuickAddTriggerContext | null,
 	): Promise<void>;
 	/**
 	 * Executes a Template/Capture choice and returns its structured outcome

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -4,6 +4,7 @@ import type ICaptureChoice from "./types/choices/ICaptureChoice";
 import type { MacroAbortError } from "./errors/MacroAbortError";
 import type { ChoiceOutcome } from "./types/ChoiceOutcome";
 import type { FrontmatterPropertyTarget } from "./utils/frontmatterPropertyLinks";
+import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
 
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
@@ -45,6 +46,15 @@ export interface IChoiceExecutor {
 	 * while a Properties field owns focus.
 	 */
 	focusedProperty?: FrontmatterPropertyTarget | null;
+	/**
+	 * Snapshot of the editor context (currently just the active file) taken when
+	 * the OUTERMOST choice execution began, before any QuickAdd UI opens or a
+	 * Template choice creates/opens a new note. `{{FIELD:<field>|default-from:active}}`
+	 * reads the active note's current property from this to default the prompt.
+	 * Optional so existing stubs and the legacy void {@link execute} path are
+	 * unaffected; absent/undefined means "no trigger-derived default".
+	 */
+	triggerContext?: QuickAddTriggerContext | null;
 	/**
 	 * Records the structured outcome of the current execution so an orchestrator
 	 * (the URI x-callback handler, via {@link ChoiceExecutor.executeWithOutcome}) can

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -22,6 +22,7 @@ import {
 	getFocusedPropertyTarget,
 	type FrontmatterPropertyTarget,
 } from "./utils/frontmatterPropertyLinks";
+import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
@@ -30,6 +31,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	// without `ui`) flip this to false so engine prompts abort instead of hanging.
 	public interactive = true;
 	public focusedProperty: FrontmatterPropertyTarget | null = null;
+	public triggerContext: QuickAddTriggerContext | null = null;
 	private pendingAbort: MacroAbortError | null = null;
 	private pendingResult: ChoiceOutcome | null = null;
 	private executionDepth = 0;
@@ -57,6 +59,16 @@ export class ChoiceExecutor implements IChoiceExecutor {
 				this.focusedPropertyOverride !== undefined
 					? this.focusedPropertyOverride
 					: getFocusedPropertyTarget(this.app);
+			// Snapshot the trigger-time editor context ONCE, at the outermost
+			// boundary. Deliberately depth-0-only: a nested execute() (a {{MACRO}}
+			// that opens a file then runs a FIELD template, or the API path) keeps the
+			// ORIGINAL trigger note as the source for {{...|default-from:active}},
+			// mirroring focusedProperty's depth-0 semantics. getActiveFile() tracks the
+			// active markdown leaf — which the QuickAdd suggester/modal overlay does not
+			// change — so a live read here is the trigger note, with no focus-drift
+			// override needed (unlike focusedProperty, whose DOM activeElement IS stolen
+			// by the modal).
+			this.triggerContext = { activeFile: this.app.workspace.getActiveFile() };
 		}
 		this.executionDepth++;
 	}
@@ -65,6 +77,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		this.executionDepth = Math.max(0, this.executionDepth - 1);
 		if (this.executionDepth === 0) {
 			this.focusedProperty = null;
+			this.triggerContext = null;
 		}
 	}
 

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -59,15 +59,17 @@ export class ChoiceExecutor implements IChoiceExecutor {
 				this.focusedPropertyOverride !== undefined
 					? this.focusedPropertyOverride
 					: getFocusedPropertyTarget(this.app);
-			// Snapshot the trigger-time editor context ONCE, at the outermost
-			// boundary. Deliberately depth-0-only: a nested execute() (a {{MACRO}}
-			// that opens a file then runs a FIELD template, or the API path) keeps the
-			// ORIGINAL trigger note as the source for {{...|default-from:active}},
-			// mirroring focusedProperty's depth-0 semantics. getActiveFile() tracks the
-			// active markdown leaf — which the QuickAdd suggester/modal overlay does not
-			// change — so a live read here is the trigger note, with no focus-drift
-			// override needed (unlike focusedProperty, whose DOM activeElement IS stolen
-			// by the modal).
+			// Snapshot the trigger-time editor context at the outermost boundary, so a
+			// nested execute() (a {{MACRO}} that opens a file then runs a FIELD
+			// template, or the API path) keeps the ORIGINAL trigger note as the source
+			// for {{...|default-from:active}}, mirroring focusedProperty's depth-0
+			// semantics. Unlike focusedProperty — whose DOM activeElement IS stolen by
+			// the modal and so must be captured+re-injected through the Multi suggester
+			// — getActiveFile() tracks the active markdown LEAF, which a suggester/modal
+			// overlay does not change. So the Multi path (outer execute() clears this,
+			// then the chosen leaf's own depth-0 execute() re-reads it) still yields the
+			// trigger note on the live re-read; no focus-drift override is needed.
+			// Verified live: launcher → Multi → leaf still defaults from the trigger note.
 			this.triggerContext = { activeFile: this.app.workspace.getActiveFile() };
 		}
 		this.executionDepth++;

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -36,6 +36,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	private pendingResult: ChoiceOutcome | null = null;
 	private executionDepth = 0;
 	private focusedPropertyOverride: FrontmatterPropertyTarget | null | undefined;
+	private triggerContextOverride: QuickAddTriggerContext | null | undefined;
 
 	constructor(private app: App, private plugin: QuickAdd) {}
 
@@ -63,14 +64,17 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			// nested execute() (a {{MACRO}} that opens a file then runs a FIELD
 			// template, or the API path) keeps the ORIGINAL trigger note as the source
 			// for {{...|default-from:active}}, mirroring focusedProperty's depth-0
-			// semantics. Unlike focusedProperty — whose DOM activeElement IS stolen by
-			// the modal and so must be captured+re-injected through the Multi suggester
-			// — getActiveFile() tracks the active markdown LEAF, which a suggester/modal
-			// overlay does not change. So the Multi path (outer execute() clears this,
-			// then the chosen leaf's own depth-0 execute() re-reads it) still yields the
-			// trigger note on the live re-read; no focus-drift override is needed.
-			// Verified live: launcher → Multi → leaf still defaults from the trigger note.
-			this.triggerContext = { activeFile: this.app.workspace.getActiveFile() };
+			// semantics. The Multi path opens a nested suggester and lets the outer
+			// execute() return (clearing this at depth 0), so — like focusedProperty —
+			// the captured context is threaded through the suggester and re-injected as
+			// triggerContextOverride for the chosen leaf's own depth-0 run, instead of a
+			// live re-read at leaf time. A direct execute() (command palette/ribbon) has
+			// no override and reads live, which is the trigger note (the active markdown
+			// leaf is unchanged by the launching modal).
+			this.triggerContext =
+				this.triggerContextOverride !== undefined
+					? this.triggerContextOverride
+					: { activeFile: this.app.workspace.getActiveFile() };
 		}
 		this.executionDepth++;
 	}
@@ -141,13 +145,20 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	async executeWithFocusedProperty(
 		choice: IChoice,
 		focusedProperty: FrontmatterPropertyTarget | null,
+		triggerContext?: QuickAddTriggerContext | null,
 	): Promise<void> {
-		const previousOverride = this.focusedPropertyOverride;
+		const previousFocusedOverride = this.focusedPropertyOverride;
+		const previousTriggerOverride = this.triggerContextOverride;
 		this.focusedPropertyOverride = focusedProperty;
+		// `triggerContext` is `undefined` only when the caller didn't capture one;
+		// leave the override unset so the executor reads it live. A captured value
+		// (including `null` for "no active note at trigger time") IS injected.
+		this.triggerContextOverride = triggerContext;
 		try {
 			await this.execute(choice);
 		} finally {
-			this.focusedPropertyOverride = previousOverride;
+			this.focusedPropertyOverride = previousFocusedOverride;
+			this.triggerContextOverride = previousTriggerOverride;
 		}
 	}
 
@@ -302,6 +313,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		ChoiceSuggester.Open(this.plugin, multiChoice.choices, {
 			choiceExecutor: this,
 			focusedProperty: this.focusedProperty,
+			triggerContext: this.triggerContext,
 			// Fall back to the folder name when no custom placeholder is set, matching the
 			// picker drill-down (choiceSuggester.onChooseMultiType) so both entry points to
 			// the same folder show the same search hint.

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -296,6 +296,54 @@ describe("applyTemplateToNote (non-interactive)", () => {
 		expect(executor.variables.get("value")).toBe("Custom");
 	});
 
+	it("seeds the trigger context with the target note, then restores it (issue #1429)", async () => {
+		const file = makeFile();
+		const executor = makeExecutor();
+		let contextDuringApply: unknown;
+		engineApplyMock.mockImplementationOnce(async () => {
+			contextDuringApply = (
+				executor as unknown as { triggerContext?: unknown }
+			).triggerContext;
+			return file;
+		});
+
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: executor,
+		});
+
+		// During apply, default-from:active resolves against the target note...
+		expect(contextDuringApply).toEqual({ activeFile: file });
+		// ...and the executor is restored afterward so a reused executor (a script
+		// applying templates to several notes) never leaks the stale note.
+		expect(
+			(executor as unknown as { triggerContext?: unknown }).triggerContext,
+		).toBeUndefined();
+	});
+
+	it("does not clobber a caller-supplied trigger context", async () => {
+		const file = makeFile();
+		const callerContext = { activeFile: makeFile() };
+		const executor = makeExecutor();
+		const ctx = () =>
+			(executor as unknown as { triggerContext?: unknown }).triggerContext;
+		(executor as unknown as { triggerContext?: unknown }).triggerContext =
+			callerContext;
+		let contextDuringApply: unknown;
+		engineApplyMock.mockImplementationOnce(async () => {
+			contextDuringApply = ctx();
+			return file;
+		});
+
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: executor,
+		});
+
+		expect(contextDuringApply).toBe(callerContext);
+		expect(ctx()).toBe(callerContext);
+	});
+
 	it("returns null without an active markdown note", async () => {
 		const result = await applyTemplateToNote(makeApp("", null), plugin, {
 			templatePath: "templates/tpl.md",

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -125,6 +125,15 @@ export async function applyTemplateToNote(
 			return null;
 		}
 
+		// This path runs a template through the executor WITHOUT going through
+		// ChoiceExecutor.execute(), so beginExecutionContext() never captures the
+		// trigger context. Seed it here so {{FIELD:<field>|default-from:active}} in
+		// the applied template can read the note being applied to (issue #1429). Use
+		// the resolved target file: it is the active note for the command, and the
+		// explicit params.file for the API path. `??=` so a caller that already
+		// captured a context is never clobbered.
+		params.choiceExecutor.triggerContext ??= { activeFile: file };
+
 		const interactive = !params.templatePath;
 		let source: TemplatePickerItem;
 		if (params.templatePath) {

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -118,22 +118,27 @@ export async function applyTemplateToNote(
 	plugin: QuickAdd,
 	params: ApplyTemplateToNoteParams,
 ): Promise<TFile | null> {
+	const file = params.file ?? app.workspace.getActiveFile();
+	if (!file || file.extension !== "md") {
+		new Notice("QuickAdd: No active markdown note to apply a template to.");
+		return null;
+	}
+
+	// This path runs a template through the executor WITHOUT going through
+	// ChoiceExecutor.execute(), so beginExecutionContext() never captures the
+	// trigger context. Seed it here so {{FIELD:<field>|default-from:active}} in
+	// the applied template can read the note being applied to (issue #1429): the
+	// active note for the command, or the explicit params.file for the API path.
+	// Seed only when absent (never clobber a caller-supplied context) and restore
+	// the prior value in `finally`, so a reused executor — e.g. a script applying
+	// templates to several notes in turn, or a later `format()` on the same API
+	// object — never inherits this call's note for a subsequent default-from:active.
+	const previousTriggerContext = params.choiceExecutor.triggerContext;
+	if (previousTriggerContext == null) {
+		params.choiceExecutor.triggerContext = { activeFile: file };
+	}
+
 	try {
-		const file = params.file ?? app.workspace.getActiveFile();
-		if (!file || file.extension !== "md") {
-			new Notice("QuickAdd: No active markdown note to apply a template to.");
-			return null;
-		}
-
-		// This path runs a template through the executor WITHOUT going through
-		// ChoiceExecutor.execute(), so beginExecutionContext() never captures the
-		// trigger context. Seed it here so {{FIELD:<field>|default-from:active}} in
-		// the applied template can read the note being applied to (issue #1429). Use
-		// the resolved target file: it is the active note for the command, and the
-		// explicit params.file for the API path. `??=` so a caller that already
-		// captured a context is never clobbered.
-		params.choiceExecutor.triggerContext ??= { activeFile: file };
-
 		const interactive = !params.templatePath;
 		let source: TemplatePickerItem;
 		if (params.templatePath) {
@@ -217,6 +222,10 @@ export async function applyTemplateToNote(
 		}
 		reportError(err, "Error applying template to note");
 		return null;
+	} finally {
+		// Restore the executor's prior trigger context (see the seeding note above)
+		// so this direct, non-execute() path never leaks state across calls.
+		params.choiceExecutor.triggerContext = previousTriggerContext;
 	}
 }
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -157,6 +157,10 @@ vi.mock("../utils/FieldValueProcessor", async () => {
 				actual.FieldValueProcessor.promoteValueToFront.bind(
 					actual.FieldValueProcessor,
 				),
+			canonicalizeAgainst:
+				actual.FieldValueProcessor.canonicalizeAgainst.bind(
+					actual.FieldValueProcessor,
+				),
 		},
 	};
 });
@@ -1129,6 +1133,28 @@ describe("CompleteFormatter - FIELD default-from:active (issue #1429)", () => {
 		const [, , , opts] = mocks.multiSuggesterSuggest.mock.calls[0];
 		expect(opts.preselected).toEqual(["Beta", "Zeta"]);
 		expect(opts.allowCustomValue).toBe(true);
+	});
+
+	it("canonicalizes a case-variant active value onto the collected option (no duplicate row)", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "topics",
+			filters: { defaultFrom: "active" },
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["done", "open"],
+			hasDefaultValue: false,
+		});
+		// Active note uses different casing than the collected vault value.
+		mocks.resolveActiveDefault.mockReturnValue(["Done"]);
+		mocks.multiSuggesterSuggest.mockResolvedValue(["done"]);
+
+		const f = formatterWithActiveFile({ extension: "md", path: "A.md" });
+		await f.formatFolderPath("{{FIELD:topics|multi|default-from:active}}");
+
+		const [, , , opts] = mocks.multiSuggesterSuggest.mock.calls[0];
+		// "Done" is folded onto the collected "done" option, not added as custom.
+		expect(opts.preselected).toEqual(["done"]);
 	});
 
 	it("pre-checks a scalar active value in a multi-select picker as a single item", async () => {

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TemplateInclusionState } from "./formatter";
+import type { FieldValueProcessor as FieldValueProcessorType } from "../utils/FieldValueProcessor";
 
 /**
  * Unit tests for the concrete CompleteFormatter.
@@ -33,6 +34,7 @@ const mocks = vi.hoisted(() => ({
 	collectProcessedDetailed: vi.fn(),
 	collectRaw: vi.fn(),
 	getSmartDefaults: vi.fn(() => [] as string[]),
+	resolveActiveDefault: vi.fn(() => null as string | string[] | null),
 	dateAliases: {} as Record<string, string>,
 }));
 
@@ -142,8 +144,25 @@ vi.mock("../utils/FieldValueCollector", () => ({
 	generateFieldCacheKey: (f: unknown) => JSON.stringify(f),
 }));
 
-vi.mock("../utils/FieldValueProcessor", () => ({
-	FieldValueProcessor: { getSmartDefaults: mocks.getSmartDefaults },
+vi.mock("../utils/FieldValueProcessor", async () => {
+	// Keep the real promoteValueToFront (issue #1429) so the active-default
+	// promotion is exercised end-to-end; only getSmartDefaults is stubbed.
+	const actual = (await vi.importActual(
+		"../utils/FieldValueProcessor",
+	)) as { FieldValueProcessor: typeof FieldValueProcessorType };
+	return {
+		FieldValueProcessor: {
+			getSmartDefaults: mocks.getSmartDefaults,
+			promoteValueToFront:
+				actual.FieldValueProcessor.promoteValueToFront.bind(
+					actual.FieldValueProcessor,
+				),
+		},
+	};
+});
+
+vi.mock("../utils/activeNoteFieldDefault", () => ({
+	resolveActiveNoteFieldDefault: mocks.resolveActiveDefault,
 }));
 
 vi.mock("../settingsStore", () => ({
@@ -250,6 +269,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	mocks.macroGetVariables.mockReturnValue(new Map());
 	mocks.getSmartDefaults.mockReturnValue([]);
+	mocks.resolveActiveDefault.mockReturnValue(null);
 
 	// Deterministic clipboard: empty by default. navigator may not exist in
 	// the jsdom-less environment, so define it.
@@ -980,6 +1000,195 @@ describe("CompleteFormatter - field suggestion (suggestForField)", () => {
 		await expect(
 			f.formatFolderPath("{{FIELD:status}}"),
 		).rejects.toBeInstanceOf(MacroAbortError);
+	});
+});
+
+describe("CompleteFormatter - FIELD default-from:active (issue #1429)", () => {
+	// A formatter whose choiceExecutor carries a trigger-time active file, so the
+	// resolver receives the captured file (and we can assert it).
+	function formatterWithActiveFile(activeFile: unknown) {
+		const app = makeApp({
+			activeFile: null,
+			selection: null,
+			generatedLink: "",
+		});
+		const choiceExecutor = {
+			variables: new Map<string, unknown>(),
+			triggerContext: { activeFile },
+		};
+		return new CompleteFormatter(
+			app as any,
+			makePlugin() as any,
+			choiceExecutor as any,
+		);
+	}
+
+	it("promotes the active note's scalar value to the top suggestion and accepts it", async () => {
+		const activeFile = { extension: "md", path: "Active.md" };
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "project",
+			filters: { defaultFrom: "active" },
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Old Project", "The Great Endeavor"],
+			hasDefaultValue: false,
+		});
+		mocks.resolveActiveDefault.mockReturnValue("The Great Endeavor");
+		mocks.inputSuggesterSuggest.mockImplementation(
+			(_app, _display, items) => Promise.resolve(items[0]),
+		);
+
+		const f = formatterWithActiveFile(activeFile);
+		await expect(
+			f.formatFolderPath("{{FIELD:project|default-from:active}}"),
+		).resolves.toBe("The Great Endeavor");
+
+		// The resolver was handed the captured trigger-time active file.
+		expect(mocks.resolveActiveDefault).toHaveBeenCalledWith(
+			expect.anything(),
+			activeFile,
+			"project",
+		);
+		// The active value is promoted to the front, de-duplicated.
+		const [, , items, opts] = mocks.inputSuggesterSuggest.mock.calls[0];
+		expect(items).toEqual(["The Great Endeavor", "Old Project"]);
+		expect(opts.placeholder).toContain("default: The Great Endeavor");
+	});
+
+	it("prepends the active value when it is not already a vault suggestion", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "project",
+			filters: { defaultFrom: "active" },
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Other"],
+			hasDefaultValue: false,
+		});
+		mocks.resolveActiveDefault.mockReturnValue("Fresh");
+		mocks.inputSuggesterSuggest.mockResolvedValue("Fresh");
+
+		const f = formatterWithActiveFile({ extension: "md", path: "A.md" });
+		await f.formatFolderPath("{{FIELD:project|default-from:active}}");
+
+		const [, , items] = mocks.inputSuggesterSuggest.mock.calls[0];
+		expect(items).toEqual(["Fresh", "Other"]);
+	});
+
+	it("falls back to normal FIELD behavior when there is no active default", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "project",
+			filters: { defaultFrom: "active" },
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["A", "B"],
+			hasDefaultValue: false,
+		});
+		mocks.resolveActiveDefault.mockReturnValue(null);
+		mocks.inputSuggesterSuggest.mockResolvedValue("A");
+
+		const f = formatterWithActiveFile(null);
+		await f.formatFolderPath("{{FIELD:project|default-from:active}}");
+
+		const [, , items, opts] = mocks.inputSuggesterSuggest.mock.calls[0];
+		expect(items).toEqual(["A", "B"]);
+		expect(opts.placeholder).not.toContain("default:");
+	});
+
+	it("does NOT resolve an active default for a plain FIELD (no default-from)", async () => {
+		mocks.fieldParse.mockReturnValue({ fieldName: "project", filters: {} });
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["A"],
+			hasDefaultValue: false,
+		});
+		mocks.inputSuggesterSuggest.mockResolvedValue("A");
+
+		const f = formatterWithActiveFile({ extension: "md", path: "A.md" });
+		await f.formatFolderPath("{{FIELD:project}}");
+
+		expect(mocks.resolveActiveDefault).not.toHaveBeenCalled();
+	});
+
+	it("pre-checks the active note's list value in the multi-select picker", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "topics",
+			filters: { defaultFrom: "active" },
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Alpha", "Beta", "Gamma"],
+			hasDefaultValue: false,
+		});
+		mocks.resolveActiveDefault.mockReturnValue(["Beta", "Zeta"]);
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Beta", "Zeta"]);
+
+		const f = formatterWithActiveFile({ extension: "md", path: "A.md" });
+		await expect(
+			f.formatFolderPath("{{FIELD:topics|multi|default-from:active}}"),
+		).resolves.toBe("Beta,Zeta");
+
+		const [, , , opts] = mocks.multiSuggesterSuggest.mock.calls[0];
+		expect(opts.preselected).toEqual(["Beta", "Zeta"]);
+		expect(opts.allowCustomValue).toBe(true);
+	});
+
+	it("pre-checks a scalar active value in a multi-select picker as a single item", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "topics",
+			filters: { defaultFrom: "active" },
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Alpha"],
+			hasDefaultValue: false,
+		});
+		mocks.resolveActiveDefault.mockReturnValue("Alpha");
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Alpha"]);
+
+		const f = formatterWithActiveFile({ extension: "md", path: "A.md" });
+		await f.formatFolderPath("{{FIELD:topics|multi|default-from:active}}");
+
+		const [, , , opts] = mocks.multiSuggesterSuggest.mock.calls[0];
+		expect(opts.preselected).toEqual(["Alpha"]);
+	});
+
+	it("does not preselect anything in multi when there is no active value", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "topics",
+			filters: { defaultFrom: "active" },
+			multiSelect: true,
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["Alpha"],
+			hasDefaultValue: false,
+		});
+		mocks.resolveActiveDefault.mockReturnValue(null);
+		mocks.multiSuggesterSuggest.mockResolvedValue([]);
+
+		const f = formatterWithActiveFile(null);
+		await f.formatFolderPath("{{FIELD:topics|multi|default-from:active}}");
+
+		const [, , , opts] = mocks.multiSuggesterSuggest.mock.calls[0];
+		expect(opts.preselected).toBeUndefined();
+	});
+
+	it("does not prefill a single-select default when the active value is a list", async () => {
+		mocks.fieldParse.mockReturnValue({
+			fieldName: "project",
+			filters: { defaultFrom: "active" },
+		});
+		mocks.collectProcessedDetailed.mockResolvedValue({
+			values: ["A", "B"],
+			hasDefaultValue: false,
+		});
+		mocks.resolveActiveDefault.mockReturnValue(["X", "Y"]);
+		mocks.inputSuggesterSuggest.mockResolvedValue("A");
+
+		const f = formatterWithActiveFile({ extension: "md", path: "A.md" });
+		await f.formatFolderPath("{{FIELD:project|default-from:active}}");
+
+		const [, , items, opts] = mocks.inputSuggesterSuggest.mock.calls[0];
+		expect(items).toEqual(["A", "B"]);
+		expect(opts.placeholder).not.toContain("default:");
 	});
 });
 

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -728,12 +728,23 @@ export class CompleteFormatter extends Formatter {
 				}
 				// Pre-check the active note's value(s) (scalar -> one, list -> each).
 				// Never [undefined]: activeDefault is null | string | string[].
+				// Canonicalize each against the collected suggestions under the dedup
+				// case fold, so an active "Done" toggles a collected "done" option
+				// instead of adding a duplicate custom row (matching FIELD's
+				// case-insensitive dedup).
 				const preselected =
 					activeDefault === null
 						? undefined
-						: Array.isArray(activeDefault)
-							? activeDefault
-							: [activeDefault];
+						: (Array.isArray(activeDefault)
+								? activeDefault
+								: [activeDefault]
+							).map((v) =>
+								FieldValueProcessor.canonicalizeAgainst(
+									multiValues,
+									v,
+									filters.caseSensitive,
+								),
+							);
 				return await MultiSuggester.Suggest(this.app, multiValues, multiValues, {
 					placeholder,
 					allowCustomValue: true,

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -31,6 +31,8 @@ import {
 	generateFieldCacheKey,
 } from "../utils/FieldValueCollector";
 import { FieldValueProcessor } from "../utils/FieldValueProcessor";
+import { resolveActiveNoteFieldDefault } from "../utils/activeNoteFieldDefault";
+import { log } from "../logger/logManager";
 import { Formatter, type PromptContext } from "./formatter";
 import {
 	buildSectionSubpath,
@@ -654,18 +656,60 @@ export class CompleteFormatter extends Formatter {
 			const { fieldName, filters, multiSelect } =
 				FieldSuggestionParser.parse(fieldInput);
 
-			// Collect and process via shared collector
-			const { values, hasDefaultValue } =
+			// Resolve the active-note default (issue #1429) BEFORE collection but apply
+			// it AFTER, so the resolved value never enters the collection cache key
+			// (which is keyed partly on filters.defaultValue). Gate strictly on
+			// "active"; an unknown source is ignored. `null` => no usable active value
+			// (no/non-Markdown active file, or a missing/empty/object property).
+			const activeDefault =
+				filters.defaultFrom === "active"
+					? resolveActiveNoteFieldDefault(
+							this.app,
+							this.choiceExecutor?.triggerContext?.activeFile ?? null,
+							fieldName,
+						)
+					: null;
+
+			// Collect and process via shared collector (filters unmutated).
+			const { values: collectedValues, hasDefaultValue: literalHasDefault } =
 				await collectFieldValuesProcessedDetailed(this.app, fieldName, filters);
+
+			let values = collectedValues;
+			let hasDefaultValue = literalHasDefault;
+			// The default shown in the placeholder hint: the active-note value wins
+			// over a literal |default: when both are present.
+			let effectiveDefault = filters.defaultValue;
+
+			if (!multiSelect && typeof activeDefault === "string") {
+				// Promote the active note's scalar value to the top so an empty-query
+				// Enter accepts it, matching the existing default-always semantics.
+				values = FieldValueProcessor.promoteValueToFront(
+					values,
+					activeDefault,
+					filters.caseSensitive,
+				);
+				effectiveDefault = activeDefault;
+				hasDefaultValue = true;
+			} else if (
+				!multiSelect &&
+				Array.isArray(activeDefault) &&
+				activeDefault.length > 0
+			) {
+				// A list-valued property has no single default; lists apply to |multi
+				// only. Log (console-only) so a user expecting a default isn't mystified.
+				log.logMessage(
+					`{{FIELD:${fieldName}|default-from:active}}: the active note's "${fieldName}" is a list value, which applies only to |multi FIELD prompts, so no default was prefilled.`,
+				);
+			}
 
 			// Enhance placeholder with context
 			let placeholder = multiSelect
 				? `Select values for ${fieldName}`
 				: `Enter value for ${fieldName}`;
-			if (hasDefaultValue) {
+			if (hasDefaultValue && effectiveDefault) {
 				placeholder = multiSelect
-					? `Select values for ${fieldName} (default: ${filters.defaultValue})`
-					: `Enter value for ${fieldName} (default: ${filters.defaultValue})`;
+					? `Select values for ${fieldName} (default: ${effectiveDefault})`
+					: `Enter value for ${fieldName} (default: ${effectiveDefault})`;
 			}
 
 			if (multiSelect) {
@@ -682,9 +726,20 @@ export class CompleteFormatter extends Formatter {
 					);
 					if (smartDefaults.length > 0) multiValues = smartDefaults;
 				}
+				// Pre-check the active note's value(s) (scalar -> one, list -> each).
+				// Never [undefined]: activeDefault is null | string | string[].
+				const preselected =
+					activeDefault === null
+						? undefined
+						: Array.isArray(activeDefault)
+							? activeDefault
+							: [activeDefault];
 				return await MultiSuggester.Suggest(this.app, multiValues, multiValues, {
 					placeholder,
 					allowCustomValue: true,
+					...(preselected && preselected.length > 0
+						? { preselected }
+						: {}),
 				});
 			}
 

--- a/src/gui/MultiSuggester/multiSuggester.preselect-1429.test.ts
+++ b/src/gui/MultiSuggester/multiSuggester.preselect-1429.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { Modal } from "obsidian";
+
+// Mirror the polyfills the sibling MultiSuggester test installs: the Modal stub
+// calls titleEl.setText and subclasses call super.onClose().
+(HTMLElement.prototype as unknown as { setText?: unknown }).setText ??= function (
+	this: HTMLElement,
+	text: string,
+) {
+	this.textContent = text;
+};
+(Modal.prototype as unknown as { onClose?: unknown }).onClose ??= function () {};
+
+const MultiSuggester = (await import("./multiSuggester")).default;
+
+function clickButton(suggester: { contentEl: HTMLElement }, label: string) {
+	const button = Array.from(
+		suggester.contentEl.querySelectorAll("button"),
+	).find((b) => b.textContent === label);
+	if (!button) throw new Error(`button "${label}" not found`);
+	button.click();
+}
+
+function listCheckboxes(suggester: { contentEl: HTMLElement }) {
+	const list = suggester.contentEl.querySelector(".qa-multi-list");
+	if (!list) throw new Error("multi list not found");
+	return Array.from(list.querySelectorAll<HTMLInputElement>("input[type=checkbox]"));
+}
+
+describe("MultiSuggester preselection (issue #1429)", () => {
+	it("resolves preselected option-list values on Done with no interaction", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["Alpha", "Beta", "Gamma"],
+			["Alpha", "Beta", "Gamma"],
+			{ preselected: ["Beta"] },
+		);
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual(["Beta"]);
+	});
+
+	it("preselects values not in the option list as pre-checked custom rows", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["Alpha"],
+			["Alpha"],
+			{ allowCustomValue: true, preselected: ["Zeta"] },
+		);
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual(["Zeta"]);
+	});
+
+	it("returns option values in option order, then custom preselections", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["Alpha", "Beta", "Gamma"],
+			["Alpha", "Beta", "Gamma"],
+			{ allowCustomValue: true, preselected: ["Gamma", "Alpha", "Zeta"] },
+		);
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual([
+			"Alpha",
+			"Gamma",
+			"Zeta",
+		]);
+	});
+
+	it("ignores blank/whitespace preselected entries", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["Alpha", "Beta"],
+			["Alpha", "Beta"],
+			{ preselected: ["", "  ", "Beta"] },
+		);
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual(["Beta"]);
+	});
+
+	it("lets the user deselect a preselected value", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["Alpha", "Beta"],
+			["Alpha", "Beta"],
+			{ preselected: ["Alpha"] },
+		);
+
+		// Uncheck the first row (Alpha).
+		const [alphaToggle] = listCheckboxes(suggester);
+		alphaToggle.checked = false;
+		alphaToggle.dispatchEvent(new Event("change"));
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual([]);
+	});
+
+	it("preselects nothing when the option is absent (no crash)", async () => {
+		const suggester = new MultiSuggester(
+			{} as never,
+			["Alpha", "Beta"],
+			["Alpha", "Beta"],
+			{ preselected: [] },
+		);
+
+		clickButton(suggester, "Done");
+		await expect(suggester.waitForClose).resolves.toEqual([]);
+	});
+});

--- a/src/gui/MultiSuggester/multiSuggester.ts
+++ b/src/gui/MultiSuggester/multiSuggester.ts
@@ -9,6 +9,14 @@ export interface MultiSuggesterOptions {
 	allowCustomValue?: boolean;
 	/** Optional token: a "Skip" affordance resolves an empty selection. */
 	skippable?: boolean;
+	/**
+	 * Values pre-checked when the picker opens (issue #1429). Values present in
+	 * the option list are toggled on; values not in the list are added as
+	 * pre-checked custom rows (so e.g. a list-valued active-note property whose
+	 * members aren't all in the vault still preselects them). The user can deselect
+	 * any of them. Empty/undefined preselects nothing.
+	 */
+	preselected?: string[];
 }
 
 /**
@@ -55,12 +63,34 @@ export default class MultiSuggester extends Modal {
 		this.displayItems =
 			displayItems.length === items.length ? displayItems : items;
 		this.opts = options;
+		this.seedPreselection(options.preselected);
 		this.waitForClose = new Promise<string[]>((resolve, reject) => {
 			this.resolvePromise = resolve;
 			this.rejectPromise = reject;
 		});
 		this.render();
 		this.open();
+	}
+
+	/**
+	 * Pre-checks the given values before the first render. Option-list values are
+	 * simply marked selected; values not in the list become pre-checked custom
+	 * rows (deduped) so they render alongside the options. Blank entries are
+	 * ignored. Order of the custom rows follows the preselection order.
+	 */
+	private seedPreselection(preselected?: string[]): void {
+		if (!preselected?.length) return;
+		for (const raw of preselected) {
+			const value = raw?.trim();
+			if (!value) continue;
+			if (
+				!this.items.includes(value) &&
+				!this.customValues.includes(value)
+			) {
+				this.customValues.push(value);
+			}
+			this.selected.add(value);
+		}
 	}
 
 	private render() {

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -427,6 +427,9 @@ describe("ChoiceSuggester", () => {
 			expect(executeWithFocusedProperty).toHaveBeenCalledWith(
 				newMeeting,
 				focusedProperty,
+				// Trigger context (issue #1429) is threaded as the 3rd arg; the stub
+				// workspace has no active file.
+				{ activeFile: null },
 			);
 			expect(executed).toEqual([]);
 		});
@@ -447,6 +450,9 @@ describe("ChoiceSuggester", () => {
 			expect(executeWithFocusedProperty).toHaveBeenCalledWith(
 				newMeeting,
 				focusedProperty,
+				// Trigger context (issue #1429) is threaded as the 3rd arg; the stub
+				// workspace has no active file.
+				{ activeFile: null },
 			);
 			expect(executed).toEqual([]);
 		});
@@ -469,6 +475,7 @@ describe("ChoiceSuggester", () => {
 				{
 					choiceExecutor?: IChoiceExecutor;
 					focusedProperty?: FrontmatterPropertyTarget | null;
+					triggerContext?: { activeFile: unknown } | null;
 					placeholder?: string;
 					placeholderStack?: Array<string | undefined>;
 				},
@@ -481,8 +488,31 @@ describe("ChoiceSuggester", () => {
 			// drill-down, and the placeholder stack records the origin level.
 			expect(options.choiceExecutor).toBe(executor);
 			expect(options.focusedProperty).toBe(focusedProperty);
+			// The trigger context (issue #1429) is threaded down so a leaf choice
+			// still defaults from the original trigger note, not a re-read.
+			expect(options.triggerContext).toEqual({ activeFile: null });
 			expect(options.placeholder).toBe("Work");
 			expect(options.placeholderStack).toEqual([undefined]);
+		});
+
+		it("threads a captured trigger context to the leaf execution (issue #1429)", () => {
+			const triggerContext = {
+				activeFile: { path: "Trigger.md", extension: "md" },
+			} as never;
+			const executeWithFocusedProperty = vi.fn(async () => {});
+			executor.executeWithFocusedProperty = executeWithFocusedProperty;
+			// Simulate a nested level that received the context from its parent.
+			const suggester = makeSuggester(rootChoices, {
+				triggerContext,
+			} as never);
+
+			suggester.onChooseItem(newMeeting, new MouseEvent("click"));
+
+			expect(executeWithFocusedProperty).toHaveBeenCalledWith(
+				newMeeting,
+				null,
+				triggerContext,
+			);
 		});
 
 		it("navigates back without appending another back item", () => {

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -17,6 +17,7 @@ import { settingsStore } from "../../settingsStore";
 import { flattenChoicesWithPath } from "../../utils/choiceUtils";
 import type { FrontmatterPropertyTarget } from "../../utils/frontmatterPropertyLinks";
 import { getFocusedPropertyTarget } from "../../utils/frontmatterPropertyLinks";
+import type { QuickAddTriggerContext } from "../../types/QuickAddTriggerContext";
 import {
 	hasConfiguredTemplateFolders,
 	runTemplateFromFolder,
@@ -82,6 +83,13 @@ type NestedSearchCandidate = {
 type ChoiceSuggesterOptions = {
 	choiceExecutor?: IChoiceExecutor;
 	focusedProperty?: FrontmatterPropertyTarget | null;
+	/**
+	 * Trigger-time editor context (the active note) captured when the launcher
+	 * opened, threaded through nested Multi levels so a leaf choice's
+	 * {{...|default-from:active}} still reads the original trigger note (issue
+	 * #1429). Absent at the top level → captured live in the constructor.
+	 */
+	triggerContext?: QuickAddTriggerContext | null;
 	placeholder?: string;
 	placeholderStack?: Array<string | undefined>;
 	/**
@@ -103,6 +111,7 @@ function createTemplateFolderRow(): IChoice {
 export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 	private choiceExecutor: IChoiceExecutor;
 	private focusedProperty: FrontmatterPropertyTarget | null = null;
+	private triggerContext: QuickAddTriggerContext | null = null;
 	private placeholderStack: Array<string | undefined> = [];
 	private currentPlaceholder?: string;
 	private nestedSearchCandidates?: NestedSearchCandidate[];
@@ -137,6 +146,13 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 			options && "focusedProperty" in options
 				? options.focusedProperty ?? null
 				: getFocusedPropertyTarget(this.app);
+		// Capture the trigger-time active note when the launcher opens (top level),
+		// or reuse the one threaded down from a parent Multi level. getActiveFile()
+		// reads the active markdown leaf, which the suggester overlay doesn't change.
+		this.triggerContext =
+			options && "triggerContext" in options
+				? options.triggerContext ?? null
+				: { activeFile: this.app.workspace.getActiveFile() };
 		this.placeholderStack = options?.placeholderStack ?? [];
 		this.currentPlaceholder = options?.placeholder?.trim() || undefined;
 		if (this.currentPlaceholder) this.setPlaceholder(this.currentPlaceholder);
@@ -299,13 +315,18 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		if (item.type === "Multi")
 			this.onChooseMultiType(<IMultiChoice>item);
 		else {
-			const execute =
-				this.focusedProperty && this.choiceExecutor.executeWithFocusedProperty
-					? this.choiceExecutor.executeWithFocusedProperty(
-							item,
-							this.focusedProperty,
-						)
-					: this.choiceExecutor.execute(item);
+			// Route through executeWithFocusedProperty whenever it exists so the
+			// captured focusedProperty AND triggerContext (issue #1429) are both
+			// re-injected for the leaf run — the suggester cleared the executor's
+			// live context when the outer Multi execute() returned. Falls back to
+			// execute() only for stub executors without the method.
+			const execute = this.choiceExecutor.executeWithFocusedProperty
+				? this.choiceExecutor.executeWithFocusedProperty(
+						item,
+						this.focusedProperty,
+						this.triggerContext,
+					)
+				: this.choiceExecutor.execute(item);
 			void execute.catch((error) => {
 				log.logError(`Failed to execute selected choice: ${error}`);
 			});
@@ -332,6 +353,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		ChoiceSuggester.Open(this.plugin, choices, {
 			choiceExecutor: this.choiceExecutor,
 			focusedProperty: this.focusedProperty,
+			triggerContext: this.triggerContext,
 			placeholder: nextPlaceholder,
 			placeholderStack: nextStack,
 		});

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -335,6 +335,38 @@ Body`);
       const req = rc.requirements.get("FIELD:project|default-from:active");
       expect(req?.defaultValue).toBeUndefined();
     });
+
+    it("falls back to the literal |default: for the prefill when the active value is absent", async () => {
+      const rc = new RequirementCollector(
+        appWithActive({ other: "x" }),
+        makePlugin(),
+        executorWithActive() as any,
+      );
+      await rc.scanString(
+        "{{FIELD:project|default:Inbox|default-from:active}}",
+      );
+
+      expect(
+        rc.requirements.get("FIELD:project|default:Inbox|default-from:active")
+          ?.defaultValue,
+      ).toBe("Inbox");
+    });
+
+    it("prefers the active value over the literal |default:", async () => {
+      const rc = new RequirementCollector(
+        appWithActive({ project: "Endeavor" }),
+        makePlugin(),
+        executorWithActive() as any,
+      );
+      await rc.scanString(
+        "{{FIELD:project|default:Inbox|default-from:active}}",
+      );
+
+      expect(
+        rc.requirements.get("FIELD:project|default:Inbox|default-from:active")
+          ?.defaultValue,
+      ).toBe("Endeavor");
+    });
   });
 });
 

--- a/src/preflight/RequirementCollector.test.ts
+++ b/src/preflight/RequirementCollector.test.ts
@@ -264,6 +264,78 @@ Body`);
       });
     });
   });
+
+  // Issue #1429: a single-select |default-from:active FIELD prefills the one-page
+  // form with the active note's current property value via req.defaultValue.
+  describe("FIELD default-from:active (issue #1429)", () => {
+    const mdFile = { extension: "md", path: "Active.md" } as any;
+    const appWithActive = (frontmatter: Record<string, unknown>) =>
+      ({
+        workspace: { getActiveFile: () => mdFile },
+        vault: { getAbstractFileByPath: () => null, cachedRead: async () => "" },
+        metadataCache: {
+          getFileCache: (f: any) =>
+            f === mdFile ? { frontmatter } : null,
+        },
+      } as any);
+    const executorWithActive = () => ({
+      variables: new Map<string, unknown>(),
+      triggerContext: { activeFile: mdFile },
+    });
+
+    it("prefills req.defaultValue from the active note's scalar property", async () => {
+      const rc = new RequirementCollector(
+        appWithActive({ project: "The Great Endeavor" }),
+        makePlugin(),
+        executorWithActive() as any,
+      );
+      await rc.scanString("project: {{FIELD:project|default-from:active}}");
+
+      expect(
+        rc.requirements.get("FIELD:project|default-from:active"),
+      ).toMatchObject({
+        type: "field-suggest",
+        defaultValue: "The Great Endeavor",
+      });
+    });
+
+    it("leaves defaultValue undefined when the active note lacks the property", async () => {
+      const rc = new RequirementCollector(
+        appWithActive({ other: "x" }),
+        makePlugin(),
+        executorWithActive() as any,
+      );
+      await rc.scanString("{{FIELD:project|default-from:active}}");
+
+      const req = rc.requirements.get("FIELD:project|default-from:active");
+      expect(req?.type).toBe("field-suggest");
+      expect(req?.defaultValue).toBeUndefined();
+    });
+
+    it("does not prefill (and stays runtime-only) for a multi FIELD", async () => {
+      const rc = new RequirementCollector(
+        appWithActive({ topics: ["Alpha", "Beta"] }),
+        makePlugin(),
+        executorWithActive() as any,
+      );
+      await rc.scanString("{{FIELD:topics|multi|default-from:active}}");
+
+      const req = rc.requirements.get("FIELD:topics|multi|default-from:active");
+      expect(req?.runtimeOnly).toBe(true);
+      expect(req?.defaultValue).toBeUndefined();
+    });
+
+    it("leaves defaultValue undefined when no executor/trigger context is present", async () => {
+      const rc = new RequirementCollector(
+        appWithActive({ project: "Endeavor" }),
+        makePlugin(),
+      );
+      await rc.scanString("{{FIELD:project|default-from:active}}");
+
+      const req = rc.requirements.get("FIELD:project|default-from:active");
+      expect(req?.defaultValue).toBeUndefined();
+    });
+  });
 });
 
 describe("RequirementCollector — named suggester (issue #148)", () => {

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -21,6 +21,7 @@ import {
 import { parseVDateOptions } from "src/utils/vdateSyntax";
 import { EnhancedFieldSuggestionFileFilter } from "src/utils/EnhancedFieldSuggestionFileFilter";
 import { FieldSuggestionParser } from "src/utils/FieldSuggestionParser";
+import { resolveActiveNoteFieldDefault } from "src/utils/activeNoteFieldDefault";
 import {
 	buildFileDisplayLabels,
 	FILE_PICK_PREFIX,
@@ -481,13 +482,29 @@ export class RequirementCollector extends Formatter {
 		const parsed = FieldSuggestionParser.parse(variableName);
 		const key = `${FIELD_VARIABLE_PREFIX}${variableName}`;
 		if (!this.requirements.has(key)) {
-			this.requirements.set(key, {
+			const requirement: FieldRequirement = {
 				id: key,
 				label: parsed.fieldName || variableName,
 				type: "field-suggest",
 				source: "collected",
 				runtimeOnly: parsed.multiSelect,
-			});
+			};
+			// Single-select |default-from:active (issue #1429): resolve the active
+			// note's current value so the one-page form prefills it (OnePageInputModal
+			// reads req.defaultValue as the starting value). Gate strictly on "active".
+			// Multi FIELD is runtimeOnly — it bypasses the one-page form and preselects
+			// at runtime in the MultiSuggester instead, so it sets no defaultValue here.
+			if (!parsed.multiSelect && parsed.filters.defaultFrom === "active") {
+				const resolved = resolveActiveNoteFieldDefault(
+					this.app,
+					this.choiceExecutor?.triggerContext?.activeFile ?? null,
+					parsed.fieldName,
+				);
+				if (typeof resolved === "string") {
+					requirement.defaultValue = resolved;
+				}
+			}
+			this.requirements.set(key, requirement);
 		}
 		return "";
 	}

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -500,8 +500,16 @@ export class RequirementCollector extends Formatter {
 					this.choiceExecutor?.triggerContext?.activeFile ?? null,
 					parsed.fieldName,
 				);
-				if (typeof resolved === "string") {
-					requirement.defaultValue = resolved;
+				// The active value wins; when it resolves nothing (no active note,
+				// missing/empty property) fall back to the literal |default: so the
+				// one-page form matches the runtime path, which still prepends that
+				// default. `{{FIELD:x|default:Inbox|default-from:active}}` therefore
+				// prefills Inbox instead of an empty field.
+				const effectiveDefault =
+					(typeof resolved === "string" ? resolved : undefined) ??
+					parsed.filters.defaultValue;
+				if (effectiveDefault !== undefined) {
+					requirement.defaultValue = effectiveDefault;
 				}
 			}
 			this.requirements.set(key, requirement);

--- a/src/types/QuickAddTriggerContext.ts
+++ b/src/types/QuickAddTriggerContext.ts
@@ -1,0 +1,23 @@
+import type { TFile } from "obsidian";
+
+/**
+ * A snapshot of the editor context at the moment a top-level QuickAdd choice
+ * began executing (issue #1429). Captured once at the outermost execution
+ * boundary — before any QuickAdd modal/suggester opens or a Template choice
+ * creates and opens a new note — so context-derived format tokens read the note
+ * that *triggered* the run rather than whatever happens to be active by the time
+ * the token resolves.
+ *
+ * Threaded via {@link IChoiceExecutor}, which both {@link CompleteFormatter} and
+ * {@link RequirementCollector} already hold, so every FIELD resolution path
+ * (runtime and one-page preflight) can reach it without extra plumbing.
+ */
+export interface QuickAddTriggerContext {
+	/**
+	 * The file active when the run started, or `null` when no file (or a
+	 * non-Markdown view such as a Canvas/PDF/graph leaf) was active. Used by
+	 * `{{FIELD:<field>|default-from:active}}` to read the active note's current
+	 * frontmatter property as the prompt's default.
+	 */
+	activeFile: TFile | null;
+}

--- a/src/utils/FieldSuggestionParser.test.ts
+++ b/src/utils/FieldSuggestionParser.test.ts
@@ -168,6 +168,41 @@ describe("FieldSuggestionParser", () => {
 			});
 		});
 
+		it("parses default-from:active into a lowercased defaultFrom (issue #1429)", () => {
+			const result = FieldSuggestionParser.parse(
+				"project|default-from:active",
+			);
+			expect(result).toEqual({
+				fieldName: "project",
+				filters: { defaultFrom: "active" },
+			});
+		});
+
+		it("lowercases the default-from source value", () => {
+			const result = FieldSuggestionParser.parse(
+				"project|default-from:Active",
+			);
+			expect(result).toEqual({
+				fieldName: "project",
+				filters: { defaultFrom: "active" },
+			});
+		});
+
+		it("keeps default-from alongside the literal default and other filters", () => {
+			const result = FieldSuggestionParser.parse(
+				"project|folder:Projects|default:Inbox|default-from:active",
+			);
+			expect(result).toEqual({
+				fieldName: "project",
+				filters: {
+					folder: "Projects",
+					folders: ["Projects"],
+					defaultValue: "Inbox",
+					defaultFrom: "active",
+				},
+			});
+		});
+
 		it("should parse default-empty and default-always filters", () => {
 			const result = FieldSuggestionParser.parse(
 				"fieldname|default:To Do|default-empty:true|default-always:false",

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -19,6 +19,15 @@ export interface FieldFilter {
 	defaultValue?: string;
 	defaultEmpty?: boolean;
 	defaultAlways?: boolean;
+	/**
+	 * Source for a context-derived default (issue #1429). The only value v1
+	 * understands is `"active"`: resolve the default from the active note's
+	 * current frontmatter property at QuickAdd trigger time. Stored lowercased;
+	 * an unrecognized source is ignored (the FIELD prompt behaves as if no
+	 * `default-from` were present). Intentionally distinct from the literal
+	 * `default:` option and from `default:current` (see the issue's rationale).
+	 */
+	defaultFrom?: string;
 	caseSensitive?: boolean;
 	excludeFolders?: string[];
 	excludeTags?: string[];
@@ -100,6 +109,13 @@ export class FieldSuggestionParser {
 				case "default":
 					filters.defaultValue = filterValue;
 					break;
+				case "default-from":
+					// e.g. |default-from:active — resolve the default from a context
+					// source (the active note's property) rather than a literal value.
+					// The resolution happens in the runtime/preflight FIELD paths; here
+					// we only record the requested source (lowercased).
+					filters.defaultFrom = filterValue.toLowerCase();
+					break;
 				case "default-empty":
 					filters.defaultEmpty = filterValue.toLowerCase() === "true";
 					break;
@@ -146,7 +162,7 @@ export class FieldSuggestionParser {
 					// sentinels like __capture_scope.
 					if (options?.warnUnknown) {
 						log.logWarning(
-							`Unknown FIELD filter "${filterType}" in "{{FIELD:${input}}}" was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-empty, default-always, case-sensitive, multi.`,
+							`Unknown FIELD filter "${filterType}" in "{{FIELD:${input}}}" was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-from, default-empty, default-always, case-sensitive, multi.`,
 						);
 					}
 					break;

--- a/src/utils/FieldValueProcessor.test.ts
+++ b/src/utils/FieldValueProcessor.test.ts
@@ -250,4 +250,47 @@ describe("FieldValueProcessor", () => {
 			expect(result.hasDefaultValue).toBe(true);
 		});
 	});
+
+	describe("promoteValueToFront (issue #1429)", () => {
+		it("prepends a value not already present", () => {
+			expect(
+				FieldValueProcessor.promoteValueToFront(
+					["Beta", "Gamma"],
+					"Alpha",
+				),
+			).toEqual(["Alpha", "Beta", "Gamma"]);
+		});
+
+		it("promotes an existing value to the front without duplicating it", () => {
+			expect(
+				FieldValueProcessor.promoteValueToFront(
+					["Beta", "Alpha", "Gamma"],
+					"Alpha",
+				),
+			).toEqual(["Alpha", "Beta", "Gamma"]);
+		});
+
+		it("removes a case-insensitive duplicate and keeps the promoted casing", () => {
+			// The active note's casing ("Done") wins over the vault's ("done").
+			expect(
+				FieldValueProcessor.promoteValueToFront(["done", "Open"], "Done"),
+			).toEqual(["Done", "Open"]);
+		});
+
+		it("keeps a case-differing value when caseSensitive is true", () => {
+			expect(
+				FieldValueProcessor.promoteValueToFront(
+					["done", "Open"],
+					"Done",
+					true,
+				),
+			).toEqual(["Done", "done", "Open"]);
+		});
+
+		it("handles an empty source list", () => {
+			expect(
+				FieldValueProcessor.promoteValueToFront([], "Alpha"),
+			).toEqual(["Alpha"]);
+		});
+	});
 });

--- a/src/utils/FieldValueProcessor.test.ts
+++ b/src/utils/FieldValueProcessor.test.ts
@@ -293,4 +293,30 @@ describe("FieldValueProcessor", () => {
 			).toEqual(["Alpha"]);
 		});
 	});
+
+	describe("canonicalizeAgainst (issue #1429)", () => {
+		it("maps a value to its case-folded match in the list", () => {
+			expect(
+				FieldValueProcessor.canonicalizeAgainst(["done", "open"], "Done"),
+			).toBe("done");
+		});
+
+		it("returns the value unchanged when no case-fold match exists", () => {
+			expect(
+				FieldValueProcessor.canonicalizeAgainst(["open"], "Done"),
+			).toBe("Done");
+		});
+
+		it("returns the value unchanged under caseSensitive", () => {
+			expect(
+				FieldValueProcessor.canonicalizeAgainst(["done"], "Done", true),
+			).toBe("Done");
+		});
+
+		it("folds diacritics like the deduplicator", () => {
+			expect(
+				FieldValueProcessor.canonicalizeAgainst(["café"], "CAFE"),
+			).toBe("café");
+		});
+	});
 });

--- a/src/utils/FieldValueProcessor.ts
+++ b/src/utils/FieldValueProcessor.ts
@@ -122,6 +122,29 @@ export class FieldValueProcessor {
 	}
 
 	/**
+	 * Returns the entry in `values` that matches `value` under the dedup case fold,
+	 * or `value` itself when none does (issue #1429). Used to map an active-note
+	 * preselection onto the existing (vault-cased) suggestion before handing it to
+	 * the multi-select picker, so a case variant (active `Done` vs collected `done`)
+	 * toggles the existing option instead of adding a duplicate custom row. With
+	 * `caseSensitive` the value is returned unchanged.
+	 */
+	static canonicalizeAgainst(
+		values: string[],
+		value: string,
+		caseSensitive = false,
+	): string {
+		if (caseSensitive) return value;
+		const normalized = this.normalizeForComparison(value);
+		return (
+			values.find(
+				(candidate) =>
+					this.normalizeForComparison(candidate) === normalized,
+			) ?? value
+		);
+	}
+
+	/**
 	 * Normalize a value for case-insensitive comparison, mirroring
 	 * FieldValueDeduplicator's fold (Unicode NFD + diacritic strip + lowercase)
 	 * so default-value matching is consistent with case-insensitive dedup.

--- a/src/utils/FieldValueProcessor.ts
+++ b/src/utils/FieldValueProcessor.ts
@@ -99,6 +99,29 @@ export class FieldValueProcessor {
 	}
 
 	/**
+	 * Promotes `value` to the front of an already-processed suggestion list,
+	 * removing any existing entry that matches under the same case fold used for
+	 * deduplication (issue #1429). Used for a context-derived default
+	 * (`default-from:active`) so it appears first without duplicating an existing
+	 * suggestion, mirroring the `default-always` branch of {@link applyDefaultValues}
+	 * — but applied AFTER vault collection, so it never perturbs the collection
+	 * cache key. The promoted entry keeps the supplied value's casing (the active
+	 * note's current value), which is the value the user is inheriting.
+	 */
+	static promoteValueToFront(
+		values: string[],
+		value: string,
+		caseSensitive = false,
+	): string[] {
+		const isPresent = (candidate: string): boolean =>
+			caseSensitive
+				? candidate === value
+				: this.normalizeForComparison(candidate) ===
+					this.normalizeForComparison(value);
+		return [value, ...values.filter((candidate) => !isPresent(candidate))];
+	}
+
+	/**
 	 * Normalize a value for case-insensitive comparison, mirroring
 	 * FieldValueDeduplicator's fold (Unicode NFD + diacritic strip + lowercase)
 	 * so default-value matching is consistent with case-insensitive dedup.

--- a/src/utils/activeNoteFieldDefault.test.ts
+++ b/src/utils/activeNoteFieldDefault.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import type { App, TFile } from "obsidian";
+import {
+	resolveFieldDefaultFromFrontmatter,
+	resolveActiveNoteFieldDefault,
+} from "./activeNoteFieldDefault";
+
+describe("resolveFieldDefaultFromFrontmatter (issue #1429)", () => {
+	it("returns a trimmed string for a scalar string value", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter(
+				{ project: "  The Great Endeavor  " },
+				"project",
+			),
+		).toBe("The Great Endeavor");
+	});
+
+	it("stringifies a number scalar (including 0)", () => {
+		expect(resolveFieldDefaultFromFrontmatter({ year: 2026 }, "year")).toBe(
+			"2026",
+		);
+		expect(resolveFieldDefaultFromFrontmatter({ count: 0 }, "count")).toBe("0");
+	});
+
+	it("stringifies a boolean scalar (including false)", () => {
+		expect(resolveFieldDefaultFromFrontmatter({ done: true }, "done")).toBe(
+			"true",
+		);
+		expect(resolveFieldDefaultFromFrontmatter({ done: false }, "done")).toBe(
+			"false",
+		);
+	});
+
+	it("returns a list of trimmed scalar strings for a YAML list value", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter(
+				{ topics: ["Alpha", " Beta ", 3, true] },
+				"topics",
+			),
+		).toEqual(["Alpha", "Beta", "3", "true"]);
+	});
+
+	it("drops null and object entries inside a list", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter(
+				{ topics: ["Alpha", null, { a: 1 }, "Beta"] },
+				"topics",
+			),
+		).toEqual(["Alpha", "Beta"]);
+	});
+
+	it("returns null for a missing property", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter({ other: "x" }, "project"),
+		).toBeNull();
+	});
+
+	it("returns null for a null property", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter({ project: null }, "project"),
+		).toBeNull();
+	});
+
+	it("returns null for an empty/whitespace string scalar", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter({ project: "" }, "project"),
+		).toBeNull();
+		expect(
+			resolveFieldDefaultFromFrontmatter({ project: "   " }, "project"),
+		).toBeNull();
+	});
+
+	it("returns null for an empty list", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter({ topics: [] }, "topics"),
+		).toBeNull();
+	});
+
+	it("returns null for a list of only non-scalar entries", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter(
+				{ topics: [null, { a: 1 }, [1, 2]] },
+				"topics",
+			),
+		).toBeNull();
+	});
+
+	it("returns null for an object/map value", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter(
+				{ meta: { nested: "value" } },
+				"meta",
+			),
+		).toBeNull();
+	});
+
+	it("returns null when there is no frontmatter", () => {
+		expect(resolveFieldDefaultFromFrontmatter(undefined, "project")).toBeNull();
+		expect(resolveFieldDefaultFromFrontmatter(null, "project")).toBeNull();
+	});
+
+	it("returns null for an empty field name", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter({ project: "x" }, "   "),
+		).toBeNull();
+	});
+
+	it("matches the key case-sensitively first", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter(
+				{ project: "lower", Project: "upper" },
+				"Project",
+			),
+		).toBe("upper");
+	});
+
+	it("falls back to a case-insensitive key match (Obsidian Properties are case-insensitive)", () => {
+		expect(
+			resolveFieldDefaultFromFrontmatter({ project: "Endeavor" }, "Project"),
+		).toBe("Endeavor");
+	});
+});
+
+describe("resolveActiveNoteFieldDefault (issue #1429)", () => {
+	function makeApp(
+		file: TFile | null,
+		frontmatter: Record<string, unknown> | undefined,
+	): App {
+		return {
+			metadataCache: {
+				getFileCache: (f: TFile) =>
+					f === file ? { frontmatter } : null,
+			},
+		} as unknown as App;
+	}
+
+	const mdFile = { extension: "md", path: "Active.md" } as unknown as TFile;
+
+	it("reads the active note's frontmatter property", () => {
+		const app = makeApp(mdFile, { project: "The Great Endeavor" });
+		expect(resolveActiveNoteFieldDefault(app, mdFile, "project")).toBe(
+			"The Great Endeavor",
+		);
+	});
+
+	it("returns null when there is no active file", () => {
+		const app = makeApp(null, undefined);
+		expect(resolveActiveNoteFieldDefault(app, null, "project")).toBeNull();
+		expect(
+			resolveActiveNoteFieldDefault(app, undefined, "project"),
+		).toBeNull();
+	});
+
+	it("returns null for a non-Markdown active file (Canvas/PDF/etc.)", () => {
+		const canvas = {
+			extension: "canvas",
+			path: "Board.canvas",
+		} as unknown as TFile;
+		const app = makeApp(canvas, { project: "x" });
+		expect(resolveActiveNoteFieldDefault(app, canvas, "project")).toBeNull();
+	});
+
+	it("returns null when the note has no frontmatter", () => {
+		const app = makeApp(mdFile, undefined);
+		expect(resolveActiveNoteFieldDefault(app, mdFile, "project")).toBeNull();
+	});
+
+	it("returns a list value for a YAML list property", () => {
+		const app = makeApp(mdFile, { topics: ["Alpha", "Beta"] });
+		expect(resolveActiveNoteFieldDefault(app, mdFile, "topics")).toEqual([
+			"Alpha",
+			"Beta",
+		]);
+	});
+});

--- a/src/utils/activeNoteFieldDefault.ts
+++ b/src/utils/activeNoteFieldDefault.ts
@@ -1,0 +1,89 @@
+import type { App, TFile } from "obsidian";
+
+/**
+ * Resolves the default value for a `{{FIELD:<field>|default-from:active}}` prompt
+ * from a frontmatter object (issue #1429). Pure and App-free so it is fully unit
+ * testable; {@link resolveActiveNoteFieldDefault} adds the metadata-cache lookup.
+ *
+ * Returns:
+ *  - a trimmed string for a scalar string/number/boolean value,
+ *  - a string[] of trimmed scalar entries for a YAML list of scalars,
+ *  - `null` for a missing/null property, an empty scalar, an object/map value,
+ *    an empty list, or a list of only non-scalar entries.
+ *
+ * The field name is matched against the frontmatter keys case-sensitively first
+ * (mirroring how the vault-wide FIELD collector reads `frontmatter[fieldName]`),
+ * then case-insensitively as a fallback — Obsidian Properties are
+ * case-insensitive, so `{{FIELD:Project|default-from:active}}` should still
+ * inherit a `project:` property. The fallback is scoped to this single
+ * active-note read; vault-wide collection stays exact-case and self-consistent.
+ */
+export function resolveFieldDefaultFromFrontmatter(
+	frontmatter: Record<string, unknown> | undefined | null,
+	fieldName: string,
+): string | string[] | null {
+	const key = fieldName.trim();
+	if (!key || !frontmatter) return null;
+
+	let raw: unknown = frontmatter[key];
+	if (raw === undefined) {
+		const lowerKey = key.toLowerCase();
+		const match = Object.keys(frontmatter).find(
+			(candidate) => candidate.toLowerCase() === lowerKey,
+		);
+		if (match !== undefined) raw = frontmatter[match];
+	}
+	if (raw === undefined || raw === null) return null;
+
+	if (Array.isArray(raw)) {
+		const values: string[] = [];
+		for (const entry of raw) {
+			const scalar = scalarToDefaultString(entry);
+			if (scalar !== null) values.push(scalar);
+		}
+		// A list of only null/object entries (or an empty list) yields no default,
+		// so the FIELD prompt falls back to normal behavior.
+		return values.length > 0 ? values : null;
+	}
+
+	return scalarToDefaultString(raw);
+}
+
+/**
+ * Reads the active note's current frontmatter via the metadata cache and resolves
+ * the `default-from:active` default for `fieldName`. Returns `null` when there is
+ * no active Markdown file, the file has no frontmatter, or the property does not
+ * resolve to a usable scalar/list value (see
+ * {@link resolveFieldDefaultFromFrontmatter}). Read-only: it never mutates a file.
+ */
+export function resolveActiveNoteFieldDefault(
+	app: App,
+	activeFile: TFile | null | undefined,
+	fieldName: string,
+): string | string[] | null {
+	// Only Markdown notes carry frontmatter properties; a non-md active file (or
+	// no active file) means "no active-derived default", matching the issue's
+	// "fall back to normal {{FIELD:project}} behavior" rule.
+	if (!activeFile || activeFile.extension !== "md") return null;
+
+	const frontmatter = app.metadataCache.getFileCache(activeFile)?.frontmatter;
+	return resolveFieldDefaultFromFrontmatter(frontmatter, fieldName);
+}
+
+/**
+ * Converts a single frontmatter value into a default string when it is a usable
+ * scalar (string/number/boolean), or `null` otherwise. Numbers and booleans are
+ * stringified ("0", "false"); an empty/whitespace-only string yields `null` so an
+ * empty property never becomes a default. Objects, arrays, null, and undefined are
+ * rejected (`null`).
+ */
+function scalarToDefaultString(value: unknown): string | null {
+	if (value === undefined || value === null) return null;
+	const type = typeof value;
+	if (type === "string" || type === "number" || type === "boolean") {
+		const text = String(value).trim();
+		return text.length > 0 ? text : null;
+	}
+	// Objects, arrays, and other non-scalars are not valid defaults.
+	return null;
+}

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -337,7 +337,9 @@ export class App {
   };
   workspace: any = {
     getActiveViewOfType: () => undefined,
+    getActiveFile: () => null,
     getLeaf: () => ({}),
+    getLeavesOfType: () => [],
     setActiveLeaf: () => {},
     iterateRootLeaves: () => {},
     getLastOpenFiles: () => [],


### PR DESCRIPTION
Closes #1429.

## What

Adds `{{FIELD:<field>|default-from:active}}`: a FIELD prompt now defaults to the value the **active note** (the note focused when QuickAdd was triggered) already has for that frontmatter property. The user can accept, change, or type a different value — normal FIELD behavior.

```yaml
# Active note
---
project: The Great Endeavor
---
```
```md
# Capture/template format
project: {{FIELD:project|default-from:active}}   # → defaults to "The Great Endeavor"
```

## How

- **Trigger context** — `ChoiceExecutor.beginExecutionContext()` snapshots the active file once at the outermost execution boundary into a `QuickAddTriggerContext` on `IChoiceExecutor` (mirroring the existing `focusedProperty` precedent). Both `CompleteFormatter` and `RequirementCollector` already hold the executor, so no extra plumbing. `getActiveFile()` tracks the active markdown leaf (not DOM focus, which the modal steals), so the live read is the trigger note even through the Multi suggester — no focus-drift override needed.
- **Parsing** — `FieldSuggestionParser` parses `|default-from:active` into `FieldFilter.defaultFrom` (gated strictly to `"active"`).
- **Resolution** — `activeNoteFieldDefault.ts` reads the captured file's current frontmatter via the metadata cache (the issue's prescribed seam). Scalar string/number/boolean → string; YAML list of scalars → `string[]`; object/map/null/missing/empty → no default. Case-insensitive key fallback (Obsidian Properties are case-insensitive). Non-markdown / no active file → silent no-op.
- **Runtime single-select** — the active value is promoted to the top of the suggestions **after** collection (`FieldValueProcessor.promoteValueToFront`), so the collection cache key stays clean. Empty-query Enter accepts it.
- **Multi-select** — the active value(s) are pre-checked via a new `MultiSuggester` `preselected` seam, canonicalized against the collected options under the dedup case fold so a case variant toggles the existing option instead of adding a duplicate row.
- **One-page preflight** — `RequirementCollector` sets `req.defaultValue` so the field prefills; falls back to the literal `|default:` when the active value resolves nothing (matches the runtime path).
- **Apply Template to active note** seeds the trigger context too (it runs a template through the executor without `execute()`).

Non-goals honored: no `|current` alias, no `default:current` overload, no `{{ACTIVE:}}` token, and `quickAddApi.fieldSuggestions.getFieldValues()` does **not** read ambient active-file state (untouched).

## Validation

**Gates** (all green): `tsc -noEmit`, `eslint .`, `svelte-check` (0 errors), `vitest` — **3222 passed / 37 skipped**.

**New tests**: pure resolver matrix (scalar/list/object/null/empty/non-md/no-file/case-insensitive); parser; `promoteValueToFront` + `canonicalizeAgainst` (case-fold dedupe); MultiSuggester preselection (option/custom/order/blank/deselect); CompleteFormatter runtime (promote, prepend, no-active fallback, plain-FIELD untouched, multi list/scalar preselection + case-fold, single-select list-skip); RequirementCollector preflight (prefill, missing-prop, multi runtime-only, no-executor, literal-default fallback).

**Live e2e** in this worktree's isolated Obsidian vault (`pnpm run build; pnpm run provision:e2e-vault; pnpm run obsidian:e2e`):

| Scenario | Result |
|---|---|
| Scalar property (one-page) | field prefilled `The Great Endeavor`, editable |
| Accept default → capture | `project: The Great Endeavor` written to the target |
| Missing property | empty field (falls back to normal FIELD) |
| List property `\|multi` | `Alpha` + `Beta` pre-checked in the runtime picker |
| No active note | empty field (falls back) |
| Multi → leaf via launcher | still defaults from the trigger note (trigger-context survives the Multi async path) |
| Apply template to active note | applied template inherits the note's current `project` value |

## Review

Planned via an ultracode design review (3 lenses + synthesis) which caught a cache-key fragmentation issue (fixed by post-collection promotion) before the build. After implementation, a cross-model (Codex) adversarial review (Skeptic + Architect) — **no HIGH findings**; the substantive findings (apply-template threading, one-page literal-default fallback, multi case-fold) were folded in and live-verified, and the rejected ones are documented with rationale in the fix commit.

## Docs

`docs/docs/FormatSyntax.md` documents the feature and retargets the FIELD beta-feedback link from the closed #337 to this issue (per the issue's docs follow-up). Documented for the unreleased (Next) docs only.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `default-from:active` in FIELD prompts to pull defaults from the active note’s frontmatter value.
  * Single-select FIELD prompts prefill the resolved active value; multi-select FIELD prompts support preselected values (including values not present in the option list).
* **Bug Fixes**
  * Improved case-insensitive matching and deduping for active defaults/preselections to avoid duplicate or mismatched selections.
* **Documentation**
  * Updated FIELD syntax documentation and refreshed the beta disclaimer link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->