### PR TITLE
fix(security): close package-import disclosure gap and asset-path collisions

### DIFF
--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -91,6 +91,9 @@ function createFakeApp(initialExisting: string[] = []): {
 	const app = {
 		vault: {
 			adapter,
+			// isVaultCaseInsensitive probes a case-swapped variant of configDir;
+			// seed ".OBSIDIAN" into existing paths to simulate a case-insensitive vault.
+			configDir: ".obsidian",
 			createFolder: vi.fn(async (path: string) => {
 				state.createdFolders.push(path);
 				state.existingPaths.add(path);
@@ -227,6 +230,81 @@ describe("parseQuickAddPackage", () => {
 		} as unknown as Partial<QuickAddPackage>);
 		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
 			/not a valid QuickAdd package/,
+		);
+	});
+
+	it("rejects a package with duplicate asset originalPaths", () => {
+		// Two assets at the same path is last-write-wins on disk while the review
+		// pane resolves the FIRST match (decodeAssetPreview): a crafted package could
+		// show benign content while malicious content lands on disk. Reject at the
+		// untrusted-input boundary so reviewed bytes always equal written bytes.
+		const bad = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "scripts/x.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => 'benign';"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "scripts/x.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => exfiltrate();"),
+				},
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/duplicate asset path/i,
+		);
+	});
+
+	it("rejects assets whose paths differ only by slash normalization", () => {
+		// "scripts//x.js" and "scripts/x.js" are distinct strings but normalize to one
+		// on-disk destination, so they still collide last-write-wins. Key the dedup on
+		// the normalized path the writer uses, not the raw string.
+		const bad = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "scripts/x.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => 'benign';"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "scripts//x.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => exfiltrate();"),
+				},
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/duplicate asset path/i,
+		);
+	});
+
+	it("rejects duplicate EMPTY asset paths (falsy path must still fail closed)", () => {
+		// isPackageAsset accepts originalPath: "" (string), so two empty paths must not
+		// slip the duplicate gate via a truthiness check on the returned path.
+		const bad = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "",
+					contentEncoding: "base64",
+					content: encodeToBase64("benign"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "",
+					contentEncoding: "base64",
+					content: encodeToBase64("evil"),
+				},
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/duplicate asset path/i,
 		);
 	});
 });
