### PR TITLE
docs(examples): fix data-loss & raw-crash defects in EzImport and migrate-dataview

### DIFF
--- a/docs/docs/Examples/Macro_MigrateDataviewProperties.md
+++ b/docs/docs/Examples/Macro_MigrateDataviewProperties.md
@@ -285,22 +285,24 @@ function parseCommaSeparatedWithWikilinks(value) {
 }
 ```
 
-### Race Condition Prevention
+### How the write works (and a concurrency caveat)
 
-The script uses `processFrontMatter` to update the frontmatter, then re-reads the file before removing inline properties. This prevents race conditions where the frontmatter changes might be overwritten:
+The script updates the frontmatter with `processFrontMatter`, then strips the migrated inline properties from the body inside an `app.vault.process` callback. Using `process` for the body rewrite (rather than a separate `read` + `modify`) means the body's read-and-rewrite happens in one callback, so it does not clobber an unrelated concurrent edit elsewhere in the body:
 
 ```javascript
-// Update frontmatter first
+// Update the frontmatter first
 await app.fileManager.processFrontMatter(activeFile, (frontmatter) => {
     // Add properties to frontmatter
 });
 
-// Re-read the file to get updated frontmatter
-const updatedContent = await app.vault.read(activeFile);
-
-// Then remove inline properties
-await app.vault.modify(activeFile, cleanedContent);
+// Then strip the migrated inline properties from the body
+await app.vault.process(activeFile, (data) => {
+    const { cleanedContent } = parseInlineFieldsWithWikilinks(data, propertiesToMigrate, migrateAll);
+    return cleanedContent;
+});
 ```
+
+These are still two separate steps. The frontmatter is written from the file as it was first read, while the body is re-scanned at rewrite time. If another device or window adds a *new* inline field to the same note in the brief window between the two steps, that field can be removed from the body without being captured in frontmatter. This is why the Tips above matter: avoid running a bulk migration on a note that is being edited or synced at the same time, and keep a backup.
 
 ## Tips
 
@@ -316,7 +318,11 @@ await app.vault.modify(activeFile, cleanedContent);
 **Properties not migrating:**
 - Check that the property names are spelled correctly in the settings
 - Ensure the inline properties use `::` syntax (two colons)
-- Verify that the properties aren't inside code blocks or task checkboxes
+- Verify that the properties aren't inside fenced/inline code or task checkboxes (these are intentionally skipped - see "Code blocks" below)
+
+- Inline-field-shaped lines inside fenced code blocks (` ``` ` or `~~~`) and inline code spans (`` `...` ``) are detected and left untouched, so they are never migrated or removed. This holds for fences at the top level, inside blockquotes, and nested in a list item (for example a ` ``` ` fence whose opener sits on the same line as a `-` bullet).
+- 4-space *indented* code blocks are **not** detected. A line shaped like `name:: value` inside an indented code block can still be migrated and removed from the body. Distinguishing a genuine indented code block from ordinary indented list or paragraph text requires block context that a single-pass line scanner does not have, and a partial heuristic would either delete real indented code or silently skip a genuine inline field that is merely indented under a list (which Dataview *does* treat as a field). The script therefore favors migrating real fields over silently skipping them - so use a fenced code block (` ``` `) rather than 4-space indentation for any code you want to protect.
+- As a general safety net, prefer migrating a specific property list over "Migrate All Properties", and follow the Tips above - test on a copy and keep your vault under version control before a bulk migration.
 
 **Commas not handled correctly:**
 - Make sure wikilinks use proper `[[` and `]]` syntax

