### PR TITLE
docs(examples): fix four robustness bugs in example userscripts

### DIFF
--- a/docs/static/scripts/BookFinder.js
+++ b/docs/static/scripts/BookFinder.js
@@ -23,17 +23,26 @@ module.exports =  async function start(params) {
   const response = await fetch(finalURL);
   const bookDesc = await response.json();
 
+  // The Google Books API omits `items` entirely when a title yields no matches.
+  if (!bookDesc.items || bookDesc.items.length === 0) {
+    notice("No results found for: " + title);
+    throw new Error("No results found for: " + title);
+  }
+
   // In an ideal world we would popup a picker that shows the user: Book Title, Author(s) and cover. They would select the correct version from there
+  const book = bookDesc.items[0];
+  const volumeInfo = book.volumeInfo;
 
   QuickAdd.variables = {
-    ...bookDesc.items[0],
-    title: bookDesc.items[0].volumeInfo.title,
+    ...book,
+    title: volumeInfo.title,
     // How to get mutiple authors or categories out with commas between them
-    authors: bookDesc.items[0].volumeInfo.authors,
-    categories: bookDesc.items[0].volumeInfo.categories,
-    description: bookDesc.items[0].volumeInfo.description,
-    fileName: replaceIllegalFileNameCharactersInString(bookDesc.items[0].volumeInfo.title),
-    Poster:bookDesc.items[0].volumeInfo.imageLinks.smallThumbnail
+    authors: volumeInfo.authors,
+    categories: volumeInfo.categories,
+    description: volumeInfo.description,
+    fileName: replaceIllegalFileNameCharactersInString(volumeInfo.title),
+    // Many valid volumes have no cover, so the imageLinks object can be missing.
+    Poster: volumeInfo.imageLinks?.smallThumbnail
   };
 }
 

