### PR TITLE
fix: three deepsec data-integrity BUG fixes (collision non-termination, dropped imported child, prompt backslash corruption)

### DIFF
--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.test.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.test.ts
@@ -1,126 +1,114 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Modal } from "obsidian";
+import type QuickAdd from "../../main";
+import { setQuickAddInstance } from "../../quickAddInstance";
+import GenericWideInputPrompt from "./GenericWideInputPrompt";
 
-// Test helper to access the private escapeBackslashes method
-class TestableGenericWideInputPrompt {
-	escapeBackslashes(input: string): string {
-		return input.replace(/\\/g, "\\\\");
-	}
+// The obsidian-stub Modal does not implement onOpen/onClose; the prompt calls
+// super.onOpen()/super.onClose(). Provide no-ops so construction and close do not
+// throw. Guarded so a richer stub still wins. (Mirrors the suggester-cleanup test.)
+const modalProto = Modal.prototype as unknown as {
+	onOpen?: unknown;
+	onClose?: unknown;
+};
+if (typeof modalProto.onOpen !== "function") modalProto.onOpen = () => {};
+if (typeof modalProto.onClose !== "function") modalProto.onClose = () => {};
+
+const htmlProto = HTMLElement.prototype as unknown as {
+	toggleClass?: unknown;
+	setAttr?: unknown;
+};
+if (typeof htmlProto.toggleClass !== "function") {
+	htmlProto.toggleClass = function toggleClass(
+		this: Element,
+		cls: string,
+		value: boolean,
+	) {
+		this.classList.toggle(cls, value);
+	};
+}
+if (typeof htmlProto.setAttr !== "function") {
+	htmlProto.setAttr = function setAttr(
+		this: Element,
+		name: string,
+		value: string | number | boolean | null,
+	) {
+		if (value === null || value === false) this.removeAttribute(name);
+		else this.setAttribute(name, String(value));
+	};
 }
 
-describe("GenericWideInputPrompt - Escape Backslashes", () => {
-	let prompt: TestableGenericWideInputPrompt;
+function makeFakeApp() {
+	return {
+		dom: { appContainerEl: document.body },
+		keymap: { pushScope: () => {}, popScope: () => {} },
+		workspace: { on: () => ({}), getActiveFile: () => null },
+		metadataCache: {
+			on: () => ({}),
+			getTags: () => ({}),
+			getFileCache: () => undefined,
+			isUserIgnored: () => false,
+			unresolvedLinks: {},
+		},
+		vault: {
+			on: () => ({}),
+			getMarkdownFiles: () => [],
+			getAllLoadedFiles: () => [],
+			getFiles: () => [],
+			getAbstractFileByPath: () => null,
+		},
+		fileManager: { getNewFileParent: () => ({ path: "" }) },
+	};
+}
 
+/**
+ * Drives the REAL wide prompt through its PUBLIC contract: open it via the static
+ * Prompt(), type into the rendered textarea, fire the documented ctrl+Enter submit
+ * gesture, and resolve the value the formatter / quickAddApi.wideInputPrompt()
+ * consumer receives. `typed` is the literal text the user keys in (so "C:\\temp" in
+ * source is the on-screen `C:\temp`).
+ */
+function submitWideValue(typed: string): Promise<string> {
+	const waitForClose = GenericWideInputPrompt.Prompt(fakeApp as never, "Header");
+	const textarea = document.querySelector(
+		"textarea.wideInputPromptInputEl",
+	) as HTMLTextAreaElement;
+	textarea.value = typed;
+	textarea.dispatchEvent(
+		new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true }),
+	);
+	return waitForClose;
+}
+
+let fakeApp: ReturnType<typeof makeFakeApp>;
+
+describe("GenericWideInputPrompt returns the user's input verbatim", () => {
 	beforeEach(() => {
-		prompt = new TestableGenericWideInputPrompt();
+		fakeApp = makeFakeApp();
+		setQuickAddInstance({
+			app: fakeApp,
+			registerEvent: () => {},
+		} as unknown as QuickAdd);
 	});
 
-	describe("Basic escape sequences", () => {
-		it("should escape single backslash-n sequence", () => {
-			const input = 'let str = "aa\\nbb";';
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe('let str = "aa\\\\nbb";');
-		});
-
-		it("should escape multiple backslash-n sequences", () => {
-			const input = "Line1\\nLine2\\nLine3";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("Line1\\\\nLine2\\\\nLine3");
-		});
-
-		it("should escape backslash-t sequences", () => {
-			const input = "Column1\\tColumn2";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("Column1\\\\tColumn2");
-		});
-
-		it("should handle text without backslashes", () => {
-			const input = "No escapes here";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("No escapes here");
-		});
+	afterEach(() => {
+		for (const el of Array.from(document.body.children)) el.remove();
 	});
 
-	describe("Already escaped backslashes", () => {
-		it("should double-escape already escaped backslashes", () => {
-			const input = "Path\\\\to\\\\file";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("Path\\\\\\\\to\\\\\\\\file");
-		});
-
-		it("should handle mixed escape patterns", () => {
-			const input = "Line1\\nLine2\\\\nLine3";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("Line1\\\\nLine2\\\\\\\\nLine3");
-		});
+	it("preserves a literal backslash-n in code (issue #799)", async () => {
+		// #799's intent — keep a typed `\n` from corrupting code — is met without
+		// doubling: a typed `\n` stays literal (not "\\n", not a real newline) because
+		// the substituted value is never linebreak-expanded downstream.
+		const typed = 'let s = "aa\\nbb";';
+		await expect(submitWideValue(typed)).resolves.toBe(typed);
 	});
 
-	describe("Real-world code examples", () => {
-		it("should preserve JavaScript string escape sequences", () => {
-			const input = `function test() {
-  let str = "aa\\nbb";
-  return str;
-}`;
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe(`function test() {
-  let str = "aa\\\\nbb";
-  return str;
-}`);
-		});
-
-		it("should preserve regex patterns with backslashes", () => {
-			const input = 'const regex = /\\d+\\s+\\w+/;';
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("const regex = /\\\\d+\\\\s+\\\\w+/;");
-		});
-
-		it("should preserve path separators", () => {
-			const input = "C:\\Users\\Documents\\file.txt";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("C:\\\\Users\\\\Documents\\\\file.txt");
-		});
-	});
-
-	describe("Edge cases", () => {
-		it("should handle empty string", () => {
-			const input = "";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("");
-		});
-
-		it("should handle single backslash", () => {
-			const input = "\\";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("\\\\");
-		});
-
-		it("should handle trailing backslash", () => {
-			const input = "Some text\\";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("Some text\\\\");
-		});
-
-		it("should not affect actual newlines", () => {
-			const input = "Line1\nLine2\nLine3";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("Line1\nLine2\nLine3");
-		});
-
-		it("should not affect literal tab characters (issue #764)", () => {
-			// A real tab (0x09) inserted via Tab is not a backslash, so it passes
-			// through untouched and renders as indentation in the capture.
-			const input = "- item\n\tsub-item";
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe("- item\n\tsub-item");
-		});
-	});
-
-	describe("Issue #799 test case", () => {
-		it("should preserve backslash-n in JavaScript code from issue", () => {
-			const input = `let str = "aa\\nbb";
-let d = 1;`;
-			const result = prompt.escapeBackslashes(input);
-			expect(result).toBe(`let str = "aa\\\\nbb";
-let d = 1;`);
-		});
+	it("is an identity transform like the single-line prompt (Windows path + real newline)", async () => {
+		// Backslashes survive un-doubled ("C:\x", not "C:\\x") and a real newline
+		// passes through, so the same {{VALUE}} token stores identical bytes whether
+		// the user is on the wide or single-line prompt.
+		await expect(submitWideValue("C:\\temp\nC:\\x")).resolves.toBe(
+			"C:\\temp\nC:\\x",
+		);
 	});
 });

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -221,15 +221,19 @@ export default class GenericWideInputPrompt extends Modal {
 		}
 	};
 
-	private escapeBackslashes(input: string): string {
-		return input.replace(/\\/g, "\\\\");
-	}
-
 	private submit() {
 		if (this.didSubmit) return;
+		// Resolve the textarea value verbatim — identical to the single-line
+		// GenericInputPrompt (whose transformInputOnSubmit is the identity). The
+		// substituted {{VALUE}} is never linebreak-processed (the formatter's
+		// expandLinebreakEscapesOutsideTokens runs on the template before
+		// substitution and skips token spans), and the only un-doubler
+		// replaceLinebreakInString has no production callers, so any transform here
+		// would corrupt the value with no downstream reversal (issue: a typed
+		// "C:\temp" must reach the note and quickAddApi.wideInputPrompt() as
+		// "C:\temp", not "C:\\temp").
 		this.input = this.inputComponent?.inputEl?.value ?? this.input;
 		this.didSubmit = true;
-		this.input = this.escapeBackslashes(this.input);
 
 		this.close();
 	}

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -264,6 +264,32 @@ describe("OnePageInputModal", () => {
 		});
 	});
 
+	it("returns a textarea field value verbatim, without doubling backslashes", async () => {
+		// A |type:multiline ({{VALUE}}) field used to backslash-double its value here;
+		// nothing downstream un-doubled it, so "C:\temp" became "C:\\temp" in the note
+		// (and compounded with the |type:text YAML quoter). Keep it literal.
+		const requirements: FieldRequirement[] = [
+			{ id: "body", label: "Body", type: "textarea" },
+		];
+		const typed = 'C:\\temp\nlet s = "a\\nb";';
+
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		const textarea = (modal as any).contentEl.querySelector(
+			"textarea",
+		) as HTMLTextAreaElement;
+		textarea.value = typed;
+		textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+		const submitButton = Array.from(
+			(modal as any).contentEl.querySelectorAll(
+				"button",
+			) as NodeListOf<HTMLButtonElement>,
+		).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+		submitButton.click();
+
+		await expect(modal.waitForClose).resolves.toEqual({ body: typed });
+	});
+
 	it("normalizes stale initial dropdown values to the first raw option", async () => {
 		const id = "#BF616A,#8CC570,#42A5F5";
 		const requirements: FieldRequirement[] = [

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -637,18 +637,17 @@ export class OnePageInputModal extends Modal {
 				if (!requirement.optional || hasParseError) return;
 			}
 
-			out[k] =
-				requirement?.type === "textarea"
-					? this.escapeBackslashes(v)
-					: v;
+			// Store the field value verbatim. A textarea value used to be
+			// backslash-doubled here; nothing downstream un-doubled it (the formatter
+			// substitutes a {{VALUE}} verbatim and never linebreak-processes it), so
+			// the doubling corrupted paths/regex/code — and compounded with the
+			// |type:text YAML quoter, which escapes backslashes again. Keep it literal,
+			// matching the wide and single-line prompts.
+			out[k] = v;
 		});
 		this.settled = true;
 		this.close();
 		this.resolvePromise(out);
-	}
-
-	private escapeBackslashes(input: string): string {
-		return input.replace(/\\/g, "\\\\");
 	}
 
 	private cancel() {

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -461,6 +461,57 @@ describe("parseQuickAddPackage", () => {
 		// And the consistency check accepts it.
 		expect(() => parseQuickAddPackage(JSON.stringify(pkg))).not.toThrow();
 	});
+
+	it("rejects an importable child its declared parent does not carry inline", () => {
+		// applyPackageImport skips a parented child (trusting the parent's subtree to
+		// install it) but remapChoiceTree only keeps children listed INLINE in the
+		// parent. A hand-edited package where entry "child" names parentChoiceId="parent"
+		// while "parent".choices omits it would import "child" nowhere — silently
+		// dropped while the modal listed it and reported success. Fail closed here.
+		const parent = makeMulti("parent", "Parent", []); // does NOT list "child"
+		const child = makeChoice("child", "Child", "Template");
+		const bad = makePackage({
+			rootChoiceIds: ["parent"],
+			choices: [
+				makePackageChoice(parent, null, ["Parent"]),
+				makePackageChoice(child, "parent", ["Parent", "Child"]),
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/names a parent that does not list it/i,
+		);
+	});
+
+	it("rejects a child whose declared parent entry is not a Multi", () => {
+		// parentChoiceId pointing at a non-container (e.g. a Template) is the same
+		// silent-drop shape: the importer skips the child as "parent-carried" but a
+		// Template has no inline choices to carry it.
+		const parent = makeChoice("parent", "Parent", "Template");
+		const child = makeChoice("child", "Child", "Template");
+		const bad = makePackage({
+			rootChoiceIds: ["parent"],
+			choices: [
+				makePackageChoice(parent, null, ["Parent"]),
+				makePackageChoice(child, "parent", ["Parent", "Child"]),
+			],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(bad))).toThrow(
+			/names a parent that does not list it/i,
+		);
+	});
+
+	it("accepts a child whose declared parent is NOT in the package", () => {
+		// The legit excluded-parent shape: the parent Multi was excluded from the
+		// export while the child was pulled in (e.g. as a macro dependency). The
+		// importer routes such a child to its existing-vault parent / root, so it must
+		// not be rejected at the boundary.
+		const child = makeChoice("child", "Child", "Template");
+		const ok = makePackage({
+			rootChoiceIds: ["child"],
+			choices: [makePackageChoice(child, "missing-parent", ["Missing", "Child"])],
+		});
+		expect(() => parseQuickAddPackage(JSON.stringify(ok))).not.toThrow();
+	});
 });
 
 // --- readQuickAddPackage ----------------------------------------------------

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -164,6 +164,23 @@ export function parseQuickAddPackage(raw: string): QuickAddPackage {
 		);
 	}
 
+	// Reject a parented choice whose declared parent does not actually carry it
+	// inline. applyPackageImport installs a child SOLELY through its parent Multi's
+	// inline `choices` (remapChoiceTree keeps only the children listed there) and,
+	// in the insertion loop, SKIPS the child's own flat entry assuming the parent
+	// will carry it. So a hand-edited/cross-version package where entry X names
+	// parentChoiceId=M (M an importable entry) while M does not list X inline would
+	// import X nowhere — silently dropped while the preview still listed X and the
+	// import reports success. A legitimately exported package always inlines a
+	// parented child as a direct member of its parent Multi, so failing closed here
+	// keeps the previewed set of choices identical to the installed set.
+	const uncarriedChildId = findUncarriedChildChoiceId(parsed.choices);
+	if (uncarriedChildId !== null) {
+		throw new Error(
+			`Package choice "${uncarriedChildId}" names a parent that does not list it as a child. Each parented choice must appear inside its parent.`,
+		);
+	}
+
 	return parsed;
 }
 
@@ -281,6 +298,47 @@ function canonicalizeJsonValue(value: unknown): string {
 	return `{${keys
 		.map((key) => `${JSON.stringify(key)}:${canonicalizeJsonValue(record[key])}`)
 		.join(",")}}`;
+}
+
+/**
+ * The id of the first flat entry whose declared parent is also a package entry but
+ * does NOT carry it inline, or null if every parented entry is carried.
+ *
+ * Mirrors {@link applyPackageImport}'s carry rule EXACTLY: a parented child is
+ * installed only as a DIRECT member of its parent Multi's `choices` array (that is
+ * the single level {@link remapChoiceTree} keeps and the same level the insertion
+ * loop skips the child's own entry for). `parentChoiceId` in any real export is
+ * always the direct Multi parent (buildChoiceCatalog only assigns it via Multi
+ * recursion; macro/NestedChoice embedded choices are never their own entries), so
+ * a direct-membership check neither false-rejects a legitimate package nor
+ * false-accepts a child buried under a non-importable grandchild (which the import
+ * would still drop). Entries whose `parentChoiceId` is not itself an entry are
+ * exempt — the importer routes those to the existing-vault parent or root, so they
+ * are never dropped.
+ */
+function findUncarriedChildChoiceId(
+	choices: QuickAddPackage["choices"],
+): string | null {
+	const entryById = new Map(choices.map((entry) => [entry.choice.id, entry]));
+
+	for (const entry of choices) {
+		const parentId = entry.parentChoiceId;
+		if (parentId === null) continue;
+
+		const parentEntry = entryById.get(parentId);
+		if (!parentEntry) continue;
+
+		const parent = parentEntry.choice;
+		const carriedInline =
+			parent.type === "Multi" &&
+			Array.isArray((parent as IMultiChoice).choices) &&
+			(parent as IMultiChoice).choices.some(
+				(child) => child?.id === entry.choice.id,
+			);
+		if (!carriedInline) return entry.choice.id;
+	}
+
+	return null;
 }
 
 export async function analysePackage(
@@ -587,7 +645,11 @@ export async function applyPackageImport(
 				: null;
 
 		if (parentImported) {
-			// Parent will be handled separately; avoid double-inserting children.
+			// Parent carries this child inline, so skip its own entry to avoid
+			// double-inserting. This trusts the parent to actually list the child
+			// inline (remapChoiceTree keeps only direct inline children); a package
+			// where it does not is rejected up front by findUncarriedChildChoiceId in
+			// parseQuickAddPackage, so a parsed import never silently drops it here.
 			handledChoices.add(originalId);
 			continue;
 		}

--- a/src/template/fileExistsPolicy.test.ts
+++ b/src/template/fileExistsPolicy.test.ts
@@ -239,3 +239,67 @@ describe("fileExistsPolicy collision naming", () => {
 		).resolves.toBe("tt0780504 (1).md");
 	});
 });
+
+describe("fileExistsPolicy collision naming terminates on large trailing numbers", () => {
+	// 2^53 (Number.MAX_SAFE_INTEGER + 1): the IEEE-754 ceiling where the old
+	// `parseInt(n, 10) + 1` arithmetic became a no-op. The recursive resolvers then
+	// computed a "next" path identical to the current one, so `exists` stayed true
+	// and they spun forever. A filename like `Foo9007199254740992` is only 19 chars
+	// and trivially constructible from a {{VALUE}}/CLI/URI-derived target, and a
+	// synced vault can already contain such a note - so this was reachable.
+	const TWO_POW_53 = "9007199254740992";
+
+	// Returns false for any path not in `existing`, and throws if probed more than
+	// `cap` times so a regression (the old infinite loop) fails loudly instead of
+	// hanging the whole suite.
+	const boundedExists = (existing: Iterable<string>, cap = 1000) => {
+		const present = new Set(existing);
+		let calls = 0;
+		return vi.fn(async (path: string) => {
+			if (++calls > cap) {
+				throw new Error(
+					`collision resolver did not terminate: ${calls} exists() probes`,
+				);
+			}
+			return present.has(path);
+		});
+	};
+
+	it("increments past 2^53 instead of looping forever on an identical path", async () => {
+		const exists = boundedExists([`Note${TWO_POW_53}.md`]);
+
+		await expect(
+			resolveIncrementedCollisionPath(`Note${TWO_POW_53}.md`, exists),
+		).resolves.toBe("Note9007199254740993.md");
+		expect(exists.mock.calls.length).toBeLessThanOrEqual(2);
+	});
+
+	it("increments a duplicate suffix past 2^53 instead of looping forever", async () => {
+		const exists = boundedExists([`Note (${TWO_POW_53}).md`]);
+
+		await expect(
+			resolveDuplicateSuffixCollisionPath(`Note (${TWO_POW_53}).md`, exists),
+		).resolves.toBe("Note (9007199254740993).md");
+		expect(exists.mock.calls.length).toBeLessThanOrEqual(2);
+	});
+
+	it("walks a chain of >=2^53 collisions to the first free name", async () => {
+		const exists = boundedExists([
+			"Note9007199254740992.md",
+			"Note9007199254740993.md",
+			"Note9007199254740994.md",
+		]);
+
+		await expect(
+			resolveIncrementedCollisionPath("Note9007199254740992.md", exists),
+		).resolves.toBe("Note9007199254740995.md");
+	});
+
+	it("grows the width when a fully-padded number rolls over (999 -> 1000)", async () => {
+		const exists = boundedExists(["Note999.md"]);
+
+		await expect(
+			resolveIncrementedCollisionPath("Note999.md", exists),
+		).resolves.toBe("Note1000.md");
+	});
+});

--- a/src/template/fileExistsPolicy.ts
+++ b/src/template/fileExistsPolicy.ts
@@ -204,47 +204,39 @@ export async function resolveIncrementedCollisionPath(
 	filePath: string,
 	exists: ExistsFn,
 ): Promise<string> {
-	if (!(await exists(filePath))) {
-		return filePath;
+	// Iterate (never recurse) and bump the trailing number with BigInt so the
+	// candidate always advances by exactly one - even past 2^53, where the old
+	// `parseInt(n, 10) + 1` became a no-op (the computed "next" path equalled the
+	// current one, `exists` stayed true, and the recursion spun forever). The
+	// numeric part strictly increases, so no name repeats and a finite vault
+	// guarantees `exists` eventually returns false. BigInt swaps in for parseInt
+	// with no other change, so this is byte-for-byte identical below 2^53.
+	let candidate = filePath;
+	while (await exists(candidate)) {
+		const { basename, extension } = splitCollisionFileName(candidate);
+		const match = basename.match(/^(.*?)(\d+)$/);
+		const nextBasename = match
+			? `${match[1]}${String(BigInt(match[2]) + 1n).padStart(match[2].length, "0")}`
+			: `${basename}1`;
+		candidate = `${nextBasename}${extension}`;
 	}
-
-	const { basename, extension } = splitCollisionFileName(filePath);
-	const match = basename.match(/^(.*?)(\d+)$/);
-	const nextBasename = match
-		? `${match[1]}${String(parseInt(match[2], 10) + 1).padStart(
-				match[2].length,
-				"0",
-			)}`
-		: `${basename}1`;
-	const nextFilePath = `${nextBasename}${extension}`;
-
-	if (await exists(nextFilePath)) {
-		return await resolveIncrementedCollisionPath(nextFilePath, exists);
-	}
-
-	return nextFilePath;
+	return candidate;
 }
 
 export async function resolveDuplicateSuffixCollisionPath(
 	filePath: string,
 	exists: ExistsFn,
 ): Promise<string> {
-	if (!(await exists(filePath))) {
-		return filePath;
+	let candidate = filePath;
+	while (await exists(candidate)) {
+		const { basename, extension } = splitCollisionFileName(candidate);
+		const match = basename.match(/^(.*) \((\d+)\)$/);
+		const nextBasename = match
+			? `${match[1]} (${String(BigInt(match[2]) + 1n)})`
+			: `${basename} (1)`;
+		candidate = `${nextBasename}${extension}`;
 	}
-
-	const { basename, extension } = splitCollisionFileName(filePath);
-	const match = basename.match(/^(.*) \((\d+)\)$/);
-	const nextBasename = match
-		? `${match[1]} (${parseInt(match[2], 10) + 1})`
-		: `${basename} (1)`;
-	const nextFilePath = `${nextBasename}${extension}`;
-
-	if (await exists(nextFilePath)) {
-		return await resolveDuplicateSuffixCollisionPath(nextFilePath, exists);
-	}
-
-	return nextFilePath;
+	return candidate;
 }
 
 function splitCollisionFileName(filePath: string) {


### PR DESCRIPTION
Three independent deepsec clean-room BUG findings, fixed at the root. Each is a distinct file/subsystem with no overlap; each ships as `fix:` with unit tests. All three were reproduced (red) before fixing and proven (green) after - the prompt fix additionally has a live Obsidian-vault red→green. All findings were confirmed real (none refuted/by-design).

## 1. `fix(template)` - collision resolvers spun forever past 2^53

`resolveIncrementedCollisionPath` / `resolveDuplicateSuffixCollisionPath` self-recursed with a `parseInt(n,10)+1` trailing-number increment. At/above `Number.MAX_SAFE_INTEGER` (2^53), `parseInt(n)+1` is a no-op, so the computed "next" path equalled the current one; since execution was already in the `exists(current)===true` branch, `exists(next)` stayed true and the resolver recursed forever on an identical path (a hung async microtask loop, not a stack overflow). The target path comes from a template's `fileNameFormat` (`{{VALUE}}`/CLI/URI), and a synced vault can already contain a note like `Foo9007199254740992.md`, so it was reachable.

**Fix:** bounded iterative loop + swap `parseInt` for `BigInt` in the increment, so the candidate always advances by exactly one. `BigInt` replaces `parseInt` with no other change, so output is **byte-for-byte identical below 2^53** (increment keeps `padStart` width; duplicate-suffix keeps no padding). The trailing number strictly increases each step, so no name repeats and a finite vault guarantees termination.

**Evidence:** new tests drive both resolvers from a 2^53 collision; a bounded `exists()` probe **throws on the >1000th call** so a regression fails loudly instead of hanging. Red (old recursion): `collision resolver did not terminate: 1001 exists() probes`. Green: terminates in ≤2 probes, advancing `...992 → ...993`.

## 2. `fix(import)` - imported child silently dropped when its parent doesn't carry it

`applyPackageImport` installs a parented child **solely** through its parent Multi's inline `choices` (`remapChoiceTree` keeps only inline children), and the insertion loop skips a child's own flat entry when `parentChoiceId` names an importable parent (`handledChoices.add; continue`). So a hand-edited / cross-version / tampered `.quickadd.json` where entry `X` declares `parentChoiceId=M` but `M.choices` omits `X` imports `X` **nowhere** - dropped while the modal listed it and reported success. Not caught by `findDivergentChoiceId` (`X` appears once) nor the structural validator. Fails safe (fewer choices than previewed), so it's a data-integrity/trust bug, not a disclosure-gate bypass.

**Fix:** `findUncarriedChildChoiceId` at the `parseQuickAddPackage` trust boundary (every untrusted package flows through it - `ImportPackageModal` and the CLI's `readQuickAddPackage`), mirroring the sibling fail-closed validators `findDivergentChoiceId` / `findDuplicateAssetPath`. It rejects a package where a flat entry's `parentChoiceId` names another entry that doesn't list it as a **direct** inline Multi child - exactly the level `remapChoiceTree` carries. `parentChoiceId` in a real export is always the direct Multi parent, so this never false-rejects a legitimate package (round-trip "gold" test), and direct-membership avoids false-accepting a child buried under a non-importable grandchild. Entries whose parent is not itself a package entry stay exempt (the importer routes those to the existing-vault parent / root).

**Evidence:** new parse-reject tests (uncarried child; non-Multi parent) are red without the validator (`expected [Function] to throw`) and green with it; the exemption + round-trip tests confirm no false-reject.

## 3. `fix(prompt)` - wide/multiline prompts doubled every backslash

`GenericWideInputPrompt.submit()` ran `escapeBackslashes()` (`\` → `\\`) with **no downstream un-doubling**, so a value typed into a wide/multiline prompt landed double-backslashed in note content and in scripts via `quickAddApi.wideInputPrompt()`. The escape was added for #799 back when the formatter's `replaceLinebreakInString` un-doubled `\\`→`\` over the whole content; once linebreak expansion was scoped to the format template (`expandLinebreakEscapesOutsideTokens` runs **before** `{{VALUE}}` substitution and skips token spans) and `replaceLinebreakInString` lost all production callers, the escape became pure corruption - `C:\temp` reached the note as `C:\\temp`, compounding with the `|type:text` YAML quoter. The single-line `GenericInputPrompt` is the identity, so the same `{{VALUE}}` token stored different bytes depending only on a UI setting. Same stale escape existed in the `OnePageInputModal` textarea branch.

**Fix:** return the textarea value verbatim, matching the single-line prompt. #799's intent (a typed `\n` must not become a real newline) still holds because the substituted value is never linebreak-expanded. Same removal in the `OnePageInputModal` `|type:multiline` branch.

**Evidence (live Obsidian 1.13.0, production build):** typed `C:\temp`:
- Red (pre-fix bundle): `wideInputPrompt` returned `C:\\temp` (`doubled:true`)
- Green (post-fix bundle): returned `C:\temp` exactly (`ok:true, doubled:false`)

Unit tests now drive the **real** prompt through its public `Prompt()` API (the previous test only exercised a copy of the escape helper, locking in the corruption), plus a `OnePageInputModal` textarea verbatim test.

## Adversarial review

Each finding+fix was challenged by an opposing-model panel (Codex: Skeptic / Architect / Minimalist) before and after coding. No high/medium correctness findings survived. Accepted refinements folded into the commits:
- **Skeptic + Minimalist:** use `BigInt` instead of a hand-rolled string incrementer - simpler and byte-identical to the original for the duplicate-suffix leading-zero case too.
- **Minimalist:** deleted a brittle apply-level characterization test that pinned the buggy `applyPackageImport` behavior (the parse-reject tests are the real contract); drove the prompt test through the public API instead of private state; trimmed a padded identity matrix.
- **Architect:** added a coupling comment at the import skip pointing to the parse-time guard (declined an import-side duplicate guard - every untrusted package already passes through `parseQuickAddPackage`, consistent with the sibling validators).

## Gates

`tsc -noEmit -skipLibCheck`, `eslint .`, `svelte-check --threshold error`, and full `vitest` (3444 passing) all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text inputs in prompts and one-page forms now keep backslashes and newlines exactly as entered.
  * Package imports now reject invalid nested choices more reliably, reducing missing or mismatched options during import.
  * Filename collision handling now works correctly for very large numbers and avoids getting stuck when many similarly named files exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->