### PR TITLE
fix(security): contain attacker-injectable capture-target redirection

### DIFF
--- a/src/ai/tools/assignableVariable.ts
+++ b/src/ai/tools/assignableVariable.ts
@@ -1,7 +1,10 @@
+import { isReservedVariableKey } from "../../utils/reservedVariableKeys";
+
 /**
  * Guard for the `assignToVariable` option shared by ai.agent and ai.prompt/chunkedPrompt (#714).
- * Rejects names that the formatter treats specially (so they cannot be hijacked) or
- * that are unreachable by the {{VALUE:name}} grammar.
+ * Rejects names that the formatter treats specially (so they cannot be hijacked),
+ * that are reserved for QuickAdd internal plumbing, or that are unreachable by the
+ * {{VALUE:name}} grammar.
  */
 export function assertAssignableVariableName(name: string): void {
 	const trimmed = name.trim();
@@ -18,7 +21,14 @@ export function assertAssignableVariableName(name: string): void {
 			`assignToVariable "${trimmed}" cannot end with "-quoted" (collides with the quoted output variable).`,
 		);
 	}
-	if (/[|,]/.test(trimmed) || trimmed.startsWith("__qa.")) {
+	// Reserved internal namespace (shared with the URI/CLI boundaries) and the
+	// pipe/comma characters the {{VALUE:name}} grammar cannot reference.
+	if (isReservedVariableKey(trimmed)) {
+		throw new Error(
+			`assignToVariable "${trimmed}" uses the reserved "__qa." prefix for QuickAdd internal variables.`,
+		);
+	}
+	if (/[|,]/.test(trimmed)) {
 		throw new Error(
 			`assignToVariable "${trimmed}" contains characters unreachable by {{VALUE:name}}.`,
 		);

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -170,6 +170,15 @@ function parseVarsJson(value: string): Record<string, unknown> {
 	return parsed as Record<string, unknown>;
 }
 
+// Unlike the obsidian:// URI boundary, the CLI intentionally does NOT drop the
+// reserved "__qa." prefix here: `value-__qa.captureTargetFilePath` is the
+// documented way to pick a capture target non-interactively for a folder/tag/
+// property-scoped Capture choice (see collectChoiceRequirements + the
+// missingFlags hint). That stays safe because the capture engine only honours a
+// preselected target within the configured scope (CaptureChoiceEngine
+// getFormattedPathToCaptureTo), and CLI access already grants arbitrary code
+// execution (quickadd:run can run a Macro choice), so this is not an escalation
+// boundary.
 function extractVariables(
 	params: CliData,
 	reservedKeys: Set<string>,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -263,9 +263,11 @@ export const TIME_FORMAT_SYNTAX_SUGGEST_REGEX = new RegExp(
 );
 
 // == Internal (reserved) variable keys == //
-// Keys starting with "__qa." are reserved for QuickAdd internal preflight/runtime plumbing.
-export const QA_INTERNAL_CAPTURE_TARGET_FILE_PATH =
-	"__qa.captureTargetFilePath";
+// Keys starting with this prefix are reserved for QuickAdd internal
+// preflight/runtime plumbing and must never be settable from across a trust
+// boundary (obsidian:// URI, CLI, AI tool output). See isReservedVariableKey.
+export const RESERVED_VARIABLE_PREFIX = "__qa.";
+export const QA_INTERNAL_CAPTURE_TARGET_FILE_PATH = `${RESERVED_VARIABLE_PREFIX}captureTargetFilePath`;
 
 // == MISC == //
 export const WIKI_LINK_REGEX = new RegExp(/\[\[([^\]]*)\]\]/);

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1932,4 +1932,76 @@ describe("CaptureChoiceEngine reserved capture-target variable (security)", () =
 		expect(result).toBe("Work/A.md");
 		expect(suggestSpy).not.toHaveBeenCalled();
 	});
+
+	// With "create if it doesn't exist" on, a filter scope allows a NEW note name
+	// (the picker's "type to create"), so a preselected non-existing path is kept.
+	it("honours a preselected NEW note for a filter scope (create on)", async () => {
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([
+			{ path: "Work/A.md" } as any,
+		]);
+		const app = createApp();
+		(app.vault.getAbstractFileByPath as any) = vi.fn(() => null); // nothing exists yet
+		const executor = createExecutor();
+		executor.variables.set(
+			QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			"Work/Fresh.md",
+		);
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "tag:work",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			executor,
+		);
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Work/Fresh.md");
+	});
+
+	// But it must NOT let an injected value append to an EXISTING note the filter
+	// does not match - the interactive picker suppresses that, and it is the
+	// arbitrary-note redirect this fix exists to prevent.
+	it("rejects a preselected EXISTING unmatched note for a filter scope (create on)", async () => {
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([
+			{ path: "Work/A.md" } as any,
+		]);
+		const app = createApp();
+		// The injected target already exists but is NOT in the matched set.
+		(app.vault.getAbstractFileByPath as any) = vi.fn((p: string) =>
+			p === "Secrets/Dangerous.md" ? ({ path: p } as any) : null,
+		);
+		const suggestSpy = vi.fn(async () => "Work/A.md");
+		(InputSuggester as any).Suggest = suggestSpy;
+		const executor = createExecutor();
+		executor.variables.set(
+			QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			"Secrets/Dangerous.md",
+		);
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "tag:work",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			executor,
+		);
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Work/A.md");
+		expect(result).not.toBe("Secrets/Dangerous.md");
+		expect(suggestSpy).toHaveBeenCalled();
+	});
 });

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -2004,4 +2004,77 @@ describe("CaptureChoiceEngine reserved capture-target variable (security)", () =
 		expect(result).not.toBe("Secrets/Dangerous.md");
 		expect(suggestSpy).toHaveBeenCalled();
 	});
