### PR TITLE
ci: harden release-bot token handling and e2e temp-dir squatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,14 +48,28 @@ jobs:
               with:
                   app-id: ${{ secrets.RELEASE_APP_ID }}
                   private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+                  # Least privilege: without these, the minted token inherits ALL of the
+                  # App's installation permissions. semantic-release only needs to push the
+                  # release commit/tag + create the Release (contents) and comment on the
+                  # released issues/PRs (issues/pull-requests). Attestation/Find-PR/Comment
+                  # steps use the default GITHUB_TOKEN, not this token.
+                  permission-contents: write
+                  permission-issues: write
+                  permission-pull-requests: write
 
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
-                  # semantic-release needs full history + tags and the persisted App
-                  # credential to push the release commit. Do not change these.
+                  # semantic-release needs full history + tags to analyze commits.
                   fetch-depth: 0
+                  # The token is still passed so checkout fetches as the App, but we do
+                  # NOT persist it into .git/config: install/build/test run BEFORE the
+                  # release and a compromised dependency could otherwise read the App
+                  # credential off disk. semantic-release authenticates its push from the
+                  # GITHUB_TOKEN env on the Release step (it builds an x-access-token URL,
+                  # it never reads .git/config), so the push still works without it.
                   token: ${{ steps.app-token.outputs.token }}
+                  persist-credentials: false
 
             - name: Setup pnpm
               uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/scripts/obsidian-e2e-cli.mjs
