### PR TITLE
fix(field): remove two ReDoS regexes from inline-field parsing

### DIFF
--- a/src/utils/InlineFieldParser.test.ts
+++ b/src/utils/InlineFieldParser.test.ts
@@ -258,4 +258,127 @@ Id:: 999999
 			expect(result).toEqual(new Set(["343434", "121212"]));
 		});
 	});
+
+	describe("fenced code block edge cases", () => {
+		it("leaves an unclosed fence intact (behaviour-preserving)", () => {
+			// The old regex only stripped a fence once it found a matching
+			// closer, so an unclosed opener stripped nothing and its fields
+			// still surfaced. The linear scanner preserves that exactly rather
+			// than guessing the rest of the note is code.
+			const content = `
+real:: kept
+\`\`\`
+secret:: stillseen
+trailing:: alsoseen`;
+			const result = InlineFieldParser.parseInlineFields(content);
+
+			expect(result.get("real")).toEqual(new Set(["kept"]));
+			expect(result.get("secret")).toEqual(new Set(["stillseen"]));
+			expect(result.get("trailing")).toEqual(new Set(["alsoseen"]));
+		});
+
+		it("ignores a nested fence of a shorter backtick run", () => {
+			// A 4-backtick fence wrapping a 3-backtick sample (the canonical way
+			// to show fenced code inside Markdown) is one block: the inner
+			// 3-backtick lines do not close the 4-backtick opener.
+			const content = `
+before:: a
+\`\`\`\`markdown
+\`\`\`
+inside:: ignored
+\`\`\`
+\`\`\`\`
+after:: b`;
+			const result = InlineFieldParser.parseInlineFields(content);
+
+			expect(result.get("before")).toEqual(new Set(["a"]));
+			expect(result.has("inside")).toBe(false);
+			expect(result.get("after")).toEqual(new Set(["b"]));
+		});
+
+		it("resumes parsing fields after a properly closed fence", () => {
+			const content = `
+before:: a
+\`\`\`
+inside:: ignored
+\`\`\`
+after:: b`;
+			const result = InlineFieldParser.parseInlineFields(content);
+
+			expect(result.get("before")).toEqual(new Set(["a"]));
+			expect(result.has("inside")).toBe(false);
+			expect(result.get("after")).toEqual(new Set(["b"]));
+		});
+
+		it("closes a fence with a longer run of backticks (CommonMark >=)", () => {
+			const content = `
+\`\`\`
+inside:: ignored
+\`\`\`\`\`
+after:: b`;
+			const result = InlineFieldParser.parseInlineFields(content);
+
+			expect(result.has("inside")).toBe(false);
+			expect(result.get("after")).toEqual(new Set(["b"]));
+		});
+	});
+
+	describe("ReDoS resistance", () => {
+		// Regression guard for the super-linear backtracking that the old
+		// FENCED_CODE_BLOCK_REGEX exhibited. The linear line scanner finishes
+		// pathological input in well under a millisecond; the old regex took
+		// ~10s on 64KB and grew quadratically, so a generous budget keeps the
+		// test non-flaky while still failing hard on any regression.
+		const BUDGET_MS = 1500;
+
+		it(
+			"strips an unclosed fence + long whitespace run in linear time",
+			() => {
+				const content = "```\n" + " ".repeat(100_000);
+				const start = performance.now();
+				InlineFieldParser.parseInlineFields(content);
+				const elapsed = performance.now() - start;
+
+				expect(elapsed).toBeLessThan(BUDGET_MS);
+			},
+			20_000,
+		);
+
+		it(
+			"parses a long whitespace-led line with no field in linear time",
+			() => {
+				// No fence at all: this exercises INLINE_FIELD_REGEX directly.
+				// A long run of leading whitespace with no `::` made the old
+				// `[ \t]*([^:\n\r]+?)::` overlap backtrack quadratically.
+				const content = " ".repeat(200_000);
+				const start = performance.now();
+				const result = InlineFieldParser.parseInlineFields(content);
+				const elapsed = performance.now() - start;
+
+				expect(result.size).toBe(0);
+				expect(elapsed).toBeLessThan(BUDGET_MS);
+			},
+			20_000,
+		);
+
+		it(
+			"handles many never-closed fence-open lines in linear time",
+			() => {
+				// Each line looks like an opening fence with an info string, so
+				// none of them is a valid closing fence. The old regex retried
+				// from every opener (an O(n^2) outer scan on top of the inner
+				// backtracking); the scanner visits each line once.
+				const content = Array.from(
+					{ length: 50_000 },
+					() => "```info",
+				).join("\n");
+				const start = performance.now();
+				InlineFieldParser.parseInlineFields(content);
+				const elapsed = performance.now() - start;
+
+				expect(elapsed).toBeLessThan(BUDGET_MS);
+			},
+			20_000,
+		);
+	});
 });