@@ -495,6 +573,170 @@ describe("asset write containment (security)", () => {
 			app,
 			"scripts/escapes.js",
 		);
+	});
+
+	it("refuses two assets that resolve to the same on-disk destination", async () => {
+		// The import modal defaults every template/capture asset to
+		// `<templateFolder>/<basename>`, so two DISTINCT originalPaths sharing a
+		// basename collide on ONE file. Parse-time originalPath dedup can't see this
+		// (the paths differ); writing them in order is silent last-write-wins, so the
+		// bytes the user reviewed are not the bytes that land. The writer must refuse.
+		const { app, state } = createFakeApp();
+		const pkg = makePackage({
+			assets: [
+				{
+					kind: "template",
+					originalPath: "A/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => 'benign';"),
+				},
+				{
+					kind: "template",
+					originalPath: "B/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => exfiltrate();"),
+				},
+			],
+		});
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				// Mirrors defaultAssetDestination: both basenames land in one folder.
+				assetDecisions: [
+					{
+						originalPath: "A/payload.js",
+						destinationPath: "Templates/payload.js",
+						mode: "write",
+					},
+					{
+						originalPath: "B/payload.js",
+						destinationPath: "Templates/payload.js",
+						mode: "write",
+					},
+				],
+			}),
+		).rejects.toThrow(/resolve to the same destination/);
+
+		// All-or-nothing: nothing is written, so no silent last-write-wins.
+		expect(state.writes.size).toBe(0);
+	});
+
+	it("refuses two assets that collide only by case (case-insensitive vaults)", async () => {
+		// macOS/Windows vaults are case-insensitive, so "Scripts/x.js" and
+		// "scripts/x.js" are ONE physical file even though their normalized strings
+		// differ. Seed the case-swapped configDir so the case-sensitivity probe
+		// reports insensitive; the collision key then folds and refuses the import.
+		const { app, state } = createFakeApp([".OBSIDIAN"]);
+		const pkg = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "Scripts/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => 'benign';"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "scripts/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("module.exports = () => exfiltrate();"),
+				},
+			],
+		});
+
+		await expect(
+			applyPackageImport({
+				app,
+				existingChoices: [],
+				pkg,
+				choiceDecisions: [],
+				assetDecisions: [],
+			}),
+		).rejects.toThrow(/resolve to the same destination/);
+		expect(state.writes.size).toBe(0);
+	});
+
+	it("allows two case-distinct destinations on a case-sensitive vault", async () => {
+		// On Linux/case-sensitive vaults "Scripts/x.js" and "scripts/x.js" are TWO
+		// distinct files a legitimate package may ship. With the probe reporting
+		// case-sensitive (no swapped configDir seeded), both must import, not throw.
+		const { app, state } = createFakeApp();
+		const pkg = makePackage({
+			assets: [
+				{
+					kind: "user-script",
+					originalPath: "Scripts/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("benign"),
+				},
+				{
+					kind: "user-script",
+					originalPath: "scripts/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("other"),
+				},
+			],
+		});
+
+		const result = await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions: [],
+		});
+
+		expect(result.writtenAssets).toContain("Scripts/payload.js");
+		expect(result.writtenAssets).toContain("scripts/payload.js");
+		expect(state.writes.size).toBe(2);
+	});
+
+	it("allows a destination collision when the colliding asset is skipped", async () => {
+		// A skipped asset never writes, so it cannot collide. Only the surviving
+		// (non-skipped) asset lands; no false rejection.
+		const { app, state } = createFakeApp();
+		const pkg = makePackage({
+			assets: [
+				{
+					kind: "template",
+					originalPath: "A/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("benign"),
+				},
+				{
+					kind: "template",
+					originalPath: "B/payload.js",
+					contentEncoding: "base64",
+					content: encodeToBase64("evil"),
+				},
+			],
+		});
+
+		await applyPackageImport({
+			app,
+			existingChoices: [],
+			pkg,
+			choiceDecisions: [],
+			assetDecisions: [
+				{
+					originalPath: "A/payload.js",
+					destinationPath: "Templates/payload.js",
+					mode: "write",
+				},
+				{
+					originalPath: "B/payload.js",
+					destinationPath: "Templates/payload.js",
+					mode: "skip",
+				},
+			],
+		});
+
+		expect(state.writes.get("Templates/payload.js")).toBe("benign");
+		expect(state.writes.size).toBe(1);
 	});
 
 	it("aborts on a vault-escaping destination even when that asset is marked skip", async () => {

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -129,7 +129,36 @@ export function parseQuickAddPackage(raw: string): QuickAddPackage {
 		);
 	}
 
+	// Reject duplicate asset paths at the untrusted-input boundary. The writer is
+	// last-write-wins per destination while the review pane resolves the FIRST
+	// match (decodeAssetPreview), so two assets at one path could show benign bytes
+	// in review while malicious bytes land on disk — a silent review-gate desync.
+	// Failing closed here keeps reviewed bytes identical to written bytes.
+	const duplicateAssetPath = findDuplicateAssetPath(parsed.assets);
+	if (duplicateAssetPath !== null) {
+		throw new Error(
+			`Package contains duplicate asset path "${duplicateAssetPath}". Each asset must have a unique path.`,
+		);
+	}
+
 	return parsed;
+}
+
+function findDuplicateAssetPath(
+	assets: QuickAddPackage["assets"],
+): string | null {
+	const seen = new Set<string>();
+	for (const asset of assets) {
+		// Key on the normalized destination the writer collides on (so "scripts//x.js"
+		// and "scripts/x.js" — distinct strings, one on-disk file — are caught too),
+		// not the raw string. normalizePath only collapses slashes/whitespace; it does
+		// not resolve "..", so escaping paths still compare honestly (and the write
+		// path rejects them regardless).
+		const key = normalizePath(asset.originalPath ?? "");
+		if (seen.has(key)) return asset.originalPath;
+		seen.add(key);
+	}
+	return null;
 }
 
 export async function analysePackage(
@@ -502,6 +531,40 @@ export async function applyPackageImport(
 		return { asset, destinationPath };
 	});
 
