### PR TITLE
fix(ai): close allowedRoots fence bypass + honest truncated flag in vault read tools

### DIFF
--- a/src/ai/tools/builtins/builtins.test.ts
+++ b/src/ai/tools/builtins/builtins.test.ts
@@ -223,3 +223,68 @@ describe("workspace tools — allowedRoots confinement", () => {
 		});
 	});
 });
+
+// allowedRoots confinement for the vault READ group (#714, other-confinement-bypass).
+// list_notes/search_notes/get_property_values filter app-owned TFile.path against the
+// fence. A TFile.path is an IDENTITY, so the filter must compare it without trimming or
+// re-spelling — otherwise a sibling folder named " AI" (leading space) trims to "AI" and
+// masquerades as the allowed root, leaking out-of-fence paths/snippets/frontmatter into
+// the LLM transcript. (Same class the workspace group fixed in #1432; a leading-space
+// folder is creatable in Obsidian and getMarkdownFiles() preserves the space — verified
+// live.)
+describe("vault read tools — allowedRoots confinement is identity-preserving", () => {
+	const ctx = (name: string) => ({ toolCallId: "c", toolName: name });
+
+	// A real leading-space sibling folder " AI" alongside the allowed root "AI".
+	const SIBLING = fileLike(" AI/secret.md", "secret");
+	const INROOT = fileLike("AI/ok.md", "ok");
+
+	it("list_notes (no folder) excludes a leading-space sibling of the root", async () => {
+		const app = makeApp({ vault: { getMarkdownFiles: () => [SIBLING, INROOT] } });
+		const tools = createVaultTools(app, { allowedRoots: ["AI"] });
+		const res = (await tools.list_notes.execute({}, ctx("list_notes"))) as {
+			total: number;
+			notes: Array<{ path: string }>;
+		};
+		expect(res.notes.map((n) => n.path)).toEqual(["AI/ok.md"]);
+		expect(res.total).toBe(1);
+	});
+
+	it("search_notes excludes a leading-space sibling of the root", async () => {
+		const cachedRead = vi.fn(async (f: TFile) => (f.path === " AI/secret.md" ? "needle" : "haystack"));
+		const app = makeApp({ vault: { getMarkdownFiles: () => [SIBLING, INROOT], cachedRead } });
+		const tools = createVaultTools(app, { allowedRoots: ["AI"] });
+		const res = (await tools.search_notes.execute(
+			{ query: "needle", in: "content" },
+			ctx("search_notes"),
+		)) as { results: Array<{ path: string }> };
+		expect(res.results.map((r) => r.path)).toEqual([]);
+		// The out-of-fence sibling must never be read for content.
+		expect(cachedRead).not.toHaveBeenCalledWith(SIBLING);
+	});
+
+	it("get_property_values (no folder) excludes a leading-space sibling of the root", async () => {
+		const getFileCache = vi.fn((f: TFile) => ({
+			frontmatter: { status: f.path === " AI/secret.md" ? "LEAKED" : "ok" },
+		}));
+		const app = makeApp({
+			vault: { getMarkdownFiles: () => [SIBLING, INROOT] },
+			metadataCache: { getFileCache },
+		});
+		const tools = createVaultTools(app, { allowedRoots: ["AI"] });
+		const res = (await tools.get_property_values.execute(
+			{ field: "status" },
+			ctx("get_property_values"),
+		)) as { values: string[] };
+		expect(res.values).toEqual(["ok"]);
+	});
+
+	it("default (no roots) lists every folder unchanged", async () => {
+		const app = makeApp({ vault: { getMarkdownFiles: () => [SIBLING, INROOT] } });
+		const tools = createVaultTools(app);
+		const res = (await tools.list_notes.execute({}, ctx("list_notes"))) as {
+			notes: Array<{ path: string }>;
+		};
+		expect(res.notes.map((n) => n.path).sort()).toEqual([" AI/secret.md", "AI/ok.md"]);
+	});
+});

--- a/src/ai/tools/builtins/builtins.test.ts
+++ b/src/ai/tools/builtins/builtins.test.ts
@@ -288,3 +288,59 @@ describe("vault read tools — allowedRoots confinement is identity-preserving",
 		expect(res.notes.map((n) => n.path).sort()).toEqual([" AI/secret.md", "AI/ok.md"]);
 	});
 });
