### PR TITLE
fix(core): resolve 7 deepsec correctness/robustness BUG findings (core data utilities)

### DIFF
--- a/src/gui/suggesters/FileIndex.test.ts
+++ b/src/gui/suggesters/FileIndex.test.ts
@@ -612,4 +612,46 @@ describe('FileIndex recency accessors (note-picker seam)', () => {
 		expect(first).toBe(second);
 		expect(typeof first).toBe('number');
 	});
+
+	it('a full reindex does not reorder the recency LRU (createIndexedFile peeks)', async () => {
+		// Open order establishes recency: A (oldest) -> B -> C (newest).
+		fireFileOpen({ path: 'A.md' } as TFile);
+		fireFileOpen({ path: 'B.md' } as TFile);
+		fireFileOpen({ path: 'C.md' } as TFile);
+
+		const lruKeys = () =>
+			Array.from(
+				(
+					(fileIndex as unknown as {
+						recentFiles: { cache: Map<string, number> };
+					}).recentFiles.cache
+				).keys(),
+			);
+		expect(lruKeys()).toEqual(['A.md', 'B.md', 'C.md']);
+
+		// Vault iteration order intentionally differs from open order. With the
+		// mutating get() bug, reindexing each file rewrites the LRU to this order,
+		// leaving C.md (not A.md) as the next eviction victim.
+		const makeFile = (path: string): TFile =>
+			({
+				path,
+				basename: path.replace(/\.md$/, ''),
+				extension: 'md',
+				parent: { path: '' },
+				stat: { mtime: 1 },
+			}) as unknown as TFile;
+		(mockApp.vault.getMarkdownFiles as unknown as ReturnType<typeof vi.fn>).mockReturnValue([
+			makeFile('C.md'),
+			makeFile('B.md'),
+			makeFile('A.md'),
+		]);
+		mockApp.metadataCache.getFileCache = vi.fn(() => ({}));
+
+		await fileIndex.ensureIndexed();
+
+		// Recency order is preserved: A.md is still the oldest / next-evicted.
+		expect(lruKeys()).toEqual(['A.md', 'B.md', 'C.md']);
+		// And openedAt values survive the reindex unchanged.
+		expect(typeof fileIndex.getFile('A.md')?.openedAt).toBe('number');
+	});
 });

--- a/src/gui/suggesters/FileIndex.ts
+++ b/src/gui/suggesters/FileIndex.ts
@@ -39,17 +39,12 @@ class LRUCache<T> {
 		this.maxSize = maxSize;
 	}
 
-	get(key: string): T | undefined {
-		const value = this.cache.get(key);
-		if (value !== undefined) {
-			// Move to end (most recently used)
-			this.cache.delete(key);
-			this.cache.set(key, value);
-		}
-		return value;
-	}
-
-	/** Reads a value without affecting recency ordering (safe inside sort comparators). */
+	/**
+	 * Reads a value without affecting recency ordering. This is the ONLY read
+	 * accessor: recency must be promoted exclusively by real file-open events via
+	 * set(), never by index reads. A mutating get() was deliberately removed - it
+	 * reordered the LRU to vault-iteration order during reindex (see git history).
+	 */
 	peek(key: string): T | undefined {
 		return this.cache.get(key);
 	}
@@ -376,7 +371,12 @@ export class FileIndex {
 			blockIds,
 			tags,
 			modified: file.stat.mtime,
-			openedAt: this.recentFiles.get(file.path),
+			// peek() (not get()) so building/rebuilding the index never reorders
+			// the recency LRU. get() is a mutating accessor (moves the key to
+			// most-recently-used), so a full reindex - which calls this for every
+			// file in vault-iteration order - would rewrite the LRU to vault order
+			// and evict the wrong "oldest" entry on the next file open.
+			openedAt: this.recentFiles.peek(file.path),
 			folder: file.parent?.path ?? ""
 		};
 	}