--- a/src/utils/InlineFieldParser.ts
+++ b/src/utils/InlineFieldParser.ts
@@ -1,15 +1,31 @@
 import { splitWikilinkAwareList } from "./splitWikilinkAwareList";
 
 export class InlineFieldParser {
-	// Regex to match inline fields in the format "fieldname:: value"
-	// Captures: fieldname and value (until end of line or next field)
+	// Regex to match inline fields in the format "fieldname:: value".
+	// Captures: fieldname (trimmed by the caller) and value, until end of line.
+	//
+	// The field name has no separate leading `[ \t]*`: a standalone `[ \t]*`
+	// before the lazy `([^:\n\r]+?)` (which also matches spaces/tabs) lets the
+	// engine try every split of a long whitespace run against a line with no
+	// `::`, which is O(n^2) backtracking (ReDoS) over untrusted note content.
+	// Leading indentation is instead absorbed by the capture (the caller trims
+	// it) and skipped inside the task-checkbox lookahead, leaving a single
+	// line-consuming quantifier so matching stays linear.
 	private static readonly INLINE_FIELD_REGEX =
-		/(?:^|[\n\r])[ \t]*(?![-*+][ \t]+\[[ xX]\])([^:\n\r]+?)::[ \t]*(.*)$/gmu;
+		/(?:^|[\n\r])(?![ \t]*[-*+][ \t]+\[[ xX]\])([^:\n\r]+?)::[ \t]*(.*)$/gmu;
 
 	private static readonly FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n/;
-	private static readonly FENCED_CODE_BLOCK_REGEX =
-		/(`{3,})([^\r\n`]*)\r?\n([\s\S]*?)(?:\r?\n[ \t]*|[ \t]*)\1/g;
 	private static readonly INLINE_CODE_SPAN_REGEX = /`[^`]*`/g;
+
+	// A fenced-code-block opening line: optional indentation, a run of >=3
+	// backticks, then an info string that itself contains no backtick. Applied
+	// per line (no `g` flag, no cross-line `[\s\S]*?`), so it cannot backtrack
+	// across the whole note.
+	private static readonly FENCE_OPEN_REGEX = /^[ \t]*(`{3,})([^`]*)$/;
+	// A closing line: optional indentation, a run of >=3 backticks, then only
+	// trailing whitespace. The run length is compared against the opener
+	// separately (CommonMark requires the closer to be at least as long).
+	private static readonly FENCE_CLOSE_REGEX = /^[ \t]*(`{3,})[ \t]*$/;
 
 	/**
 	 * Extracts inline fields from the content of a file
@@ -67,33 +83,129 @@ export class InlineFieldParser {
 		return content.replace(this.INLINE_CODE_SPAN_REGEX, "");
 	}
 
+	/**
+	 * Remove fenced code blocks from the content so inline-field-looking lines
+	 * inside code samples (e.g. ```dataview``` blocks) are not collected as real
+	 * fields. Blocks whose info-string type is allowlisted keep their body.
+	 *
+	 * Implemented as a single-pass, line-based scanner. The previous regex
+	 * (`(`{3,})([^\r\n`]*)\r?\n([\s\S]*?)(?:\r?\n[ \t]*|[ \t]*)\1`) backtracked
+	 * catastrophically: on an unclosed fence followed by a long whitespace run
+	 * its lazy body and the `[ \t]*` in the closing alternation overlapped, so
+	 * `String.replace` over full untrusted note content was O(n^2) and froze the
+	 * main thread (~10s on 64KB, growing quadratically). This scanner pushes each
+	 * line to the output (or the in-progress fence buffer) exactly once, so
+	 * stripping is linear in the note length.
+	 *
+	 * The parsed field set is preserved for well-formed notes and the existing
+	 * tests, and - unlike a look-ahead scanner - for unclosed fences too: an
+	 * opener with no matching closer is emitted verbatim, exactly as the old
+	 * regex left it (its backreference never matched, so it stripped nothing).
+	 * The differences are confined to unusual/malformed fences, where this
+	 * follows CommonMark instead of the old regex's quirks:
+	 *   - a fence must begin a line (after optional indentation); a backtick run
+	 *     mid-line is no longer mistaken for a fence,
+	 *   - a closing fence is backticks plus trailing whitespace only and may be
+	 *     longer than the opener (the old regex matched only the opener's exact
+	 *     backtick count, leaking the extra backticks into the next value).
+	 *
+	 * Only backtick fences are stripped, preserving prior behaviour; `~~~`
+	 * fences were never handled here and are left untouched. This is deliberately
+	 * a narrower, autocomplete-only subset than the file-rewriting migration
+	 * script (docs/static/scripts/migrateDataviewToFrontmatter.js), which must
+	 * also track tildes and blockquoted fences to avoid destroying note content.
+	 */
 	private static filterFencedCodeBlocks(
 		content: string,
 		includeCodeBlocks?: string[],
 	): string {
+		// A fence needs at least three backticks, so a note without any cannot
+		// contain one. Skip the line split/join (and its allocation) entirely -
+		// this is the common case for vault-wide autocomplete scans.
+		if (!content.includes("```")) return content;
+
 		const allowlistedTypes = new Set(
 			(includeCodeBlocks ?? [])
 				.map((type) => type.trim().toLowerCase())
 				.filter((type) => type.length > 0),
 		);
 
-		return content.replace(
-			this.FENCED_CODE_BLOCK_REGEX,
-			(_fullMatch, _fence, infoString, body: string) => {
-				const normalizedType = String(infoString)
+		const lines = content.split("\n");
+		const out: string[] = [];
+
+		// While inside a fence we buffer its lines (opener first) so an unclosed
+		// fence can be flushed verbatim at EOF instead of guessed to be code.
+		let inside = false;
+		let openLength = 0;
+		let openInfo = "";
+		let buffer: string[] = [];
+
+		for (const line of lines) {
+			if (!inside) {
+				const open = this.matchFenceOpen(line);
+				if (open) {
+					inside = true;
+					openLength = open.length;
+					openInfo = open.info;
+					buffer = [line];
+				} else {
+					out.push(line);
+				}
+				continue;
+			}
+
+			if (this.matchFenceClose(line, openLength)) {
+				// Closed block: drop it, or keep only its body (the buffered
+				// lines after the opener) if its type is allowlisted.
+				const normalizedType = openInfo
 					.trim()
 					.split(/\s+/)[0]
 					?.toLowerCase();
-				if (
+				const keepBody =
 					allowlistedTypes.size > 0 &&
-					normalizedType &&
-					allowlistedTypes.has(normalizedType)
-				) {
-					return body;
+					normalizedType !== undefined &&
+					normalizedType.length > 0 &&
+					allowlistedTypes.has(normalizedType);
+				if (keepBody) {
+					for (let b = 1; b < buffer.length; b++) out.push(buffer[b]);
 				}
-				return "";
-			},
+				inside = false;
+				buffer = [];
+			} else {
+				buffer.push(line);
+			}
+		}
+
+		// Unclosed fence: emit the buffered lines unchanged, matching the old
+		// regex (which stripped nothing when its closing backreference never
+		// matched).
+		if (inside) {
+			for (const line of buffer) out.push(line);
+		}
+
+		return out.join("\n");
+	}
+
+	/** Match a fence opening line, returning its backtick count and info string. */
+	private static matchFenceOpen(
+		line: string,
+	): { length: number; info: string } | null {
+		const match = this.FENCE_OPEN_REGEX.exec(this.stripTrailingCarriage(line));
+		if (!match) return null;
+		return { length: match[1].length, info: match[2] };
+	}
+
+	/** Does this line close a fence opened with `minLength` backticks? */
+	private static matchFenceClose(line: string, minLength: number): boolean {
+		const match = this.FENCE_CLOSE_REGEX.exec(
+			this.stripTrailingCarriage(line),
 		);
+		return match !== null && match[1].length >= minLength;
+	}
+
+	/** Drop a single trailing `\r` so CRLF lines are detected like LF lines. */
+	private static stripTrailingCarriage(line: string): string {
+		return line.endsWith("\r") ? line.slice(0, -1) : line;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`InlineFieldParser` parses the **full content of every scanned note**, and that content is untrusted: `FieldValueCollector` and `quickAddApi.fieldSuggestions` read every markdown file in the vault (Obsidian-Sync'd, shared, AI-generated, and imported-package notes included) and feed it into this parser **on the main thread, batched across the whole vault**. Two regexes here backtrack super-linearly (ReDoS), so a single crafted/synced note freezes Obsidian's field-value autocomplete.

This came from a deepsec clean-room finding (MEDIUM `other-redos`) on the fenced-code regex. Reproducing it surfaced a **second, independent ReDoS** in the inline-field regex on the same untrusted-input path. This PR fixes both at the root.

## The two ReDoS, and the fixes

**1. Fenced-code-block stripping** — `FENCED_CODE_BLOCK_REGEX`
``/(`{3,})([^\r\n`]*)\r?\n([\s\S]*?)(?:\r?\n[ \t]*|[ \t]*)\1/g`` run via `String.replace`. On an unclosed fence followed by a long whitespace run, the lazy body `[\s\S]*?` and the closer alternation's `[ \t]*` overlap, so the engine tries every split point → **O(n²)**. Measured **235 s on a 200 KB note**.

Replaced with a **single-pass, line-based scanner** that buffers each fence and emits it once → linear. An unclosed fence is emitted **verbatim**, exactly as the old regex left it (its backreference never matched, so it stripped nothing), so the parsed field set is preserved. A no-`` ``` `` fast path skips the line split/join for the common (fence-less) note.

**2. Inline-field extraction** — `INLINE_FIELD_REGEX`
``/(?:^|[\n\r])[ \t]*(?![-*+]…)([^:\n\r]+?)::…/`` — the standalone leading `[ \t]*` overlaps the lazy field-name `([^:\n\r]+?)` (both match spaces/tabs), so a long whitespace-led line with **no fence at all** is also **O(n²)** (~1.7 s on 80 KB, quadratic). Folded the indentation into the trimmed capture and into the task-checkbox lookahead, leaving a single line-consuming quantifier → linear.

## Why this shape (alternatives considered)

- **Unclosed fences: emit verbatim vs. drop-to-EOF.** Two opposing-model reviewers disagreed — one argued dropping *hides* real autocomplete values, the other that keeping *leaks* code-looking fields. Since either is defensible, I chose the **behaviour-preserving** option: match the old regex exactly (it stripped nothing on an unclosed fence). Zero change to which fields surface on real notes; only adversarial malformed fences differ, following CommonMark.
- **Two scanners, not one shared helper.** The sibling migration script (`docs/static/scripts/migrateDataviewToFrontmatter.js`) rewrites files and must also track tildes and blockquoted fences; this parser is read-only autocomplete. Different requirements → kept separate, documented in-code.

## Verification (red → green)

- **Unit timing guards:** the pathological inputs that froze for **26.6 s / 235 s** now finish in **~1 ms**. New ReDoS regression tests cover the fence bomb, the no-fence whitespace bomb, and many never-closing fence-open lines (1.5 s budget).
- **Differential fuzz (500k inputs):** the new inline-field regex never invents a field and never drops a real one — the only divergence is that malformed checkbox-prefixed lines (e.g. `- [ ] ::x`) no longer leak a garbage field name (aligns with the existing "don't parse task checkboxes" rule). A separate 500k-note fence fuzz showed **0 divergences on well-formed notes**.
- **Live Obsidian smoke test:** an isolated vault holding a normal note **plus a 200 KB fence bomb and a 200 KB whitespace bomb** returns the correct suggestion (`["active"]`) in **8 ms** via `quickAddApi.fieldSuggestions.getFieldValues(..., {includeInline:true})`. The old regex took **235 s** on the same fence bomb.
- **Gates:** `tsc`, `eslint`, `svelte-check` (0 errors), `vitest` (3370 passed) all green.

## Reviewer notes

- The fenced-code regex **predates #1439** — it was introduced in #1128 (opt-in inline values from fenced code blocks). #1439 only touched the comma-splitting in this file. The deepsec note attributing the regression to #1439 is inaccurate on provenance; the ReDoS itself is real and is fixed here.
- Impact is a main-thread freeze (DoS) over read-only autocomplete data — no data is written and no value reaches an eval/HTML/path sink.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline field parsing around fenced code blocks, including tricky edge cases like unclosed fences and varying backtick lengths.
  * Made parsing more reliable for large inputs by reducing the chance of slowdowns or hangs on content that previously stressed the parser.
  * Preserved expected behavior for unclosed code fences while continuing to ignore disallowed fenced blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->