### PR TITLE
fix(security): reject import packages with divergent same-id choices

### DIFF
--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -41,6 +41,7 @@ import {
 	analysePackagePreview,
 	applyPackageImport,
 } from "./packageImportService";
+import { buildPackage } from "./packageExportService";
 import { assertWriteStaysInVault } from "../utils/vaultWriteGuards";
 import type {
 	ChoiceImportDecision,
@@ -306,6 +307,159 @@ describe("parseQuickAddPackage", () => {
 		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
 			/duplicate asset path/i,
 		);
+	});
+
+	it("rejects a Multi inline child that DIVERGES from its same-id top-level entry", () => {
+		// Disclosure bypass: the preview walks the benign top-level entry and SKIPS
+		// the same-id inline child (entryIds.has -> continue), while applyPackageImport
+		// installs the inline child and drops the entry. A crafted package pairs a
+		// benign entry (runOnStartup:false, no commands) with a malicious inline child
+		// (runOnStartup:true + an Obsidian command) so the import auto-runs an
+		// undisclosed macro on startup with hasCritical=false. Reject at the boundary.
+		const maliciousInline: IChoice = {
+			id: "m",
+			name: "M",
+			type: "Macro",
+			command: false,
+			runOnStartup: true,
+			macro: {
+				id: "macro-m",
+				name: "M",
+				commands: [
+					{
+						id: "c1",
+						name: "Toggle",
+						type: CommandType.Obsidian,
+						commandId: "app:toggle-left-sidebar",
+					},
+				],
+			},
+		} as unknown as IChoice;
+		const benignEntry: IChoice = {
+			id: "m",
+			name: "M",
+			type: "Macro",
+			command: false,
+			runOnStartup: false,
+			macro: { id: "macro-m", name: "M", commands: [] },
+		} as unknown as IChoice;
+		const folder = makeMulti("folder", "Folder", [maliciousInline]);
+		const bad = makePackage({
+			rootChoiceIds: ["folder"],
+			choices: [
+				makePackageChoice(folder, null, ["Folder"]),
+				makePackageChoice(benignEntry, "folder", ["Folder", "M"]),
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/conflicting definitions for choice "m"/,
+		);
+	});
+
+	it("rejects divergence even when only a single field (runOnStartup) differs", () => {
+		// The cleanest abuse needs no bundled asset: runOnStartup is a critical row
+		// derived purely from the choice during the walk. A one-bit divergence between
+		// the benign entry and the installed inline copy must still fail closed.
+		const inline = {
+			id: "m",
+			name: "M",
+			type: "Macro",
+			command: false,
+			runOnStartup: true,
+			macro: { id: "macro-m", name: "M", commands: [] },
+		} as unknown as IChoice;
+		const entry = {
+			...inline,
+			runOnStartup: false,
+		} as unknown as IChoice;
+		const bad = makePackage({
+			rootChoiceIds: ["folder"],
+			choices: [
+				makePackageChoice(makeMulti("folder", "Folder", [inline]), null, [
+					"Folder",
+				]),
+				makePackageChoice(entry, "folder", ["Folder", "M"]),
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/conflicting definitions/,
+		);
+	});
+
+	it("accepts a nested package whose inline child EQUALS its same-id entry", () => {
+		// The legitimate exported shape: the child appears both inline in its parent
+		// Multi and as its own entry, but the two are identical. This must still parse.
+		const child = makeChoice("child", "Child", "Template");
+		const parent = makeMulti("parent", "Parent", [child]);
+		const ok = makePackage({
+			rootChoiceIds: ["parent"],
+			choices: [
+				makePackageChoice(parent, null, ["Parent"]),
+				makePackageChoice(child, "parent", ["Parent", "Child"]),
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(ok))).not.toThrow();
+	});
+
+	it("accepts identical appearances that differ only in JSON key order", () => {
+		// The consistency check is key-order-insensitive, so a re-serialized-but-equal
+		// package (e.g. round-tripped through a tool that reorders object keys) is not
+		// wrongly rejected.
+		const inlineRaw = `{"type":"Template","id":"child","name":"Child","command":false}`;
+		const entryRaw = `{"command":false,"name":"Child","id":"child","type":"Template"}`;
+		const raw = `{
+			"schemaVersion": 1,
+			"quickAddVersion": "1.18.0",
+			"createdAt": "2026-06-01T00:00:00.000Z",
+			"rootChoiceIds": ["parent"],
+			"choices": [
+				{ "choice": {"id":"parent","name":"Parent","type":"Multi","command":false,"collapsed":false,"choices":[${inlineRaw}]}, "pathHint": ["Parent"], "parentChoiceId": null },
+				{ "choice": ${entryRaw}, "pathHint": ["Parent","Child"], "parentChoiceId": "parent" }
+			],
+			"assets": []
+		}`;
+		expect(() => parseQuickAddPackage(raw)).not.toThrow();
+	});
+
+	it("accepts a real exported package round-trip (no false rejection of runOnStartup macros)", async () => {
+		// Gold anti-false-rejection proof: build a package from a live nested tree the
+		// SAME way the exporter does, then parse it. buildPackage emits the child both
+		// inline in its parent and as its own entry; both are clones of one source, so
+		// the consistency check must accept it - even though the macro is runOnStartup.
+		const { app } = createFakeApp();
+		const childMacro = {
+			id: "child",
+			name: "Child",
+			type: "Macro",
+			command: false,
+			runOnStartup: true,
+			macro: {
+				id: "macro-child",
+				name: "Child",
+				commands: [
+					{
+						id: "c1",
+						name: "Toggle",
+						type: CommandType.Obsidian,
+						commandId: "app:toggle-left-sidebar",
+					},
+				],
+			},
+		} as unknown as IChoice;
+		const parent = makeMulti("parent", "Parent", [childMacro]);
+		const { pkg } = await buildPackage(app, {
+			choices: [parent],
+			rootChoiceIds: ["parent"],
+			quickAddVersion: "1.18.0",
+			createdAt: "2026-06-01T00:00:00.000Z",
+		});
+		// The exporter really did emit both appearances of "child".
+		const childAppearances = pkg.choices.filter((c) => c.choice.id === "child");
+		expect(childAppearances.length).toBe(1); // one flat entry
+		const parentEntry = pkg.choices.find((c) => c.choice.id === "parent");
+		expect((parentEntry?.choice as IMultiChoice).choices[0].id).toBe("child"); // + inline
+		// And the consistency check accepts it.
+		expect(() => parseQuickAddPackage(JSON.stringify(pkg))).not.toThrow();
 	});
 });
 

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -141,6 +141,29 @@ export function parseQuickAddPackage(raw: string): QuickAddPackage {
 		);
 	}
 
+	// Reject internally-inconsistent choices at the untrusted-input boundary. The
+	// same choice id can appear in MORE than one place in a package: as a flat
+	// `pkg.choices` entry AND inline inside a Multi's `choices` array (or as a
+	// NestedChoice/Conditional-branch embedded choice). The preview and the writer
+	// each pick ONE of those copies and assume the others are identical:
+	// buildPackagePreview's walk SKIPS an inline Multi child whose id is also an
+	// entry (trusting the entry's walk to cover it), while applyPackageImport's
+	// remapChoiceTree INSTALLS the inline copy and drops the standalone entry. A
+	// crafted package can make those copies DIVERGE — a benign top-level entry that
+	// the preview discloses, paired with a malicious inline child (e.g.
+	// runOnStartup:true) that actually installs — suppressing the capability
+	// disclosure and acknowledgement gate entirely. The structural validator
+	// (isQuickAddPackage) never checks this. A legitimately-exported package always
+	// clones every appearance of an id from one source choice, so all appearances
+	// are identical; divergence implies tampering. Fail closed so the copy the user
+	// reviews is provably the copy that installs.
+	const divergentChoiceId = findDivergentChoiceId(parsed.choices);
+	if (divergentChoiceId !== null) {
+		throw new Error(
+			`Package contains conflicting definitions for choice "${divergentChoiceId}". Each choice id must describe the same choice everywhere it appears.`,
+		);
+	}
+
 	return parsed;
 }
 
@@ -159,6 +182,105 @@ function findDuplicateAssetPath(
 		seen.add(key);
 	}
 	return null;
+}
+
+/**
+ * The id of the first choice that appears more than once in the package with
+ * DIFFERENT content, or null if every id is internally consistent.
+ *
+ * Walks every choice node anywhere in the package — flat `pkg.choices` entries
+ * plus all descendants reachable via Multi `choices`, Macro-command
+ * `NestedChoice` embedded choices, and Conditional then/else branches — keyed by
+ * `choice.id`, and compares a canonical serialization of each appearance. The
+ * comparison is over the FULL subtree (a divergence deep inside is caught at both
+ * the inner id and every enclosing id), key-order-insensitive (so it never
+ * false-rejects a re-serialized-but-equal package), and array-order-sensitive (so
+ * a reordered command list — which changes behavior — counts as divergent).
+ */
+function findDivergentChoiceId(
+	choices: QuickAddPackage["choices"],
+): string | null {
+	const canonicalById = new Map<string, string>();
+	let divergentId: string | null = null;
+
+	const visit = (choice: IChoice | null | undefined): void => {
+		if (divergentId !== null) return;
+		if (!choice || typeof choice !== "object") return;
+
+		const id = (choice as { id?: unknown }).id;
+		if (typeof id === "string") {
+			const canonical = canonicalizeJsonValue(choice);
+			const prior = canonicalById.get(id);
+			if (prior === undefined) {
+				canonicalById.set(id, canonical);
+			} else if (prior !== canonical) {
+				divergentId = id;
+				return;
+			}
+		}
+
+		if (choice.type === "Multi") {
+			const multi = choice as IMultiChoice;
+			if (Array.isArray(multi.choices)) {
+				for (const child of multi.choices) visit(child);
+			}
+		}
+
+		if (choice.type === "Macro") {
+			const macro = choice as IMacroChoice;
+			visitNestedChoicesInCommands(macro.macro?.commands, visit);
+		}
+	};
+
+	for (const entry of choices) {
+		if (divergentId !== null) break;
+		visit(entry?.choice);
+	}
+
+	return divergentId;
+}
+
+function visitNestedChoicesInCommands(
+	commands: ICommand[] | undefined,
+	visit: (choice: IChoice | null | undefined) => void,
+): void {
+	if (!Array.isArray(commands)) return;
+	for (const command of commands) {
+		if (!command) continue;
+		if (command.type === CommandType.NestedChoice) {
+			visit((command as INestedChoiceCommand).choice);
+		} else if (command.type === CommandType.Conditional) {
+			const conditional = command as IConditionalCommand;
+			visitNestedChoicesInCommands(conditional.thenCommands, visit);
+			visitNestedChoicesInCommands(conditional.elseCommands, visit);
+		}
+	}
+}
+
+/**
+ * Deterministic, lossless serialization of a JSON value (the parsed package only
+ * ever holds JSON primitives, arrays, and plain objects). Object keys are sorted
+ * so two appearances that differ only in key order compare equal, while array
+ * order is preserved so a reordered list compares unequal. `JSON.parse` exposes a
+ * payload `__proto__` as an OWN enumerable property (it does not pollute the
+ * prototype), so `Object.keys` includes it and divergence there is still caught.
+ */
+function canonicalizeJsonValue(value: unknown): string {
+	if (value === null || typeof value !== "object") {
+		const serialized = JSON.stringify(value);
+		// `undefined` (not valid JSON, never produced by JSON.parse) stringifies to
+		// the JS value `undefined`; encode it distinctly so it can't collide with a
+		// real value.
+		return serialized === undefined ? " undefined" : serialized;
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(canonicalizeJsonValue).join(",")}]`;
+	}
+	const record = value as Record<string, unknown>;
+	const keys = Object.keys(record).sort();
+	return `{${keys
+		.map((key) => `${JSON.stringify(key)}:${canonicalizeJsonValue(record[key])}`)
+		.join(",")}}`;
 }
 
 export async function analysePackage(

--- a/src/services/packagePreview.ts
+++ b/src/services/packagePreview.ts
@@ -415,6 +415,12 @@ function walkPackage(pkg: QuickAddPackage): PackageWalk {
 	// inline-only child (present in a Multi.choices array but NOT an entry) is
 	// recursed and attributed to its host — so a crafted package can't hide a
 	// capability by inlining a child without listing it as an entry.
+	//
+	// Skipping the same-id inline child is only safe because parseQuickAddPackage
+	// (findDivergentChoiceId) rejects any package whose inline child diverges from
+	// its same-id entry: the copy walked here is provably the copy applyPackageImport
+	// installs. Without that boundary check a benign entry could mask a malicious
+	// inline child (e.g. runOnStartup:true) and suppress the disclosure gate.
 	const entryIds = new Set(pkg.choices.map((entry) => entry.choice.id));
 
 	for (const entry of pkg.choices) {


### PR DESCRIPTION
## What

`parseQuickAddPackage` now rejects an untrusted `.quickadd.json` package whose
same `choice.id` appears more than once with **divergent content**, closing a
disclosure / acknowledgement-gate bypass in the package importer.

## Why (the bug)

The same choice id can appear in a package both as a flat `pkg.choices` entry
**and** inline inside a Multi's `choices` array (this is how the exporter
serializes nested choices). The preview and the writer each trust a *different*
copy and assume they're identical:

- `buildPackagePreview` / `walkPackage` **skips** an inline Multi child whose id
  is also a top-level entry (`if (entryIds.has(child.id)) continue;`), trusting
  the entry's walk to cover it.
- `applyPackageImport` / `remapChoiceTree` **installs the inline copy** and drops
  the standalone entry (`Parent will be handled separately`).

`isQuickAddPackage` is purely structural and never verifies the two copies match,
so a crafted package can make them **diverge**: a benign top-level entry that the
preview discloses, paired with a malicious inline Multi child that actually
installs. The cleanest abuse needs no bundled asset - `runOnStartup` is a
critical capability derived purely from the choice during the walk:

> entry `M'` (id `m`, `runOnStartup:false`, benign) + inline child `M` (id `m`,
> `runOnStartup:true` + an Obsidian command) inside Multi `Folder`