+	// Resolved-destination uniqueness, as a PRE-PASS before any write: two assets
+	// can carry DISTINCT originalPaths yet resolve to ONE on-disk destination — the
+	// import modal defaults every template/capture asset to
+	// `<templateFolder>/<basename>`, so "A/x.md" and "B/x.md" both land at
+	// "Templates/x.md". Parse-time dedup keys on originalPath and can't see that.
+	// Writing them in sequence is silent last-write-wins: the user reviewed two
+	// files but only one set of bytes survives, and a choice rewired to that path
+	// (applyAssetPathOverrides) then runs the surviving bytes — breaking the
+	// "what you reviewed is what lands" gate. Refuse the whole import instead.
+	// Skipped assets never write, so they cannot collide.
+	// Fold case ONLY on a case-insensitive vault (macOS/Windows), where
+	// "Scripts/x.js" and "scripts/x.js" are ONE physical file. On a case-sensitive
+	// vault they are distinct files a legitimate package may ship, so comparing
+	// folded would wrongly reject a valid import.
+	const foldCase = await isVaultCaseInsensitive(app);
+	const destinationOwners = new Map<
+		string,
+		{ originalPath: string; destinationPath: string }
+	>();
+	for (const { asset, destinationPath } of resolvedAssetDestinations) {
+		if (assetDecisionMap.get(asset.originalPath)?.mode === "skip") continue;
+		const key = foldCase ? destinationPath.toLowerCase() : destinationPath;
+		const prior = destinationOwners.get(key);
+		if (prior) {
+			throw new Error(
+				`Refusing to import: assets "${prior.originalPath}" and "${asset.originalPath}" resolve to the same destination ("${destinationPath}"). Rename one so each imported file is unique.`,
+			);
+		}
+		destinationOwners.set(key, {
+			originalPath: asset.originalPath,
+			destinationPath,
+		});
+	}
+
 	// Symlink/realpath containment, as a PRE-PASS before any write: if a
 	// destination resolves through a pre-existing in-vault symlink to outside the
 	// vault, abort the whole import before touching disk. Every destination is
