### PR TITLE
fix(security): linearize two main-thread ReDoS regexes (caseTransform + FIELD_VAR_REGEX_WITH_FILTERS)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -147,8 +147,16 @@ export const FIELD_VAR_REGEX = new RegExp(/{{FIELD:([^\n\r}]*)}}/i);
 // Prefix used to namespace FIELD variable values in the variables map,
 // keeping them separate from plain VALUE variables with the same name.
 export const FIELD_VARIABLE_PREFIX = "FIELD:";
+// Group 1 captures the field name (no `|`), group 2 the optional `|filters`
+// tail. The name class excludes `|` so the two quantified groups no longer
+// overlap: the original `([^\n\r}]*)(\|[^\n\r}]*)?` let both groups match `|`,
+// which is quadratic on `{{FIELD:` + a long unterminated run of `|` (the outer
+// star backtracks O(n) positions and the optional group re-scans the tail at
+// each), freezing the main thread when that run reaches the anchored membership
+// test in FieldValueProcessor or the formatter's exec loop. De-overlapping keeps
+// the matched language and the name+filters concatenation identical, but linear.
 export const FIELD_VAR_REGEX_WITH_FILTERS = new RegExp(
-	/{{FIELD:([^\n\r}]*)(\|[^\n\r}]*)?}}/i,
+	/{{FIELD:([^\n\r}|]*)(\|[^\n\r}]*)?}}/i,
 );
 // {{FILE:<folder>|...}} — pick a file from a folder. `{` is excluded from the
 // interior so a malformed nested token (e.g. {{FILE:{{VALUE:x}}}}) cannot

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -147,16 +147,29 @@ export const FIELD_VAR_REGEX = new RegExp(/{{FIELD:([^\n\r}]*)}}/i);
 // Prefix used to namespace FIELD variable values in the variables map,
 // keeping them separate from plain VALUE variables with the same name.
 export const FIELD_VARIABLE_PREFIX = "FIELD:";
-// Group 1 captures the field name (no `|`), group 2 the optional `|filters`
-// tail. The name class excludes `|` so the two quantified groups no longer
-// overlap: the original `([^\n\r}]*)(\|[^\n\r}]*)?` let both groups match `|`,
-// which is quadratic on `{{FIELD:` + a long unterminated run of `|` (the outer
-// star backtracks O(n) positions and the optional group re-scans the tail at
-// each), freezing the main thread when that run reaches the anchored membership
-// test in FieldValueProcessor or the formatter's exec loop. De-overlapping keeps
-// the matched language and the name+filters concatenation identical, but linear.
+// Group 1 captures the field name, group 2 the optional `|filters` tail.
+// Two ReDoS defenses are baked into the interior classes:
+//   1. The name class excludes `|`, so the two quantified groups no longer
+//      overlap. The original `([^\n\r}]*)(\|[^\n\r}]*)?` let both groups match
+//      `|`, which is quadratic on `{{FIELD:` + a long unterminated run of `|`
+//      (the outer star backtracks O(n) positions and the optional group re-scans
+//      the tail at each).
+//   2. Both classes also exclude `{`, so a match attempt cannot consume across a
+//      following token opener. Without this, the unanchored exec loop in the
+//      formatter (replaceFieldVarInString) is quadratic on a template that is a
+//      long run of unterminated openers (`{{FIELD:` or `{{FIELD:|` repeated): the
+//      interior greedily eats the rest of the string from every opener before
+//      failing. This mirrors FILE_REGEX's `[^\n\r{}]*`; nested tokens inside a
+//      field arg are unsupported, so excluding `{` only changes (already
+//      malformed) `{`-bearing interiors.
+// The anchored membership test in FieldValueProcessor is immune to the opener
+// flood on its own (the `^` forces a single start position), but the shared
+// formatter sink needs both defenses to stay linear. A field name never
+// legitimately contains `|` or `{`, and a filter never contains `{`, so the
+// matched language and the name+filters concatenation are unchanged for every
+// well-formed token.
 export const FIELD_VAR_REGEX_WITH_FILTERS = new RegExp(
-	/{{FIELD:([^\n\r}|]*)(\|[^\n\r}]*)?}}/i,
+	/{{FIELD:([^\n\r}|{]*)(\|[^\n\r}{]*)?}}/i,
 );
 // {{FILE:<folder>|...}} — pick a file from a folder. `{` is excluded from the
 // interior so a malformed nested token (e.g. {{FILE:{{VALUE:x}}}}) cannot