The preview walks the benign entry and skips the malicious inline child →
`hasCritical=false`, `runsOnStartup=false`, `requiresAcknowledgement()=false`
(gate fully suppressed). The install keeps the inline child and drops the entry,
so a never-disclosed macro auto-runs on **every Obsidian start**.

The asset-level floor still flags bundled executable scripts, so this is limited
to the disclosure / acknowledgement-gate bypass (run-on-startup, obsidian-command,
capture-writes, nested user-scripts), not new-code RCE - consistent with MEDIUM.

## The fix

After the existing duplicate-asset-path rejection (same untrusted-input
boundary, same "what you review is what lands" rationale), `findDivergentChoiceId`
collects **every** choice node anywhere in the package - flat entries + all
descendants via `Multi.choices`, Macro-command `NestedChoice.choice`, and
`Conditional` then/else branches - groups by `choice.id`, and compares a
canonical serialization of each appearance. If any id diverges, the whole import
is rejected.

`canonicalizeJsonValue` is key-order-insensitive (never false-rejects a
re-serialized-but-equal package) and array-order-sensitive (a reordered command
list counts as divergent). A legitimately-exported package always clones every
appearance of an id from one source choice (`buildPackage` →
`deepClone` + `pruneChoiceTree` against one global `includedChoiceIds` set), so
all appearances are byte-identical and **no real package is rejected**;
divergence implies tampering. The `walkPackage` comment was updated to document
that the skip-by-id is only safe because of this parse-time invariant.

