### PR TITLE
fix(ui): resolve deepsec UI/settings BUG findings (suggester leaks, AI modals, provider migration)

### DIFF
--- a/src/ai/aiHelpers.maxChunkTokens.test.ts
+++ b/src/ai/aiHelpers.maxChunkTokens.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS } from "src/settings";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+import type { AIProvider } from "src/ai/Provider";
+import {
+	getLargestModelMaxTokens,
+	getMaxChunkTokensUpperBound,
+} from "./aiHelpers";
+import { estimateModelInputBudget } from "./tokenEstimator";
+
+function setProviders(providers: AIProvider[]): void {
+	settingsStore.setState({
+		ai: { ...settingsStore.getState().ai, providers },
+	});
+}
+
+function provider(name: string, models: AIProvider["models"]): AIProvider {
+	return {
+		name,
+		endpoint: "https://example.com/v1",
+		apiKey: "",
+		models,
+		modelSource: "providerApi",
+	};
+}
+
+describe("getLargestModelMaxTokens", () => {
+	beforeEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	it("returns the most permissive configured model's context window", () => {
+		setProviders([
+			provider("A", [{ name: "small", maxTokens: 4096 }]),
+			provider("B", [{ name: "big", maxTokens: 200000 }]),
+		]);
+		expect(getLargestModelMaxTokens()).toBe(200000);
+	});
+
+	it("ignores non-finite / non-positive maxTokens values", () => {
+		setProviders([
+			provider("A", [
+				{ name: "bad", maxTokens: Number.NaN },
+				{ name: "zero", maxTokens: 0 },
+				{ name: "ok", maxTokens: 8000 },
+			]),
+		]);
+		expect(getLargestModelMaxTokens()).toBe(8000);
+	});
+
+	it("falls back to a conservative default when no models are configured", () => {
+		setProviders([]);
+		expect(getLargestModelMaxTokens()).toBe(4096);
+	});
+});
+
+describe("getMaxChunkTokensUpperBound", () => {
+	beforeEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+		setProviders([
+			provider("OpenAI", [{ name: "gpt-x", maxTokens: 128000 }]),
+			provider("Big", [{ name: "huge", maxTokens: 1000000 }]),
+		]);
+	});
+
+	it("uses the selected model's budget minus the system-prompt overhead", () => {
+		expect(getMaxChunkTokensUpperBound("gpt-x", 0)).toBe(
+			estimateModelInputBudget(128000),
+		);
+		expect(getMaxChunkTokensUpperBound("gpt-x", 1000)).toBe(
+			estimateModelInputBudget(128000) - 1000,
+		);
+	});
+
+	it("falls back to the largest configured model for the 'Ask me' sentinel", () => {
+		// "Ask me" is not a real model; it must not throw and must yield the
+		// most-permissive bound rather than collapsing to the floor.
+		expect(getMaxChunkTokensUpperBound("Ask me", 0)).toBe(
+			estimateModelInputBudget(1000000),
+		);
+	});
+
+	it("falls back for a model that no longer exists", () => {
+		expect(getMaxChunkTokensUpperBound("deleted-model", 0)).toBe(
+			estimateModelInputBudget(1000000),
+		);
+	});
+
+	it("never returns below 1 even when the system prompt exceeds the budget", () => {
+		expect(getMaxChunkTokensUpperBound("gpt-x", 10_000_000)).toBe(1);
+	});
+});

--- a/src/ai/aiHelpers.ts
+++ b/src/ai/aiHelpers.ts
@@ -1,4 +1,8 @@
 import { settingsStore } from "src/settingsStore";
+import { estimateModelInputBudget } from "./tokenEstimator";
+
+/** Conservative context-window fallback when no model is known or configured. */
+const FALLBACK_MODEL_MAX_TOKENS = 4096;
 
 export function getModelNames() {
 	const aiSettings = settingsStore.getState().ai;
@@ -36,4 +40,41 @@ export function getModelProvider(modelName: string) {
 	return aiSettings.providers.find((provider) =>
 		provider.models.some((m) => m.name === modelName)
 	);
+}
+
+/**
+ * Largest context window among all configured models, or a conservative
+ * fallback when none are configured. Used when the selected model is unknown at
+ * config time (see getMaxChunkTokensUpperBound).
+ */
+export function getLargestModelMaxTokens(): number {
+	const aiSettings = settingsStore.getState().ai;
+
+	const tokens = aiSettings.providers
+		.flatMap((provider) => provider.models)
+		.map((model) => model.maxTokens)
+		.filter((value) => Number.isFinite(value) && value > 0);
+
+	return tokens.length ? Math.max(...tokens) : FALLBACK_MODEL_MAX_TOKENS;
+}
+
+/**
+ * Upper bound for the "Max Chunk Tokens" slider: the model's estimated input
+ * budget minus the system-prompt overhead, floored at 1.
+ *
+ * The selected model can be unknown at config time — the "Ask me" sentinel
+ * (resolved at runtime) or a model that was removed from settings. In that case
+ * we fall back to the most permissive configured model instead of throwing,
+ * which would blank the settings modal. The runtime still caps each chunk to the
+ * actual model's budget, so a generous UI bound never lets a request exceed the
+ * real limit.
+ */
+export function getMaxChunkTokensUpperBound(
+	modelName: string,
+	systemPromptTokens: number,
+): number {
+	const model = getModelByName(modelName);
+	const maxTokens = model?.maxTokens ?? getLargestModelMaxTokens();
+
+	return Math.max(1, estimateModelInputBudget(maxTokens) - systemPromptTokens);
 }

--- a/src/gui/AIAssistantProvidersModal.discard.test.ts
+++ b/src/gui/AIAssistantProvidersModal.discard.test.ts
@@ -22,6 +22,28 @@ function provider(): AIProvider {
 	};
 }
 
