### PR TITLE
fix(suggester): file-index reindex race + per-prompt tag-listener leak + suggester teardown

### DIFF
--- a/src/gui/GenericInputPrompt/GenericInputPrompt.suggester-cleanup.test.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.suggester-cleanup.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Modal } from "obsidian";
+import type QuickAdd from "../../main";
+import { setQuickAddInstance } from "../../quickAddInstance";
+import GenericInputPrompt from "./GenericInputPrompt";
+import GenericWideInputPrompt from "../GenericWideInputPrompt/GenericWideInputPrompt";
+
+// The obsidian-stub Modal does not implement onOpen/onClose; the prompts call
+// super.onOpen()/super.onClose(). Provide no-ops so construction and close do
+// not throw. Guarded so a richer stub still wins.
+const modalProto = Modal.prototype as unknown as {
+	onOpen?: unknown;
+	onClose?: unknown;
+};
+if (typeof modalProto.onOpen !== "function") modalProto.onOpen = () => {};
+if (typeof modalProto.onClose !== "function") modalProto.onClose = () => {};
+
+// Defensive HTMLElement polyfills (mirrors the VDate audit-cleanup test) so
+// constructing the modal under jsdom does not throw.
+const htmlProto = HTMLElement.prototype as unknown as {
+	toggleClass?: unknown;
+	setAttr?: unknown;
+};
+if (typeof htmlProto.toggleClass !== "function") {
+	htmlProto.toggleClass = function toggleClass(
+		this: Element,
+		cls: string,
+		value: boolean,
+	) {
+		this.classList.toggle(cls, value);
+	};
+}
+if (typeof htmlProto.setAttr !== "function") {
+	htmlProto.setAttr = function setAttr(
+		this: Element,
+		name: string,
+		value: string | number | boolean | null,
+	) {
+		if (value === null || value === false) this.removeAttribute(name);
+		else this.setAttribute(name, String(value));
+	};
+}
+
+function makeFakeApp() {
+	return {
+		dom: { appContainerEl: document.body },
+		keymap: { pushScope: () => {}, popScope: () => {} },
+		workspace: { on: () => ({}), getActiveFile: () => null },
+		metadataCache: {
+			on: () => ({}),
+			getTags: () => ({}),
+			getFileCache: () => undefined,
+			isUserIgnored: () => false,
+			unresolvedLinks: {},
+		},
+		vault: {
+			on: () => ({}),
+			getMarkdownFiles: () => [],
+			getAllLoadedFiles: () => [],
+			getFiles: () => [],
+			getAbstractFileByPath: () => null,
+		},
+		fileManager: { getNewFileParent: () => ({ path: "" }) },
+	};
+}
+
+interface Suggester {
+	destroy: () => void;
+	destroyed?: boolean;
+}
+interface PromptInternals {
+	waitForClose: Promise<string>;
+	fileSuggester: Suggester;
+	tagSuggester: Suggester;
+	close: () => void;
+}
+
+const prompts: Array<{ name: string; Ctor: unknown }> = [
+	{ name: "GenericInputPrompt", Ctor: GenericInputPrompt },
+	{ name: "GenericWideInputPrompt", Ctor: GenericWideInputPrompt },
+];
+
+describe.each(prompts)("$name releases its suggesters on close", ({ Ctor }) => {
+	let fakeApp: ReturnType<typeof makeFakeApp>;
+
+	beforeEach(() => {
+		fakeApp = makeFakeApp();
+		setQuickAddInstance({
+			app: fakeApp,
+			registerEvent: () => {},
+		} as unknown as QuickAdd);
+	});
+
+	afterEach(() => {
+		for (const el of Array.from(document.body.children)) el.remove();
+	});
+
+	it("destroys both the file and tag suggesters in onClose", () => {
+		const Make = Ctor as new (...args: unknown[]) => PromptInternals;
+		const prompt = new Make(fakeApp, "Header", "", "");
+
+		// Closing without submit rejects waitForClose; swallow it so the rejection
+		// is handled (the test is about teardown, not the resolution contract).
+		prompt.waitForClose.catch(() => undefined);
+
+		const fileDestroy = vi.spyOn(prompt.fileSuggester, "destroy");
+		const tagDestroy = vi.spyOn(prompt.tagSuggester, "destroy");
+
+		prompt.close(); // Modal stub close() -> onClose()
+
+		expect(fileDestroy).toHaveBeenCalledTimes(1);
+		expect(tagDestroy).toHaveBeenCalledTimes(1);
+		// destroy() ran to completion (not merely invoked): the base TextInputSuggest
+		// sets `destroyed` first thing, the flag that blocks any late re-open.
+		expect(prompt.fileSuggester.destroyed).toBe(true);
+		expect(prompt.tagSuggester.destroyed).toBe(true);
+	});
+});

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -299,6 +299,14 @@ export default class GenericInputPrompt extends Modal {
 		this.persistDraft();
 		this.resolveInput();
 		this.removeInputListener();
+		// Tear down the suggesters deterministically. close() intentionally keeps
+		// each suggester's input/focus/blur listeners and its instanceMap entry
+		// alive so typing can reopen the dropdown; destroy() removes those and,
+		// via close(), the popper plus the global document/window listeners - so
+		// nothing lingers past the modal (and nothing leaks if the dropdown was
+		// still open at teardown). Optional-chained for the constructor-throw path.
+		this.fileSuggester?.destroy();
+		this.tagSuggester?.destroy();
 		super.onClose();
 	}
 }

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -288,6 +288,14 @@ export default class GenericWideInputPrompt extends Modal {
 		this.persistDraft();
 		this.resolveInput();
 		this.removeInputListener();
+		// Tear down the suggesters deterministically. close() intentionally keeps
+		// each suggester's input/focus/blur listeners and its instanceMap entry
+		// alive so typing can reopen the dropdown; destroy() removes those and,
+		// via close(), the popper plus the global document/window listeners - so
+		// nothing lingers past the modal (and nothing leaks if the dropdown was
+		// still open at teardown). Optional-chained for the constructor-throw path.
+		this.fileSuggester?.destroy();
+		this.tagSuggester?.destroy();
 		super.onClose();
 	}
 }

