### PR TITLE
fix(security): contain untrusted package-import paths to the vault

### DIFF
--- a/src/ai/tools/builtins/vaultTools.ts
+++ b/src/ai/tools/builtins/vaultTools.ts
@@ -13,7 +13,7 @@ import { type App, TFile } from "obsidian";
 import { getMarkdownFilesInFolder } from "../../../utilityObsidian";
 import { insertAtNoteBodyStart } from "../../../utils/noteContentInsertion";
 import { sanitizeVaultPath } from "../sanitizeVaultPath";
-import { assertWriteStaysInVault } from "./vaultWriteGuards";
+import { assertWriteStaysInVault } from "../../../utils/vaultWriteGuards";
 import type { JSONSchema } from "../NormalizedTools";
 import type { QATool } from "../aiToolTypes";
 import { applyGroupOptions, type BuiltinGroupOptions, type ToolSetMap } from "./shared";

--- a/src/ai/tools/sanitizeVaultPath.ts
+++ b/src/ai/tools/sanitizeVaultPath.ts
@@ -17,7 +17,7 @@
  *
  * This module is PURE (no Obsidian import) so it is fully unit-testable. The
  * symlink / realpath-containment check that writers MUST also perform needs the
- * FileSystemAdapter and lives with the writers (see builtins/vaultWriteGuards.ts).
+ * FileSystemAdapter and lives in the shared util (see utils/vaultWriteGuards.ts).
  */
 import {
 	INVALID_FOLDER_CHARS_REGEX,

--- a/src/gui/PackageManager/importDecisions.test.ts
+++ b/src/gui/PackageManager/importDecisions.test.ts
@@ -216,3 +216,45 @@ describe("ExistenceResolver — monotonic token (regression: re-paste race)", ()
 		expect(result).toBe(true);
 	});
 });
+
+describe("ExistenceResolver — vault-boundary containment (security)", () => {
+	function spyApp() {
+		// adapter.exists would happily stat anything (incl. out-of-vault) and the
+		// index lookup would too — so the spies prove the boundary check, not luck.
+		const exists = vi.fn(async () => true);
+		const getAbstractFileByPath = vi.fn(() => ({}) as unknown);
+		const app = {
+			vault: { getAbstractFileByPath, adapter: { exists } },
+		} as unknown as App;
+		return { app, exists, getAbstractFileByPath };
+	}
+	const flush = () => new Promise((r) => setTimeout(r, 0));
+
+	it("never stats an out-of-vault destination and reports it not-present", async () => {
+		const { app, exists } = spyApp();
+		const resolver = new ExistenceResolver(app);
+		const escaping = "../../../etc/passwd";
+		let result: boolean | undefined;
+		resolver.schedule(escaping, escaping, (e) => (result = e));
+		await flush();
+		expect(result).toBe(false);
+		expect(exists).not.toHaveBeenCalled();
+	});
+
+	it("optimistic() reports an out-of-vault path not-present without an index lookup", () => {
+		const { app, getAbstractFileByPath } = spyApp();
+		const resolver = new ExistenceResolver(app);
+		expect(resolver.optimistic("/etc/passwd")).toBe(false);
+		expect(getAbstractFileByPath).not.toHaveBeenCalled();
+	});
+
+	it("still resolves a legitimate in-vault path via the adapter", async () => {
+		const { app, exists } = spyApp();
+		const resolver = new ExistenceResolver(app);
+		let result: boolean | undefined;
+		resolver.schedule("scripts/x.js", "scripts/x.js", (e) => (result = e));
+		await flush();
+		expect(exists).toHaveBeenCalledWith("scripts/x.js");
+		expect(result).toBe(true);
+	});
+});

--- a/src/gui/PackageManager/importDecisions.ts
+++ b/src/gui/PackageManager/importDecisions.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
 import { normalizePath } from "obsidian";
