### PR TITLE
fix: three deepsec functional bugs (folder scoping, migration guard, date preview)

### DIFF
--- a/src/formatters/helpers/previewHelpers.test.ts
+++ b/src/formatters/helpers/previewHelpers.test.ts
@@ -116,5 +116,31 @@ describe('PreviewHelpers', () => {
 			const result = DateFormatPreviewGenerator.generate('MMM D, YYYY', testDate);
 			expect(result).toBe('Jan 15, 2024');
 		});
+
+		// Regression: the old sequential .replace() chain re-scanned already
+		// substituted output, so later single-letter tokens (M, m, s, D, ...)
+		// clobbered letters inside spelled-out month/day names.
+		it('does not corrupt spelled-out month names', () => {
+			expect(DateFormatPreviewGenerator.generate('MMMM', new Date(2024, 2, 15))).toBe('March'); // was "3arch"
+			expect(DateFormatPreviewGenerator.generate('MMMM', new Date(2024, 4, 15))).toBe('May'); // was "5ay"
+			expect(DateFormatPreviewGenerator.generate('MMMM', new Date(2024, 7, 15))).toBe('August'); // was "Augu45t"
+			expect(DateFormatPreviewGenerator.generate('MMMM', new Date(2024, 8, 15))).toBe('September'); // was "Septe30ber"
+			expect(DateFormatPreviewGenerator.generate('MMMM', new Date(2024, 10, 15))).toBe('November'); // was "Nove30ber"
+			expect(DateFormatPreviewGenerator.generate('MMMM', new Date(2024, 11, 15))).toBe('December'); // was "15ece30ber"
+		});
+
+		it('does not corrupt spelled-out weekday names containing token letters', () => {
+			// 2024-08-13 Tue, -14 Wed, -15 Thu — each contains a lowercase 's'.
+			expect(DateFormatPreviewGenerator.generate('dddd', new Date(2024, 7, 13))).toBe('Tuesday'); // was "Tue45day"
+			expect(DateFormatPreviewGenerator.generate('dddd', new Date(2024, 7, 14))).toBe('Wednesday'); // was "Wedne45day"
+			expect(DateFormatPreviewGenerator.generate('dddd', new Date(2024, 7, 15))).toBe('Thursday'); // was "Thur45day"
+		});
+
+		it('preserves spelled-out names inside a combined format', () => {
+			// 2024-09-05 is a Thursday — exercises dddd + MMMM + D + YYYY together.
+			expect(
+				DateFormatPreviewGenerator.generate('dddd, MMMM D, YYYY', new Date(2024, 8, 5)),
+			).toBe('Thursday, September 5, 2024');
+		});
 	});
 });

