### PR TITLE
fix(security): retry secret migration instead of stranding plaintext API keys

### DIFF
--- a/src/migrations/Migrations.ts
+++ b/src/migrations/Migrations.ts
@@ -2,16 +2,17 @@ import type QuickAdd from "src/main";
 import type { QuickAddSettings } from "src/settings";
 
 /**
- * Result a migration may return to control whether it is marked done.
+ * Result a migration may return to keep itself pending.
  *
  * Migrations are run exactly once and then flagged complete forever, so a
  * migration that could not finish its work this launch (e.g. an environment
  * that lacks a required capability, or a transient failure) must be able to
  * stay pending and retry on a later launch. Returning `{ complete: false }`
  * keeps the migration's flag unset; any partial progress it persisted to the
- * settings store is still kept. Returning `void`/`undefined` means "done".
+ * settings store is still kept. Returning `void`/`undefined` means "done" -
+ * there is no `{ complete: true }`, since that is just `void`.
  */
-export type MigrationResult = { complete: boolean };
+export type MigrationResult = { complete: false };
 
 export type Migration = {
 	description: string;

--- a/src/migrations/Migrations.ts
+++ b/src/migrations/Migrations.ts
@@ -1,9 +1,21 @@
 import type QuickAdd from "src/main";
 import type { QuickAddSettings } from "src/settings";
 
+/**
+ * Result a migration may return to control whether it is marked done.
+ *
+ * Migrations are run exactly once and then flagged complete forever, so a
+ * migration that could not finish its work this launch (e.g. an environment
+ * that lacks a required capability, or a transient failure) must be able to
+ * stay pending and retry on a later launch. Returning `{ complete: false }`
+ * keeps the migration's flag unset; any partial progress it persisted to the
+ * settings store is still kept. Returning `void`/`undefined` means "done".
+ */
+export type MigrationResult = { complete: boolean };
+
 export type Migration = {
 	description: string;
-	migrate: (plugin: QuickAdd) => Promise<void>;
+	migrate: (plugin: QuickAdd) => Promise<MigrationResult | void>;
 };
 
 export type Migrations = {

--- a/src/migrations/migrate.test.ts
+++ b/src/migrations/migrate.test.ts
@@ -703,6 +703,43 @@ describe("Migration completeness signal (retry on incomplete)", () => {
 		expect(plugin.settings.ai.providers[0].apiKey).toBe("sk-legacy-plaintext");
 	});
 
+	it("completes the secret migration on a SecretStorage-less build when there is nothing to migrate", async () => {
+		const loaded = {
+			...structuredClone(DEFAULT_SETTINGS),
+			ai: {
+				...structuredClone(DEFAULT_SETTINGS.ai),
+				providers: [
+					{
+						name: "OpenAI",
+						endpoint: "https://api.openai.com/v1",
+						apiKey: "",
+						apiKeyRef: "quickadd-ai-openai",
+						models: [],
+						modelSource: "providerApi" as const,
+					},
+				],
+			},
+			migrations: allOtherMigrationsComplete(
+				"migrateProviderApiKeysToSecretStorage",
+			),
+		};
+		settingsStore.replaceState(structuredClone(loaded));
+
+		// No SecretStorage AND no plaintext key: the goal already holds, so the
+		// migration should drain instead of re-running forever.
+		const plugin: any = {
+			app: {},
+			settings: structuredClone(loaded),
+			saveSettings: vi.fn(),
+		};
+
+		await migrate(plugin);
+
+		expect(
+			plugin.settings.migrations.migrateProviderApiKeysToSecretStorage,
+		).toBe(true);
+	});
+
 	it("marks the secret migration complete when there are no plaintext keys to move", async () => {
 		const loaded = {
 			...structuredClone(DEFAULT_SETTINGS),

--- a/src/migrations/migrate.test.ts
+++ b/src/migrations/migrate.test.ts
@@ -8,6 +8,7 @@ vi.mock("src/logger/logManager", () => ({
 	log: {
 		logMessage: vi.fn(),
 		logError: vi.fn(),
+		logWarning: vi.fn(),
 	},
 }));
 
@@ -576,5 +577,165 @@ describe("Migration Re-entrance Safety", () => {
 			expect(choice.macro.name).toBe("Custom Macro");
 			expect(choice.macroId).toBeUndefined();
 		});
+	});
+});
+
+/**
+ * Regression coverage for the secret-hygiene bug: a migration that could not
+ * complete its work (e.g. SecretStorage was unavailable on this launch) must
+ * NOT be permanently marked done. Otherwise legacy plaintext API keys are left
+ * in data.json forever and never retried once SecretStorage becomes available.
+ */
+describe("Migration completeness signal (retry on incomplete)", () => {
+	function allOtherMigrationsComplete(
+		except: keyof typeof DEFAULT_SETTINGS.migrations,
+	) {
+		const flags = Object.fromEntries(
+			Object.keys(DEFAULT_SETTINGS.migrations).map((key) => [key, true]),
+		) as typeof DEFAULT_SETTINGS.migrations;
+		flags[except] = false;
+		return flags;
+	}
+
+	function mapBackedSecretStorage() {
+		const store = new Map<string, string>();
+		return {
+			store,
+			secretStorage: {
+				getSecret: (id: string) => store.get(id) ?? null,
+				setSecret: (id: string, value: string) => {
+					store.set(id, value);
+				},
+			},
+		};
+	}
+
+	function seedLegacyProvider(apiKey: string) {
+		return {
+			...structuredClone(DEFAULT_SETTINGS),
+			ai: {
+				...structuredClone(DEFAULT_SETTINGS.ai),
+				providers: [
+					{
+						name: "OpenAI",
+						endpoint: "https://api.openai.com/v1",
+						apiKey,
+						models: [],
+						modelSource: "providerApi" as const,
+					},
+				],
+			},
+			migrations: allOtherMigrationsComplete(
+				"migrateProviderApiKeysToSecretStorage",
+			),
+		};
+	}
+
+	beforeEach(() => {
+		settingsStore.replaceState(structuredClone(DEFAULT_SETTINGS));
+	});
+
+	afterEach(() => {
+		settingsStore.replaceState(structuredClone(DEFAULT_SETTINGS));
+	});
+
+	it("leaves the secret migration pending when SecretStorage is unavailable, then completes on a later SecretStorage-capable launch", async () => {
+		const loaded = seedLegacyProvider("sk-legacy-plaintext");
+
+		// Launch 1: old Obsidian / mobile - no SecretStorage.
+		settingsStore.replaceState(structuredClone(loaded));
+		const launch1: any = {
+			app: {},
+			settings: structuredClone(loaded),
+			saveSettings: vi.fn(),
+		};
+		await migrate(launch1);
+
+		// The plaintext key cannot be moved, so the migration must stay pending
+		// and the key must remain intact (still resolvable via the fallback).
+		expect(
+			launch1.settings.migrations.migrateProviderApiKeysToSecretStorage,
+		).toBe(false);
+		expect(launch1.settings.ai.providers[0].apiKey).toBe(
+			"sk-legacy-plaintext",
+		);
+
+		// Launch 2: user upgraded / opened on desktop - SecretStorage now exists.
+		const { store, secretStorage } = mapBackedSecretStorage();
+		settingsStore.replaceState(structuredClone(launch1.settings));
+		const launch2: any = {
+			app: { secretStorage },
+			settings: structuredClone(launch1.settings),
+			saveSettings: vi.fn(),
+		};
+		await migrate(launch2);
+
+		const migratedProvider = launch2.settings.ai.providers[0];
+		expect(
+			launch2.settings.migrations.migrateProviderApiKeysToSecretStorage,
+		).toBe(true);
+		expect(migratedProvider.apiKey).toBe("");
+		expect(migratedProvider.apiKeyRef).toBeTruthy();
+		expect(store.get(migratedProvider.apiKeyRef)).toBe("sk-legacy-plaintext");
+	});
+
+	it("leaves the secret migration pending when a provider key fails to move", async () => {
+		const loaded = seedLegacyProvider("sk-legacy-plaintext");
+		settingsStore.replaceState(structuredClone(loaded));
+
+		const secretStorage = {
+			getSecret: vi.fn().mockReturnValue(null),
+			setSecret: vi.fn(() => {
+				throw new Error("write failed");
+			}),
+		};
+		const plugin: any = {
+			app: { secretStorage },
+			settings: structuredClone(loaded),
+			saveSettings: vi.fn(),
+		};
+
+		await migrate(plugin);
+
+		expect(
+			plugin.settings.migrations.migrateProviderApiKeysToSecretStorage,
+		).toBe(false);
+		expect(plugin.settings.ai.providers[0].apiKey).toBe("sk-legacy-plaintext");
+	});
+
+	it("marks the secret migration complete when there are no plaintext keys to move", async () => {
+		const loaded = {
+			...structuredClone(DEFAULT_SETTINGS),
+			ai: {
+				...structuredClone(DEFAULT_SETTINGS.ai),
+				providers: [
+					{
+						name: "OpenAI",
+						endpoint: "https://api.openai.com/v1",
+						apiKey: "",
+						apiKeyRef: "quickadd-ai-openai",
+						models: [],
+						modelSource: "providerApi" as const,
+					},
+				],
+			},
+			migrations: allOtherMigrationsComplete(
+				"migrateProviderApiKeysToSecretStorage",
+			),
+		};
+		settingsStore.replaceState(structuredClone(loaded));
+
+		const { secretStorage } = mapBackedSecretStorage();
+		const plugin: any = {
+			app: { secretStorage },
+			settings: structuredClone(loaded),
+			saveSettings: vi.fn(),
+		};
+
+		await migrate(plugin);
+
+		expect(
+			plugin.settings.migrations.migrateProviderApiKeysToSecretStorage,
+		).toBe(true);
 	});
 });

--- a/src/migrations/migrate.ts
+++ b/src/migrations/migrate.ts
@@ -56,16 +56,26 @@ async function migrate(plugin: QuickAdd): Promise<void> {
 		const storeBeforeMigration = settingsStore.getState();
 
 		try {
-			await migrations[migration].migrate(plugin);
+			const result = await migrations[migration].migrate(plugin);
 
 			if (settingsStore.getState() !== storeBeforeMigration) {
 				plugin.settings = deepClone(settingsStore.getState());
 			}
 
-			plugin.settings.migrations[migration] = true;
+			// A migration may report that it could not finish (e.g. a required
+			// capability was unavailable this launch). Persist any partial
+			// progress it made, but leave the flag unset so it retries later.
+			const incomplete = result?.complete === false;
+			if (!incomplete) {
+				plugin.settings.migrations[migration] = true;
+			}
 			settingsStore.replaceState(deepClone(plugin.settings));
 
-			log.logMessage(`Migration ${migration} successful.`);
+			log.logMessage(
+				incomplete
+					? `Migration ${migration} incomplete; will retry on a later launch.`
+					: `Migration ${migration} successful.`
+			);
 		} catch (error) {
 			log.logError(
 				`Migration '${migration}' was unsuccessful. Please create an issue with the following error message: \n\n${error as string}\n\nQuickAdd will now revert to backup.`

--- a/src/migrations/migrateProviderApiKeysToSecretStorage.test.ts
+++ b/src/migrations/migrateProviderApiKeysToSecretStorage.test.ts
@@ -150,4 +150,39 @@ describe("migrateProviderApiKeysToSecretStorage migration", () => {
 		expect(readProviders()[0].apiKeyRef).toBeUndefined();
 		expect(logWarningMock).toHaveBeenCalled();
 	});
+
+	it("signals incomplete when SecretStorage is unavailable", async () => {
+		const plugin = setup([createProvider({ apiKey: "fake-test-key" })], undefined);
+
+		const result = await migration.default.migrate(plugin);
+
+		expect(result).toEqual({ complete: false });
+	});
+
+	it("signals incomplete when a legacy key cannot be moved", async () => {
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const setSecret = vi.fn().mockRejectedValue(new Error("write failed"));
+		const plugin = setup(
+			[createProvider({ name: "OpenAI", apiKey: "fake-test-key" })],
+			{ getSecret, setSecret },
+		);
+
+		const result = await migration.default.migrate(plugin);
+
+		expect(result).toEqual({ complete: false });
+	});
+
+	it("signals complete once every legacy key has been moved", async () => {
+		const getSecret = vi.fn().mockResolvedValue(null);
+		const setSecret = vi.fn().mockResolvedValue(undefined);
+		const plugin = setup(
+			[createProvider({ name: "OpenAI", apiKey: "fake-test-key" })],
+			{ getSecret, setSecret },
+		);
+
+		const result = await migration.default.migrate(plugin);
+
+		expect(result).toBeUndefined();
+		expect(readProviders()[0].apiKey).toBe("");
+	});
 });

--- a/src/migrations/migrateProviderApiKeysToSecretStorage.test.ts
+++ b/src/migrations/migrateProviderApiKeysToSecretStorage.test.ts
@@ -159,6 +159,20 @@ describe("migrateProviderApiKeysToSecretStorage migration", () => {
 		expect(result).toEqual({ complete: false });
 	});
 
+	it("completes without warning when SecretStorage is unavailable but no legacy key is waiting", async () => {
+		const plugin = setup(
+			[createProvider({ apiKey: "", apiKeyRef: "provider-secret" })],
+			undefined,
+		);
+
+		const result = await migration.default.migrate(plugin);
+
+		// Nothing to migrate, so the invariant already holds - do not stay
+		// pending (and re-save) on every launch, and do not cry wolf.
+		expect(result).toBeUndefined();
+		expect(logWarningMock).not.toHaveBeenCalled();
+	});
+
 	it("signals incomplete when a legacy key cannot be moved", async () => {
 		const getSecret = vi.fn().mockResolvedValue(null);
 		const setSecret = vi.fn().mockRejectedValue(new Error("write failed"));

--- a/src/migrations/migrateProviderApiKeysToSecretStorage.ts
+++ b/src/migrations/migrateProviderApiKeysToSecretStorage.ts
@@ -8,20 +8,30 @@ import { storeProviderApiKeyInSecretStorage } from "src/ai/providerSecrets";
 const migrateProviderApiKeysToSecretStorage: Migration = {
 	description: "Move AI provider API keys into Obsidian SecretStorage",
 	migrate: async (plugin: QuickAdd) => {
+		const providers = settingsStore.getState().ai.providers ?? [];
+		// The migration's single invariant: it is complete iff no provider
+		// still holds a plaintext apiKey. SecretStorage availability only
+		// decides whether we can act to reach that state, not whether we are
+		// done.
+		const hasPlaintextKey = () =>
+			providers.some(
+				(provider) => (provider.apiKey?.trim() ?? "") !== "",
+			);
+
 		const secretStorage = plugin.app?.secretStorage;
 		if (!secretStorage?.getSecret || !secretStorage?.setSecret) {
-			// SecretStorage does not exist on this build (old Obsidian / mobile).
-			// Stay pending so the keys are migrated once it becomes available,
-			// rather than marking the migration done and leaving them in
-			// plaintext forever.
+			// SecretStorage does not exist on this build (old Obsidian / mobile),
+			// so we cannot move keys now. Stay pending only while a plaintext key
+			// is actually waiting, so it migrates once SecretStorage becomes
+			// available instead of being stranded in plaintext forever. With
+			// nothing to migrate the invariant already holds, so complete.
+			if (!hasPlaintextKey()) return;
 			log.logWarning(
 				"SecretStorage unavailable; deferring AI provider API key migration until it is available.",
 			);
 			return { complete: false };
 		}
 
-		const currentSettings = settingsStore.getState();
-		const providers = currentSettings.ai.providers ?? [];
 		let updated = false;
 
 		for (const provider of providers) {
@@ -81,14 +91,10 @@ const migrateProviderApiKeysToSecretStorage: Migration = {
 			}));
 		}
 
-		// The migration's goal is that no provider keeps a plaintext apiKey.
 		// If any key is still present, a move failed (write error, read error,
 		// helper returned null) - stay pending so it is retried on a later
 		// launch instead of being silently marked complete.
-		const hasRemainingPlaintextKey = providers.some(
-			(provider) => (provider.apiKey?.trim() ?? "") !== "",
-		);
-		if (hasRemainingPlaintextKey) {
+		if (hasPlaintextKey()) {
 			return { complete: false };
 		}
 	},

--- a/src/migrations/migrateProviderApiKeysToSecretStorage.ts
+++ b/src/migrations/migrateProviderApiKeysToSecretStorage.ts
@@ -10,10 +10,14 @@ const migrateProviderApiKeysToSecretStorage: Migration = {
 	migrate: async (plugin: QuickAdd) => {
 		const secretStorage = plugin.app?.secretStorage;
 		if (!secretStorage?.getSecret || !secretStorage?.setSecret) {
+			// SecretStorage does not exist on this build (old Obsidian / mobile).
+			// Stay pending so the keys are migrated once it becomes available,
+			// rather than marking the migration done and leaving them in
+			// plaintext forever.
 			log.logWarning(
-				"SecretStorage unavailable; skipping AI provider API key migration.",
+				"SecretStorage unavailable; deferring AI provider API key migration until it is available.",
 			);
-			return;
+			return { complete: false };
 		}
 
 		const currentSettings = settingsStore.getState();
@@ -67,15 +71,26 @@ const migrateProviderApiKeysToSecretStorage: Migration = {
 			}
 		}
 
-		if (!updated) return;
+		if (updated) {
+			settingsStore.setState((state) => ({
+				...state,
+				ai: {
+					...state.ai,
+					providers: deepClone(providers),
+				},
+			}));
+		}
 
-		settingsStore.setState((state) => ({
-			...state,
-			ai: {
-				...state.ai,
-				providers: deepClone(providers),
-			},
-		}));
+		// The migration's goal is that no provider keeps a plaintext apiKey.
+		// If any key is still present, a move failed (write error, read error,
+		// helper returned null) - stay pending so it is retried on a later
+		// launch instead of being silently marked complete.
+		const hasRemainingPlaintextKey = providers.some(
+			(provider) => (provider.apiKey?.trim() ?? "") !== "",
+		);
+		if (hasRemainingPlaintextKey) {
+			return { complete: false };
+		}
 	},
 };
 


### PR DESCRIPTION
## What & why

QuickAdd's `migrateProviderApiKeysToSecretStorage` migration moves AI provider API keys from **plaintext in `data.json`** into Obsidian SecretStorage. The migration runner (`migrate.ts`) set `migrations[migration] = true` on **any non-throwing return**, but the migration returned early when SecretStorage was unavailable (old Obsidian / mobile) and **swallowed per-provider get/setSecret failures**. Since migrations run **exactly once**, the plaintext keys were then marked "migrated" and left in `data.json` **forever** - never retried even after the user upgraded to a SecretStorage-capable Obsidian. This silently defeats the security improvement the migration exists to deliver.

> deepsec finding `other-permanent-skip-leaves-plaintext-secret` (severity **BUG** / secret-hygiene). Not attacker-exploitable in the single-user, client-side, full-trust threat model - the keys were already plaintext and keep working via `resolveProviderApiKey`'s fallback - but the migration's whole point is to stop storing them in plaintext.

## Root-cause fix

Let a migration report that it could not finish, so the runner can keep it pending:

- **`Migrations.ts`** - `Migration.migrate` may now return `{ complete: false }` (`MigrationResult`). Returning `void`/`undefined` still means "done"; there is no `{ complete: true }` (that is just `void`). The change is additive - every other migration returns `void` and is unaffected.
- **`migrate.ts`** - capture the return; when a migration reports incomplete, **persist any partial progress it made but leave the flag unset**, and log a normal "will retry" message instead of the alarming error/backup path. For `void` returns the behavior is byte-identical to before (`undefined?.complete === false` is `false`).
- **`migrateProviderApiKeysToSecretStorage.ts`** - one clean invariant: **the migration is complete iff no provider still holds a plaintext `apiKey`.** SecretStorage availability only decides whether we can *act* to reach that state:
  - SecretStorage absent + a plaintext key waiting → warn + stay pending (retry when it becomes available).
  - SecretStorage absent + nothing to migrate → complete (don't re-run/re-save every launch).
  - SecretStorage present → move each key, then complete iff none remain (a write error / read error / `null` from the helper leaves the key in place → stays pending).

This never strands a key: the flag and the keys live in the **one synced `data.json`**, and the settings UI only ever writes `apiKeyRef` (never plaintext `apiKey`), so a completed flag can never coexist with a plaintext key.

Scoped deliberately to the mark-complete-on-failure bug - the runner is **not** broadly refactored (issue #1451 / general `data.json` corruption is owned elsewhere). Only `migrate.ts`'s flag-setting branch changed; error/backup semantics for every other migration are untouched.

## Proof (red → green)

**Failing-then-passing tests** at both the runner and migration level:
- A legacy plaintext key under an **unavailable** SecretStorage stays pending and the key is left intact (was: flag set `true`, key stranded) → then **migrates on a later SecretStorage-capable launch** (key moved, plaintext cleared, flag set).
- A per-provider key that **fails to move** keeps the migration pending.
- Nothing-to-migrate **completes** (no perpetual re-run / no cry-wolf warning), including on a SecretStorage-less build.

**Live Obsidian 1.13.0 smoke** (isolated vault, real OS SecretStorage): seeded a plaintext `apiKey`, loaded the plugin → key moved into real SecretStorage (`secretMatches: true`), plaintext cleared, flag set, **no load errors**. Re-smoked after the refactor.

**Gates:** `tsc -noEmit` ✅ · `eslint .` ✅ · `svelte-check` (0 errors) ✅ · `vitest` **3457 passed / 0 failed** ✅

## Adversarial review

Reviewed by opposing-model (Codex) Skeptic / Architect / Minimalist plus 3 independent skeptics - **0 blockers, 0 majors**. Two findings were accepted and are folded in (commit 2): the unified completeness invariant (kills a false-positive-incomplete that re-saved `data.json` every launch when nothing needed migrating) and narrowing `MigrationResult`. The Architect found no issue; the Skeptic independently confirmed the by-reference copy-back is correct across all three code paths (no `data.json` corruption).

**Known pre-existing limitation (out of scope, follow-up):** `storeProviderApiKeyInSecretStorage` / `readSecretStorageEntry` (in `src/ai/providerSecrets.ts`, untouched here) swallow `getSecret` read errors as `null`. If a write *resolves* but the backend's reads are *permanently* broken, the plaintext could be cleared against an unverifiable secret. This pre-exists this PR, is not worsened by it (the old code also cleared + completed), requires a pathological SecretStorage state, and closing it properly means a read-back-verify in that shared helper (used by the live UI) - a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrations can now stay pending and retry on later launches if they are not fully complete.
  * Sensitive provider keys are moved to secure storage when available, with progress saved incrementally.

* **Bug Fixes**
  * Prevents migrations from being marked complete when secure storage is unavailable or a secret write fails.
  * Allows migration completion when there is nothing left to update, even on launches without secure storage.

* **Tests**
  * Added coverage for retry behavior, partial completion, and successful key migration cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->