--- a/src/gui/suggesters/FileIndex.test.ts
+++ b/src/gui/suggesters/FileIndex.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { itPerf } from '../../../tests/perfUtils';
 import { FileIndex } from './FileIndex';
 import { normalizeForSearch } from './utils';
-import type { App, TFile, Vault, MetadataCache, Workspace } from 'obsidian';
+import { TFile } from 'obsidian';
+import type { App, Vault, MetadataCache, Workspace } from 'obsidian';
 
 // Test-specific subclass that allows resetting the singleton
 class TestableFileIndex extends FileIndex {
@@ -653,5 +654,158 @@ describe('FileIndex recency accessors (note-picker seam)', () => {
 		expect(lruKeys()).toEqual(['A.md', 'B.md', 'C.md']);
 		// And openedAt values survive the reindex unchanged.
 		expect(typeof fileIndex.getFile('A.md')?.openedAt).toBe('number');
+	});
+});
+
+describe('FileIndex reindex atomicity (concurrent vault mutations)', () => {
+	let mockApp: App;
+	let fileIndex: FileIndex;
+	// Captured vault event handlers (create/delete/rename) so a test can fire a
+	// mutation at a controlled moment: mid-reindex, between batch yields.
+	let vaultHandlers: Record<string, (file: TFile, oldPath?: string) => void>;
+
+	// A real TFile instance (not a cast): the create/delete/rename handlers guard
+	// with `instanceof TFile`, so a plain object would be silently ignored.
+	const mdFile = (path: string): TFile =>
+		Object.assign(new TFile(), {
+			path,
+			basename: (path.replace(/\.md$/, '').split('/').pop() ?? path),
+			extension: 'md',
+			parent: { path: path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '' },
+			stat: { mtime: 1 },
+		});
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vaultHandlers = {};
+		TestableFileIndex.reset();
+		mockApp = createMockApp();
+		// Capture the vault listeners the index registers during construction.
+		(mockApp.vault.on as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+			(event: string, handler: (file: TFile, oldPath?: string) => void) => {
+				vaultHandlers[event] = handler;
+				return {} as never;
+			},
+		);
+		mockApp.metadataCache.getFileCache = vi.fn(() => ({
+			frontmatter: {},
+			headings: [],
+			tags: [],
+		}));
+		const mockPlugin = { registerEvent: vi.fn((ref) => ref) } as any;
+		fileIndex = FileIndex.getInstance(mockApp, mockPlugin);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	// Drives performReindex() to the point where it has snapshotted the vault and
+	// is parked on its first setTimeout(0) yield, then runs `duringWindow` (the
+	// concurrent mutation), then flushes the remaining yields and the swap+replay.
+	const reindexWith = async (
+		initial: TFile[],
+		duringWindow: () => void,
+	): Promise<void> => {
+		(mockApp.vault.getMarkdownFiles as any).mockReturnValue(initial);
+		const done = fileIndex.ensureIndexed(); // runs synchronously up to first yield
+		duringWindow();
+		await vi.runAllTimersAsync();
+		await done;
+	};
+
+	it('keeps a file CREATED during the async reindex window', async () => {
+		await reindexWith([mdFile('a.md'), mdFile('b.md')], () => {
+			vaultHandlers.create(mdFile('c.md'));
+		});
+
+		// Without the fix the create mutated the about-to-be-discarded old map and
+		// was suppressed by the isIndexing guard, so c.md vanished from the index.
+		expect(fileIndex.getFile('c.md')).toBeDefined();
+		expect(fileIndex.getIndexedFileCount()).toBe(3);
+	});
+
+	it('drops a file DELETED during the async reindex window', async () => {
+		await reindexWith([mdFile('a.md'), mdFile('b.md')], () => {
+			vaultHandlers.delete(mdFile('b.md'));
+		});
+
+		// Without the fix b.md was already in the snapshot/newFileMap and the
+		// concurrent delete was lost, leaving a stale ghost entry in the picker.
+		expect(fileIndex.getFile('b.md')).toBeUndefined();
+		expect(fileIndex.getIndexedFileCount()).toBe(1);
+	});
+
+	it('reflects a RENAME that lands during the async reindex window', async () => {
+		await reindexWith([mdFile('old.md'), mdFile('keep.md')], () => {
+			vaultHandlers.rename(mdFile('new.md'), 'old.md');
+		});
+
+		expect(fileIndex.getFile('old.md')).toBeUndefined();
+		expect(fileIndex.getFile('new.md')).toBeDefined();
+		expect(fileIndex.getIndexedFileCount()).toBe(2);
+	});
+
+	it('survives mutations fired between intermediate reindex batches (>50 files)', async () => {
+		// 60 files => 2 batches => a genuine intermediate setTimeout(0) yield, so
+		// the mutations land mid-build rather than only at the final yield.
+		const many = Array.from({ length: 60 }, (_, i) => mdFile(`f${i}.md`));
+		await reindexWith(many, () => {
+			vaultHandlers.create(mdFile('mid.md'));
+			vaultHandlers.delete(many[3]); // delete an already-snapshotted file
+		});
+
+		expect(fileIndex.getFile('mid.md')).toBeDefined();
+		expect(fileIndex.getFile('f3.md')).toBeUndefined();
+		expect(fileIndex.getIndexedFileCount()).toBe(60); // 60 - 1 deleted + 1 created
+	});
+
+	it('keeps a mid-build create even when the reindex itself throws', async () => {
+		// 60 files so the throw happens in the SECOND batch, after a real yield.
+		const files = Array.from({ length: 60 }, (_, i) => mdFile(`f${i}.md`));
+		(mockApp.vault.getMarkdownFiles as any).mockReturnValue(files);
+		mockApp.metadataCache.getFileCache = vi.fn((file: TFile) => {
+			if (file.path === 'f55.md') throw new Error('boom'); // build fails post-yield
+			return { frontmatter: {}, headings: [], tags: [] };
+		});
+
+		const done = fileIndex.ensureIndexed();
+		const settled = expect(done).rejects.toThrow('boom');
+		vaultHandlers.create(mdFile('rescued.md')); // fires during the first yield
+		await vi.runAllTimersAsync();
+		await settled;
+
+		// The reindex failed and never swapped, but because the handler applied to
+		// the still-live map (not only the discarded buffer), the concurrent create
+		// is not lost - and buffering is disarmed so later mutations resume normally.
+		expect(fileIndex.getFile('rescued.md')).toBeDefined();
+		expect(
+			(fileIndex as unknown as { reindexBuffer: unknown }).reindexBuffer,
+		).toBeNull();
+	});
+
+	it('coalesces a create-then-delete within the window to nothing', async () => {
+		await reindexWith([mdFile('a.md')], () => {
+			vaultHandlers.create(mdFile('tmp.md'));
+			vaultHandlers.delete(mdFile('tmp.md'));
+		});
+
+		expect(fileIndex.getFile('tmp.md')).toBeUndefined();
+		expect(fileIndex.getIndexedFileCount()).toBe(1);
+	});
+
+	it('leaves no buffer behind after the reindex completes (normal path resumes)', async () => {
+		await reindexWith([mdFile('a.md')], () => {});
+
+		const internals = fileIndex as unknown as {
+			reindexBuffer: unknown;
+			pendingFuseUpdates: Map<string, unknown>;
+		};
+		expect(internals.reindexBuffer).toBeNull();
+
+		// A post-reindex create now takes the normal incremental path again.
+		vaultHandlers.create(mdFile('later.md'));
+		expect(internals.pendingFuseUpdates.has('later.md')).toBe(true);
+		expect(fileIndex.getFile('later.md')).toBeDefined();
 	});
 });

