### PR TITLE
fix: self-heal duplicate choice ids on load (blank settings page)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { CommandType } from "./types/macros/CommandType";
 import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { parseSemver } from "./utils/semver";
-import { resolveChoiceIcon } from "./utils/choiceUtils";
+import { dedupeChoicesById, resolveChoiceIcon } from "./utils/choiceUtils";
 import { isReservedVariableKey } from "./utils/reservedVariableKeys";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
@@ -452,6 +452,18 @@ export default class QuickAdd extends Plugin {
 
 		if (typeof settings.announceUpdates === "boolean") {
 			settings.announceUpdates = settings.announceUpdates ? "all" : "none";
+		}
+
+		// Heal duplicate choice ids (#1451): a repeated id makes the settings tab's
+		// keyed {#each} throw each_key_duplicate and render blank (commands keep
+		// working, so it looks like "corrupted data"). Cheap and idempotent, so it
+		// runs every load; the next ordinary save rewrites data.json cleaned. No
+		// data is lost - see dedupeChoicesById. Only touch a real array: a missing
+		// `choices` already defaults to [] via the merge above, and a null/corrupt
+		// value is left exactly as-is rather than being silently replaced with []
+		// (which a later save would persist, destroying recoverable data).
+		if (Array.isArray(settings.choices)) {
+			settings.choices = dedupeChoicesById(settings.choices);
 		}
 
 		this.settings = settings;

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -3,6 +3,7 @@ import type IChoice from "src/types/choices/IChoice";
 import type IMultiChoice from "src/types/choices/IMultiChoice";
 import type { ChoiceType } from "src/types/choices/choiceType";
 import {
+	dedupeChoicesById,
 	defaultIconForChoiceType,
 	flattenChoices,
 	flattenChoicesWithPath,
@@ -83,6 +84,120 @@ describe("flattenChoicesWithPath", () => {
 		const broken = multi("Broken", undefined as unknown as IChoice[]);
 
 		expect(flattenChoicesWithPath([broken])).toHaveLength(1);
+	});
+});
+
+describe("dedupeChoicesById", () => {
+	function withId(id: string, name = id): IChoice {
+		return { name, id, type: "Template", command: false };
+	}
+	function multiWithId(
+		id: string,
+		children: IChoice[],
+		name = id,
+	): IMultiChoice {
+		return {
+			name,
+			id,
+			type: "Multi",
+			command: false,
+			choices: children,
+			collapsed: false,
+		};
+	}
+
+	const UUID_RE =
+		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+	it("leaves a tree with no duplicates unchanged", () => {
+		const tree = [withId("a"), multiWithId("m", [withId("b"), withId("c")])];
+		expect(flattenChoices(dedupeChoicesById(tree)).map((c) => c.id)).toEqual([
+			"a",
+			"m",
+			"b",
+			"c",
+		]);
+	});
+
+	it("drops a byte-identical later duplicate (no data lost)", () => {
+		const result = dedupeChoicesById([withId("dup"), withId("x"), withId("dup")]);
+		expect(result.map((c) => c.id)).toEqual(["dup", "x"]);
+	});
+
+	it("drops a byte-identical duplicate nested inside a Multi (the #1451 signature)", () => {
+		// Two byte-identical children sharing one id inside a folder - exactly what
+		// blanks the settings tab via the keyed {#each}.
+		const dup = (): IChoice => withId("d", "supprimer taches dones");
+		const folder = multiWithId("folder", [withId("a"), dup(), dup()]);
+		const deduped = dedupeChoicesById([folder])[0] as IMultiChoice;
+		expect(deduped.choices.map((c) => c.id)).toEqual(["a", "d"]);
+	});
+
+	it("re-ids a DIVERGENT same-id choice instead of dropping it (no data lost)", () => {
+		const result = dedupeChoicesById([
+			withId("dup", "first"),
+			withId("dup", "second"), // same id, different content
+		]);
+		expect(result).toHaveLength(2);
+		expect(result[0].name).toBe("first");
+		expect(result[0].id).toBe("dup");
+		expect(result[1].name).toBe("second"); // kept, content intact
+		expect(result[1].id).not.toBe("dup");
+		expect(result[1].id).toMatch(UUID_RE);
+	});
+
+	it("re-ids a divergent duplicated Multi and PRESERVES its unique children", () => {
+		// A naive drop-by-id would delete the second folder and lose child2.
+		// Re-id-ing keeps both folders and all children.
+		const first = multiWithId("m", [withId("child1")], "first folder");
+		const second = multiWithId("m", [withId("child2")], "second folder");
+		const result = dedupeChoicesById([first, second]);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].id).toBe("m");
+		const rebuilt = result[1] as IMultiChoice;
+		expect(rebuilt.id).not.toBe("m");
+		expect(rebuilt.id).toMatch(UUID_RE);
+		expect(rebuilt.choices.map((c) => c.id)).toEqual(["child2"]); // not lost
+	});
+
+	it("de-dups globally across nesting levels (identical child re-using a top id -> dropped)", () => {
+		const folder = dedupeChoicesById([
+			withId("shared"),
+			multiWithId("m", [withId("shared"), withId("ok")]),
+		])[1] as IMultiChoice;
+		expect(folder.choices.map((c) => c.id)).toEqual(["ok"]);
+	});
+
+	it("produces a fully unique id set when there were collisions", () => {
+		const result = dedupeChoicesById([
+			withId("a", "a1"),
+			withId("a", "a2"), // divergent -> re-id
+			multiWithId("a", [withId("a", "deep")], "folderA"), // divergent -> re-id
+		]);
+		const ids = flattenChoices(result).map((c) => c.id);
+		expect(new Set(ids).size).toBe(ids.length); // all unique
+	});
+
+	it("does not mutate the input tree", () => {
+		const folder = multiWithId("m", [withId("d"), withId("d")]);
+		const input = [folder];
+		dedupeChoicesById(input);
+
+		expect(input[0]).toBe(folder);
+		expect((input[0] as IMultiChoice).choices).toHaveLength(2); // original intact
+	});
+
+	it("leaves a Multi with a missing children array exactly as-is (no fabricated [])", () => {
+		const broken = multiWithId("m", undefined as unknown as IChoice[]);
+		const result = dedupeChoicesById([broken]);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toBe(broken); // untouched - not rebuilt with choices: []
+		expect((result[0] as IMultiChoice).choices).toBeUndefined();
+	});
+
+	it("handles an empty list", () => {
+		expect(dedupeChoicesById([])).toEqual([]);
 	});
 });
 