+// A provider shaped like the built-in defaults: no apiKeyRef key at all.
+function providerWithoutApiKeyRef(): AIProvider {
+	return {
+		name: "Custom",
+		endpoint: "https://api.custom.ai/v1",
+		apiKey: "",
+		models: [],
+		modelSource: "providerApi",
+	};
+}
+
+function providerWithModels(): AIProvider {
+	return {
+		name: "Custom",
+		endpoint: "https://api.custom.ai/v1",
+		apiKey: "",
+		apiKeyRef: "",
+		models: [{ name: "m1", maxTokens: 1000 }],
+		modelSource: "providerApi",
+	};
+}
+
 function clickButtonByText(modal: AIAssistantProvidersModal, text: string) {
 	const button = Array.from(
 		modal.contentEl.querySelectorAll<HTMLButtonElement>("button"),
@@ -50,6 +72,21 @@ function renameInEditForm(
 	if (!nameInput) throw new Error(`Name input for "${currentName}" not found`);
 	nameInput.value = nextName;
 	nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+// Select a SecretStorage entry in the edit form. The API-key SecretComponent is
+// the only empty-valued text input in edit mode (Name/Endpoint are non-empty,
+// the auto-sync toggle is a checkbox).
+function setApiKeyRefInEditForm(
+	modal: AIAssistantProvidersModal,
+	value: string,
+) {
+	const secretInput = Array.from(
+		modal.contentEl.querySelectorAll<HTMLInputElement>("input"),
+	).find((el) => el.type === "text" && el.value === "");
+	if (!secretInput) throw new Error("API Key (secret) input not found");
+	secretInput.value = value;
+	secretInput.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
 // Finding: ai-assistant-providers-cancel-discard — Cancel/Escape while editing a
@@ -112,5 +149,42 @@ describe("AIAssistantProvidersModal discards edits on cancel/dismiss", () => {
 		clickButtonByText(modal, "Save");
 
 		expect(providers[0].name).toBe("Renamed");
+	});
+
+	it("discards an apiKeyRef added during edit on Cancel (a key the snapshot lacked)", () => {
+		const providers = [providerWithoutApiKeyRef()];
+		const modal = openProviderEdit(providers);
+
+		setApiKeyRefInEditForm(modal, "secret-ref-123");
+		expect(providers[0].apiKeyRef).toBe("secret-ref-123"); // live during edit
+
+		clickButtonByText(modal, "Cancel");
+
+		// Object.assign(provider, snapshot) could not remove apiKeyRef because the
+		// snapshot never had it; the snapshot-restore must.
+		expect(providers[0].apiKeyRef).toBeUndefined();
+		expect("apiKeyRef" in providers[0]).toBe(false);
+	});
+
+	it("discards an apiKeyRef added during edit on dismiss (Escape/X)", () => {
+		const providers = [providerWithoutApiKeyRef()];
+		const modal = openProviderEdit(providers);
+
+		setApiKeyRefInEditForm(modal, "secret-ref-123");
+		modal.close();
+
+		expect(providers[0].apiKeyRef).toBeUndefined();
+	});
+
+	it("discards nested model edits on Cancel", () => {
+		const providers = [providerWithModels()];
+		const modal = openProviderEdit(providers);
+
+		// The Add Model flow mutates selectedProvider.models in place; simulate it.
+		providers[0].models.push({ name: "leaked", maxTokens: 5 });
+
+		clickButtonByText(modal, "Cancel");
+
+		expect(providers[0].models).toEqual([{ name: "m1", maxTokens: 1000 }]);
 	});
 });

--- a/src/gui/AIAssistantProvidersModal.discard.test.ts
+++ b/src/gui/AIAssistantProvidersModal.discard.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { App, ButtonComponent } from "obsidian";
+import type { AIProvider } from "src/ai/Provider";
+
+vi.mock("./GenericInputPrompt/GenericInputPrompt", () => ({
+	default: { Prompt: vi.fn() },
+}));
+vi.mock("./GenericYesNoPrompt/GenericYesNoPrompt", () => ({
+	default: { Prompt: vi.fn().mockResolvedValue(true) },
+}));
+
+import { AIAssistantProvidersModal } from "./AIAssistantProvidersModal";
+
+function provider(): AIProvider {
+	return {
+		name: "Custom",
+		endpoint: "https://api.custom.ai/v1",
+		apiKey: "",
+		apiKeyRef: "",
+		models: [],
+		modelSource: "providerApi",
+	};
+}
+
+function clickButtonByText(modal: AIAssistantProvidersModal, text: string) {
+	const button = Array.from(
+		modal.contentEl.querySelectorAll<HTMLButtonElement>("button"),
+	).find((candidate) => candidate.textContent === text);
+	if (!button) throw new Error(`Button "${text}" not found`);
+	button.click();
+}
+
+function openProviderEdit(providers: AIProvider[]): AIAssistantProvidersModal {
+	const modal = new AIAssistantProvidersModal(providers, new App() as App);
+	clickButtonByText(modal, "Edit");
+	return modal;
+}
+
+// Type the new provider name into the edit form's Name field (the only input
+// whose value matches the current name) and fire the onChange the modal listens
+// for.
+function renameInEditForm(
+	modal: AIAssistantProvidersModal,
+	currentName: string,
+	nextName: string,
+) {
+	const nameInput = Array.from(
+		modal.contentEl.querySelectorAll<HTMLInputElement>("input"),
+	).find((el) => el.value === currentName);
+	if (!nameInput) throw new Error(`Name input for "${currentName}" not found`);
+	nameInput.value = nextName;
+	nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+// Finding: ai-assistant-providers-cancel-discard — Cancel/Escape while editing a
+// provider must discard the in-progress edits (restoring the snapshot taken on
+// Edit), not persist them. Earlier code left the mutated provider in the array.
+describe("AIAssistantProvidersModal discards edits on cancel/dismiss", () => {
+	beforeAll(() => {
+		const modalProto = Object.getPrototypeOf(
+			AIAssistantProvidersModal.prototype,
+		) as { onClose?: () => void };
+		modalProto.onClose ??= function onClose() {};
+
+		const btnProto = ButtonComponent.prototype as unknown as {
+			setDestructive?: () => unknown;
+			setIcon?: () => unknown;
+		};
+		btnProto.setDestructive ??= function setDestructive(this: unknown) {
+			return this;
+		};
+		btnProto.setIcon ??= function setIcon(this: unknown) {
+			return this;
+		};
+	});
+
+	afterEach(() => {
+		document.body.empty?.();
+		document.body.innerHTML = "";
+	});
+
+	it("restores the original provider when Cancel is clicked", () => {
+		const providers = [provider()];
+		const modal = openProviderEdit(providers);
+
+		renameInEditForm(modal, "Custom", "Renamed");
+		expect(providers[0].name).toBe("Renamed"); // edit is live until cancelled
+
+		clickButtonByText(modal, "Cancel");
+
+		expect(providers[0].name).toBe("Custom");
+	});
+
+	it("restores the original provider when the modal is dismissed (Escape/X)", () => {
+		const providers = [provider()];
+		const modal = openProviderEdit(providers);
+
+		renameInEditForm(modal, "Custom", "Renamed");
+		expect(providers[0].name).toBe("Renamed");
+
+		// close() runs onClose — the Escape/X dismissal path.
+		modal.close();
+
+		expect(providers[0].name).toBe("Custom");
+	});
+
+	it("keeps the edit when Save is clicked", () => {
+		const providers = [provider()];
+		const modal = openProviderEdit(providers);
+
+		renameInEditForm(modal, "Custom", "Renamed");
+		clickButtonByText(modal, "Save");
+
+		expect(providers[0].name).toBe("Renamed");
+	});
+});

--- a/src/gui/AIAssistantProvidersModal.ts
+++ b/src/gui/AIAssistantProvidersModal.ts
@@ -333,6 +333,23 @@ export class AIAssistantProvidersModal extends Modal {
 			});
 	}
 
+	// Discard in-progress edits to the selected provider by restoring the
+	// snapshot taken on Edit. We swap the array entry wholesale rather than
+	// Object.assign-ing the clone over the live object: Object.assign cannot
+	// remove keys the edit ADDED but the snapshot lacks (e.g. an apiKeyRef set on
+	// a default provider that had none), so those edits would survive Cancel.
+	private restoreSelectedProviderFromClone(): void {
+		if (!this.selectedProvider || !this._selectedProviderClone) return;
+
+		const index = this.providers.indexOf(this.selectedProvider);
+		if (index !== -1) {
+			this.providers[index] = this._selectedProviderClone;
+		}
+
+		this.selectedProvider = null;
+		this._selectedProviderClone = null;
+	}
+
 	addProviderSettingButtonRow(container: HTMLElement) {
 		const buttonRow = container.createDiv({
 			cls: "button-row qa-ai-provider-button-row",
@@ -342,14 +359,10 @@ export class AIAssistantProvidersModal extends Modal {
 		CancelButton.setButtonText("Cancel");
 		CancelButton.setDestructive();
 		CancelButton.onClick(() => {
-			if (!this.selectedProvider || !this._selectedProviderClone) return;
-
-			// Cancel always returns to the provider list. Restore the original
-			// values (discarding edits), then reload — never close(), so the
-			// modal doesn't flash-close-and-reopen via onClose's reopen branch.
-			Object.assign(this.selectedProvider, this._selectedProviderClone);
-			this.selectedProvider = null;
-			this._selectedProviderClone = null;
+			// Cancel always returns to the provider list, discarding edits. We
+			// never close() here so the modal doesn't flash-close-and-reopen via
+			// onClose's path.
+			this.restoreSelectedProviderFromClone();
 
 			this.reload();
 		});
@@ -377,14 +390,10 @@ export class AIAssistantProvidersModal extends Modal {
 
 	onClose(): void {
 		// If the user dismissed while editing a provider (Escape / X), discard
-		// the in-progress edits by restoring the clone, then resolve and close.
+		// the in-progress edits by restoring the snapshot, then resolve and close.
 		// We do NOT reopen the modal here — reopening on close made Escape re-show
 		// the dialog and required a second Escape to actually leave.
-		if (this.selectedProvider && this._selectedProviderClone) {
-			Object.assign(this.selectedProvider, this._selectedProviderClone);
-		}
-		this.selectedProvider = null;
-		this._selectedProviderClone = null;
+		this.restoreSelectedProviderFromClone();
 
 		this.resolvePromise(this.providers);
 		super.onClose();

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.test.ts
@@ -102,6 +102,25 @@ describe("InfiniteAIAssistantCommandSettingsModal max-chunk-tokens", () => {
 		}).not.toThrow();
 	});
 
+	it("surfaces a removed model as a disabled (missing) option instead of a blank dropdown", () => {
+		const settings = makeSettings("removed-model-9000");
+
+		const modal = new InfiniteAIAssistantCommandSettingsModal(
+			new App() as App,
+			settings,
+		);
+
+		const select = modal.contentEl.querySelector<HTMLSelectElement>("select");
+		expect(select).not.toBeNull();
+
+		const missing = Array.from(select!.options).find(
+			(option) => option.value === "removed-model-9000",
+		);
+		expect(missing).toBeDefined();
+		expect(missing!.textContent).toBe("(missing) removed-model-9000");
+		expect(missing!.disabled).toBe(true);
+	});
+
 	it("still renders for a known model", () => {
 		const settings = makeSettings("gpt-4o");
 

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { App, Setting } from "obsidian";
+import { DEFAULT_SETTINGS } from "src/settings";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+import type { IInfiniteAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
+
+// The system-prompt field wires up a format-syntax suggester and a live
+// formatter; neither is relevant to this regression, so stub them out to keep
+// the modal constructable in jsdom.
+vi.mock("src/quickAddInstance", () => ({
+	getQuickAddInstance: () => ({}),
+}));
+vi.mock("./../suggesters/formatSyntaxSuggester", () => ({
+	FormatSyntaxSuggester: class {
+		constructor() {
+			// no-op: real suggester needs app.dom/keymap
+		}
+	},
+}));
+vi.mock("src/formatters/formatDisplayFormatter", () => ({
+	FormatDisplayFormatter: class {
+		async format(input: string): Promise<string> {
+			return input;
+		}
+	},
+}));
+
+import { InfiniteAIAssistantCommandSettingsModal } from "./AIAssistantInfiniteCommandSettingsModal";
+
+function makeSettings(model: string): IInfiniteAIAssistantCommand {
+	return {
+		id: "infinite-test",
+		name: "Summarize",
+		type: "AIAssistant",
+		model,
+		systemPrompt: "You are a helpful assistant.",
+		outputVariableName: "output",
+		modelParameters: {},
+		resultJoiner: "\n",
+		chunkSeparator: "\n",
+		maxChunkTokens: 1000,
+		mergeChunks: false,
+	} as unknown as IInfiniteAIAssistantCommand;
+}
+
+describe("InfiniteAIAssistantCommandSettingsModal max-chunk-tokens", () => {
+	beforeAll(() => {
+		// The shared obsidian stub's Setting lacks addSlider; shim it locally so
+		// the modal can render the Max Chunk Tokens slider (documented harness gap).
+		const settingProto = Setting.prototype as unknown as {
+			addSlider?: (cb: (slider: unknown) => void) => unknown;
+		};
+		settingProto.addSlider ??= function addSlider(
+			this: unknown,
+			cb: (slider: unknown) => void,
+		) {
+			const slider = {
+				setLimits: () => slider,
+				setValue: () => slider,
+				setInstant: () => slider,
+				setDynamicTooltip: () => slider,
+				onChange: () => slider,
+			};
+			cb(slider);
+			return this;
+		};
+	});
+
+	beforeEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = "";
+	});
+
+	it("renders the full modal when the model is the 'Ask me' sentinel instead of throwing/blanking", () => {
+		const settings = makeSettings("Ask me");
+
+		let modal: InfiniteAIAssistantCommandSettingsModal | undefined;
+		expect(() => {
+			modal = new InfiniteAIAssistantCommandSettingsModal(
+				new App() as App,
+				settings,
+			);
+		}).not.toThrow();
+
+		// Both the slider (early in display()) and the System Prompt (last in
+		// display()) must render — proving display() did not abort midway and
+		// blank the modal.
+		const text = modal!.contentEl.textContent ?? "";
+		expect(text).toContain("Max Chunk Tokens");
+		expect(text).toContain("System Prompt");
+	});
+
+	it("renders without throwing when the configured model no longer exists", () => {
+		const settings = makeSettings("removed-model-9000");
+
+		expect(() => {
+			new InfiniteAIAssistantCommandSettingsModal(new App() as App, settings);
+		}).not.toThrow();
+	});
+
+	it("still renders for a known model", () => {
+		const settings = makeSettings("gpt-4o");
+
+		let modal: InfiniteAIAssistantCommandSettingsModal | undefined;
+		expect(() => {
+			modal = new InfiniteAIAssistantCommandSettingsModal(
+				new App() as App,
+				settings,
+			);
+		}).not.toThrow();
+		expect(modal!.contentEl.textContent ?? "").toContain("Max Chunk Tokens");
+	});
+});

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -117,10 +117,25 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 
 				dropdown.addOption("Ask me", "Ask me");
 
-				dropdown.setValue(this.settings.model);
+				// If the pinned model was deleted, the option no longer exists and
+				// setValue would silently fall back to the first option while the
+				// stored (now invalid) name persists. Surface the mismatch with a
+				// disabled "(missing)" entry so the dropdown reflects the saved
+				// value (mirrors AIAssistantCommandSettingsModal).
+				const stored = this.settings.model;
+				const isKnown = stored === "Ask me" || models.includes(stored);
+				if (stored && !isKnown) {
+					dropdown.addOption(stored, `(missing) ${stored}`);
+					const missingOption = Array.from(
+						dropdown.selectEl.options,
+					).find((option) => option.value === stored);
+					if (missingOption) missingOption.disabled = true;
+				}
+
+				dropdown.setValue(stored);
 				dropdown.onChange((value) => {
 					this.settings.model = value;
-					
+
 					this.reload();
 				});
 			});

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -11,11 +11,8 @@ import {
 	DEFAULT_TEMPERATURE,
 	DEFAULT_TOP_P,
 } from "src/ai/OpenAIModelParameters";
-import {
-	estimateModelInputBudget,
-	estimateTokenCount,
-} from "src/ai/tokenEstimator";
-import { getModelByName, getModelNames } from "src/ai/aiHelpers";
+import { estimateTokenCount } from "src/ai/tokenEstimator";
+import { getMaxChunkTokensUpperBound, getModelNames } from "src/ai/aiHelpers";
 
 export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 	public waitForClose: Promise<IInfiniteAIAssistantCommand>;
@@ -317,20 +314,12 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 				"Maximum estimated tokens for each chunk of your text (the {{chunk}} portion only — the system prompt and prompt template are accounted for separately). Counts are estimated locally; the provider enforces the exact limit. Leave room for the model's response. Values above the model's estimated input budget are capped automatically."
 			)
 			.addSlider((slider) => {
-				const model = getModelByName(this.settings.model);
-
-				if (!model) {
-					throw new Error(
-						`Model ${this.settings.model} not found in settings`
-					);
-				}
-
-				// Upper bound mirrors the runtime budget: the model's estimated
-				// input budget minus the (estimated) system prompt overhead.
-				const sliderMax = Math.max(
-					1,
-					estimateModelInputBudget(model.maxTokens) -
-						this.systemPromptTokenLength
+				// The selected model may be unknown at config time — the "Ask me"
+				// sentinel (resolved at runtime) or a model that was removed. Use
+				// a fallback bound instead of throwing, which would blank the modal.
+				const sliderMax = getMaxChunkTokensUpperBound(
+					this.settings.model,
+					this.systemPromptTokenLength,
 				);
 				slider.setLimits(1, sliderMax, 1);
 

--- a/src/gui/suggesters/suggest.test.ts
+++ b/src/gui/suggesters/suggest.test.ts
@@ -1,5 +1,33 @@
 import type { App } from "obsidian";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Track Popper instances so we can assert that the existing one is reused
+// (update) rather than recreated — and leaked — on every keystroke.
+const { createPopperMock, popperInstances } = vi.hoisted(() => {
+	const popperInstances: Array<{
+		destroy: ReturnType<typeof vi.fn>;
+		update: ReturnType<typeof vi.fn>;
+	}> = [];
+	const createPopperMock = vi.fn(() => {
+		const instance = { destroy: vi.fn(), update: vi.fn() };
+		popperInstances.push(instance);
+		return instance;
+	});
+	return { createPopperMock, popperInstances };
+});
+
+vi.mock("@popperjs/core", () => ({
+	createPopper: createPopperMock,
+}));
+
+vi.mock("src/logger/logManager", () => ({
+	log: {
+		logError: vi.fn(),
+		logMessage: vi.fn(),
+		logWarning: vi.fn(),
+	},
+}));
+
 import { GenericTextSuggester } from "./genericTextSuggester";
 
 function createApp(): App {
@@ -51,5 +79,74 @@ describe("TextInputSuggest", () => {
 		);
 
 		expect(input.value).toBe("Adventure");
+	});
+});
+
+describe("TextInputSuggest resource lifecycle", () => {
+	let app: App;
+	let input: HTMLInputElement;
+
+	beforeEach(() => {
+		createPopperMock.mockClear();
+		popperInstances.length = 0;
+		app = createApp();
+		input = document.createElement("input");
+		document.body.appendChild(input);
+	});
+
+	afterEach(() => {
+		document.body.replaceChildren();
+		vi.restoreAllMocks();
+	});
+
+	it("reuses a single Popper across keystrokes instead of leaking one per keystroke", async () => {
+		const suggest = new GenericTextSuggester(app, input, ["abcde", "abcxyz"]);
+
+		// First keystroke opens the dropdown and creates the Popper.
+		input.value = "a";
+		await suggest.onInputChanged();
+		expect(createPopperMock).toHaveBeenCalledTimes(1);
+
+		// Subsequent keystrokes re-open while already open. The Popper must be
+		// reused (update) rather than recreated, otherwise an instance — and the
+		// scroll/resize listeners it attaches — leaks on every keystroke.
+		input.value = "ab";
+		await suggest.onInputChanged();
+		input.value = "abc";
+		await suggest.onInputChanged();
+
+		expect(createPopperMock).toHaveBeenCalledTimes(1);
+		expect(popperInstances[0].update).toHaveBeenCalled();
+		expect(popperInstances[0].destroy).not.toHaveBeenCalled();
+
+		// Closing destroys the Popper; the next open creates a fresh one.
+		suggest.close();
+		expect(popperInstances[0].destroy).toHaveBeenCalledTimes(1);
+
+		input.value = "abcd";
+		await suggest.onInputChanged();
+		expect(createPopperMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps the instance registered after close() so a later same-class suggester destroys it", async () => {
+		const destroySpy = vi.spyOn(GenericTextSuggester.prototype, "destroy");
+
+		const first = new GenericTextSuggester(app, input, ["abcde"]);
+		input.value = "a";
+		await first.onInputChanged();
+		// Confirm it actually opened (close() early-returns when never opened,
+		// which would skip the historically-buggy unregister path).
+		expect(createPopperMock).toHaveBeenCalledTimes(1);
+
+		// close() only hides the dropdown; it must NOT unregister the instance.
+		first.close();
+		expect(destroySpy).not.toHaveBeenCalled();
+
+		// Attaching a new suggester of the same class to the same input must
+		// find and destroy the previous (still-registered) instance via the
+		// constructor dedup. If close() had unregistered it, the old instance's
+		// input listeners would leak and produce duplicate popups.
+		new GenericTextSuggester(app, input, ["abcde"]);
+		expect(destroySpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/gui/suggesters/suggest.test.ts
+++ b/src/gui/suggesters/suggest.test.ts
@@ -29,6 +29,24 @@ vi.mock("src/logger/logManager", () => ({
 }));
 
 import { GenericTextSuggester } from "./genericTextSuggester";
+import { TextInputSuggest } from "./suggest";
+
+// A suggester whose getSuggestions stays pending until the test resolves it, so
+// we can interleave destroy() with an in-flight async lookup.
+class DeferredSuggest extends TextInputSuggest<string> {
+	public resolvePending: ((items: string[]) => void) | null = null;
+	getSuggestions(): Promise<string[]> {
+		return new Promise((resolve) => {
+			this.resolvePending = resolve;
+		});
+	}
+	renderSuggestion(item: string, el: HTMLElement): void {
+		el.textContent = item;
+	}
+	selectSuggestion(): void {
+		// no-op for tests
+	}
+}
 
 function createApp(): App {
 	return {
@@ -148,5 +166,31 @@ describe("TextInputSuggest resource lifecycle", () => {
 		// input listeners would leak and produce duplicate popups.
 		new GenericTextSuggester(app, input, ["abcde"]);
 		expect(destroySpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not re-open when an in-flight async getSuggestions resolves after destroy()", async () => {
+		const suggest = new DeferredSuggest(app, input);
+
+		input.value = "a";
+		const inFlight = suggest.onInputChanged(); // awaits the pending lookup
+		expect(suggest.resolvePending).not.toBeNull();
+
+		// Destroy mid-flight, then let the lookup resolve. A destroyed instance
+		// must not spawn an orphaned popup.
+		suggest.destroy();
+		suggest.resolvePending?.(["a", "ab"]);
+		await inFlight;
+
+		expect(createPopperMock).not.toHaveBeenCalled();
+	});
+
+	it("ignores onInputChanged fired after destroy() (pending debounce)", async () => {
+		const suggest = new GenericTextSuggester(app, input, ["abcde"]);
+
+		suggest.destroy();
+		input.value = "a";
+		await suggest.onInputChanged();
+
+		expect(createPopperMock).not.toHaveBeenCalled();
 	});
 });

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -194,6 +194,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	private suggest: Suggest<T>;
 	private currentRequestId = 0;
 	private isOpen = false;
+	private destroyed = false;
 	private noResultsTimeout: number | null = null;
 	private currentQuery = "";
 
@@ -293,6 +294,9 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	}
 
 	async onInputChanged(event?: Event): Promise<void> {
+		// A pending debounced call can fire after destroy() removed the input
+		// listeners; bail so a destroyed instance never re-opens.
+		if (this.destroyed) return;
 		const completionEvent = event as CompletionInputEvent | undefined;
 		// Handle multi-select mode: keep suggestions open after selection
 		if (completionEvent?.fromCompletion && completionEvent.keepOpen) {
@@ -366,6 +370,9 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	}
 
 	open(container: HTMLElement, inputEl: HTMLElement): void {
+		// An async getSuggestions() may resolve after destroy() and reach open();
+		// refuse to re-open a destroyed instance (would spawn an orphaned popup).
+		if (this.destroyed) return;
 		// Always add listeners; if already open just update popper position
 		if (!this.isOpen) {
 			this.app.keymap.pushScope(this.scope);
@@ -479,6 +486,9 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	}
 
 	destroy(): void {
+		// Mark dead first so any in-flight async getSuggestions() or pending
+		// debounced onInputChanged() that resolves after this point can't re-open.
+		this.destroyed = true;
 		this.close();
 		// Remove input listeners
 		this.inputEl.removeEventListener("input", this.inputEventListener);

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -381,7 +381,16 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 			containerDocument === inputDocument ? container : inputDocument.body;
 		ownerCompatibleContainer.appendChild(this.suggestEl);
 
-		// Create Popper only when needed
+		// open() runs on every keystroke (onInputChanged re-opens to refresh the
+		// suggestions). If a Popper already exists, reposition it instead of
+		// creating a new one — recreating here would leak a Popper instance, and
+		// the scroll/resize listeners it attaches, on every keystroke. The Popper
+		// (and the global listeners below) are torn down together in close().
+		if (this.popper) {
+			void this.popper.update();
+			return;
+		}
+
 		this.popper = createPopper(inputEl, this.suggestEl, {
 			placement: "bottom-start",
 			modifiers: [
@@ -417,7 +426,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 			],
 		});
 
-		// Add global listeners (idempotent due to capture true)
+		// Add global listeners (paired with the Popper lifecycle: removed in close()).
 		const activeDocument = inputDocument;
 		const activeWindow = getOwnerWindow(inputEl);
 		activeDocument.addEventListener("pointerdown", this.globalClickListener, true);
@@ -460,14 +469,13 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 		activeWindow.removeEventListener("resize", this.globalResizeListener);
 		activeWindow.removeEventListener("blur", this.globalBlurListener);
 
-		const classKey = this.constructor.name;
-		const byClass = instanceMap.get(this.inputEl);
-		if (byClass) {
-			byClass.delete(classKey);
-			if (byClass.size === 0) {
-				instanceMap.delete(this.inputEl);
-			}
-		}
+		// Intentionally keep this instance registered in instanceMap. close()
+		// only hides the dropdown; the input/focus/blur listeners stay attached
+		// so typing can re-open it. Unregistering here (while leaving those
+		// listeners live) would orphan the instance: a later same-class suggester
+		// on this input would miss the dedup in the constructor and never
+		// destroy() us, leaking our input listeners and spawning duplicate
+		// popups. Deregistration belongs to destroy().
 	}
 
 	destroy(): void {

--- a/src/migrations/addDefaultAIProviders.test.ts
+++ b/src/migrations/addDefaultAIProviders.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type QuickAdd from "src/main";
+import { DefaultProviders } from "src/ai/Provider";
+import { DEFAULT_SETTINGS } from "src/settings";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+import addDefaultAIProviders from "./addDefaultAIProviders";
+
+const mockPlugin = {} as unknown as QuickAdd;
+
+function seedLegacyOpenAiKey(key: string): void {
+	// OpenAIApiKey is a legacy field that no longer exists on the typed ai
+	// settings; attach it via a cast so the migration's `"OpenAIApiKey" in ai`
+	// branch has something to migrate.
+	const current = settingsStore.getState();
+	settingsStore.setState({
+		ai: { ...current.ai, OpenAIApiKey: key } as typeof current.ai,
+	});
+}
+
+describe("addDefaultAIProviders migration", () => {
+	beforeEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	afterEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	});
+
+	it("does not mutate the shared DefaultProviders global with the user's key", async () => {
+		seedLegacyOpenAiKey("sk-legacy");
+
+		const openAiDefault = DefaultProviders.find((p) => p.name === "OpenAI");
+		expect(openAiDefault?.apiKey).toBe("");
+
+		await addDefaultAIProviders.migrate(mockPlugin);
+
+		// The global default must stay pristine — the key must not leak into it.
+		expect(openAiDefault?.apiKey).toBe("");
+	});
+
+	it("migrates the legacy key into the stored provider without aliasing the global", async () => {
+		seedLegacyOpenAiKey("sk-legacy");
+
+		await addDefaultAIProviders.migrate(mockPlugin);
+
+		const storedProviders = settingsStore.getState().ai.providers;
+		const storedOpenAi = storedProviders.find((p) => p.name === "OpenAI");
+		expect(storedOpenAi?.apiKey).toBe("sk-legacy");
+
+		// Stored providers must be independent copies, not the shared globals.
+		for (const globalProvider of DefaultProviders) {
+			expect(storedProviders).not.toContain(globalProvider);
+		}
+
+		// Mutating a stored copy must not bleed back into the global default.
+		storedOpenAi?.models.push({ name: "leak-check", maxTokens: 1 });
+		const openAiDefault = DefaultProviders.find((p) => p.name === "OpenAI");
+		expect(openAiDefault?.models.some((m) => m.name === "leak-check")).toBe(
+			false,
+		);
+
+		// The legacy plaintext key is removed from the ai settings.
+		expect("OpenAIApiKey" in settingsStore.getState().ai).toBe(false);
+	});
+
+	it("still populates default providers when there is no legacy key", async () => {
+		await addDefaultAIProviders.migrate(mockPlugin);
+
+		const storedProviders = settingsStore.getState().ai.providers;
+		expect(storedProviders.map((p) => p.name)).toEqual(
+			DefaultProviders.map((p) => p.name),
+		);
+		for (const globalProvider of DefaultProviders) {
+			expect(storedProviders).not.toContain(globalProvider);
+		}
+	});
+});

--- a/src/migrations/addDefaultAIProviders.test.ts
+++ b/src/migrations/addDefaultAIProviders.test.ts
@@ -64,13 +64,16 @@ describe("addDefaultAIProviders migration", () => {
 		expect("OpenAIApiKey" in settingsStore.getState().ai).toBe(false);
 	});
 
-	it("still populates default providers when there is no legacy key", async () => {
+	it("populates providers byte-for-byte identical to the defaults (deep equal, no shared refs) when there is no legacy key", async () => {
 		await addDefaultAIProviders.migrate(mockPlugin);
 
 		const storedProviders = settingsStore.getState().ai.providers;
-		expect(storedProviders.map((p) => p.name)).toEqual(
-			DefaultProviders.map((p) => p.name),
-		);
+
+		// Same serialized data as the defaults — endpoint, kind, models,
+		// autoSyncModels, modelSource, apiKey are all preserved.
+		expect(storedProviders).toEqual(DefaultProviders);
+
+		// ...but independent copies, not the shared global objects.
 		for (const globalProvider of DefaultProviders) {
 			expect(storedProviders).not.toContain(globalProvider);
 		}

--- a/src/migrations/addDefaultAIProviders.ts
+++ b/src/migrations/addDefaultAIProviders.ts
@@ -1,24 +1,29 @@
 import { DefaultProviders } from "src/ai/Provider";
 import type { Migration } from "./Migrations";
 import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
 
 const addDefaultAIProviders: Migration = {
 	description: "Add default AI providers to the settings.",
-	 
+
 	migrate: async (_) => {
 		const ai = settingsStore.getState().ai;
 
-		const defaultProvidersWithOpenAIKey = DefaultProviders.map(
-			(provider) => {
-				if (provider.name === "OpenAI") {
-					if ("OpenAIApiKey" in ai && typeof ai.OpenAIApiKey === "string") {
-						provider.apiKey = ai.OpenAIApiKey;
-					}
-				}
+		// Clone the defaults before mutating. DefaultProviders is a shared module
+		// global: mutating a provider in place would bake the user's legacy API
+		// key into the global (leaking it into every later read of the defaults)
+		// and store references to the same objects, aliasing settings.providers to
+		// the global so edits to one would silently change the other.
+		const providers = deepClone(DefaultProviders);
 
-				return provider;
+		if ("OpenAIApiKey" in ai && typeof ai.OpenAIApiKey === "string") {
+			const openAiProvider = providers.find(
+				(provider) => provider.name === "OpenAI",
+			);
+			if (openAiProvider) {
+				openAiProvider.apiKey = ai.OpenAIApiKey;
 			}
-		);
+		}
 
 		if ("OpenAIApiKey" in ai) {
 			delete ai.OpenAIApiKey;
@@ -27,11 +32,9 @@ const addDefaultAIProviders: Migration = {
 		settingsStore.setState({
 			ai: {
 				...settingsStore.getState().ai,
-				providers: defaultProvidersWithOpenAIKey,
+				providers,
 			},
 		});
-
-
 	},
 };
 


### PR DESCRIPTION
Resolves a deepsec subgroup of functional (correctness/robustness) BUG findings across the suggester infrastructure, the AI Assistant settings modals, and the default-providers migration. Each fix is at the root, with a regression test that fails without it (verified red/green). Findings were adversarially reviewed (Codex, 3 lenses, verdict PASS); the review surfaced four extra defects that are fixed here too (noted inline).

## Findings

### A. `suggest.ts` — a Popper instance leaked on every keystroke
`open()` runs on every input change (`onInputChanged` re-opens to refresh suggestions) and unconditionally called `createPopper`, leaking the previous Popper instance and the scroll/resize listeners it attaches **per keystroke**. Now we reuse the existing Popper (`update()` + early-return) and only create one — paired with its global listeners — when none exists; `close()` still tears both down. (`af5a3bb2`)

### B. `suggest.ts` — `close()` orphaned suggester instances (leaked input listeners + duplicate popups)
`close()` deleted the instance from the per-input `instanceMap` while leaving the input/focus/blur listeners attached. A later same-class suggester on the same input then missed the constructor dedup and never `destroy()`ed the old one, leaking its listeners and spawning duplicate popups. This is reachable today: `validatedInput.ts` does `suggester.close(); new GenericTextSuggester(sameInput)`. `close()` now keeps the registration; only `destroy()` unregisters. (`af5a3bb2`)

- **Review hardening:** `destroy()` removed listeners but never invalidated work already in flight, so an async `getSuggestions()` (e.g. `FieldValueInputSuggest`) resolving after destroy — or a pending debounced `onInputChanged()` — could still call `open()` and spawn an orphaned popup. Added a `destroyed` flag guarding `onInputChanged()`/`open()`. (`a206ae73`)

### C. `AIAssistantProvidersModal` — Cancel/Escape did not discard provider edits
The core finding was already fixed by #1413 (snapshot on Edit, restore on Cancel/onClose). Added a guard regression test that drives the real modal (rename → Cancel / dismiss / Save). (`b47a0b79`)

- **Review hardening (real residual bug):** the #1413 restore used `Object.assign(provider, snapshot)`, which cannot remove keys the edit **added** but the snapshot lacked. Editing a default provider (no `apiKeyRef`) to pick a SecretStorage entry, then Cancel/Escape, left the secret reference behind — a discard leak. Now the array entry is swapped back to the snapshot via a shared `restoreSelectedProviderFromClone()`. Regression tests cover the `apiKeyRef` leak (Cancel + dismiss) and nested-model discard. (`cf55ffe4`)

### D. `AIAssistantInfiniteCommandSettingsModal` — threw/blanked on an unknown model
`addMaxTokensSetting` threw `Model <name> not found` when `getModelByName` returned undefined — which happens for the `"Ask me"` sentinel (the **default** model) and for a removed model. The throw escaped `display()` and left the modal blank. Replaced with `aiHelpers.getMaxChunkTokensUpperBound`, which falls back to the most permissive configured model (`getLargestModelMaxTokens`, floored at 4096) instead of throwing. The runtime still caps each chunk to the actual model's budget, so the generous UI bound never lets a request exceed the real limit. (`4e145c6e`)

- **Review hardening:** not throwing still left the model dropdown blank for a removed model. Mirrored `AIAssistantCommandSettingsModal` and added a disabled `(missing) <name>` option. Added direct unit tests pinning the fallback's actual bound values (known/Ask-me/removed/empty-providers/invalid-token/floor-at-1), since the modal tests only proved "does not throw". (`b78d12b1`)

### E. `addDefaultAIProviders` migration — mutated the shared `DefaultProviders` global
The migration mapped `DefaultProviders` but mutated each provider in place (`provider.apiKey = …`) and stored those same global object references into `settings.providers`. That baked the user's legacy API key into the shared module global (leaking it into every later read of the defaults) and aliased settings to the global. Now it `deepClone`s the defaults first and sets the key on the clone; the no-legacy-key path is behavior-preserving. (`cfe10baf`, test strengthened in `cc8bb55e`)

## Design note
For `"Ask me"`/unknown models I keep the most-permissive-configured-model fallback rather than a fixed low cap: a fixed cap would wrongly limit `maxChunkTokens` for users who pick a large-context model at runtime, and the runtime already enforces the real per-model budget.

## Testing
- `tsc -noEmit`, `eslint .`, `svelte-check --threshold error` (0 errors) — all clean.
- Full suite: 3342 passed / 37 skipped (+13 new regression tests).
- Every fix verified red-without / green-with via controlled reverts.

## Reviewer focus
- `suggest.ts` `open()` reuse early-return and the `close()`/`destroy()` lifecycle split.
- The providers-modal snapshot-swap restore (array-entry replacement vs `Object.assign`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI settings so edits are safely discarded when canceled or closed.
  * Prevented missing or removed AI models from breaking the settings dialogs.
  * Fixed chunk-token limits to stay valid even when model limits are unknown or prompt overhead is high.
  * Improved autocomplete stability so suggestion popups no longer reopen or leak after closing.
* **Tests**
  * Added coverage for AI settings, token limits, migration behavior, and suggestion lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## E2E validation (Obsidian vault)

Every fix was validated end-to-end in this worktree's own isolated Obsidian vault (Obsidian **1.13.0**, the declared `minAppVersion`), driving the **real bundled classes** in the live renderer via `obsidian … eval`. RED = pre-fix bundle built from `origin/master`; GREEN = this branch. Both bundles were exercised by the identical measurement scripts, swapped via `plugin:reload`.

> Harness note: eval scope has no `require`, so a small **uncommitted** dev hook (`window.__qaE2E`, reverted after capture — the tree and bundle are clean, `grep __qaE2E main.js` → 0) exposed the same shipped classes for driving. No fix code was modified to test it.

| Fix | RED (pre-fix, in-app) | GREEN (this branch, in-app) | Observability |
|-----|-----------------------|------------------------------|---------------|
| **A** Popper-per-keystroke leak | distinct `resize` listeners on `window` grow **per keystroke**: `[2,3,4,5,6,7]` over 6 keys (`scroll`: 6) | flat **`[2,2,2,2,2,2]`** (`scroll`: 1) — Popper reused | executed-in-app, measured (leak not itself visual) |
| **B** `close()` orphans instance → leaked listeners + duplicate popups | after `close()`+reconstruct on the same input: **2** `input`/**2** `focus`/**2** `blur` listeners live, **2** `.suggestion-container` popups | **1**/**1**/**1** listeners, **1** popup — reconstruct destroyed the old instance | duplicate popups are **UI-visible**; listeners measured |
| **C** Cancel/Escape leaks added `apiKeyRef` | edit a default provider (no `apiKeyRef`) → add a secret ref → **Cancel**: `apiKeyRef` = `"secret-ref-xyz"` survives (key still present) | `apiKeyRef` = `null`, key removed — discarded | real ProvidersModal in-app; state data-observable |
| **D** Infinite-assistant modal on unknown model | constructing the real modal with `model:"Ask me"` (the default) **throws** `Model Ask me not found in settings` → blank; same for a removed model | renders fully (`Max Chunk Tokens` + `System Prompt` present); removed model shows a disabled **`(missing) removed-model-9000`** option | **UI-visible** (modal renders; `(missing)` option in the dropdown) |
| **E** Migration mutates shared `DefaultProviders` | run the real migration against a legacy `ai.OpenAIApiKey`: global `DefaultProviders` OpenAI key becomes `"sk-legacy-LIVE"` (**polluted**), settings **aliased** to the global | global key stays `""` (not polluted), settings **not** aliased; legacy key still migrated into the stored copy | executed-in-app, not visually observable (internal/global state) |

**Explicitly UI-visible:** B (duplicate suggestion popups) and D (modal renders vs blanks; the `(missing)` dropdown option).
**Executed in the live plugin but not purely visual:** A (event-listener accumulation), C (provider object state through the real modal's Cancel handler), E (the shared global + settings references after the real migration runs).

**Disclosed caveat (separate, pre-existing):** on the harness's Obsidian **1.13.0**, `ButtonComponent.setDestructive` is **absent**, so `AIAssistantProvidersModal` (and `GenericYesNoPrompt`) throw on construction. I shimmed it for the C run (the same affordance the unit tests use); it does not affect the discard logic under test. This looks like a real `minAppVersion` compatibility gap unrelated to this PR — flagging it for a follow-up.