--- a/docs/static/scripts/EzImport.js
+++ b/docs/static/scripts/EzImport.js
@@ -28,7 +28,14 @@ function getReadwiseCache() {
 	if (!window.localStorage) return null;
 	const cacheStr = window.localStorage.getItem(READWISE_CACHE_KEY);
 	if (!cacheStr) return null;
-	return JSON.parse(cacheStr);
+	try {
+		return JSON.parse(cacheStr);
+	} catch (e) {
+		// A corrupt cache (e.g. a partial write or a bad sync) must not crash the
+		// import with a raw SyntaxError - ignore it and rebuild from scratch.
+		new Notice("EzImport: Readwise cache was corrupt and has been ignored.", 10000);
+		return null;
+	}
 }
 
 function getCacheItem(itemKey) {
@@ -119,7 +126,15 @@ async function start(params, settings, type) {
 
 async function getReadwiseHighlights(type) {
 	const results = await getHighlightsByCategory(type);
-	if (!results || results.length === 0) {
+	if (!Array.isArray(results)) {
+		// An error/rate-limit body (e.g. `{ detail: "Request was throttled." }`)
+		// has no results array - surface that instead of a misleading "no
+		// highlights" message or a raw crash downstream.
+		LogAndThrowError(
+			"Could not read highlights from Readwise (the API may be rate-limited or returned an error). Please try again.",
+		);
+	}
+	if (results.length === 0) {
 		LogAndThrowError("No highlights found.");
 	}
 
@@ -223,13 +238,25 @@ async function getReadwiseHighlights(type) {
 }
 
 async function handleAddToExistingFile(file, item) {
-	const lastHighlightAt =
-		QuickAdd.app.metadataCache.getFileCache(file).frontmatter.lastHighlightAt;
+	// The matched file is found purely by path, so it may be a pre-existing note
+	// that this script never created (no frontmatter) or one Obsidian hasn't
+	// indexed yet (getFileCache returns null). Optional-chain both so the friendly
+	// guard below runs instead of a raw TypeError.
+	const fileCache = QuickAdd.app.metadataCache.getFileCache(file);
+	const lastHighlightAt = fileCache?.frontmatter?.lastHighlightAt;
 	if (!lastHighlightAt) {
 		LogAndThrowError("File does not have a lastHighlightAt property.");
 	}
 
 	const resolve = await getHighlightsAfterDateForItem(item, lastHighlightAt);
+	if (!Array.isArray(resolve?.results)) {
+		// Readwise resolves the fetch even on an error/rate-limit response (e.g. a
+		// 429 returns `{ detail: "Request was throttled." }`), so require an actual
+		// results array before reading it instead of crashing with a raw TypeError.
+		LogAndThrowError(
+			"Could not read highlights from Readwise (the API may be rate-limited or returned an error). Please try again.",
+		);
+	}
 	const highlights = resolve.results.reverse();
 
 	if (highlights.length > 0) {
@@ -255,8 +282,12 @@ async function handleCreateSourceFile(item) {
 	if (item.title === MANUAL_ENTRY) return;
 
 	const resolve = await getHighlightsForItem(item);
-	if (!resolve) {
-		LogAndThrowError("No highlights found.");
+	// `{ detail: ... }` error bodies are truthy, so require an actual results array
+	// rather than just a truthy response object.
+	if (!Array.isArray(resolve?.results)) {
+		LogAndThrowError(
+			"Could not read highlights from Readwise (the API may be rate-limited or returned an error). Please try again.",
+		);
 	}
 
 	const highlights = resolve.results.reverse();

--- a/docs/static/scripts/migrateDataviewToFrontmatter.js
+++ b/docs/static/scripts/migrateDataviewToFrontmatter.js
@@ -107,9 +107,10 @@ async function start(params, settings) {
 
                 // Handle special property names (Obsidian reserved fields)
                 // "tags" must be lowercase and tag values should not have "#" prefix
-                const normalizedFieldName = fieldName.toLowerCase() === 'tags' ? 'tags' : fieldName;
+                const isTags = fieldName.toLowerCase() === 'tags';
+                const normalizedFieldName = isTags ? 'tags' : fieldName;
 
-                if (normalizedFieldName === 'tags') {
+                if (isTags) {
                     // Strip "#" from tag values
                     valuesArray = valuesArray.map(tag => {
                         // Remove leading "#" if present
@@ -117,8 +118,25 @@ async function start(params, settings) {
                     });
                 }
 
-                // Merge with existing frontmatter values instead of overwriting
-                const existingValue = frontmatter[normalizedFieldName];
+                // Frontmatter property names behave case-insensitively in Obsidian,
+                // so find an existing key that matches case-insensitively to merge
+                // into rather than creating a near-duplicate (e.g. both "Reference"
+                // and "reference").
+                const existingKey = Object.keys(frontmatter).find(
+                    key => key.toLowerCase() === normalizedFieldName.toLowerCase()
+                );
+
+                // The reserved "tags" property must be stored lowercase, so always
+                // target "tags"; other properties reuse the existing key's case (or
+                // the field name) so we never strand a duplicate behind.
+                const targetKey = isTags ? 'tags' : (existingKey ?? normalizedFieldName);
+
+                // Read the existing value from wherever it currently lives, and drop
+                // a wrong-cased key so the merge does not leave a duplicate.
+                const existingValue = existingKey !== undefined ? frontmatter[existingKey] : undefined;
+                if (existingKey !== undefined && existingKey !== targetKey) {
+                    delete frontmatter[existingKey];
+                }
 
                 if (existingValue !== undefined && existingValue !== null) {
                     // Property already exists - merge the values
@@ -126,20 +144,30 @@ async function start(params, settings) {
                         ? existingValue
                         : [existingValue];
 
-                    // Combine existing and new values, then deduplicate
+                    // Combine, then deduplicate by string form WITHOUT coercing the
+                    // stored values - keep the original typed values (numbers,
+                    // booleans) so an existing "rating: 5" stays a number.
                     const combined = [...existingArray, ...valuesArray];
-                    const deduplicated = [...new Set(combined.map(v => String(v)))];
+                    const seen = new Set();
+                    const deduplicated = [];
+                    for (const value of combined) {
+                        const key = String(value);
+                        if (!seen.has(key)) {
+                            seen.add(key);
+                            deduplicated.push(value);
+                        }
+                    }
 
                     // Store as string or array depending on count
-                    frontmatter[normalizedFieldName] = deduplicated.length === 1
+                    frontmatter[targetKey] = deduplicated.length === 1
                         ? deduplicated[0]
                         : deduplicated;
                 } else {
                     // Property doesn't exist - add it
                     if (valuesArray.length === 1) {
-                        frontmatter[normalizedFieldName] = valuesArray[0];
+                        frontmatter[targetKey] = valuesArray[0];
                     } else if (valuesArray.length > 1) {
-                        frontmatter[normalizedFieldName] = valuesArray;
+                        frontmatter[targetKey] = valuesArray;
                     }
                 }
             });
@@ -193,10 +221,13 @@ function parseInlineFieldsWithWikilinks(content, allowedProperties = [], migrate
 
     // Track the currently open fenced code block, if any. fenceDepth is the
     // blockquote nesting level the fence opened at (0 = top level), so a fence
-    // inside "> ..." is closed by a closer at the same quote depth.
+    // inside "> ..." is closed by a closer at the same quote depth. fenceListIndent
+    // is the list-item content indent the fence opened at (0 = not in a list), so a
+    // fence opened by "- ```" has its body and closing fence tracked at that indent.
     let fenceChar = null; // '`' or '~'
     let fenceLen = 0;
     let fenceDepth = 0;
+    let fenceListIndent = 0;
 
     for (let i = 0; i < bodyLines.length; i++) {
         const line = bodyLines[i];
@@ -208,35 +239,59 @@ function parseInlineFieldsWithWikilinks(content, allowedProperties = [], migrate
             // non-fence so a real field after the block still migrates.
             const { depth, content } = stripBlockquote(line, fenceDepth);
             if (depth >= fenceDepth) {
-                // Still inside the block: preserve verbatim, never migrate. Only a
-                // matching closing fence (same marker, long enough, no info string)
-                // at the same quote depth ends it.
-                if (isClosingFence(content, fenceChar, fenceLen)) {
+                // If the fence opened inside a list item, its body and closing fence
+                // sit at the list's content indent - strip that before matching the
+                // closer. For a non-list fence fenceListIndent is 0, so this is a
+                // no-op and behaviour is identical to a plain top-level fence.
+                const { rest, indent } = stripLeadingSpaces(content, fenceListIndent);
+                if (fenceListIndent > 0 && indent < fenceListIndent && rest.trim() !== '') {
+                    // A non-blank line indented LESS than the list content has left
+                    // the list item, so per CommonMark the (unclosed) fence ends
+                    // here. Exit and fall through to reprocess the line - it may be a
+                    // real field or a NEW top-level fence (e.g. a bare ``` that would
+                    // otherwise be mistaken for this fence's closer). Blank lines stay
+                    // in the block.
                     fenceChar = null;
                     fenceLen = 0;
                     fenceDepth = 0;
+                    fenceListIndent = 0;
+                } else {
+                    // Still inside the block: preserve verbatim, never migrate. Only a
+                    // matching closing fence (same marker, long enough, no info string)
+                    // at the same quote + list depth ends it.
+                    if (isClosingFence(rest, fenceChar, fenceLen)) {
+                        fenceChar = null;
+                        fenceLen = 0;
+                        fenceDepth = 0;
+                        fenceListIndent = 0;
+                    }
+                    cleanedBodyLines.push(line);
+                    protectedFlags.push(true);
+                    continue;
                 }
-                cleanedBodyLines.push(line);
-                protectedFlags.push(true);
-                continue;
+            } else {
+                // Blockquote container exited: end the fence and fall through so this
+                // line is handled normally.
+                fenceChar = null;
+                fenceLen = 0;
+                fenceDepth = 0;
+                fenceListIndent = 0;
             }
-            // Blockquote container exited: end the fence and fall through so this
-            // line is handled normally.
-            fenceChar = null;
-            fenceLen = 0;
-            fenceDepth = 0;
         }
 
-        // Not inside a code block: an opening fence (top-level or blockquoted)
-        // starts one. Detect it on the blockquote-stripped content and remember the
-        // quote depth so the matching closer is recognised.
+        // Not inside a code block: an opening fence (top-level, blockquoted, or as
+        // the first content of a list item) starts one. Detect it on the
+        // blockquote-stripped content, after optionally stripping a list marker, and
+        // remember the quote depth + list indent so the matching closer is found.
         {
             const { depth, content } = stripBlockquote(line, Infinity);
-            const fence = openingFence(content);
+            const { rest, indent } = stripListMarker(content);
+            const fence = openingFence(rest);
             if (fence) {
                 fenceChar = fence.char;
                 fenceLen = fence.len;
                 fenceDepth = depth;
+                fenceListIndent = indent;
                 cleanedBodyLines.push(line);
                 protectedFlags.push(true);
                 continue;
@@ -349,23 +404,46 @@ function stripBlockquote(line, max) {
 }
 
 /**
- * Detect an opening code fence (``` or ~~~) on a line whose blockquote markers
- * have already been stripped. Per CommonMark a fence may be indented 0-3 spaces
- * (4+ is an indented code block) and may carry an info string. Returns
+ * Strip an optional leading list-item marker ("- ", "* ", "+ ", "1. ", "1) ")
+ * from a line whose blockquote markers have already been removed. Returns the
+ * remaining text and the number of columns the marker consumed (the list content
+ * indent). This lets a code fence that opens as the first content of a list item
+ * (e.g. "- ```") be recognised, with its body and closing fence tracked at that
+ * indent. A list marker is an unambiguous block container, so detecting it here is
+ * safe - unlike a bare indent, it cannot be confused with ordinary text.
+ */
+function stripListMarker(content) {
+    const match = content.match(/^ {0,3}(?:[-*+]|\d{1,9}[.)])\s+/);
+    if (!match) return { rest: content, indent: 0 };
+    return { rest: content.slice(match[0].length), indent: match[0].length };
+}
+
+/**
+ * Strip up to `max` leading spaces from a line. Returns the remaining text and the
+ * number of spaces actually removed.
+ */
+function stripLeadingSpaces(content, max) {
+    let indent = 0;
+    while (indent < max && content[indent] === ' ') indent += 1;
+    return { rest: content.slice(indent), indent };
+}
+
+/**
+ * Detect an opening code fence (``` or ~~~) on a line whose blockquote and list
+ * markers have already been stripped. Per CommonMark a fence may be indented 0-3
+ * spaces (4+ is an indented code block) and may carry an info string. Returns
  * { char, len } for the marker, or null.
  *
  * Out of scope - 4-space INDENTED code blocks are not detected. Telling a genuine
- * indented code block apart from list-continuation text needs list/paragraph block
- * context (CommonMark: indented code cannot interrupt a paragraph, a 4-space indent
- * under a list item is list content rather than code, and loose lists even put a
- * blank line before such continuation). A line-based script lacks that context, and
- * a partial heuristic would either reintroduce data loss (deleting indented code)
- * or cause the opposite bug - silently skipping a real inline field merely indented
- * under a list (Dataview parses those as fields, so users expect them to migrate).
- * Only indented code at the very start of the body is unambiguous, which is too
- * narrow to justify a separate indented-block parser. Fenced code (top-level and
- * blockquoted) and inline code ARE detected without that context and are preserved;
- * an inline-field-like line inside a genuine indented code block may still migrate.
+ * indented code block apart from indented text needs paragraph block context
+ * (CommonMark: indented code cannot interrupt a paragraph, and a 4-space indent
+ * under a list item is list content rather than code). A line-based script lacks
+ * that context, and a partial heuristic would either reintroduce data loss
+ * (deleting indented code) or cause the opposite bug - silently skipping a real
+ * inline field merely indented under a list (Dataview parses those as fields, so
+ * users expect them to migrate). Fenced code (top-level, blockquoted, AND list-
+ * nested) and inline code ARE detected and preserved; only an inline-field-like
+ * line inside a genuine INDENTED code block may still migrate.
  */
 function openingFence(line) {
     const match = line.match(/^ {0,3}(`{3,}|~{3,})/);

--- a/docs/static/scripts/migrateDataviewToFrontmatter.js
+++ b/docs/static/scripts/migrateDataviewToFrontmatter.js
@@ -119,35 +119,37 @@ async function start(params, settings) {
                 }
 
                 // Frontmatter property names behave case-insensitively in Obsidian,
-                // so find an existing key that matches case-insensitively to merge
-                // into rather than creating a near-duplicate (e.g. both "Reference"
-                // and "reference").
-                const existingKey = Object.keys(frontmatter).find(
+                // so collect EVERY key that matches case-insensitively. A hand-edited
+                // or synced note (or a note migrated by an older version of this
+                // script) can hold more than one case variant - e.g. both "Reference"
+                // and "reference", or both "Tags" and "tags" - and we must merge them
+                // all into one key rather than stranding (or dropping) a variant.
+                const matchingKeys = Object.keys(frontmatter).filter(
                     key => key.toLowerCase() === normalizedFieldName.toLowerCase()
                 );
 
                 // The reserved "tags" property must be stored lowercase, so always
-                // target "tags"; other properties reuse the existing key's case (or
-                // the field name) so we never strand a duplicate behind.
-                const targetKey = isTags ? 'tags' : (existingKey ?? normalizedFieldName);
+                // target "tags"; other properties reuse the first existing key's case
+                // (or the field name).
+                const targetKey = isTags ? 'tags' : (matchingKeys[0] ?? normalizedFieldName);
 
-                // Read the existing value from wherever it currently lives, and drop
-                // a wrong-cased key so the merge does not leave a duplicate.
-                const existingValue = existingKey !== undefined ? frontmatter[existingKey] : undefined;
-                if (existingKey !== undefined && existingKey !== targetKey) {
-                    delete frontmatter[existingKey];
+                // Gather the existing values from every case variant, then drop the
+                // non-target keys so no duplicate survives.
+                const existingValues = [];
+                for (const key of matchingKeys) {
+                    const value = frontmatter[key];
+                    if (value !== undefined && value !== null) {
+                        if (Array.isArray(value)) existingValues.push(...value);
+                        else existingValues.push(value);
+                    }
+                    if (key !== targetKey) delete frontmatter[key];
                 }
 
-                if (existingValue !== undefined && existingValue !== null) {
-                    // Property already exists - merge the values
-                    const existingArray = Array.isArray(existingValue)
-                        ? existingValue
-                        : [existingValue];
-
+                if (existingValues.length > 0) {
                     // Combine, then deduplicate by string form WITHOUT coercing the
                     // stored values - keep the original typed values (numbers,
                     // booleans) so an existing "rating: 5" stays a number.
-                    const combined = [...existingArray, ...valuesArray];
+                    const combined = [...existingValues, ...valuesArray];
                     const seen = new Set();
                     const deduplicated = [];
                     for (const value of combined) {


### PR DESCRIPTION
Resolves two deepsec clean-room findings in the bundled example scripts under `docs/static/scripts`, plus a set of adjacent same-class defects surfaced while reproducing them under the local-plugin threat model (untrusted input = synced/shared notes, synced localStorage, third-party Readwise API responses). Ships as `docs(examples):` - no plugin runtime change, no release. Example-script tests are kept out of the PR per repo convention (proven locally with throwaway Node harnesses + a live Obsidian vault).

## Assigned finding 1 - EzImport null-deref (BUG, true-positive) → FIXED

`handleAddToExistingFile` matched the target note purely by path, then read `getFileCache(file).frontmatter.lastHighlightAt` directly. A pre-existing note that happens to share the computed file name but has no frontmatter (or that Obsidian has not indexed yet → `getFileCache` returns `null`) crashed with a raw `TypeError` *before* the intended friendly guard could run.

- **Red:** `getFileCache=null` → `Cannot read properties of null (reading 'frontmatter')`; no-frontmatter → `Cannot read properties of undefined (reading 'lastHighlightAt')`.
- **Green:** both now reach the friendly `File does not have a lastHighlightAt property.`
- Optional-chained the lookup (`getFileCache(file)?.frontmatter?.lastHighlightAt`).

## Assigned finding 2 - migrate-dataview "data loss in code blocks" → CONFIRMED as the documented residual (by-design), with the user-facing docs corrected

The original HIGH data-loss (inline-field-shaped lines inside fenced/inline code being migrated + deleted) was already fixed in #1439. The clean-room re-flag is the **documented 4-space-indented-code residual** - a line-based scanner cannot tell a genuine indented code block from indented list/paragraph text without block context, and a partial heuristic would either delete real indented code or skip a genuine inline field merely indented under a list (which Dataview *does* migrate). Confirmed via harness that all #1439 protections (top-level fenced, blockquoted fenced, inline code, blank-lines-in-fence) are intact and only the indented case remains. No parser regression of #1439.

The guide over-promised here, so the docs are corrected to be honest (see below).

## Adjacent defects found while reproducing (adversarial review, 3 opposing-model reviewers + a fresh-context skeptic) → FIXED at root

These are the same two defect families as the assigned findings (raw-crash robustness in EzImport; code-block data-loss/merge correctness in migrate-dataview), so they are fixed in the same vertical slices rather than left as separate symptom-level work.

**migrate-dataview - list-nested fenced code data loss (HIGH, 3/3 reviewer consensus).** A genuine fenced block whose opener sits on a list-marker line (`- ` ```` ``` ```` then `  reference:: x` then `  ` ```` ``` ````) was not detected, so the inline-field-shaped line inside it was migrated and **deleted** - reachable even in the default `Reference`/`Related` mode. Unlike a bare indent, a list marker is an *unambiguous* block container, so it is safe to detect: strip an optional list marker before fence detection and track the list content indent for the body/closer. The new path only runs when a list marker is present, so top-level and blockquoted fences are byte-for-byte unchanged.
- *A fresh-context adversarial pass then caught a HIGH data-loss **regression** in my first attempt:* with no dedent-exit, an un-indented ```` ``` ```` after a list-opened fence (which CommonMark reads as a *new* top-level fence) was misread as the list fence's closer, causing real code after it to be deleted. Added a dedent-exit (a non-blank line indented less than the list content ends the list item and its fence) and proved it red→green.
- **Live Obsidian proof:** `listcode:: x` inside a list-nested fence is preserved; for the regression-guard note, `realfield:: yes` (a real field after the list) migrates while `codefield:: no` (inside the new fence) is preserved as code - no data loss.

**migrate-dataview - frontmatter merge correctness (medium).**
- Case-insensitive existing-key resolution: migrating `Reference::` into a note that already has lowercase `reference` now merges into the one key instead of creating a duplicate `Reference`/`reference` pair.
- Reserved `tags` canonicalized to lowercase, folding+removing any wrong-cased existing key.
- Dedup no longer `String()`-coerces stored values, so an existing typed value (e.g. `rating: 5`) keeps its number/boolean type. (Verified live: `rating: [5, "9"]`.)

**EzImport - sibling raw-crashes on Readwise error responses (medium).** Readwise resolves `fetch()` even on error/rate-limit responses (a 429 returns `{ detail: "Request was throttled." }`), so `resolve.results.reverse()` raw-crashed in both `handleAddToExistingFile` and `handleCreateSourceFile`, and the initial category listing showed a misleading "No highlights found." Require an actual results array (`Array.isArray`) on all three paths and surface a rate-limit/error message. Also wrapped `getReadwiseCache`'s `JSON.parse` so a corrupt/synced cache is ignored and rebuilt instead of throwing a raw `SyntaxError`.

## Docs honesty

`Macro_MigrateDataviewProperties.md`:
- The stale "Race Condition Prevention" section described a `read` + `modify` flow the script no longer uses and over-claimed atomicity. It now describes the real `processFrontMatter` + `vault.process` flow and is honest that the two steps are not a single transaction (a *pre-existing* concurrency window, unchanged by this PR: a field added by another device between the two steps can be removed from the body without being captured in frontmatter - surfaced as a follow-up rather than folded in, since a correct fix needs a single-snapshot rewrite of the write strategy).
- The code-block note now matches the implementation: fenced (top-level, blockquoted, list-nested) and inline code are preserved; only a 4-space *indented* code block remains the residual.

## Reviewer-rejected items (with rationale)
- **Type-aware dedup** (keep `5` and `"5"` as distinct): rejected - it breaks the common, correct case where an existing number `5` should dedup against an inline string `"5"`. The string-keyed dedup that preserves the first value's type is the right semantic.
- **Deep per-highlight field validation** (null `text`/`note` from Readwise): out of scope - not a documented Readwise response; guarding the real error-body/array shape is the right boundary for an example script.

## Gates
`tsc -noEmit` clean · `eslint .` clean · `svelte-check` 0 errors · `vitest` 312 files / 3363 tests pass. (Example scripts under `docs/**` are outside the lint/type/test scope; verified via local harnesses + live vault.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import reliability by safely handling corrupted Readwise cache data and unexpected (non-array) API responses.
  * Prevented crashes when highlight/appending logic encounters files without cached frontmatter data.
  * Fixed Dataview inline property migration inside list-based fenced code blocks, and improved frontmatter merging to avoid duplicate fields, normalize tag formatting, and preserve original value types.
* **Documentation**
  * Updated technical migration notes with a clearer explanation of the write flow and concurrency caveat.
  * Expanded troubleshooting guidance for non-migrating code blocks and inline code, including detection limitations and safer migration recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->