+
+	// A trailing-space/dot variant normalizes to an existing note before the write,
+	// so the existence check must normalize too - otherwise it slips past as "new".
+	it("rejects a trailing-space variant of an existing note for a filter scope (create on)", async () => {
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([]);
+		const app = createApp();
+		(app.vault.getAbstractFileByPath as any) = vi.fn((p: string) =>
+			p === "Secrets/Dangerous.md" ? ({ path: p } as any) : null,
+		);
+		const suggestSpy = vi.fn(async () => {
+			throw "cancelled";
+		});
+		(InputSuggester as any).Suggest = suggestSpy;
+		const executor = createExecutor();
+		executor.variables.set(
+			QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			"Secrets/Dangerous.md ", // trailing space
+		);
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "tag:work",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			executor,
+		);
+
+		// Rejected -> falls through to the (cancelling) picker, never honoured.
+		await expect(
+			(engine as any).getFormattedPathToCaptureTo(false),
+		).rejects.toBeTruthy();
+		expect(suggestSpy).toHaveBeenCalled();
+	});
+
+	// Mirror the picker's basename guard: a bare name colliding with an existing
+	// note's basename anywhere must not be accepted as a new note.
+	it("rejects a basename-colliding preselected for a filter scope (create on)", async () => {
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([]);
+		const app = createApp();
+		(app.vault.getAbstractFileByPath as any) = vi.fn(() => null);
+		(app.vault.getMarkdownFiles as any) = vi.fn(() => [
+			{ path: "Archive/Daily.md", basename: "Daily" },
+		]);
+		const suggestSpy = vi.fn(async () => {
+			throw "cancelled";
+		});
+		(InputSuggester as any).Suggest = suggestSpy;
+		const executor = createExecutor();
+		executor.variables.set(QA_INTERNAL_CAPTURE_TARGET_FILE_PATH, "Daily");
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({
+				captureTo: "tag:work",
+				createFileIfItDoesntExist: {
+					enabled: true,
+					createWithTemplate: false,
+					template: "",
+				},
+			}),
+			executor,
+		);
+
+		await expect(
+			(engine as any).getFormattedPathToCaptureTo(false),
+		).rejects.toBeTruthy();
+		expect(suggestSpy).toHaveBeenCalled();
+	});
 });

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -713,10 +713,12 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 			QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
 			"Boards/Kanban.base",
 		);
+		// A vault-wide "Capture to" legitimately honours a preselected pick, so the
+		// `.base` guard is exercised on the path it actually uses.
 		const engine = new CaptureChoiceEngine(
 			app,
 			{ settings: { useSelectionAsCaptureValue: false } } as any,
-			createChoice(),
+			createChoice({ captureTo: "" }),
 			executor,
 		);
 
@@ -1800,5 +1802,134 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(fileExistsMock).not.toHaveBeenCalled();
 		expect(onFileExistsMock).not.toHaveBeenCalled();
 		expect(app.vault.modify).not.toHaveBeenCalled();