--- a/docs/static/scripts/EzImport.js
+++ b/docs/static/scripts/EzImport.js
@@ -10,10 +10,12 @@ const READWISE_API_URL = "https://readwise.io/api/v2/";
 const READWISE_CACHE_KEY = "ez-import-readwise-cache";
 
 /*
-    Cache structure:
+    Cache structure (keyed by the stable Readwise item id, NOT the title, so
+    two items that happen to share a title don't collide into one entry):
     {
         ...
-        [item title]: {
+        [item id]: {
+            id: item id,
             title: item title,
             createdFileWithItem: true/false,
             ignore: true/false,
@@ -54,7 +56,7 @@ function setCacheItems(items) {
 }
 
 const LogAndThrowError = (error) => {
-	new Notice("error", 10000);
+	new Notice(error, 10000);
 	throw new Error(error);
 };
 
@@ -127,7 +129,7 @@ async function getReadwiseHighlights(type) {
 		const cache = getReadwiseCache();
 		if (cache) {
 			for (const result of results) {
-				const cacheItem = cache[result.title];
+				const cacheItem = cache[result.id];
 				if (
 					!cacheItem ||
 					(cacheItem && !cacheItem.ignore && !cacheItem.createdFileWithItem)
@@ -139,7 +141,8 @@ async function getReadwiseHighlights(type) {
 			// No cache. Build.
 			const newCache = {};
 			for (const item of results) {
-				newCache[item.title] = {
+				newCache[item.id] = {
+					id: item.id,
 					title: item.title,
 					createdFileWithItem: false,
 				};
@@ -162,8 +165,9 @@ async function getReadwiseHighlights(type) {
 		LogAndThrowError("No item selected.");
 	}
 
-	if (Settings[USE_CACHE]) {
-		const cacheItem = getCacheItem(item.title);
+	// Manual Entry has no Readwise id, so it is never cached.
+	if (Settings[USE_CACHE] && item.id != null) {
+		const cacheItem = getCacheItem(item.id);
 		let newCacheItem;
 
 		if (cacheItem) {
@@ -173,12 +177,13 @@ async function getReadwiseHighlights(type) {
 			};
 		} else {
 			newCacheItem = {
+				id: item.id,
 				title: item.title,
 				createdFileWithItem: true,
 			};
 		}
 
-		setCacheItem(item.title, newCacheItem);
+		setCacheItem(item.id, newCacheItem);
 	}
 
 	const safeTitle = replaceIllegalFileNameCharactersInString(item.title);

--- a/docs/static/scripts/citationsManager.js
+++ b/docs/static/scripts/citationsManager.js
@@ -45,10 +45,15 @@ async function handleCitationsPlugin(params, citationsPlugin, settings) {
 
     params.variables = {
         ...params.variables,
-        fileName: replaceIllegalFileNameCharactersInString(entry.title),
+        // Fall back to the citekey when an entry has no usable title. Use ||
+        // (not ??) so an empty-string title is treated as missing too, matching
+        // the suggester's `if (item.title)` display check above.
+        fileName: replaceIllegalFileNameCharactersInString(entry.title || selectedLibraryEntryKey),
         citekey: selectedLibraryEntryKey,
         id: selectedLibraryEntryKey,
-        author: entry.authorString.split(', ').map(author => `[[${author}]]`).join(", "),
+        author: entry.authorString
+            ? entry.authorString.split(', ').map(author => `[[${author}]]`).join(", ")
+            : "",
         doi: entry.DOI,
 
         // https://github.com/hans/obsidian-citation-plugin/blob/cb601fceda8c70c0404dd250c50cdf83d5d04979/src/types.ts#L46
@@ -86,7 +91,17 @@ function replaceIllegalFileNameCharactersInString(string) {
 }
 
 function importAllKeywordsAsTags(keywords) {
-    keywords.forEach((element , index) => keywords[index] = (" #" + element.replace(" ","_")))
+    // BibTeX 'keywords' fields are sometimes a single delimited string rather
+    // than an array; normalize to an array first.
+    const list = Array.isArray(keywords)
+        ? keywords
+        : String(keywords).split(/[;,]/);
 
-    return(keywords)
+    // Map to a NEW array so we never mutate the citation plugin's own library
+    // object, and replace every space (not just the first) so multi-word
+    // keywords become a single valid tag.
+    return list
+        .map((keyword) => String(keyword).trim())
+        .filter((keyword) => keyword.length > 0)
+        .map((keyword) => " #" + keyword.replace(/\s+/g, "_"));
 }


### PR DESCRIPTION
Fixes four functional **BUG** findings (correctness/robustness, not security) surfaced by the deepsec scan in the QuickAdd example userscripts that users copy from the docs (`docs/static/scripts/`). Each fix is conservative and keeps the script illustrative.

These scripts are documentation assets and are **not** bundled into the plugin (`main.js`), so the commits use the `docs(examples):` type to avoid triggering an empty plugin release.

## Findings & fixes

### 1. BookFinder.js - empty results / missing cover crash (`other-null-deref`, lines 24, 29, 36)
The script unconditionally dereferenced `bookDesc.items[0]` and `items[0].volumeInfo.imageLinks.smallThumbnail`. The Google Books API omits `items` entirely when a title yields zero matches, and many valid volumes have no cover, so a missed search or a coverless book surfaced as an opaque `Cannot read properties of undefined` crash.
**Fix:** bail out with a friendly notice + error when `items` is absent/empty; optional-chain `imageLinks?.smallThumbnail`.

### 2. EzImport.js - error toast showed the literal "error" (`other-logic-bug`, lines 56-57)
`LogAndThrowError` called `new Notice("error", 10000)`, so every user-facing toast read the word "error" regardless of the real cause. The thrown `Error` carried the real message but the on-screen feedback was useless.
**Fix:** pass the variable - `new Notice(error, 10000)`.

### 3. EzImport.js - cache keyed by title collides for same-titled items (`other-logic-bug`, lines 130, 142, 209)
The Readwise cache was built and read keyed solely by `item.title`, so two distinct items sharing a title collided into one entry. Importing the first marked the shared title `createdFileWithItem: true`, silently filtering the second item out of the suggester on later runs.
**Fix:** key the cache by the stable `item.id` across all read/write sites (build, filter, post-selection), store `id` in each entry, update the cache-structure comment, and skip caching the id-less Manual Entry.

> Note: the destination note path is still derived from the user's `File name format` setting (title-based by default), so a user who wants per-item files can include a unique token. The cache-keying fix is what stops the silent skip; forcing ids into file names would change every user's output and was intentionally left out of a sample script.

### 4. citationsManager.js - keyword-to-tag conversion mutated source data and more (`other-logic-bug`, lines 72, 88, 89)
`importAllKeywordsAsTags()` rewrote `keywords[index]` in place (mutating the citation plugin's own library object); used `element.replace(" ", "_")`, which replaces only the **first** space (so `machine learning theory` became `#machine_learning theory`, truncated at the next space); and assumed `keywords` is always an array, while BibTeX keywords fields are frequently a single delimited string (`keywords.forEach` then throws). The variable build also crashed on entries with no title or no authorString.
**Fix:** map to a **new** array (no source mutation), trim + drop empties, replace every space via `/\s+/g`, normalize a string-valued keywords field into an array first, fall back to the citekey when the title is missing (using `||` so an empty-string title is treated as missing too, matching the suggester's `if (item.title)` check), and guard `authorString` before splitting.

## Verification
- **RED/GREEN proven** with regression tests kept as a **local verification artifact** (intentionally not part of this PR, since these are copy-paste doc scripts). With the script fixes reverted, every test fails with the exact original errors (`Cannot read properties of undefined`, `keywords.forEach is not a function`, the literal `"error"` toast, the silently-dropped same-title item); with the fixes they pass.
- The tests drive the **actual** script source (loaded via `createRequire`) with the exact crash-inducing inputs - the faithful reproduction, since these scripts aren't loaded by the plugin and a live Obsidian smoke would need Readwise API keys, the citation plugin, and Google Books network.
- Repo gates green locally: `tsc -noEmit`, `eslint .`, `svelte-check`, and the full `vitest` suite.

## Reviewer notes
Adversarial-reviewed (3 Codex lenses: skeptic, architect, minimalist). No high-severity findings against the fixes. The one consensus medium - the citationsManager empty-string title falling back to the citekey - was folded into finding 4. Deliberately rejected as out of scope for sample scripts: extra guards for malformed Google Books volumes that the API contract doesn't produce.