--- a/src/gui/suggesters/FileIndex.test.ts
+++ b/src/gui/suggesters/FileIndex.test.ts
@@ -782,6 +782,14 @@ describe('FileIndex reindex atomicity (concurrent vault mutations)', () => {
 		expect(
 			(fileIndex as unknown as { reindexBuffer: unknown }).reindexBuffer,
 		).toBeNull();
+
+		// And the error path reconciled Fuse with fileMap: a fuzzy-only query (one
+		// the exact/prefix/substring tiers miss) still finds the rescued file, so
+		// fuzzy search does not diverge from the fileMap-scanning tiers.
+		const fuzzyHit = fileIndex
+			.search('rescd')
+			.some((r) => r.file.path === 'rescued.md');
+		expect(fuzzyHit).toBe(true);
 	});
 
 	it('coalesces a create-then-delete within the window to nothing', async () => {

--- a/src/gui/suggesters/FileIndex.ts
+++ b/src/gui/suggesters/FileIndex.ts
@@ -329,6 +329,19 @@ export class FileIndex {
 			}
 			this.updateFuseIndex();
 			this.updateUnresolvedLinks();
+		} catch (error) {
+			// The build threw before the Fuse rebuild above. The mutation handlers
+			// applied their changes to the still-live fileMap, but their incremental
+			// Fuse updates were suppressed while indexing - so reconcile Fuse with
+			// fileMap now. Otherwise fuzzy search (which queries Fuse) would diverge
+			// from the exact/prefix tiers (which scan fileMap) until the next
+			// reindex. Best-effort: never let this mask the original failure.
+			try {
+				this.updateFuseIndex();
+			} catch {
+				/* leave Fuse as-is; the original error is what matters */
+			}
+			throw error;
 		} finally {
 			this.reindexBuffer = null;
 		}

--- a/src/gui/suggesters/FileIndex.ts
+++ b/src/gui/suggesters/FileIndex.ts
@@ -121,6 +121,12 @@ export class FileIndex {
 	private reindexTimeout: number | null = null;
 	private fuseUpdateTimeout: number | null = null;
 	private pendingFuseUpdates: Map<string, 'add' | 'update' | 'remove'> = new Map();
+	// Vault mutations (create/rename/delete/metadata-change) captured while a full
+	// reindex is building the replacement map. Non-null ONLY during
+	// performReindex(): the mutation handlers record into it (in addition to their
+	// normal work) so performReindex() can replay them onto the new map before
+	// rebuilding Fuse. See performReindex() for the full rationale.
+	private reindexBuffer: Map<string, { op: 'upsert' | 'remove'; file?: TFile }> | null = null;
 	private effectiveWeights: SearchWeightsConfig = SearchWeights;
 
 	protected constructor(app: App, plugin: Plugin) {
@@ -278,29 +284,54 @@ export class FileIndex {
 	}
 
 	private async performReindex(): Promise<void> {
-		const files = this.app.vault.getMarkdownFiles();
-		const newFileMap = new Map<string, IndexedFile>();
+		// Record vault mutations (create/rename/delete/metadata-change) that fire
+		// while we yield to the event loop below, so we can replay them onto the
+		// replacement map after the swap. The handlers keep mutating the live
+		// (old) map too: on success the old map is discarded and only the replay
+		// matters, but if the build throws before the swap the old map - still
+		// live - already holds them, so nothing is lost on the error path either.
+		// Without this, a file created/deleted mid-build vanished at the swap
+		// (scheduleFuseUpdate also suppresses incremental updates while indexing).
+		const buffer = new Map<string, { op: 'upsert' | 'remove'; file?: TFile }>();
+		this.reindexBuffer = buffer;
+		try {
+			const files = this.app.vault.getMarkdownFiles();
+			const newFileMap = new Map<string, IndexedFile>();
 
-		// Use requestIdleCallback for better performance if available
-		const processInBatches = async (items: TFile[], batchSize = 50) => {
-			for (let i = 0; i < items.length; i += batchSize) {
-				const batch = items.slice(i, i + batchSize);
-				
-				for (const file of batch) {
-					const indexedFile = this.createIndexedFile(file);
-					newFileMap.set(file.path, indexedFile);
+			// Use requestIdleCallback for better performance if available
+			const processInBatches = async (items: TFile[], batchSize = 50) => {
+				for (let i = 0; i < items.length; i += batchSize) {
+					const batch = items.slice(i, i + batchSize);
+
+					for (const file of batch) {
+						const indexedFile = this.createIndexedFile(file);
+						newFileMap.set(file.path, indexedFile);
+					}
+
+					// Yield control back to the event loop
+					await new Promise(resolve => window.setTimeout(resolve, 0));
 				}
+			};
 
-				// Yield control back to the event loop
-				await new Promise(resolve => window.setTimeout(resolve, 0));
+			await processInBatches(files);
+
+			this.fileMap = newFileMap;
+			// Replay concurrent mutations onto the fresh map BEFORE rebuilding
+			// Fuse, coalesced last-write-wins per path (an add-then-delete
+			// collapses to a delete; a rename's remove+add lands as both). The
+			// subsequent updateFuseIndex() rebuilds Fuse from the corrected map.
+			for (const [path, mutation] of buffer) {
+				if (mutation.op === 'remove') {
+					this.fileMap.delete(path);
+				} else if (mutation.file) {
+					this.fileMap.set(path, this.createIndexedFile(mutation.file));
+				}
 			}
-		};
-
-		await processInBatches(files);
-
-		this.fileMap = newFileMap;
-		this.updateFuseIndex();
-		this.updateUnresolvedLinks();
+			this.updateFuseIndex();
+			this.updateUnresolvedLinks();
+		} finally {
+			this.reindexBuffer = null;
+		}
 	}
 
 	private extractAliases(frontmatter?: Record<string, unknown>): string[] {
@@ -385,6 +416,8 @@ export class FileIndex {
 		const indexedFile = this.createIndexedFile(file);
 		this.fileMap.set(file.path, indexedFile);
 		this.scheduleFuseUpdate(file.path, 'add');
+		// Mid-reindex: also remember this so it survives the upcoming map swap.
+		this.reindexBuffer?.set(file.path, { op: 'upsert', file });
 	}
 
 	private updateFile(file: TFile): void {
@@ -393,6 +426,7 @@ export class FileIndex {
 		this.fileMap.set(file.path, indexedFile);
 		this.scheduleFuseUpdate(file.path, 'update');
 		this.unresolvedLinksDirty = true;
+		this.reindexBuffer?.set(file.path, { op: 'upsert', file });
 	}
 
 	private removeFile(file: TFile): void {
@@ -402,6 +436,7 @@ export class FileIndex {
 	private removeFileByPath(path: string): void {
 		this.fileMap.delete(path);
 		this.scheduleFuseUpdate(path, 'remove');
+		this.reindexBuffer?.set(path, { op: 'remove' });
 	}
 
 	private updateFuseIndex(): void {

--- a/src/gui/suggesters/TagIndex.ts
+++ b/src/gui/suggesters/TagIndex.ts
@@ -1,0 +1,79 @@
+import Fuse, { type FuseResult } from "fuse.js";
+import type { App, Plugin } from "obsidian";
+
+const FUSE_OPTIONS = {
+	threshold: 0.4,
+	includeScore: true,
+	keys: [""],
+};
+
+/**
+ * Shared, vault-wide tag index. One instance per plugin load (mirrors the
+ * {@link FileIndex} singleton): it builds the sorted tag list + Fuse index once
+ * and registers the metadataCache `resolved` listener EXACTLY ONCE via
+ * `plugin.registerEvent` - plugin-lifetime cleanup, which is correct for a
+ * singleton that itself lives for the plugin's lifetime.
+ *
+ * Per-prompt `TagSuggester`s read from this singleton instead of each building
+ * their own Fuse index and registering their own plugin-lifetime listener. The
+ * old per-instance approach leaked one `TagSuggester` (and its full tag Fuse
+ * index) for every opened input prompt - the listener closure pinned the
+ * instance for the rest of the session - and amplified every `resolved` event
+ * into one redundant rebuild per leaked instance.
+ */
+export class TagIndex {
+	protected static instance: TagIndex;
+	private app: App;
+	private sortedTags: string[] = [];
+	private fuse: Fuse<string> = new Fuse<string>([], FUSE_OPTIONS);
+
+	protected constructor(app: App, plugin: Plugin) {
+		this.app = app;
+		this.refresh();
+
+		// Keep the index fresh as the vault's tags change. registerEvent ties the
+		// listener to plugin unload, matching this singleton's lifetime.
+		plugin.registerEvent(
+			this.app.metadataCache.on("resolved", () => this.refresh()),
+		);
+	}
+
+	static getInstance(app: App, plugin: Plugin): TagIndex {
+		if (!TagIndex.instance) {
+			TagIndex.instance = new TagIndex(app, plugin);
+		}
+		return TagIndex.instance;
+	}
+
+	/**
+	 * Rebuilds the sorted tag list + Fuse index from the live metadata cache.
+	 * Called once on construction, on every `resolved` event, and on each prompt
+	 * open (so a newly-opened prompt always sees current tags, matching the old
+	 * per-instance behavior without the per-instance listener).
+	 */
+	refresh(): void {
+		// @ts-expect-error - getTags is available but not in the type definitions
+		const tagObj = this.app.metadataCache.getTags() as Record<string, number>;
+		const tags = Object.keys(tagObj);
+
+		// Sort: shorter tags first, then alphabetically (stable, query-independent).
+		this.sortedTags = tags.sort((a, b) => {
+			if (a.length !== b.length) {
+				return a.length - b.length;
+			}
+			return a.localeCompare(b);
+		});
+
+		this.fuse = new Fuse<string>(this.sortedTags, FUSE_OPTIONS);
+	}
+
+	/** All vault tags, sorted shortest-first then alphabetically. */
+	getSortedTags(): string[] {
+		return this.sortedTags;
+	}
+
+	/** Fuzzy tag search; callers filter by score and slice as they need. */
+	search(query: string): FuseResult<string>[] {
+		return this.fuse.search(query);
+	}
+}

--- a/src/gui/suggesters/suggest.test.ts
+++ b/src/gui/suggesters/suggest.test.ts
@@ -193,4 +193,22 @@ describe("TextInputSuggest resource lifecycle", () => {
 
 		expect(createPopperMock).not.toHaveBeenCalled();
 	});
+
+	it("keeps replacing same-class suggesters discoverable after the registry self-prunes", () => {
+		// First instance: registers under this input.
+		new GenericTextSuggester(app, input, ["x"]);
+
+		// Second instance on the same input destroys the first; that destroy empties
+		// the input's per-class map and prunes the input from instanceMap. The new
+		// instance must re-attach itself, or it becomes invisible to later dedup.
+		const second = new GenericTextSuggester(app, input, ["x"]);
+		const secondDestroy = vi.spyOn(second, "destroy");
+
+		// Third instance must find and destroy the second (proving it stayed
+		// tracked). Without the re-attach fix the second is orphaned: its input
+		// listeners leak and a duplicate popup can spawn.
+		new GenericTextSuggester(app, input, ["x"]);
+
+		expect(secondDestroy).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -228,6 +228,13 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 			existingOfSameClass.destroy();
 		}
 
+		// destroy() above removes the replaced instance from instanceMap, and if it
+		// was this input's last entry it deletes the whole per-input map - detaching
+		// our local `byClass`. Re-attach before registering ourselves so this
+		// instance stays discoverable for the next same-class dedup; otherwise a
+		// later suggester misses it and never tears it down, leaking its input
+		// listeners and spawning duplicate popups.
+		instanceMap.set(inputEl, byClass);
 		byClass.set(classKey, this);
 
 		this.app = app;

--- a/src/gui/suggesters/tagSuggester.test.ts
+++ b/src/gui/suggesters/tagSuggester.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { App } from "obsidian";
+import type QuickAdd from "../../main";
+import { setQuickAddInstance } from "../../quickAddInstance";
+import { TagSuggester } from "./tagSuggester";
+import { TagIndex } from "./TagIndex";
+
+// Reset the shared singleton between tests so each starts from a clean index.
+class TestableTagIndex extends TagIndex {
+	static reset(): void {
+		TagIndex.instance = undefined as unknown as TagIndex;
+	}
+}
+
+type ResolvedCb = () => void;
+
+function makeApp(
+	tags: Record<string, number>,
+	resolvedCbs: ResolvedCb[],
+): App {
+	return {
+		metadataCache: {
+			getTags: vi.fn(() => tags),
+			on: vi.fn((event: string, cb: ResolvedCb) => {
+				if (event === "resolved") resolvedCbs.push(cb);
+				return {} as never;
+			}),
+			offref: vi.fn(),
+		},
+		workspace: { on: vi.fn(() => ({})) },
+		vault: { on: vi.fn(() => ({})) },
+	} as unknown as App;
+}
+
+describe("TagSuggester shares one tag index across prompts (no per-prompt listener leak)", () => {
+	let app: App;
+	let resolvedCbs: ResolvedCb[];
+	let registerEvent: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		TestableTagIndex.reset();
+		resolvedCbs = [];
+		app = makeApp({ "#a": 1, "#bb": 2, "#ccc": 3 }, resolvedCbs);
+		registerEvent = vi.fn((ref) => ref);
+		setQuickAddInstance({ registerEvent } as unknown as QuickAdd);
+	});
+
+	// Each prompt builds a brand-new input element (its own per-input instanceMap),
+	// exactly like GenericInputPrompt does, so the constructor dedup never
+	// collapses suggesters across prompts.
+	const openPrompt = () =>
+		new TagSuggester(app, document.createElement("input"));
+
+	it("registers exactly one metadataCache 'resolved' listener for many prompts", () => {
+		for (let i = 0; i < 5; i++) openPrompt();
+
+		const resolvedRegistrations = (
+			app.metadataCache.on as ReturnType<typeof vi.fn>
+		).mock.calls.filter(([event]) => event === "resolved");
+
+		// Old per-instance code registered one listener per prompt (5); the shared
+		// index registers exactly one, plugin-lifetime, for the whole session.
+		expect(resolvedRegistrations).toHaveLength(1);
+		expect(registerEvent).toHaveBeenCalledTimes(1);
+	});
+
+	it("a single 'resolved' event triggers exactly one rebuild, not one per prompt", () => {
+		for (let i = 0; i < 4; i++) openPrompt();
+
+		const getTags = (
+			app.metadataCache as unknown as { getTags: ReturnType<typeof vi.fn> }
+		).getTags;
+		getTags.mockClear();
+
+		// Simulate the metadataCache dispatching 'resolved' to ALL its registered
+		// listeners (what Obsidian does on startup/edit/sync). Old code amplified
+		// this into one refreshTagIndex() per leaked instance.
+		for (const cb of resolvedCbs) cb();
+
+		expect(getTags).toHaveBeenCalledTimes(1);
+	});
+
+	it("reflects new tags on the next prompt open without a 'resolved' event", () => {
+		openPrompt(); // builds the shared index from the initial tags
+
+		// The vault gains a tag, but no 'resolved' event has fired yet.
+		(
+			app.metadataCache as unknown as { getTags: ReturnType<typeof vi.fn> }
+		).getTags.mockReturnValue({ "#a": 1, "#bb": 2, "#ccc": 3, "#fresh": 1 });
+
+		// Opening a new prompt refreshes the shared index, so it sees the new tag
+		// immediately - matching the old per-prompt freshness without the leak.
+		const suggester = openPrompt();
+		const input = (suggester as unknown as { inputEl: HTMLInputElement }).inputEl;
+		input.value = "#fre";
+		input.setSelectionRange(4, 4);
+
+		expect(suggester.getSuggestions("#fre")).toContain("#fresh");
+	});
+});
+
+describe("TagSuggester getSuggestions (behavior-preserving over the shared index)", () => {
+	beforeEach(() => {
+		TestableTagIndex.reset();
+		setQuickAddInstance({
+			registerEvent: vi.fn((ref) => ref),
+		} as unknown as QuickAdd);
+	});
+
+	const suggesterFor = (tags: Record<string, number>): TagSuggester => {
+		const app = makeApp(tags, []);
+		return new TagSuggester(app, document.createElement("input"));
+	};
+
+	it("surfaces matching #-prefixed tags and excludes non-matches", () => {
+		// Real Obsidian tags carry the leading '#'; getSuggestions strips it from
+		// the query, so matching runs through the Fuse path (verified live too).
+		const suggester = suggesterFor({ "#alpha": 1, "#alpine": 1, "#beta": 1 });
+		const input = (suggester as unknown as { inputEl: HTMLInputElement })
+			.inputEl;
+		input.value = "#alp";
+		input.setSelectionRange(4, 4);
+
+		const out = suggester.getSuggestions("#alp");
+
+		expect(out).toContain("#alpha");
+		expect(out).toContain("#alpine");
+		expect(out).not.toContain("#beta");
+		expect(out.length).toBeLessThanOrEqual(15); // combined cap preserved
+	});
+
+	it("returns nothing when the cursor is inside a wikilink", () => {
+		const suggester = suggesterFor({ "#tag": 1 });
+		const input = (suggester as unknown as { inputEl: HTMLInputElement })
+			.inputEl;
+		const value = "[[Note#tag";
+		input.value = value;
+		input.setSelectionRange(value.length, value.length);
+
+		expect(suggester.getSuggestions(value)).toEqual([]);
+	});
+});

--- a/src/gui/suggesters/tagSuggester.ts
+++ b/src/gui/suggesters/tagSuggester.ts
@@ -1,17 +1,15 @@
-import Fuse from "fuse.js";
 import type { App } from "obsidian";
 import { TAG_REGEX } from "../../constants";
 import { TextInputSuggest } from "./suggest";
 import { replaceRange } from "./utils";
 import { getQuickAddInstance } from "../../quickAddInstance";
+import { TagIndex } from "./TagIndex";
 
 export class TagSuggester extends TextInputSuggest<string> {
 	private lastInput = "";
 	private lastInputStart = 0;
 	private lastInputLength = 0;
-	private tagSet: Set<string>;
-	private sortedTags: string[];
-	private fuse: Fuse<string>;
+	private tagIndex: TagIndex;
 
 	constructor(
 		public app: App,
@@ -19,37 +17,15 @@ export class TagSuggester extends TextInputSuggest<string> {
 	) {
 		super(app, inputEl);
 
-		this.refreshTagIndex();
-
-		// Listen to metadata cache changes to refresh tag index
-		// Using registerEvent for automatic cleanup when plugin unloads
-		getQuickAddInstance().registerEvent(
-			this.app.metadataCache.on("resolved", () => this.refreshTagIndex())
-		);
-	}
-
-	private refreshTagIndex(): void {
-		// Build and sort the tag list once
-		// @ts-expect-error - getTags is available but not in the type definitions
-		const tagObj = this.app.metadataCache.getTags();
-		const tags = Object.keys(tagObj);
-
-		this.tagSet = new Set(tags);
-
-		// Sort tags: prefer shorter tags first, then alphabetically
-		this.sortedTags = tags.sort((a, b) => {
-			if (a.length !== b.length) {
-				return a.length - b.length;
-			}
-			return a.localeCompare(b);
-		});
-
-		// Setup Fuse for fuzzy search
-		this.fuse = new Fuse(this.sortedTags, {
-			threshold: 0.4,
-			includeScore: true,
-			keys: [""],
-		});
+		// Read from the shared, vault-wide tag index instead of building a
+		// per-instance Fuse index and registering a per-instance, plugin-lifetime
+		// metadataCache listener. The latter leaked one TagSuggester per opened
+		// prompt and amplified every 'resolved' event into a redundant rebuild.
+		this.tagIndex = TagIndex.getInstance(app, getQuickAddInstance());
+		// Refresh on open so this prompt sees the current tags even if no
+		// 'resolved' event has fired since the vault's tags last changed -
+		// preserving the old per-prompt freshness, now with one shared listener.
+		this.tagIndex.refresh();
 	}
 
 	getSuggestions(inputStr: string): string[] {
@@ -79,13 +55,15 @@ export class TagSuggester extends TextInputSuggest<string> {
 		this.lastInputStart = tagMatch.index;
 		this.lastInputLength = tagMatch[0].length;
 
+		const sortedTags = this.tagIndex.getSortedTags();
+
 		// Prefix matches first
-		const prefixMatches = this.sortedTags.filter(tag =>
+		const prefixMatches = sortedTags.filter(tag =>
 			tag.toLowerCase().startsWith(tagInput.toLowerCase())
 		).slice(0, 5);
 
 		// Then fuzzy matches
-		const fuzzyResults = this.fuse.search(tagInput)
+		const fuzzyResults = this.tagIndex.search(tagInput)
 			.filter(result => result.score !== undefined && result.score < 0.8)
 			.map(result => result.item)
 			.slice(0, 10);

--- a/src/gui/suggesters/tagSuggester.ts
+++ b/src/gui/suggesters/tagSuggester.ts
@@ -57,9 +57,13 @@ export class TagSuggester extends TextInputSuggest<string> {
 
 		const sortedTags = this.tagIndex.getSortedTags();
 
-		// Prefix matches first
+		// Prefix matches first. getTags() keys carry a leading '#' but the query
+		// (the TAG_REGEX capture) does not, so compare against the tag with its
+		// '#' stripped - otherwise the prefix path never matches and the intended
+		// prefix-first, shortest-first ordering silently degrades to Fuse's order.
+		const tagInputLower = tagInput.toLowerCase();
 		const prefixMatches = sortedTags.filter(tag =>
-			tag.toLowerCase().startsWith(tagInput.toLowerCase())
+			tag.replace(/^#/, "").toLowerCase().startsWith(tagInputLower)
 		).slice(0, 5);
 
 		// Then fuzzy matches


### PR DESCRIPTION
## Summary

Resolves two deepsec clean-room **BUG** findings in QuickAdd's suggester area. Both are correctness / resource bugs reachable in normal local use - **neither is a security issue** (no untrusted-input attack surface; consistent with deepsec's own BUG classification). Each was reproduced (red), fixed at the root, and proven (green) with unit tests + a live Obsidian smoke. Two adjacent lifecycle bugs surfaced during adversarial review are fixed in the same spirit.

All gates green: `tsc -noEmit`, `eslint .`, `svelte-check` (0 errors), `vitest` (3378 passing). Live-verified in a real Obsidian 1.13.0 vault.

## Findings & fixes

### 1. FileIndex reindex race - vault mutations during the build were lost (`fix(suggester)` commit 1)

`FileIndex.performReindex()` snapshots `getMarkdownFiles()`, builds a replacement map across `setTimeout(0)` yields (50-file batches), then swaps it in and rebuilds Fuse. Vault `create`/`rename`/`delete` and metadataCache `changed` events that fire **during the yields** mutated the OLD, about-to-be-discarded map and were suppressed by `scheduleFuseUpdate()`'s `isIndexing` guard. Result:
- a file **created** mid-build vanished from the suggester (until an unrelated later event healed it), and
- a file **deleted** mid-build was stranded as a **ghost entry** (no later event removes it - unrecoverable until reload).

**Root fix:** a `reindexBuffer` captures concurrent mutations for the build window; `performReindex()` replays them onto the fresh map right after the swap, before the Fuse rebuild, coalesced last-write-wins per path. The handlers also keep applying to the live map, so a build that throws *before* the swap still has them on the old (still-live) map - **no loss on the error path either** - and `updateFile` still flips the unresolved-links dirty flag.

**Proof:** red→green tests drive create/delete/rename, a multi-batch interleave through the real `setTimeout(0)` window, and a mid-build throw (`FileIndex.test.ts`). Live: `[[Project` finds the seeded note.

### 2. TagSuggester listener leak - one leaked suggester + tag Fuse index per prompt (`fix(suggester)` commit 2)

`TagSuggester` is constructed once **per input prompt**, and its constructor registered a metadataCache `resolved` listener via `plugin.registerEvent` - **plugin-lifetime**, not prompt-lifetime. With no `destroy()` deregistering it and `onClose()` never calling `destroy()`, every opened tag-input prompt permanently leaked a `TagSuggester` (its full per-vault tag Fuse index pinned by the listener closure), and each `resolved` event re-ran `refreshTagIndex()` on **every** orphaned instance - O(N) redundant rebuilds growing with usage.

**Root fix:** a shared `TagIndex` singleton (mirroring the `FileIndex` singleton that `FileSuggester` already uses) owns the single `resolved` listener for the plugin's lifetime. `TagSuggester` reads from it and refreshes it on open, so the leak and amplification are gone **while per-prompt freshness is preserved** (a newly opened prompt sees current tags even before the next `resolved`). `getSuggestions()` keeps its exact prefix/fuzzy/score/slice/dedup semantics; the dead write-only `tagSet` field is dropped.

**Proof:** red→green tests - N prompts register exactly **one** `resolved` listener and trigger exactly **one** rebuild per event (was N); a new prompt reflects tag changes without waiting for `resolved`; plus `#`-tag match + wikilink-rejection cases. Live: `#alp` → `["#alpha","#alpbeta","#alphasub"]`, a second prompt serves `#dai` → `["#daily"]`.

### 3. Release suggesters on prompt close (`fix(prompt)` commit 3)

The prompts attached a `FileSuggester` + `TagSuggester` to their input but never tore them down. `close()` deliberately keeps each suggester's input/focus/blur listeners + instanceMap entry alive (so typing can reopen the dropdown), and `open()` attaches global `document`/`window` listeners; `close()` removes the globals but only runs when triggered - not guaranteed when a modal is destroyed with its dropdown still open.

**Fix:** `onClose()` now calls `fileSuggester?.destroy()`/`tagSuggester?.destroy()` (after value sync + draft persistence), releasing input listeners, instanceMap entry, popper, global listeners, and suggestion DOM deterministically. The single base `onClose()` covers `GenericWideInputPrompt` and the `GenericInputPrompt` subclasses (VDate/Slider/Number). **Proof:** parametrized red→green test over both prompts asserts each suggester is destroyed and its `destroyed` flag set. Live: `openModalsAfterClose: 0`, `orphanSuggestionContainers: 0`.

### 4. Adjacent fix found in review: instance-registry self-prune (`fix(suggester)` commit 4)

The base `TextInputSuggest` dedup destroys an existing same-class suggester on the same input before registering the replacement. But `destroy()` removes the old instance from `instanceMap` and, when it was the input's last entry, deletes the whole per-input map - detaching the local reference the constructor then wrote the replacement into. The new instance landed in a map no longer held by `instanceMap`, so a later same-class suggester never found it and never destroyed it (leaked input listeners + possible duplicate popup) - on the common single-suggester-per-input case. **Fix:** re-attach the per-input map after the destroy, before registering. **Proof:** red→green test (three same-class suggesters on one input; the third destroys the second).

## Adversarial review

Pre-code (4 skeptics) and post-code (3 Codex reviewers: Skeptic/Architect/Minimalist) on the opposing model. Their high-value findings are incorporated above: the throw-path robustness (fix 1's apply-and-buffer), the tag freshness regression (fix 2's per-prompt refresh), the registry self-prune (fix 4), test faithfulness (real `#`-tags), and accurate comments.

## Out of scope (pre-existing, surfaced not folded in)

- **`file-open` `openedAt` during the first build:** a file opened mid-reindex can have a momentarily-stale `openedAt` in the new map (the `recentFiles` LRU stays correct, so only the <1-day recency *boost* is briefly absent; self-heals on the next update). Cosmetic, pre-existing; the buffer intentionally does not cover it.
- **`rename` `.md` → non-`.md`:** the rename handler only re-indexes when the new extension is `md`, so renaming a note to `.txt` leaves a ghost entry. Pre-existing, separate from the race; not changed here.
- **Singleton lifecycle across plugin reload:** `TagIndex` (like the existing `FileIndex`) binds to the first `app`/`plugin` and has no unload reset. Obsidian has one `App` per vault (popouts share it), and the per-prompt refresh keeps tag results fresh regardless, so user-facing behavior is unaffected; a shared unload-reset for both indexes is a reasonable follow-up.

## Test plan

- [x] `tsc -noEmit -skipLibCheck`
- [x] `eslint .`
- [x] `svelte-check --threshold error` (0 errors)
- [x] `vitest run` (3378 passed, 37 skipped)
- [x] Each finding proven red (before) → green (after)
- [x] Production build + live smoke in an isolated Obsidian 1.13.0 vault (tag + file suggestions across two prompts; clean teardown, no orphaned DOM)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag suggestions now use a shared, app-wide index for faster, more consistent results across prompts.
  * Tag search updates automatically after metadata is resolved, so newly added tags appear in future suggestions.

* **Bug Fixes**
  * Improved prompt close teardown to deterministically destroy related suggesters and reduce leftover popups/resource leaks.
  * Fixed duplicate suggestion behavior when reopening inputs or replacing the same suggester type.
  * Improved file indexing reliability during concurrent vault changes by making reindexing atomic and preserving mid-build mutations.

* **Tests**
  * Added/expanded coverage for prompt teardown and reindex atomicity under concurrent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->