+import { escapesVaultBoundary } from "../../utils/vaultPathBoundary";
 import type {
 	AssetImportMode,
 	AssetImportDecision,
@@ -248,6 +249,8 @@ export class ExistenceResolver {
 	optimistic(path: string): boolean {
 		const trimmed = path.trim();
 		if (!trimmed) return false;
+		// Untrusted package paths that escape the vault are never "present".
+		if (escapesVaultBoundary(trimmed)) return false;
 		return Boolean(
 			this.app.vault.getAbstractFileByPath(normalizePath(trimmed)),
 		);
@@ -256,6 +259,9 @@ export class ExistenceResolver {
 	private async resolve(path: string): Promise<boolean> {
 		const trimmed = path.trim();
 		if (!trimmed) return false;
+		// Never stat an out-of-vault path from an untrusted package: a crafted
+		// destination like "../../../etc/passwd" must not reach the filesystem.
+		if (escapesVaultBoundary(trimmed)) return false;
 		try {
 			return await this.app.vault.adapter.exists(normalizePath(trimmed));
 		} catch {

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -489,12 +489,67 @@ describe("asset write containment (security)", () => {
 		// All-or-nothing: the lexically-safe, FIRST-ordered asset is NOT written,
 		// proving the guard ran as a pre-pass (not inline per-asset).
 		expect(state.writes.size).toBe(0);
-		// Wired with the resolved DESTINATION path, for every asset.
+		// Wired with the resolved DESTINATION path, for every written asset.
 		expect(assertWriteStaysInVault).toHaveBeenCalledWith(app, "scripts/safe.js");
 		expect(assertWriteStaysInVault).toHaveBeenCalledWith(
 			app,
 			"scripts/escapes.js",
 		);
+	});
+
+	it("does not realpath-guard an explicitly skipped asset (skip the unsafe, import the rest)", async () => {
+		const { app, state } = createFakeApp();
+		// The skipped asset's destination "escapes"; the guard would throw for it.
+		vi.mocked(assertWriteStaysInVault).mockImplementation(
+			async (_app, destinationPath) => {
+				if (destinationPath === "linked/evil.js") {
+					throw new Error(
+						`Refusing to write to "${destinationPath}": resolves outside the vault.`,
+					);
+				}
+			},
+		);
+
+		const pkg = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "scripts/safe.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("safe"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "linked/evil.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("evil"),
+				},
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions: [
+				{
+					originalPath: "linked/evil.js",
+					destinationPath: "linked/evil.js",
+					mode: "skip",
+				},
+			],
+		});
+
+		// The unsafe asset is skipped (never guarded, never written); the rest imports.
+		expect(result.writtenAssets).toEqual(["scripts/safe.js"]);
+		expect(result.skippedAssets).toEqual(["linked/evil.js"]);
+		expect(state.writes.has("scripts/safe.js")).toBe(true);
+		expect(assertWriteStaysInVault).not.toHaveBeenCalledWith(
+			app,
+			"linked/evil.js",
+		);
+		expect(assertWriteStaysInVault).toHaveBeenCalledWith(app, "scripts/safe.js");
 	});
 });
 

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -24,12 +24,24 @@ vi.mock("uuid", () => ({
 	v4: () => `uuid-${++uuidMock.counter}`,
 }));
 
+// The realpath/symlink write guard is desktop-only and a no-op against the
+// plain-object test adapter. Mock it so we can (a) keep that no-op default and
+// (b) assert how applyPackageImport WIRES it (called with destinations, as an
+// all-or-nothing pre-pass before any write). The guard's real containment logic
+// is covered by src/utils/vaultWriteGuards.test.ts with an actual symlink.
+vi.mock("../utils/vaultWriteGuards", () => ({
+	assertWriteStaysInVault: vi.fn(async () => {}),
+	VaultWriteEscapeError: class VaultWriteEscapeError extends Error {},
+}));
+
 import {
 	parseQuickAddPackage,
 	readQuickAddPackage,
 	analysePackage,
+	analysePackagePreview,
 	applyPackageImport,
 } from "./packageImportService";
+import { assertWriteStaysInVault } from "../utils/vaultWriteGuards";
 import type {
 	ChoiceImportDecision,
 	AssetImportDecision,
@@ -48,6 +60,7 @@ interface FakeVaultState {
 function createFakeApp(initialExisting: string[] = []): {
 	app: App;
 	state: FakeVaultState;
+	adapter: { exists: ReturnType<typeof vi.fn> };
 } {
 	const state: FakeVaultState = {
 		existingPaths: new Set(initialExisting),
@@ -85,7 +98,7 @@ function createFakeApp(initialExisting: string[] = []): {
 		},
 	} as unknown as App;
 
-	return { app, state };
+	return { app, state, adapter };
 }
 
 // --- Fixture builders -------------------------------------------------------
@@ -150,6 +163,10 @@ function decisions(
 
 beforeEach(() => {
 	uuidMock.counter = 0;
+	// Default the write guard back to a no-op so a per-test override (the
+	// pre-pass wiring test) never leaks into other cases.
+	vi.mocked(assertWriteStaysInVault).mockReset();
+	vi.mocked(assertWriteStaysInVault).mockImplementation(async () => {});
 });
 
 // --- parseQuickAddPackage ---------------------------------------------------
@@ -319,6 +336,165 @@ describe("analysePackage", () => {
 			{ originalPath: "scripts/exists.js", exists: true, kind: "user-script" },
 			{ originalPath: "templates/new.md", exists: false, kind: "template" },
 		]);
+	});
+});
+
+// --- Path-traversal containment (security) ----------------------------------
+
+describe("existence probes stay inside the vault boundary", () => {
+	const ESCAPING_PATHS = [
+		"../../../etc/passwd",
+		"/etc/passwd",
+		"C:\\Windows\\System32\\drivers\\etc\\hosts",
+		"\\\\server\\share\\secret",
+	];
+
+	it("never stats an out-of-vault asset originalPath in analysePackage", async () => {
+		const { app, adapter } = createFakeApp();
+		const pkg = makePackage({
+			assets: ESCAPING_PATHS.map((originalPath) => ({
+				kind: "template" as const,
+				originalPath,
+				contentEncoding: "base64" as const,
+				content: "",
+			})),
+		});
+
+		const analysis = await analysePackage(app, [], pkg);
+
+		// Each escaping path is reported as not-present WITHOUT a filesystem probe.
+		for (const originalPath of ESCAPING_PATHS) {
+			expect(adapter.exists).not.toHaveBeenCalledWith(originalPath);
+			expect(
+				analysis.assetConflicts.find((c) => c.originalPath === originalPath)
+					?.exists,
+			).toBe(false);
+		}
+	});
+
+	it("never stats an out-of-vault path in analysePackagePreview and surfaces it as missing", async () => {
+		const { app, adapter } = createFakeApp();
+		// A choice that REFERENCES (does not bundle) an out-of-vault template path.
+		const escaping = "../../../etc/passwd";
+		const templateChoice = makeChoice("t", "T", "Template", {
+			templatePath: escaping,
+		} as Partial<IChoice>);
+		const pkg = makePackage({
+			rootChoiceIds: ["t"],
+			choices: [makePackageChoice(templateChoice)],
+		});
+
+		const preview = await analysePackagePreview(app, [], pkg);
+
+		expect(adapter.exists).not.toHaveBeenCalledWith(escaping);
+		// Honest preview: an out-of-vault reference is "missing", never silently
+		// reported as a present/reused vault file.
+		expect(preview.missingReferences.map((m) => m.path)).toContain(escaping);
+	});
+
+	it("still probes in-vault config-dir references (no over-rejection)", async () => {
+		const inVaultDotDir = ".obsidian/snippets/x.js";
+		const { app, adapter } = createFakeApp([inVaultDotDir]);
+		const templateChoice = makeChoice("t", "T", "Template", {
+			templatePath: inVaultDotDir,
+		} as Partial<IChoice>);
+		const pkg = makePackage({
+			rootChoiceIds: ["t"],
+			choices: [makePackageChoice(templateChoice)],
+		});
+
+		const preview = await analysePackagePreview(app, [], pkg);
+
+		// The in-vault dot-dir path IS probed and recognized as present, so it is
+		// NOT mislabeled as a missing reference.
+		expect(adapter.exists).toHaveBeenCalledWith(inVaultDotDir);
+		expect(preview.missingReferences.map((m) => m.path)).not.toContain(
+			inVaultDotDir,
+		);
+	});
+});
+
+describe("asset write containment (security)", () => {
+	it("rejects writing into a NESTED config/hidden directory", async () => {
+		for (const originalPath of [
+			"notes/.git/hooks/post-commit",
+			"docs/.obsidian/plugins/x/main.js",
+			"a/b/.trash/x.md",
+		]) {
+			const { app, state } = createFakeApp();
+			const pkg = makePackage({
+				assets: [
+					{
+						kind: "template",
+						originalPath,
+						contentEncoding: "base64",
+						content: encodeToBase64("payload"),
+					},
+				],
+			});
+
+			await expect(
+				applyPackageImport({
+					app,
+					existingChoices: [],
+					pkg,
+					choiceDecisions: [],
+					assetDecisions: [],
+				}),
+			).rejects.toThrow(/config directory/);
+			expect(state.writes.size).toBe(0);
+		}
+	});
+
+	it("runs the realpath guard as an all-or-nothing pre-pass before any write", async () => {
+		const { app, state } = createFakeApp();
+		// Second asset's destination "escapes"; the guard (mocked) throws for it.
+		vi.mocked(assertWriteStaysInVault).mockImplementation(
+			async (_app, destinationPath) => {
+				if (destinationPath === "scripts/escapes.js") {
+					throw new Error(
+						`Refusing to write to "${destinationPath}": it resolves (via a symlink) outside the vault.`,
+					);
+				}
+			},
+		);
+
+		const pkg = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "scripts/safe.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("safe"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "scripts/escapes.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("evil"),
+				},
+			],
+		});
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [],
+			}),
+		).rejects.toThrow(/outside the vault/);
+
+		// All-or-nothing: the lexically-safe, FIRST-ordered asset is NOT written,
+		// proving the guard ran as a pre-pass (not inline per-asset).
+		expect(state.writes.size).toBe(0);
+		// Wired with the resolved DESTINATION path, for every asset.
+		expect(assertWriteStaysInVault).toHaveBeenCalledWith(app, "scripts/safe.js");
+		expect(assertWriteStaysInVault).toHaveBeenCalledWith(
+			app,
+			"scripts/escapes.js",
+		);
 	});
 });
 

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -497,9 +497,12 @@ describe("asset write containment (security)", () => {
 		);
 	});
 
