### PR TITLE
fix(security): align capture-target scope classifier with the write-path resolver + case-insensitive assignToVariable guard

### DIFF
--- a/src/ai/tools/assignableVariable.test.ts
+++ b/src/ai/tools/assignableVariable.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { assertAssignableVariableName } from "./assignableVariable";
+
+describe("assertAssignableVariableName", () => {
+	it("rejects the formatter-reserved names", () => {
+		for (const name of ["value", "title", "text", "meta"]) {
+			expect(() => assertAssignableVariableName(name)).toThrow(/reserved/);
+		}
+	});
+
+	it("rejects formatter-reserved names case-insensitively", () => {
+		// The formatter resolves {{VALUE:name}} case-insensitively
+		// (resolveExistingVariableKey -> findCaseInsensitiveMatch), so a case
+		// variant must be rejected just like the lowercase form - otherwise
+		// `assignToVariable: "Value"` slips the guard and hijacks {{VALUE:value}}.
+		for (const name of [
+			"Value",
+			"VALUE",
+			"Title",
+			"TITLE",
+			"Text",
+			"TEXT",
+			"Meta",
+			"META",
+		]) {
+			expect(() => assertAssignableVariableName(name)).toThrow(/reserved/);
+		}
+	});
+
+	it("rejects a reserved name with surrounding whitespace", () => {
+		expect(() => assertAssignableVariableName("  Value  ")).toThrow(/reserved/);
+	});
+
+	it("rejects the reserved internal namespace case-insensitively", () => {
+		expect(() => assertAssignableVariableName("__qa.foo")).toThrow(/__qa\./);
+		expect(() => assertAssignableVariableName("__QA.foo")).toThrow(/__qa\./);
+	});
+
+	it("rejects names that collide with the quoted output variable", () => {
+		expect(() => assertAssignableVariableName("city-quoted")).toThrow(
+			/-quoted/,
+		);
+	});
+
+	it("rejects the quoted-output collision case-insensitively", () => {
+		// The formatter resolves {{VALUE:name}} case-insensitively, so a case
+		// variant of the `-quoted` suffix would still collide with the
+		// auto-generated `${key}-quoted` companion variable.
+		expect(() => assertAssignableVariableName("summary-Quoted")).toThrow(
+			/-quoted/,
+		);
+		expect(() => assertAssignableVariableName("summary-QUOTED")).toThrow(
+			/-quoted/,
+		);
+	});
+
+	it("rejects names unreachable by the {{VALUE:name}} grammar", () => {
+		expect(() => assertAssignableVariableName("a|b")).toThrow(/unreachable/);
+		expect(() => assertAssignableVariableName("a,b")).toThrow(/unreachable/);
+	});
+
+	it("rejects an empty name", () => {
+		expect(() => assertAssignableVariableName("   ")).toThrow(/empty/);
+	});
+
+	it("allows a normal author-chosen variable name", () => {
+		expect(() => assertAssignableVariableName("category")).not.toThrow();
+		expect(() => assertAssignableVariableName("My Value Notes")).not.toThrow();
+	});
+});