+++ b/scripts/obsidian-e2e-cli.mjs
@@ -5,6 +5,7 @@ import process from "node:process";
 import { promisify } from "node:util";
 import { provisionVault } from "./provision-obsidian-e2e-vault.mjs";
 import {
+	ensureSecureDir,
 	launchObsidianInstance,
 	parseArgs as parseInstanceArgs,
 	prepareObsidianProfile,
@@ -170,6 +171,9 @@ async function main() {
 	}
 
 	const options = resolveInstanceOptions(parseInstanceArgs(parsed.instanceArgs));
+	// Validate the profile root we own before the reaper scans/removes anything in
+	// it, so a hijacked root aborts the run loudly instead of being trusted.
+	await ensureSecureDir(options.profileRoot);
 	await reapStaleInstances(options);
 	await ensureObsidianInstance(options);
 	process.exitCode = await spawnObsidian(options, parsed.commandArgs);

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -302,9 +302,12 @@ async function writeJson(filePath, value) {
 }
 
 export async function launchObsidianInstance(options) {
-	// Validate (and create when absent) the instance dir here too, so a future
-	// "relaunch existing instance" path cannot bypass the temp-squat guard that
-	// prepareObsidianProfile applies in the normal start flow.
+	// Validate (and create when absent) the profile tree here too, so a future
+	// "relaunch existing instance" path that calls launch without the normal
+	// prepareObsidianProfile/main preflight cannot bypass the temp-squat guard.
+	// Parent-first: a loose profileRoot must not stay attacker-writable around
+	// the validated instance dir.
+	await ensureSecureDir(options.profileRoot);
 	await ensureSecureDir(options.instancePath);
 	await execFileAsync("/usr/bin/open", [
 		"-n",

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -134,7 +134,60 @@ function safeName(value) {
 		.replace(/^-+|-+$/g, "") || "vault";
 }
 
+// Refuse to write our Obsidian profile into a directory we do not exclusively
+// own. The profile root defaults under world-writable /tmp; if a co-located
+// actor pre-creates it (or symlinks it elsewhere) before our first run,
+// fs.mkdir(..., {recursive}) is a no-op for ownership/mode and we would
+// otherwise write the keychain-bearing HOME (and obsidian.json) through their
+// directory. lstat FIRST so we never mkdir THROUGH a pre-existing symlink, then
+// create only when absent, then assert the result is a real directory we own
+// with no group/other access. Callers must secure a parent before its children
+// so each child is created inside an already-0o700 tree the attacker cannot
+// enter (and /tmp's sticky bit then prevents swapping our owned dir entry).
+export async function ensureSecureDir(dir, options = {}) {
+	const currentUid =
+		"currentUid" in options
+			? options.currentUid
+			: typeof process.getuid === "function"
+				? process.getuid()
+				: null;
+
+	let stat;
+	try {
+		stat = await fs.lstat(dir);
+	} catch (error) {
+		if (error?.code !== "ENOENT") throw error;
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		stat = await fs.lstat(dir);
+	}
+
+	if (stat.isSymbolicLink() || !stat.isDirectory()) {
+		throw new Error(
+			`Refusing to use ${dir}: it is a symlink or not a regular directory.`,
+		);
+	}
+	if (currentUid !== null && stat.uid !== currentUid) {
+		throw new Error(
+			`Refusing to use ${dir}: owned by uid ${stat.uid}, not ${currentUid}.`,
+		);
+	}
+	// We own it; if it is group/other-accessible (an older run under a loose
+	// umask, or another tool) tighten it so the keychain-bearing profile stays
+	// private.
+	if ((stat.mode & 0o077) !== 0) {
+		await fs.chmod(dir, 0o700);
+	}
+
+	return dir;
+}
+
 export async function prepareObsidianProfile(options) {
+	// Fail closed if our profile tree is not a private directory we own
+	// (temp-squat / TOCTOU guard). Secure the root before the instance dir so the
+	// instance dir is created inside an already-validated 0o700 tree.
+	await ensureSecureDir(options.profileRoot);
+	await ensureSecureDir(options.instancePath);
+
 	const userDataPath = path.join(options.obsidianHome, "Library", "Application Support", "obsidian");
 	await fs.mkdir(userDataPath, { recursive: true, mode: 0o700 });
 	await fs.mkdir(path.join(options.obsidianHome, "Library", "Logs"), { recursive: true, mode: 0o700 });
@@ -352,6 +405,9 @@ async function main() {
 	}
 
 	const options = resolveInstanceOptions(rawOptions);
+	// Validate the profile root we own before the reaper scans/removes anything in
+	// it, so a hijacked root aborts the run loudly instead of being trusted.
+	await ensureSecureDir(options.profileRoot);
 	await reapStaleInstances(options);
 	const provisionResult = await provisionVault(options);
 	const profileResult = await prepareObsidianProfile(options);

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -134,33 +134,22 @@ function safeName(value) {
 		.replace(/^-+|-+$/g, "") || "vault";
 }
 
-// Refuse to write our Obsidian profile into a directory we do not exclusively
-// own. The profile root defaults under world-writable /tmp; if a co-located
-// actor pre-creates it (or symlinks it elsewhere) before our first run,
-// fs.mkdir(..., {recursive}) is a no-op for ownership/mode and we would
-// otherwise write the keychain-bearing HOME (and obsidian.json) through their
-// directory. lstat FIRST so we never mkdir THROUGH a pre-existing symlink, then
-// create only when absent, then assert the result is a real directory we own
-// with no group/other access. Callers must secure a parent before its children
-// so each child is created inside an already-0o700 tree the attacker cannot
-// enter (and /tmp's sticky bit then prevents swapping our owned dir entry).
-export async function ensureSecureDir(dir, options = {}) {
-	const currentUid =
-		"currentUid" in options
-			? options.currentUid
-			: typeof process.getuid === "function"
-				? process.getuid()
-				: null;
+// The uid we require every profile directory to be owned by. Injectable so the
+// foreign-owner branch is testable without a second account; null on a platform
+// without process.getuid (none we support — the harness is macOS-only) skips the
+// ownership check rather than comparing against undefined.
+function resolveCurrentUid(options) {
+	if ("currentUid" in options) return options.currentUid;
+	return typeof process.getuid === "function" ? process.getuid() : null;
+}
 
-	let stat;
-	try {
-		stat = await fs.lstat(dir);
-	} catch (error) {
-		if (error?.code !== "ENOENT") throw error;
-		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
-		stat = await fs.lstat(dir);
-	}
-
+// Reject any directory we do not exclusively own. A directory we own with no
+// group/other access cannot have a foreign-planted child (only we can write into
+// it), so descending into it later is safe. We REJECT a loose (group/other-
+// accessible) dir rather than chmod-repairing it: an attacker who could write
+// while it was loose may already have planted a `home` symlink that a parent
+// chmod would not undo, and a later recursive mkdir / keychain link would follow.
+function assertOwnedDir(dir, stat, currentUid) {
 	if (stat.isSymbolicLink() || !stat.isDirectory()) {
 		throw new Error(
 			`Refusing to use ${dir}: it is a symlink or not a regular directory.`,
@@ -171,14 +160,54 @@ export async function ensureSecureDir(dir, options = {}) {
 			`Refusing to use ${dir}: owned by uid ${stat.uid}, not ${currentUid}.`,
 		);
 	}
-	// We own it; if it is group/other-accessible (an older run under a loose
-	// umask, or another tool) tighten it so the keychain-bearing profile stays
-	// private.
 	if ((stat.mode & 0o077) !== 0) {
-		await fs.chmod(dir, 0o700);
+		throw new Error(
+			`Refusing to use ${dir}: it is group/other-accessible (mode ${(
+				stat.mode & 0o777
+			).toString(8)}); remove it and retry.`,
+		);
 	}
+}
 
+// Create (when absent) and validate a private profile directory we own. The
+// profile root defaults under world-writable /tmp; if a co-located actor
+// pre-creates it (or symlinks it elsewhere) before our first run,
+// fs.mkdir(..., {recursive}) is a no-op for ownership/mode and we would
+// otherwise write the keychain-bearing HOME (and obsidian.json) through their
+// directory. lstat FIRST so we never mkdir THROUGH a pre-existing symlink, then
+// create only when absent, then assert ownership/mode. Callers must secure a
+// parent before its children so each child is created inside an already-0o700
+// tree the attacker cannot enter (and /tmp's sticky bit then prevents swapping
+// our owned dir entry).
+export async function ensureSecureDir(dir, options = {}) {
+	const currentUid = resolveCurrentUid(options);
+	let stat;
+	try {
+		stat = await fs.lstat(dir);
+	} catch (error) {
+		if (error?.code !== "ENOENT") throw error;
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+		stat = await fs.lstat(dir);
+	}
+	assertOwnedDir(dir, stat, currentUid);
 	return dir;
+}
+
+// Validate an EXISTING profile directory without creating or modifying it.
+// Teardown paths (stop/reap) read and remove inside the root, so they must
+// refuse a hijacked/symlinked root, but must not create one — a missing root
+// just means there is nothing to clean up. Returns false when the path is absent.
+export async function assertSecureDirIfPresent(dir, options = {}) {
+	const currentUid = resolveCurrentUid(options);
+	let stat;
+	try {
+		stat = await fs.lstat(dir);
+	} catch (error) {
+		if (error?.code === "ENOENT") return false;
+		throw error;
+	}
+	assertOwnedDir(dir, stat, currentUid);
+	return true;
 }
 
 export async function prepareObsidianProfile(options) {
@@ -273,7 +302,10 @@ async function writeJson(filePath, value) {
 }
 
 export async function launchObsidianInstance(options) {
-	await fs.mkdir(options.instancePath, { recursive: true });
+	// Validate (and create when absent) the instance dir here too, so a future
+	// "relaunch existing instance" path cannot bypass the temp-squat guard that
+	// prepareObsidianProfile applies in the normal start flow.
+	await ensureSecureDir(options.instancePath);
 	await execFileAsync("/usr/bin/open", [
 		"-n",
 		"-g",

--- a/scripts/stop-obsidian-e2e-instance.mjs
+++ b/scripts/stop-obsidian-e2e-instance.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import {
+	assertSecureDirIfPresent,
 	INSTANCE_MARKER_FILE,
 	resolveInstanceOptions,
 } from "./start-obsidian-e2e-instance.mjs";
@@ -364,6 +365,13 @@ export async function reapOrphanedInstances(options = {}) {
 
 	if (!profileRoot) return { scanned: 0, reaped: [] };
 
+	// Refuse to scan/remove through a hijacked or symlinked profile root (the same
+	// temp-squat guard the start path applies before writing into it). Absent root
+	// => nothing to reap.
+	if (!(await assertSecureDirIfPresent(profileRoot))) {
+		return { scanned: 0, reaped: [] };
+	}
+
 	let entries;
 	try {
 		entries = await readdir(profileRoot);
@@ -416,6 +424,9 @@ async function main() {
 	}
 
 	const options = resolveInstanceOptions(rawOptions);
+	// Refuse to operate inside a hijacked/symlinked profile root before we stop or
+	// remove anything under it.
+	await assertSecureDirIfPresent(options.profileRoot);
 	const summary = await stopInstance(options.instancePath, {
 		dryRun: rawOptions.dryRun,
 		profileRoot: options.profileRoot,

--- a/tests/release-workflow-hardening.test.ts
+++ b/tests/release-workflow-hardening.test.ts
@@ -53,13 +53,23 @@ describe("release workflow hardening", () => {
 		expect(checkout).toMatch(/^\s*persist-credentials:\s*false\s*$/m);
 	});
 
-	it("scopes the minted App token to least privilege", () => {
+	it("scopes the minted App token to exactly the least-privilege set", () => {
 		const appToken = stepContaining("uses: actions/create-github-app-token@");
+		// Collect every permission-* input declared on the step (comments already
+		// stripped by stepBlocks).
+		const permissions: Record<string, string> = {};
+		for (const line of appToken.split("\n")) {
+			const match = line.match(/^\s*(permission-[a-z-]+):\s*(\S+)\s*$/);
+			if (match) permissions[match[1]] = match[2];
+		}
 		// Without explicit permission-* inputs the token inherits ALL of the App's
-		// installation permissions. These three are the complete set semantic-release
-		// uses (push commit/tag + create Release; comment on issues/PRs).
-		expect(appToken).toMatch(/^\s*permission-contents:\s*write\s*$/m);
-		expect(appToken).toMatch(/^\s*permission-issues:\s*write\s*$/m);
-		expect(appToken).toMatch(/^\s*permission-pull-requests:\s*write\s*$/m);
+		// installation permissions. Assert the list is CLOSED: exactly these three
+		// scopes (push commit/tag + create Release; comment on issues/PRs) and
+		// nothing broader - a future over-permission addition must fail this test.
+		expect(permissions).toEqual({
+			"permission-contents": "write",
+			"permission-issues": "write",
+			"permission-pull-requests": "write",
+		});
 	});
 });

--- a/tests/release-workflow-hardening.test.ts
+++ b/tests/release-workflow-hardening.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// These tests pin the security hardening of the privileged Release workflow:
+// the minted GitHub App token (a branch-protection bypass actor) must be scoped
+// to least privilege and must NOT be persisted into .git/config while untrusted
+// dependency install / build / test code runs ahead of semantic-release. They
+// fail loudly if a future edit regresses either guard. No YAML dependency is
+// available, so we extract the relevant step block textually and assert on it.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const releaseYmlPath = path.resolve(here, "..", ".github", "workflows", "release.yml");
+const releaseYml = fs.readFileSync(releaseYmlPath, "utf8");
+
+// Each step in release.yml begins with a `- name:` list item. Split the file
+// into those blocks so an assertion targets exactly one step (and is immune to
+// steps being reordered).
+function stepBlocks(content: string): string[] {
+	const blocks: string[] = [];
+	let current: string[] = [];
+	for (const line of content.split("\n")) {
+		if (/^\s*- name:/.test(line)) {
+			if (current.length > 0) blocks.push(current.join("\n"));
+			current = [line];
+		} else if (current.length > 0) {
+			current.push(line);
+		}
+	}
+	if (current.length > 0) blocks.push(current.join("\n"));
+	return blocks;
+}
+
+function stepContaining(needle: string): string {
+	const matches = stepBlocks(releaseYml).filter((block) => block.includes(needle));
+	expect(matches, `exactly one step should contain ${needle}`).toHaveLength(1);
+	return matches[0];
+}
+
+describe("release workflow hardening", () => {
+	it("does not persist the App credential to disk during install/build/test", () => {
+		const checkout = stepContaining("uses: actions/checkout@");
+		// The token is still passed (semantic-release pushes via the GITHUB_TOKEN env
+		// on the Release step, but checkout fetches as the App); we just refuse to
+		// write it into .git/config where untrusted install/build/test code could read it.
+		expect(checkout).toContain("token: ${{ steps.app-token.outputs.token }}");
+		expect(checkout).toContain("persist-credentials: false");
+	});
+
+	it("scopes the minted App token to least privilege", () => {
+		const appToken = stepContaining("uses: actions/create-github-app-token@");
+		// Without explicit permission-* inputs the token inherits ALL of the App's
+		// installation permissions. These three are the complete set semantic-release
+		// uses (push commit/tag + create Release; comment on issues/PRs).
+		expect(appToken).toContain("permission-contents: write");
+		expect(appToken).toContain("permission-issues: write");
+		expect(appToken).toContain("permission-pull-requests: write");
+	});
+});

--- a/tests/release-workflow-hardening.test.ts
+++ b/tests/release-workflow-hardening.test.ts
@@ -16,11 +16,13 @@ const releaseYml = fs.readFileSync(releaseYmlPath, "utf8");
 
 // Each step in release.yml begins with a `- name:` list item. Split the file
 // into those blocks so an assertion targets exactly one step (and is immune to
-// steps being reordered).
+// steps being reordered). Full-line comments are dropped first so a guard that
+// is COMMENTED OUT (e.g. `# persist-credentials: false`) cannot satisfy a check.
 function stepBlocks(content: string): string[] {
+	const lines = content.split("\n").filter((line) => !/^\s*#/.test(line));
 	const blocks: string[] = [];
 	let current: string[] = [];
-	for (const line of content.split("\n")) {
+	for (const line of lines) {
 		if (/^\s*- name:/.test(line)) {
 			if (current.length > 0) blocks.push(current.join("\n"));
 			current = [line];
@@ -43,9 +45,12 @@ describe("release workflow hardening", () => {
 		const checkout = stepContaining("uses: actions/checkout@");
 		// The token is still passed (semantic-release pushes via the GITHUB_TOKEN env
 		// on the Release step, but checkout fetches as the App); we just refuse to
-		// write it into .git/config where untrusted install/build/test code could read it.
-		expect(checkout).toContain("token: ${{ steps.app-token.outputs.token }}");
-		expect(checkout).toContain("persist-credentials: false");
+		// write it into .git/config where untrusted install/build/test code could read
+		// it. Anchored to real YAML lines so a commented-out guard cannot pass.
+		expect(checkout).toMatch(
+			/^\s*token:\s*\$\{\{\s*steps\.app-token\.outputs\.token\s*\}\}\s*$/m,
+		);
+		expect(checkout).toMatch(/^\s*persist-credentials:\s*false\s*$/m);
 	});
 
 	it("scopes the minted App token to least privilege", () => {
@@ -53,8 +58,8 @@ describe("release workflow hardening", () => {
 		// Without explicit permission-* inputs the token inherits ALL of the App's
 		// installation permissions. These three are the complete set semantic-release
 		// uses (push commit/tag + create Release; comment on issues/PRs).
-		expect(appToken).toContain("permission-contents: write");
-		expect(appToken).toContain("permission-issues: write");
-		expect(appToken).toContain("permission-pull-requests: write");
+		expect(appToken).toMatch(/^\s*permission-contents:\s*write\s*$/m);
+		expect(appToken).toMatch(/^\s*permission-issues:\s*write\s*$/m);
+		expect(appToken).toMatch(/^\s*permission-pull-requests:\s*write\s*$/m);
 	});
 });

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	ensureSecureDir,
 	INSTANCE_MARKER_FILE,
 	parseArgs,
 	prepareObsidianProfile,
@@ -101,6 +102,66 @@ describe("start-obsidian-e2e-instance", () => {
 			vaultPath: options.vaultPath,
 		});
 		expect(path.resolve(marker.worktreePath)).toBe(path.resolve(cwd));
+	});
+});
+
+describe("ensureSecureDir", () => {
+	it("creates a fresh profile dir owned by us with 0o700", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const dir = path.join(root, "profile-root");
+
+		await ensureSecureDir(dir);
+
+		const stat = await fs.lstat(dir);
+		expect(stat.isDirectory()).toBe(true);
+		expect(stat.mode & 0o777).toBe(0o700);
+		if (typeof process.getuid === "function") {
+			expect(stat.uid).toBe(process.getuid());
+		}
+	});
+
+	it("tightens a pre-existing group/world-accessible dir we own", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const dir = path.join(root, "loose");
+		await fs.mkdir(dir, { recursive: true });
+		await fs.chmod(dir, 0o777);
+
+		await ensureSecureDir(dir);
+
+		expect((await fs.lstat(dir)).mode & 0o077).toBe(0);
+	});
+
+	it("refuses a symlink at the profile path (never follows it)", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const target = path.join(root, "attacker-owned");
+		await fs.mkdir(target, { recursive: true });
+		const link = path.join(root, "profile-root");
+		await fs.symlink(target, link);
+
+		await expect(ensureSecureDir(link)).rejects.toThrow(/symlink or not a regular directory/);
+		// The symlink target must be untouched - we must not have written through it.
+		expect((await fs.readdir(target)).length).toBe(0);
+	});
+
+	it("refuses a dir owned by a different uid (temp-squat)", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const dir = path.join(root, "foreign");
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+		const foreignUid = (process.getuid?.() ?? 0) + 4242;
+		await expect(
+			ensureSecureDir(dir, { currentUid: foreignUid }),
+		).rejects.toThrow(/owned by uid/);
+	});
+
+	it("skips the owner check when getuid is unavailable (currentUid null)", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const dir = path.join(root, "no-getuid");
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+		// Platforms without process.getuid resolve currentUid to null; the owner
+		// check is then skipped rather than throwing against an undefined uid.
+		await expect(ensureSecureDir(dir, { currentUid: null })).resolves.toBe(dir);
 	});
 });
 

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	assertSecureDirIfPresent,
 	ensureSecureDir,
 	INSTANCE_MARKER_FILE,
 	parseArgs,
@@ -120,15 +121,15 @@ describe("ensureSecureDir", () => {
 		}
 	});
 
-	it("tightens a pre-existing group/world-accessible dir we own", async () => {
+	it("rejects a pre-existing group/world-accessible dir (planted-child race)", async () => {
 		const root = await makeTempDir("quickadd-secure");
 		const dir = path.join(root, "loose");
 		await fs.mkdir(dir, { recursive: true });
 		await fs.chmod(dir, 0o777);
 
-		await ensureSecureDir(dir);
-
-		expect((await fs.lstat(dir)).mode & 0o077).toBe(0);
+		// A loose dir may already hold a foreign-planted child symlink that a parent
+		// chmod would not undo, so we refuse it outright rather than "repair" it.
+		await expect(ensureSecureDir(dir)).rejects.toThrow(/group\/other-accessible/);
 	});
 
 	it("refuses a symlink at the profile path (never follows it)", async () => {
@@ -162,6 +163,37 @@ describe("ensureSecureDir", () => {
 		// Platforms without process.getuid resolve currentUid to null; the owner
 		// check is then skipped rather than throwing against an undefined uid.
 		await expect(ensureSecureDir(dir, { currentUid: null })).resolves.toBe(dir);
+	});
+});
+
+describe("assertSecureDirIfPresent", () => {
+	it("returns false for an absent dir without creating it", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const dir = path.join(root, "missing");
+
+		await expect(assertSecureDirIfPresent(dir)).resolves.toBe(false);
+		// Teardown must not create the root it is asked to clean up.
+		await expect(fs.lstat(dir)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("accepts an existing private dir we own", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const dir = path.join(root, "ours");
+		await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+		await expect(assertSecureDirIfPresent(dir)).resolves.toBe(true);
+	});
+
+	it("refuses a symlinked profile root (teardown must not traverse it)", async () => {
+		const root = await makeTempDir("quickadd-secure");
+		const target = path.join(root, "attacker-owned");
+		await fs.mkdir(target, { recursive: true });
+		const link = path.join(root, "profile-root");
+		await fs.symlink(target, link);
+
+		await expect(assertSecureDirIfPresent(link)).rejects.toThrow(
+			/symlink or not a regular directory/,
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

Hardens two MEDIUM dev/CI hygiene findings from the security scan. Both are **defense-in-depth** for the build/release toolchain, not user-facing plugin behavior, and both are assessed honestly against QuickAdd's threat model below. No legitimate local/dev functionality is weakened - the live Obsidian e2e harness still launches and `quickadd:list` returns `ok:true`, and the release push path is unchanged.

## Finding 1 - Release-bot token persisted to disk before untrusted install/build/test (`.github/workflows/release.yml`)

**The gap (real):** the Release job mints a GitHub App token - the *"QuickAdd Release Bot"*, a branch-protection **bypass actor** - and checked out *with* `persist-credentials` defaulting to `true`, writing the App credential into `.git/config` (`http.extraheader`). `pnpm install --frozen-lockfile` (which runs dependency lifecycle scripts), `pnpm run build`, and `pnpm run test` then run **before** semantic-release consumes the token, so a compromised dependency's postinstall could read it off disk. The token was also over-scoped: `create-github-app-token` was called with no `permission-*` inputs, so it inherited **all** of the App's installation permissions. Every other workflow in the repo (`ci.yml`, `codeql.yml`, `dependency-review.yml`) already sets `persist-credentials: false` - this was the lone gap.

**Fix:**
1. `persist-credentials: false` on the app-token checkout. The token is still passed (checkout fetches as the App), but it is no longer written to `.git/config`. The push still works: semantic-release authenticates from the `GITHUB_TOKEN` env on the Release step - it overwrites `options.repositoryUrl` with a token-embedded `x-access-token:` URL (`semantic-release/index.js:67` + `lib/get-git-auth-url.js:69,99-102`) and never reads `.git/config`.
2. Scope the minted token to `permission-contents/issues/pull-requests: write` (the complete set semantic-release uses: push commit/tag + create Release via `contents`; comment on released issues/PRs via `issues`/`pull-requests`). Attestation, Find-PR, and Comment-on-PR all use the default `GITHUB_TOKEN`, not this token.

`harden-runner` is deliberately left on `egress-policy: audit`: switching to `block` needs an allowlist of every endpoint a real release touches (GitHub API, codeload, npm registry, asset-upload host, Sigstore) and silently breaks releases if incomplete - it cannot be validated without a real release run, and the disk-exposure window is already closed by (1).

## Finding 2 - Predictable `/tmp` profile dir holding a symlink to the real keychain (`scripts/start-obsidian-e2e-instance.mjs`)

**The gap (low likelihood, real pattern):** the e2e profile root defaults to `/tmp/quickadd-obsidian-e2e` (world-writable parent) and symlinks the real `~/Library/Keychains` into a `HOME` Obsidian launches with. `fs.mkdir(..., {recursive})` is a no-op for ownership/mode on a pre-existing dir, so a co-located actor on a shared/reused host could temp-squat the predictable root before the victim's first run and TOCTOU-hijack the keychain-bearing writes. This is a **dev/CI harness on macOS, not the shipped plugin**; the common single-user-dev case has no attacker. But the asset (the login keychain) and the recognized insecure-temp pattern justify proportionate hardening.

**Fix - `ensureSecureDir` (fail-closed), not a redesign:**
- `lstat` **first** so we never `mkdir` through a pre-existing symlink; create only when absent; then assert the dir is a real directory we own with **no** group/other access. A symlink, a foreign owner, or a loose mode is **rejected** (not chmod-repaired - see review note). A `0o700`-owned dir cannot have foreign-planted children, so descending into it is then safe.
- Applied parent-first (`profileRoot` before `instancePath`) in `prepareObsidianProfile`, before the reaper in both mains, in `launchObsidianInstance`, and - validate-only via `assertSecureDirIfPresent` - in the stop/reap teardown paths.
- The `/tmp` default and the stable instance-id layout are **kept**. Moving the root under `os.tmpdir()` was prototyped and **reproduced to break the harness**: `/var/folders/.../T` pushes Obsidian's `$HOME/.obsidian-cli.sock` past the macOS 104-byte `sun_path` limit (`EINVAL`), and vitest wouldn't catch it. The keychain symlink is load-bearing (SecretStorage parity, pinned by tests) and is left intact; the temp-dir guard removes the hijack vector without touching it.

## Exploit / mitigation evidence (run live in this worktree's isolated vault)

- **Legitimate path intact:** `pnpm run obsidian:e2e -- quickadd:list` launches Obsidian and returns `{"ok":true,"command":"quickadd:list","count":0,"choices":[]}`; `pnpm run stop:e2e-obsidian` terminates the process tree and removes the instance dir.
- **Temp-squat refused, no write-through:** a symlinked profile root makes both `start` and `stop --prune` abort with `Refusing to use <path>: it is a symlink or not a regular directory.`, and the symlink target stays empty.
- **Release auth unchanged:** verified at the installed `semantic-release@25.0.5` source that the push URL is built from `GITHUB_TOKEN`, independent of `.git/config`.

## Regression tests (fail without the fix)

- `tests/release-workflow-hardening.test.ts` - asserts `persist-credentials: false`, the retained `token:` line, and the three scoped `permission-*` inputs, anchored to real YAML lines with full-line comments stripped (a commented-out guard cannot satisfy it). RED on `master` (all four guard strings absent), GREEN here.
- `tests/start-obsidian-e2e-instance.test.ts` - `ensureSecureDir` / `assertSecureDirIfPresent`: fresh -> `0o700`/ours, loose -> **rejected**, symlink -> rejected (no write-through), foreign uid -> rejected, `currentUid:null` -> owner-check skipped, absent -> `false` without creating. The symlink + foreign-uid cases are RED when the guards are removed.

## Process

Threat-model judgment and fix design were validated by an adversarial reviewer fleet **before** coding (it caught and rejected the `os.tmpdir()` break), and the implemented diff was reviewed by three opposite-model (Codex) reviewers (skeptic/architect/minimalist) whose consensus findings - reject-only over chmod-repair, guard the teardown paths, anchor the YAML test - are folded in.

**Gates:** `tsc -noEmit`, `eslint .`, `svelte-check` (0 errors), full vitest (3179 passed / 37 skipped) all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened the release automation workflow to avoid writing privileged credentials to local Git config and to apply least-privilege permissions for the minted app token.
  * Added stricter validation for Obsidian E2E profile/instance directories, rejecting symlinked or insecurely owned locations and refusing cleanup/start operations when the profile root is not trusted.

* **Tests**
  * Added security-focused tests to ensure the release workflow stays hardened and to verify directory security behavior (creation, ownership, permissions, and symlink rejection).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->