### PR TITLE
fix(ai): enforce allowedRoots confinement in workspace tools

### DIFF
--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -704,7 +704,8 @@ dialog no one can answer.
 ### Built-in tools — `ai.tools.{vault, workspace, system}(options)`
 
 Opt-in groups of ready-made tools. Each returns a tool map you spread into an agent's `tools`.
-Options: `{ only, exclude, prefix, allowedRoots }` (`allowedRoots` confines vault paths to folders).
+Options: `{ only, exclude, prefix, allowedRoots }` (`allowedRoots` confines a group to the listed
+folders).
 
 | Group | Read-only (auto-run) | Write (asks for approval) |
 |---|---|---|
@@ -715,6 +716,16 @@ Options: `{ only, exclude, prefix, allowedRoots }` (`allowedRoots` confines vaul
 Write tools sanitise every model-chosen path (rejecting traversal and config dirs like `.obsidian`/
 `.git`, and symlinks that escape the vault), fail rather than overwrite an existing note, and are
 frontmatter-aware. There are **no ambient tools** — nothing runs unless you spread it into `tools`.
+
+`allowedRoots` confines both groups it applies to. For `vault` it bounds the paths the model may
+read or write. For `workspace` it bounds which file's content the agent can pull in: `get_active_note`
+returns `active:null` and `get_selection` returns an empty string whenever the currently-open file
+lives **outside** the roots, so a note you fenced off can't be surfaced into the transcript by a
+model steered through injected content. (`system` ignores it — `get_date` touches no files.) An
+absent or all-blank `allowedRoots` is vault-wide, the default. Note that confinement scopes what
+*these* tools expose; it is not a sandbox for an untrusted agent — your own script's `require`/
+`fetch`/`quickAddApi.utility.*` remain ambient — so only hand a group to an agent you trust with the
+folders you grant it.
 
 ### Structured output — `agent.generate({ prompt, schema })`
 

--- a/src/ai/tools/allowedRoots.test.ts
+++ b/src/ai/tools/allowedRoots.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { isUnderAllowedRoot, isWithinAllowedRoots, normalizeRoot } from "./allowedRoots";
+
+// "Cafe" with an accented final e, in both Unicode normalization forms. Built from
+// an explicit decomposed source (e + combining acute) so the two are byte-distinct.
+const CAFE_BASE = "Café";
+const CAFE_NFC = CAFE_BASE.normalize("NFC"); // composed   (Caf + U+00E9)
+const CAFE_NFD = CAFE_BASE.normalize("NFD"); // decomposed (Cafe + U+0301)
+
+describe("normalizeRoot", () => {
+	it("trims, unifies separators, strips slashes, and NFC-normalizes a config root", () => {
+		expect(normalizeRoot("  AI/  ")).toBe("AI");
+		expect(normalizeRoot("\\AI\\notes\\")).toBe("AI/notes");
+		expect(normalizeRoot("AI//notes")).toBe("AI/notes");
+		expect(normalizeRoot(CAFE_NFD)).toBe(CAFE_NFC);
+	});
+	it("collapses an all-blank root to empty", () => {
+		expect(normalizeRoot("   ")).toBe("");
+		expect(normalizeRoot("")).toBe("");
+	});
+});
+
+describe("isUnderAllowedRoot", () => {
+	it("is segment-aware (root itself or a child, never a prefix sibling)", () => {
+		expect(isUnderAllowedRoot("AI", ["AI"])).toBe(true);
+		expect(isUnderAllowedRoot("AI/x.md", ["AI"])).toBe(true);
+		expect(isUnderAllowedRoot("AInotes/x.md", ["AI"])).toBe(false);
+		expect(isUnderAllowedRoot("Other/x.md", ["AI"])).toBe(false);
+	});
+});
+
+describe("isWithinAllowedRoots", () => {
+	it("absent or all-blank roots are vault-wide (identical)", () => {
+		for (const roots of [undefined, [], [""], ["  "], ["", "  "]]) {
+			expect(isWithinAllowedRoots("Anywhere/secret.md", roots)).toBe(true);
+		}
+	});
+
+	it("confines an in-fence path and rejects an out-of-fence one", () => {
+		expect(isWithinAllowedRoots("AI/scratch.md", ["AI"])).toBe(true);
+		expect(isWithinAllowedRoots("Secret/passwords.md", ["AI"])).toBe(false);
+	});
+
+	it("denies an unknown path when confined", () => {
+		expect(isWithinAllowedRoots(undefined, ["AI"])).toBe(false);
+		expect(isWithinAllowedRoots("", ["AI"])).toBe(false);
+	});
+
+	// Regression: the predicate must compare the app-owned path by IDENTITY. A prior
+	// version ran the path through normalizeRoot (which .trim()s), so a sibling folder
+	// literally named " AI" trimmed to "AI/..." and slipped past the fence.
+	it("does NOT trim the path: a leading-space sibling folder stays out of scope", () => {
+		expect(isWithinAllowedRoots(" AI/secret.md", ["AI"])).toBe(false);
+		// A real in-fence path is unaffected.
+		expect(isWithinAllowedRoots("AI/secret.md", ["AI"])).toBe(true);
+	});
+
+	// Regression: a genuinely in-root NFD path under an NFC root must MATCH (else
+	// confinement wrongly hides the user's own note on macOS / imported vaults).
+	it("matches across Unicode normalization forms (NFC root vs NFD path)", () => {
+		expect(isWithinAllowedRoots(`${CAFE_NFD}/notes/x.md`, [CAFE_NFC])).toBe(true);
+		expect(isWithinAllowedRoots(`${CAFE_NFC}/x.md`, [CAFE_NFC])).toBe(true);
+	});
+
+	it("honors multiple roots and accepts a trailing-slash / backslash root spelling", () => {
+		expect(isWithinAllowedRoots("Notes/x.md", ["AI", "Notes"])).toBe(true);
+		expect(isWithinAllowedRoots("AI/x.md", ["AI/"])).toBe(true);
+		expect(isWithinAllowedRoots("AI/sub/x.md", ["AI\\sub"])).toBe(true);
+	});
+});

--- a/src/ai/tools/allowedRoots.ts
+++ b/src/ai/tools/allowedRoots.ts
@@ -1,0 +1,76 @@
+/**
+ * Allowed-roots confinement policy for the AI tool groups (#714).
+ *
+ * One policy module, two DISTINCT jobs kept deliberately separate so the same
+ * normalization is never misapplied across a trust boundary:
+ *
+ *  - {@link normalizeRoot} canonicalizes a user/config-supplied root STRING
+ *    (trim, backslash→'/', collapse + strip slashes, NFC). Roots are untrusted
+ *    input, so trimming/rewriting them is correct.
+ *
+ *  - {@link isWithinAllowedRoots} tests whether an ALREADY-CANONICAL, app-owned
+ *    vault path (e.g. Obsidian's `TFile.path`) sits inside the fence. Such a path
+ *    is an identity, not raw input: it must NOT be trimmed or have its separators
+ *    rewritten (that would let a sibling folder literally named " AI" masquerade
+ *    as "AI"). Only its Unicode form is unified (NFC) so it compares equal to an
+ *    NFC-normalized root when the user typed/pasted the root in NFD.
+ *
+ * NFC is safe here (it cannot merge two distinct folders into a bypass): Obsidian
+ * already normalizes every vault path to NFC — verified live, an NFD-named folder
+ * is reported by `TFile.path` as NFC and `getAbstractFileByPath` matches only the
+ * NFC spelling — so canonical-equivalent paths cannot coexist or reach this code
+ * un-normalized. Normalizing the (already-NFC) path is thus a no-op for real
+ * inputs; normalizing the root only lets an NFD-typed root match its NFC folder.
+ *
+ * `sanitizeVaultPath` (which validates MODEL-CHOSEN write/read targets) reuses
+ * normalizeRoot + isUnderAllowedRoot for its own root check; the workspace tools
+ * reuse isWithinAllowedRoots for the active-note/selection fence. Centralizing the
+ * logic here is what stops a future tool group from silently re-spelling — and
+ * forgetting — confinement (the gap this module closes for the workspace group).
+ */
+
+/**
+ * Canonicalize a user/config-supplied vault-relative root: trim, backslash→'/',
+ * collapse repeated slashes, strip leading/trailing slashes, then NFC so it
+ * compares equal to an NFC-normalized path.
+ */
+export function normalizeRoot(root: string): string {
+	return (root ?? "")
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/\/+/g, "/")
+		.replace(/^\/+|\/+$/g, "")
+		.normalize("NFC");
+}
+
+/**
+ * Segment-aware prefix test: is `path` the root itself or under it. Both
+ * arguments must already be normalized (see {@link normalizeRoot}); `path` is
+ * compared by identity, so callers pass a canonical app-owned path.
+ */
+export function isUnderAllowedRoot(path: string, roots: string[]): boolean {
+	return roots.some((root) => path === root || path.startsWith(`${root}/`));
+}
+
+/**
+ * Confinement predicate for an ALREADY-EXISTING, app-owned path (the active note
+ * or the source file of the editor selection). Answers exactly one question: is
+ * this path inside the configured `allowedRoots` fence?
+ *
+ * An absent OR all-blank `allowedRoots` means vault-wide (no confinement) and is
+ * treated identically to passing none. A confined call with an unknown path
+ * (undefined) denies — there is no in-fence path to compare against. The path's
+ * identity is preserved (NFC only, never trimmed), so a sibling folder whose name
+ * merely shares the root's characters cannot slip through.
+ */
+export function isWithinAllowedRoots(
+	path: string | undefined,
+	allowedRoots: string[] | undefined,
+): boolean {
+	const roots = (allowedRoots ?? [])
+		.map((root) => normalizeRoot(root))
+		.filter((root) => root.length > 0);
+	if (roots.length === 0) return true;
+	if (!path) return false;
+	return isUnderAllowedRoot(path.normalize("NFC"), roots);
+}