--- a/src/formatters/helpers/previewHelpers.ts
+++ b/src/formatters/helpers/previewHelpers.ts
@@ -133,37 +133,55 @@ export class DateFormatPreviewGenerator {
 	 */
 	static generate(format: string, date: Date = new Date()): string {
 		const year = date.getFullYear();
-		const month = (date.getMonth() + 1).toString().padStart(2, '0');
-		const day = date.getDate().toString().padStart(2, '0');
-		const hours = date.getHours().toString().padStart(2, '0');
-		const minutes = date.getMinutes().toString().padStart(2, '0');
-		const seconds = date.getSeconds().toString().padStart(2, '0');
-		
-		// Handle common format patterns - order matters for longer patterns first!
-		return format
-			// Year patterns
-			.replace(/YYYY/g, year.toString())
-			.replace(/YY/g, year.toString().slice(-2))
-			// Month patterns  
-			.replace(/MMMM/g, this.MONTH_NAMES[date.getMonth()])
-			.replace(/MMM/g, this.MONTH_NAMES_SHORT[date.getMonth()])
-			.replace(/MM/g, month)
-			.replace(/M/g, (date.getMonth() + 1).toString())
-			// Day patterns
-			.replace(/dddd/g, this.DAY_NAMES[date.getDay()])
-			.replace(/ddd/g, this.DAY_NAMES_SHORT[date.getDay()])
-			.replace(/DD/g, day)
-			.replace(/D/g, date.getDate().toString())
-			// Time patterns
-			.replace(/HH/g, hours)
-			.replace(/H/g, date.getHours().toString())
-			.replace(/mm/g, minutes)
-			.replace(/m/g, date.getMinutes().toString())
-			.replace(/ss/g, seconds)
-			.replace(/s/g, date.getSeconds().toString())
-			// Week patterns
-			.replace(/ww/g, this.getWeekNumber(date).toString().padStart(2, '0'))
-			.replace(/w/g, this.getWeekNumber(date).toString());
+		const week = this.getWeekNumber(date);
+
+		// Token -> replacement value, ordered longest-first WITHIN each leading
+		// character so a single left-to-right scan always consumes the longest
+		// matching token at each position. The previous implementation chained
+		// `.replace()` calls, which re-scanned already-substituted text: a later
+		// single-letter token (M, m, s, D, ...) would clobber letters inside a
+		// spelled-out month/day name (e.g. "March" -> "3arch", "September" ->
+		// "Septe<min>ber", "Thursday" -> "Thur<sec>day"). Appending matched values
+		// to a separate buffer means substituted names are never re-scanned.
+		const tokens: Array<[string, string]> = [
+			['YYYY', year.toString()],
+			['YY', year.toString().slice(-2)],
+			['MMMM', this.MONTH_NAMES[date.getMonth()]],
+			['MMM', this.MONTH_NAMES_SHORT[date.getMonth()]],
+			['MM', (date.getMonth() + 1).toString().padStart(2, '0')],
+			['M', (date.getMonth() + 1).toString()],
+			['dddd', this.DAY_NAMES[date.getDay()]],
+			['ddd', this.DAY_NAMES_SHORT[date.getDay()]],
+			['DD', date.getDate().toString().padStart(2, '0')],
+			['D', date.getDate().toString()],
+			['HH', date.getHours().toString().padStart(2, '0')],
+			['H', date.getHours().toString()],
+			['mm', date.getMinutes().toString().padStart(2, '0')],
+			['m', date.getMinutes().toString()],
+			['ss', date.getSeconds().toString().padStart(2, '0')],
+			['s', date.getSeconds().toString()],
+			['ww', week.toString().padStart(2, '0')],
+			['w', week.toString()],
+		];
+
+		let result = '';
+		let i = 0;
+		while (i < format.length) {
+			let matched = false;
+			for (const [token, value] of tokens) {
+				if (format.startsWith(token, i)) {
+					result += value;
+					i += token.length;
+					matched = true;
+					break;
+				}
+			}
+			if (!matched) {
+				result += format[i];
+				i += 1;
+			}
+		}
+		return result;
 	}
 
 	private static getWeekNumber(date: Date): number {

--- a/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.test.ts
+++ b/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { CommandType } from "../types/macros/CommandType";
+import migration from "./mutualExclusionInsertAfterAndWriteToBottomOfFile";
+
+describe("mutualExclusionInsertAfterAndWriteToBottomOfFile migration", () => {
+	it("does not throw on a legacy capture choice that lacks insertAfter", async () => {
+		// A capture choice persisted by an old version / imported / hand-edited in
+		// data.json may have no `insertAfter` object at all. Migrations run on RAW
+		// settings before CaptureChoice.Load normalizes them, so reading
+		// `insertAfter.enabled` unguarded throws TypeError, the migration runner
+		// reverts to backup WITHOUT marking the migration done, and it re-fails on
+		// every startup.
+		const plugin = {
+			settings: {
+				choices: [
+					{
+						id: "legacy-capture",
+						name: "Legacy Capture",
+						type: "Capture",
+						prepend: true,
+						// no `insertAfter`
+					},
+				],
+				macros: [],
+			},
+		} as any;
+
+		await expect(migration.migrate(plugin)).resolves.toBeUndefined();
+		// insertAfter absent -> treated as not-enabled -> prepend is left untouched.
+		expect(plugin.settings.choices[0].prepend).toBe(true);
+	});
+
+	it("does not throw on a nested macro capture choice that lacks insertAfter", async () => {
+		const plugin = {
+			settings: {
+				choices: [],
+				macros: [
+					{
+						id: "macro-1",
+						name: "Macro",
+						commands: [
+							{
+								type: CommandType.NestedChoice,
+								choice: {
+									id: "nested-capture",
+									name: "Nested Capture",
+									type: "Capture",
+									prepend: true,
+									// no `insertAfter`
+								},
+							},
+						],
+					},
+				],
+			},
+		} as any;
+
+		await expect(migration.migrate(plugin)).resolves.toBeUndefined();
+		expect(
+			plugin.settings.macros[0].commands[0].choice.prepend,
+		).toBe(true);
+	});
+
+	it("still disables prepend when insertAfter is enabled (top-level and nested)", async () => {
+		const plugin = {
+			settings: {
+				choices: [
+					{
+						id: "top-capture",
+						name: "Top Capture",
+						type: "Capture",
+						prepend: true,
+						insertAfter: { enabled: true },
+					},
+				],
+				macros: [
+					{
+						id: "macro-1",
+						name: "Macro",
+						commands: [
+							{
+								type: CommandType.NestedChoice,
+								choice: {
+									id: "nested-capture",
+									name: "Nested Capture",
+									type: "Capture",
+									prepend: true,
+									insertAfter: { enabled: true },
+								},
+							},
+						],
+					},
+				],
+			},
+		} as any;
+
+		await migration.migrate(plugin);
+
+		expect(plugin.settings.choices[0].prepend).toBe(false);
+		expect(
+			plugin.settings.macros[0].commands[0].choice.prepend,
+		).toBe(false);
+	});
+});

--- a/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.test.ts
+++ b/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.test.ts
@@ -61,6 +61,46 @@ describe("mutualExclusionInsertAfterAndWriteToBottomOfFile migration", () => {
 		).toBe(true);
 	});
 
+	it("handles a capture choice nested inside a Multi choice (recursion path)", async () => {
+		// recursiveMigrateSettingInChoices recurses into Multi.choices, so a grouped
+		// capture lacking insertAfter hits the same guarded line. Multi groups are a
+		// common data.json shape; lock the recursion path in so a future refactor of
+		// the Multi branch can't silently reintroduce the throw.
+		const plugin = {
+			settings: {
+				choices: [
+					{
+						id: "multi-1",
+						name: "Group",
+						type: "Multi",
+						choices: [
+							{
+								id: "grouped-legacy",
+								name: "Grouped Legacy",
+								type: "Capture",
+								prepend: true,
+								// no `insertAfter`
+							},
+							{
+								id: "grouped-enabled",
+								name: "Grouped Enabled",
+								type: "Capture",
+								prepend: true,
+								insertAfter: { enabled: true },
+							},
+						],
+					},
+				],
+				macros: [],
+			},
+		} as any;
+
+		await expect(migration.migrate(plugin)).resolves.toBeUndefined();
+		// Missing insertAfter -> untouched; enabled insertAfter -> prepend disabled.
+		expect(plugin.settings.choices[0].choices[0].prepend).toBe(true);
+		expect(plugin.settings.choices[0].choices[1].prepend).toBe(false);
+	});
+
 	it("still disables prepend when insertAfter is enabled (top-level and nested)", async () => {
 		const plugin = {
 			settings: {

--- a/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
+++ b/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
@@ -16,7 +16,10 @@ function recursiveMigrateSettingInChoices(choices: IChoice[]): IChoice[] {
 		}
 
 		if (isCaptureChoice(choice)) {
-			if (choice.insertAfter.enabled && choice.prepend) {
+			// `insertAfter` may be absent on legacy/imported/hand-edited choices;
+			// migrations run on raw settings before CaptureChoice.Load normalizes
+			// them. Treat a missing object as not-enabled instead of throwing.
+			if (choice.insertAfter?.enabled && choice.prepend) {
 				choice.prepend = false;
 			}
 		}
@@ -35,7 +38,7 @@ function migrateSettingsInMacros(macros: IMacro[]): IMacro[] {
 				isCaptureChoice(command.choice)
 			) {
 				if (
-					command.choice.insertAfter.enabled &&
+					command.choice.insertAfter?.enabled &&
 					command.choice.prepend
 				) {
 					command.choice.prepend = false;

--- a/src/utils/vaultQueries.test.ts
+++ b/src/utils/vaultQueries.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { App, TFile } from "obsidian";
 import {
 	frontmatterValueMatches,
+	getMarkdownFilesInFolder,
 	getMarkdownFilesMatchingFilter,
 	getMarkdownFilesWithProperty,
 	getMarkdownFilesWithTag,
@@ -136,6 +137,46 @@ describe("getMarkdownFilesWithProperty", () => {
 		}).map((f) => f.path);
 
 		expect(paths).toEqual(["Draft A.md"]);
+	});
+});
+
+describe("getMarkdownFilesInFolder", () => {
+	function folderApp(paths: string[]): App {
+		const files = paths.map((p) => ({
+			path: p,
+			basename: (p.split("/").pop() ?? p).replace(/\.md$/, ""),
+		}));
+		return {
+			vault: { getMarkdownFiles: () => files as unknown as TFile[] },
+		} as unknown as App;
+	}
+
+	const app = folderApp([
+		"Projects/a.md",
+		"Projects/sub/b.md",
+		"ProjectsArchive/c.md",
+		"Projects 2024/d.md",
+		"Projects.md",
+		"Other/e.md",
+	]);
+
+	it("anchors a bare folder name and ignores prefix-sharing siblings", () => {
+		const paths = getMarkdownFilesInFolder(app, "Projects")
+			.map((f) => f.path)
+			.sort();
+		// NOT ProjectsArchive/, "Projects 2024/", or the sibling file Projects.md.
+		expect(paths).toEqual(["Projects/a.md", "Projects/sub/b.md"].sort());
+	});
+
+	it("treats a trailing slash identically (callers pre-append '/')", () => {
+		const paths = getMarkdownFilesInFolder(app, "Projects/")
+			.map((f) => f.path)
+			.sort();
+		expect(paths).toEqual(["Projects/a.md", "Projects/sub/b.md"].sort());
+	});
+
+	it("returns the whole vault for an empty folder path", () => {
+		expect(getMarkdownFilesInFolder(app, "").length).toBe(6);
 	});
 });
 

--- a/src/utils/vaultQueries.ts
+++ b/src/utils/vaultQueries.ts
@@ -21,9 +21,21 @@ export function isFolder(app: App, path: string): boolean {
 }
 
 export function getMarkdownFilesInFolder(app: App, folderPath: string): TFile[] {
+	// Anchor the match to a path-segment boundary so a folder scope never bleeds
+	// into prefix-sharing siblings (e.g. folder "Projects" must not match
+	// "ProjectsArchive/x.md" or "Projects.md"). A trailing slash is normalized
+	// away first so callers that pre-append "/" (CaptureChoiceEngine,
+	// collectChoiceRequirements) and callers that pass a bare folder name (AI
+	// tools, AIAssistant) both scope identically. An empty path means the whole
+	// vault.
+	const normalized = folderPath.replace(/\/+$/, "");
+	if (normalized === "") {
+		return app.vault.getMarkdownFiles();
+	}
+	const prefix = `${normalized}/`;
 	return app.vault
 		.getMarkdownFiles()
-		.filter((f) => f.path.startsWith(folderPath));
+		.filter((f) => f.path === normalized || f.path.startsWith(prefix));
 }
 
 function getFrontmatterTags(fileCache: CachedMetadata): string[] {


### PR DESCRIPTION
## Summary

Fixes three functional bugs surfaced by the deepsec scan (severity BUG = correctness/robustness). Each fix is minimal, made at the root, and ships a regression test that fails without it. All confirmed reproducing against the current code before fixing.

| # | File | deepsec slug | Bug |
|---|------|--------------|-----|
| 1 | `src/utils/vaultQueries.ts` | other-logic-bug | Folder-scoped listing over-matched prefix-sharing siblings |
| 2 | `src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts` | other-unguarded-property-access | Unguarded `insertAfter.enabled` could throw and stall the migration |
| 3 | `src/formatters/helpers/previewHelpers.ts` | other-logic-bug | Date-format preview corrupted spelled-out month/day names |

## 1 - Folder-scoped listing over-matches sibling folders (`getMarkdownFilesInFolder`)

**Bug:** `getMarkdownFilesInFolder` filtered with an unanchored `f.path.startsWith(folderPath)`. A bare folder name matched any sibling sharing the prefix - scoping to `Projects` also returned `ProjectsArchive/x.md`, `Projects 2024/y.md`, and the sibling file `Projects.md`. The deepsec finding is owned under `vaultTools.ts`, but the root is this shared helper; fixing it here covers all callers (AI `list_notes`/`get_property_values`, and the `AIAssistant` prompt-template listing, which the finding noted also over-includes).

**Fix:** Normalize a trailing slash, treat `""` as the whole vault, and match `f.path === folder || f.path.startsWith(folder + "/")`. Byte-identical for the callers that pre-append `/` (`CaptureChoiceEngine`, `collectChoiceRequirements`) and for the `captureAnywhereInVault` `""` path; now exact for the bare-folder callers.

**Test:** `vaultQueries.test.ts` - bare folder ignores prefix-sharing siblings; trailing slash behaves identically; `""` returns the whole vault.

## 2 - Unguarded `insertAfter.enabled` can stall the migration

**Bug:** `recursiveMigrateSettingInChoices` and `migrateSettingsInMacros` read `insertAfter.enabled` unguarded. Migrations run on RAW settings (only a shallow `Object.assign`) before `CaptureChoice.Load` normalizes them, so a capture choice persisted by an old version, imported, or hand-edited in `data.json` may lack `insertAfter`. The access throws `TypeError`; the migration runner reverts to backup but never sets `migrations[...] = true`, so it re-runs and re-fails on every startup and the mutual-exclusion fix is never applied.

**Fix:** Optional chaining (`insertAfter?.enabled`), matching `CaptureChoice.Load` which already treats `insertAfter` as possibly-absent.

**Test:** new `mutualExclusionInsertAfterAndWriteToBottomOfFile.test.ts` - legacy choice without `insertAfter` (top-level, nested-in-macro, and nested-in-Multi) no longer throws; the positive path (enabled `insertAfter` disables `prepend`) still works. The Multi-nested case (the migration recurses through `Multi.choices`) was added after adversarial review and asserted RED against the pre-fix source.

## 3 - Date-format preview corrupts spelled-out month/day names

**Bug:** `DateFormatPreviewGenerator.generate` rewrote the format with a chain of sequential `.replace()` calls. Long tokens (`MMMM`/`dddd`) expanded first, then later single-letter tokens (`M`, `m`, `s`, `D`, `H`, `w`) ran over the already-substituted text, clobbering matching letters inside the names: `MMMM` produced `3arch` (March), `5ay` (May), `Augu<sec>t`, `Septe<min>ber`; `dddd` produced `Tue<sec>day`/`Wedne<sec>day`/`Thur<sec>day`. The existing tests only used 2024-01-15 (January/Monday - none of `M,m,s,w,D`), so it passed CI. Impact is the builder's preview only; real note/filename formatting uses moment.js.

**Fix:** Replace the re-scanning `.replace()` chain with a single left-to-right pass that consumes the longest matching token at each position and appends substituted values to a separate buffer, so spelled-out names are never re-scanned. Same token set and semantics; previously-correct previews stay byte-identical.

**Design note:** The deepsec recommendation offered (a) a single-pass tokenizer or (b) delegating to moment.js. I chose (a): it keeps the helper pure and self-contained (the test `window.moment` stub returns a hardcoded date, so (b) would force test-harness churn across every preview test and silently change week-number semantics). (a) is the surgical root fix for the reported corruption without expanding scope.

**Test:** `previewHelpers.test.ts` - `MMMM` for March/May/August/September/November/December; `dddd` for Tue/Wed/Thu; a combined `dddd, MMMM D, YYYY`. The original six token tests are preserved unchanged.

## Validation

- Reproduced all three against current code before fixing; each regression test was confirmed RED pre-fix, GREEN post-fix.
- `tsc -noEmit -skipLibCheck`: clean
- `eslint .`: clean
- `svelte-check --threshold error`: 0 errors
- `vitest run`: 3179 passed, 0 failed
- Reviewed adversarially across correctness, regression, edge-case, and test-completeness lenses (10 independent agents). Five raised concerns were refuted on verification; the one confirmed (a nit: missing Multi-nested regression coverage) was folded in.

Commits are split per fix for clean rebasing.
