### PR TITLE
test(e2e): fail loudly when the harness runs Obsidian below minAppVersion

### DIFF
--- a/scripts/obsidian-e2e-cli.mjs
+++ b/scripts/obsidian-e2e-cli.mjs
@@ -5,6 +5,7 @@ import process from "node:process";
 import { promisify } from "node:util";
 import { provisionVault } from "./provision-obsidian-e2e-vault.mjs";
 import {
+	assertObsidianMeetsMinAppVersion,
 	ensureSecureDir,
 	launchObsidianInstance,
 	parseArgs as parseInstanceArgs,
@@ -124,6 +125,17 @@ export async function ensureObsidianInstance(options) {
 	const provisionResult = await provisionVault(options);
 	const profileResult = await prepareObsidianProfile(options);
 	options.userDataPath = profileResult.userDataPath;
+
+	// Assert the Obsidian app-code version BEFORE launching or reusing an instance:
+	// a build below minAppVersion makes every "missing API" e2e failure a false
+	// signal, so abort with a clear version error instead of spawning (or trusting
+	// a reused) sub-minimum instance. Stderr keeps the note off command stdout.
+	const compatibility = await assertObsidianMeetsMinAppVersion(options);
+	console.error(
+		`Obsidian app ${compatibility.appVersion}` +
+			`${compatibility.installerVersion ? ` (installer ${compatibility.installerVersion})` : ""}` +
+			`, plugin minAppVersion ${compatibility.minAppVersion}`,
+	);
 
 	if (!(await isInstanceReady(options))) {
 		await launchObsidianInstance(options);

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
@@ -393,6 +394,181 @@ export async function trustVaultAndVerifyQuickAdd(options) {
 	throw new Error(`QuickAdd did not become available in ${options.vaultName}. Last error: ${lastError}`);
 }
 
+// --- minAppVersion guard ------------------------------------------------------
+//
+// Obsidian has TWO versions: the installer shell (the .app, shown in the window
+// title) and the auto-updated app code (obsidian-<version>.asar, == the
+// `apiVersion` plugins see). minAppVersion is enforced against the app-code
+// version, not the installer. On macOS the app-code asar lives in the LOGIN
+// user's Application Support dir, resolved from getpwuid (os.userInfo) rather
+// than $HOME — so even though this harness isolates $HOME/--user-data-dir, the
+// launched instance loads the newest asar from the real config dir, floored at
+// the installer's bundled asar. When NO installed asar reaches minAppVersion,
+// Obsidian silently runs the bundled installer build, which can be BELOW
+// minAppVersion. e2e then runs against an app QuickAdd does not support, so a
+// "missing API" crash there is a false signal (this is exactly what makes a
+// 1.13.0-only call like ButtonComponent.setDestructive look "absent on 1.13.0").
+// This guard resolves the real app-code version and fails loudly when it is
+// below the plugin's declared minAppVersion.
+//
+// Why predict from disk instead of querying the live instance: Obsidian does not
+// expose `apiVersion` to a CDP-evaluated snippet (require("obsidian") is not
+// resolvable outside plugin scope, and the window title carries the INSTALLER
+// version, not the app-code version), so the app-code version cannot be read from
+// the running renderer. We therefore resolve it the same way Obsidian does — the
+// newest valid installed asar in the real config dir, floored at the bundled
+// installer asar. The guard runs BEFORE launch, so a fresh instance loads exactly
+// what we resolved. Residual edge: a warm instance reused from an earlier run
+// (see the CLI's isInstanceReady reuse) reflects the asar resolution at ITS
+// launch; an Obsidian update mid-session is not re-detected. Instances are reaped
+// per worktree and Obsidian versions are stable within a run, so this is bounded.
+
+const OBSIDIAN_ASAR_VERSION_RE = /^obsidian-(\d+\.\d+\.\d+)\.asar$/;
+
+function macObsidianConfigDir() {
+	return path.join(
+		os.userInfo().homedir,
+		"Library",
+		"Application Support",
+		"obsidian",
+	);
+}
+
+// Only consulted as the floor when the config dir has no usable cached asar
+// (a fresh machine / CI that never auto-updated). Standard install locations
+// only — a bundle registered elsewhere with an empty cache resolves to null and
+// the guard then refuses to run blind rather than guess.
+function bundledAsarCandidates(obsidianApp) {
+	const leaf = path.join(
+		`${obsidianApp}.app`,
+		"Contents",
+		"Resources",
+		"obsidian.asar",
+	);
+	return [
+		path.join("/Applications", leaf),
+		path.join(os.userInfo().homedir, "Applications", leaf),
+	];
+}
+
+// Numeric 3-part compare; ignores any pre-release suffix. >0 if a>b, 0, <0.
+export function compareObsidianVersions(a, b) {
+	const parse = (v) => {
+		const m = String(v).match(/(\d+)\.(\d+)\.(\d+)/);
+		return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : [0, 0, 0];
+	};
+	const x = parse(a);
+	const y = parse(b);
+	return x[0] - y[0] || x[1] - y[1] || x[2] - y[2];
+}
+
+// Read the `version` from an asar archive's package.json without unpacking it.
+// Returns null on any malformed/missing input (never throws) so a stray file in
+// the config dir cannot break the guard.
+async function readAsarPackageVersion(asarPath) {
+	let handle;
+	try {
+		handle = await fs.open(asarPath, "r");
+		const head = Buffer.alloc(16);
+		await handle.read(head, 0, 16, 0);
+		const headerSize = head.readUInt32LE(12);
+		if (!Number.isInteger(headerSize) || headerSize <= 0 || headerSize > 64 * 1024 * 1024) {
+			return null;
+		}
+		const headerBuf = Buffer.alloc(headerSize);
+		await handle.read(headerBuf, 0, headerSize, 16);
+		const header = JSON.parse(headerBuf.toString("utf8"));
+		const entry = header?.files?.["package.json"];
+		if (!entry) return null;
+		const size = Number(entry.size);
+		const offset = Number(entry.offset);
+		if (!Number.isFinite(size) || !Number.isFinite(offset) || size <= 0) return null;
+		const fileBuf = Buffer.alloc(size);
+		await handle.read(fileBuf, 0, size, 16 + headerSize + offset);
+		const version = JSON.parse(fileBuf.toString("utf8"))?.version;
+		return typeof version === "string" ? version : null;
+	} catch {
+		return null;
+	} finally {
+		await handle?.close().catch(() => {});
+	}
+}
+
+// Resolve the Obsidian app-code version that the launched instance runs:
+// the newest installed obsidian-*.asar in the real config dir, floored at the
+// bundled installer asar. configDir/bundledAsarCandidates are injectable for
+// tests. appVersion is null when no version can be determined at all.
+export async function resolveObsidianAppVersion(options = {}) {
+	const obsidianApp = options.obsidianApp ?? DEFAULT_OBSIDIAN_APP;
+	const configDir = options.obsidianConfigDir ?? macObsidianConfigDir();
+
+	const cachedVersions = [];
+	try {
+		for (const name of await fs.readdir(configDir)) {
+			if (!OBSIDIAN_ASAR_VERSION_RE.test(name)) continue;
+			// Trust the asar's own package.json, not the filename: a partial/corrupt
+			// download parses to null and is skipped (Obsidian would not load it
+			// either), so a half-downloaded obsidian-<newer>.asar cannot make the
+			// guard pass while the live app actually falls back to an older build.
+			const version = await readAsarPackageVersion(path.join(configDir, name));
+			if (version) cachedVersions.push(version);
+		}
+	} catch {
+		// Config dir missing/unreadable — fall back to the bundled installer below.
+	}
+
+	let installerVersion = null;
+	const candidates = options.bundledAsarCandidates ?? bundledAsarCandidates(obsidianApp);
+	for (const candidate of candidates) {
+		installerVersion = await readAsarPackageVersion(candidate);
+		if (installerVersion) break;
+	}
+
+	const all = [...cachedVersions, installerVersion].filter(Boolean);
+	const appVersion = all.length
+		? all.reduce((max, v) => (compareObsidianVersions(v, max) > 0 ? v : max))
+		: null;
+
+	return { appVersion, installerVersion, cachedVersions, configDir };
+}
+
+async function readPluginMinAppVersion(worktreePath) {
+	const manifestPath = path.join(worktreePath, "manifest.json");
+	const minAppVersion = JSON.parse(await fs.readFile(manifestPath, "utf8"))?.minAppVersion;
+	if (typeof minAppVersion !== "string" || !/\d+\.\d+\.\d+/.test(minAppVersion)) {
+		throw new Error(`manifest.json at ${manifestPath} has no usable minAppVersion.`);
+	}
+	return minAppVersion;
+}
+
+// Fail loudly when the running Obsidian app-code version is below the plugin's
+// minAppVersion (or cannot be determined). Returns the resolved versions for the
+// caller to surface. Filesystem-based: independent of the running instance.
+export async function assertObsidianMeetsMinAppVersion(options) {
+	const minAppVersion = await readPluginMinAppVersion(options.worktreePath);
+	const { appVersion, installerVersion, configDir } = await resolveObsidianAppVersion(options);
+
+	if (!appVersion) {
+		throw new Error(
+			`Could not determine the running Obsidian app version (no obsidian-*.asar in ${configDir} ` +
+				`and no bundled installer asar found). Refusing to run e2e against an unknown build that may ` +
+				`be below the plugin's minAppVersion ${minAppVersion}.`,
+		);
+	}
+
+	if (compareObsidianVersions(appVersion, minAppVersion) < 0) {
+		throw new Error(
+			`Obsidian app version ${appVersion} is BELOW the plugin's minAppVersion ${minAppVersion}` +
+				`${installerVersion ? ` (installer shell ${installerVersion})` : ""}. Obsidian fell back to a ` +
+				`build QuickAdd does not support, so any e2e "missing API" failure here is a FALSE signal, not a ` +
+				`real bug. Update Obsidian to >= ${minAppVersion} (install it, or let it download an ` +
+				`obsidian-*.asar into ${configDir}) before running e2e.`,
+		);
+	}
+
+	return { appVersion, installerVersion, minAppVersion };
+}
+
 function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -447,6 +623,14 @@ async function main() {
 	const provisionResult = await provisionVault(options);
 	const profileResult = await prepareObsidianProfile(options);
 	options.userDataPath = profileResult.userDataPath;
+	// Resolve and assert the Obsidian app-code version BEFORE launching: a build
+	// below minAppVersion makes every "missing API" failure a false signal, so fail
+	// loudly here rather than spawn a doomed sub-minimum instance (which would be
+	// left running for later reuse) and hit a confusing "QuickAdd did not become
+	// available" timeout. Filesystem-based, so it needs no running instance.
+	const compatibility = options.launch
+		? await assertObsidianMeetsMinAppVersion(options)
+		: null;
 	const launchResult = options.launch
 		? await launchObsidianInstance(options)
 		: { pid: null, pidPath: null };
@@ -460,6 +644,7 @@ async function main() {
 		...provisionResult,
 		...profileResult,
 		...launchResult,
+		...(compatibility ?? {}),
 		obsidianHome: options.obsidianHome,
 		resolvedVaultPath,
 		verifiedQuickAdd,
@@ -472,6 +657,12 @@ async function main() {
 		console.log(`Vault path: ${result.vaultPath}`);
 		console.log(`Obsidian HOME: ${result.obsidianHome}`);
 		if (result.pid) console.log(`Obsidian PID: ${result.pid}`);
+		if (result.appVersion) {
+			const installer = result.installerVersion ? `, installer ${result.installerVersion}` : "";
+			console.log(
+				`Obsidian app version: ${result.appVersion}${installer} (plugin minAppVersion ${result.minAppVersion})`,
+			);
+		}
 		if (result.verifiedQuickAdd) console.log("QuickAdd command check: ok");
 	}
 

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -465,18 +465,28 @@ export function compareObsidianVersions(a, b) {
 // Read the `version` from an asar archive's package.json without unpacking it.
 // Returns null on any malformed/missing input (never throws) so a stray file in
 // the config dir cannot break the guard.
+//
+// asar layout: [size pickle (8 bytes)] [header pickle] [file data]. The size
+// pickle's payload (byte 4, UInt32LE) is the header pickle's byte length, so file
+// data begins at 8 + headerPickleLength. The header pickle wraps a Pickle string:
+// its raw length is at byte 12 and its JSON bytes start at byte 16. Pickle
+// 4-byte-aligns the string, so the data base must come from the header pickle
+// length, NOT `16 + jsonLength` (which lands in the alignment padding when the
+// JSON length is not a multiple of 4).
 async function readAsarPackageVersion(asarPath) {
 	let handle;
 	try {
 		handle = await fs.open(asarPath, "r");
 		const head = Buffer.alloc(16);
 		await handle.read(head, 0, 16, 0);
-		const headerSize = head.readUInt32LE(12);
-		if (!Number.isInteger(headerSize) || headerSize <= 0 || headerSize > 64 * 1024 * 1024) {
+		const headerPickleLength = head.readUInt32LE(4);
+		const jsonLength = head.readUInt32LE(12);
+		if (!Number.isInteger(jsonLength) || jsonLength <= 0 || jsonLength > 64 * 1024 * 1024) {
 			return null;
 		}
-		const headerBuf = Buffer.alloc(headerSize);
-		await handle.read(headerBuf, 0, headerSize, 16);
+		const dataBase = 8 + headerPickleLength;
+		const headerBuf = Buffer.alloc(jsonLength);
+		await handle.read(headerBuf, 0, jsonLength, 16);
 		const header = JSON.parse(headerBuf.toString("utf8"));
 		const entry = header?.files?.["package.json"];
 		if (!entry) return null;
@@ -484,7 +494,7 @@ async function readAsarPackageVersion(asarPath) {
 		const offset = Number(entry.offset);
 		if (!Number.isFinite(size) || !Number.isFinite(offset) || size <= 0) return null;
 		const fileBuf = Buffer.alloc(size);
-		await handle.read(fileBuf, 0, size, 16 + headerSize + offset);
+		await handle.read(fileBuf, 0, size, dataBase + offset);
 		const version = JSON.parse(fileBuf.toString("utf8"))?.version;
 		return typeof version === "string" ? version : null;
 	} catch {

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -200,21 +200,29 @@ describe("assertSecureDirIfPresent", () => {
 	});
 });
 
-// Build a minimal asar archive whose package.json carries `version`, laid out to
-// match readAsarPackageVersion's parser (header size at byte 12, header at 16,
-// file data at 16 + headerSize + offset).
-function buildAsar(version: string): Buffer {
+function u32(n: number): Buffer {
+	const b = Buffer.alloc(4);
+	b.writeUInt32LE(n, 0);
+	return b;
+}
+
+// Build a spec-correct asar (matching the real Pickle layout: [size pickle][header
+// pickle][file data], with the header JSON 4-byte aligned inside the header
+// pickle). `extraJsonPad` widens the header JSON so its length lands on a chosen
+// 4-byte residue, exercising the alignment padding that a naive `16 + jsonLength`
+// reader gets wrong.
+function buildAsar(version: string, extraJsonPad = 0): Buffer {
 	const pkg = Buffer.from(JSON.stringify({ version }), "utf8");
-	const header = Buffer.from(
-		JSON.stringify({ files: { "package.json": { offset: "0", size: pkg.length } } }),
-		"utf8",
-	);
-	const prefix = Buffer.alloc(16);
-	prefix.writeUInt32LE(4, 0);
-	prefix.writeUInt32LE(header.length + 8, 4);
-	prefix.writeUInt32LE(header.length + 4, 8);
-	prefix.writeUInt32LE(header.length, 12);
-	return Buffer.concat([prefix, header, pkg]);
+	const files: Record<string, unknown> = {
+		"package.json": { offset: "0", size: pkg.length },
+	};
+	if (extraJsonPad > 0) files._pad = "x".repeat(extraJsonPad);
+	const json = Buffer.from(JSON.stringify({ files }), "utf8");
+	const aligned = Buffer.concat([json, Buffer.alloc((4 - (json.length % 4)) % 4)]);
+	const headerPayload = Buffer.concat([u32(json.length), aligned]);
+	const headerPickle = Buffer.concat([u32(headerPayload.length), headerPayload]);
+	const sizePickle = Buffer.concat([u32(4), u32(headerPickle.length)]);
+	return Buffer.concat([sizePickle, headerPickle, pkg]);
 }
 
 async function makeConfigDir(versions: string[]): Promise<string> {
@@ -289,6 +297,24 @@ describe("resolveObsidianAppVersion", () => {
 		});
 		expect(resolved.appVersion).toBe("1.12.7");
 		expect(resolved.cachedVersions).toEqual(["1.12.7"]);
+	});
+
+	it("reads the asar version at every header-length 4-byte alignment residue", async () => {
+		// Real asar headers are arbitrary lengths; the parser must not assume the
+		// header JSON is 4-byte aligned. Cover all four residues — a reader that uses
+		// `16 + jsonLength` instead of the header pickle size misreads 3 of these.
+		for (let pad = 0; pad < 4; pad++) {
+			const dir = await makeTempDir("asar-align");
+			await fs.writeFile(
+				path.join(dir, "obsidian-1.13.0.asar"),
+				buildAsar("1.13.0", pad),
+			);
+			const resolved = await resolveObsidianAppVersion({
+				obsidianConfigDir: dir,
+				bundledAsarCandidates: [],
+			});
+			expect(resolved.appVersion, `pad=${pad}`).toBe("1.13.0");
+		}
 	});
 });
 

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -3,12 +3,15 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	assertObsidianMeetsMinAppVersion,
 	assertSecureDirIfPresent,
+	compareObsidianVersions,
 	ensureSecureDir,
 	INSTANCE_MARKER_FILE,
 	parseArgs,
 	prepareObsidianProfile,
 	resolveInstanceOptions,
+	resolveObsidianAppVersion,
 	toInstanceShellExports,
 } from "../scripts/start-obsidian-e2e-instance.mjs";
 
@@ -194,6 +197,142 @@ describe("assertSecureDirIfPresent", () => {
 		await expect(assertSecureDirIfPresent(link)).rejects.toThrow(
 			/symlink or not a regular directory/,
 		);
+	});
+});
+
+// Build a minimal asar archive whose package.json carries `version`, laid out to
+// match readAsarPackageVersion's parser (header size at byte 12, header at 16,
+// file data at 16 + headerSize + offset).
+function buildAsar(version: string): Buffer {
+	const pkg = Buffer.from(JSON.stringify({ version }), "utf8");
+	const header = Buffer.from(
+		JSON.stringify({ files: { "package.json": { offset: "0", size: pkg.length } } }),
+		"utf8",
+	);
+	const prefix = Buffer.alloc(16);
+	prefix.writeUInt32LE(4, 0);
+	prefix.writeUInt32LE(header.length + 8, 4);
+	prefix.writeUInt32LE(header.length + 4, 8);
+	prefix.writeUInt32LE(header.length, 12);
+	return Buffer.concat([prefix, header, pkg]);
+}
+
+async function makeConfigDir(versions: string[]): Promise<string> {
+	const dir = await makeTempDir("obsidian-config");
+	// Real asars (carrying their own package.json version), so the resolver reads
+	// the same code path it does against a live config dir, not a filename shortcut.
+	await Promise.all(
+		versions.map((v) => fs.writeFile(path.join(dir, `obsidian-${v}.asar`), buildAsar(v))),
+	);
+	return dir;
+}
+
+async function makeWorktreeWithManifest(minAppVersion: string): Promise<string> {
+	const dir = await makeTempDir("quickadd-worktree");
+	await fs.writeFile(
+		path.join(dir, "manifest.json"),
+		JSON.stringify({ id: "quickadd", minAppVersion }),
+	);
+	return dir;
+}
+
+describe("compareObsidianVersions", () => {
+	it("orders by major, minor, then patch and ignores suffixes", () => {
+		expect(compareObsidianVersions("1.13.0", "1.13.0")).toBe(0);
+		expect(compareObsidianVersions("1.13.1", "1.13.0")).toBeGreaterThan(0);
+		expect(compareObsidianVersions("1.12.7", "1.13.0")).toBeLessThan(0);
+		expect(compareObsidianVersions("1.13.0-insider", "1.13.0")).toBe(0);
+		expect(compareObsidianVersions("2.0.0", "1.99.99")).toBeGreaterThan(0);
+	});
+});
+
+describe("resolveObsidianAppVersion", () => {
+	it("picks the newest installed asar in the config dir", async () => {
+		const configDir = await makeConfigDir(["1.12.7", "1.13.0"]);
+		const resolved = await resolveObsidianAppVersion({
+			obsidianConfigDir: configDir,
+			bundledAsarCandidates: [],
+		});
+		expect(resolved.appVersion).toBe("1.13.0");
+		expect(resolved.cachedVersions.sort()).toEqual(["1.12.7", "1.13.0"]);
+	});
+
+	it("floors at the bundled installer asar when the config dir is empty", async () => {
+		const configDir = await makeConfigDir([]);
+		const bundled = path.join(await makeTempDir("obsidian-app"), "obsidian.asar");
+		await fs.writeFile(bundled, buildAsar("1.12.7"));
+		const resolved = await resolveObsidianAppVersion({
+			obsidianConfigDir: configDir,
+			bundledAsarCandidates: [bundled],
+		});
+		expect(resolved.appVersion).toBe("1.12.7");
+		expect(resolved.installerVersion).toBe("1.12.7");
+	});
+
+	it("returns null appVersion when nothing can be determined", async () => {
+		const configDir = await makeConfigDir([]);
+		const resolved = await resolveObsidianAppVersion({
+			obsidianConfigDir: configDir,
+			bundledAsarCandidates: [path.join(configDir, "does-not-exist.asar")],
+		});
+		expect(resolved.appVersion).toBeNull();
+	});
+
+	it("skips a partial/corrupt cached asar instead of trusting its filename", async () => {
+		// A half-downloaded obsidian-1.13.0.asar (truncated/garbage) must NOT count as
+		// a runnable 1.13.0 — Obsidian would fall back to the valid 1.12.7 build.
+		const configDir = await makeConfigDir(["1.12.7"]);
+		await fs.writeFile(path.join(configDir, "obsidian-1.13.0.asar"), "not-a-real-asar");
+		const resolved = await resolveObsidianAppVersion({
+			obsidianConfigDir: configDir,
+			bundledAsarCandidates: [],
+		});
+		expect(resolved.appVersion).toBe("1.12.7");
+		expect(resolved.cachedVersions).toEqual(["1.12.7"]);
+	});
+});
+
+describe("assertObsidianMeetsMinAppVersion", () => {
+	it("passes when the running app meets minAppVersion (green)", async () => {
+		const worktreePath = await makeWorktreeWithManifest("1.13.0");
+		const configDir = await makeConfigDir(["1.12.7", "1.13.0"]);
+		await expect(
+			assertObsidianMeetsMinAppVersion({
+				worktreePath,
+				obsidianConfigDir: configDir,
+				bundledAsarCandidates: [],
+			}),
+		).resolves.toEqual({
+			appVersion: "1.13.0",
+			installerVersion: null,
+			minAppVersion: "1.13.0",
+		});
+	});
+
+	it("fails loudly when Obsidian fell back below minAppVersion (red)", async () => {
+		const worktreePath = await makeWorktreeWithManifest("1.13.0");
+		// Only a sub-minimum 1.12.7 build installed — the exact fallback that made
+		// setDestructive look "absent on 1.13.0".
+		const configDir = await makeConfigDir(["1.12.7"]);
+		await expect(
+			assertObsidianMeetsMinAppVersion({
+				worktreePath,
+				obsidianConfigDir: configDir,
+				bundledAsarCandidates: [],
+			}),
+		).rejects.toThrow(/1\.12\.7 is BELOW the plugin's minAppVersion 1\.13\.0/);
+	});
+
+	it("refuses to run when the app version cannot be determined", async () => {
+		const worktreePath = await makeWorktreeWithManifest("1.13.0");
+		const configDir = await makeConfigDir([]);
+		await expect(
+			assertObsidianMeetsMinAppVersion({
+				worktreePath,
+				obsidianConfigDir: configDir,
+				bundledAsarCandidates: [],
+			}),
+		).rejects.toThrow(/Could not determine the running Obsidian app version/);
 	});
 });
 

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -208,15 +208,16 @@ function u32(n: number): Buffer {
 
 // Build a spec-correct asar (matching the real Pickle layout: [size pickle][header
 // pickle][file data], with the header JSON 4-byte aligned inside the header
-// pickle). `extraJsonPad` widens the header JSON so its length lands on a chosen
-// 4-byte residue, exercising the alignment padding that a naive `16 + jsonLength`
+// pickle). `extraJsonPad` widens the header JSON by EXACTLY that many bytes (the
+// `_pad` key is always present, so each +1 shifts the length to the next 4-byte
+// residue) — exercising the alignment padding that a naive `16 + jsonLength`
 // reader gets wrong.
 function buildAsar(version: string, extraJsonPad = 0): Buffer {
 	const pkg = Buffer.from(JSON.stringify({ version }), "utf8");
 	const files: Record<string, unknown> = {
 		"package.json": { offset: "0", size: pkg.length },
+		_pad: "x".repeat(extraJsonPad),
 	};
-	if (extraJsonPad > 0) files._pad = "x".repeat(extraJsonPad);
 	const json = Buffer.from(JSON.stringify({ files }), "utf8");
 	const aligned = Buffer.concat([json, Buffer.alloc((4 - (json.length % 4)) % 4)]);
 	const headerPayload = Buffer.concat([u32(json.length), aligned]);
@@ -303,18 +304,22 @@ describe("resolveObsidianAppVersion", () => {
 		// Real asar headers are arbitrary lengths; the parser must not assume the
 		// header JSON is 4-byte aligned. Cover all four residues — a reader that uses
 		// `16 + jsonLength` instead of the header pickle size misreads 3 of these.
+		const residues = new Set<number>();
 		for (let pad = 0; pad < 4; pad++) {
+			const asar = buildAsar("1.13.0", pad);
+			// Header JSON length lives at byte 12 (raw, pre-alignment) in the layout.
+			residues.add(asar.readUInt32LE(12) % 4);
 			const dir = await makeTempDir("asar-align");
-			await fs.writeFile(
-				path.join(dir, "obsidian-1.13.0.asar"),
-				buildAsar("1.13.0", pad),
-			);
+			await fs.writeFile(path.join(dir, "obsidian-1.13.0.asar"), asar);
 			const resolved = await resolveObsidianAppVersion({
 				obsidianConfigDir: dir,
 				bundledAsarCandidates: [],
 			});
 			expect(resolved.appVersion, `pad=${pad}`).toBe("1.13.0");
 		}
+		// Guard the guard: prove the four builds really span all four residues, so a
+		// future tweak can't silently collapse coverage (as an earlier version did).
+		expect(residues).toEqual(new Set([0, 1, 2, 3]));
 	});
 });
 


### PR DESCRIPTION
## TL;DR

This branch began as a compatibility audit: a worker e2e-validating PR #1438 reported that `ButtonComponent.setDestructive` "appears ABSENT on Obsidian 1.13.0", crashing `AIAssistantProvidersModal` and `GenericYesNoPrompt` on QuickAdd's declared `minAppVersion`.

**The premise is refuted.** `setDestructive` is `@since 1.13.0` and is present in the real Obsidian 1.13.0 build. **No QuickAdd plugin code is changed.** The real defect is in the **e2e harness**: it could silently run a *sub-minimum* Obsidian build and mislabel it, which is exactly what produced the false "missing API" signal. This PR fixes that with a pre-launch `minAppVersion` guard.

## Part 1 - The audit: no real compatibility gap

Obsidian ships two versions: the **installer shell** (the `.app`, shown in the window title) and the auto-updated **app code** (`obsidian-<version>.asar`, == the `apiVersion` plugins see). `minAppVersion` is enforced against the **app-code** version. On the worker's machine the installer was `1.12.7`; with no `>= 1.13.0` asar reachable, Obsidian fell back to the bundled `1.12.7` build - which genuinely lacks `setDestructive`. That sub-minimum app, not a real 1.13.0, is what crashed.

Four independent sources agree `setDestructive` lands at **1.13.0**:

| Source | `setDestructive`? |
|---|---|
| Real **1.13.0** asar (`package.json: "1.13.0"`) | ✅ present (`prototype.setDestructive=`, 15×) |
| **1.12.7** asar (installer fallback) | ❌ absent (only deprecated `setWarning`) |
| Typings `obsidian.d.ts` | ✅ `@since 1.13.0` (`setWarning` now `@deprecated`) |
| Live isolated **1.13.0** e2e instance | ✅ `api.yesNoPrompt(...)` constructed, no throw |

Full sweep (`src/` incl. `src/gui`): the newest Obsidian API QuickAdd uses is `@since 1.13.0` (`SettingDefinitionGroup`/`SettingDefinitionItem` and `setDestructive`) - which is *why* `minAppVersion` is 1.13.0. The only API members `@since > 1.13.0` in the typings are all `@since 1.13.1` declarative-settings additions (`DisplayValueComponent`, `addDisplayValue`, `setStatus`, `SettingDefinition.displayValue/status/displayFormat/search/match/placeholder`) - **none used**. Every `@ts-ignore`/`as any`/`.svelte` runtime path reaches only ancient untyped APIs (`metadataCache.getTags`, `app.commands.commands`, `String.contains`). An adversarial refutation panel (4 lenses, every claim grep-verified against the real 1.13.0 binary) found **0 gaps**.

**Conclusion: `minAppVersion: 1.13.0` is accurate and is the lowest honest value. No plugin code change is warranted.**

## Part 2 - The fix: the harness must not run below minAppVersion

The e2e harness launches the locally-installed Obsidian via `open -a`. Obsidian loads the newest auto-updated `obsidian-*.asar` from the **real login-user config dir** (resolved via `getpwuid`, so the harness's isolated `$HOME`/`--user-data-dir` do not affect it), floored at the bundled installer asar. When nothing reaches `minAppVersion`, it silently runs the bundled installer build - which can be **below** `minAppVersion`. e2e then runs against an app QuickAdd does not support, turning every genuine "missing API" result into a **false** crash signal. That is the trap that started this whole investigation.

`assertObsidianMeetsMinAppVersion` (in `scripts/start-obsidian-e2e-instance.mjs`, wired into both entry points: `start` `main()` and the `obsidian:e2e` CLI) now, **before launch**:
- resolves the app-code version the way Obsidian does - newest **valid** installed asar (validated by reading its own `package.json`, so a partial/corrupt download is skipped rather than trusted by filename), floored at the bundled installer asar;
- aborts with a clear, actionable error when it is below the worktree manifest's `minAppVersion`, before spawning a doomed instance;
- surfaces the resolved version in the ready banner / CLI stderr.

### Live red/green

```
# GREEN (this machine: real app-code 1.13.0)
$ pnpm run obsidian:e2e -- eval code='"green"'
Obsidian app 1.13.0 (installer 1.12.7), plugin minAppVersion 1.13.0
=> green

# RED (sub-minimum build, the worker's scenario)
Obsidian app version 1.12.7 is BELOW the plugin's minAppVersion 1.13.0 (installer
shell 1.12.7). Obsidian fell back to a build QuickAdd does not support, so any e2e
"missing API" failure here is a FALSE signal, not a real bug. Update Obsidian to
>= 1.13.0 ... before running e2e.
```

## Design notes / why predict from disk

Obsidian does not expose `apiVersion` to a CDP-evaluated snippet (`require("obsidian")` is unresolvable outside plugin scope; the window title carries the *installer* version), so the app-code version cannot be read from the running renderer. The guard therefore resolves it the same way Obsidian does and runs **before** launch, so a fresh instance loads exactly what was resolved. Documented residual: a warm instance reused from an earlier run reflects the asar resolution at *its* launch (an Obsidian update mid-session is not re-detected) - bounded, since instances are reaped per worktree and Obsidian versions are stable within a run.

This was adversarially reviewed (opposing model); the HIGH findings (post-launch placement, filename-trust of cached asars) are addressed here (pre-launch guard, asar content validation + a corrupt-asar test).

## Gates
`tsc -noEmit` ✅ · `eslint .` ✅ · `svelte-check` ✅ 0 errors · `vitest` ✅ 3326 passed / 37 skipped (+8 new guard tests: green / red / corrupt-asar skip / undeterminable refusal).

No conflict with #1438 - this PR touches only `scripts/` + `tests/`, not `AIAssistantProvidersModal.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a minimum Obsidian app-code version check before starting or reusing an end-to-end instance.
  * Enhanced non-JSON output to show the resolved Obsidian app version together with the plugin’s required `minAppVersion` when available.
* **Bug Fixes**
  * Improved app-code version resolution by inspecting installed archives, selecting the best candidate, and handling malformed/corrupt archives with clear failures.
  * Strengthened version comparison to correctly order major/minor/patch values and enforce minimum requirements.
* **Tests**
  * Added coverage for version comparison, archive-based app-version resolution (including edge-case alignment), and min-version enforcement/rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->