+
+// search_notes completeness flag (#714, other-logic-bug). Content scanning is capped at
+// MAX_SEARCH_FILE_SCAN (400). When that cap is hit while files remain, `truncated` must
+// be true so the agent knows coverage was partial — returning truncated:false would tell
+// the agent the term is absent / the search was exhaustive when it silently stopped.
+describe("search_notes — content-scan cap reports truncated", () => {
+	const ctx = (name: string) => ({ toolCallId: "c", toolName: name });
+
+	it("flags truncated when the >400th file (the only match) is never scanned", async () => {
+		// 401 markdown files. Only the LAST one contains the query; the first 400 do not.
+		const files: TFile[] = [];
+		for (let i = 0; i < 400; i++) files.push(fileLike(`big/note${i}.md`, `note${i}`));
+		files.push(fileLike("big/match.md", "match"));
+		const cachedRead = vi.fn(async (f: TFile) => (f.path === "big/match.md" ? "the needle is here" : "no hit"));
+		const app = makeApp({ vault: { getMarkdownFiles: () => files, cachedRead } });
+		const tools = createVaultTools(app);
+		const res = (await tools.search_notes.execute(
+			{ query: "needle", in: "content" },
+			ctx("search_notes"),
+		)) as { results: unknown[]; scannedFiles: number; truncated: boolean };
+		expect(res.results).toEqual([]);
+		expect(res.scannedFiles).toBe(400);
+		// The match in file #401 was silently skipped — coverage was NOT exhaustive.
+		expect(res.truncated).toBe(true);
+	});
+
+	it("does NOT over-report truncated for a small fully-scanned vault", async () => {
+		const files = [fileLike("a.md", "a"), fileLike("b.md", "b")];
+		const cachedRead = vi.fn(async () => "nothing here");
+		const app = makeApp({ vault: { getMarkdownFiles: () => files, cachedRead } });
+		const tools = createVaultTools(app);
+		const res = (await tools.search_notes.execute(
+			{ query: "zzz", in: "content" },
+			ctx("search_notes"),
+		)) as { results: unknown[]; truncated: boolean };
+		expect(res.results).toEqual([]);
+		expect(res.truncated).toBe(false);
+	});
+
+	it("does NOT over-report truncated at exactly the scan cap (every file scanned)", async () => {
+		// Exactly 400 content-eligible files: all are scanned, none is skipped, so the
+		// cap is reached but never EXCEEDED — coverage is complete, truncated must be false.
+		const files: TFile[] = [];
+		for (let i = 0; i < 400; i++) files.push(fileLike(`big/note${i}.md`, `note${i}`));
+		const cachedRead = vi.fn(async () => "no hit");
+		const app = makeApp({ vault: { getMarkdownFiles: () => files, cachedRead } });
+		const tools = createVaultTools(app);
+		const res = (await tools.search_notes.execute(
+			{ query: "zzz", in: "content" },
+			ctx("search_notes"),
+		)) as { scannedFiles: number; truncated: boolean };
+		expect(res.scannedFiles).toBe(400);
+		expect(res.truncated).toBe(false);
+		expect(cachedRead).toHaveBeenCalledTimes(400);
+	});
+});

--- a/src/ai/tools/builtins/vaultTools.ts
+++ b/src/ai/tools/builtins/vaultTools.ts
@@ -12,6 +12,7 @@
 import { type App, TFile } from "obsidian";
 import { getMarkdownFilesInFolder } from "../../../utilityObsidian";
 import { insertAtNoteBodyStart } from "../../../utils/noteContentInsertion";
+import { isWithinAllowedRoots } from "../allowedRoots";
 import { sanitizeVaultPath } from "../sanitizeVaultPath";
 import { assertWriteStaysInVault } from "../../../utils/vaultWriteGuards";
 import type { JSONSchema } from "../NormalizedTools";
