### PR TITLE
fix(security): guard front matter assignment against prototype pollution

### DIFF
--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -366,6 +366,30 @@ describe("TemplateInsertEngine.apply", () => {
 		expect(harness.frontmatter).toEqual({ status: "draft" });
 	});
 
+	it("top: merges a legitimately-named 'prototype' property without dropping it or polluting (prototype-pollution guard is collateral-free)", async () => {
+		const harness = makeHarness({
+			templateContent: "---\nprototype: Board A\nstatus: draft\n---\nTPL_BODY",
+			noteContent: "EXISTING",
+		});
+		const file = makeFile();
+
+		try {
+			await makeEngine(harness, file, "top").apply();
+
+			// A leaf key named `prototype`/`constructor` is legitimate user metadata
+			// and must still merge - the guard only blocks prototype-pollution
+			// traversal, not these names outright.
+			expect(harness.frontmatter).toEqual({
+				prototype: "Board A",
+				status: "draft",
+			});
+			// And nothing leaked onto the global prototype.
+			expect(({} as Record<string, unknown>).prototype).toBeUndefined();
+		} finally {
+			delete (Object.prototype as Record<string, unknown>).prototype;
+		}
+	});
+
 	it("frontmatter-only template: merges properties without touching the body", async () => {
 		const harness = makeHarness({
 			templateContent: "---\nstatus: draft\n---\n",

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -366,9 +366,10 @@ describe("TemplateInsertEngine.apply", () => {
 		expect(harness.frontmatter).toEqual({ status: "draft" });
 	});
 
-	it("top: merges a legitimately-named 'prototype' property without dropping it or polluting (prototype-pollution guard is collateral-free)", async () => {
+	it("top: merges legitimately-named 'prototype'/'constructor' properties without dropping them or polluting (guard is collateral-free)", async () => {
 		const harness = makeHarness({
-			templateContent: "---\nprototype: Board A\nstatus: draft\n---\nTPL_BODY",
+			templateContent:
+				"---\nprototype: Board A\nconstructor: Class notes\nstatus: draft\n---\nTPL_BODY",
 			noteContent: "EXISTING",
 		});
 		const file = makeFile();
@@ -376,11 +377,13 @@ describe("TemplateInsertEngine.apply", () => {
 		try {
 			await makeEngine(harness, file, "top").apply();
 
-			// A leaf key named `prototype`/`constructor` is legitimate user metadata
+			// Leaf keys named `prototype`/`constructor` are legitimate user metadata
 			// and must still merge - the guard only blocks prototype-pollution
-			// traversal, not these names outright.
+			// traversal, not these names outright. `constructor` only merges once
+			// the existing-value check looks at own (not inherited) properties.
 			expect(harness.frontmatter).toEqual({
 				prototype: "Board A",
+				constructor: "Class notes",
 				status: "draft",
 			});
 			// And nothing leaked onto the global prototype.

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -374,7 +374,13 @@ export class TemplateInsertEngine extends TemplateEngine {
 						);
 						continue;
 					}
-					const existing = frontmatter[key];
+					// Only an OWN value counts as "existing": reading inherited
+					// members (e.g. Object.prototype.constructor / toString) would
+					// wrongly treat a legitimately-named template key as already
+					// present and silently drop it.
+					const existing = Object.hasOwn(frontmatter, key)
+						? frontmatter[key]
+						: undefined;
 					if (
 						existing === undefined ||
 						existing === null ||

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -8,7 +8,10 @@ import {
 	getMarkdownEditorViewForFile,
 	templaterParseTemplate,
 } from "../utilityObsidian";
-import { assignFrontmatterValue } from "./helpers/frontmatterPostProcessor";
+import {
+	assignFrontmatterValue,
+	hasUnsafeFrontmatterKey,
+} from "./helpers/frontmatterPostProcessor";
 import invariant from "../utils/invariant";
 import { TemplatePropertyCollector } from "../utils/TemplatePropertyCollector";
 import { coerceYamlValue } from "../utils/yamlValues";
@@ -363,6 +366,14 @@ export class TemplateInsertEngine extends TemplateEngine {
 			this.targetFile,
 			(frontmatter: Record<string, unknown>) => {
 				for (const [key, value] of Object.entries(parsed)) {
+					// Defense in depth: never merge a prototype-pollution key from
+					// template front matter authored elsewhere.
+					if (hasUnsafeFrontmatterKey([key])) {
+						log.logWarning(
+							`Skipping front matter merge for unsafe key "${key}" to avoid prototype pollution.`,
+						);
+						continue;
+					}
 					const existing = frontmatter[key];
 					if (
 						existing === undefined ||

--- a/src/engine/helpers/frontmatterPostProcessor.prototype-pollution.test.ts
+++ b/src/engine/helpers/frontmatterPostProcessor.prototype-pollution.test.ts
@@ -165,6 +165,65 @@ describe("prototype pollution - collector reachability", () => {
 	});
 });
 
+/**
+ * Second sink: the parsed-front-matter merge loop in
+ * TemplateInsertEngine.mergeFrontmatterProperties writes `frontmatter[key] = value`
+ * directly over `Object.entries(parsed)`, bypassing assignFrontmatterValue.
+ *
+ * Obsidian's real parseYaml (js-yaml 4.x) stores a top-level `__proto__:` key as
+ * an OWN, enumerable property via `Object.defineProperty` - so `Object.entries`
+ * enumerates it - rather than tripping the prototype setter. The shared test
+ * stub cannot reproduce this (it does `result[key] = value`, and the setter
+ * ignores a string value), so this models the real shape directly to prove the
+ * merge loop's guard fires for the `__proto__` key js-yaml actually emits.
+ */
+describe("prototype pollution - parsed front matter merge guard", () => {
+	afterEach(() => {
+		delete (Object.prototype as Record<string, unknown>).polluted;
+	});
+
+	/** A parsed object shaped the way real js-yaml emits `__proto__:`. */
+	function parsedLikeJsYaml(): Record<string, unknown> {
+		const parsed: Record<string, unknown> = { safe: "kept" };
+		Object.defineProperty(parsed, "__proto__", {
+			value: { polluted: "x" },
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+		return parsed;
+	}
+
+	it("enumerates __proto__ as an own key (real js-yaml shape) and the guard flags it", () => {
+		const parsed = parsedLikeJsYaml();
+		expect(Object.keys(parsed)).toContain("__proto__");
+		expect(
+			Object.keys(parsed).filter((key) => hasUnsafeFrontmatterKey([key])),
+		).toEqual(["__proto__"]);
+	});
+
+	it("guarded merge loop drops __proto__ without polluting and keeps safe keys", () => {
+		const parsed = parsedLikeJsYaml();
+		const frontmatter: Record<string, unknown> = {};
+
+		// Mirrors TemplateInsertEngine.mergeFrontmatterProperties' merge loop.
+		for (const [key, value] of Object.entries(parsed)) {
+			if (hasUnsafeFrontmatterKey([key])) continue;
+			const existing = Object.hasOwn(frontmatter, key)
+				? frontmatter[key]
+				: undefined;
+			if (existing === undefined || existing === null || existing === "") {
+				frontmatter[key] = value;
+			}
+		}
+
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		// Without the guard, frontmatter['__proto__'] = {...} reparents this object.
+		expect(Object.getPrototypeOf(frontmatter)).toBe(Object.prototype);
+		expect(frontmatter).toEqual({ safe: "kept" });
+	});
+});
+
 describe("hasUnsafeFrontmatterKey", () => {
 	it("flags __proto__ at any position", () => {
 		expect(hasUnsafeFrontmatterKey(["__proto__"])).toBe(true);

--- a/src/engine/helpers/frontmatterPostProcessor.prototype-pollution.test.ts
+++ b/src/engine/helpers/frontmatterPostProcessor.prototype-pollution.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+	assignFrontmatterValue,
+	hasUnsafeFrontmatterKey,
+} from "./frontmatterPostProcessor";
+import { TemplatePropertyCollector } from "../../utils/TemplatePropertyCollector";
+
+/**
+ * Regression coverage for the prototype-pollution guard in
+ * {@link assignFrontmatterValue}.
+ *
+ * Front-matter key paths originate from template/note content that can be
+ * authored elsewhere (synced/shared data.json, imported community packages).
+ * A crafted nested key such as `__proto__` must never be followed while walking
+ * the path - doing so would mutate global JS prototype state for the entire
+ * Electron renderer (Obsidian core + every other plugin), not the file's own
+ * front matter.
+ */
+describe("assignFrontmatterValue - prototype pollution guard", () => {
+	afterEach(() => {
+		// Defensive cleanup so a regression here cannot leak into other tests.
+		delete (Object.prototype as Record<string, unknown>).polluted;
+		delete (Object.prototype as Record<string, unknown>).polluted2;
+	});
+
+	it("refuses a __proto__ path and does not pollute Object.prototype", () => {
+		const frontmatter: Record<string, unknown> = {};
+
+		// Without the guard this walks into Object.prototype and sets it globally.
+		assignFrontmatterValue(frontmatter, ["__proto__", "polluted"], "PWNED");
+
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		// The whole assignment is refused, so nothing is written to the target.
+		expect(Object.keys(frontmatter)).toHaveLength(0);
+	});
+
+	it("refuses a __proto__ segment anywhere in the path", () => {
+		const frontmatter: Record<string, unknown> = {};
+
+		assignFrontmatterValue(
+			frontmatter,
+			["safe", "__proto__", "polluted"],
+			"PWNED",
+		);
+
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.keys(frontmatter)).toHaveLength(0);
+	});
+
+	it("refuses descent through a constructor/prototype segment (gadget defense in depth)", () => {
+		const frontmatter: Record<string, unknown> = {};
+
+		assignFrontmatterValue(
+			frontmatter,
+			["constructor", "prototype", "polluted2"],
+			"PWNED",
+		);
+
+		expect(({} as Record<string, unknown>).polluted2).toBeUndefined();
+		// Refused outright - no stray `constructor` own key written either.
+		expect(
+			Object.prototype.hasOwnProperty.call(frontmatter, "constructor"),
+		).toBe(false);
+		expect(Object.keys(frontmatter)).toHaveLength(0);
+	});
+
+	it("still nests safe multi-segment paths (minimality lock)", () => {
+		const frontmatter: Record<string, unknown> = {};
+
+		assignFrontmatterValue(frontmatter, ["a", "b", "c"], 1);
+		assignFrontmatterValue(frontmatter, ["top"], 2);
+
+		expect(frontmatter).toEqual({ a: { b: { c: 1 } }, top: 2 });
+	});
+
+	it("preserves legitimate terminal constructor/prototype keys (no collateral)", () => {
+		const frontmatter: Record<string, unknown> = {};
+
+		// As a leaf, these are normal own-property writes - valid front-matter
+		// metadata names (e.g. a programming or design note). They must be kept.
+		assignFrontmatterValue(frontmatter, ["constructor"], "Class notes");
+		assignFrontmatterValue(frontmatter, ["prototype"], "Board A");
+		assignFrontmatterValue(frontmatter, ["spec", "prototype"], 2);
+
+		expect(
+			Object.prototype.hasOwnProperty.call(frontmatter, "constructor"),
+		).toBe(true);
+		expect(frontmatter.constructor).toBe("Class notes");
+		expect(frontmatter.prototype).toBe("Board A");
+		expect((frontmatter.spec as Record<string, unknown>).prototype).toBe(2);
+		// None of these touch the global prototype.
+		expect(({} as Record<string, unknown>).constructor).toBe(Object);
+	});
+});
+
+/**
+ * End-to-end reachability: prove that a crafted YAML template (the kind that
+ * can arrive via a synced/shared data.json or an imported community package)
+ * actually drives the real {@link TemplatePropertyCollector} to emit a
+ * `__proto__`-rooted key path, and that the guard in {@link assignFrontmatterValue}
+ * neutralizes it. This exercises the full collector -> post-processor chain with
+ * no JavaScript in the payload, only the opt-in comma-list heuristic.
+ */
+describe("prototype pollution - collector reachability", () => {
+	afterEach(() => {
+		delete (Object.prototype as Record<string, unknown>).polluted;
+	});
+
+	/** Mirrors how Formatter.replaceVariableInString calls maybeCollect. */
+	function collectFromTemplate(
+		input: string,
+		token: string,
+		rawValue: unknown,
+	): Map<string, unknown> {
+		const collector = new TemplatePropertyCollector();
+		const matchStart = input.indexOf(token);
+		const matchEnd = matchStart + token.length;
+		collector.maybeCollect({
+			input,
+			matchStart,
+			matchEnd,
+			rawValue,
+			fallbackKey: "item",
+			collectionActive: true,
+			heuristicEnabled: true,
+		});
+		return collector.drain();
+	}
+
+	const MALICIOUS_TEMPLATE = [
+		"---",
+		"__proto__:",
+		"  polluted:",
+		"    - {{VALUE:item}}",
+		"---",
+		"body",
+	].join("\n");
+
+	it("collector derives the __proto__-rooted path from the template", () => {
+		// The comma-list heuristic turns "a,b" into an array, which the collector
+		// gathers under the path walked up from the list item: ['__proto__','polluted'].
+		const vars = collectFromTemplate(MALICIOUS_TEMPLATE, "{{VALUE:item}}", "a,b");
+
+		const dangerousKey = ["__proto__", "polluted"].join(
+			TemplatePropertyCollector.PATH_SEPARATOR,
+		);
+		expect(vars.has(dangerousKey)).toBe(true);
+		expect(vars.get(dangerousKey)).toEqual(["a", "b"]);
+	});
+
+	it("guard neutralizes the derived path during front matter assignment", () => {
+		const vars = collectFromTemplate(MALICIOUS_TEMPLATE, "{{VALUE:item}}", "a,b");
+		const frontmatter: Record<string, unknown> = {};
+
+		// Replays postProcessFrontMatter's split-and-assign over the collected vars.
+		for (const [key, value] of vars) {
+			const segments = key.includes(TemplatePropertyCollector.PATH_SEPARATOR)
+				? key.split(TemplatePropertyCollector.PATH_SEPARATOR)
+				: [key];
+			assignFrontmatterValue(frontmatter, segments, value);
+		}
+
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.keys(frontmatter)).toHaveLength(0);
+	});
+});
+
+describe("hasUnsafeFrontmatterKey", () => {
+	it("flags __proto__ at any position", () => {
+		expect(hasUnsafeFrontmatterKey(["__proto__"])).toBe(true);
+		expect(hasUnsafeFrontmatterKey(["__proto__", "x"])).toBe(true);
+		expect(hasUnsafeFrontmatterKey(["safe", "__proto__", "x"])).toBe(true);
+		expect(hasUnsafeFrontmatterKey(["a", "b", "__proto__"])).toBe(true);
+	});
+
+	it("flags constructor/prototype only as a non-terminal descent segment", () => {
+		// Descending THROUGH these is the classic constructor.prototype gadget.
+		expect(hasUnsafeFrontmatterKey(["constructor", "x"])).toBe(true);
+		expect(hasUnsafeFrontmatterKey(["prototype", "x"])).toBe(true);
+		expect(hasUnsafeFrontmatterKey(["a", "constructor", "b"])).toBe(true);
+	});
+
+	it("permits constructor/prototype as a legitimate terminal key (no collateral)", () => {
+		// As a leaf key these are harmless own-property writes and valid metadata
+		// names (e.g. a programming/design note). They must NOT be dropped.
+		expect(hasUnsafeFrontmatterKey(["constructor"])).toBe(false);
+		expect(hasUnsafeFrontmatterKey(["prototype"])).toBe(false);
+		expect(hasUnsafeFrontmatterKey(["spec", "prototype"])).toBe(false);
+		expect(hasUnsafeFrontmatterKey(["class", "constructor"])).toBe(false);
+	});
+
+	it("does not flag safe keys or whitespace-padded near-matches", () => {
+		// Collected segments are always trimmed upstream, and only the exact
+		// string "__proto__" trips the JS prototype setter, so a padded variant
+		// is inert and must not be treated as unsafe.
+		expect(hasUnsafeFrontmatterKey([" __proto__ ", "x"])).toBe(false);
+		expect(hasUnsafeFrontmatterKey(["a", "b"])).toBe(false);
+		expect(hasUnsafeFrontmatterKey(["proto"])).toBe(false);
+		expect(hasUnsafeFrontmatterKey([])).toBe(false);
+	});
+});

--- a/src/engine/helpers/frontmatterPostProcessor.ts
+++ b/src/engine/helpers/frontmatterPostProcessor.ts
@@ -240,12 +240,55 @@ export async function postProcessFrontMatter(
 	}
 }
 
+/**
+ * Key segments that become a prototype-pollution gadget only when a value is
+ * assigned by DESCENDING THROUGH them (i.e. they appear as a non-terminal path
+ * segment). As a terminal/leaf key they are harmless own-property writes and are
+ * also legitimate user metadata names, so they are permitted in that position.
+ */
+const UNSAFE_DESCENT_SEGMENTS = new Set(["prototype", "constructor"]);
+
+/**
+ * True when assigning a value along this front-matter key path would corrupt JS
+ * prototype state instead of writing the file's own front matter.
+ *
+ * `__proto__` is rejected at every position: descending through it reaches
+ * `Object.prototype` and pollutes it globally for the whole renderer, and
+ * assigning to it as a leaf invokes the prototype setter (reparenting the
+ * object). `constructor`/`prototype` are rejected only as a non-terminal segment
+ * - the classic `constructor.prototype` descent gadget; as a terminal key they
+ * are plain, legitimate front-matter properties and must not be dropped.
+ *
+ * Exact-string match is intentional: every collected segment is trimmed upstream
+ * (see {@link import("../../utils/TemplatePropertyCollector")}) and only the
+ * exact string `__proto__` trips the JS prototype setter, so whitespace-padded
+ * or differently-cased variants are inert and must not be rejected.
+ */
+export function hasUnsafeFrontmatterKey(path: string[]): boolean {
+	return path.some((segment, index) => {
+		if (segment === "__proto__") return true;
+		const isTerminal = index === path.length - 1;
+		return !isTerminal && UNSAFE_DESCENT_SEGMENTS.has(segment);
+	});
+}
+
 export function assignFrontmatterValue(
 	frontmatter: Record<string, unknown>,
 	path: string[],
 	value: unknown,
 ): void {
 	if (path.length === 0) return;
+	// Refuse to write through prototype-pollution vectors. The path can originate
+	// from template/note content authored elsewhere (synced/shared data.json,
+	// imported packages); following a `__proto__`/`constructor`/`prototype`
+	// segment would corrupt global JS prototype state for the whole renderer
+	// rather than the file's own front matter, so we drop the assignment.
+	if (hasUnsafeFrontmatterKey(path)) {
+		log.logWarning(
+			`Skipping front matter assignment for unsafe key path "${path.join(".")}" to avoid prototype pollution.`,
+		);
+		return;
+	}
 	let target = frontmatter;
 	for (let i = 0; i < path.length - 1; i++) {
 		const segment = path[i];


### PR DESCRIPTION
## Summary

`assignFrontmatterValue()` (`src/engine/helpers/frontmatterPostProcessor.ts`) wrote template-property values into a front matter object by walking a key path: `for (...) { target = target[segment] }` then `target[last] = value`, with **no guard** against the dangerous segment `__proto__`. With a path like `['__proto__','polluted']`, `target['__proto__']` returns `Object.prototype` (a non-null, non-array object, so the existing reset branch is skipped), `target` becomes `Object.prototype`, and the final write sets `Object.prototype.polluted` **globally** - polluting every object in the Obsidian/Electron renderer (Obsidian core + every other plugin) for the session.

## Why this is a real vulnerability (threat model)

QuickAdd is a local plugin, but this is reachable from **untrusted input**, not user-authored-over-own-data:

- The key path is derived from template/note front matter. `TemplatePropertyCollector.findListParentPath` builds a multi-segment path from the parent property names written in a template/capture's own front matter, e.g.:

  ```yaml
  ---
  __proto__:
    polluted:
      - {{VALUE:item}}
  ---
  ```

  yields `propertyPath = ['__proto__','polluted']`. The list item resolves to a structured value via the comma-list heuristic (`"a,b"` -> `['a','b']`) with **no JavaScript in the payload**.
- A **synced/shared `data.json`** carries both `enableTemplatePropertyTypes: true` and the malicious Capture `format` / Template choice in one blob. An **imported `.quickadd.json` package** ships the front matter verbatim; the import disclosure gate only scans bundled executable scripts, not front-matter data. Either way a script-free choice corrupts global JS prototype state the first time the victim runs it (hard-to-diagnose corruption / DoS across the app session).

Confidence: the finding was filed MEDIUM; reachability is gated by the opt-in `enableTemplatePropertyTypes` setting on the no-JS path, but a single synced/shared config blob supplies both the flag and the payload.

## Fix

A **position-aware** guard, centralized so both sinks are covered:

- Reject `__proto__` at **any** position (descending through it reaches `Object.prototype`; assigning to it as a leaf invokes the prototype setter).
- Reject `constructor`/`prototype` **only as a non-terminal descent segment** (the classic `constructor.prototype` gadget). As a **terminal** key they are harmless own-property writes and legitimate front-matter metadata names (e.g. a programming/design note), so they are **preserved** - the guard is collateral-free.
- Apply the same predicate to the separate `Object.entries(parsed)` merge loop in `TemplateInsertEngine.mergeFrontmatterProperties`, which writes parsed front-matter keys directly and bypasses `assignFrontmatterValue` (defense in depth).

I deliberately did **not** extend `validateStructuredVariables` to reject the batch on a bad key: that would skip post-processing for all the legitimate keys alongside one bad one. The runtime guard is surgical (drops only the unsafe assignment, logs a warning) and uniformly covers both callers.

## Exploit / mitigation evidence

`src/engine/helpers/frontmatterPostProcessor.prototype-pollution.test.ts` drives the **real** `TemplatePropertyCollector` from the malicious YAML and proves the end-to-end chain. Stashing only the source fix and re-running:

- **Without the fix (RED):** `refuses a __proto__ path ... AssertionError: expected 'PWNED' to be undefined` and the collector-reachability test `guard neutralizes the derived path ... expected [ 'a', 'b' ] to be undefined` - i.e. a no-JS template polluted `Object.prototype.polluted` globally through production collector code.
- **With the fix (GREEN):** all pass; `Object.prototype` stays clean and the target gets no stray keys.

## No regression to legitimate functionality

- `TemplateInsertEngine.test.ts` adds an engine-level case: a template with a legitimately-named `prototype:` property still merges into the note front matter (this fails under a naive blanket guard, passes here).
- Predicate tests lock terminal `constructor:`/`prototype:` as allowed and non-terminal descent as blocked.

## Review

- Validated threat-model judgment + fix design via an adversarial workflow before coding (REAL verdict).
- Adversarial review of the diff (opposite-model reviewers) caught two real issues in round 1 - a `tsc`-breaking test and an overbroad blanket guard that dropped legitimate `constructor:`/`prototype:` keys - both fixed and re-reviewed clean (including a live Obsidian load smoke).

## Gates

`tsc -noEmit`, `eslint`, `svelte-check` (0 errors), full `pnpm test` (3181 passed / 37 skipped), and `pnpm run build` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML frontmatter merging and assignment to block prototype-pollution–style unsafe path segments, skipping the affected entries and logging a warning.
  * Ensured merge/override behavior only considers own properties, preventing inherited values from interfering.
  * Kept legitimate metadata keys (including `constructor`/`prototype` when used as terminal keys) working correctly without impacting global prototypes.
* **Tests**
  * Added regression coverage for unsafe frontmatter detection and end-to-end reachability, confirming no prototype pollution occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->