-	it("does not realpath-guard an explicitly skipped asset (skip the unsafe, import the rest)", async () => {
+	it("aborts on a vault-escaping destination even when that asset is marked skip", async () => {
+		// Consistency: the lexical guard already aborts the whole import on an
+		// absolute/".." destination regardless of mode; the realpath pre-pass does
+		// the same for a symlink escape. A package carrying a vault-escaping asset is
+		// refused wholesale and surfaced loudly, not silently dropped via "skip".
 		const { app, state } = createFakeApp();
-		// The skipped asset's destination "escapes"; the guard would throw for it.
 		vi.mocked(assertWriteStaysInVault).mockImplementation(
 			async (_app, destinationPath) => {
 				if (destinationPath === "linked/evil.js") {
@@ -527,29 +530,56 @@ describe("asset write containment (security)", () => {
 			],
 		});
 
-		const result = await applyPackageImport({
-			app,
-			existingChoices: [],
-			pkg,
-			choiceDecisions: [],
-			assetDecisions: [
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [
+					{
+						originalPath: "linked/evil.js",
+						destinationPath: "linked/evil.js",
+						mode: "skip",
+					},
+				],
+			}),
+		).rejects.toThrow(/outside the vault/);
+
+		// All-or-nothing: nothing is written, including the lexically-safe asset.
+		expect(state.writes.size).toBe(0);
+	});
+
+	it("aborts on a lexically-unsafe destination even when that asset is marked skip", async () => {
+		// Documents the pre-existing lexical behavior the realpath pre-pass matches.
+		const { app, state } = createFakeApp();
+		const pkg = makePackage({
+			assets: [
 				{
-					originalPath: "linked/evil.js",
-					destinationPath: "linked/evil.js",
-					mode: "skip",
+					kind: "template",
+					originalPath: "../evil.md",
+					contentEncoding: "base64",
+					content: encodeToBase64("evil"),
 				},
 			],
 		});
 
-		// The unsafe asset is skipped (never guarded, never written); the rest imports.
-		expect(result.writtenAssets).toEqual(["scripts/safe.js"]);
-		expect(result.skippedAssets).toEqual(["linked/evil.js"]);
-		expect(state.writes.has("scripts/safe.js")).toBe(true);
-		expect(assertWriteStaysInVault).not.toHaveBeenCalledWith(
-			app,
-			"linked/evil.js",
-		);
-		expect(assertWriteStaysInVault).toHaveBeenCalledWith(app, "scripts/safe.js");
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [
+					{
+						originalPath: "../evil.md",
+						destinationPath: "../evil.md",
+						mode: "skip",
+					},
+				],
+			}),
+		).rejects.toThrow(/traversal|\.\./);
+		expect(state.writes.size).toBe(0);
 	});
 });
 

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -156,7 +156,7 @@ export async function analysePackage(
 		// Treat it as not-present (the write path rejects it anyway).
 		const exists = escapesVaultBoundary(asset.originalPath)
 			? false
-			: await assetExists(app, asset.originalPath);
+			: await app.vault.adapter.exists(asset.originalPath);
 		assetConflicts.push({
 			originalPath: asset.originalPath,
 			exists,
@@ -502,12 +502,14 @@ export async function applyPackageImport(
 		return { asset, destinationPath };
 	});
 
-	// Symlink/realpath containment, as a PRE-PASS before any write so the import
-	// is all-or-nothing (matching the lexical validation above): if a destination
-	// resolves through a pre-existing in-vault symlink to outside the vault, abort
-	// before touching disk rather than after partially writing earlier assets.
+	// Symlink/realpath containment: reject BEFORE any write so a destination that
+	// resolves through a pre-existing in-vault symlink to outside the vault aborts
+	// the import without first writing earlier (safe) assets. Only assets that will
+	// actually be written are checked — an explicitly skipped asset is never
+	// written, so the user can still skip an unsafe asset and import the rest.
 	// Desktop-only; a no-op on mobile and in tests (non-FileSystemAdapter).
-	for (const { destinationPath } of resolvedAssetDestinations) {
+	for (const { asset, destinationPath } of resolvedAssetDestinations) {
+		if (assetDecisionMap.get(asset.originalPath)?.mode === "skip") continue;
 		await assertWriteStaysInVault(app, destinationPath);
 	}
 

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -22,6 +22,8 @@ import { log } from "../logger/logManager";
 import { decodeFromBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
 import { ensureParentFolders } from "../utils/ensureParentFolders";
+import { assertWriteStaysInVault } from "../utils/vaultWriteGuards";
+import { escapesVaultBoundary } from "../utils/vaultPathBoundary";
 import {
 	detectUserScriptSecretOptions,
 	stripUserScriptSecretRefsFromCommand,
@@ -149,7 +151,12 @@ export async function analysePackage(
 
 	const assetConflicts: AssetConflict[] = [];
 	for (const asset of pkg.assets) {
-		const exists = await app.vault.adapter.exists(asset.originalPath);
+		// Never stat an out-of-vault path from an untrusted package: a crafted
+		// originalPath like "../../../etc/passwd" must not reach the filesystem.
+		// Treat it as not-present (the write path rejects it anyway).
+		const exists = escapesVaultBoundary(asset.originalPath)
+			? false
+			: await assetExists(app, asset.originalPath);
 		assetConflicts.push({
 			originalPath: asset.originalPath,
 			exists,
@@ -183,6 +190,11 @@ export async function analysePackagePreview(
 	await Promise.all(
 		Array.from(candidatePaths, async (path) => {
 			if (!path) return;
+			// Out-of-vault paths from an untrusted package never reach the
+			// filesystem; leaving them out of existsByPath surfaces them honestly
+			// as missing/orphan references in the preview instead of stat-probing
+			// (and possibly mislabeling an outside file as "present").
+			if (escapesVaultBoundary(path)) return;
 			if (await assetExists(app, path)) existsByPath.add(path);
 		}),
 	);
@@ -236,7 +248,18 @@ function validateAssetDestination(rawPath: string): string {
 		);
 	}
 
-	if (segments[0]?.startsWith(".") && !segments[0].startsWith("..%")) {
+	// Reject a leading-dot config/hidden directory at ANY depth, not just the
+	// first segment: "notes/.git/hooks/post-commit" or "docs/.obsidian/plugins/
+	// x/main.js" would otherwise pass (segments[0] is "notes"/"docs") yet drop a
+	// code-execution payload into a trusted dir on the real filesystem — a vector
+	// the realpath guard can't see because the target stays inside the vault. The
+	// check is structural (segment starts with "."), so casing variants
+	// (.Obsidian) are caught too. The "..%"-prefix carve-out keeps url-encoded
+	// traversal text (e.g. "..%2fevil.md") importable as a benign literal filename.
+	const configSegment = segments.find(
+		(segment) => segment.startsWith(".") && !segment.startsWith("..%"),
+	);
+	if (configSegment) {
 		throw new Error(
 			`Refusing to import asset into a config directory: "${normalized}".`,
 		);
@@ -478,6 +501,15 @@ export async function applyPackageImport(
 		);
 		return { asset, destinationPath };
 	});
+
+	// Symlink/realpath containment, as a PRE-PASS before any write so the import
+	// is all-or-nothing (matching the lexical validation above): if a destination
+	// resolves through a pre-existing in-vault symlink to outside the vault, abort
+	// before touching disk rather than after partially writing earlier assets.
+	// Desktop-only; a no-op on mobile and in tests (non-FileSystemAdapter).
+	for (const { destinationPath } of resolvedAssetDestinations) {
+		await assertWriteStaysInVault(app, destinationPath);
+	}
 
 	for (const { asset, destinationPath } of resolvedAssetDestinations) {
 		const decision = assetDecisionMap.get(asset.originalPath);

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -502,14 +502,15 @@ export async function applyPackageImport(
 		return { asset, destinationPath };
 	});
 
-	// Symlink/realpath containment: reject BEFORE any write so a destination that
-	// resolves through a pre-existing in-vault symlink to outside the vault aborts
-	// the import without first writing earlier (safe) assets. Only assets that will
-	// actually be written are checked — an explicitly skipped asset is never
-	// written, so the user can still skip an unsafe asset and import the rest.
+	// Symlink/realpath containment, as a PRE-PASS before any write: if a
+	// destination resolves through a pre-existing in-vault symlink to outside the
+	// vault, abort the whole import before touching disk. Every destination is
+	// checked (mirroring the lexical validateAssetDestination pass above), so a
+	// package carrying a vault-escaping asset is refused wholesale and surfaced
+	// loudly rather than silently dropped — consistent with how an absolute/".."
+	// destination already aborts regardless of the per-asset import mode.
 	// Desktop-only; a no-op on mobile and in tests (non-FileSystemAdapter).
-	for (const { asset, destinationPath } of resolvedAssetDestinations) {
-		if (assetDecisionMap.get(asset.originalPath)?.mode === "skip") continue;
+	for (const { destinationPath } of resolvedAssetDestinations) {
 		await assertWriteStaysInVault(app, destinationPath);
 	}
 

--- a/src/utils/vaultPathBoundary.test.ts
+++ b/src/utils/vaultPathBoundary.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { escapesVaultBoundary } from "./vaultPathBoundary";
+
+describe("escapesVaultBoundary", () => {
+	it("rejects POSIX-absolute paths", () => {
+		expect(escapesVaultBoundary("/etc/passwd")).toBe(true);
+		expect(escapesVaultBoundary("/")).toBe(true);
+	});
+
+	it("rejects Windows drive and drive-relative paths", () => {
+		expect(escapesVaultBoundary("C:\\Windows\\System32\\x")).toBe(true);
+		expect(escapesVaultBoundary("C:/Windows/x")).toBe(true);
+		expect(escapesVaultBoundary("C:foo")).toBe(true);
+	});
+
+	it("rejects backslash-normalized UNC paths", () => {
+		expect(escapesVaultBoundary("\\\\server\\share\\x")).toBe(true);
+	});
+
+	it("rejects '..' traversal at any depth and with any separator", () => {
+		expect(escapesVaultBoundary("../escape.md")).toBe(true);
+		expect(escapesVaultBoundary("../../../etc/passwd")).toBe(true);
+		expect(escapesVaultBoundary("notes/../../escape.md")).toBe(true);
+		expect(escapesVaultBoundary("..\\..\\escape.md")).toBe(true);
+	});
+
+	it("allows in-vault relative paths, including dot/config dirs", () => {
+		expect(escapesVaultBoundary("templates/note.md")).toBe(false);
+		expect(escapesVaultBoundary("scripts/run.js")).toBe(false);
+		// Probing an in-vault config-dir file is in-bounds; only the WRITE path
+		// forbids dropping INTO config dirs.
+		expect(escapesVaultBoundary(".obsidian/plugins/x/script.js")).toBe(false);
+		expect(escapesVaultBoundary("notes/.git/HEAD")).toBe(false);
+	});
+
+	it("treats url-encoded traversal text as a benign literal segment", () => {
+		// "%2f" is never decoded into a slash, so this is one literal filename
+		// inside the vault — not a traversal.
+		expect(escapesVaultBoundary("..%2fevil.md")).toBe(false);
+	});
+
+	it("does not treat an empty path as an escape", () => {
+		expect(escapesVaultBoundary("")).toBe(false);
+		expect(escapesVaultBoundary("   ")).toBe(false);
+	});
+});

--- a/src/utils/vaultPathBoundary.ts
+++ b/src/utils/vaultPathBoundary.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure lexical vault-boundary checks for untrusted package paths.
+ *
+ * An imported QuickAdd package is untrusted data; its asset `originalPath` and
+ * referenced template/script paths are attacker-controlled strings. The write
+ * path confines them with {@link validateAssetDestination} (which throws), but
+ * the preview/analysis phase only needs a cheap boolean: "would probing this
+ * path's existence escape the vault?". {@link escapesVaultBoundary} answers that
+ * without throwing and without touching the filesystem, so callers can skip the
+ * `adapter.exists` probe (treating an out-of-vault path as not-present) instead
+ * of issuing an `fs.stat` outside the vault boundary.
+ *
+ * CRITICAL ordering invariant: the absolute-path check runs on the raw string
+ * (after backslash→'/') BEFORE any call to Obsidian's `normalizePath`, which
+ * strips leading slashes and would silently turn "/etc/passwd" into the in-vault
+ * "etc/passwd". This mirrors `sanitizeVaultPath`/`validateAssetDestination`.
+ *
+ * Unlike the write validator, this does NOT reject in-vault dot/config dirs:
+ * probing `.obsidian/x` is in-bounds and harmless, and a legitimate package may
+ * reference an existing config-dir file — rejecting it would mislabel a present
+ * reference as "missing". The only concern here is escaping the vault.
+ */
+
+/** Trim and convert backslashes to '/'. Does NOT resolve '.'/'..' or strip
+ * slashes, so absolute/traversal markers survive for the checks below. */
+export function toSlashedPath(rawPath: string): string {
+	return (rawPath ?? "").trim().replace(/\\/g, "/");
+}
+
+/** True for POSIX-absolute ("/x", and backslash-normalized UNC "//host/share"),
+ * Windows drive ("C:\\x" → "C:/x") and drive-relative ("C:x") paths. Expects a
+ * backslash-normalized string (see {@link toSlashedPath}). */
+export function isAbsoluteVaultPath(slashedPath: string): boolean {
+	return slashedPath.startsWith("/") || /^[a-zA-Z]:/.test(slashedPath);
+}
+
+/** True if any '/'-separated segment is exactly "..", i.e. a path-traversal
+ * segment at any depth. ("..%2fevil.md" is a single literal segment, NOT "..".) */
+export function hasTraversalSegment(slashedPath: string): boolean {
+	return slashedPath.split("/").some((segment) => segment === "..");
+}
+
+/**
+ * Does this raw (untrusted) path escape the vault boundary? Rejects absolute /
+ * drive / UNC paths and any ".." traversal segment; allows in-vault dot-dirs.
+ * Pure: no filesystem access, no Obsidian dependency.
+ */
+export function escapesVaultBoundary(rawPath: string): boolean {
+	const slashed = toSlashedPath(rawPath);
+	if (!slashed) return false;
+	return isAbsoluteVaultPath(slashed) || hasTraversalSegment(slashed);
+}

--- a/src/utils/vaultPathBoundary.ts
+++ b/src/utils/vaultPathBoundary.ts
@@ -21,22 +21,27 @@
  * reference as "missing". The only concern here is escaping the vault.
  */
 
+// These primitives are intentionally NOT exported: each is only safe in the
+// fixed order escapesVaultBoundary applies them (e.g. hasTraversalSegment must
+// run on a backslash-normalized string). Exporting them invites a caller to use
+// one in isolation and silently reopen a bypass. Export only escapesVaultBoundary.
+
 /** Trim and convert backslashes to '/'. Does NOT resolve '.'/'..' or strip
  * slashes, so absolute/traversal markers survive for the checks below. */
-export function toSlashedPath(rawPath: string): string {
+function toSlashedPath(rawPath: string): string {
 	return (rawPath ?? "").trim().replace(/\\/g, "/");
 }
 
 /** True for POSIX-absolute ("/x", and backslash-normalized UNC "//host/share"),
  * Windows drive ("C:\\x" → "C:/x") and drive-relative ("C:x") paths. Expects a
  * backslash-normalized string (see {@link toSlashedPath}). */
-export function isAbsoluteVaultPath(slashedPath: string): boolean {
+function isAbsoluteVaultPath(slashedPath: string): boolean {
 	return slashedPath.startsWith("/") || /^[a-zA-Z]:/.test(slashedPath);
 }
 
 /** True if any '/'-separated segment is exactly "..", i.e. a path-traversal
  * segment at any depth. ("..%2fevil.md" is a single literal segment, NOT "..".) */
-export function hasTraversalSegment(slashedPath: string): boolean {
+function hasTraversalSegment(slashedPath: string): boolean {
 	return slashedPath.split("/").some((segment) => segment === "..");
 }
 

--- a/src/utils/vaultWriteGuards.test.ts
+++ b/src/utils/vaultWriteGuards.test.ts
@@ -99,6 +99,24 @@ describe("assertWriteStaysInVault (real symlink containment)", () => {
 		).rejects.toBeInstanceOf(VaultWriteEscapeError);
 	});
 
+	it("rejects a write that resolves (via an in-vault symlink) INTO a config dir", async () => {
+		// safe -> .obsidian/plugins/pkg (an in-vault symlink to a config dir). The
+		// literal "safe/main.js" has no dot segment so the lexical floor passes, and
+		// it stays inside the vault so the containment check passes — but the write
+		// would land in .obsidian/plugins. The resolved-segment dot check blocks it.
+		fs.mkdirSync(path.join(vaultDir, ".obsidian", "plugins", "pkg"), {
+			recursive: true,
+		});
+		fs.symlinkSync(
+			path.join(vaultDir, ".obsidian", "plugins", "pkg"),
+			path.join(vaultDir, "safe"),
+			"dir",
+		);
+		await expect(
+			assertWriteStaysInVault(app, "safe/main.js"),
+		).rejects.toBeInstanceOf(VaultWriteEscapeError);
+	});
+
 	it("fails closed when realpath cannot resolve an existing target (Linux ENOENT path)", async () => {
 		// Deterministically exercise the fail-closed branch on every platform: the
 		// target exists (lstat) but realpath throws. The pre-fix `.catch(() =>

--- a/src/utils/vaultWriteGuards.test.ts
+++ b/src/utils/vaultWriteGuards.test.ts
@@ -83,4 +83,51 @@ describe("assertWriteStaysInVault (real symlink containment)", () => {
 			assertWriteStaysInVault(plainApp, "../escape.js"),
 		).resolves.toBeUndefined();
 	});
+
+	it("rejects a write through a DANGLING in-vault symlink (target not yet created)", async () => {
+		// out.md -> ../outside/new.md, where new.md does NOT exist. A write still
+		// follows the symlink and lands outside. (macOS realpath resolves the path
+		// and the escape is caught; Linux realpath throws ENOENT and the fail-closed
+		// branch catches it — both must reject.)
+		fs.symlinkSync(
+			path.join(outsideDir, "new.md"),
+			path.join(vaultDir, "out.md"),
+			"file",
+		);
+		await expect(
+			assertWriteStaysInVault(app, "out.md"),
+		).rejects.toBeInstanceOf(VaultWriteEscapeError);
+	});
+
+	it("fails closed when realpath cannot resolve an existing target (Linux ENOENT path)", async () => {
+		// Deterministically exercise the fail-closed branch on every platform: the
+		// target exists (lstat) but realpath throws. The pre-fix `.catch(() =>
+		// probe)` fallback trusted the unresolved in-vault path and let it through.
+		const base = vaultDir;
+		const shimFs = {
+			promises: {
+				realpath: async (p: string) => {
+					if (p === base) return base;
+					throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+				},
+			},
+			lstatSync: () => ({}),
+		};
+		(window as unknown as { require: (m: string) => unknown }).require = (
+			mod: string,
+		) => {
+			if (mod === "fs") return shimFs;
+			if (mod === "path") return path;
+			throw new Error(`unexpected require(${mod})`);
+		};
+		const AdapterCtor = FileSystemAdapter as unknown as new (
+			basePath: string,
+		) => FileSystemAdapter;
+		const shimApp = {
+			vault: { adapter: new AdapterCtor(base) },
+		} as unknown as App;
+		await expect(
+			assertWriteStaysInVault(shimApp, "out.md"),
+		).rejects.toBeInstanceOf(VaultWriteEscapeError);
+	});
 });

--- a/src/utils/vaultWriteGuards.test.ts
+++ b/src/utils/vaultWriteGuards.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import type { App } from "obsidian";
+import { FileSystemAdapter } from "obsidian";
+import {
+	assertWriteStaysInVault,
+	VaultWriteEscapeError,
+} from "./vaultWriteGuards";
+
+/**
+ * Exercises the REAL realpath/symlink containment with an actual on-disk
+ * symlink — not a mocked throw. The guard only engages when the adapter is a
+ * FileSystemAdapter and `window.require("fs"/"path")` yields real Node modules,
+ * so we shim both locally (restored in afterEach) and back the adapter with a
+ * temp vault directory.
+ */
+describe("assertWriteStaysInVault (real symlink containment)", () => {
+	let tmpRoot: string;
+	let vaultDir: string;
+	let outsideDir: string;
+	let app: App;
+
+	beforeEach(() => {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "qa-guard-"));
+		vaultDir = path.join(tmpRoot, "vault");
+		outsideDir = path.join(tmpRoot, "outside");
+		fs.mkdirSync(vaultDir);
+		fs.mkdirSync(outsideDir);
+
+		// Escape symlink: vault/linked -> ../outside (outside the vault).
+		fs.symlinkSync(outsideDir, path.join(vaultDir, "linked"), "dir");
+		// In-vault symlink: vault/linkdir -> vault/realdir (stays inside).
+		const realdir = path.join(vaultDir, "realdir");
+		fs.mkdirSync(realdir);
+		fs.symlinkSync(realdir, path.join(vaultDir, "linkdir"), "dir");
+
+		// The real obsidian FileSystemAdapter constructor is 0-arg in the .d.ts;
+		// the test stub takes a base path. Cast the ctor so tsc (which type-checks
+		// against the real types) accepts it while runtime uses the stub.
+		const AdapterCtor = FileSystemAdapter as unknown as new (
+			basePath: string,
+		) => FileSystemAdapter;
+		const adapter = new AdapterCtor(vaultDir);
+		app = { vault: { adapter } } as unknown as App;
+
+		(window as unknown as { require: (m: string) => unknown }).require = (
+			mod: string,
+		) => {
+			if (mod === "fs") return fs;
+			if (mod === "path") return path;
+			throw new Error(`unexpected require(${mod})`);
+		};
+	});
+
+	afterEach(() => {
+		delete (window as unknown as { require?: unknown }).require;
+		fs.rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("rejects a write that resolves through a symlink to outside the vault", async () => {
+		await expect(
+			assertWriteStaysInVault(app, "linked/evil.js"),
+		).rejects.toBeInstanceOf(VaultWriteEscapeError);
+	});
+
+	it("allows a write through an in-vault symlink (no over-rejection)", async () => {
+		await expect(
+			assertWriteStaysInVault(app, "linkdir/ok.js"),
+		).resolves.toBeUndefined();
+	});
+
+	it("allows a plain in-vault path", async () => {
+		await expect(
+			assertWriteStaysInVault(app, "notes/new.md"),
+		).resolves.toBeUndefined();
+	});
+
+	it("is a no-op when the adapter is not a FileSystemAdapter (mobile/tests)", async () => {
+		const plainApp = { vault: { adapter: {} } } as unknown as App;
+		await expect(
+			assertWriteStaysInVault(plainApp, "../escape.js"),
+		).resolves.toBeUndefined();
+	});
+});

--- a/src/utils/vaultWriteGuards.ts
+++ b/src/utils/vaultWriteGuards.ts
@@ -96,6 +96,21 @@ export async function assertWriteStaysInVault(
 			`Refusing to write to "${vaultRelativePath}": it resolves (via a symlink) outside the vault.`,
 		);
 	}
+
+	// Reject a target that RESOLVES into a dot/config directory (.obsidian, .git,
+	// .trash, ...) even though it stays inside the vault. The lexical per-segment
+	// dot-floor only sees the LITERAL destination, so a pre-existing in-vault
+	// symlink like `safe -> .obsidian/plugins/pkg` would otherwise smuggle an
+	// untrusted "safe/main.js" write into a config/executable directory. Checking
+	// the realpath-resolved segments closes that symlink-mediated config-dir drop.
+	const resolvedEscapesIntoConfigDir = rel
+		.split(path.sep)
+		.some((segment) => segment.startsWith("."));
+	if (resolvedEscapesIntoConfigDir) {
+		throw new VaultWriteEscapeError(
+			`Refusing to write to "${vaultRelativePath}": it resolves (via a symlink) into a config/hidden directory.`,
+		);
+	}
 }
 
 function exists(fs: NodeFs, p: string): boolean {

--- a/src/utils/vaultWriteGuards.ts
+++ b/src/utils/vaultWriteGuards.ts
@@ -75,7 +75,20 @@ export async function assertWriteStaysInVault(
 		probe = parent;
 	}
 
-	const realTarget = await fs.promises.realpath(probe).catch(() => probe);
+	let realTarget: string;
+	try {
+		realTarget = await fs.promises.realpath(probe);
+	} catch {
+		// `probe` exists (lstatSync above) yet cannot be resolved: it is, or passes
+		// through, a DANGLING symlink whose ultimate target does not exist. A write
+		// still FOLLOWS that symlink and can land outside the vault, and we cannot
+		// prove where — so fail CLOSED. (On Linux/glibc realpath throws ENOENT here;
+		// the previous `.catch(() => probe)` fallback trusted the unresolved in-vault
+		// path and let the escape through.)
+		throw new VaultWriteEscapeError(
+			`Refusing to write to "${vaultRelativePath}": it resolves through an unresolvable (dangling) symlink.`,
+		);
+	}
 	const rel = path.relative(realBase, realTarget);
 	const escapes = rel === ".." || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel);
 	if (escapes) {

--- a/src/utils/vaultWriteGuards.ts
+++ b/src/utils/vaultWriteGuards.ts
@@ -1,11 +1,16 @@
 /**
- * Runtime write guard for AI built-in vault writers (#714).
+ * Runtime symlink/realpath write guard for untrusted-input vault writers.
  *
- * String sanitization (sanitizeVaultPath) is not enough: Obsidian's desktop adapter
- * follows symlinks, so a write to an in-vault symlink can land OUTSIDE the vault
- * while a confirm shows an in-vault path (runtime-proven in review). This resolves
- * the realpath of the target (or its nearest existing ancestor, since the file may
- * not exist yet) and the vault root, and throws if the target is not contained.
+ * Shared by the AI built-in vault writers (#714) and the package-import asset
+ * writer — both write data the user did not author byte-for-byte (model output /
+ * an imported community package), so both must confine writes to the vault.
+ *
+ * Lexical string sanitization (sanitizeVaultPath / validateAssetDestination) is
+ * not enough: Obsidian's desktop adapter follows symlinks, so a write to an
+ * in-vault symlink can land OUTSIDE the vault while a confirm shows an in-vault
+ * path (runtime-proven in review). This resolves the realpath of the target (or
+ * its nearest existing ancestor, since the file may not exist yet) and the vault
+ * root, and throws if the target is not contained.
  *
  * Desktop only — FileSystemAdapter + Node fs/path are accessed lazily via
  * `window.require` so the mobile bundle (no symlinks, no require) is never affected.

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -845,9 +845,30 @@ export function prepareFuzzySearch(query: string) {
   };
 }
 
+// Minimal FileSystemAdapter so the symlink/realpath write guard
+// (src/utils/vaultWriteGuards.ts) can be exercised in a unit test. The guard
+// bails out unless `adapter instanceof FileSystemAdapter`; existing tests pass
+// plain-object adapters (never `instanceof` a class), so they remain no-ops.
+// `getFullPath` joins with a forward slash — tests drive it with POSIX base
+// paths (os.tmpdir()), matching the desktop adapter's contract closely enough
+// for realpath containment checks.
+export class FileSystemAdapter {
+  private readonly basePath: string;
+  constructor(basePath = "/vault") {
+    this.basePath = basePath;
+  }
+  getBasePath(): string {
+    return this.basePath;
+  }
+  getFullPath(normalizedPath: string): string {
+    return `${this.basePath}/${normalizedPath}`.replace(/\/+/g, "/");
+  }
+}
+
 // Default export for compatibility
 export default {
   App,
+  FileSystemAdapter,
   Component,
   BaseComponent,
   ButtonComponent,


### PR DESCRIPTION
## Summary

Imported QuickAdd packages are untrusted, attacker-authored data. Their asset paths must never let the importer read or write outside the vault. This closes two reported path-traversal findings in `src/services/packageImportService.ts` (plus three real gaps surfaced by adversarial review), with the minimal correct containment and no loss of legitimate functionality.

### Threat-model assessment

QuickAdd is a local Obsidian plugin running with the user's full trust over their own vault. A finding is a real vulnerability only when an **untrusted** input can exploit it — here, an imported community package (`.quickadd.json`).

- **F2 (asset write) — REAL.** The write path mutates the filesystem from untrusted input. It had only *lexical* confinement and its config-dir floor checked just the first path segment. Fixed to the same standard the AI vault writers already use.
- **F1 (existence probe) — REAL but low.** A crafted `originalPath` caused `fs.stat` outside the vault during preview, but the boolean result is shown only to the local machine owner and is never returned to the package author over any channel. Closed anyway: it's cheap, removes an out-of-vault syscall on untrusted input, and fixes a real preview-honesty bug (an out-of-vault path was reported "present/reused" instead of "missing").

## What changed

**Write-path containment (F2)** — `src/services/packageImportService.ts`, `src/utils/vaultWriteGuards.ts`
- `validateAssetDestination`'s dot-config-dir floor is now **per-segment at any depth**, not just `segments[0]`. This closes a vector *worse* than the reported symlink case: `notes/.git/hooks/post-commit` and `docs/.obsidian/plugins/x/main.js` previously passed validation and landed in a trusted dir on the real filesystem (a plugin-drop / hook payload needing **no** symlink). The `..%` carve-out and exact error messages are preserved.
- `assertWriteStaysInVault` (realpath/symlink containment) was **promoted from `src/ai/tools/builtins/` to `src/utils/`** and now runs as an all-or-nothing **pre-pass** over every destination before any write, so a destination that resolves through a pre-existing in-vault symlink to outside the vault aborts the import before touching disk.
- The two guards are layered: lexical/structural catches in-vault config-dir drops the realpath guard can't see; realpath catches symlink escapes the lexical guard can't see.

**Probe-path containment (F1)** — new pure `src/utils/vaultPathBoundary.ts`
- `escapesVaultBoundary()` rejects absolute / drive / UNC / `..` paths, computed on the raw string **before** `normalizePath` (which strips leading slashes and would hide `/etc/passwd`). It **allows** in-vault dot-dirs so a legitimate `.obsidian/x` reference is still recognized as present. It guards `analysePackage`, `analysePackagePreview`, and the GUI `ExistenceResolver`.

## Adversarial review (Codex, opposite model)

Three rounds. Round 1 validated the threat framing and design before coding. Rounds 2–3 (post-impl) found **three real gaps, all fixed with RED→GREEN tests**:

1. **HIGH** — the GUI `ExistenceResolver` independently re-probed attacker paths, so F1 wasn't fully closed. Now guarded.
2. **HIGH** — `assertWriteStaysInVault` failed **open** for a *dangling* in-vault symlink (target not yet created): on Linux/glibc `realpath` throws `ENOENT` and the old `.catch(() => probe)` trusted the unresolved in-vault path → write escaped. Now **fails closed**. (macOS resolves the path and already caught it; this makes the guard correct cross-platform.)
3. **MEDIUM** — pre-pass consistency: a vault-escaping destination now aborts the whole import regardless of per-asset mode, matching the existing lexical behavior (refuse loudly, don't silently drop via "skip").

**Accepted scope boundary (documented):** symlink-*mediated* probes (an in-vault symlink pointing outside, statted during preview) remain lexical-only. Realpath-guarding every preview probe for a boolean shown only to the local user is disproportionate; the reported `..`/absolute vector is closed. Consistent with the F1-is-low framing.

## Exploit / mitigation evidence (real filesystem)

Reproduced against a real vault + real out-of-vault file/symlink, using the actual shipped `escapesVaultBoundary`:

```
PROBE:  [no guard] fs.stat OUTSIDE vault -> exists=true  (leaks out-of-vault file)
        [fixed]    escapes=true -> stat issued? false  reported exists=false
        legit in-vault 'real.md': escapes=false  exists=true   ✔ unaffected

WRITE:  [no guard] wrote linked/evil.js -> landed OUTSIDE vault   (ESCAPED)
        [fixed]    Refusing to write to "linked/evil.js": resolves (via a symlink) outside the vault
        in-vault symlink 'linkdir/ok.js' allowed   ✔ no over-rejection
```

## Tests

Regression tests fail without the fix and pass with it (verified by reverting the implementation):
- probe never stats out-of-vault paths and surfaces them as missing (asserted on the `adapter.exists` spy); in-vault config references are still probed (no over-rejection)
- nested config-dir writes rejected; `..%2f`-literal still allowed; absolute/`..`/drive/UNC still rejected
- `ExistenceResolver` boundary containment (optimistic + async)
- **real on-disk symlink** containment for `assertWriteStaysInVault` (escape rejected, in-vault symlink allowed, dangling fail-closed)
- vault-escaping destination aborts regardless of import mode

## Gates
`tsc` ✓ · `eslint .` ✓ · `svelte-check` 0 errors ✓ · `vitest` 3192 passed ✓ · `build` ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import safety by blocking paths that escape the vault boundary.
  * Prevented hidden/config-style destination paths from being written in nested folders.
  * Made write handling more strict for symlink and unresolved-path cases, reducing the risk of unsafe file writes.
  * Updated package import preview and conflict checks so out-of-vault paths are treated as missing instead of being probed or misclassified.
* **Tests**
  * Added coverage for vault-boundary checks, symlink containment, and safe import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->