--- a/src/ai/tools/builtins/builtins.test.ts
+++ b/src/ai/tools/builtins/builtins.test.ts
@@ -129,3 +129,97 @@ describe("workspace + system tools", () => {
 		expect(res.date.length).toBeGreaterThan(0);
 	});
 });
+
+// allowedRoots confinement for the workspace group (#714, other-confinement-gap).
+// get_active_note/get_selection expose the user's ambient editor state; when a
+// script author opts into allowedRoots they expect notes OUTSIDE those folders to
+// stay invisible — the vault group already honors this, the workspace group did not.
+describe("workspace tools — allowedRoots confinement", () => {
+	function mdFile(path: string): TFile {
+		const f = Object.create(TFile.prototype) as TFile;
+		const basename = path.replace(/^.*\//, "").replace(/\.[^.]+$/, "");
+		Object.assign(f, { path, basename, extension: "md" });
+		return f;
+	}
+	function appWithActive(path: string, content: string, cachedRead = vi.fn(async () => content)) {
+		return makeApp({
+			vault: { cachedRead },
+			workspace: { getActiveFile: () => mdFile(path) },
+		});
+	}
+	function appWithSelection(filePath: string | null, selection: string) {
+		const view = {
+			file: filePath === null ? null : mdFile(filePath),
+			editor: { getSelection: () => selection },
+		};
+		return makeApp({ workspace: { getActiveViewOfType: () => view } });
+	}
+	const call = (tools: ReturnType<typeof createWorkspaceTools>, name: "get_active_note" | "get_selection") =>
+		tools[name].execute({}, { toolCallId: "c", toolName: name });
+
+	describe("get_active_note", () => {
+		it("hides the active note (and skips the read) when it is OUTSIDE the roots", async () => {
+			const cachedRead = vi.fn(async () => "TOP SECRET");
+			const app = appWithActive("Secret/passwords.md", "TOP SECRET", cachedRead);
+			const tools = createWorkspaceTools(app, { allowedRoots: ["AI"] });
+			expect(await call(tools, "get_active_note")).toEqual({ active: null });
+			// Confinement must short-circuit before any content is read.
+			expect(cachedRead).not.toHaveBeenCalled();
+		});
+		it("returns the note when it is INSIDE the roots", async () => {
+			const app = appWithActive("AI/scratch.md", "# in scope");
+			const tools = createWorkspaceTools(app, { allowedRoots: ["AI"] });
+			const res = (await call(tools, "get_active_note")) as { active: { path: string; content: string } | null };
+			expect(res.active).toMatchObject({ path: "AI/scratch.md", content: "# in scope" });
+		});
+		it("is NOT fooled by a sibling whose path shares the root prefix", async () => {
+			const app = appWithActive("AInotes/leak.md", "leak");
+			const tools = createWorkspaceTools(app, { allowedRoots: ["AI"] });
+			expect(await call(tools, "get_active_note")).toEqual({ active: null });
+		});
+		it("is NOT fooled by a leading-space sibling folder (path compared by identity)", async () => {
+			const cachedRead = vi.fn(async () => "TOP SECRET");
+			const app = appWithActive(" AI/secret.md", "TOP SECRET", cachedRead);
+			const tools = createWorkspaceTools(app, { allowedRoots: ["AI"] });
+			expect(await call(tools, "get_active_note")).toEqual({ active: null });
+			expect(cachedRead).not.toHaveBeenCalled();
+		});
+		it("default (no roots) returns the note unchanged regardless of folder", async () => {
+			const app = appWithActive("Secret/passwords.md", "TOP SECRET");
+			const tools = createWorkspaceTools(app);
+			const res = (await call(tools, "get_active_note")) as { active: { path: string } | null };
+			expect(res.active).toMatchObject({ path: "Secret/passwords.md" });
+		});
+		it("all-blank roots behave identically to no roots (vault-wide)", async () => {
+			for (const allowedRoots of [[""], ["  "]]) {
+				const app = appWithActive("Secret/passwords.md", "TOP SECRET");
+				const tools = createWorkspaceTools(app, { allowedRoots });
+				const res = (await call(tools, "get_active_note")) as { active: { path: string } | null };
+				expect(res.active).toMatchObject({ path: "Secret/passwords.md" });
+			}
+		});
+	});
+
+	describe("get_selection", () => {
+		it("returns empty when the active view's file is OUTSIDE the roots", async () => {
+			const app = appWithSelection("Secret/passwords.md", "secret highlight");
+			const tools = createWorkspaceTools(app, { allowedRoots: ["AI"] });
+			expect(await call(tools, "get_selection")).toEqual({ selection: "" });
+		});
+		it("returns the selection when the active view's file is INSIDE the roots", async () => {
+			const app = appWithSelection("AI/scratch.md", "in-scope highlight");
+			const tools = createWorkspaceTools(app, { allowedRoots: ["AI"] });
+			expect(await call(tools, "get_selection")).toEqual({ selection: "in-scope highlight" });
+		});
+		it("denies a confined view whose file is null (deferred/empty view)", async () => {
+			const app = appWithSelection(null, "orphan selection");
+			const tools = createWorkspaceTools(app, { allowedRoots: ["AI"] });
+			expect(await call(tools, "get_selection")).toEqual({ selection: "" });
+		});
+		it("default (no roots) returns the selection regardless of folder", async () => {
+			const app = appWithSelection("Secret/passwords.md", "secret highlight");
+			const tools = createWorkspaceTools(app);
+			expect(await call(tools, "get_selection")).toEqual({ selection: "secret highlight" });
+		});
+	});
+});

--- a/src/ai/tools/builtins/workspaceTools.ts
+++ b/src/ai/tools/builtins/workspaceTools.ts
@@ -2,6 +2,7 @@
  * Built-in `workspace` tools (#714): read-only views of the active note + selection.
  */
 import { type App, MarkdownView, TFile } from "obsidian";
+import { isWithinAllowedRoots } from "../allowedRoots";
 import { applyGroupOptions, defineTool, type BuiltinGroupOptions, type ToolSetMap } from "./shared";
 
 const MAX_ACTIVE_CHARS = 16_000;
@@ -10,6 +11,41 @@ export function createWorkspaceTools(
 	app: App,
 	options: BuiltinGroupOptions = {},
 ): ToolSetMap {
+	const roots = options.allowedRoots;
+
+	// get_active_note/get_selection expose AMBIENT editor state and take NO path
+	// argument, so a model can't TARGET a file — it only ever gets whatever the user
+	// currently has open/selected. But a script author who confined the group with
+	// allowedRoots (the same option the `vault` group honors on every read) expects
+	// notes OUTSIDE those folders to stay invisible to the agent. Without this gate, a
+	// model steered by injection planted in in-scope content could pull the user's
+	// currently-open out-of-root note into the transcript sent to the LLM provider,
+	// silently defeating the configured fence. Absent allowedRoots ⇒ vault-wide
+	// (byte-identical to before). Every ambient read goes through these two confining
+	// accessors so a future workspace tool can't forget the fence.
+
+	/** The active markdown note, but only when it is inside the configured fence. */
+	const confinedActiveMarkdownFile = (): TFile | null => {
+		const file = app.workspace.getActiveFile();
+		// Only markdown notes count as the "active note": getActiveFile() returns a
+		// TFile for ANY active file (PDF, image, canvas, …), and cachedRead-ing those
+		// would feed raw/binary bytes into the transcript.
+		if (!(file instanceof TFile) || file.extension !== "md") return null;
+		// Out-of-fence ⇒ treat as no active note. Silent on purpose: signalling
+		// out-of-scope would itself leak the fenced file's existence/location.
+		return isWithinAllowedRoots(file.path, roots) ? file : null;
+	};
+
+	/** The active markdown view, but only when its file is inside the fence. */
+	const confinedActiveMarkdownView = (): MarkdownView | null => {
+		const view = app.workspace.getActiveViewOfType(MarkdownView);
+		if (!view) return null;
+		// Keyed on the active view's own file. NOTE: in rare split/hover-editor
+		// layouts the highlighted text's true source could differ, so this is
+		// best-effort confinement, not an airtight provenance guarantee.
+		return isWithinAllowedRoots(view.file?.path, roots) ? view : null;
+	};
+
 	const tools: ToolSetMap = {
 		get_active_note: defineTool({
 			description:
@@ -17,13 +53,8 @@ export function createWorkspaceTools(
 			inputSchema: { type: "object", properties: {} },
 			readOnly: true,
 			execute: async () => {
-				const file = app.workspace.getActiveFile();
-				// Only markdown notes count as the "active note": getActiveFile()
-				// returns a TFile for ANY active file (PDF, image, canvas, …), and
-				// cachedRead-ing those would feed raw/binary bytes into the transcript.
-				if (!(file instanceof TFile) || file.extension !== "md") {
-					return { active: null };
-				}
+				const file = confinedActiveMarkdownFile();
+				if (!file) return { active: null };
 				const content = await app.vault.cachedRead(file);
 				return {
 					active: {
@@ -43,9 +74,8 @@ export function createWorkspaceTools(
 			inputSchema: { type: "object", properties: {} },
 			readOnly: true,
 			execute: async () => {
-				const view = app.workspace.getActiveViewOfType(MarkdownView);
-				const selection = view?.editor?.getSelection() ?? "";
-				return { selection };
+				const view = confinedActiveMarkdownView();
+				return { selection: view?.editor?.getSelection() ?? "" };
 			},
 		}),
 	};

--- a/src/ai/tools/sanitizeVaultPath.ts
+++ b/src/ai/tools/sanitizeVaultPath.ts
@@ -25,6 +25,7 @@ import {
 	INVALID_FOLDER_TRAILING_CHARS_REGEX,
 	isReservedWindowsDeviceName,
 } from "../../utils/pathValidation";
+import { isUnderAllowedRoot, normalizeRoot } from "./allowedRoots";
 
 export class UnsafeVaultPathError extends Error {
 	constructor(message: string) {
@@ -106,6 +107,9 @@ export function sanitizeVaultPath(
 	return normalized;
 }
 
+// Root-confinement helpers (normalizeRoot / isUnderAllowedRoot) live in
+// ./allowedRoots so the workspace tools and this sanitizer share ONE policy.
+
 function validateSegment(segment: string, fullPath: string): void {
 	if (INVALID_FOLDER_CONTROL_CHARS_REGEX.test(segment)) {
 		throw new UnsafeVaultPathError(
@@ -131,14 +135,3 @@ function validateSegment(segment: string, fullPath: string): void {
 	}
 }
 
-function normalizeRoot(root: string): string {
-	return (root ?? "")
-		.trim()
-		.replace(/\\/g, "/")
-		.replace(/\/+/g, "/")
-		.replace(/^\/+|\/+$/g, "");
-}
-
-function isUnderAllowedRoot(path: string, roots: string[]): boolean {
-	return roots.some((root) => path === root || path.startsWith(`${root}/`));
-}


### PR DESCRIPTION
## Summary

The `workspace` AI tool group (`quickAddApi.ai.tools.workspace({ allowedRoots })`) documented `allowedRoots` as confinement, but `get_active_note` / `get_selection` never consulted it - while the `vault` group enforces it on every read. So a script author who confined the group got **no confinement** for these two tools.

This is a real gap under QuickAdd's threat model (model output is semi-untrusted and can be steered by prompt-injection planted in untrusted in-scope content): a model could pull the user's currently-open **out-of-root** note (up to 16k chars) or live selection into the transcript sent to the third-party LLM provider, silently defeating the fence the user configured. Bounded to whatever the user has open (these tools take no path argument, so the model can't *target* a file) - hence MEDIUM, not HIGH.

## Fix

Honor `allowedRoots` in the workspace group, mirroring the vault group:
- `get_active_note` returns `active:null` and `get_selection` returns `""` when the active file is **outside** the roots.
- Absent or all-blank `allowedRoots` stays vault-wide - **byte-identical** to today's default.

New pure module `src/ai/tools/allowedRoots.ts` owns the confinement policy as a single source of truth:
- `normalizeRoot` - canonicalize a config-supplied root (trim / `\`→`/` / collapse / strip slashes / NFC). Roots are untrusted input.
- `isUnderAllowedRoot` - segment-safe prefix test (`AInotes` never matches root `AI`).
- `isWithinAllowedRoots` - tests an **already-canonical, app-owned** path (`TFile.path`). The path is compared **by identity** (NFC only, **never trimmed**), so a sibling folder literally named `" AI"` (leading space) cannot masquerade as `AI`.

`sanitizeVaultPath` now imports the shared primitives, so confinement logic lives in **one** place (this gap existed precisely because it had been duplicated and one copy forgotten). `workspaceTools` routes both ambient reads through `confinedActiveMarkdownFile` / `confinedActiveMarkdownView`, so a future workspace tool can't forget the fence.

## Exploit / mitigation evidence (live Obsidian runtime)

Out-of-root secret note active, confined to \`["AI"]\`:
\`\`\`json
{ "activePath":"Secret/passwords.md", "confined_active":null, "unconfined_leaks_secret":true }
\`\`\`
- `confined_active:null` - the fix hides the out-of-root note.
- `unconfined_leaks_secret:true` - default (no roots) still returns content (the real leak, and proof legit behavior is preserved).

In-scope note + all-blank roots:
\`\`\`json
{ "inscope_returns_content":true, "allBlankRoots_is_vaultwide":true }
\`\`\`

Leading-space bypass (a folder literally named \`" AI"\` IS creatable in Obsidian), confined to \`["AI"]\`:
\`\`\`json
{ "leadingSpace_active_path":" AI/secret.md", "leadingSpace_spoof_denied":true }
\`\`\`

## Tests

`src/ai/tools/allowedRoots.test.ts` + workspace cases in `builtins.test.ts`: leak-before/confined-after, leading-space identity bypass, NFC/NFD parity, segment safety, all-blank == vault-wide, deferred-view (null file) deny. The confinement assertions are **red without the fix** (verified by reverting each gate). Full suite: 3188 passed.

## Review notes / risk

- `normalizeRoot` now NFC-normalizes the root. Verified live that Obsidian normalizes every `TFile.path` to NFC and only matches the NFC spelling, so canonical-equivalent folders cannot coexist or reach this code un-normalized: NFC is safe (no distinct-folder bypass) and only lets an NFD-typed root match its NFC folder. ASCII roots (all existing tests + the common case) are unchanged.
- **Out of scope (surfaced, not folded in):** `vaultTools`' list/search filter still routes existing `TFile.path` through `sanitizeVaultPath` (which keeps it consistent with `read_note`). It shares the same theoretical leading-space-trim quirk but is pre-existing and changing it would alter a separately-shipped tool's list/search semantics - left for a focused follow-up. The shared `isWithinAllowedRoots` predicate is now available should it adopt it.
- Docs updated to state what workspace `allowedRoots` does and does **not** promise (it scopes what these tools expose; it is not a sandbox for an untrusted agent).

Reviewed via dual-model adversarial passes (threat-model + fix-design); both round-1 High findings (path-trim bypass, boundary) fixed, round-2 High (NFC merge) refuted by live evidence.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened file access in AI workspace tools so notes and selections are only shown when they’re within permitted folders.
  * When the active note is outside allowed folders, AI responses now return no note content instead of exposing it.
  * Selection text is now hidden for files outside allowed folders.
  * Improved path handling for folder rules, including support for mixed separators, extra slashes, and Unicode-normalized names.
* **Documentation**
  * Clarified how folder restrictions affect AI tools in the Quick Add documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->