## Proof (red → green)

**Pure-function reproduction** through the real `buildPackagePreview` +
`applyPackageImport`: pre-fix the preview reports `hasCritical=false` while the
installed macro has `runOnStartup=true` with its command.

**Live Obsidian 1.13.0** via the real user path
(`quickadd:package-preview` → `readQuickAddPackage` → `parseQuickAddPackage`):

| | exploit package | legit nested package |
|---|---|---|
| **before** | `ok:true, hasCritical:false, runsOnStartup:false` (gate suppressed) | `ok:true` |
| **after** | `ok:false, error: "Package contains conflicting definitions for choice \"m\"…"` | `ok:true` (no false rejection) |

## Tests

New `parseQuickAddPackage` unit tests: rejects divergent inline-vs-entry,
rejects single-field (`runOnStartup`) divergence, accepts identical inline+entry,
accepts key-order-only differences, and an **export→import round-trip** proving a
real `buildPackage` output (with a `runOnStartup` nested macro) parses cleanly -
the anti-false-rejection proof.

## Risk / review notes

- Single untrusted-input boundary: both the CLI (`readQuickAddPackage`) and the
  Svelte `ImportPackageModal` parse once and feed the same object to preview and
  install, so the gate validates the exact graph both downstream paths consume.
- Does **not** touch / regress #1445 (non-`.md` bundled-asset disclosure,
  duplicate `originalPath`, colliding resolved-dest) - purely additive, zero
  deletions.
- An adversarial review confirmed no false-rejection, no canonical-equal bypass
  (array order, JSON-parsed `__proto__` own-key, key-with-`:` impersonation all
  handled), and complete node coverage. The one LOW note - `canonicalizeJsonValue`
  is unguarded recursion that stack-overflows at ~3000 nesting depth - is left
  as-is: it fails closed (rejects), both callers catch it, and it matches the
  pervasive unguarded-recursion idiom in this path (JSON.parse ~6000,
  preview-walk ~8000); no real package nests folders that deep.

Gates: `tsc --noEmit`, `eslint .`, `svelte-check` (0 errors), `vitest`
(3449 passed) all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package import consistency so matching nested and top-level entries are handled correctly.
  * Prevented invalid package definitions from being accepted when a nested entry differs from its top-level counterpart, reducing import errors and unexpected behavior.
  * Made package parsing more reliable for equivalent JSON data regardless of key order.
  * Added coverage for exporting and re-importing packages to help avoid false rejections of valid setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->