### PR TITLE
fix(field): wikilink-aware inline-field parsing + stop migration deleting code blocks

### DIFF
--- a/docs/static/scripts/migrateDataviewToFrontmatter.js
+++ b/docs/static/scripts/migrateDataviewToFrontmatter.js
@@ -145,11 +145,14 @@ async function start(params, settings) {
             });
         });
 
-        // Now update the content to remove inline properties
-        // We need to read the file again because processFrontMatter already saved it
-        const updatedContent = await app.vault.read(activeFile);
-        const { cleanedContent: finalContent } = parseInlineFieldsWithWikilinks(updatedContent, propertiesToMigrate, migrateAll);
-        await app.vault.modify(activeFile, finalContent);
+        // Now strip the migrated inline properties from the body. Use vault.process
+        // so the read + rewrite is a single atomic operation (processFrontMatter
+        // already persisted the frontmatter; a separate read-then-modify could
+        // clobber a concurrent edit or sync that landed in between).
+        await app.vault.process(activeFile, (data) => {
+            const { cleanedContent } = parseInlineFieldsWithWikilinks(data, propertiesToMigrate, migrateAll);
+            return cleanedContent;
+        });
 
         // Show success message
         const fieldNames = Array.from(fields.keys()).join(", ");
@@ -176,47 +179,114 @@ function parseInlineFieldsWithWikilinks(content, allowedProperties = [], migrate
     const fields = new Map();
     const allowedPropertiesLower = allowedProperties.map(p => p.toLowerCase());
 
-    // Split content into frontmatter and body
+    // Split content into frontmatter and body. Frontmatter is preserved verbatim
+    // and is never scanned for fields or collapsed.
     const { frontmatterEnd, hasExistingFrontmatter, frontmatterText } = findFrontmatterEnd(content);
     const bodyContent = hasExistingFrontmatter ? content.slice(frontmatterEnd) : content;
 
-    // Process each line in the body
+    // Process each line in the body.
     const bodyLines = bodyContent.split('\n');
     const cleanedBodyLines = [];
+    // Parallel to cleanedBodyLines: a "protected" line (a fence delimiter or any
+    // line inside a fenced code block) is kept verbatim and never collapsed.
+    const protectedFlags = [];
+
+    // Track the currently open fenced code block, if any. fenceDepth is the
+    // blockquote nesting level the fence opened at (0 = top level), so a fence
+    // inside "> ..." is closed by a closer at the same quote depth.
+    let fenceChar = null; // '`' or '~'
+    let fenceLen = 0;
+    let fenceDepth = 0;
 
     for (let i = 0; i < bodyLines.length; i++) {
         const line = bodyLines[i];
-        const trimmedLine = line.trim();
 
-        // Check if this line is an inline field
+        if (fenceChar !== null) {
+            // Inside a fenced code block. Strip exactly the fence's blockquote
+            // container; if this line carries fewer markers, the blockquote (and
+            // therefore the fenced block) has ended - reprocess the line below as
+            // non-fence so a real field after the block still migrates.
+            const { depth, content } = stripBlockquote(line, fenceDepth);
+            if (depth >= fenceDepth) {
+                // Still inside the block: preserve verbatim, never migrate. Only a
+                // matching closing fence (same marker, long enough, no info string)
+                // at the same quote depth ends it.
+                if (isClosingFence(content, fenceChar, fenceLen)) {
+                    fenceChar = null;
+                    fenceLen = 0;
+                    fenceDepth = 0;
+                }
+                cleanedBodyLines.push(line);
+                protectedFlags.push(true);
+                continue;
+            }
+            // Blockquote container exited: end the fence and fall through so this
+            // line is handled normally.
+            fenceChar = null;
+            fenceLen = 0;
+            fenceDepth = 0;
+        }
+
+        // Not inside a code block: an opening fence (top-level or blockquoted)
+        // starts one. Detect it on the blockquote-stripped content and remember the
+        // quote depth so the matching closer is recognised.
+        {
+            const { depth, content } = stripBlockquote(line, Infinity);
+            const fence = openingFence(content);
+            if (fence) {
+                fenceChar = fence.char;
+                fenceLen = fence.len;
+                fenceDepth = depth;
+                cleanedBodyLines.push(line);
+                protectedFlags.push(true);
+                continue;
+            }
+        }
+
+        // Outside any code fence: decide whether this line is a migratable field.
+        const trimmedLine = line.trim();
         let isPropertyToRemove = false;
 
-        if (trimmedLine && trimmedLine.includes('::')) {
-            // Skip task checkboxes
-            if (!/^[-*+]\s+\[[xX ]\]/.test(trimmedLine)) {
-                // Try to match inline field
-                const fieldMatch = trimmedLine.match(/^([^:]+?)::\s*(.+?)$/);
+        if (
+            trimmedLine.includes('::') &&
+            // Skip task checkboxes (e.g. "- [ ] do:: thing").
+            !/^[-*+]\s+\[[xX ]\]/.test(trimmedLine)
+        ) {
+            // Mask inline code spans so a "::" inside code is not read as a field
+            // separator. Masking preserves length so positions stay aligned with
+            // the original line.
+            const maskedLine = maskInlineCode(trimmedLine);
+            const fieldMatch = maskedLine.match(/^([^:]+?)::(.*)$/);
 
-                if (fieldMatch) {
-                    const fieldName = fieldMatch[1].trim();
-                    const fieldValue = fieldMatch[2].trim();
+            if (fieldMatch) {
+                const nameEnd = fieldMatch[1].length;
+                // The field name must be free of inline code. If masking changed
+                // the name region, the line is mid-content (e.g. a code span sits
+                // before the colon), not a clean "name:: value" field - leave it
+                // verbatim so we never delete the code span that precedes it.
+                const nameIsClean =
+                    maskedLine.slice(0, nameEnd) === trimmedLine.slice(0, nameEnd);
 
-                    // Check if this is a property we should migrate
-                    if (fieldValue) {
+                if (nameIsClean) {
+                    const fieldName = trimmedLine.slice(0, nameEnd).trim();
+                    // Skip the "::" separator; recover the real value (including any
+                    // backticks) from the original line.
+                    const fieldValue = trimmedLine.slice(nameEnd + 2).trim();
+
+                    if (fieldName && fieldValue) {
                         const fieldNameLower = fieldName.toLowerCase();
                         const shouldMigrate = migrateAll ||
                             (allowedPropertiesLower.length > 0 && allowedPropertiesLower.includes(fieldNameLower));
 
                         if (shouldMigrate) {
-                            // This line should be removed
+                            // This line should be removed (moved to frontmatter).
                             isPropertyToRemove = true;
 
-                            // Store the field value for frontmatter
                             if (!fields.has(fieldName)) {
                                 fields.set(fieldName, new Set());
                             }
 
-                            // Parse the value with special handling for wikilinks
+                            // Parse the value with special handling for wikilinks.
                             const parsedValues = parseCommaSeparatedWithWikilinks(fieldValue);
                             parsedValues.forEach(value => fields.get(fieldName).add(value));
                         }
@@ -225,24 +295,104 @@ function parseInlineFieldsWithWikilinks(content, allowedProperties = [], migrate
             }
         }
 
-        // Keep the line if it's not a property to remove
+        // Keep the line if it's not a property to remove.
         if (!isPropertyToRemove) {
             cleanedBodyLines.push(line);
+            protectedFlags.push(false);
         }
     }
 
-    // Reconstruct the content
-    let cleanedContent;
-    if (hasExistingFrontmatter) {
-        cleanedContent = frontmatterText + cleanedBodyLines.join('\n');
-    } else {
-        cleanedContent = cleanedBodyLines.join('\n');
+    // Collapse runs of 2+ consecutive blank lines down to a single blank line, but
+    // never touch blank lines inside fenced code blocks (verbatim guarantee). This
+    // also leaves the frontmatter untouched, unlike a global newline regex.
+    const collapsedLines = [];
+    let blankRun = 0;
+    for (let i = 0; i < cleanedBodyLines.length; i++) {
+        const bodyLine = cleanedBodyLines[i];
+        if (!protectedFlags[i] && bodyLine.trim() === '') {
+            blankRun += 1;
+            if (blankRun <= 1) {
+                collapsedLines.push(bodyLine);
+            }
+        } else {
+            blankRun = 0;
+            collapsedLines.push(bodyLine);
+        }
     }
 
-    // Remove excessive blank lines (more than 2 consecutive)
-    cleanedContent = cleanedContent.replace(/\n{3,}/g, '\n\n');
+    const cleanedBody = collapsedLines.join('\n');
+    const cleanedContent = hasExistingFrontmatter
+        ? frontmatterText + cleanedBody
+        : cleanedBody;
 
     return { fields, cleanedContent };
+}
+
+/**
+ * Strip up to `max` leading blockquote markers from a line. A marker is up to 3
+ * spaces of indentation, a ">", and one optional following space, and markers
+ * nest ("> > " or ">> "). Returns the number of markers stripped (`depth`) and the
+ * remaining `content`. This lets fenced code blocks be tracked inside blockquotes:
+ * the block's content and its closing fence sit at the same quote depth as the
+ * opener, and a line with fewer markers means the blockquote (and the block) ended.
+ */
+function stripBlockquote(line, max) {
+    let content = line;
+    let depth = 0;
+    while (depth < max) {
+        const match = content.match(/^ {0,3}>( ?)/);
+        if (!match) break;
+        depth += 1;
+        content = content.slice(match[0].length);
+    }
+    return { depth, content };
+}
+
+/**
+ * Detect an opening code fence (``` or ~~~) on a line whose blockquote markers
+ * have already been stripped. Per CommonMark a fence may be indented 0-3 spaces
+ * (4+ is an indented code block) and may carry an info string. Returns
+ * { char, len } for the marker, or null.
+ *
+ * Out of scope - 4-space INDENTED code blocks are not detected. Telling a genuine
+ * indented code block apart from list-continuation text needs list/paragraph block
+ * context (CommonMark: indented code cannot interrupt a paragraph, a 4-space indent
+ * under a list item is list content rather than code, and loose lists even put a
+ * blank line before such continuation). A line-based script lacks that context, and
+ * a partial heuristic would either reintroduce data loss (deleting indented code)
+ * or cause the opposite bug - silently skipping a real inline field merely indented
+ * under a list (Dataview parses those as fields, so users expect them to migrate).
+ * Only indented code at the very start of the body is unambiguous, which is too
+ * narrow to justify a separate indented-block parser. Fenced code (top-level and
+ * blockquoted) and inline code ARE detected without that context and are preserved;
+ * an inline-field-like line inside a genuine indented code block may still migrate.
+ */
+function openingFence(line) {
+    const match = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (!match) return null;
+    return { char: match[1][0], len: match[1].length };
+}
+
+/**
+ * A closing fence uses the same marker character, is at least as long as the
+ * opening fence, and carries no info string (only optional trailing whitespace).
+ */
+function isClosingFence(line, fenceChar, fenceLen) {
+    // Allow a trailing CR so CRLF files close their fences correctly.
+    const match = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*\r?$/);
+    if (!match) return false;
+    const marker = match[1];
+    return marker[0] === fenceChar && marker.length >= fenceLen;
+}
+
+/**
+ * Replace inline code spans with equal-length blanks so a "::" inside code is not
+ * mistaken for an inline-field separator. Supports arbitrary backtick-run lengths
+ * (`code`, ``co`de``). Character positions are preserved so the caller can slice
+ * the original line by offsets computed on the masked line.
+ */
+function maskInlineCode(text) {
+    return text.replace(/(`+)(?:(?!\1)[\s\S])*?\1/g, (span) => ' '.repeat(span.length));
 }
 
 /**

--- a/src/utils/DataviewIntegration.ts
+++ b/src/utils/DataviewIntegration.ts
@@ -2,6 +2,7 @@ import type { App } from "obsidian";
 import { getAPI } from "obsidian-dataview";
 import { log } from "src/logger/logManager";
 import type { FieldFilter } from "./FieldSuggestionParser";
+import { splitWikilinkAwareList } from "./splitWikilinkAwareList";
 
 type DataviewFileLike = { path: string };
 
@@ -97,15 +98,9 @@ export class DataviewIntegration {
 						// Handle single file object from Dataview
 						values.add(fieldValue.path);
 					} else if (fieldValue && typeof fieldValue === 'string') {
-						// Handle comma-separated values
-						if (fieldValue.includes(',')) {
-							fieldValue.split(',')
-								.map(v => v.trim())
-								.filter(v => v.length > 0)
-								.forEach(v => values.add(v));
-						} else {
-							values.add(fieldValue.trim());
-						}
+						// Handle comma-separated values, keeping commas inside
+						// `[[wikilinks]]` attached to their link.
+						splitWikilinkAwareList(fieldValue).forEach(v => values.add(v));
 					} else if (fieldValue && typeof fieldValue !== 'object') {
 						// Handle other non-object values
 						values.add(String(fieldValue).trim());
@@ -227,14 +222,9 @@ export class DataviewIntegration {
 						// Handle single file object from Dataview
 						values.add(fieldValue.path);
 					} else if (fieldValue && typeof fieldValue === 'string') {
-						if (fieldValue.includes(',')) {
-							fieldValue.split(',')
-								.map(v => v.trim())
-								.filter(v => v.length > 0)
-								.forEach(v => values.add(v));
-						} else {
-							values.add(fieldValue.trim());
-						}
+						// Handle comma-separated values, keeping commas inside
+						// `[[wikilinks]]` attached to their link.
+						splitWikilinkAwareList(fieldValue).forEach(v => values.add(v));
 					} else if (fieldValue && typeof fieldValue !== 'object') {
 						values.add(String(fieldValue).trim());
 					}

--- a/src/utils/InlineFieldParser.test.ts
+++ b/src/utils/InlineFieldParser.test.ts
@@ -33,6 +33,25 @@ assignee:: John Doe
 			);
 		});
 
+		it("should keep a comma inside a wikilink attached to its link", () => {
+			const content = "Related:: [[Note, with comma]]";
+			const result = InlineFieldParser.parseInlineFields(content);
+
+			expect(result.get("Related")).toEqual(
+				new Set(["[[Note, with comma]]"]),
+			);
+		});
+
+		it("should split a wikilink list while preserving inner commas", () => {
+			const content =
+				"Related:: [[Plain Note]], [[Another, with comma]]";
+			const result = InlineFieldParser.parseInlineFields(content);
+
+			expect(result.get("Related")).toEqual(
+				new Set(["[[Plain Note]]", "[[Another, with comma]]"]),
+			);
+		});
+
 		it("should handle multiple occurrences of same field", () => {
 			const content = `
 First note

--- a/src/utils/InlineFieldParser.ts
+++ b/src/utils/InlineFieldParser.ts
@@ -1,3 +1,5 @@
+import { splitWikilinkAwareList } from "./splitWikilinkAwareList";
+
 export class InlineFieldParser {
 	// Regex to match inline fields in the format "fieldname:: value"
 	// Captures: fieldname and value (until end of line or next field)
@@ -41,15 +43,10 @@ export class InlineFieldParser {
 				fields.set(fieldName, new Set());
 			}
 
-			// Handle list syntax (comma-separated values)
-			if (fieldValue.includes(",")) {
-				const values = fieldValue
-					.split(",")
-					.map((v) => v.trim())
-					.filter((v) => v.length > 0);
-				values.forEach((v) => fields.get(fieldName)?.add(v));
-			} else {
-				fields.get(fieldName)?.add(fieldValue);
+			// Handle list syntax (comma-separated values), keeping commas inside
+			// `[[wikilinks]]` attached to their link instead of splitting them.
+			for (const v of splitWikilinkAwareList(fieldValue)) {
+				fields.get(fieldName)?.add(v);
 			}
 		}
 

--- a/src/utils/splitWikilinkAwareList.test.ts
+++ b/src/utils/splitWikilinkAwareList.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { splitWikilinkAwareList } from "./splitWikilinkAwareList";
+
+describe("splitWikilinkAwareList", () => {
+	it("keeps a comma inside a single wikilink attached to its link", () => {
+		expect(splitWikilinkAwareList("[[Note, with comma]]")).toEqual([
+			"[[Note, with comma]]",
+		]);
+	});
+
+	it("splits a list while preserving commas inside each wikilink", () => {
+		expect(
+			splitWikilinkAwareList("[[Plain Note]], [[Another, with comma]]"),
+		).toEqual(["[[Plain Note]]", "[[Another, with comma]]"]);
+	});
+
+	it("still splits plain comma lists (byte-identical to the old behaviour)", () => {
+		expect(splitWikilinkAwareList("work, project, urgent")).toEqual([
+			"work",
+			"project",
+			"urgent",
+		]);
+	});
+
+	it("preserves a comma inside a wikilink alias", () => {
+		expect(splitWikilinkAwareList("[[Page|Alias, label]]")).toEqual([
+			"[[Page|Alias, label]]",
+		]);
+	});
+
+	it("preserves a comma inside an embed", () => {
+		expect(splitWikilinkAwareList("![[Image, v2.png]]")).toEqual([
+			"![[Image, v2.png]]",
+		]);
+	});
+
+	it("mixes wikilinks and plain values", () => {
+		expect(
+			splitWikilinkAwareList("[[A, b]], plain, [[C]]"),
+		).toEqual(["[[A, b]]", "plain", "[[C]]"]);
+	});
+
+	it("returns a single trimmed value when there is no comma", () => {
+		expect(splitWikilinkAwareList("  single value  ")).toEqual([
+			"single value",
+		]);
+	});
+
+	it("drops empty fragments from trailing/duplicate commas", () => {
+		expect(splitWikilinkAwareList("a,, b, ")).toEqual(["a", "b"]);
+	});
+
+	it("treats an unbalanced wikilink open as one value (no spurious split)", () => {
+		expect(splitWikilinkAwareList("[[Unclosed, link")).toEqual([
+			"[[Unclosed, link",
+		]);
+	});
+
+	it("returns an empty array for an empty or whitespace string", () => {
+		expect(splitWikilinkAwareList("")).toEqual([]);
+		expect(splitWikilinkAwareList("   ")).toEqual([]);
+	});
+});

--- a/src/utils/splitWikilinkAwareList.ts
+++ b/src/utils/splitWikilinkAwareList.ts
@@ -1,0 +1,66 @@
+/**
+ * Split a comma-separated inline-field value into individual values while
+ * treating commas inside `[[wikilinks]]` as literal content rather than list
+ * separators.
+ *
+ * Dataview-style inline fields use commas to separate list items
+ * (`tags:: a, b, c`), but a single wikilink target can itself contain a comma
+ * (`Related:: [[Note, with comma]]`). A naive `value.split(",")` shreds such a
+ * wikilink into `"[[Note"` and `"with comma]]"`, which then surfaces as garbled
+ * field-value autocomplete suggestions. This helper walks the string once and
+ * only splits on commas that sit outside a `[[ ... ]]` span.
+ *
+ * Values are trimmed and empty fragments are dropped, matching the previous
+ * `split(",").map(trim).filter(length)` behaviour for non-wikilink input so the
+ * change is byte-identical for plain comma lists.
+ *
+ * Known limitation: commas inside Markdown link destinations (`[text](a,b)`) are
+ * still treated as separators. Inline fields rarely carry raw Markdown links and
+ * the only consumer is read-only autocomplete, so wikilink awareness covers the
+ * real cases without turning this into a full Markdown parser.
+ */
+export function splitWikilinkAwareList(value: string): string[] {
+	// Fast path: no comma means there is nothing to split.
+	if (!value.includes(",")) {
+		const trimmed = value.trim();
+		return trimmed ? [trimmed] : [];
+	}
+
+	const values: string[] = [];
+	let current = "";
+	let insideWikilink = false;
+
+	for (let i = 0; i < value.length; i++) {
+		const char = value[i];
+		const nextChar = value[i + 1];
+
+		// Enter a wikilink span on `[[` so its inner commas are preserved.
+		if (char === "[" && nextChar === "[") {
+			insideWikilink = true;
+			current += char;
+			continue;
+		}
+
+		// Leave the span on `]]`.
+		if (char === "]" && nextChar === "]") {
+			insideWikilink = false;
+			current += char;
+			continue;
+		}
+
+		// Only commas outside a wikilink span separate list items.
+		if (char === "," && !insideWikilink) {
+			const trimmed = current.trim();
+			if (trimmed) values.push(trimmed);
+			current = "";
+			continue;
+		}
+
+		current += char;
+	}
+
+	const trimmed = current.trim();
+	if (trimmed) values.push(trimmed);
+
+	return values;
+}


### PR DESCRIPTION
Two independent deepsec BUG findings, fixed at the root and proven in a live Obsidian vault. Kept as two commits because they are separate file areas.

---

## 1. HIGH (silent data loss) - migration deleted fenced-code-block content
`docs/static/scripts/migrateDataviewToFrontmatter.js`

The inline-field -> frontmatter migration scanned the note body line by line and treated **any** `key:: value` line as an inline field, with no awareness of fenced code blocks or inline code. Lines such as `Reference:: [[x]]` inside a ```` ```dataview ```` fence (or any code sample) were stripped from the body and pulled into frontmatter - silently destroying the user's code-block content. The global `\n{3,}` blank-line collapse could also delete blank lines inside code blocks and mangle frontmatter block scalars.

**Root fix** - `parseInlineFieldsWithWikilinks` is now code-aware:
- Track fenced code blocks (```` ``` ````/`~~~`) line by line with CommonMark-ish rules: 0-3 space indent, info string allowed on the opener, and a closer must match the marker char, be at least as long, and carry **no** info string (so ```` ```js ```` inside a ```` ``` ```` block does not falsely close it). CRLF closers handled. Every fence line and every line inside a fence is preserved verbatim and never migrated.
- **Blockquoted fenced blocks are tracked too** (see extended coverage below).
- Mask inline code spans (any backtick-run length) before field detection, and require the field-**name** region to be free of inline code - so a code span sitting before a real field never causes the whole line (and its code) to be deleted.
- Collapse blank lines only **outside** fences, and never touch the frontmatter.
- Strip the body via `vault.process` so the read + rewrite is atomic.

### Live red -> green (real script, real Obsidian app)
Ran the **actual** on-disk script via the Obsidian CLI `eval` against notes containing code blocks.

**Before (master):**
- default config: `Reference:: [[Inside Fence Should Survive]]` inside a ```` ```dataview ```` block was **deleted**.
- migrate-all: the **entire** body of a ```` ```markdown ```` block (`Author::`, `Status::`, blank lines, `BodyAfterBlankLines::`) was **deleted**.

**After:** `fencesPreservedVerbatim: true` for both - code blocks survive byte-for-byte, while real outside-code fields still migrate (with `[[Note, with comma]]` kept as one value).

### Extended coverage (update): blockquoted fences
A fenced code block can live inside a blockquote (`> ```lang` ... `> ...` ... `> ``` `, including nested `>>`). These are unambiguously code, so they are now tracked and preserved like top-level fences: `stripBlockquote()` peels blockquote markers, the opening quote depth is recorded, and the closer must sit at the same depth. If a line carries **fewer** markers, the blockquote container has ended - so the fence ends there and the line is reprocessed normally, which means a real field after a quoted block still migrates (no false-negative). Field detection still runs on the raw line, so blockquoted *plain* fields are unchanged.

Live red -> green (migrate-all, real script) on a note with a blockquoted ```` ```dataview ```` block + an outside field + a list-indented field:
- **Before (this PR's first revision):** `> Reference:: [[Inside Quoted Fence]]` inside the quoted fence was **deleted** (garbage-keyed into frontmatter as `"> Reference"`).
- **After:** the quoted-fence line is **preserved verbatim**; `Reference:: [[Real Outside]]` still migrates; and the list-indented `Status:: active under list` still migrates (no new false-negative).

### Decision: 4-space indented code blocks (out of scope, reasoned)
I assessed indented code blocks and deliberately did **not** implement them. Distinguishing a genuine indented code block from list-continuation text requires list/paragraph block context that a line-based script lacks:
- CommonMark: an indented code block cannot interrupt a paragraph and must follow a blank line / block boundary; a 4-space indent **under a list item is list content, not code**; loose lists even put a blank line before such continuation.
- The two lines are textually identical but must be classified oppositely: `␣␣␣␣Reference:: [[x]]` at body top after a blank line is indented code (should *not* migrate), but the same line under `- item` is list continuation (Dataview parses it as a field, so it *should* migrate).
- A partial heuristic would therefore either reintroduce data loss (deleting indented code) **or** cause the opposite, maintainer-flagged bug - silently skipping a real inline field merely indented under a list. Only indented code at the very start of the body is unambiguous, which is too narrow to justify a separate indented-block parser that would still leave the general case open and imply "indented code is handled" when it is not.

Residual (documented in code): an inline-field-like line inside a genuine 4-space *indented* code block may still be migrated. This is narrow (fenced blocks are the modern norm; dataview users use ```` ```dataview ```` fences) and is the safer side of the false-negative tradeoff. Fenced code (top-level **and** blockquoted) and inline code are fully preserved.

Per project convention, tests for this example userscript are **not** committed (validated locally via a `vm`-loaded harness, 50 assertions covering fences, blockquoted fences, container-exit, inline code, CRLF, frontmatter block scalars, and the list-indented false-negative guard, plus the live runs above).

---

## 2. Minor - garbled field-value autocomplete from wikilink-unaware comma split
`src/utils/InlineFieldParser.ts`, `src/utils/DataviewIntegration.ts`, new `src/utils/splitWikilinkAwareList.ts`

Inline field value parsing split on **every** comma, so a wikilink target containing a comma (`Related:: [[Note, with comma]]`) was shredded into `[[Note` and `with comma]]`. These feed the read-only field-value autocomplete (`FieldValueCollector`, `quickAddApi.fieldSuggestions`). No data-write or security impact.

**Root fix** - factor a single wikilink-aware splitter (`splitWikilinkAwareList`) that only splits on commas outside `[[ ... ]]` spans, and use it at all three duplicated split sites (`InlineFieldParser` once, `DataviewIntegration` twice). Plain comma lists stay byte-identical; wikilink commas are preserved. (The `DataviewIntegration` sites are mostly DRY + hardening, since Dataview pre-parses wikilinks into Link objects.)

### Live red -> green (real plugin API)
`fieldSuggestions.getFieldValues('Related', { includeInline: true })` against a note with `Related:: [[Note, with comma]]` and `[[Another, with comma]]`:
- **Before:** `["[[Another", "[[Note", "[[Plain Note]]", "with comma]]"]`
- **After:** `["[[Another, with comma]]", "[[Note, with comma]]", "[[Plain Note]]"]`
- Regression guard: `PlainTest:: alpha, beta, gamma` still returns `["alpha","beta","gamma"]`.

Committed unit tests: `splitWikilinkAwareList.test.ts` (helper) + wikilink cases in `InlineFieldParser.test.ts`.

---

## Validation
- Gates green: `tsc -noEmit`, `eslint .`, `svelte-check` (0 errors), `vitest` (3330 passed / 0 failed).
- Both bugs reproduced on current master and proven fixed in this worktree's isolated Obsidian vault.
- Adversarial review (opposing model) at design and on each diff, including the blockquote extension - design-stage high-severity findings folded in (notably the blockquote container-exit rule that prevents a mass missed-migration); final-diff reviews returned no real issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline field parsing so commas inside wikilinks, aliases, and embeds are preserved and split correctly.
  * Prevented inline-field migration from altering frontmatter and fenced code blocks (including quote/nesting handling).
  * Improved Dataview field value parsing to use wikilink-aware comma splitting for more accurate extraction.
* **Tests**
  * Added a new test suite for wikilink-aware list splitting.
  * Added inline-field parsing tests covering wikilink comma edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->