--- a/src/utils/DataviewIntegration.test.ts
+++ b/src/utils/DataviewIntegration.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import { getAPI } from "obsidian-dataview";
+import { DataviewIntegration } from "./DataviewIntegration";
+
+vi.mock("obsidian-dataview", () => ({
+	getAPI: vi.fn(),
+}));
+
+vi.mock("src/logger/logManager", () => ({
+	log: { logMessage: vi.fn(), logError: vi.fn() },
+}));
+
+const app = {} as App;
+
+function mockDataview(): { query: ReturnType<typeof vi.fn> } {
+	const dv = {
+		query: vi.fn().mockResolvedValue({
+			successful: true,
+			value: { values: [] },
+		}),
+	};
+	vi.mocked(getAPI).mockReturnValue(dv as unknown as ReturnType<typeof getAPI>);
+	return dv;
+}
+
+describe("DataviewIntegration folder DQL escaping", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("escapes a double quote in an include-folder so it cannot break the DQL string literal", async () => {
+		const dv = mockDataview();
+
+		await DataviewIntegration.getFieldValuesWithFilter(app, "status", {
+			folder: 'a"b',
+		});
+
+		const query = dv.query.mock.calls[0][0] as string;
+		// The quote must be backslash-escaped inside the DQL string literal.
+		expect(query).toContain('regexmatch("^a\\"b/", file.path)');
+		// And the raw, literal-terminating form must NOT appear.
+		expect(query).not.toContain('regexmatch("^a"b/"');
+	});
+
+	it("escapes a double quote in an exclude-folder", async () => {
+		const dv = mockDataview();
+
+		await DataviewIntegration.getFieldValuesWithFilter(app, "status", {
+			excludeFolders: ['x"y'],
+		});
+
+		const query = dv.query.mock.calls[0][0] as string;
+		expect(query).toContain('!regexmatch("^x\\"y/", file.path)');
+	});
+
+	it("still escapes regex metacharacters and leaves plain folders intact", async () => {
+		const dv = mockDataview();
+
+		await DataviewIntegration.getFieldValuesWithFilter(app, "status", {
+			folders: ["Projects", "a.b"],
+		});
+
+		const query = dv.query.mock.calls[0][0] as string;
+		// Plain folders are byte-identical to the pre-fix output.
+		expect(query).toContain('regexmatch("^Projects/", file.path)');
+		// The '.' is regex-escaped (\.), then the backslash is DQL-escaped (\\),
+		// so the source carries "\\." which Dataview's string lexer turns back
+		// into the regex "\." that matches a literal dot.
+		expect(query).toContain('regexmatch("^a\\\\.b/", file.path)');
+	});
+});