@@ -30,14 +31,13 @@ export function createVaultTools(
 	options: BuiltinGroupOptions = {},
 ): ToolSetMap {
 	const roots = options.allowedRoots;
-	const withinRoots = (path: string) => {
-		try {
-			sanitizeVaultPath(path, { allowedRoots: roots });
-			return true;
-		} catch {
-			return false;
-		}
-	};
+	// The read tools below confine results to the allowedRoots fence by filtering each
+	// app-owned TFile.path through isWithinAllowedRoots — the SAME identity-preserving
+	// predicate the workspace group uses (#1432). A TFile.path is an identity, so it is
+	// compared NFC-only and never trimmed/re-spelled; that is what stops a sibling folder
+	// named " AI" from masquerading as the allowed root "AI". sanitizeVaultPath is kept
+	// only for MODEL-CHOSEN inputs (read_note's path and the folder args), where trimming
+	// and structural validation are correct. Absent/all-blank roots ⇒ vault-wide.
 
 	const tools: ToolSetMap = {
 		read_note: tool({
@@ -74,7 +74,7 @@ export function createVaultTools(
 				const base = folder ? sanitizeVaultPath(String(folder), { allowedRoots: roots }) : "";
 				const cap = clamp(toInt(limit, DEFAULT_LIST), 1, MAX_LIST);
 				const files = getMarkdownFilesInFolder(app, base).filter((f) =>
-					roots ? withinRoots(f.path) : true,
+					isWithinAllowedRoots(f.path, roots),
 				);
 				return {
 					total: files.length,
@@ -101,7 +101,7 @@ export function createVaultTools(
 				const cap = clamp(toInt(limit, DEFAULT_SEARCH), 1, MAX_SEARCH);
 				const files = app.vault
 					.getMarkdownFiles()
-					.filter((f) => (roots ? withinRoots(f.path) : true));
+					.filter((f) => isWithinAllowedRoots(f.path, roots));
 				const results: Array<{ path: string; snippet?: string }> = [];
 				let scanned = 0;
 				for (const f of files) {
@@ -136,7 +136,7 @@ export function createVaultTools(
 				const base = folder ? sanitizeVaultPath(String(folder), { allowedRoots: roots }) : "";
 				const files = (
 					folder ? getMarkdownFilesInFolder(app, base) : app.vault.getMarkdownFiles()
-				).filter((f) => (roots ? withinRoots(f.path) : true));
+				).filter((f) => isWithinAllowedRoots(f.path, roots));
 				const values = new Set<string>();
 				for (const f of files) {
 					const fm = app.metadataCache.getFileCache(f)?.frontmatter;

--- a/src/ai/tools/builtins/vaultTools.ts
+++ b/src/ai/tools/builtins/vaultTools.ts
@@ -104,6 +104,12 @@ export function createVaultTools(
 					.filter((f) => isWithinAllowedRoots(f.path, roots));
 				const results: Array<{ path: string; snippet?: string }> = [];
 				let scanned = 0;
+				// True once the content-scan cap forces us to skip a file we WOULD have
+				// scanned. Without this, a search whose only match sits past the 400th file
+				// returns truncated:false — telling the agent the term is absent when scanning
+				// silently stopped. Name matches are exhaustive (no scan cap), so the flag is
+				// only ever set on the content path.
+				let scanCapHit = false;
 				for (const f of files) {
 					if (results.length >= cap) break;
 					const nameHit = scope !== "content" && f.basename.toLowerCase().includes(q);
@@ -111,7 +117,11 @@ export function createVaultTools(
 						results.push({ path: f.path });
 						continue;
 					}
-					if (scope !== "name" && scanned < MAX_SEARCH_FILE_SCAN) {
+					if (scope !== "name") {
+						if (scanned >= MAX_SEARCH_FILE_SCAN) {
+							scanCapHit = true;
+							continue;
+						}
 						scanned++;
 						const text = await app.vault.cachedRead(f);
 						const idx = text.toLowerCase().indexOf(q);
@@ -120,7 +130,11 @@ export function createVaultTools(
 						}
 					}
 				}
-				return { results, scannedFiles: scanned, truncated: results.length >= cap };
+				return {
+					results,
+					scannedFiles: scanned,
+					truncated: results.length >= cap || scanCapHit,
+				};
 			},
 		}),
 


### PR DESCRIPTION
## Summary

Closes two deepsec clean-room findings in the AI Agent's built-in `vault` read tools (`src/ai/tools/builtins/vaultTools.ts`, #714). Both ship as `fix:` with unit tests.

Threat model: QuickAdd is a local Obsidian plugin with full user trust, so a "real" issue needs **untrusted** input. The relevant vector here is a **prompt-injectable LLM** steering the agent's tool calls. `allowedRoots` is the documented exfiltration fence a script author configures to keep an injectable agent away from sensitive notes.

### 1. MEDIUM - allowedRoots fence bypass on app-owned paths (confinement)

`list_notes` / `search_notes` / `get_property_values` confined results by filtering each app-owned `TFile.path` through the **trimming** `sanitizeVaultPath` (via a local `withinRoots` helper). `sanitizeVaultPath` is built for **model-chosen** input, so it `.trim()`s its argument. A `TFile.path` is an **identity**, not model input - trimming it lets a real out-of-fence file at `" AI/secret.md"` (leading-space sibling folder) trim to `"AI/secret.md"` and pass the fence when `allowedRoots=["AI"]`.

In the no-folder calls (`list_notes` w/o folder, all `search_notes`, `get_property_values` w/o folder) this filter is the **sole** confinement over `getMarkdownFiles()`, so out-of-fence **paths**, content **snippets**, and frontmatter **values** leaked into the transcript uploaded to the LLM provider. This is the exact regression class already fixed for the workspace group in #1432.

**Fix:** filter app-owned paths with the identity-preserving `isWithinAllowedRoots` (NFC-only, never trimmed), inlined at the three call sites exactly as `workspaceTools.ts` does - so both tool groups now share one visible fence predicate. `read_note` and the `folder` / write-tool args keep `sanitizeVaultPath`, which is correct for genuine model input.

### 2. BUG - search_notes `truncated` ignored the content-scan cap

`search_notes` caps content scanning at `MAX_SEARCH_FILE_SCAN` (400) but returned `truncated: results.length >= cap`, reflecting only the result-count cap (25/50). On a vault with > 400 notes, a content search whose only match lives past the 400th file scanned the first 400 (no match), silently skipped the rest, and returned `{results:[], truncated:false}` - telling the agent the term is **absent / search exhaustive** when scanning had stopped. The agent then wrongly concludes a note doesn't exist.

**Fix:** track when the scan cap forces a content-eligible file to be skipped (`scanCapHit`) and OR it into `truncated`. The flag only trips on a genuinely-skipped file (the early `continue` keeps the 400th file scanned), so a fully-scanned vault of exactly 400 notes still reports `truncated:false`; name matches (no scan cap) are unaffected.

## Proof (red -> green)

`src/ai/tools/builtins/builtins.test.ts`:

- **Finding 1** - 3 tests model the exact attack (a real `TFile` at `" AI/secret.md"`, `allowedRoots:["AI"]`, no-folder calls). Against the trimming code all three **failed**: `list_notes` returned the sibling path, `search_notes` read **and** returned the sibling content snippet, `get_property_values` returned the sibling's frontmatter value. After the fix they pass; the out-of-fence sibling is never even read. A no-roots control proves vault-wide behavior is byte-identical.
- **Finding 2** - a 401-file test where the only match sits in file #401: against the old flag `truncated` was wrongly `false`; after the fix it is `true`. A 2-file and an exactly-400-file test prove no over-reporting at/under the cap.

**Live verification (isolated vault):** confirmed the empirical precondition that unit tests can't cover - Obsidian creates a leading-space `" AI"` folder and `getMarkdownFiles()` returns `" AI/secret.md"` with the space preserved; `getAbstractFileByPath(" AI/secret.md")` resolves it exactly. So the bypass vector is real, not theoretical.

## Adversarial review

- Pre-coding design-review (3 independent refuters, opposite lenses): both findings **HOLD**, fix design **sound**.
- Post-implementation opposite-model (Codex) Skeptic + Architect pass: **no correctness bug found in either fix** (Skeptic confirmed `scanCapHit` is never wrongly true/false and the no-roots change is an improvement, not a regression). Remaining reviewer findings are out of scope and surfaced below rather than folded in.

## Out of scope (surfaced, not fixed here)

Pre-existing, unrelated to the two assigned findings - flagging for follow-up:

- `get_property_values` matches the frontmatter **key** case-sensitively (`fm?.[field]`), unlike `getMarkdownFilesWithProperty` which is case-insensitive.
- `allowedRoots` is a **lexical** fence; the write guard is a **physical** realpath check. A user-created in-vault symlink crossing the fence isn't covered. (The agent cannot create symlinks via these tools - dot-floor + realpath guard block it - so this needs a pre-existing user symlink.)
- `ensureMarkdownPath` runs before `sanitizeVaultPath`, so a model path with a trailing space normalizes oddly.
- `read_note` reads any `TFile`, not strictly markdown.
- Richer `search_notes` coverage signal (separate `resultLimitHit` / `contentScanLimitHit` fields) instead of one `truncated` boolean.

## Gates

`tsc -noEmit` ✓ · `eslint .` ✓ · `svelte-check --threshold error` ✓ · `vitest` ✓ (3370 passed) · `build` ✓

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault read tools now respect allowed folder boundaries more consistently, preventing notes from nearby similarly named folders from appearing unexpectedly.
  * Search results now better reflect when content scanning stops early: empty results can now be marked as truncated when the scan limit is reached, even if no match is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->