@@ -580,6 +643,27 @@ function buildSecretOptionNamesByPath(
 async function assetExists(app: App, path: string): Promise<boolean> {
 	try {
 		return await app.vault.adapter.exists(path);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Probe whether the vault filesystem is case-insensitive (macOS/Windows). A
+ * case-swapped variant of the always-present config dir resolves to the same
+ * entry only when the filesystem ignores case. Used to decide whether two
+ * destination paths that differ only by case denote one physical file.
+ */
+async function isVaultCaseInsensitive(app: App): Promise<boolean> {
+	const configDir = app.vault.configDir;
+	if (!configDir) return false;
+	const swapped =
+		configDir === configDir.toLowerCase()
+			? configDir.toUpperCase()
+			: configDir.toLowerCase();
+	if (swapped === configDir) return false;
+	try {
+		return await app.vault.adapter.exists(swapped);
 	} catch {
 		return false;
 	}

--- a/src/services/packagePreview.test.ts
+++ b/src/services/packagePreview.test.ts
@@ -540,6 +540,38 @@ describe("buildPackagePreview - files manifest, overwrites, orphans, captures", 
 		expect(isFullyReviewed(preview, NONE)).toBe(false);
 	});
 
+	it("flags an orphan non-.js asset the loader still runs as raw JavaScript", () => {
+		// The user-script loader (src/utils/userScript.ts) runs the RAW bytes of any
+		// non-.md file a macro points at as JavaScript — not just .js. A bundled asset
+		// with a benign-looking extension (or none) that lies about its kind would
+		// otherwise slip the .js-only disclosure heuristic, land on disk, and run via
+		// any macro pointing at its path. The gate must treat it as executable code.
+		const m = macro("m1", "Empty", []);
+		const payload = "module.exports = () => exfiltrate();";
+		const pkg = makePackage(
+			[pkgChoice(m, ["Empty"])],
+			[
+				asset("template", "scripts/payload.txt", payload),
+				asset("capture-template", "scripts/payload.cjs", payload),
+				asset("template", "scripts/payload", payload),
+			],
+		);
+		const preview = buildPackagePreview(NO_EXISTING, pkg, NONE);
+
+		for (const path of [
+			"scripts/payload.txt",
+			"scripts/payload.cjs",
+			"scripts/payload",
+		]) {
+			const file = preview.files.find((f) => f.originalPath === path);
+			expect(file?.orphan).toBe(true);
+			expect(file?.requiresReview).toBe(true);
+			expect(preview.criticalScriptPaths).toContain(path);
+		}
+		expect(requiresAcknowledgement(preview)).toBe(true);
+		expect(isFullyReviewed(preview, NONE)).toBe(false);
+	});
+
 	it("does not flag a plain .md template with no js code block", () => {
 		const m = macro("m1", "Empty", []);
 		const note = asset(

--- a/src/services/packagePreview.ts
+++ b/src/services/packagePreview.ts
@@ -78,7 +78,7 @@ const FLAG_META: Record<PreviewFlag, FlagMeta> = {
 	"bundled-script": {
 		severity: "critical",
 		label: "SCRIPT FILE",
-		description: "Bundles a JavaScript file that will be written to your vault and can be run as code.",
+		description: "Bundles a file that will be written to your vault and can be run as code.",
 	},
 	"run-on-startup": {
 		severity: "critical",
@@ -169,16 +169,19 @@ function isScriptKind(kind: QuickAddPackageAssetKind): boolean {
 	return kind === "user-script" || kind === "conditional-script";
 }
 
-// A bundled asset that can be executed as code: a declared script kind, OR
-// any file with a `.js` destination path — because `kind` is an untrusted
-// hint and a macro (in this package or already in the vault) will load any
-// `.js` at its path as a user script. Path-only check keeps this App-free.
-const EXECUTABLE_ASSET_PATH_REGEX = /\.js$/i;
+// A bundled asset that can be executed as code: a declared script kind, OR any
+// non-`.md` file — because `kind` is an untrusted hint and a macro (in this
+// package or already in the vault) loads it via the user-script loader, which
+// runs the RAW bytes of ANY non-`.md` file as JavaScript (src/utils/userScript.ts:
+// only `.md` is special-cased, to extract its first ```js fence). A `.js`-only
+// check under-discloses: a payload at `scripts/x.txt`, `x.cjs`, or no extension
+// runs identically. `.md` notes are handled by markdownAssetIsExecutable so plain
+// templates stay un-flagged. Path-only check keeps this App-free.
 function isExecutableBundledAsset(
 	kind: QuickAddPackageAssetKind,
 	originalPath: string,
 ): boolean {
-	return isScriptKind(kind) || EXECUTABLE_ASSET_PATH_REGEX.test(originalPath);
+	return isScriptKind(kind) || !MARKDOWN_FILE_EXTENSION_REGEX.test(originalPath);
 }
 
 // Since #1065 a `.md` note is loadable as a user script (its first ```js fence
@@ -816,18 +819,19 @@ export function buildPackagePreview(
 		});
 	}
 
-	// A bundled script file is written to disk and can be executed by any macro
-	// that points at its path (in this package OR already in the user's vault),
-	// so it must be reviewed even when no choice in THIS package references it.
-	// isExecutableBundledAsset covers both declared script kinds AND `.js`-path
-	// assets that lie about their `kind`.
+	// A bundled file written to disk can be executed by any macro that points at
+	// its path (in this package OR already in the user's vault), so it must be
+	// reviewed even when no choice in THIS package references it.
+	// isExecutableBundledAsset covers declared script kinds AND every non-`.md`
+	// path (the loader runs the raw bytes of any non-`.md` file), regardless of
+	// what `kind` the package claims.
 	for (const file of files) {
 		if (!file.requiresReview) continue;
 		if (file.executable) continue; // already a critical user-script/mislabeled row + in criticalScriptPaths
 		capabilityRows.push({
 			flag: "bundled-script",
 			severity: "critical",
-			title: "Bundles a script file that will be written to your vault",
+			title: "Bundles a file that will be written to your vault and can be run as code",
 			detail: file.originalPath,
 			scriptPath: file.originalPath,
 		});

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -738,10 +738,13 @@ export function getFrontMatterInfo(content: string): FrontMatterInfo {
   };
 }
 
-// Minimal normalizePath for tests: convert Windows separators to POSIX
+// Minimal normalizePath for tests: convert Windows separators to POSIX and
+// collapse repeated slashes, matching the parts of Obsidian's normalizePath that
+// callers rely on ("a//b" and "a/b" denote one path). (Real Obsidian also trims
+// edge slashes and NFC-normalizes; those are not modelled here.)
 export function normalizePath(p: string): string {
   if (typeof p !== 'string') return '' as unknown as string;
-  return p.replace(/\\/g, '/');
+  return p.replace(/\\/g, '/').replace(/\/+/g, '/');
 }
 
 // Minimal debounce for tests: execute immediately.


### PR DESCRIPTION
Closes two transparency/validation gaps for **untrusted imported `.qapackage` data** (a clean-room deepsec re-investigation surfaced both). QuickAdd itself runs with full user trust; the real attack surface is a shared/synced package file the user imports.

## Finding 1 - disclosure gate only matched `.js` (MEDIUM, `other-disclosure-gate-gap`)

`packagePreview.ts` flagged a bundled asset as executable code only when its path ended in `.js`. But the user-script loader (`src/utils/userScript.ts`) runs the **raw bytes of ANY non-`.md` file** as JavaScript via `new Function` - only `.md` is special-cased (extract the first ```js fence). So an orphan bundled asset at `scripts/payload.txt`, `payload.cjs`, or no extension (kind lied as `"template"`) slipped the gate yet runs identically if any macro - in the package or already in the vault - points at its path.

**Fix:** `isExecutableBundledAsset` now treats any non-`.md` path as executable, using the **same** `MARKDOWN_FILE_EXTENSION_REGEX` the loader imports (so loader and disclosure can't drift). `.md` notes stay handled by `markdownAssetIsExecutable` (flagged only when they carry a runnable js fence), so plain templates are still not flagged. A legitimate export only ever bundles `.js` scripts and `.md` templates/notes (verified in `packageExportService.ts`), so this adds **zero** new flags to real packages - only crafted non-`.md`/`.js` payloads get disclosed.

## Finding 2 - colliding asset paths/destinations (BUG, `other-package-validation`)

Several aliases let attacker bytes land on disk that differ from what the user reviewed (the writer is last-write-wins; `decodeAssetPreview` resolves the FIRST match):

1. **Duplicate `originalPath`** - now rejected in `parseQuickAddPackage` (the single untrusted-input boundary both the CLI and modal funnel through), keyed on `normalizePath` so `scripts//x.js` vs `scripts/x.js` are caught. Empty-path edge fails closed (`!== null`).
2. **Colliding resolved destinations** - distinct `originalPath`s can resolve to ONE on-disk file: the import modal defaults every template/capture asset to `<templateFolder>/<basename>`, so `A/x.md` and `B/x.md` both land at `Templates/x.md` with **no user action**. `applyPackageImport` now runs a resolved-destination uniqueness pre-pass before any write (mirroring the realpath pre-pass) and refuses the whole import on a collision. The key is **case-folded** because macOS/Windows vaults are case-insensitive (`Scripts/x.js` and `scripts/x.js` are one physical file there). Skipped assets never write, so they don't collide.

The abort is atomic: the pre-pass throws before any `adapter.write`, and the modal commits choices only after `applyPackageImport` resolves, so a refused import is a clean no-op.

## Proof (red → green)

- **Unit:** new failing-then-passing tests in `packagePreview.test.ts` (orphan `.txt`/`.cjs`/no-ext payload now gated) and `packageImportService.test.ts` (duplicate path, slash-normalized dup, empty-path dup, basename destination collision, case-only collision, skip-allowed). The destination-collision test was confirmed RED with the pre-pass disabled.
- **Live, in an isolated Obsidian 1.13.0 vault** via the real `quickadd:package-preview` CLI on a freshly-restarted instance (caught and avoided a stale-plugin-cache false GREEN): a crafted orphan `.txt`/`.cjs`/no-ext package was `requiresReview=false` / `hasCritical=false` before and critical+gated after; duplicate-path and `//`-collision packages are rejected by real Obsidian's parse.
- **Gates:** `tsc` clean, `eslint .` clean, `svelte-check` 0 errors, `vitest` 3370 passing.

## Adversarial review (opposing-model, refuting findings + fixes)

Confirmed the legit-package no-noise claim, that `markdownAssetIsExecutable` and the `normalizePath` key are load-bearing (not gold-plating), and skip/abort atomicity. The review also caught the destination-collision and case-only-collision vectors, both fixed here.

Documented low-severity residuals (not fixed here; surfaced rather than scope-crept):
- **In-vault symlink-alias collision** (`realdir/x.js` + `linkdir/x.js` → one physical file). Requires a pre-existing in-vault symlink - same precondition/severity class the team accepted as low for the related symlink finding in #1434. Fully closing it needs realpath-comparing destinations in `vaultWriteGuards` (desktop-only, untestable in jsdom).
- **Destination extension edit** - a plain `.md` note containing raw JS (no fence) is unflagged; if a user is socially-engineered to rename its destination to a script-y path AND a macro already points there, it runs. Contrived (social engineering + pre-existing macro); the gate is a pure function of the package's declared path.
- `userScriptSecrets.ts` keeps a private duplicate of the `.md` regex (pre-existing; not a drift risk for loader↔disclosure, which share the constant) - worth consolidating in a follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Package previews now flag more bundled payloads for review, including non-Markdown files and extensionless “script-like” assets.
  - The bundled-file warning text is more generic and reflects the broader review behavior.

- **Bug Fixes**
  - Import validation now rejects duplicate asset paths earlier, including slash-normalized duplicates and empty paths.
  - Package imports now prevent silent destination overwrites, including collisions caused by case-only differences on case-insensitive vaults; case-distinct destinations are allowed, and explicitly skipped assets don’t trigger conflicts.

- **Tests**
  - Expanded coverage for duplicate-path detection, write-collision handling, and path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->