--- a/src/ai/tools/assignableVariable.ts
+++ b/src/ai/tools/assignableVariable.ts
@@ -11,12 +11,19 @@ export function assertAssignableVariableName(name: string): void {
 	if (!trimmed) throw new Error("assignToVariable cannot be empty.");
 	// `value` (the programmatic {{VALUE}} slot) and `title` (file-name title) are
 	// formatter-reserved; assigning them would silently hijack those tokens.
-	if (new Set(["value", "title", "text", "meta"]).has(trimmed)) {
+	// Matched case-INSENSITIVELY because the formatter resolves {{VALUE:name}}
+	// that way (resolveExistingVariableKey -> findCaseInsensitiveMatch), so a
+	// `Value`/`TITLE` variant would otherwise slip the guard and still hijack the
+	// built-in token - consistent with isReservedVariableKey below.
+	if (new Set(["value", "title", "text", "meta"]).has(trimmed.toLowerCase())) {
 		throw new Error(
 			`assignToVariable "${trimmed}" is reserved (it would hijack a built-in formatter token).`,
 		);
 	}
-	if (trimmed.endsWith("-quoted")) {
+	// Case-insensitive for the same reason as the reserved-name set above: the
+	// formatter resolves {{VALUE:name}} case-insensitively, so `summary-Quoted`
+	// would still collide with the auto-generated `${key}-quoted` companion.
+	if (trimmed.toLowerCase().endsWith("-quoted")) {
 		throw new Error(
 			`assignToVariable "${trimmed}" cannot end with "-quoted" (collides with the quoted output variable).`,
 		);

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Notice, TFile, type App } from "obsidian";
+import { Notice, TFile, TFolder, type App } from "obsidian";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
 import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
@@ -553,10 +553,14 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(result).toEqual({ kind: "folder", folder: "journals" });
 	});
 
-	it("treats folder path as file when a file exists", () => {
+	it("treats folder path as file when a same-name note exists", () => {
 		const app = createApp();
 		vi.mocked(isFolder).mockReturnValue(true);
-		vi.mocked(app.vault.getAbstractFileByPath).mockReturnValue({} as any);
+		// A real note (TFile) at `journals.md`, not just any abstract file - a
+		// folder that merely shares the name must NOT count (see the TFolder case).
+		vi.mocked(app.vault.getAbstractFileByPath).mockReturnValue(
+			Object.assign(new TFile(), { path: "journals.md" }),
+		);
 
 		const engine = new CaptureChoiceEngine(
 			app,
@@ -568,6 +572,27 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		const result = (engine as any).resolveCaptureTarget("journals");
 
 		expect(result).toEqual({ kind: "file", path: "journals" });
+	});
+
+	it("treats folder path as folder when a same-name FOLDER (not a note) exists", () => {
+		const app = createApp();
+		vi.mocked(isFolder).mockReturnValue(true);
+		// `journals.md` is a folder, not a note -> the bare name stays a folder
+		// scope; resolving to the file path would target a folder and fail the write.
+		vi.mocked(app.vault.getAbstractFileByPath).mockReturnValue(
+			Object.assign(new TFolder(), { path: "journals.md" }),
+		);
+
+		const engine = new CaptureChoiceEngine(
+			app,
+			{ settings: { useSelectionAsCaptureValue: false } } as any,
+			createChoice({ captureTo: "journals" }),
+			createExecutor(),
+		);
+
+		const result = (engine as any).resolveCaptureTarget("journals");
+
+		expect(result).toEqual({ kind: "folder", folder: "journals" });
 	});
 
 	it("resolves a property:field=value target", () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -932,9 +932,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				{
 					isFolder: (path) => isFolder(this.app, path),
 					markdownFileExists: (path) =>
-						!!this.app.vault.getAbstractFileByPath(
+						this.app.vault.getAbstractFileByPath(
 							markdownFilePathForFolderCandidate(path),
-						),
+						) instanceof TFile,
 				},
 				this.choice.captureTo ?? "",
 				false,

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -58,6 +58,7 @@ import {
 } from "./helpers/captureTargetResolution";
 import {
 	classifyCaptureTargetScope,
+	markdownFilePathForFolderCandidate,
 	type CaptureTargetScope,
 } from "./helpers/captureTargetScope";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
@@ -928,7 +929,13 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const preselected = this.getPreselectedCaptureTargetPath();
 		if (preselected !== undefined) {
 			const scope = classifyCaptureTargetScope(
-				{ isFolder: (path) => isFolder(this.app, path) },
+				{
+					isFolder: (path) => isFolder(this.app, path),
+					markdownFileExists: (path) =>
+						!!this.app.vault.getAbstractFileByPath(
+							markdownFilePathForFolderCandidate(path),
+						),
+				},
 				this.choice.captureTo ?? "",
 				false,
 			);

--- a/src/engine/helpers/captureTargetResolution.test.ts
+++ b/src/engine/helpers/captureTargetResolution.test.ts
@@ -1,15 +1,25 @@
 import { describe, it, expect } from "vitest";
-import type { TAbstractFile } from "obsidian";
+import { TFile, TFolder, type TAbstractFile } from "obsidian";
 import {
 	resolveCaptureTarget,
 	type CaptureTargetDeps,
 } from "./captureTargetResolution";
 import { ChoiceAbortError } from "../../errors/ChoiceAbortError";
 
-function deps(opts: { isFolder?: boolean; fileExists?: boolean } = {}): CaptureTargetDeps {
+function deps(
+	opts: {
+		isFolder?: boolean;
+		fileExists?: boolean;
+		fileIsFolder?: boolean;
+	} = {},
+): CaptureTargetDeps {
 	return {
-		getAbstractFileByPath: () =>
-			opts.fileExists ? ({} as TAbstractFile) : null,
+		getAbstractFileByPath: (): TAbstractFile | null => {
+			// A real note is a TFile; a folder that merely shares the `X.md` name is
+			// a TFolder and must NOT count as the same-name note.
+			if (opts.fileIsFolder) return new TFolder() as unknown as TAbstractFile;
+			return opts.fileExists ? (new TFile() as unknown as TAbstractFile) : null;
+		},
 		isFolder: () => !!opts.isFolder,
 		// Faithful to QuickAddEngine.normalizeMarkdownFilePath for the ""+folderPath call.
 		normalizeMarkdownFilePath: (folderPath, fileName) => {
@@ -58,6 +68,14 @@ describe("resolveCaptureTarget", () => {
 		expect(
 			resolveCaptureTarget("journals", deps({ isFolder: false })),
 		).toEqual({ kind: "file", path: "journals" });
+		// a FOLDER named `journals.md` is NOT a note, so the bare name stays a folder
+		// scope (resolving to a file would target a path that is itself a folder).
+		expect(
+			resolveCaptureTarget(
+				"journals",
+				deps({ isFolder: true, fileIsFolder: true }),
+			),
+		).toEqual({ kind: "folder", folder: "journals" });
 	});
 
 	it("routes property:<field>[=<value>] to the property picker before any file/folder branch", () => {

--- a/src/engine/helpers/captureTargetResolution.ts
+++ b/src/engine/helpers/captureTargetResolution.ts
@@ -1,4 +1,4 @@
-import type { TAbstractFile } from "obsidian";
+import { TFile, type TAbstractFile } from "obsidian";
 import {
 	BASE_FILE_EXTENSION_REGEX,
 	CANVAS_FILE_EXTENSION_REGEX,
@@ -112,10 +112,14 @@ export function resolveCaptureTarget(
 		return { kind: "file", path: normalizedCaptureTo };
 	}
 
-	// Guard against ambiguity where a folder and file share the same name.
+	// Guard against ambiguity where a folder and file share the same name. Only a
+	// real NOTE (TFile) at the candidate path makes the bare name a definite file;
+	// a folder that merely happens to be named `X.md` is NOT a note, so the bare
+	// name stays a folder scope (otherwise we would resolve to a file path that is
+	// itself a folder and fail the write).
 	const fileCandidatePath = deps.normalizeMarkdownFilePath("", folderPath);
 	const fileCandidate = deps.getAbstractFileByPath(fileCandidatePath);
-	const fileExists = !!fileCandidate;
+	const fileExists = fileCandidate instanceof TFile;
 
 	if (deps.isFolder(folderPath) && !fileExists) {
 		return { kind: "folder", folder: folderPath };

--- a/src/engine/helpers/captureTargetScope.test.ts
+++ b/src/engine/helpers/captureTargetScope.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { classifyCaptureTargetScope } from "./captureTargetScope";
 
-const noFolders = { isFolder: () => false };
-const withFolders = (folders: string[]) => ({
+const noFolders = { isFolder: () => false, markdownFileExists: () => false };
+// `folders` are existing folder paths; `notes` are the bare names whose
+// `<name>.md` note exists (what the markdownFileExists probe reports on).
+const withFolders = (folders: string[], notes: string[] = []) => ({
 	isFolder: (path: string) => folders.includes(path),
+	markdownFileExists: (path: string) => notes.includes(path),
 });
 
 describe("classifyCaptureTargetScope", () => {
@@ -16,6 +19,71 @@ describe("classifyCaptureTargetScope", () => {
 		expect(
 			classifyCaptureTargetScope(noFolders, "Notes/Daily.md", false),
 		).toBeNull();
+	});
+
+	it("keeps a definite .md/.canvas target definite even when a same-named folder exists", () => {
+		// resolveCaptureTarget tests the file extension BEFORE the folder-ambiguity
+		// check, so `X.md` is a definite file regardless of a colliding folder `X`.
+		// The scope classifier must agree, or the engine honours an injected
+		// __qa.captureTargetFilePath for a configured definite-file target (#1448).
+		expect(
+			classifyCaptureTargetScope(withFolders(["Inbox"]), "Inbox.md", false),
+		).toBeNull();
+		expect(
+			classifyCaptureTargetScope(
+				withFolders(["Notes/Daily"]),
+				"Notes/Daily.md",
+				false,
+			),
+		).toBeNull();
+		expect(
+			classifyCaptureTargetScope(withFolders(["Board"]), "Board.canvas", false),
+		).toBeNull();
+		// Leading slash / surrounding whitespace must not let the collision back in.
+		expect(
+			classifyCaptureTargetScope(withFolders(["Inbox"]), "  /Inbox.md  ", false),
+		).toBeNull();
+	});
+
+	it("returns null for an unsupported .base target even when a same-named folder exists", () => {
+		// resolveCaptureTarget throws on `.base` BEFORE the folder-ambiguity check,
+		// so a `.base` target is never a runtime-pick scope. Returning null keeps the
+		// engine from honouring an injected pick for it (it falls through to the
+		// resolver's unsupported-target abort) and matches the extension-first order.
+		expect(
+			classifyCaptureTargetScope(
+				withFolders(["Archive.base"]),
+				"Archive.base",
+				false,
+			),
+		).toBeNull();
+	});
+
+	it("treats a bare name as a definite file when a same-named note also exists", () => {
+		// resolveCaptureTarget disambiguates a folder/file collision in the file's
+		// favour (docs: "if both Projects/ and Projects.md exist, Projects targets
+		// Projects.md"). The classifier must agree so it neither prompts nor honours
+		// an injected pick for a bare name the write path resolves to a definite file.
+		expect(
+			classifyCaptureTargetScope(
+				withFolders(["Projects"], ["Projects"]),
+				"Projects",
+				false,
+			),
+		).toBeNull();
+		// Folder exists but NO same-name note -> still a folder scope.
+		expect(
+			classifyCaptureTargetScope(withFolders(["Projects"]), "Projects", false),
+		).toEqual({ kind: "folder", folderPathSlash: "Projects/" });
+		// An explicit trailing slash forces the folder picker even when the note
+		// exists (docs: "use Projects/ to force the folder picker").
+		expect(
+			classifyCaptureTargetScope(
+				withFolders(["Projects"], ["Projects"]),
+				"Projects/",
+				false,
+			),
+		).toEqual({ kind: "folder", folderPathSlash: "Projects/" });
 	});
 
 	it("returns null for a tokenized file path (resolved only at run time)", () => {

--- a/src/engine/helpers/captureTargetScope.ts
+++ b/src/engine/helpers/captureTargetScope.ts
@@ -1,7 +1,23 @@
+import {
+	BASE_FILE_EXTENSION_REGEX,
+	CANVAS_FILE_EXTENSION_REGEX,
+	MARKDOWN_FILE_EXTENSION_REGEX,
+} from "../../constants";
 import { hasTemplatePathSyntax } from "../../utils/templatePathSyntax";
 import { parsePropertyTarget } from "../../utils/propertyTarget";
 import { parseCaptureFileFilterTarget } from "../../utils/captureFileFilterTarget";
 import type { FieldFilter } from "../../utils/FieldSuggestionParser";
+
+/**
+ * The vault path of the Markdown note a bare folder-candidate path would collide
+ * with, i.e. {@link QuickAddEngine.normalizeMarkdownFilePath}`("", candidate)`.
+ * Callers bind {@link CaptureTargetScopeDeps.markdownFileExists} by probing the
+ * vault for exactly this path, so the classifier's folder-vs-file disambiguation
+ * matches resolveCaptureTarget's (which uses the same normalize) byte-for-byte.
+ */
+export function markdownFilePathForFolderCandidate(candidate: string): string {
+	return `${candidate.replace(/^\/+/, "").replace(MARKDOWN_FILE_EXTENSION_REGEX, "")}.md`;
+}
 
 /**
  * The runtime "pick a destination" scope a Capture choice's "Capture to" string
@@ -20,6 +36,15 @@ export type CaptureTargetScope =
 export interface CaptureTargetScopeDeps {
 	/** Whether the given vault-relative path is an existing folder. */
 	isFolder(path: string): boolean;
+	/**
+	 * Whether a same-named Markdown note exists for a bare folder-candidate path,
+	 * i.e. whether {@link markdownFilePathForFolderCandidate}`(path)` resolves to an
+	 * existing file. Mirrors the disambiguation resolveCaptureTarget performs (a
+	 * bare name targets a folder only when the folder exists AND no same-name note
+	 * does), so the classifier never offers a folder pick for a bare name the write
+	 * path would resolve to a definite file.
+	 */
+	markdownFileExists(path: string): boolean;
 }
 
 /**
@@ -70,14 +95,44 @@ export function classifyCaptureTargetScope(
 		!fileFilterTarget &&
 		normalizedTarget.startsWith("#");
 
-	const trimmedPath = normalizedTarget.replace(/\/$|\.md$/g, "");
+	const endsWithSlash = normalizedTarget.endsWith("/");
+
+	// A target carrying a recognized file extension with no trailing slash is never
+	// a runtime-pick scope. This mirrors resolveCaptureTarget, which tests the
+	// extension BEFORE the folder-ambiguity check, so an extensioned target that
+	// happens to collide with a same-named folder is NOT misrouted to that folder
+	// in either classifier. `.md`/`.canvas` are definite files; `.base` is
+	// unsupported (the resolver throws on it downstream) - in all three cases the
+	// engine must NOT honour an injected `__qa.captureTargetFilePath`, so returning
+	// `null` here both stops the spurious folder prompt AND preserves the #1448
+	// reserved-key confinement for a configured definite/unsupported file target.
+	const hasRecognizedFileExtension =
+		!isTagTarget &&
+		!isPropertyTarget &&
+		!isFilterTarget &&
+		!endsWithSlash &&
+		(MARKDOWN_FILE_EXTENSION_REGEX.test(normalizedTarget) ||
+			CANVAS_FILE_EXTENSION_REGEX.test(normalizedTarget) ||
+			BASE_FILE_EXTENSION_REGEX.test(normalizedTarget));
+
+	const folderProbePath = normalizedTarget.replace(/\/+$/, "");
+	// A bare name targets a folder only when the folder exists AND no same-name
+	// note does (resolveCaptureTarget's disambiguation; docs: "if both Projects/
+	// and Projects.md exist, Projects targets Projects.md"). Probing for the note
+	// keeps the classifier from offering a folder pick - and honouring an injected
+	// pick - for a bare name the write path resolves to a definite file. An empty
+	// target is the whole-vault scope and needs no probe. A trailing-slash target
+	// forces the folder regardless (handled by looksLikeFolderBySuffix below).
 	const isFolderTarget =
 		!isTagTarget &&
 		!isPropertyTarget &&
 		!isFilterTarget &&
-		(normalizedTarget === "" || deps.isFolder(trimmedPath));
+		!hasRecognizedFileExtension &&
+		(normalizedTarget === "" ||
+			(deps.isFolder(folderProbePath) &&
+				!deps.markdownFileExists(folderProbePath)));
 	const looksLikeFolderBySuffix =
-		!isPropertyTarget && !isFilterTarget && normalizedTarget.endsWith("/");
+		!isPropertyTarget && !isFilterTarget && endsWithSlash;
 
 	if (isPropertyTarget && propertyTarget) {
 		return {
@@ -94,9 +149,12 @@ export function classifyCaptureTargetScope(
 		return { kind: "tag", tag: normalizedTarget };
 	}
 	if (isFolderTarget || looksLikeFolderBySuffix) {
-		const folder = normalizedTarget.replace(/(?:\/|\.md)+$/g, "");
-		const folderPathSlash =
-			folder === "" ? "" : folder.endsWith("/") ? folder : `${folder}/`;
+		// Strip only trailing slashes (NOT `.md`): a `.md` target is already
+		// short-circuited to a definite file above, so a folder named `X.md`
+		// reached via a trailing slash (`X.md/`) must keep its name - matching
+		// resolveCaptureTarget's folder branch (`replace(/\/+$/, "")`).
+		const folder = folderProbePath;
+		const folderPathSlash = folder === "" ? "" : `${folder}/`;
 		return { kind: "folder", folderPathSlash };
 	}
 

--- a/src/engine/helpers/captureTargetScope.ts
+++ b/src/engine/helpers/captureTargetScope.ts
@@ -37,12 +37,13 @@ export interface CaptureTargetScopeDeps {
 	/** Whether the given vault-relative path is an existing folder. */
 	isFolder(path: string): boolean;
 	/**
-	 * Whether a same-named Markdown note exists for a bare folder-candidate path,
+	 * Whether a same-named Markdown NOTE exists for a bare folder-candidate path,
 	 * i.e. whether {@link markdownFilePathForFolderCandidate}`(path)` resolves to an
-	 * existing file. Mirrors the disambiguation resolveCaptureTarget performs (a
-	 * bare name targets a folder only when the folder exists AND no same-name note
-	 * does), so the classifier never offers a folder pick for a bare name the write
-	 * path would resolve to a definite file.
+	 * existing file (a `TFile`, NOT a folder that merely shares the `X.md` name).
+	 * Mirrors the disambiguation resolveCaptureTarget performs (a bare name targets
+	 * a folder only when the folder exists AND no same-name note does), so the
+	 * classifier never offers a folder pick for a bare name the write path would
+	 * resolve to a definite file.
 	 */
 	markdownFileExists(path: string): boolean;
 }

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { App } from "obsidian";
+import { TFile, TFolder, type App } from "obsidian";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import type ICaptureChoice from "src/types/choices/ICaptureChoice";
 import type IMacroChoice from "src/types/choices/IMacroChoice";
@@ -865,7 +865,9 @@ describe("collectChoiceRequirements - capture targets", () => {
 		// path resolves to a definite file.
 		isFolderMock.mockReturnValue(true);
 		getAbstractFileByPathMock.mockImplementation((path: string) =>
-			path === "Projects.md" ? ({ path } as unknown) : null,
+			path === "Projects.md"
+				? Object.assign(new TFile(), { path })
+				: null,
 		);
 
 		const requirements = await collectChoiceRequirements(
@@ -882,6 +884,33 @@ describe("collectChoiceRequirements - capture targets", () => {
 					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
 			),
 		).toBe(false);
+	});
+
+	it("still forces the dropdown when a same-named FOLDER (not a note) shares the X.md name", async () => {
+		// A folder named `Projects.md` is NOT a note, so it must not suppress the
+		// folder scope for bare `Projects` - otherwise the run resolves to the file
+		// path `Projects.md`, which is itself a folder, and the write fails.
+		isFolderMock.mockReturnValue(true);
+		getAbstractFileByPathMock.mockImplementation((path: string) =>
+			path === "Projects.md"
+				? Object.assign(new TFolder(), { path })
+				: null,
+		);
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createCaptureChoice("Projects"),
+		);
+
+		expect(getMarkdownFilesInFolderMock).toHaveBeenCalledWith(app, "Projects/");
+		expect(
+			requirements.some(
+				(requirement) =>
+					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			),
+		).toBe(true);
 	});
 
 	it("forces the capture target dropdown for a bare folder name with no same-named note", async () => {

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -784,7 +784,11 @@ describe("collectChoiceRequirements - macro script metadata", () => {
 
 describe("collectChoiceRequirements - capture targets", () => {
 	const getFileCacheMock = vi.fn();
+	const getAbstractFileByPathMock = vi.fn();
 	const app = {
+		vault: {
+			getAbstractFileByPath: getAbstractFileByPathMock,
+		},
 		metadataCache: {
 			getFileCache: getFileCacheMock,
 		},
@@ -812,6 +816,8 @@ describe("collectChoiceRequirements - capture targets", () => {
 		getMarkdownFilesMatchingFilterMock.mockReturnValue([]);
 		getMarkdownFilesWithTagMock.mockReturnValue([]);
 		getMarkdownFilesWithPropertyMock.mockReturnValue([]);
+		getAbstractFileByPathMock.mockReset();
+		getAbstractFileByPathMock.mockReturnValue(null);
 		getFileCacheMock.mockReset();
 		getFileCacheMock.mockImplementation((file: { path: string }) => {
 			if (file.path === "Goals/Alpha.md") {
@@ -824,20 +830,81 @@ describe("collectChoiceRequirements - capture targets", () => {
 		});
 	});
 
-	it("normalizes capture folder paths ending in .md", async () => {
+	it("treats a definite .md target as a file even when a same-named folder exists", async () => {
+		// A `.md` (or `.canvas`) extension is a definite file - exactly how the
+		// write-path resolver (resolveCaptureTarget) and the docs ("a value ending
+		// in a supported file extension ... targets that file path directly")
+		// behave. So even with a colliding folder `Projects`, no runtime file pick
+		// is required: the folder is never enumerated and no capture-target
+		// requirement is emitted. (Regression guard for the #1448 follow-up: a
+		// definite-file target must not be misrouted to a folder scope, which would
+		// both spuriously prompt AND honour an injected __qa.captureTargetFilePath.)
 		isFolderMock.mockReturnValue(true);
 
-		await collectChoiceRequirements(
+		const requirements = await collectChoiceRequirements(
 			app,
 			plugin,
 			choiceExecutor,
 			createCaptureChoice("Projects.md"),
 		);
 
-		expect(getMarkdownFilesInFolderMock).toHaveBeenCalledWith(
-			app,
-			"Projects/",
+		expect(getMarkdownFilesInFolderMock).not.toHaveBeenCalled();
+		expect(
+			requirements.some(
+				(requirement) =>
+					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			),
+		).toBe(false);
+	});
+
+	it("treats a bare name as a file when both the folder and a same-named note exist", async () => {
+		// resolveCaptureTarget disambiguates `Projects` (folder `Projects/` AND note
+		// `Projects.md` both exist) to the note. The collector must agree: no folder
+		// enumeration, no capture-target requirement - otherwise it would prompt for
+		// a pick AND let the engine honour an injected pick for a target the write
+		// path resolves to a definite file.
+		isFolderMock.mockReturnValue(true);
+		getAbstractFileByPathMock.mockImplementation((path: string) =>
+			path === "Projects.md" ? ({ path } as unknown) : null,
 		);
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createCaptureChoice("Projects"),
+		);
+
+		expect(getMarkdownFilesInFolderMock).not.toHaveBeenCalled();
+		expect(
+			requirements.some(
+				(requirement) =>
+					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			),
+		).toBe(false);
+	});
+
+	it("forces the capture target dropdown for a bare folder name with no same-named note", async () => {
+		// Folder exists but NO `Projects.md` - a genuine folder scope, so the pick
+		// requirement IS emitted (regression guard that the same-name-note probe did
+		// not over-suppress the legitimate folder picker).
+		isFolderMock.mockReturnValue(true);
+		getAbstractFileByPathMock.mockReturnValue(null);
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createCaptureChoice("Projects"),
+		);
+
+		expect(getMarkdownFilesInFolderMock).toHaveBeenCalledWith(app, "Projects/");
+		expect(
+			requirements.some(
+				(requirement) =>
+					requirement.id === QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+			),
+		).toBe(true);
 	});
 
 	it("does not force capture target dropdown for tokenized file paths", async () => {

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -25,7 +25,10 @@ import {
 } from "src/utilityObsidian";
 import { log } from "src/logger/logManager";
 import { hasTemplatePathSyntax } from "src/utils/templatePathSyntax";
-import { classifyCaptureTargetScope } from "src/engine/helpers/captureTargetScope";
+import {
+	classifyCaptureTargetScope,
+	markdownFilePathForFolderCandidate,
+} from "src/engine/helpers/captureTargetScope";
 import { orderFilesForPicker } from "src/utils/fileOrdering";
 import { buildFileDisplayLabels } from "src/utils/fileSyntax";
 import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
@@ -333,7 +336,13 @@ async function collectForCaptureChoice(
 	// collector on the same classification guarantees a preselected pick is honoured
 	// exactly when it was legitimately collected, never silently dropped or hijacked.
 	const captureScope = classifyCaptureTargetScope(
-		{ isFolder: (path) => isFolder(app, path) },
+		{
+			isFolder: (path) => isFolder(app, path),
+			markdownFileExists: (path) =>
+				!!app.vault.getAbstractFileByPath(
+					markdownFilePathForFolderCandidate(path),
+				),
+		},
 		choice.captureTo ?? "",
 		choice.captureToActiveFile,
 	);

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -1,5 +1,5 @@
-import type { App, TFile } from "obsidian";
-import { MarkdownView } from "obsidian";
+import type { App } from "obsidian";
+import { MarkdownView, TFile } from "obsidian";
 import { MAX_TEMPLATE_INCLUSION_DEPTH } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import {
@@ -339,9 +339,9 @@ async function collectForCaptureChoice(
 		{
 			isFolder: (path) => isFolder(app, path),
 			markdownFileExists: (path) =>
-				!!app.vault.getAbstractFileByPath(
+				app.vault.getAbstractFileByPath(
 					markdownFilePathForFolderCandidate(path),
-				),
+				) instanceof TFile,
 		},
 		choice.captureTo ?? "",
 		choice.captureToActiveFile,


### PR DESCRIPTION
Two #1448 follow-ups closing adjacent gaps the capture-target/reserved-var confinement left open. Both are deepsec **BUG** findings (correctness + defense-in-depth; not live exploits under the threat model - see *Security framing*). Adversarial review (opposing-model Codex + a 3-lens panel) turned each into its full invariant rather than just the literal flagged line.

## Finding 1 - capture-target scope classifier diverged from the write-path resolver

`classifyCaptureTargetScope` is the single source of truth shared by the preflight requirement collector and the engine's #1448 reserved-key confinement: the engine honours a preselected/injected `__qa.captureTargetFilePath` **only** for the runtime-picker scopes this classifier returns, and a configured definite-file target must yield no scope so the injected value is *ignored*. It disagreed with the actual write path (`resolveCaptureTarget`, which decides definite-vs-pick **before** any folder-ambiguity check) in several ways. Each divergence (1) spuriously prompted *"Select capture target file"* for a target the write path resolves to a definite file, and (2) weakened the #1448 invariant by honouring an injected pick (confined to the colliding folder) for it.

Closed all of them so classifier, resolver, collector, and the published docs (`docs/docs/Choices/CaptureChoice.md` -> *"How QuickAdd picks a target"*) agree:

- **`.md`/`.canvas` + same-named folder** (the flagged case): the classifier stripped a trailing `.md` then probed `isFolder`, so `X.md` with a folder `X` was misrouted to a folder scope. Now a recognized file extension short-circuits to a null scope before the folder branch, and the folder path no longer strips `.md` (so a folder literally named `X.md` reached via `X.md/` keeps its name - a latent divergence the review caught).
- **`.base` + same-named folder**: the resolver throws on `.base` (unsupported) before the folder check, so it is never a pick scope. Short-circuited too; the engine falls through to the resolver's unsupported-target abort instead of honouring an injected pick.
- **bare name + same-named note**: the resolver disambiguates `Projects` (folder `Projects/` **and** note `Projects.md` both exist) to the note (docs: *"if both `Projects/` and `Projects.md` exist, `Projects` targets `Projects.md`"*), but the classifier only had an `isFolder` probe. Added a `markdownFileExists` dep, bound at both call sites via a shared `markdownFilePathForFolderCandidate` helper that is a byte-faithful mirror of `normalizeMarkdownFilePath("", candidate)` (so the existence check normalizes exactly like the write path).

## Finding 2 - reserved-name `assignToVariable` guard was case-sensitive

`assertAssignableVariableName` rejected `value`/`title`/`text`/`meta` via a case-**sensitive** `Set.has`, and the sibling `-quoted` collision guard via a case-**sensitive** `endsWith`. But the formatter resolves `{{VALUE:name}}` case-**insensitively** (`resolveExistingVariableKey` -> `findCaseInsensitiveMatch`). So `assignToVariable: "Value"`/`"TITLE"` slipped the guard and could hijack the built-in token the docstring says it protects, and `"summary-Quoted"` slipped the `-quoted` guard and could collide with the auto-generated `${key}-quoted` companion. Both now lowercase before the test, consistent with the formatter and with the sibling `isReservedVariableKey`. (The `-quoted` half was found by adversarial review of the reserved-name fix.)

## Proof - live RED -> GREEN (real Obsidian, app 1.13.0)

Drove the real non-interactive capture path (`quickadd:run`) against a vault with folder `Inbox` + folder `Projects` + note `Projects.md`:

| | pre-fix (parent) | post-fix |
|---|---|---|
| `captureTo = Inbox.md` | aborts: `Missing required inputs ... missing: [Select capture target file] ... missingFlags: ["value-__qa.captureTargetFilePath=<value>"]` | writes to **`Inbox.md`**, `Inbox/` stays empty, no prompt |
| `captureTo = Projects` (folder+note exist) | same abort (spurious pick demand) | appends to note **`Projects.md`**, `Projects/` stays empty |

The pre-fix `missingFlags: ["value-__qa.captureTargetFilePath=<value>"]` is literally the #1448 injection channel: pre-fix these definite targets were treated as runtime-pick scopes an injected reserved key would satisfy/redirect.

Also: RED-before/GREEN-after unit tests at the classifier layer **and** the real `collectChoiceRequirements` collector layer (each new closure proven to fail without its fix); the collector test that codified the old folder-divergent `.md` behavior is corrected.

## Gates

`tsc -noEmit` clean - `eslint .` clean - `svelte-check` 0 errors - `vitest` full suite **3463 passed** / 37 skipped.

## Security framing

Per #1448, the URI and AI-tool boundaries already reject reserved keys via `isReservedVariableKey`; the CLI deliberately allows `value-__qa.*` but is acknowledged as already granting arbitrary code execution (it runs Macro choices). So these are primarily **correctness + defense-in-depth**: they remove spurious prompts and shrink the honour-on-definite-file surface, keeping the classifier/resolver agreement the #1448 confinement relies on. Confirmed by differential traces from 4 independent reviewers: zero legit collected picks dropped; the fix strictly *reduces* the honour-on-file surface.

## Known residuals (surfaced, not closed - out of scope / disproportionate risk)

- **Trailing-dot/space targets** (e.g. `captureTo = "X.md."` with a folder literally named `X.md.`): the classifier classifies on the lightly-normalized raw string while the resolver runs `normalizeGeneratedFilePath` (which strips trailing dots/spaces) before the extension check, so they can still disagree for a path with a trailing dot/space *and* a same-shaped folder. Confined to that folder, requires a bizarrely-named folder, and is **not** a regression from these closures. Fully closing it means running `normalizeGeneratedFilePath` inside the classifier with throw-handling - a broad, higher-risk normalization change best done deliberately, not folded in here.
- **`ai.prompt`/`ai.chunkedPrompt` store the raw (untrimmed) `assignToVariable`** as `outputVariableName` (`quickAddApi.ts`), while `ai.agent` stores the trimmed key. So `" summary "` validates (guard trims) but stores `" summary "`, which `{{VALUE:summary}}` then can't resolve. A pre-existing whitespace-trim footgun in a different subsystem, separate from the case-sensitivity findings here.

Refs #1448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capture target handling so files, folders, and preselected “capture to” scopes are distinguished more reliably when names collide (including `.md` and `.canvas`).
  * Prevented misidentification of folder targets when an abstract path exists as a folder rather than a note.
  * Made variable-name validation stricter by rejecting formatter-reserved names and `-quoted` suffix collisions case-insensitively.
* **Tests**
  * Added/expanded test coverage for edge-case variable names and capture-target disambiguation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->