--- a/src/utils/DataviewIntegration.ts
+++ b/src/utils/DataviewIntegration.ts
@@ -24,6 +24,16 @@ function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// A folder is embedded into a regex pattern that itself lives inside a DQL
+// double-quoted string literal: regexmatch("^<folder>/", file.path). It must be
+// escaped for BOTH contexts: escapeRegex neutralizes regex metacharacters but
+// NOT the double-quote that would terminate the DQL string early, so wrap the
+// result with escapeDataviewString. Order matters - regex first (so the pattern
+// is correct), then DQL (so the backslashes/quotes survive the string lexer).
+function escapeRegexForDataviewString(value: string): string {
+	return escapeDataviewString(escapeRegex(value));
+}
+
 function isDataviewFileLike(value: unknown): value is DataviewFileLike {
 	return (
 		typeof value === "object" &&
@@ -147,7 +157,7 @@ export class DataviewIntegration {
 				.filter(Boolean);
 			if (includeFolders.length > 0) {
 				const folderConditions = includeFolders.map(folder => {
-					const escapedFolder = escapeRegex(folder);
+					const escapedFolder = escapeRegexForDataviewString(folder);
 					return `regexmatch("^${escapedFolder}/", file.path)`;
 				});
 				conditions.push(`(${folderConditions.join(" OR ")})`);
@@ -165,7 +175,7 @@ export class DataviewIntegration {
 			if (filters.excludeFolders && filters.excludeFolders.length > 0) {
 				filters.excludeFolders.forEach(excludeFolder => {
 					const normalizedFolder = excludeFolder.replace(/^\/+|\/+$/g, '');
-					conditions.push(`!regexmatch("^${escapeRegex(normalizedFolder)}/", file.path)`);
+					conditions.push(`!regexmatch("^${escapeRegexForDataviewString(normalizedFolder)}/", file.path)`);
 				});
 			}
 			

--- a/src/utils/FieldSuggestionCache.test.ts
+++ b/src/utils/FieldSuggestionCache.test.ts
@@ -67,6 +67,31 @@ describe("FieldSuggestionCache", () => {
 			expect(cache.get("field1")).toBeNull();
 			expect(cache.get("field2")).toBeNull();
 		});
+
+		it("clears only the exact field, not a colon-prefixed sibling field", () => {
+			cache.set("foo", new Set(["a"]), "folder");
+			cache.set("foo:bar", new Set(["b"]));
+
+			cache.clear("foo");
+
+			// The distinct field "foo:bar" must survive clearing "foo".
+			expect(cache.get("foo", "folder")).toBeNull();
+			expect(cache.get("foo:bar")).toEqual(new Set(["b"]));
+		});
+	});
+
+	describe("key collisions", () => {
+		it("keeps (fieldName, cacheKey) pairs distinct when a field name contains a colon", () => {
+			const valuesA = new Set(["a"]);
+			const valuesB = new Set(["b"]);
+
+			// With a raw ':' join these two pairs both map to "foo:bar:baz".
+			cache.set("foo", valuesA, "bar:baz");
+			cache.set("foo:bar", valuesB, "baz");
+
+			expect(cache.get("foo", "bar:baz")).toEqual(valuesA);
+			expect(cache.get("foo:bar", "baz")).toEqual(valuesB);
+		});
 	});
 
 	describe("automatic cleanup", () => {

--- a/src/utils/FieldSuggestionCache.ts
+++ b/src/utils/FieldSuggestionCache.ts
@@ -107,10 +107,13 @@ export class FieldSuggestionCache {
 	 */
 	clear(fieldName?: string): void {
 		if (fieldName) {
-			// Clear all entries for this field
+			// Clear all entries for this field. Compare the decoded field-name
+			// component rather than a raw `${fieldName}:` prefix, which would both
+			// over-match (a different field literally named `${fieldName}:...`) and
+			// mis-match once keys are JSON-encoded.
 			const keysToDelete: string[] = [];
 			for (const key of this.cache.keys()) {
-				if (key.startsWith(`${fieldName}:`) || key === fieldName) {
+				if (this.keyFieldName(key) === fieldName) {
 					keysToDelete.push(key);
 				}
 			}
@@ -166,6 +169,25 @@ export class FieldSuggestionCache {
 	}
 
 	private makeKey(fieldName: string, cacheKey?: string): string {
-		return cacheKey ? `${fieldName}:${cacheKey}` : fieldName;
+		// Encode both components unambiguously. A raw `${fieldName}:${cacheKey}`
+		// join collides when a field name itself contains a colon, e.g.
+		// makeKey("foo", "bar:baz") === makeKey("foo:bar", "baz"). JSON-encoding a
+		// tuple keeps every (fieldName, cacheKey) pair distinct. Empty/undefined
+		// cacheKey collapse to the same key (legacy behavior).
+		return JSON.stringify([fieldName, cacheKey || null]);
+	}
+
+	/** Decode the field-name component of a key produced by {@link makeKey}. */
+	private keyFieldName(key: string): string | undefined {
+		try {
+			const parsed = JSON.parse(key) as unknown;
+			if (Array.isArray(parsed) && typeof parsed[0] === "string") {
+				return parsed[0];
+			}
+		} catch {
+			// Keys are always produced by makeKey, so this is unreachable in
+			// practice; fall through to undefined defensively.
+		}
+		return undefined;
 	}
 }

--- a/src/utils/errorUtils.test.ts
+++ b/src/utils/errorUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { toError } from "./errorUtils";
+
+describe("toError", () => {
+	it("returns the same Error instance when no context is provided", () => {
+		const original = new Error("boom");
+		expect(toError(original)).toBe(original);
+	});
+
+	it("does not mutate the caller's Error when adding context", () => {
+		const original = new Error("original");
+		const wrapped = toError(original, "ctx");
+
+		// The caller's object is untouched...
+		expect(original.message).toBe("original");
+		// ...and a new Error carries the prefixed message.
+		expect(wrapped).not.toBe(original);
+		expect(wrapped.message).toBe("ctx: original");
+	});
+
+	it("does not compound prefixes across repeated wrapping of one instance", () => {
+		const original = new Error("original");
+
+		// Simulate the same Error flowing through two reporting layers.
+		toError(original, "inner");
+		const outer = toError(original, "outer");
+
+		expect(original.message).toBe("original");
+		expect(outer.message).toBe("outer: original");
+	});
+
+	it("preserves the original name and stack when wrapping", () => {
+		const original = new TypeError("bad type");
+		const wrapped = toError(original, "ctx");
+
+		expect(wrapped.name).toBe("TypeError");
+		expect(wrapped.stack).toBe(original.stack);
+	});
+
+	it("wraps non-Error values into an Error with optional context", () => {
+		expect(toError("plain").message).toBe("plain");
+		expect(toError("plain", "ctx").message).toBe("ctx: plain");
+		expect(toError(42, "ctx").message).toBe("ctx: 42");
+	});
+});

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -25,12 +25,19 @@ export const MAX_ERROR_LOG_SIZE = 100;
  * ```
  */
 export function toError(err: unknown, contextMessage?: string): Error {
-  // If it's already an Error, just add context if needed
+  // If it's already an Error, return it as-is when there's no context to add.
   if (err instanceof Error) {
-    if (contextMessage) {
-      err.message = `${contextMessage}: ${err.message}`;
+    if (!contextMessage) {
+      return err;
     }
-    return err;
+    // Do NOT mutate the caller's Error. Mutating err.message compounds context
+    // prefixes when the same Error instance is reported through multiple layers
+    // (e.g. "outer: inner: original"). Return a fresh Error that prepends the
+    // context while preserving the original name and stack trace.
+    const wrapped = new Error(`${contextMessage}: ${err.message}`);
+    wrapped.name = err.name;
+    wrapped.stack = err.stack;
+    return wrapped;
   }
   
   // If it's a string, create a new Error with it

--- a/src/utils/templatePropertyStringParser.test.ts
+++ b/src/utils/templatePropertyStringParser.test.ts
@@ -61,4 +61,27 @@ describe('templatePropertyStringParser', () => {
 		const expectedFirst = "\"value with \\\"quote\\\" inside\"";
 		expect(segments).toEqual([expectedFirst, '"second"']);
 	});
+
+	it('treats apostrophes as literal text, not quote delimiters', () => {
+		// The apostrophe in O'Brien must not open a quote and swallow the comma.
+		const segments = splitTopLevel("O'Brien, Alice");
+		expect(segments).toEqual(["O'Brien", "Alice"]);
+	});
+
+	it('splits multi-value property values containing an apostrophe into an array', () => {
+		const result = parseStructuredPropertyValueFromString("O'Brien, Alice");
+		expect(result).toEqual(["O'Brien", "Alice"]);
+	});
+
+	it('still protects commas inside straight double quotes', () => {
+		const segments = splitTopLevel('"Doe, Jane", Bob');
+		expect(segments).toEqual(['"Doe, Jane"', 'Bob']);
+	});
+
+	it('treats curly quotes as literal text (only the straight quote is a delimiter)', () => {
+		// A lone curly close-quote (e.g. the inches symbol) must not open a quote
+		// context and swallow the following comma.
+		const segments = splitTopLevel('5” long, blue');
+		expect(segments).toEqual(['5” long', 'blue']);
+	});
 });

--- a/src/utils/templatePropertyStringParser.ts
+++ b/src/utils/templatePropertyStringParser.ts
@@ -30,7 +30,11 @@ function splitTopLevel(value: string, delimiter = ","): string[] {
 			continue;
 		}
 
-		if (char === '"' || char === "'") {
+		// Only the straight double quote is a delimiter. Single quotes/apostrophes
+		// are intentionally NOT quotes - they are ubiquitous in property text
+		// (O'Brien, 'tis), and treating them as quotes silently swallowed the comma
+		// in values like "O'Brien, Alice" so the value never split.
+		if (char === '"') {
 			quote = char;
 			current += char;
 			continue;

--- a/src/utils/variablesProxy.test.ts
+++ b/src/utils/variablesProxy.test.ts
@@ -77,6 +77,26 @@ describe("createVariablesProxy", () => {
 		expect((proxy as Record<string, unknown>).toString).toBeUndefined();
 	});
 
+	it("does not throw when introspecting the hasOwnProperty descriptor", () => {
+		const backing = new Map<string, unknown>();
+		const proxy = createVariablesProxy(backing);
+
+		// Reporting configurable:false for the configurable target property
+		// violates the [[GetOwnProperty]] invariant and throws a TypeError.
+		const descriptor = Object.getOwnPropertyDescriptor(
+			proxy,
+			"hasOwnProperty",
+		);
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.configurable).toBe(true);
+		expect(typeof descriptor?.value).toBe("function");
+
+		// Related introspection paths must also not throw.
+		expect(() =>
+			Object.prototype.propertyIsEnumerable.call(proxy, "hasOwnProperty"),
+		).not.toThrow();
+	});
+
 	it("enumerates via Object.entries and Object.values", () => {
 		const backing = new Map<string, unknown>([
 			["a", 1],

--- a/src/utils/variablesProxy.ts
+++ b/src/utils/variablesProxy.ts
@@ -36,9 +36,14 @@ export function createVariablesProxy(
 		getOwnPropertyDescriptor(_t, prop: string | symbol) {
 			if (prop === "hasOwnProperty") {
 				return {
+					// Must stay consistent with the actual target property, which
+					// is a normal (configurable + writable) own property of the
+					// object literal. Reporting configurable:false here violates
+					// the [[GetOwnProperty]] proxy invariant and makes
+					// Object.getOwnPropertyDescriptor(proxy, "hasOwnProperty") throw.
 					value: target.hasOwnProperty,
-					writable: false,
-					configurable: false,
+					writable: true,
+					configurable: true,
 					enumerable: false,
 				};
 			}


### PR DESCRIPTION
Fixes 6 correctness/robustness `BUG`-severity findings from the deepsec scan, scoped to core data-handling utilities. Each is an internal logic/data-structure defect (not a security vulnerability); each is fixed at the root with a regression test that is RED without the fix and GREEN with it. Commits are one-per-fix in independent files.

All findings were independently re-verified against current code, then adversarially reviewed (one reviewer per fix, opposite-lens, RED-without-fix confirmation). All came back **sound** with rigorous tests.

> **Scope note:** a 7th finding in this subgroup - `getMarkdownFilesInFolder` unanchored `startsWith` in `vaultQueries.ts` - was also owned by a sibling subgroup and landed first in #1435 with a functionally identical fix. This branch was rebased onto that change and the redundant commit dropped; the finding (and its sibling `vaultTools.ts` over-matching report) is fully resolved on master. The remaining 6 files here do not overlap #1435/#1431/#1432.

## Findings & fixes (per commit)

**`fix(suggesters): use peek() not get() in createIndexedFile`** - `FileIndex.ts`
`createIndexedFile()` read the open timestamp via the mutating `LRUCache.get()`, which promotes the key to most-recently-used. Since it runs for every file during a full reindex in vault-iteration order, each reindex rewrote the `recentFiles` recency ranking to vault order, so the next file open evicted the wrong "oldest" entry and degraded the note-picker recency boost. Switched to the non-mutating `peek()` and removed the now-dead `get()` method so the bug class can't recur.

**`fix(field-suggestions): encode cache keys to avoid ':' collisions`** - `FieldSuggestionCache.ts`
`makeKey()` joined `fieldName` and `cacheKey` with a raw `:`, so `makeKey('foo','bar:baz') === makeKey('foo:bar','baz')`. `clear(fieldName)` compounded it with a `startsWith` prefix match that over-invalidated unrelated fields. Now encodes a JSON tuple and clears by the decoded field-name component.

**`fix(dataview): escape folder for the DQL string literal, not just regex`** - `DataviewIntegration.ts`
Folder filters embed as `regexmatch("^<folder>/", file.path)` inside a Dataview DQL double-quoted string literal. `escapeRegex` neutralized regex metacharacters but not the `"` that terminates the literal, so a quote produced malformed DQL and the fast path silently fell back to manual collection. Now wraps the regex-escaped folder with `escapeDataviewString` (both include and exclude sites). Plain folders stay byte-identical; also fixes regex metacharacters (e.g. a literal dot) surviving the string layer.

**`fix(template-properties): stop treating apostrophes as quote delimiters`** - `templatePropertyStringParser.ts`
`splitTopLevel` opened a quote context on both `"` and `'`, so a multi-value property value with an apostrophe before a comma (`O'Brien, Alice`) never split - the `'` opened a quote that never closed and the comma was consumed as literal, so the value stored as a raw string instead of an array. Restricted the quote class to the straight double quote only. (An earlier draft also added curly double-quotes; the adversarial pass flagged that as out-of-scope behavior expansion introducing a new `5" long` edge case, so it was narrowed to exactly the apostrophe finding.)

**`fix(variables-proxy): report a valid hasOwnProperty descriptor`** - `variablesProxy.ts`
The `getOwnPropertyDescriptor` trap returned `configurable:false` for the `hasOwnProperty` shim, but that property is a configurable own property of the proxy target. The `[[GetOwnProperty]]` invariant forbids reporting a configurable target property as non-configurable, so `Object.getOwnPropertyDescriptor(proxy, 'hasOwnProperty')` (and `propertyIsEnumerable`) threw a `TypeError`. Now returns a descriptor consistent with the target (`configurable`+`writable`, non-enumerable).

**`fix(errors): stop toError from mutating the caller's Error.message`** - `errorUtils.ts`
Given an `Error` and a context message, `toError` mutated `err.message` in place, so the same `Error` reported through multiple layers compounded prefixes (`outer: inner: original`). Now returns a fresh `Error` that prepends the context while preserving the original `name`/`stack`. Safe because `toError` has no external importers - `reportError` and the wrappers are the sole consumers, and they only log.

## Reviewer notes
- Each fix is a true root-cause fix with a RED-without-fix regression test (verified by reverting the source and re-running).
- All deferred items raised in review were confirmed pre-existing/out-of-scope (e.g. `generateFieldCacheKey` `|`-join ambiguity, `Object.freeze` on the variables proxy) and are not introduced or worsened here.

## Validation
- `tsc -noEmit -skipLibCheck`: clean
- `eslint .`: clean
- `svelte-check`: 0 errors (4 pre-existing warnings, unrelated)
- Full test suite: 3284 passed, 37 skipped, 0 failed (rebased on current master)