--- a/src/utils/choiceUtils.ts
+++ b/src/utils/choiceUtils.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from "uuid";
 import type IMultiChoice from "src/types/choices/IMultiChoice";
 import type IChoice from "../types/choices/IChoice";
 import type { ChoiceType } from "../types/choices/choiceType";
@@ -66,6 +67,65 @@ export function flattenChoices(choices: IChoice[]): IChoice[] {
 
 	choices.forEach(walk);
 	return result;
+}
+
+/**
+ * Returns the choice tree with every id made globally unique, without losing any
+ * data. Walks pre-order; the first occurrence of an id is kept, and a later
+ * choice whose id was already seen is either dropped (when byte-identical to the
+ * first, so it is a true duplicate) or kept under a fresh id (when its content
+ * differs, so a genuinely distinct choice that merely collided survives whole,
+ * children and all).
+ *
+ * Why this exists: the settings tab renders choices in a keyed Svelte
+ * `{#each ... (choice.id)}` (ChoiceList.svelte). Svelte 5 throws
+ * `each_key_duplicate` on a repeated key, which aborts the settings-tab mount and
+ * leaves it blank (#1451) - while the command palette keeps working because
+ * commands register by plain recursion (so the symptom reads as "corrupted
+ * data"). Choice ids are v4 UUIDs (Choice.ts), so global uniqueness is the real
+ * invariant (the command registry is keyed on `choice:<id>` too); a repeat only
+ * comes from external corruption - e.g. Obsidian Sync freezing a transient
+ * duplicate and propagating it via whole-file last-write-wins (no JSON/array
+ * merge) - never from a legitimately distinct choice.
+ *
+ * Called once where data enters the app (loadSettings): the cleaned tree renders
+ * and registers commands correctly, and the next ordinary settings save rewrites
+ * data.json cleaned. Pure - never mutates its input.
+ */
+export function dedupeChoicesById(choices: IChoice[]): IChoice[] {
+	// id -> first kept choice with that id (the original object, for comparison).
+	const firstById = new Map<string, IChoice>();
+
+	const walk = (list: IChoice[]): IChoice[] => {
+		const out: IChoice[] = [];
+		for (const choice of list) {
+			let current = choice;
+			const prior = firstById.get(current.id);
+			if (prior) {
+				// Compare the whole choice (incl. nested children) to the first
+				// occurrence: equal => true duplicate, drop it; otherwise a real id
+				// collision, so keep it under a fresh id (nothing lost).
+				if (JSON.stringify(current) === JSON.stringify(prior)) {
+					continue;
+				}
+				current = { ...current, id: uuidv4() };
+			}
+			firstById.set(current.id, current);
+			// Recurse only into a real children array; a malformed Multi (missing or
+			// non-array children) is kept exactly as-is, never given a fabricated [].
+			if (isMultiChoice(current) && Array.isArray(current.choices)) {
+				const repaired: IMultiChoice = {
+					...current,
+					choices: walk(current.choices),
+				};
+				current = repaired;
+			}
+			out.push(current);
+		}
+		return out;
+	};
+
+	return walk(choices);
 }
 
 export interface FlatChoicePathEntry {


### PR DESCRIPTION
Closes #1451

## Symptom

A user reported a "corrupted data file" after syncing the same vault across devices on different QuickAdd/Obsidian versions: the QuickAdd settings page renders blank, but the plugin still works (commands and shortcuts run). Their `data.json` is valid and parses fine - so this is not a parse failure or lost data.

## Root cause

Their `data.json` contains two choices that share the same `id` (a duplicated item inside a folder). The settings tab renders choices in a keyed Svelte each:

```
src/gui/choiceList/ChoiceList.svelte:138
{#each stripShadow(choices) as choice (choice.id)}
```

Svelte 5 throws `each_key_duplicate` on a repeated key (in dev *and* prod), which propagates out of `mount()` (no boundary) and aborts the settings-tab render -> blank page. The command palette is unaffected because commands register by plain recursion (`main.ts` `addCommandsForChoices`), not a keyed each - which is why everything else keeps working and it merely *looks* like corrupted data.

Choice ids are v4 UUIDs assigned at construction (`src/types/choices/Choice.ts`), so a byte-identical same-id pair is not something QuickAdd produces in normal operation. I audited the suspects and ruled them out:

- **Migrations / load-save pipeline**: no migration can duplicate, lose, or re-id a choice (the only insert, `removeMacroIndirection`, mints a fresh uuid); the runner gates correctly and deep-clones at every boundary; reproduced an old-shape upgrade with zero duplicates and idempotent re-load.
- **Import / drag / duplicate-feature**: import dedups by id, the Duplicate action assigns a fresh uuid, and the old cross-zone drag dup (#1264) is already fixed.

The most likely origin is external: Obsidian Sync replicates `data.json` whole-file (last-write-wins, no JSON merge), so it can freeze and propagate a transient in-memory duplicate across a multi-device, multi-version setup. QuickAdd can't prevent that - but it should never let one duplicate brick the entire settings UI with no recovery. That lack of resilience is the real, fixable defect.

## Fix

A pure `dedupeChoicesById` helper (`src/utils/choiceUtils.ts`), called once in `loadSettings` (`src/main.ts`), guarded on a real array:

```ts
if (Array.isArray(settings.choices)) {
    settings.choices = dedupeChoicesById(settings.choices);
}
```

It makes every id globally unique **without losing data**:
- a later choice byte-identical to an earlier one with the same id is **dropped** (a true duplicate);
- a later choice with the same id but **different content** is **kept under a fresh uuid** (a genuinely distinct choice that merely collided - preserved whole, children and all).

Design notes:
- Runs **every load**, not as a one-shot migration, so a re-duplication (e.g. another Sync round-trip) keeps healing itself.
- Heals **in memory** on load (the tab always renders and commands register cleanly); the next ordinary settings save rewrites `data.json` cleaned. No forced write, so a write failure can never abort plugin load.
- The `Array.isArray` guard is deliberate: a missing `choices` already defaults to `[]` via the `Object.assign` over `DEFAULT_SETTINGS`, so the guard only matters for a null/corrupt value - which is left exactly as-is rather than silently replaced with `[]` (which a later save would persist, destroying recoverable data).

## Validation

- Full test suite green: **3459 passing** (added unit tests for `dedupeChoicesById` covering drop-identical, re-id-divergent, preserve-unique-children, global cross-level dedup, no-mutation, and malformed/empty inputs).
- `pnpm run lint` clean, `pnpm run build` (tsc + esbuild, production) clean.
- Live e2e in an isolated Obsidian vault on the **reporter's actual `data.json`**: before -> mounting the settings view throws `each_key_duplicate` (blank); after -> heals 51 -> 50 choices, no duplicate ids, settings render (48 rows). Also verified the other Svelte-mounted settings view renders on their data, and that an old-shape upgrade (legacy `macros` array + `macroId` + string `templateFolderPath`) migrates cleanly with zero duplicates and is idempotent on second load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings loading so duplicate choices are cleaned up automatically.
  * Preserved valid data when duplicates are found, including nested folders and mixed choice structures.
  * Kept incomplete or malformed settings untouched when they can’t be safely recovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->