### PR TITLE
fix(security): contain Template/Capture file writes and package reads within the vault

### DIFF
--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -755,6 +755,31 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 		expect(result).toBe("Boards/Map.CANVAS");
 	});
 
+	// Security: a drive/absolute 'Capture to' must be rejected at path assembly,
+	// BEFORE run()'s `fileExists(filePath)` existence probe — otherwise on Windows
+	// the probe would stat an out-of-vault path. normalizeGeneratedFilePath passes
+	// drive paths through to the boundary check, so this exercises that guard.
+	it("refuses a drive/absolute capture target before the existence probe", async () => {
+		// A leading-slash "/etc/secret.md" is stripped to the in-vault "etc/secret.md"
+		// (root-relative convention), so the escapes that reach this guard are the
+		// drive forms that normalizeGeneratedFilePath passes through.
+		for (const captureTo of ["C:/secret.md", "C:\\secret.md"]) {
+			const app = createApp();
+			const engine = new CaptureChoiceEngine(
+				app,
+				{ settings: { useSelectionAsCaptureValue: false } } as any,
+				createChoice({ captureTo }),
+				createExecutor(),
+			);
+
+			await expect(
+				(engine as any).getFormattedPathToCaptureTo(false),
+			).rejects.toBeInstanceOf(ChoiceAbortError);
+			// The out-of-vault path never reached an existence probe.
+			expect(app.vault.adapter.exists).not.toHaveBeenCalled();
+		}
+	});
+
 	it("builds a single-slash path for a typed custom filename in a folder capture", async () => {
 		vi.mocked(getMarkdownFilesInFolder).mockReturnValue([
 			{ path: "Inbox/Existing.md" } as any,

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -67,6 +67,7 @@ import {
 	getAppendLinkDestinationFile,
 } from "../utils/fileLinks";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
+import { escapesVaultBoundary } from "../utils/vaultPathBoundary";
 import { InputPromptDraftStore } from "../utils/InputPromptDraftStore";
 import { appendLinkToFrontmatterProperty } from "../utils/frontmatterPropertyLinks";
 import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
@@ -1528,6 +1529,18 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		if (!basename.trim()) {
 			throw new ChoiceAbortError(
 				`Capture target file name is empty after formatting ('${finalPath}'). Make sure the tokens in 'Capture to' produce a value.`,
+			);
+		}
+
+		// Contain the assembled target at assembly — BEFORE the run() existence probe
+		// (`fileExists(filePath)`) that precedes the create sink. normalizeGeneratedFilePath
+		// intentionally leaves absolute/drive/UNC paths for the boundary check, so without
+		// this a 'Capture to' formatting to e.g. "C:/secret.md" would reach adapter.exists
+		// out-of-vault on Windows before createFileWithInput could reject it. Mirrors the
+		// Template path's normalizeTemplateFilePath guard.
+		if (escapesVaultBoundary(finalPath)) {
+			throw new ChoiceAbortError(
+				`Refusing to capture to a file outside the vault: "${finalPath}".`,
 			);
 		}
 

--- a/src/engine/QuickAddEngine.test.ts
+++ b/src/engine/QuickAddEngine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { QuickAddEngine } from "./QuickAddEngine";
 
 class TestEngine extends QuickAddEngine {
@@ -22,5 +22,75 @@ describe("QuickAddEngine path normalization", () => {
 
 	it("strips leading slashes from file-only paths", () => {
 		expect(engine.normalize("", "/review/daily")).toBe("review/daily.md");
+	});
+});
+
+class SinkTestEngine extends QuickAddEngine {
+	public readonly created: Array<{ path: string; content: string }> = [];
+	public readonly createdFolders: string[] = [];
+
+	public constructor() {
+		const app = {
+			vault: {
+				adapter: { exists: vi.fn().mockResolvedValue(false) },
+				getAbstractFileByPath: vi.fn().mockReturnValue(null),
+				createFolder: vi.fn(async (folder: string) => {
+					(this as SinkTestEngine).createdFolders.push(folder);
+				}),
+				create: vi.fn(async (path: string, content: string) => {
+					const file = { path, basename: path };
+					(this as SinkTestEngine).created.push({ path, content });
+					return file;
+				}),
+			},
+		};
+		super(app as any);
+	}
+
+	public create(path: string, content: string) {
+		return this.createFileWithInput(path, content);
+	}
+
+	public run(): void {}
+}
+
+describe("QuickAddEngine createFileWithInput vault containment", () => {
+	// Every assembled path that resolves OUTSIDE the vault must be rejected at the
+	// create sink before any filesystem touch (folder creation or vault.create).
+	const escaping = [
+		"..\\..\\..\\evil.md", // Windows-style backslash traversal (the URI/{{VALUE}} vector)
+		"../../../evil.md", // POSIX traversal
+		"folder/../../evil.md", // traversal mid-path
+		"/etc/evil.md", // POSIX-absolute
+		"C:/evil.md", // Windows drive-absolute
+		"C:\\evil.md", // Windows drive-absolute, backslash
+		"\\\\server\\share\\evil.md", // UNC
+	];
+
+	for (const path of escaping) {
+		it(`refuses to create an out-of-vault path: ${JSON.stringify(path)}`, async () => {
+			const engine = new SinkTestEngine();
+			await expect(engine.create(path, "payload")).rejects.toThrow(
+				/Refusing to create a file outside the vault/,
+			);
+			// The write AND the folder pre-creation must never have run.
+			expect(engine.created).toHaveLength(0);
+			expect(engine.createdFolders).toHaveLength(0);
+		});
+	}
+
+	it("still creates ordinary in-vault paths", async () => {
+		const engine = new SinkTestEngine();
+		const file = await engine.create("Projects/Notes/Issue 221.md", "body");
+		expect(file.path).toBe("Projects/Notes/Issue 221.md");
+		expect(engine.created).toEqual([
+			{ path: "Projects/Notes/Issue 221.md", content: "body" },
+		]);
+	});
+
+	it("allows in-vault config-dir paths (escapesVaultBoundary only blocks escapes)", async () => {
+		const engine = new SinkTestEngine();
+		const file = await engine.create(".obsidian/snippets/note.md", "body");
+		expect(file.path).toBe(".obsidian/snippets/note.md");
 	});
 });

--- a/src/engine/QuickAddEngine.ts
+++ b/src/engine/QuickAddEngine.ts
@@ -3,6 +3,7 @@ import { TFile, TFolder } from "obsidian";
 import { MARKDOWN_FILE_EXTENSION_REGEX } from "../constants";
 import { log } from "../logger/logManager";
 import { withTemplaterFileCreationSuppressed } from "../utilityObsidian";
+import { escapesVaultBoundary } from "../utils/vaultPathBoundary";
 
 export abstract class QuickAddEngine {
 	public app: App;
@@ -66,6 +67,20 @@ export abstract class QuickAddEngine {
 		fileContent: string,
 		opts: { suppressTemplaterOnCreate?: boolean } = {},
 	): Promise<TFile> {
+		// Authoritative vault-containment boundary for every new-file write (Template
+		// and Capture both funnel through here). `filePath` is assembled from formatted
+		// names that can be seeded by untrusted input — an obsidian:// URI, the CLI, or
+		// `{{VALUE}}` resolved from synced note content. A traversal/absolute/drive/UNC
+		// path (e.g. "..\\..\\..\\evil.md" or "C:/evil.md") would make `vault.create`
+		// AND the folder pre-creation below resolve OUTSIDE the vault root. Reject it
+		// here, before any filesystem touch, so the sink can never escape even if an
+		// upstream normalizer is bypassed. Mirrors the package-import write guard (#1434).
+		if (escapesVaultBoundary(filePath)) {
+			throw new Error(
+				`Refusing to create a file outside the vault: "${filePath}".`,
+			);
+		}
+
 		const dirMatch = filePath.match(/(.*)[/\\]/);
 		let dirName = "";
 		if (dirMatch) dirName = dirMatch[1];

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -26,6 +26,7 @@ import {
 } from "../constants";
 import { reportError } from "../utils/errorUtils";
 import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
+import { escapesVaultBoundary } from "../utils/vaultPathBoundary";
 import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
 import {
 	INVALID_FOLDER_CHARS_REGEX,
@@ -551,7 +552,21 @@ export abstract class TemplateEngine extends QuickAddEngine {
 				"File name is empty after formatting. Make sure the tokens in the file name format produce a value (an optional token left empty can cause this)."
 			);
 		}
-		return `${actualFolderPath}${formattedFileName}${extension}`;
+		const assembledPath = `${actualFolderPath}${formattedFileName}${extension}`;
+		// Contain the assembled target at this shared chokepoint. The file NAME is run
+		// through normalizeGeneratedFilePath above, but the FOLDER portion is only
+		// stripLeadingSlash'd — so a folder like "../../../evil" (from an untrusted,
+		// synced Template choice resolved via formatFolderPath) would assemble an
+		// out-of-vault path. Both callers act on it without a sink guard: the relocation
+		// flow (computeChoiceTargetPath -> createFolder + fileManager.renameFile) would
+		// otherwise move the active note OUTSIDE the vault. Reject any escape here so
+		// every caller of this assembler is contained.
+		if (escapesVaultBoundary(assembledPath)) {
+			throw new Error(
+				`Refusing to build a file path outside the vault: "${assembledPath}".`,
+			);
+		}
+		return assembledPath;
 	}
 
 	protected async createFileWithTemplate(

--- a/src/engine/TemplateEngine.vault-containment.test.ts
+++ b/src/engine/TemplateEngine.vault-containment.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from "vitest";
+import { TemplateEngine } from "./TemplateEngine";
+import type { App } from "obsidian";
+import type QuickAdd from "../main";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+
+// normalizeTemplateFilePath is the shared chokepoint that assembles the
+// vault-relative path for BOTH the create flow (TemplateChoiceEngine) and the
+// "Apply template to active note" relocation flow (TemplateInsertEngine ->
+// computeChoiceTargetPath -> createFolder + fileManager.renameFile). The relocation
+// flow's FOLDER portion is NOT run through normalizeGeneratedFilePath and is NOT
+// guarded by validateFolderPath, so a synced/shared malicious Template choice whose
+// folder is "../../../evil" would otherwise assemble an out-of-vault target and move
+// the note outside the vault. Assert the assembled path is vault-contained.
+
+vi.mock("../formatters/completeFormatter", () => ({
+	CompleteFormatter: vi.fn(function CompleteFormatterMock() {
+		return {
+			setTargetFolderPath: vi.fn(),
+			setTitle: vi.fn(),
+		};
+	}),
+}));
+
+class TestTemplateEngine extends TemplateEngine {
+	public constructor(
+		app: App,
+		plugin: QuickAdd,
+		choiceExecutor: IChoiceExecutor,
+	) {
+		super(app, plugin, choiceExecutor);
+	}
+
+	public async run(): Promise<void> {}
+
+	public normalize(
+		folderPath: string,
+		fileName: string,
+		templatePath: string,
+	): string {
+		return this.normalizeTemplateFilePath(folderPath, fileName, templatePath);
+	}
+}
+
+function makeEngine(): TestTemplateEngine {
+	const app = {
+		vault: { getAbstractFileByPath: vi.fn(() => null) },
+		plugins: { plugins: { "templater-obsidian": null } },
+	} as unknown as App;
+	return new TestTemplateEngine(app, {} as QuickAdd, {} as IChoiceExecutor);
+}
+
+describe("normalizeTemplateFilePath vault containment", () => {
+	const engine = makeEngine();
+
+	it("assembles ordinary in-vault paths unchanged", () => {
+		expect(engine.normalize("Projects/Sub", "Note", "t.md")).toBe(
+			"Projects/Sub/Note.md",
+		);
+		expect(engine.normalize("", "Note", "t.md")).toBe("Note.md");
+	});
+
+	it("treats a leading-slash folder as in-vault root-relative (not an escape)", () => {
+		// "/etc" -> stripLeadingSlash -> "etc": the documented root-relative convention,
+		// contained inside the vault. Only genuine traversal/drive/UNC escapes are rejected.
+		expect(engine.normalize("/etc", "Note", "t.md")).toBe("etc/Note.md");
+	});
+
+	// The folder portion is the relocation gap: it bypasses normalizeGeneratedFilePath.
+	const escapingFolders = [
+		"../../../evil", // POSIX traversal in the folder
+		"..\\..\\..\\evil", // Windows backslash traversal
+		"C:/Windows", // drive-absolute folder
+		"C:\\Windows", // drive-absolute folder, backslash
+		"\\\\server\\share", // UNC
+	];
+	for (const folder of escapingFolders) {
+		it(`refuses an out-of-vault folder portion: ${JSON.stringify(folder)}`, () => {
+			expect(() => engine.normalize(folder, "Note", "t.md")).toThrow(
+				/outside the vault/,
+			);
+		});
+	}
+
+	it("refuses the Windows trailing-space '..' collapse in the folder portion", () => {
+		// On Windows the filesystem strips trailing spaces/dots per component, so
+		// ".. " becomes the parent ".." at file-open. A lexical "=== '..'" check
+		// misses it; the boundary must catch the collapsed form.
+		expect(() => engine.normalize(".. /.. /evil", "Note", "t.md")).toThrow(
+			/outside the vault/,
+		);
+	});
+
+	it("refuses traversal that appears only in the assembled file name", () => {
+		// Defense in depth: even a folder of "" with a traversal that slipped past
+		// the name normalizer must not assemble an escaping path.
+		expect(() => engine.normalize("Projects", "..\\..\\evil", "t.md")).toThrow();
+	});
+});

--- a/src/engine/TemplateEngine.vault-containment.test.ts
+++ b/src/engine/TemplateEngine.vault-containment.test.ts
@@ -91,9 +91,13 @@ describe("normalizeTemplateFilePath vault containment", () => {
 		);
 	});
 
-	it("refuses traversal that appears only in the assembled file name", () => {
-		// Defense in depth: even a folder of "" with a traversal that slipped past
-		// the name normalizer must not assemble an escaping path.
-		expect(() => engine.normalize("Projects", "..\\..\\evil", "t.md")).toThrow();
+	it("refuses an escape that appears only in the assembled file name", () => {
+		// Defense in depth via the assembled-path guard specifically: a drive path
+		// passes normalizeGeneratedFilePath (which leaves absolute/drive forms for the
+		// boundary check), so this reaches escapesVaultBoundary(assembledPath) rather
+		// than throwing earlier in name normalization.
+		expect(() => engine.normalize("", "C:\\evil", "t.md")).toThrow(
+			/outside the vault/,
+		);
 	});
 });

--- a/src/engine/templateNoteDiscovery.test.ts
+++ b/src/engine/templateNoteDiscovery.test.ts
@@ -152,6 +152,23 @@ describe("template note discovery", () => {
 		);
 	});
 
+	it("drops unresolved-link candidates that escape the vault boundary", () => {
+		// Security: unresolvedLinks is derived from note content, untrusted on a
+		// synced/shared vault. A planted [[..\..\..\evil]] (or absolute/drive path)
+		// must never surface as a selectable "create" target.
+		expect(testExports.normalizeUnresolvedTarget("..\\..\\..\\evil")).toBeNull();
+		expect(testExports.normalizeUnresolvedTarget("../../escape")).toBeNull();
+		expect(testExports.normalizeUnresolvedTarget("/etc/passwd")).toBeNull();
+		expect(testExports.normalizeUnresolvedTarget("C:/secret")).toBeNull();
+		// Ordinary in-vault titles still pass through unchanged.
+		expect(testExports.normalizeUnresolvedTarget("Projects/Missing Roadmap")).toBe(
+			"Projects/Missing Roadmap",
+		);
+		expect(testExports.normalizeUnresolvedTarget("Missing Project")).toBe(
+			"Missing Project",
+		);
+	});
+
 	it("excludes the selected literal template file from existing-note candidates", () => {
 		const template = file("Templates/Project.md");
 		const alice = file("Existing/Alice.md");

--- a/src/engine/templateNoteDiscovery.ts
+++ b/src/engine/templateNoteDiscovery.ts
@@ -6,6 +6,7 @@ import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
 import { isCancellationError } from "src/utils/errorUtils";
 import { UserCancelError } from "src/errors/UserCancelError";
 import { normalizeGeneratedFilePath } from "src/utils/generatedFilePath";
+import { escapesVaultBoundary } from "src/utils/vaultPathBoundary";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 
 export {
@@ -113,6 +114,11 @@ function normalizeUnresolvedTarget(raw: string): string | null {
 	const withoutSubpath = withoutAlias.split("#")[0]?.trim() ?? "";
 	const withoutExtension = withoutSubpath.replace(/\.md$/i, "").trim();
 	if (!withoutExtension || withoutExtension === "/") return null;
+	// Unresolved-link candidates come from note content (metadataCache.unresolvedLinks),
+	// which is untrusted on a synced/shared vault: a planted [[..\\..\\..\\evil]] would
+	// otherwise surface as a selectable "create" target that resolves outside the vault.
+	// Drop anything that escapes the boundary so it never appears as a traversal lure.
+	if (escapesVaultBoundary(withoutExtension)) return null;
 	return withoutExtension;
 }
 

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -296,6 +296,31 @@ describe("choiceService", () => {
 			expect(JSON.stringify(copy)).not.toContain("__quickaddSecret");
 		});
 
+		it("never reads an out-of-vault userscript path when duplicating a synced macro", async () => {
+			// Security: a Macro command's `path` comes from data.json, untrusted on a
+			// synced/shared/imported vault. An escaping path must not reach adapter.read.
+			const original = createChoice("Macro", "Mac") as IMacroChoice;
+			original.macro.commands.push({
+				id: "cmd-evil",
+				name: "Run script",
+				type: "UserScript",
+				path: "../../../etc/passwd",
+				settings: { "API Key": "legacy-secret" },
+			} as unknown as IMacroChoice["macro"]["commands"][number]);
+
+			const exists = vi.fn().mockResolvedValue(true);
+			const read = vi.fn().mockResolvedValue("module.exports = {};");
+			const app = {
+				vault: { adapter: { exists, read } },
+			} as unknown as App;
+
+			await duplicateChoiceWithUserScriptSecretSanitization(original, app);
+
+			// The out-of-vault path is skipped before any filesystem touch.
+			expect(exists).not.toHaveBeenCalled();
+			expect(read).not.toHaveBeenCalled();
+		});
+
 		it("recursively duplicates nested Multi choices and preserves placeholder/collapsed", () => {
 			const inner = createChoice("Template", "Inner");
 			const nestedMulti = createChoice("Multi", "Nested") as IMultiChoice;

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -27,6 +27,7 @@ import {
 } from "../utils/userScriptSecrets";
 import type { UserScriptSecretSanitizerOptions } from "../utils/userScriptSecrets";
 import { log } from "../logger/logManager";
+import { escapesVaultBoundary } from "../utils/vaultPathBoundary";
 
 const choiceConstructors: Record<ChoiceType, new (name: string) => IChoice> = {
 	Template: TemplateChoice,
@@ -148,6 +149,12 @@ async function buildSecretOptionNamesByPath(
 
 	for (const path of paths) {
 		try {
+			// A Macro choice's userscript path comes from data.json, which is untrusted
+			// on a synced/shared/imported vault. Never stat or read an out-of-vault path
+			// (e.g. "../../../etc/passwd"); treat it as not-present, mirroring the package
+			// import probes (escapesVaultBoundary, #1434).
+			if (escapesVaultBoundary(path)) continue;
+
 			const exists = await app.vault.adapter.exists(path);
 			if (!exists) continue;
 

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -494,6 +494,30 @@ describe("readQuickAddPackage", () => {
 		expect(loaded.path).toBe("packages/p.json");
 		expect(loaded.pkg.choices[0].choice.id).toBe("a");
 	});
+
+	// Security: the read entry point is reached with an untrusted `path` (the CLI
+	// `path=` flag, the GUI file picker). It must reject any path that escapes the
+	// vault BEFORE touching the filesystem, so a crafted "../../../etc/passwd" can
+	// never disclose an out-of-vault file. normalizePath does not resolve "..".
+	it.each([
+		"../../../etc/passwd",
+		"../secret.json",
+		"packages/../../escape.json",
+		"/etc/passwd",
+		"C:/secret.json",
+		"C:\\secret.json",
+		"..\\..\\..\\etc\\passwd",
+		"\\\\server\\share\\secret.json",
+	])("refuses to read an out-of-vault package path: %s", async (escaping) => {
+		const { app, adapter } = createFakeApp();
+		await expect(readQuickAddPackage(app, escaping)).rejects.toThrow(
+			/Refusing to read a package outside the vault/,
+		);
+		// No filesystem touch at all. `adapter.exists` is the first adapter call and
+		// the read only runs after a successful existence check, so exists-not-called
+		// proves adapter.read never ran either.
+		expect(adapter.exists).not.toHaveBeenCalled();
+	});
 });
 
 // --- analysePackage ---------------------------------------------------------

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -94,6 +94,19 @@ export async function readQuickAddPackage(
 	app: App,
 	packagePath: string,
 ): Promise<LoadedQuickAddPackage> {
+	// Containment guard at the single read entry point, before any filesystem
+	// touch. `packagePath` is untrusted (the CLI `path=` flag, the GUI file
+	// picker): `normalizePath` collapses slashes but does NOT resolve "..", so a
+	// path like "../../../etc/passwd" (or an absolute/drive path) would otherwise
+	// reach `adapter.read` and disclose a file OUTSIDE the vault. The sibling
+	// analysePackage/analysePackagePreview probes already guard with this; the read
+	// path must too, so every current and future caller inherits the protection.
+	if (escapesVaultBoundary(packagePath)) {
+		throw new Error(
+			`Refusing to read a package outside the vault: "${packagePath}".`,
+		);
+	}
+
 	const normalized = normalizePath(packagePath.trim());
 	if (!normalized) throw new Error("Package path cannot be empty.");
 

--- a/src/utils/generatedFilePath.test.ts
+++ b/src/utils/generatedFilePath.test.ts
@@ -68,4 +68,23 @@ describe("normalizeGeneratedFilePath", () => {
 			'File path cannot contain "." or ".." path segments.',
 		);
 	});
+
+	it("rejects backslash traversal (Windows-style ..\\) that the slash-only split missed", () => {
+		// Regression for the path-traversal finding: a backslash is a real path
+		// separator to Obsidian's vault.create, so "..\\..\\..\\evil" must be
+		// rejected, not preserved as a single non-".." segment.
+		expect(() => normalizeGeneratedFilePath("..\\..\\..\\evil")).toThrow(
+			'File path cannot contain "." or ".." path segments.',
+		);
+		expect(() => normalizeGeneratedFilePath("Folder\\..\\Note")).toThrow(
+			'File path cannot contain "." or ".." path segments.',
+		);
+	});
+
+	it("treats a backslash as a folder separator, mirroring Obsidian's normalizePath", () => {
+		expect(normalizeGeneratedFilePath("Folder\\Note")).toBe("Folder/Note");
+		expect(normalizeGeneratedFilePath("a\\b\\Line\nBreak")).toBe(
+			"a/b/Line Break",
+		);
+	});
 });

--- a/src/utils/generatedFilePath.ts
+++ b/src/utils/generatedFilePath.ts
@@ -16,7 +16,17 @@ export function normalizeGeneratedFilePath(
 	path: string,
 	label = "File path",
 ): string {
-	const segments = path.split("/");
+	// Treat a backslash as a path separator BEFORE the per-segment "." / ".."
+	// rejection below. Obsidian's own `normalizePath` converts "\\" -> "/" before
+	// any path is touched on disk, so a formatted name like "..\\..\\..\\evil"
+	// would otherwise survive this guard as ONE non-".." segment yet still be
+	// written by `vault.create` as the traversal "../../../evil" — an out-of-vault
+	// write. Converting here makes the guard see the real segments (so "..\\" is
+	// rejected) and keeps this normalizer's view of the path identical to what
+	// Obsidian writes. The vault-containment assertion at the create sink
+	// (createFileWithInput -> escapesVaultBoundary) is the authoritative boundary
+	// for absolute / drive / UNC paths.
+	const segments = path.replace(/\\/g, "/").split("/");
 	return segments
 		.map((segment, index) => {
 			if (

--- a/src/utils/vaultPathBoundary.test.ts
+++ b/src/utils/vaultPathBoundary.test.ts
@@ -24,6 +24,24 @@ describe("escapesVaultBoundary", () => {
 		expect(escapesVaultBoundary("..\\..\\escape.md")).toBe(true);
 	});
 
+	it("rejects the Windows trailing-dot/space '..' collapse", () => {
+		// Win32 strips trailing spaces/dots per component, so ".. " / "..." resolve
+		// to the parent "..". A lexical "=== '..'" check would miss them.
+		expect(escapesVaultBoundary(".. /x.md")).toBe(true);
+		expect(escapesVaultBoundary("a/.. /b.md")).toBe(true);
+		expect(escapesVaultBoundary("...")).toBe(true);
+		expect(escapesVaultBoundary(".. ")).toBe(true);
+		expect(escapesVaultBoundary("..\\..  \\escape.md")).toBe(true);
+	});
+
+	it("does not over-reject ordinary names that merely contain dots", () => {
+		// Only a segment that is ".." + trailing dots/spaces is traversal; real
+		// filenames with leading/trailing dots stay in-vault.
+		expect(escapesVaultBoundary("..evil.md")).toBe(false);
+		expect(escapesVaultBoundary("evil...md")).toBe(false);
+		expect(escapesVaultBoundary("notes/v1.2.3/file.md")).toBe(false);
+	});
+
 	it("allows in-vault relative paths, including dot/config dirs", () => {
 		expect(escapesVaultBoundary("templates/note.md")).toBe(false);
 		expect(escapesVaultBoundary("scripts/run.js")).toBe(false);

--- a/src/utils/vaultPathBoundary.ts
+++ b/src/utils/vaultPathBoundary.ts
@@ -39,10 +39,24 @@ function isAbsoluteVaultPath(slashedPath: string): boolean {
 	return slashedPath.startsWith("/") || /^[a-zA-Z]:/.test(slashedPath);
 }
 
-/** True if any '/'-separated segment is exactly "..", i.e. a path-traversal
- * segment at any depth. ("..%2fevil.md" is a single literal segment, NOT "..".) */
+/** True if any '/'-separated segment is a parent-traversal "..", INCLUDING the
+ * Windows trailing-dot/space collapse: the Win32 filesystem strips trailing spaces
+ * and dots from each path component before opening it, so a segment like ".. " or
+ * "..." resolves to the parent ".." at file-open even though it is not literally "..".
+ * A lexical "=== '..'" check (and Node's own path math) would miss those, so match
+ * any segment that is ".." followed only by spaces/dots. ("..%2fevil.md" is a single
+ * literal segment, NOT "..", and "..evil" / "evil.." are ordinary names.)
+ *
+ * This deliberately also rejects exotic pure-dot names like "..." / "...." even on
+ * POSIX (where they are valid distinct directory names) — fail CLOSED toward
+ * Windows safety. The cost is nil in practice: QuickAdd's own folder validator
+ * already rejects any segment ending in a period/space (INVALID_FOLDER_TRAILING_CHARS),
+ * so such names are not creatable in-vault through the UI anyway. Do NOT narrow this
+ * to "spaces only" — that would reopen the Win32 trailing-dot collapse. */
 function hasTraversalSegment(slashedPath: string): boolean {
-	return slashedPath.split("/").some((segment) => segment === "..");
+	return slashedPath
+		.split("/")
+		.some((segment) => /^\.\.[. ]*$/u.test(segment));
 }
 
 /**


### PR DESCRIPTION
## Summary

Four deepsec MEDIUM path-traversal findings share one root cause: a formatted file path could
escape the vault because `normalizeGeneratedFilePath` blocked forward-slash `..` but **not**
backslash traversal (`..\..\..\evil`) or absolute paths, and the create / package-read sinks had
no vault-containment assertion. All four are fixed at the root and proven RED→GREEN in a live
Obsidian vault (macOS, Obsidian 1.13.0).

QuickAdd runs with full user trust, so these are only real because the path is **attacker-influenceable**:
an `obsidian://quickadd` URI is reachable from any webpage; the CLI and synced `data.json` / note
content carry untrusted strings.

## The vulnerabilities (all reproduced live)

**#1 + #2 — out-of-vault WRITE (Template/Capture create sink).**
`obsidian://quickadd?choice=<T>&value-value=..\..\..\evil` seeds the `value` variable
(`applyUriValueParameters` blocks only `__qa.` keys). For a Template whose `fileNameFormat` is
`{{value}}`, it flows verbatim through `normalizeGeneratedFilePath` (which split only on `/`, so the
backslash payload survived as one non-`..` segment) into `vault.create`. Obsidian normalizes `\`→`/`
before writing, so the path resolved **outside** the vault.

> RED (live): a malicious URI created a folder `QA_PWN_DIR` **and** a note `evil.md` OUTSIDE the
> vault root, with the formatted template body as content.
> GREEN: rejected (`File name cannot contain "." or ".." path segments`); nothing created outside.

**#3 — discovery-derived titles.** The same gap let a planted `[[..\..\evil]]` unresolved link
(sourced from untrusted note content) surface as a "create" candidate. Covered by the root fix;
additionally filtered so it never appears as a lure.

**#4 — out-of-vault READ (CLI/package read entry).** `quickadd:package-preview path=../../../etc/passwd`
reached `adapter.read` after only `normalizePath` (which does not resolve `..`).

> RED (live): `quickadd:package-preview path=../../../../etc/hosts` leaked `/etc/hosts` content via
> the parse-error envelope.
> GREEN: `Refusing to read a package outside the vault`.

## The fix (two layers, mirroring the package-import containment in #1434)

- **Layer A — root normalization** (`generatedFilePath.ts`): convert `\`→`/` before the segment
  split, so backslash traversal is rejected exactly like its forward-slash form. This also makes the
  normalizer's view of the path identical to what Obsidian's own `normalizePath` writes to disk
  (latent inconsistency fixed).
- **Layer B — authoritative sink guard** (`QuickAddEngine.createFileWithInput`): the single create
  sink shared by the Template **and** Capture engines throws `escapesVaultBoundary(filePath)` before
  any filesystem touch (before folder pre-creation and `vault.create`), so absolute / drive / UNC /
  `..` paths can never escape even if an upstream normalizer is bypassed.
- **Read entry** (`readQuickAddPackage`): throws `escapesVaultBoundary(packagePath)` before
  `adapter.exists`/`adapter.read`, centralizing the guard the sibling `analysePackage` /
  `analysePackagePreview` probes already have (#1434) so every caller (CLI + GUI import modal) inherits it.
- **Discovery filter** (`normalizeUnresolvedTarget`): drops unresolved-link candidates that escape
  the boundary.

## Adversarial review → two more sibling sinks contained

An adversarial panel (3 lenses: bypass-hunter, sink-completeness, regression) was run against the
core fix. It confirmed the core fix is sound (the `\`→`/` change verified behavior-preserving
against extracted Obsidian 1.13.0 internals; encoding/Unicode/drive bypass classes all
neutralized), and surfaced two **sibling sinks of the same vulnerability class** that the create-sink
guard missed:

- **Apply-template note relocation (MEDIUM, confirmed).** `maybeReconcileNoteLocation`
  (`applyTemplateToActiveNote.ts`) builds the move target via `computeChoiceTargetPath` →
  `normalizeTemplateFilePath`, whose **folder portion** is only `stripLeadingSlash`'d (never run
  through `normalizeGeneratedFilePath`, not gated by `validateFolderPath`). A synced/shared Template
  choice with `folder="../../../evil"` assembled an out-of-vault target that flowed into
  `vault.createFolder` + `fileManager.renameFile`, moving the active note OUT of the vault.
  > RED (live): `fileManager.renameFile(f, "../../../X/moved.md")` moved the note to
  > `…/quickadd/X/moved.md`, outside the vault. Fix: assert `escapesVaultBoundary` on the assembled
  > path at the shared `normalizeTemplateFilePath` chokepoint (covers create + relocation). GREEN
  > (unit + live create flow): escaping folders throw; legit creates/relocations unaffected.
- **Userscript-path read on duplicate-choice (LOW).** `choiceService.buildSecretOptionNamesByPath`
  read userscript paths from a Macro choice's `data.json` via `adapter.read` with no guard. Skip
  out-of-vault paths, mirroring the package probes.

Plus a hardening of the shared boundary helper: **Windows trailing-dot/space `..` collapse.** Win32
strips trailing spaces/dots per component, so `.. ` / `...` resolve to `..` at file-open;
`escapesVaultBoundary`'s `=== ".."` (and Node's own path math) missed them. Now any segment that is
`..` followed only by spaces/dots is treated as traversal — load-bearing so the relocation guard is
robust on Windows, and strengthening every caller (create sink + package guards).

## Scope decisions

- **`escapesVaultBoundary` (lexical), not `assertWriteStaysInVault` (realpath), at the create sink.**
  The findings are about lexical traversal (`..\`, absolute). `escapesVaultBoundary` is the right tool:
  pure, no false-positives, and it deliberately allows in-vault dot-dirs — whereas the realpath writer
  guard also rejects writes that *resolve into* a config dir, which would break legit Template/Capture
  creation into a literal dot-folder. Symlink-mediated escape is a separate vector not in these findings.
- **Layer A only converts `\`→`/`; it does not reject absolute/drive paths.** Rejecting a leading `/`
  there would break the documented root-relative `/Folder/Note` convenience (asserted by an existing
  test). Absolute/drive/UNC containment lives in one place: the sink (Layer B).
- **Audited adjacent sinks — already contained, no change needed:** the folder-selection
  `createFolder` (`validateFolderSegment` rejects `\ / : .. …` per segment — verified live: a backslash
  folder collapses to vault root); `applyTemplateToActiveNote` (path via `computeChoiceTargetPath` →
  Layer A, plus an interactive confirm); the import asset writer (`validateAssetDestination` /
  `assertWriteStaysInVault`, #1434).

## Tests (red-before / green-after, unit)

- `generatedFilePath.test.ts`: backslash traversal rejected; backslash treated as a separator.
- `QuickAddEngine.test.ts`: the create sink refuses 7 escaping forms (backslash, POSIX, mid-path,
  absolute, drive ×2, UNC) and never touches the FS; still creates ordinary in-vault and in-vault
  dot-dir paths.
- `packageImportService.test.ts`: the read entry refuses 8 escaping forms with no FS touch.
- `templateNoteDiscovery.test.ts`: escaping unresolved-link candidates dropped; legit titles pass.
- `TemplateEngine.vault-containment.test.ts`: the shared `normalizeTemplateFilePath` chokepoint
  refuses escaping folder portions (the relocation gap) and the Windows trailing-space `..`; legit
  and leading-slash root-relative folders assemble fine.
- `vaultPathBoundary.test.ts`: Windows trailing-dot/space `..` collapse rejected; ordinary
  dotted names not over-rejected.
- `choiceService.test.ts`: an out-of-vault userscript path is never stat/read on duplicate-choice.

## Verification

`tsc -noEmit` ✅ · `eslint .` ✅ · `svelte-check` ✅ (0 errors) · `vitest` ✅ (3481 passed) ·
live RED→GREEN for the URI write, the CLI read, and the relocation rename sink, plus a positive
control (`value-value=LegitNotes/Hello World` still creates the in-vault note).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked file creation, template generation, capture targets, and package reads from accepting paths that escape the vault, including traversal, absolute, drive, and UNC-style forms.
  * Prevented malicious unresolved-link targets and template/note “create” options from surfacing when they would resolve outside the vault.
  * Improved handling of Windows-style backslashes in generated paths to ensure consistent validation across platforms.
  * Skipped unsafe out-of-vault synced/untrusted user-script entries during choice duplication to avoid unintended filesystem access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->