+	});
+});
+
+describe("CaptureChoiceEngine reserved capture-target variable (security)", () => {
+	const makeEngine = (
+		choice: Partial<ICaptureChoice>,
+		preselected: string | undefined,
+	) => {
+		const app = createApp();
+		const executor = createExecutor();
+		if (preselected !== undefined) {
+			executor.variables.set(
+				QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+				preselected,
+			);
+		}
+		return new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice(choice),
+			executor,
+		);
+	};
+
+	// The reserved variable is attacker-injectable across QuickAdd's trust
+	// boundaries (obsidian:// URI, CLI value-<name>=, {{VALUE:__qa.…}} tokens). For
+	// a definite-file "Capture to" the configured path is authoritative, so a stray
+	// reserved key must NOT redirect the write to an arbitrary note.
+	it("ignores an injected target variable for a fixed-file Capture target", async () => {
+		const engine = makeEngine({ captureTo: "Inbox.md" }, "Secrets/payload.md");
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Inbox.md");
+	});
+
+	it("ignores an injected target variable for a definite file target with extension", async () => {
+		const engine = makeEngine(
+			{ captureTo: "Notes/Daily.md" },
+			"Secrets/payload.md",
+		);
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Notes/Daily.md");
+	});
+
+	it("ignores an injected target variable when capturing to the active file", async () => {
+		const app = createApp();
+		(app.workspace.getActiveFile as any) = vi.fn(() => ({ path: "Active.md" }));
+		const executor = createExecutor();
+		executor.variables.set(
+			QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			"Secrets/payload.md",
+		);
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureToActiveFile: true }),
+			executor,
+		);
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(true);
+
+		expect(result).toBe("Active.md");
+	});
+
+	// The legitimate flow: a folder-scoped capture genuinely needs a runtime file
+	// selection, supplied by trusted preflight OR a non-interactive CLI value. That
+	// selection (inside the scope) is still honoured.
+	it("honours a preselected target for a folder-scope Capture target", async () => {
+		const engine = makeEngine({ captureTo: "Inbox/" }, "Inbox/Picked.md");
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Inbox/Picked.md");
+	});
+
+	it("honours a preselected target for a vault-wide Capture target", async () => {
+		const engine = makeEngine({ captureTo: "" }, "Anywhere/Picked.md");
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Anywhere/Picked.md");
+	});
+
+	// A folder scope confines the pick to the folder (mirroring the interactive
+	// picker's re-prefix) so an injected out-of-folder value cannot escape it.
+	it("confines an out-of-folder preselected target back into the folder", async () => {
+		const engine = makeEngine({ captureTo: "Inbox/" }, "Outside/Note.md");
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Inbox/Outside/Note.md");
+		expect(result).not.toBe("Outside/Note.md");
+	});
+
+	// A filter scope without "create if it doesn't exist" only accepts notes the
+	// filter matches; an injected out-of-set value is rejected and the normal
+	// picker runs instead.
+	it("rejects an out-of-set preselected target for a filter scope (create off)", async () => {
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([
+			{ path: "Work/A.md" } as any,
+		]);
+		const suggestSpy = vi.fn(async () => "Work/A.md");
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const engine = makeEngine({ captureTo: "tag:work" }, "Secrets/Payload.md");
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Work/A.md");
+		expect(result).not.toBe("Secrets/Payload.md");
+		expect(suggestSpy).toHaveBeenCalled();
+	});
+
+	it("honours an in-set preselected target for a filter scope (create off)", async () => {
+		vi.mocked(getMarkdownFilesMatchingFilter).mockReturnValue([
+			{ path: "Work/A.md" } as any,
+		]);
+		const suggestSpy = vi.fn(async () => "should-not-be-used");
+		(InputSuggester as any).Suggest = suggestSpy;
+
+		const engine = makeEngine({ captureTo: "tag:work" }, "Work/A.md");
+
+		const result = await (engine as any).getFormattedPathToCaptureTo(false);
+
+		expect(result).toBe("Work/A.md");
+		expect(suggestSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -36,6 +36,7 @@ import {
 	getMarkdownFilesInFolder,
 	getMarkdownFilesMatchingFilter,
 	getMarkdownFilesWithProperty,
+	getMarkdownFilesWithTag,
 	insertFileLinkToActiveView,
 	insertOnNewLineAbove,
 	insertOnNewLineBelow,
@@ -55,6 +56,10 @@ import {
 	resolveCaptureTarget as resolveCaptureTargetFromString,
 	type CaptureTargetResolution,
 } from "./helpers/captureTargetResolution";
+import {
+	classifyCaptureTargetScope,
+	type CaptureTargetScope,
+} from "./helpers/captureTargetScope";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
 import {
 	appendFileLinkToDestinationFile,
@@ -905,24 +910,36 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	private async getFormattedPathToCaptureTo(
 		shouldCaptureToActiveFile: boolean,
 	): Promise<string> {
-		// One-page preflight: if a specific target file was already chosen, use it
-		const preselected = this.choiceExecutor?.variables?.get(
-			QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
-		) as string | undefined;
-		if (
-			!shouldCaptureToActiveFile &&
-			preselected &&
-			typeof preselected === "string" &&
-			preselected.length > 0
-		) {
-			return this.normalizeCaptureFilePath(preselected);
-		}
-
 		if (shouldCaptureToActiveFile) {
 			const activeFile = this.app.workspace.getActiveFile();
 			invariant(activeFile, "Cannot capture to active file - no active file.");
 
 			return activeFile.path;
+		}
+
+		// A preselected capture target (the trusted one-page preflight pick, or a
+		// non-interactive CLI `value-__qa.captureTargetFilePath`) is honoured ONLY
+		// when the configured "Capture to" actually needs a runtime file pick — the
+		// same scopes the requirement collector emits the pick for — AND the value is
+		// confined to that scope. For a definite-file target the configured path is
+		// authoritative, so a reserved variable injected across a trust boundary (an
+		// obsidian:// URI, the CLI, or a {{VALUE:__qa.…}} token in a synced/imported
+		// choice) cannot redirect the capture to an arbitrary note.
+		const preselected = this.getPreselectedCaptureTargetPath();
+		if (preselected !== undefined) {
+			const scope = classifyCaptureTargetScope(
+				{ isFolder: (path) => isFolder(this.app, path) },
+				this.choice.captureTo ?? "",
+				false,
+			);
+			if (scope) {
+				const confined = this.confinePreselectedToScope(scope, preselected);
+				if (confined !== null) {
+					return this.normalizeCaptureFilePath(confined);
+				}
+				// Out-of-scope value: ignore it and fall back to the normal
+				// picker/resolution below (which aborts a non-interactive run).
+			}
 		}
 
 		const captureTo = this.choice.captureTo;
@@ -947,6 +964,77 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				return this.selectFileInFolder(resolution.folder, false);
 			case "file":
 				return this.normalizeCaptureFilePath(resolution.path);
+		}
+	}
+
+	/**
+	 * The capture-target file path supplied out-of-band for this run, read from the
+	 * reserved internal variable: set by trusted preflight plumbing (the one-page
+	 * input modal) or by a non-interactive CLI `value-__qa.captureTargetFilePath`.
+	 * Returns `undefined` when absent or blank. The caller honours it only for a
+	 * runtime-picker scope and confines it to that scope, so a reserved key injected
+	 * across a trust boundary cannot hijack a definite-file capture target.
+	 */
+	private getPreselectedCaptureTargetPath(): string | undefined {
+		const preselected = this.choiceExecutor?.variables?.get(
+			QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+		);
+		return typeof preselected === "string" && preselected.length > 0
+			? preselected
+			: undefined;
+	}
+
+	/**
+	 * Confines a preselected capture target to the SAME destination set the matching
+	 * interactive picker would accept, so the value can never escape the configured
+	 * "Capture to" scope:
+	 *  - folder: re-prefixed into the folder, mirroring {@link selectFileInFolder}
+	 *    (an empty folderPathSlash is the whole-vault scope, so no confinement).
+	 *  - filter/property/tag with creation OFF: must be one of the matched files.
+	 *  - filter/property/tag with creation ON: any in-vault path (a new note is
+	 *    allowed, matching the runtime picker's "type to create" affordance).
+	 * Returns `null` when the value is outside the scope; the caller then falls back
+	 * to the normal picker/resolution instead of honouring it.
+	 */
+	private confinePreselectedToScope(
+		scope: CaptureTargetScope,
+		preselected: string,
+	): string | null {
+		const stripped = this.stripLeadingSlash(preselected);
+
+		if (scope.kind === "folder") {
+			return scope.folderPathSlash &&
+				!stripped.startsWith(scope.folderPathSlash)
+				? `${scope.folderPathSlash}${stripped}`
+				: stripped;
+		}
+
+		const allowCreate =
+			this.choice.createFileIfItDoesntExist?.enabled ?? false;
+		if (allowCreate) {
+			return stripped;
+		}
+
+		const matched = this.resolveScopeFiles(scope);
+		return matched.some((file) => file.path === stripped) ? stripped : null;
+	}
+
+	/** The notes a tag/filter/property capture scope currently matches. */
+	private resolveScopeFiles(scope: CaptureTargetScope): TFile[] {
+		switch (scope.kind) {
+			case "filter":
+				return getMarkdownFilesMatchingFilter(this.app, scope.filter);
+			case "property":
+				return getMarkdownFilesWithProperty(
+					this.app,
+					scope.field,
+					scope.value,
+					scope.filter,
+				);
+			case "tag":
+				return getMarkdownFilesWithTag(this.app, scope.tag);
+			case "folder":
+				return getMarkdownFilesInFolder(this.app, scope.folderPathSlash);
 		}
 	}
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -990,9 +990,12 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	 * "Capture to" scope:
 	 *  - folder: re-prefixed into the folder, mirroring {@link selectFileInFolder}
 	 *    (an empty folderPathSlash is the whole-vault scope, so no confinement).
-	 *  - filter/property/tag with creation OFF: must be one of the matched files.
-	 *  - filter/property/tag with creation ON: any in-vault path (a new note is
-	 *    allowed, matching the runtime picker's "type to create" affordance).
+	 *  - filter/property/tag: a note the scope already matches is always allowed.
+	 *    With creation OFF nothing else is (the picker only offers matched notes);
+	 *    with creation ON a NEW name is allowed too, but an EXISTING note the scope
+	 *    does not match is rejected - the picker suppresses it (InputSuggester
+	 *    getSuggestions, valueExists), and honouring it would let an injected value
+	 *    append to an arbitrary existing note.
 	 * Returns `null` when the value is outside the scope; the caller then falls back
 	 * to the normal picker/resolution instead of honouring it.
 	 */
@@ -1009,14 +1012,28 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				: stripped;
 		}
 
-		const allowCreate =
-			this.choice.createFileIfItDoesntExist?.enabled ?? false;
-		if (allowCreate) {
+		const matched = this.resolveScopeFiles(scope);
+		if (matched.some((file) => file.path === stripped)) {
 			return stripped;
 		}
 
-		const matched = this.resolveScopeFiles(scope);
-		return matched.some((file) => file.path === stripped) ? stripped : null;
+		const allowCreate =
+			this.choice.createFileIfItDoesntExist?.enabled ?? false;
+		if (!allowCreate) {
+			return null;
+		}
+
+		// Creation is on: the picker offers a new name, but never an existing
+		// unmatched note, so honour the value only when it does not already exist.
+		return this.captureTargetPathExists(stripped) ? null : stripped;
+	}
+
+	/** Whether a vault-relative path resolves to an existing note (with or without a markdown/canvas extension). */
+	private captureTargetPathExists(path: string): boolean {
+		const base = path.replace(/\.(md|canvas)$/i, "");
+		return [path, `${base}.md`, `${base}.canvas`].some(
+			(candidate) => !!this.app.vault.getAbstractFileByPath(candidate),
+		);
 	}
 
 	/** The notes a tag/filter/property capture scope currently matches. */

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -1023,17 +1023,19 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			return null;
 		}
 
-		// Creation is on: the picker offers a new name, but never an existing
-		// unmatched note, so honour the value only when it does not already exist.
-		return this.captureTargetPathExists(stripped) ? null : stripped;
-	}
-
-	/** Whether a vault-relative path resolves to an existing note (with or without a markdown/canvas extension). */
-	private captureTargetPathExists(path: string): boolean {
-		const base = path.replace(/\.(md|canvas)$/i, "");
-		return [path, `${base}.md`, `${base}.canvas`].some(
-			(candidate) => !!this.app.vault.getAbstractFileByPath(candidate),
+		// Creation is on: the picker offers a NEW name but suppresses any existing
+		// note (by normalized path OR basename anywhere - selectFileFromSet +
+		// captureTargetAlreadyExists). Mirror it exactly so an injected value cannot
+		// append to an arbitrary existing note or spawn a duplicate-basename note.
+		// captureTargetAlreadyExists normalizes the value the same way the eventual
+		// write does (trailing space/dot stripped), so a `Note.md ` variant of an
+		// existing note is still caught.
+		const vaultBasenames = new Set(
+			this.app.vault.getMarkdownFiles().map((f) => f.basename.toLowerCase()),
 		);
+		return this.captureTargetAlreadyExists(stripped, vaultBasenames)
+			? null
+			: stripped;
 	}
 
 	/** The notes a tag/filter/property capture scope currently matches. */

--- a/src/engine/helpers/captureTargetScope.test.ts
+++ b/src/engine/helpers/captureTargetScope.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { classifyCaptureTargetScope } from "./captureTargetScope";
+
+const noFolders = { isFolder: () => false };
+const withFolders = (folders: string[]) => ({
+	isFolder: (path: string) => folders.includes(path),
+});
+
+describe("classifyCaptureTargetScope", () => {
+	it("returns null for capture-to-active-file regardless of target", () => {
+		expect(classifyCaptureTargetScope(noFolders, "Inbox/", true)).toBeNull();
+	});
+
+	it("returns null for a definite file target (no runtime pick needed)", () => {
+		expect(classifyCaptureTargetScope(noFolders, "Inbox.md", false)).toBeNull();
+		expect(
+			classifyCaptureTargetScope(noFolders, "Notes/Daily.md", false),
+		).toBeNull();
+	});
+
+	it("returns null for a tokenized file path (resolved only at run time)", () => {
+		expect(
+			classifyCaptureTargetScope(noFolders, "Projects/{{VALUE}}.md", false),
+		).toBeNull();
+	});
+
+	it("classifies an empty target as the whole-vault folder scope", () => {
+		expect(classifyCaptureTargetScope(noFolders, "", false)).toEqual({
+			kind: "folder",
+			folderPathSlash: "",
+		});
+		expect(classifyCaptureTargetScope(noFolders, "/", false)).toEqual({
+			kind: "folder",
+			folderPathSlash: "",
+		});
+	});
+
+	it("classifies a trailing-slash target as a folder scope", () => {
+		expect(classifyCaptureTargetScope(noFolders, "Inbox/", false)).toEqual({
+			kind: "folder",
+			folderPathSlash: "Inbox/",
+		});
+	});
+
+	it("classifies a bare existing-folder name as a folder scope", () => {
+		expect(
+			classifyCaptureTargetScope(withFolders(["Inbox"]), "Inbox", false),
+		).toEqual({ kind: "folder", folderPathSlash: "Inbox/" });
+	});
+
+	it("classifies a bare name with no matching folder as null (a file)", () => {
+		expect(classifyCaptureTargetScope(noFolders, "Inbox", false)).toBeNull();
+	});
+
+	it("classifies a property target", () => {
+		const scope = classifyCaptureTargetScope(
+			noFolders,
+			"property:type=draft",
+			false,
+		);
+		expect(scope).toMatchObject({ kind: "property", field: "type", value: "draft" });
+	});
+
+	it("classifies a tag/filter target", () => {
+		const scope = classifyCaptureTargetScope(noFolders, "tag:work", false);
+		expect(scope?.kind).toBe("filter");
+	});
+
+	it("returns null for a multi-select filter target (not a single destination)", () => {
+		expect(
+			classifyCaptureTargetScope(noFolders, "#work|multi", false),
+		).toBeNull();
+	});
+
+	it("returns null for a property target missing a field name", () => {
+		expect(classifyCaptureTargetScope(noFolders, "property:", false)).toBeNull();
+	});
+});

--- a/src/engine/helpers/captureTargetScope.test.ts
+++ b/src/engine/helpers/captureTargetScope.test.ts
@@ -24,6 +24,20 @@ describe("classifyCaptureTargetScope", () => {
 		).toBeNull();
 	});
 
+	it("returns null for a tokenized folder-suffix target (resolved at run time)", () => {
+		expect(
+			classifyCaptureTargetScope(noFolders, "Projects/{{VALUE}}/", false),
+		).toBeNull();
+		// Even if the literal token folder happens to exist, the token defers it.
+		expect(
+			classifyCaptureTargetScope(
+				withFolders(["Projects/{{VALUE}}"]),
+				"Projects/{{VALUE}}/",
+				false,
+			),
+		).toBeNull();
+	});
+
 	it("classifies an empty target as the whole-vault folder scope", () => {
 		expect(classifyCaptureTargetScope(noFolders, "", false)).toEqual({
 			kind: "folder",

--- a/src/engine/helpers/captureTargetScope.ts
+++ b/src/engine/helpers/captureTargetScope.ts
@@ -1,0 +1,105 @@
+import { hasTemplatePathSyntax } from "../../utils/templatePathSyntax";
+import { parsePropertyTarget } from "../../utils/propertyTarget";
+import { parseCaptureFileFilterTarget } from "../../utils/captureFileFilterTarget";
+import type { FieldFilter } from "../../utils/FieldSuggestionParser";
+
+/**
+ * The runtime "pick a destination" scope a Capture choice's "Capture to" string
+ * resolves to when it does NOT point at one definite file. These are exactly the
+ * cases that legitimately need a runtime file selection (the preflight modal, or
+ * a non-interactive CLI `value-__qa.captureTargetFilePath`). A definite-file or
+ * tokenized-file target, or capture-to-active-file, has NO such scope and yields
+ * `null`.
+ */
+export type CaptureTargetScope =
+	| { kind: "folder"; folderPathSlash: string }
+	| { kind: "filter"; filter: FieldFilter }
+	| { kind: "property"; field: string; value?: string; filter: FieldFilter }
+	| { kind: "tag"; tag: string };
+
+export interface CaptureTargetScopeDeps {
+	/** Whether the given vault-relative path is an existing folder. */
+	isFolder(path: string): boolean;
+}
+
+/**
+ * Classifies a RAW (unformatted) "Capture to" string into the runtime-picker
+ * scope it represents, or `null` when the target is a definite/tokenized file (no
+ * runtime pick needed) or the choice captures to the active file.
+ *
+ * This is the SINGLE source of truth shared by:
+ *  - the preflight requirement collector, which emits the
+ *    `QA_INTERNAL_CAPTURE_TARGET_FILE_PATH` requirement (and prompts for the pick)
+ *    precisely for these scopes; and
+ *  - {@link CaptureChoiceEngine}, which only honours a preselected capture-target
+ *    variable for these same scopes, and confines it to the scope.
+ *
+ * Keeping ONE classifier means the engine can never disagree with the collector
+ * about whether a preselected value is legitimate — so a value injected across a
+ * trust boundary (an `obsidian://` URI, the CLI, or a `{{VALUE:__qa.…}}` token in
+ * a synced/imported choice) cannot redirect a definite-file capture, and a
+ * legitimately collected pick is never silently dropped.
+ */
+export function classifyCaptureTargetScope(
+	deps: CaptureTargetScopeDeps,
+	rawCaptureTo: string,
+	captureToActiveFile: boolean,
+): CaptureTargetScope | null {
+	if (captureToActiveFile) return null;
+
+	const normalizedTarget = (rawCaptureTo ?? "").trim().replace(/^\/+/, "");
+
+	// A target carrying a format token can only be resolved at run time (it is not
+	// a stable picker scope), so it never gets a preflight requirement or a
+	// preselected pick — mirror that here.
+	const tokenized = hasTemplatePathSyntax(normalizedTarget);
+
+	const propertyTarget = !tokenized
+		? parsePropertyTarget(normalizedTarget)
+		: null;
+	const isPropertyTarget = !!propertyTarget && !!propertyTarget.field;
+
+	const fileFilterTarget =
+		!isPropertyTarget && !tokenized
+			? parseCaptureFileFilterTarget(normalizedTarget)
+			: null;
+	// A multi-select filter is not a single-destination capture scope.
+	const isFilterTarget = !!fileFilterTarget && !fileFilterTarget.multiSelect;
+
+	const isTagTarget =
+		!isPropertyTarget &&
+		!fileFilterTarget &&
+		normalizedTarget.startsWith("#");
+
+	const trimmedPath = normalizedTarget.replace(/\/$|\.md$/g, "");
+	const isFolderTarget =
+		!isTagTarget &&
+		!isPropertyTarget &&
+		!isFilterTarget &&
+		(normalizedTarget === "" || deps.isFolder(trimmedPath));
+	const looksLikeFolderBySuffix =
+		!isPropertyTarget && !isFilterTarget && normalizedTarget.endsWith("/");
+
+	if (isPropertyTarget && propertyTarget) {
+		return {
+			kind: "property",
+			field: propertyTarget.field,
+			value: propertyTarget.value,
+			filter: propertyTarget.filter,
+		};
+	}
+	if (isFilterTarget && fileFilterTarget) {
+		return { kind: "filter", filter: fileFilterTarget.filter };
+	}
+	if (isTagTarget) {
+		return { kind: "tag", tag: normalizedTarget };
+	}
+	if (isFolderTarget || looksLikeFolderBySuffix) {
+		const folder = normalizedTarget.replace(/(?:\/|\.md)+$/g, "");
+		const folderPathSlash =
+			folder === "" ? "" : folder.endsWith("/") ? folder : `${folder}/`;
+		return { kind: "folder", folderPathSlash };
+	}
+
+	return null;
+}

--- a/src/engine/helpers/captureTargetScope.ts
+++ b/src/engine/helpers/captureTargetScope.ts
@@ -49,20 +49,19 @@ export function classifyCaptureTargetScope(
 
 	const normalizedTarget = (rawCaptureTo ?? "").trim().replace(/^\/+/, "");
 
-	// A target carrying a format token can only be resolved at run time (it is not
-	// a stable picker scope), so it never gets a preflight requirement or a
-	// preselected pick — mirror that here.
-	const tokenized = hasTemplatePathSyntax(normalizedTarget);
+	// A target carrying a format token (e.g. `Projects/{{VALUE}}.md`,
+	// `Notes/{{DATE}}/`, `#{{VALUE}}`) is only resolvable at run time, so in EVERY
+	// shape - file, folder, tag, property - it is never a stable picker scope: it
+	// gets no preflight requirement and the engine never honours a preselected pick
+	// for it. Returning early keeps that uniform across all branches below.
+	if (hasTemplatePathSyntax(normalizedTarget)) return null;
 
-	const propertyTarget = !tokenized
-		? parsePropertyTarget(normalizedTarget)
-		: null;
+	const propertyTarget = parsePropertyTarget(normalizedTarget);
 	const isPropertyTarget = !!propertyTarget && !!propertyTarget.field;
 
-	const fileFilterTarget =
-		!isPropertyTarget && !tokenized
-			? parseCaptureFileFilterTarget(normalizedTarget)
-			: null;
+	const fileFilterTarget = !isPropertyTarget
+		? parseCaptureFileFilterTarget(normalizedTarget)
+		: null;
 	// A multi-select filter is not a single-destination capture scope.
 	const isFilterTarget = !!fileFilterTarget && !fileFilterTarget.multiSelect;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssis
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { parseSemver } from "./utils/semver";
 import { resolveChoiceIcon } from "./utils/choiceUtils";
+import { isReservedVariableKey } from "./utils/reservedVariableKeys";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
 import { setQuickAddInstance } from "./quickAddInstance";
@@ -375,7 +376,16 @@ export default class QuickAdd extends Plugin {
 			.filter(([key]) => key.startsWith("value-"))
 			.forEach(([key, value]) => {
 				const variableName = key.slice(6);
-				if (variableName && typeof value === "string") {
+				// Never let an incoming URI populate a reserved internal variable
+				// (e.g. the capture-target file path): obsidian:// links are reachable
+				// by any webpage/app, so honouring `value-__qa.…` would let an external
+				// caller drive internal plumbing. There is no legitimate URI use for
+				// these keys.
+				if (
+					variableName &&
+					typeof value === "string" &&
+					!isReservedVariableKey(variableName)
+				) {
 					choiceExecutor.variables.set(variableName, value);
 				}
 			});

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -25,8 +25,7 @@ import {
 } from "src/utilityObsidian";
 import { log } from "src/logger/logManager";
 import { hasTemplatePathSyntax } from "src/utils/templatePathSyntax";
-import { parsePropertyTarget } from "src/utils/propertyTarget";
-import { parseCaptureFileFilterTarget } from "src/utils/captureFileFilterTarget";
+import { classifyCaptureTargetScope } from "src/engine/helpers/captureTargetScope";
 import { orderFilesForPicker } from "src/utils/fileOrdering";
 import { buildFileDisplayLabels } from "src/utils/fileSyntax";
 import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
@@ -329,59 +328,36 @@ async function collectForCaptureChoice(
 		await scanTemplateSource(app, collector, createWithTemplate.template);
 	}
 
-	const formattedTarget = choice.captureTo?.trim() ?? "";
-	const normalizedTarget = formattedTarget.replace(/^\/+/, "");
-	// A `property:` target whose field/value carries a format token can only be
-	// resolved at run time (mirrors the tokenized-file-path case), so skip the
-	// preflight dropdown for it rather than forcing a dead "no files" picker.
-	const propertyTarget =
-		!hasTemplatePathSyntax(normalizedTarget)
-			? parsePropertyTarget(normalizedTarget)
-			: null;
-	const isPropertyTarget = !!propertyTarget && !!propertyTarget.field;
-	const fileFilterTarget =
-		!isPropertyTarget && !hasTemplatePathSyntax(normalizedTarget)
-			? parseCaptureFileFilterTarget(normalizedTarget)
-			: null;
-	const isFilterTarget = !!fileFilterTarget && !fileFilterTarget.multiSelect;
-	const isTagTarget =
-		!isPropertyTarget &&
-		!fileFilterTarget &&
-		normalizedTarget.startsWith("#");
-	const trimmedPath = normalizedTarget.replace(/\/$|\.md$/g, "");
-	const isFolderTarget =
-		!isTagTarget &&
-		!isPropertyTarget &&
-		!isFilterTarget &&
-		(normalizedTarget === "" || isFolder(app, trimmedPath));
-	const looksLikeFolderBySuffix =
-		!isPropertyTarget && !isFilterTarget && normalizedTarget.endsWith("/");
+	// One classifier (shared with CaptureChoiceEngine) decides whether "Capture to"
+	// needs a runtime file pick and, if so, the scope. Keeping the engine and this
+	// collector on the same classification guarantees a preselected pick is honoured
+	// exactly when it was legitimately collected, never silently dropped or hijacked.
+	const captureScope = classifyCaptureTargetScope(
+		{ isFolder: (path) => isFolder(app, path) },
+		choice.captureTo ?? "",
+		choice.captureToActiveFile,
+	);
 
-	if (
-		!choice.captureToActiveFile &&
-		(isPropertyTarget ||
-			isFilterTarget ||
-			isTagTarget ||
-			isFolderTarget ||
-			looksLikeFolderBySuffix)
-	) {
+	if (captureScope) {
 		let files: TFile[] = [];
-		if (isPropertyTarget && propertyTarget) {
-			files = getMarkdownFilesWithProperty(
-				app,
-				propertyTarget.field,
-				propertyTarget.value,
-				propertyTarget.filter,
-			);
-		} else if (isFilterTarget && fileFilterTarget) {
-			files = getMarkdownFilesMatchingFilter(app, fileFilterTarget.filter);
-		} else if (isTagTarget) {
-			files = getMarkdownFilesWithTag(app, normalizedTarget);
-		} else {
-			const folder = normalizedTarget.replace(/(?:\/|\.md)+$/g, "");
-			const base =
-				folder === "" ? "" : folder.endsWith("/") ? folder : `${folder}/`;
-			files = getMarkdownFilesInFolder(app, base);
+		switch (captureScope.kind) {
+			case "property":
+				files = getMarkdownFilesWithProperty(
+					app,
+					captureScope.field,
+					captureScope.value,
+					captureScope.filter,
+				);
+				break;
+			case "filter":
+				files = getMarkdownFilesMatchingFilter(app, captureScope.filter);
+				break;
+			case "tag":
+				files = getMarkdownFilesWithTag(app, captureScope.tag);
+				break;
+			case "folder":
+				files = getMarkdownFilesInFolder(app, captureScope.folderPathSlash);
+				break;
 		}
 
 		const orderedFiles = orderFilesForPicker(

--- a/src/utils/reservedVariableKeys.test.ts
+++ b/src/utils/reservedVariableKeys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isReservedVariableKey } from "./reservedVariableKeys";
+import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "../constants";
+
+describe("isReservedVariableKey", () => {
+	it("flags the reserved internal capture-target key", () => {
+		expect(isReservedVariableKey(QA_INTERNAL_CAPTURE_TARGET_FILE_PATH)).toBe(
+			true,
+		);
+	});
+
+	it("flags any key in the reserved __qa. namespace", () => {
+		expect(isReservedVariableKey("__qa.somethingNew")).toBe(true);
+		expect(isReservedVariableKey("__qa.")).toBe(true);
+	});
+
+	it("does not flag ordinary user variable names", () => {
+		expect(isReservedVariableKey("value")).toBe(false);
+		expect(isReservedVariableKey("title")).toBe(false);
+		expect(isReservedVariableKey("captureTargetFilePath")).toBe(false);
+		// A near-miss that does not start with the prefix is not reserved.
+		expect(isReservedVariableKey("my__qa.value")).toBe(false);
+		expect(isReservedVariableKey("__qaTool")).toBe(false);
+	});
+});

--- a/src/utils/reservedVariableKeys.test.ts
+++ b/src/utils/reservedVariableKeys.test.ts
@@ -14,6 +14,14 @@ describe("isReservedVariableKey", () => {
 		expect(isReservedVariableKey("__qa.")).toBe(true);
 	});
 
+	// QuickAdd resolves variable names case-insensitively, so the guard must too -
+	// otherwise a value-__QA.captureTargetFilePath variant would slip past it.
+	it("flags reserved keys case-insensitively", () => {
+		expect(isReservedVariableKey("__QA.captureTargetFilePath")).toBe(true);
+		expect(isReservedVariableKey("__Qa.captureTargetFilePath")).toBe(true);
+		expect(isReservedVariableKey("__qA.somethingNew")).toBe(true);
+	});
+
 	it("does not flag ordinary user variable names", () => {
 		expect(isReservedVariableKey("value")).toBe(false);
 		expect(isReservedVariableKey("title")).toBe(false);

--- a/src/utils/reservedVariableKeys.ts
+++ b/src/utils/reservedVariableKeys.ts
@@ -1,0 +1,15 @@
+import { RESERVED_VARIABLE_PREFIX } from "../constants";
+
+/**
+ * Whether `name` targets QuickAdd's reserved internal-variable namespace
+ * (the `__qa.` prefix). These keys drive internal preflight/runtime plumbing
+ * (e.g. the resolved capture-target file path), so they must never be accepted
+ * from across a trust boundary - an `obsidian://` URI, the CLI, AI tool output,
+ * or a synced/imported choice. Trusted in-process plumbing sets them directly.
+ *
+ * Single source of truth shared by every untrusted-input boundary so a future
+ * reserved key cannot regress one guard while the others still allow it.
+ */
+export function isReservedVariableKey(name: string): boolean {
+	return name.startsWith(RESERVED_VARIABLE_PREFIX);
+}

--- a/src/utils/reservedVariableKeys.ts
+++ b/src/utils/reservedVariableKeys.ts
@@ -9,7 +9,11 @@ import { RESERVED_VARIABLE_PREFIX } from "../constants";
  *
  * Single source of truth shared by every untrusted-input boundary so a future
  * reserved key cannot regress one guard while the others still allow it.
+ *
+ * Matched case-INSENSITIVELY because QuickAdd resolves variable names that way
+ * (resolveExistingVariableKey -> findCaseInsensitiveMatch), so a `__QA.` variant
+ * must be rejected just like `__qa.`.
  */
 export function isReservedVariableKey(name: string): boolean {
-	return name.startsWith(RESERVED_VARIABLE_PREFIX);
+	return name.toLowerCase().startsWith(RESERVED_VARIABLE_PREFIX);
 }


### PR DESCRIPTION
## Summary

Fixes a **reserved-variable injection** in Capture choices (deepsec MEDIUM). `CaptureChoiceEngine.getFormattedPathToCaptureTo()` read the reserved internal variable `__qa.captureTargetFilePath` straight out of the open executor variables map and used it as the capture destination **unconditionally**, bypassing the configured "Capture to" and the file picker.

That variable is injectable across QuickAdd's trust boundaries:

- **`obsidian://` URI** — `applyUriValueParameters()` mapped every `value-<name>` query param into the executor with no filtering, and `obsidian://` links are reachable by **any webpage or app** (the default legacy URI path applies these params regardless of the `enableUriCallbacks` setting).
- **CLI** — `value-__qa.captureTargetFilePath` / `vars` JSON.
- **`{{VALUE:__qa.…}}` tokens** in a synced/imported choice (the `{{VALUE:…}}` grammar permits dots), shared across macro-nested choices via one executor.

So an external, unauthenticated caller who knew a Capture choice's name could **redirect that choice's write - and partially control its content via `{{VALUE:…}}` - to an arbitrary in-vault note**. The path stays inside the vault (`normalizeGeneratedFilePath` rejects `.`/`..`/absolute), but redirecting *which* note is written escalates to **code execution** when the target note is later rendered by Dataview JS / Templater / a "script in note" macro.

The `__qa.` namespace was already treated as a trust boundary at the AI-tools edge (`assignableVariable.ts`); the URI/CLI/engine paths simply lacked the equivalent guard.

## Fix

Two complementary layers:

1. **Sink gate + scope confinement (the root fix).** A single shared classifier, `classifyCaptureTargetScope()`, now backs **both** the preflight requirement collector and the engine. The engine honours a preselected `__qa.captureTargetFilePath` **only** when the configured "Capture to" actually needs a runtime file pick (vault / folder / filter / property / tag) **and** confines it to that scope - folder values are re-prefixed into the folder (mirroring the interactive picker), and filter/property/tag values must be in the matched set when "create if it doesn't exist" is off. A definite-file or active-file target ignores the variable entirely. Because the engine and collector share one classifier, a legitimately collected pick is never silently dropped, and the redirect is closed for **every** injecting boundary at one choke point. The existing `resolveCaptureTarget` is kept only for non-preselected routing.

2. **Reserved-key drop at the URI boundary (defense in depth).** A shared `isReservedVariableKey()` helper (single source of truth for the `__qa.` prefix) now gates the `obsidian://` boundary (`applyUriValueParameters` drops `value-__qa.*`) and the existing AI `assignToVariable` guard. The CLI **intentionally keeps** accepting `value-__qa.captureTargetFilePath` - it is the documented non-interactive folder-pick channel, the engine now confines it, and CLI access already grants arbitrary code execution (`quickadd:run` can run a Macro). That reasoning is recorded inline.

## Why not the deepsec-suggested "drop `__qa.*` at the CLI boundary"

A naive boundary drop at the CLI would break a **tested** feature: a headless caller sets `value-__qa.captureTargetFilePath` to pick a destination within a folder/tag/property scope (`collectChoiceRequirements.test.ts` "allows a CLI-provided target path to satisfy an empty create-enabled scope"; the CLI's own `missingFlags` suggests that exact flag). Fixing at the **sink** keeps that feature working while closing the redirect for all boundaries.

## Testing

**Unit (red → green):** new `captureTargetScope.test.ts` and `reservedVariableKeys.test.ts`; new security cases in `CaptureChoiceEngine.selection.test.ts` (fixed-file/active-file ignore the injected var; folder/vault honour an in-scope pick; out-of-folder value confined; out-of-set filter value rejected). The collector refactor is behaviour-preserving - all existing `collectChoiceRequirements` tests pass unchanged.

**Live Obsidian e2e (red before / green after, real vault, app 1.13.0):** a fixed-file Capture choice (`Capture to: Inbox.md`) driven with an injected `value-__qa.captureTargetFilePath=Secrets/Payload.md` via **both** the real `obsidian://quickadd` protocol handler **and** `quickadd:run`:

| | pre-fix | post-fix |
|---|---|---|
| CLI vector | wrote `Secrets/Payload.md`, `Inbox.md` empty | wrote `Inbox.md`, no `Secrets/` |
| URI vector | wrote `Secrets/UriPayload.md`, `Inbox.md` empty | wrote `Inbox.md`, no `Secrets/` |

Legit flow smoke (post-fix): a folder-scoped choice honours an in-scope `value-__qa.captureTargetFilePath=Notes/Picked.md`, and an out-of-scope `Outside/Evil.md` is confined to `Notes/Outside/Evil.md` (never the vault root).

Adversarial review (Codex) surfaced two further holes, both fixed and live-verified: a `value-__QA.…` case-variant is now dropped (QuickAdd resolves variables case-insensitively); and a create-enabled filter/property/tag scope rejects an injected **existing** note it does not match (which would append to e.g. a Dataview-rendered note) while still allowing a **new** name - confirmed live (injected existing `Secrets/Dangerous.md` left untouched, new `Work/Fresh.md` created).

**Gates:** `tsc -noEmit`, `eslint .`, `svelte-check` (0 errors), `vitest` (3388 passed) all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved “capture to” destination handling by classifying picker scope (property, tag, filter, folder) and applying preselected targets only when they fit the same scope.
* **Bug Fixes**
  * Prevented reserved internal variable keys from being overwritten via incoming URI parameters.
  * Tightened reserved preselected capture-target validation so injected out-of-scope or unsafe values reliably fall back to the standard picker flow.
* **Tests**
  * Added coverage for reserved variable key handling, scope classification, and security-focused capture-target injection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->