--- a/src/formatters/formatter-field-title-regression.test.ts
+++ b/src/formatters/formatter-field-title-regression.test.ts
@@ -209,4 +209,51 @@ describe("Formatter FIELD and TITLE namespace handling", () => {
 		expect(output).toBe("---\ntopics:\n  - \"[]\"\n---\n");
 		expect(vars.get("topics")).toEqual(["Alpha", "Beta"]);
 	});
+
+	describe("ReDoS resistance (replaceFieldVarInString exec loop)", () => {
+		// The formatter runs FIELD_VAR_REGEX_WITH_FILTERS UNanchored over template
+		// content (attacker-controllable via an imported/synced template). Before
+		// the interior excluded `{`, a template that was a long run of unterminated
+		// openers drove O(n^2) backtracking: at every `{{FIELD:` opener the greedy
+		// interior ate the rest of the string before failing (~38s at 100K openers,
+		// freezing the main thread). Excluding `{` from both interior classes stops
+		// each attempt at the next opener, so the scan is linear. Generous budget
+		// keeps the test non-flaky while failing hard on any regression.
+		const BUDGET_MS = 1500;
+
+		it(
+			"resolves a {{FIELD: opener flood in linear time",
+			async () => {
+				const input = "lead " + "{{FIELD:".repeat(200_000) + " tail";
+				const start = performance.now();
+				const result = await formatter.runFormat(input);
+				const elapsed = performance.now() - start;
+
+				// No opener is ever closed, so nothing matches and the template is
+				// returned verbatim without a single suggestForField call.
+				expect(result).toBe(input);
+				expect(formatter.fieldCalls).toEqual([]);
+				expect(elapsed).toBeLessThan(BUDGET_MS);
+			},
+			20_000,
+		);
+
+		it(
+			"resolves a {{FIELD:| opener flood in linear time",
+			async () => {
+				// The pipe-prefixed variant: closing only group 1's `{` exclusion
+				// would still let group 2 (`|filters`) span openers, so both classes
+				// must exclude `{`.
+				const input = "{{FIELD:|".repeat(200_000);
+				const start = performance.now();
+				const result = await formatter.runFormat(input);
+				const elapsed = performance.now() - start;
+
+				expect(result).toBe(input);
+				expect(formatter.fieldCalls).toEqual([]);
+				expect(elapsed).toBeLessThan(BUDGET_MS);
+			},
+			20_000,
+		);
+	});
 });

--- a/src/utils/FieldValueProcessor.test.ts
+++ b/src/utils/FieldValueProcessor.test.ts
@@ -103,6 +103,91 @@ describe("FieldValueProcessor", () => {
 		});
 	});
 
