### PR TITLE
docs(examples): make togglManager fail gracefully on unmatched Toggl project

### DIFF
--- a/docs/static/scripts/togglManager.js
+++ b/docs/static/scripts/togglManager.js
@@ -40,7 +40,7 @@ module.exports = async function togglManager(params) {
     quickAddApi = params.quickAddApi;
     projects = await togglApi.getProjects();
 
-    openMainMenu(menu);
+    await openMainMenu(menu);
 }
 
 const dateInSeconds = (date) => {
@@ -74,7 +74,11 @@ async function openSubMenu(project) {
     }
 
     const entryName = project.menuOptions[choice];
-    const projectID = projects.find(p => p.name === project.togglProjectName).id;
+    const togglProject = projects.find(p => p.name === project.togglProjectName);
+    if (!togglProject) {
+        new Notice(`Toggl project "${project.togglProjectName}" not found. Edit the menu in togglManager.js to match your Toggl projects.`, 5000);
+        return;
+    }
 
-    startTimer(entryName, projectID);
+    await startTimer(entryName, togglProject.id);
 }


### PR DESCRIPTION
## What & why

The `togglManager` example macro (`docs/static/scripts/togglManager.js`) looked up the Toggl project by name and immediately dereferenced the result:

```js
const projectID = projects.find(p => p.name === project.togglProjectName).id;
```

`projects` comes from the user's real Toggl account (`togglApi.getProjects()`), while `project.togglProjectName` comes from a menu hardcoded to the **original author's** personal project names (`"Learning & Skill Development"`, `"Personal"`, `"School"`). Any user who runs the example as-is - or who edits the menu and renames/mistypes a project - gets no match, `find()` returns `undefined`, and `.id` throws `TypeError: Cannot read properties of undefined (reading 'id')`, aborting the macro with an opaque message.

This is **not a security issue** - both the Toggl data and the menu are the vault owner's own, no trust boundary is crossed. It is a latent robustness crash, the same class previously hardened in the BookFinder (#1436) and EzImport (#1447) example scripts. Source: deepsec `other-null-deref`, severity BUG.

## The fix

1. **Guard the lookup** and surface a friendly, actionable `Notice` naming the missing project instead of crashing.
2. **`await` the two fire-and-forget calls** (`openMainMenu(menu)` at the entry point and `startTimer(...)`). Previously `togglManager` resolved while the menu was still open, so any failure - the original `TypeError`, or a failed `startTimer()` (Toggl auth/network) - escaped as an *unhandled process-level rejection* that QuickAdd's macro error handler never sees. Awaiting the chain routes every failure back to QuickAdd as a normal script error. This is the root cause of why the original crash was opaque, so fixing it here keeps the proof honest.

```diff
-    openMainMenu(menu);
+    await openMainMenu(menu);
...
-    const projectID = projects.find(p => p.name === project.togglProjectName).id;
+    const togglProject = projects.find(p => p.name === project.togglProjectName);
+    if (!togglProject) {
+        new Notice(`Toggl project "${project.togglProjectName}" not found. Edit the menu in togglManager.js to match your Toggl projects.`, 5000);
+        return;
+    }
-    startTimer(entryName, projectID);
+    await startTimer(entryName, togglProject.id);
```

`new Notice(...)` is used bare (no `require("obsidian")`), matching the sibling examples (BookFinder, EzImport, citationsManager, ...); the `Notice` global resolves to a `function` in the live isolated runtime.

## Proof (local harness driving the real `togglManager(params)` entry point)

| Scenario | Before | After |
|---|---|---|
| **no matching project** (the finding) | `TypeError ... reading 'id'` at `:77`, crashes the macro as an unhandled rejection | exit 0, friendly Notice naming the project, no `startTimer` |
| **matching project** (happy path) | `startTimer` called with correct `pid` | unchanged - `startTimer` called with correct `pid`, no Notice |
| **matching project, `startTimer()` rejects** | resolves "ok" then crashes the process with an unhandled rejection | error propagates as a **catchable** throw from `togglManager()` -> reaches QuickAdd's macro error handler |

Per repo convention for example scripts, the harness is local-only and not committed.

## Gates

`tsc -noEmit` ✅ · `eslint .` ✅ · `svelte-check --threshold error` ✅ (0 errors) · `vitest` ✅ (3449 passed, 37 skipped)

`docs/**` is eslint-ignored and `.js` isn't in `tsconfig` (`**/*.ts`), so the example script is invisible to the gates; they confirm nothing else regressed. Ships as `docs(examples):` - semantic-release won't cut a release.

## Adversarial review

Challenged by an opposing-model reviewer (Codex): confirmed the finding is real/reachable, `new Notice` is the correct global (verified `typeof Notice === "function"` live), and `docs(examples):` with no committed test matches repo precedent. Its one Medium finding - the leftover fire-and-forget pattern - is addressed by the two `await`s above. Declined its Low note to also guard `projects` itself being non-array (speculative broken-plugin scenario the finding doesn't cover, and would add defensive code for a problem we don't have).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submenu navigation so returning to the main menu now waits for the previous action to finish.
  * Added safer project selection when starting a timer, with a helpful message if a menu item can’t be matched.
  * Timer starts now complete properly before the next step continues, reducing unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->