### PR TITLE
fix: deepsec core-src BUG cluster (FILE-token collision, proto-key lookups, folder guard, null-deref)

### DIFF
--- a/src/gui/UpdateModal/UpdateModal.test.ts
+++ b/src/gui/UpdateModal/UpdateModal.test.ts
@@ -174,6 +174,17 @@ describe("getReleaseNotesAfter", () => {
 		);
 	});
 
+	it("rejects an error status even when the body is an array (no bogus release notes)", async () => {
+		// An intermediary could pair a 5xx with a stale array body; an error status
+		// must be a failure regardless of body shape, never surfaced as releases.
+		mockResponse(503, [
+			{ tag_name: "9.9.9", body: "stale", draft: false, prerelease: false },
+		]);
+		await expect(getReleaseNotesAfter("chhoumann", "quickadd", "1.0.0")).rejects.toThrow(
+			"Failed to fetch releases: Unknown error",
+		);
+	});
+
 	it("throws a clear error when the start tag is absent from the releases array", async () => {
 		mockResponse(200, [{ tag_name: "9.9.9", body: "", draft: false, prerelease: false }]);
 		await expect(getReleaseNotesAfter("chhoumann", "quickadd", "1.0.0")).rejects.toThrow(

--- a/src/gui/UpdateModal/UpdateModal.test.ts
+++ b/src/gui/UpdateModal/UpdateModal.test.ts
@@ -1,5 +1,24 @@
-import { describe, expect, it } from "vitest";
-import { renderVideoAttachments } from "./UpdateModal";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getReleaseNotesAfter, renderVideoAttachments } from "./UpdateModal";
+
+const requestUrlMock = vi.hoisted(() => vi.fn());
+
+// Keep the obsidian stub (Modal, Component, MarkdownRenderer, ...) intact - only
+// override requestUrl so getReleaseNotesAfter can be driven with crafted bodies.
+vi.mock("obsidian", async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>();
+	return { ...actual, requestUrl: requestUrlMock };
+});
+
+function mockResponse(status: number, json: unknown): void {
+	requestUrlMock.mockResolvedValue({
+		status,
+		headers: {},
+		arrayBuffer: new ArrayBuffer(0),
+		json,
+		text: typeof json === "string" ? json : JSON.stringify(json),
+	});
+}
 
 const VIDEO_URL =
 	"https://github.com/user-attachments/assets/27712a0b-a26d-4a69-ac21-a7b4af6c5616";
@@ -117,5 +136,48 @@ describe("renderVideoAttachments", () => {
 	it("leaves bodies without video attachments untouched", () => {
 		const body = "## Features\n\n- something new\n";
 		expect(renderVideoAttachments(body)).toBe(body);
+	});
+});
+
+describe("getReleaseNotesAfter", () => {
+	beforeEach(() => {
+		requestUrlMock.mockReset();
+	});
+
+	it("degrades to 'Unknown error' when the body is a literal null (status 200)", async () => {
+		mockResponse(200, null);
+		// Before the guard this threw `Cannot read properties of null (reading
+		// 'message')`, masking the real failure; now it is a clean message.
+		await expect(getReleaseNotesAfter("chhoumann", "quickadd", "1.0.0")).rejects.toThrow(
+			"Failed to fetch releases: Unknown error",
+		);
+	});
+
+	it("degrades to 'Unknown error' when an error body is null (status 500)", async () => {
+		mockResponse(500, null);
+		await expect(getReleaseNotesAfter("chhoumann", "quickadd", "1.0.0")).rejects.toThrow(
+			"Failed to fetch releases: Unknown error",
+		);
+	});
+
+	it("surfaces GitHub's error message for a non-array body", async () => {
+		mockResponse(403, { message: "API rate limit exceeded" });
+		await expect(getReleaseNotesAfter("chhoumann", "quickadd", "1.0.0")).rejects.toThrow(
+			"Failed to fetch releases: API rate limit exceeded",
+		);
+	});
+
+	it("degrades to 'Unknown error' for a non-array body with a non-string message", async () => {
+		mockResponse(500, { message: 42 });
+		await expect(getReleaseNotesAfter("chhoumann", "quickadd", "1.0.0")).rejects.toThrow(
+			"Failed to fetch releases: Unknown error",
+		);
+	});
+
+	it("throws a clear error when the start tag is absent from the releases array", async () => {
+		mockResponse(200, [{ tag_name: "9.9.9", body: "", draft: false, prerelease: false }]);
+		await expect(getReleaseNotesAfter("chhoumann", "quickadd", "1.0.0")).rejects.toThrow(
+			"Could not find release with tag 1.0.0",
+		);
 	});
 });

--- a/src/gui/UpdateModal/UpdateModal.ts
+++ b/src/gui/UpdateModal/UpdateModal.ts
@@ -39,13 +39,15 @@ export async function getReleaseNotesAfter(
 
 	const body: unknown = response.json;
 
-	if (!Array.isArray(body)) {
-		// A non-array body means there are no releases to page through: GitHub's
-		// error shape is `{ message }`, but an intermediary can also return a
-		// literal `null`/primitive. Read `.message` only when it's actually a
-		// string, so a null/primitive body degrades to "Unknown error" instead of
-		// throwing a TypeError (`null.message` / `"message" in null`) that would
-		// mask the real failure.
+	// Treat any error status OR a non-array body as a failure. GitHub returns the
+	// release list (a JSON array) only on success and a `{ message }` object on
+	// error, but with `throw: false` an error status still reaches here - and an
+	// intermediary can return an error status alongside a stale array or a literal
+	// `null`/primitive. Read `.message` only when it's actually a string, so a
+	// null/primitive body degrades to "Unknown error" instead of throwing a
+	// TypeError (`null.message` / `"message" in null`) that would mask the real
+	// failure.
+	if (response.status >= 400 || !Array.isArray(body)) {
 		const message =
 			typeof body === "object" &&
 			body !== null &&

--- a/src/gui/UpdateModal/UpdateModal.ts
+++ b/src/gui/UpdateModal/UpdateModal.ts
@@ -37,13 +37,26 @@ export async function getReleaseNotesAfter(
 		throw: false,
 	});
 
-	const releases: Release[] | { message: string } = response.json;
+	const body: unknown = response.json;
 
-	if ((response.status >= 400 && "message" in releases) || !Array.isArray(releases)) {
-		throw new Error(
-			`Failed to fetch releases: ${releases.message ?? "Unknown error"}`
-		);
+	if (!Array.isArray(body)) {
+		// A non-array body means there are no releases to page through: GitHub's
+		// error shape is `{ message }`, but an intermediary can also return a
+		// literal `null`/primitive. Read `.message` only when it's actually a
+		// string, so a null/primitive body degrades to "Unknown error" instead of
+		// throwing a TypeError (`null.message` / `"message" in null`) that would
+		// mask the real failure.
+		const message =
+			typeof body === "object" &&
+			body !== null &&
+			"message" in body &&
+			typeof (body as { message?: unknown }).message === "string"
+				? (body as { message: string }).message
+				: "Unknown error";
+		throw new Error(`Failed to fetch releases: ${message}`);
 	}
+
+	const releases = body as Release[];
 
 	const startReleaseIdx = releases.findIndex(
 		(release) => release.tag_name === releaseTagName

--- a/src/template/fileExistsPolicy.test.ts
+++ b/src/template/fileExistsPolicy.test.ts
@@ -90,6 +90,32 @@ describe("fileExistsPolicy registry", () => {
 		);
 		expect(mapLegacyFileExistsModeToId("Nothing")).toBe("doNothing");
 	});
+
+	it("returns null for unknown legacy modes", () => {
+		expect(mapLegacyFileExistsModeToId("")).toBeNull();
+		expect(mapLegacyFileExistsModeToId("not a real mode")).toBeNull();
+		expect(mapLegacyFileExistsModeToId(123)).toBeNull();
+		expect(mapLegacyFileExistsModeToId(undefined)).toBeNull();
+	});
+
+	it("returns null for prototype magic keys (no inherited members)", () => {
+		// A hand-edited data.json or imported package could set `fileExistsMode`
+		// to a JS magic key. A plain-object lookup would resolve the inherited
+		// member (truthy), defeating the `?? null` fallback and later throwing
+		// "Unknown file exists mode" at template-run time.
+		// Every key here resolves to an inherited member pre-fix (this lookup is
+		// not lowercased, so the camelCase members match too).
+		for (const key of [
+			"__proto__",
+			"constructor",
+			"toString",
+			"valueOf",
+			"hasOwnProperty",
+			"isPrototypeOf",
+		]) {
+			expect(mapLegacyFileExistsModeToId(key)).toBeNull();
+		}
+	});
 });
 
 describe("fileExistsPolicy collision naming", () => {

--- a/src/template/fileExistsPolicy.ts
+++ b/src/template/fileExistsPolicy.ts
@@ -178,6 +178,17 @@ export function mapLegacyFileExistsModeToId(
 		return null;
 	}
 
+	// `legacyFileExistsModeMap` is a plain object, so a bare `[mode]` lookup
+	// would resolve inherited members for magic keys (`__proto__` ->
+	// Object.prototype, `constructor` -> the Object function, `toString`/
+	// `valueOf` -> functions). All are truthy, silently defeating the `?? null`
+	// fallback and returning a non-`FileExistsModeId`. Restrict to own keys so
+	// any unknown input - including a hand-edited or imported `fileExistsMode` -
+	// falls back cleanly.
+	if (!Object.prototype.hasOwnProperty.call(legacyFileExistsModeMap, mode)) {
+		return null;
+	}
+
 	return legacyFileExistsModeMap[mode] ?? null;
 }
 

--- a/src/utils/FieldValueProcessor.test.ts
+++ b/src/utils/FieldValueProcessor.test.ts
@@ -143,6 +143,32 @@ describe("FieldValueProcessor", () => {
 			const defaults = FieldValueProcessor.getSmartDefaults("unknown", manyValues);
 			expect(defaults).toHaveLength(5);
 		});
+
+		it("returns an array (not a prototype member) for magic field names", () => {
+			// `{{FIELD:constructor}}` flows here verbatim and lowercased. A plain-
+			// object lookup resolves Object.prototype.constructor (the Object
+			// function, length 1), which passes the `.length > 0` guards in
+			// completeFormatter and then crashes `.slice`/`.map`, aborting the
+			// choice. `__proto__` resolves to Object.prototype (also non-array).
+			// These two are the only inherited members whose name survives
+			// `.toLowerCase()`; both must degrade to an empty list like any unknown
+			// field.
+			for (const name of ["constructor", "__proto__"]) {
+				const defaults = FieldValueProcessor.getSmartDefaults(name, []);
+				expect(Array.isArray(defaults)).toBe(true);
+				expect(defaults).toEqual([]);
+			}
+		});
+
+		it("falls back to existing values for a magic field name", () => {
+			const defaults = FieldValueProcessor.getSmartDefaults("constructor", [
+				"x",
+				"x",
+				"y",
+			]);
+			expect(Array.isArray(defaults)).toBe(true);
+			expect(defaults[0]).toBe("x");
+		});
 	});
 
 	describe("validateDefaultValue", () => {

--- a/src/utils/FieldValueProcessor.ts
+++ b/src/utils/FieldValueProcessor.ts
@@ -176,9 +176,17 @@ export class FieldValueProcessor {
 		};
 
 		const normalizedFieldName = fieldName.toLowerCase();
-		
-		// Check for exact matches
-		if (commonDefaults[normalizedFieldName]) {
+
+		// Check for exact matches. `commonDefaults` is a plain object, so a bare
+		// `[normalizedFieldName]` lookup resolves inherited members for magic field
+		// names: `{{FIELD:constructor}}` yields the Object function (truthy, length
+		// 1) instead of a `string[]`, which then crashes `.slice`/`.map` in
+		// completeFormatter and aborts the choice. The field name flows unsanitized
+		// from a `{{FIELD:<name>}}` token (and may come from an imported package
+		// template), so restrict to own keys.
+		if (
+			Object.prototype.hasOwnProperty.call(commonDefaults, normalizedFieldName)
+		) {
 			return commonDefaults[normalizedFieldName];
 		}
 

--- a/src/utils/fileOpening.test.ts
+++ b/src/utils/fileOpening.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import { TFile, TFolder } from "obsidian";
+import { openFile } from "./fileOpening";
+
+type MockLeaf = {
+	openFile: ReturnType<typeof vi.fn>;
+	getViewState: () => { state: Record<string, unknown> };
+	setViewState: ReturnType<typeof vi.fn>;
+};
+
+function makeApp(resolved: unknown): { app: App; leaf: MockLeaf } {
+	const leaf: MockLeaf = {
+		openFile: vi.fn(),
+		getViewState: () => ({ state: {} }),
+		setViewState: vi.fn(),
+	};
+	const app = {
+		vault: { getAbstractFileByPath: () => resolved },
+		workspace: {
+			rootSplit: {},
+			getMostRecentLeaf: () => null,
+			getLeaf: () => leaf,
+			setActiveLeaf: vi.fn(),
+			iterateRootLeaves: () => {},
+		},
+	} as unknown as App;
+	return { app, leaf };
+}
+
+describe("openFile folder guard", () => {
+	it("throws 'File not found' for a folder path instead of opening the folder", async () => {
+		// `getAbstractFileByPath` returns a TFolder for a folder path. A folder is
+		// not openable as a file, so QuickAdd must surface its clean error rather
+		// than handing the folder to `leaf.openFile`.
+		const folder = new TFolder();
+		folder.path = "People";
+		const { app, leaf } = makeApp(folder);
+
+		await expect(openFile(app, "People")).rejects.toThrow("File not found: People");
+		expect(leaf.openFile).not.toHaveBeenCalled();
+	});
+
+	it("rejects a path-only object that has no string extension", async () => {
+		// Asserts the guard's actual discriminator directly (rather than relying on
+		// the stub TFolder happening to lack an `extension` field): a folder-shaped
+		// value carries `path` but no `extension`, so it must not be opened.
+		const { app, leaf } = makeApp({ path: "People" });
+
+		await expect(openFile(app, "People")).rejects.toThrow("File not found: People");
+		expect(leaf.openFile).not.toHaveBeenCalled();
+	});
+
+	it("opens a real TFile path", async () => {
+		const file = new TFile();
+		file.path = "People/Tom.md";
+		file.extension = "md";
+		const { app, leaf } = makeApp(file);
+
+		await openFile(app, "People/Tom.md");
+		expect(leaf.openFile).toHaveBeenCalledWith(file);
+	});
+
+	it("still accepts a cross-realm file-like object (path + extension, no instanceof)", async () => {
+		// The duck-typing exists to tolerate TFile instances from another JS realm
+		// where `instanceof TFile` fails. Tightening the guard must not break that.
+		const fileLike = {
+			path: "People/Tom.md",
+			extension: "md",
+			name: "Tom.md",
+			basename: "Tom",
+		};
+		const { app, leaf } = makeApp(fileLike);
+
+		await openFile(app, "People/Tom.md");
+		expect(leaf.openFile).toHaveBeenCalledWith(fileLike);
+	});
+});

--- a/src/utils/fileOpening.ts
+++ b/src/utils/fileOpening.ts
@@ -98,11 +98,19 @@ function findUnpinnedNavigableSibling(
 
 function isTFileLike(file: unknown): file is TFile {
 	if (file instanceof TFile) return true;
+	// Duck-type cross-realm TFile instances (where `instanceof` fails across JS
+	// realms) by their shape, but REQUIRE a string `extension`. A TFolder also
+	// carries a string `path`, so a `path`-only check accepts folders and lets
+	// `getAbstractFileByPath("some/folder")` reach `leaf.openFile(folder)` instead
+	// of the intended "File not found". A TFolder has no `extension`, so this
+	// rejects it while still tolerating genuine cross-realm files.
 	return (
 		typeof file === "object" &&
 		file !== null &&
 		"path" in file &&
-		typeof file.path === "string"
+		typeof file.path === "string" &&
+		"extension" in file &&
+		typeof file.extension === "string"
 	);
 }
 

--- a/src/utils/fileSyntax.test.ts
+++ b/src/utils/fileSyntax.test.ts
@@ -117,6 +117,31 @@ describe("parseFileToken", () => {
 			expect(pub).not.toBe(priv);
 		});
 
+		it("does NOT collapse a comma-bearing filter value with two separate values", () => {
+			// `exclude-folder:a,b` is a single folder literally named "a,b" (the
+			// grammar only splits on `|`), whereas two `exclude-folder:` parts are
+			// two distinct folders. They scope different file lists and must keep
+			// distinct identities - a `,`-joined signature would collapse both to
+			// `xfolder=a,b` and silently reuse one token's pick for the other.
+			const single = parseFileToken("People|exclude-folder:a,b")!.variableKey;
+			const split = parseFileToken(
+				"People|exclude-folder:a|exclude-folder:b",
+			)!.variableKey;
+			expect(single).not.toBe(split);
+		});
+
+		it("keeps comma-bearing tag/exclude-tag/exclude-file values distinct from split values", () => {
+			expect(parseFileToken("People|tag:a,b")!.variableKey).not.toBe(
+				parseFileToken("People|tag:a|tag:b")!.variableKey,
+			);
+			expect(parseFileToken("People|exclude-tag:a,b")!.variableKey).not.toBe(
+				parseFileToken("People|exclude-tag:a|exclude-tag:b")!.variableKey,
+			);
+			expect(parseFileToken("People|exclude-file:a,b")!.variableKey).not.toBe(
+				parseFileToken("People|exclude-file:a|exclude-file:b")!.variableKey,
+			);
+		});
+
 		it("DOES share |name: across modes within the same scope", () => {
 			const name = parseFileToken("People|tag:x|name:ref")!.variableKey;
 			const link = parseFileToken("People|tag:x|link|name:ref")!.variableKey;

--- a/src/utils/fileSyntax.ts
+++ b/src/utils/fileSyntax.ts
@@ -50,6 +50,21 @@ function normalizeFolder(path: string): string {
 }
 
 /**
+ * Serialize a filter list into a delimiter-safe, order-insensitive token. A
+ * filter value can itself contain a comma (Obsidian folder/tag/file names may,
+ * and the token grammar only ever splits on `|`), so a plain `,`-join is NOT
+ * injective: `['a,b']` and `['a', 'b']` would both render as `a,b` and collapse
+ * two distinct tokens to one variableKey. JSON-encoding the sorted array keeps
+ * the encoding unambiguous (`["a,b"]` vs `["a","b"]`).
+ */
+function encodeSignatureList(
+	values: readonly string[],
+	transform: (value: string) => string = (value) => value,
+): string {
+	return JSON.stringify([...values].map(transform).sort());
+}
+
+/**
  * The slash- and order-insensitive part of the cache key that determines WHICH
  * files the picker lists (folder + tag/exclude-* filters). Two tokens that share
  * this list can meaningfully share a pick; two that don't, can't.
@@ -57,25 +72,17 @@ function normalizeFolder(path: string): string {
 function buildFileScopeSignature(folderPath: string, filter: FieldFilter): string {
 	const parts = [`folder=${normalizeFolder(folderPath)}`];
 	if (filter.folders?.length)
-		parts.push(
-			`folders=${[...filter.folders]
-				.map(normalizeFolder)
-				.sort()
-				.join(",")}`,
-		);
+		parts.push(`folders=${encodeSignatureList(filter.folders, normalizeFolder)}`);
 	if (filter.tags?.length)
-		parts.push(`tags=${[...filter.tags].sort().join(",")}`);
+		parts.push(`tags=${encodeSignatureList(filter.tags)}`);
 	if (filter.excludeFolders?.length)
 		parts.push(
-			`xfolder=${[...filter.excludeFolders]
-				.map(normalizeFolder)
-				.sort()
-				.join(",")}`,
+			`xfolder=${encodeSignatureList(filter.excludeFolders, normalizeFolder)}`,
 		);
 	if (filter.excludeTags?.length)
-		parts.push(`xtag=${[...filter.excludeTags].sort().join(",")}`);
+		parts.push(`xtag=${encodeSignatureList(filter.excludeTags)}`);
 	if (filter.excludeFiles?.length)
-		parts.push(`xfile=${[...filter.excludeFiles].sort().join(",")}`);
+		parts.push(`xfile=${encodeSignatureList(filter.excludeFiles)}`);
 	return parts.join("|");
 }
 


### PR DESCRIPTION
Resolves a clean-room **deepsec** re-investigation cluster of 5 BUG-severity correctness/robustness defects in core src. QuickAdd runs as a LOCAL Obsidian plugin with full user trust, so each finding was reproduced and judged under the real threat model (untrusted input = imported `.quickadd.json` packages, AI output, synced notes/`data.json`/templates, `obsidian://` URIs, CLI, 3rd-party API responses) **before** fixing. Four are untrusted-reachable; one (#3) is a genuine lying type-guard that is production-unreachable and is shipped as defensive hardening, clearly labelled as such.

Every fix is root-cause and proven red→green with a focused harness that exercises the exact mechanism the production code consumes (the `variableKey` dedup key in `formatter.ts`/`RequirementCollector.ts`, the migration lookup, the `openFile` guard, the `completeFormatter` smart-default path, the release-notes parse). One commit per finding.

## Findings & fixes

### 1. `fix(file-syntax)` - FILE-token scope signature was not injective
`buildFileScopeSignature` joined each multi-value filter list with `,` and the parts with `|`. A filter value can itself contain a `,` (Obsidian folder/tag/file names may, and the token grammar only splits on `|`), so `exclude-folder:a,b` (one folder literally named `a,b`) and `exclude-folder:a|exclude-folder:b` (two folders) both serialized to `xfolder=a,b`. Two `{{FILE:...}}` tokens differing only that way collapsed to one `variableKey`; the formatter (`formatter.ts:1011`) / preflight (`RequirementCollector.ts`) then reused the first token's pick for the second and rendered the **wrong file**. Reachable from a synced template or imported package.
**Fix:** encode each list as `JSON.stringify` of the sorted (optionally folder-normalized) array, so distinct filter sets can never collapse. Regression tests cover exclude-folder / tag / exclude-tag / exclude-file.

### 2. `fix(template)` - legacy file-exists mode lookup returned inherited members
`mapLegacyFileExistsModeToId` did `legacyFileExistsModeMap[mode] ?? null` on a plain object, so magic keys resolved inherited members (`__proto__`→`Object.prototype`, `constructor`→`Object`, `toString`/`valueOf`/`hasOwnProperty`/`isPrototypeOf`→functions), all truthy - defeating `?? null`. The migration's `?? "increment"` was defeated the same way, persisting `{ kind: "apply", mode: <Object> }`, which later throws `Unknown file exists mode` at run time and breaks the choice. Reachable from a hand-edited/synced `data.json` or imported package with `fileExistsMode` set to a magic key.
**Fix:** `Object.prototype.hasOwnProperty.call` own-key guard so any non-own key falls back cleanly. Test covers the magic keys + unknown modes.

### 3. `fix(file-open)` - isTFileLike accepted folders (defensive hardening)
`isTFileLike` returned true for any non-null object with a string `path`; a `TFolder` matches that shape, so `openFile(app, "some/folder")` passed the `file is TFile` guard and reached `leaf.openFile(folder)` instead of the clean `File not found`. **Note:** no current caller drives a folder here (Macro Open File pre-guards with `instanceof TFile`; all other callers pass a resolved `TFile`), and `getAbstractFileByPath` is vault-confined - so this is **not a reachable bug**, just a lying guard. Shipped as defensive hardening.
**Fix:** the duck-typed branch now also requires a string `extension` (a `TFolder` has none; cross-realm `TFile` instances, the reason the duck-typing exists, still pass). Tests: folder path and path-only object are rejected; real `TFile` and cross-realm file-like still open.

### 4. `fix(field)` - smart-default lookup crashed on `{{FIELD:constructor}}`
`getSmartDefaults` did `if (commonDefaults[normalizedFieldName]) return ...` on a plain object, where the name is the unsanitized `{{FIELD:<name>}}` token lowercased. `{{FIELD:constructor}}` resolves `Object.prototype.constructor` (the Object function, `length` 1), which passes `completeFormatter`'s `.length > 0` guards then crashes on `.slice`/`.map`, aborting the choice; `__proto__` resolves to `Object.prototype`. The name can come from an imported package template.
**Fix:** `hasOwnProperty.call` guard on the exact-match lookup (the partial-match loop already iterates own keys via `Object.entries`). Regression test on the two names whose lowercased form actually collides (`constructor`, `__proto__`).

### 5. `fix(update-modal)` - null/non-object release-notes body threw a TypeError
`getReleaseNotesAfter` crashed on a null response body: with status < 400 the `status >= 400 && "message" in releases` clause short-circuits, the OR falls to `!Array.isArray(null)`, and the throw evaluates `null.message`; with status >= 400 and a null body, `"message" in null` throws. The intended `"Unknown error"` fallback was unreachable and masked the real failure. A 3rd-party GitHub response or intermediary can return a literal `null`/primitive.
**Fix:** gate on `!Array.isArray(body)` and read `.message` only when the body is a non-null object whose message is a string, else `"Unknown error"`. The dropped clause was dead for arrays, so the array and GitHub-error paths are behavior-preserving. Tests cover null bodies (200/500), a non-string message, and the existing error/absent-tag paths.

## Verification
- **Red→green proven for every finding:** stashing only the 5 source fixes makes the new tests fail with the exact reported symptoms (e.g. `Cannot read properties of null (reading 'message')`, `Cannot use 'in' operator to search for 'message' in null`, colliding `variableKey`s); restoring them passes. 10 tests fail on pre-fix source, all pass after.
- **Gates green:** `tsc -noEmit`, `eslint .` (0/0), `svelte-check` (0 errors), `vitest` (3378 passed / 37 skipped), `pnpm run build`.
- **Adversarial review:** an opposing-model (Codex) pass plus an 11-agent skeptic/auditor panel independently confirmed all 5 findings real and the fixes root-cause + regression-free. Two raised concerns were **refuted**: the `folders=` branch in `buildFileScopeSignature` is harmless dead code (FILE-token scope is always the single positional folder; `|folder:` extras are discarded by design, so sharing a key is correct - it was **not** wired up), and #3 was correctly reclassified from "reachable bug" to "defensive hardening".

## Follow-up (not in scope)
`src/engine/canvasCapture.ts` has a second, looser `isTFileLike` (`'extension' in file` without the `typeof === 'string'` rigor). Worth extracting a shared file-vs-folder discriminator later so the two cannot diverge; left out here to keep this PR reviewable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file opening reliability by rejecting folder-like/vault items without a string `extension`, while still supporting cross-realm “file-like” objects.
  * Hardened “magic” property handling so inherited/prototype keys (e.g., `__proto__`, `constructor`) no longer resolve to defaults or legacy options.
  * Made update release-note fetching more robust against malformed server responses, with clearer failure messaging.
  * Fixed filter/cache behavior for comma-containing values by using delimiter-safe signatures.
* **Tests**
  * Expanded coverage for update-note parsing, file opening guards, magic-key safety, and comma-literal filter parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->