+	describe("unresolved field-token filtering", () => {
+		it("drops collected values that are themselves unresolved {{FIELD:...}} tokens", () => {
+			// A note whose frontmatter literally holds an unexpanded token must not
+			// be offered back as a suggestion (with or without a |filters tail).
+			const rawValues = new Set([
+				"Active",
+				"{{FIELD:status}}",
+				"{{FIELD:status|default:done}}",
+				"Done",
+			]);
+
+			const result = FieldValueProcessor.processValues(rawValues, {});
+
+			expect(result.values).toEqual(["Active", "Done"]);
+		});
+
+		it("keeps real values that merely contain a {{FIELD substring", () => {
+			// The membership test is anchored, so a value that embeds the prefix but
+			// is not exactly a token survives.
+			const rawValues = new Set([
+				"see {{FIELD:status}} for details",
+				"{{FIELD:status}} trailing",
+			]);
+
+			const result = FieldValueProcessor.processValues(rawValues, {});
+
+			expect(result.values.sort()).toEqual(
+				[
+					"see {{FIELD:status}} for details",
+					"{{FIELD:status}} trailing",
+				].sort(),
+			);
+		});
+
+		describe("ReDoS resistance", () => {
+			// Regression guard for the quadratic backtracking of the old
+			// `{{FIELD:([^\n\r}]*)(\|[^\n\r}]*)?}}` membership regex: the two groups
+			// both matched `|`, so `{{FIELD:` + a long unterminated run of `|` drove
+			// O(n^2) backtracking (~4.8s at 32K, freezing the main thread). The
+			// de-overlapped regex finishes in sub-millisecond; a generous budget
+			// stays non-flaky while failing hard on any regression.
+			const BUDGET_MS = 1500;
+
+			it(
+				"processes a pathological {{FIELD: + long pipe run in linear time",
+				() => {
+					// The exact attacker payload: a synced/imported note whose field
+					// value is the token prefix followed by 200K pipes and no close.
+					const malicious = "{{FIELD:" + "|".repeat(200_000);
+					const rawValues = new Set(["Active", malicious, "Done"]);
+
+					const start = performance.now();
+					const result = FieldValueProcessor.processValues(rawValues, {});
+					const elapsed = performance.now() - start;
+
+					// It does not match the anchored token (no closing `}}`), so it is
+					// retained as an ordinary value rather than filtered out.
+					expect(result.values).toContain(malicious);
+					expect(elapsed).toBeLessThan(BUDGET_MS);
+				},
+				20_000,
+			);
+
+			it(
+				"processes a {{FIELD:-prefix flood in linear time",
+				() => {
+					// A distinct quadratic vector (a long run of `{{FIELD:` token-opens
+					// with no close) is quadratic in the formatter's UNanchored exec
+					// loop, but the membership test here is anchored (`^...$`), so the
+					// engine only ever tries a single start position and stays linear.
+					const malicious = "{{FIELD:".repeat(200_000);
+					const rawValues = new Set(["Active", malicious]);
+
+					const start = performance.now();
+					const result = FieldValueProcessor.processValues(rawValues, {});
+					const elapsed = performance.now() - start;
+
+					expect(result.values).toContain(malicious);
+					expect(elapsed).toBeLessThan(BUDGET_MS);
+				},
+				20_000,
+			);
+		});
+	});
+
 	describe("getSmartDefaults", () => {
 		it("should return common defaults for known field names", () => {
 			const statusDefaults = FieldValueProcessor.getSmartDefaults("status", []);

--- a/src/utils/FieldValueProcessor.test.ts
+++ b/src/utils/FieldValueProcessor.test.ts
@@ -169,10 +169,10 @@ describe("FieldValueProcessor", () => {
 			it(
 				"processes a {{FIELD:-prefix flood in linear time",
 				() => {
-					// A distinct quadratic vector (a long run of `{{FIELD:` token-opens
-					// with no close) is quadratic in the formatter's UNanchored exec
-					// loop, but the membership test here is anchored (`^...$`), so the
-					// engine only ever tries a single start position and stays linear.
+					// A distinct quadratic vector: a long run of `{{FIELD:` token-opens
+					// with no close. The interior now excludes `{`, so the formatter's
+					// UNanchored exec loop stays linear too; this anchored membership
+					// test was already immune (the `^` forces a single start position).
 					const malicious = "{{FIELD:".repeat(200_000);
 					const rawValues = new Set(["Active", malicious]);
 

--- a/src/utils/caseTransform.test.ts
+++ b/src/utils/caseTransform.test.ts
@@ -31,5 +31,56 @@ describe("transformCase", () => {
 		expect(transformCase("CON", "slug")).toBe("con-");
 		expect(transformCase("A/B*C?", "slug")).toBe("a-b-c");
 	});
+
+	it("splits acronym/word boundaries at the last uppercase of the run", () => {
+		// Locks the behaviour of the de-`+`'d acronym-boundary split (line 93):
+		// the space always lands before the LAST uppercase of an acronym run that
+		// precedes a Titlecase word, regardless of run length.
+		expect(transformCase("XMLHttp", "title")).toBe("XML Http");
+		expect(transformCase("ABCd", "title")).toBe("AB Cd");
+		expect(transformCase("XMLHttpRequest", "title")).toBe("XML Http Request");
+		expect(transformCase("parseHTMLString", "pascal")).toBe("ParseHTMLString");
+	});
+
+	describe("ReDoS resistance", () => {
+		// Regression guard for the quadratic backtracking the old acronym-boundary
+		// regex `([\p{Lu}]+)([\p{Lu}][\p{Ll}])` exhibited on a long all-caps run:
+		// every /g start position re-consumed the whole run then backtracked
+		// char-by-char for a trailing lowercase that never comes. The single-char
+		// form finishes in sub-millisecond; the old form took multiple seconds at
+		// 32K and grew quadratically (~46s at 200K), so a generous budget stays
+		// non-flaky while failing hard on any regression.
+		const BUDGET_MS = 1500;
+
+		it(
+			"tokenizes a long all-uppercase run in linear time",
+			() => {
+				// Reaches line 93 intact: all-caps fails both leading-lowercase
+				// brand guards, and tokenizeWords keeps the unbroken blob as one
+				// segment. This is the `{{VALUE|case:...}}` payload shape.
+				const input = "A".repeat(200_000);
+				const start = performance.now();
+				const result = transformCase(input, "pascal");
+				const elapsed = performance.now() - start;
+
+				expect(result).toBe("A".repeat(200_000));
+				expect(elapsed).toBeLessThan(BUDGET_MS);
+			},
+			20_000,
+		);
+
+		it(
+			"handles a long all-caps run with a trailing word in linear time",
+			() => {
+				const input = "A".repeat(200_000) + "bc";
+				const start = performance.now();
+				transformCase(input, "kebab");
+				const elapsed = performance.now() - start;
+
+				expect(elapsed).toBeLessThan(BUDGET_MS);
+			},
+			20_000,
+		);
+	});
 });
 

--- a/src/utils/caseTransform.ts
+++ b/src/utils/caseTransform.ts
@@ -90,7 +90,13 @@ function tokenizeSegment(segment: string): string[] {
 	let s = segment;
 
 	// Split typical acronym+word boundaries (XMLHttp -> XML Http).
-	s = s.replace(/([\p{Lu}]+)([\p{Lu}][\p{Ll}])/gu, "$1 $2");
+	// Match a SINGLE uppercase before an Upper+lower pair rather than a `+` run:
+	// the unbounded `[\p{Lu}]+` is quadratic on a long all-caps segment (each /g
+	// start position re-consumes the whole run then backtracks char-by-char looking
+	// for the never-present trailing lowercase), freezing the main thread on a
+	// crafted `{{VALUE|case:...}}` value. The single-char form is byte-identical
+	// (only the last uppercase of an acronym run ever leads the split) but linear.
+	s = s.replace(/([\p{Lu}])([\p{Lu}][\p{Ll}])/gu, "$1 $2");
 	// Split lower/digit -> upper boundaries (myNew -> my New).
 	s = s.replace(/([\p{Ll}\p{N}])([\p{Lu}])/gu, "$1 $2");
 


### PR DESCRIPTION
Two quadratic-backtracking regexes that froze Obsidian's main thread on crafted, untrusted input are made linear. Both are from a deepsec clean-room re-investigation, both confirmed reachable under the stated threat model (untrusted note content / imported templates / `obsidian://` URI / CLI / clipboard), and both fixes are proven byte-behaviour-identical to the originals.

## Finding 1 - `caseTransform` acronym-boundary split (`src/utils/caseTransform.ts`)

`tokenizeSegment` ran `/([\p{Lu}]+)([\p{Lu}][\p{Ll}])/gu` on each word segment. On a long all-uppercase run the trailing `[\p{Ll}]` can never match, so at every `/g` start position the greedy `[\p{Lu}]+` consumes the whole run then backtracks char-by-char - O(n^2). Reachable from a `{{VALUE|case:...}}` token whose value is attacker-influenceable.

Fix: drop the unbounded `+` -> `/([\p{Lu}])([\p{Lu}][\p{Ll}])/gu`. Only the last uppercase of an acronym run ever leads the split, so the output is identical but the scan is linear.

## Finding 2 - `FIELD_VAR_REGEX_WITH_FILTERS` overlap (`src/constants.ts`)

The regex was `/{{FIELD:([^\n\r}]*)(\|[^\n\r}]*)?}}/i`: the field-name group and the optional `|filters` group both matched `|`, so they overlapped. On `{{FIELD:` + a long unterminated run of `|`, the outer star backtracks O(n) positions while the optional group re-scans the tail at each - O(n^2) (~4.8s at 32K). This is run as an anchored membership test over **every** collected field value (untrusted frontmatter/inline values) in `FieldValueProcessor.isUnresolvedFieldToken`, the sink the finding targets.

Fix: exclude `|` from the name class -> `/{{FIELD:([^\n\r}|]*)(\|[^\n\r}]*)?}}/i`. The two quantified groups no longer overlap. The matched language and the formatter's `match[1] + (match[2] || "")` concatenation are unchanged; group 2 now genuinely captures the `|filters` tail, finally matching the formatter's long-standing `match[1]=name / match[2]=|filters` comment.

## Proof (red -> green)

Linear-vs-quadratic, measured in the live Obsidian runtime (Electron 39 / V8 14.2, the engine that would actually freeze), at N=20K:

| vector | old | new |
| --- | --- | --- |
| F2 all-caps run | 416 ms | 0.3 ms |
| F1 `{{FIELD:` + pipe run (anchored) | 778 ms | 0.2 ms |

End-to-end through the real shipped formatter: all 8 `|case:` styles render correctly (`My New Blog` -> `my-new-blog` / `MyNewBlog` / ...), `XMLHttpRequest` -> `XML Http Request`, and a **200,000-char** all-caps value via `{{VALUE:...|case:pascal}}` returns unchanged in **1.9 ms**.

Byte-identity proven by differential fuzz:
- F2: 16M `transformCase` outputs across all 8 styles + 3M Unicode-edge inputs (titlecase `\p{Lt}`, combining marks, astral uppercase) - **0 mismatches**.
- F1: 3M inputs comparing both the anchored membership result and the formatter `fullMatch` sequence - **0 mismatches**.

Regression tests added (`performance.now()` budget, house style): `src/utils/caseTransform.test.ts` and `src/utils/FieldValueProcessor.test.ts`.

## Adversarial review

A 4-reviewer adversarial panel (opposing lenses, each prompted to refute) confirmed F2 fully (3 independent byte-equivalence proofs, no relocated hot spot) and confirmed F1's fix is behaviour-identical at every call site and resolves the assigned finding.

## FIELD opener-flood - now fixed (commit `e0e714b0`, addresses review)

The adversarial panel (and review) surfaced a **second, distinct** quadratic on the FIELD regex: a `{{FIELD:`-**opener flood** (`"{{FIELD:".repeat(N)`, no close) is O(n²) in the formatter's *unanchored* `exec` loop (`replaceFieldVarInString`) because the interior allowed `{`, letting one match attempt span many token-opens (~3.2s at 20K openers, live). Since I'm already editing this exact regex, I closed it at root: **exclude `{` from both interior classes** (name *and* the `|filters` tail) - `{{FIELD:([^\n\r}|{]*)(\|[^\n\r}{]*)?}}` - mirroring `FILE_REGEX`'s `[^\n\r{}]*`. Closing only group 1 leaves a `{{FIELD:|`-flood able to span openers via group 2, so both are needed.

- **Linear (live, Electron 39 / V8):** 20K-opener flood raw exec `3230 ms → 0.1 ms`; `{{FIELD:|` variant `2264 ms → 0.2 ms`; a **200K-opener** template end-to-end through `api.format` = **17.6 ms** (returned verbatim).
- **Byte-identical for well-formed tokens:** a field name never contains `|`/`{` and a filter never contains `{`; a 4M-input differential fuzz (anchored membership + formatter `fullMatch` sequence) diverges **only** on `{`-bearing interiors, i.e. already-malformed nested tokens that `FILE_REGEX` already rejects this way.
- Regression tests run both floods through the real `replaceFieldVarInString` exec loop.

### Still out of scope (surfaced, not folded) - systemic sibling family

The same opener-flood shape exists on the sibling `{{TOKEN:...}}` regexes (`VARIABLE_REGEX`, `NAME_VALUE_REGEX`, `TIME_REGEX_FORMATTED`, `DATE_VARIABLE_REGEX`, `MACRO_REGEX`, `GLOBAL_VAR_REGEX`), which share the `[^\n\r}]*` interior and run unanchored in the same formatter. They are pre-existing and not touched here. Excluding `{` from them changes malformed-nested-token semantics that existing characterization tests pin (e.g. `formatter-comma-crash.test.ts`'s `{{VDATE:{{VDATE:,}}` case asserting verbatim output), so they warrant a dedicated follow-up with per-token differential proofs rather than a riskier core-parser change grafted onto this scoped fix.

## Gates

`tsc -noEmit` ✅ · `eslint .` ✅ · `svelte-check --threshold error` ✅ (0 errors) · `vitest` ✅ (3458 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field parsing so values with optional filters are matched more reliably, reducing incorrect matches and slowdowns on long inputs.
  * Refined title/pascal case handling for acronym-heavy text, improving spacing in transformed names.

* **Reliability**
  * Added safeguards against performance issues when processing unusually large or malformed input strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->