### PR TITLE
fix(security): kill quadratic ReDoS in VDATE token regex

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -176,8 +176,28 @@ export const FIELD_VAR_REGEX_WITH_FILTERS = new RegExp(
 // mis-consume; nested tokens inside the folder arg are unsupported. The required
 // `:` means this never matches {{FILENAMECURRENT}} (no colon after FILE).
 export const FILE_REGEX = new RegExp(/{{FILE:([^\n\r{}]*)}}/i);
+// {{VDATE:<name>, <format>|<options>}} - group 1 is the variable name, group 2
+// the optional date format (after the first comma), group 3 the optional
+// |options tail. Two ReDoS defenses mirror FIELD_VAR_REGEX_WITH_FILTERS (#1455):
+//   1. The comma arm is `,([^\n\r}|]*)`, not `,\s*([^\n\r}|]*)`. The old `\s*`
+//      and the capture class both matched space/tab, so the two adjacent
+//      quantifiers overlapped, going quadratic on `{{VDATE:a,` followed by a long
+//      unterminated whitespace run (every split of the run is retried before the
+//      missing `}}` fails). The capture class already accepts leading spaces and
+//      every consumer trims group 2 (formatter.ts, RequirementCollector.ts, and
+//      the two display formatters), so dropping `\s*` is output-identical for a
+//      single-line token. A token literally spanning a newline after the comma no
+//      longer matches, but group 1 and group 3 already excluded `\n\r`, so the
+//      token was single-line everywhere except that artifact.
+//   2. All three interior classes exclude `{`, so a match attempt cannot consume
+//      across a following token opener. Without this the unanchored exec loop in
+//      replaceDateVariableInString is quadratic on a long run of unterminated
+//      `{{VDATE:` openers (each opener greedily eats the rest before failing).
+//      A date format escapes literals with `[...]` and never contains `{`, and a
+//      variable name never contains `{`, so this only changes already-malformed
+//      `{`-bearing (nested-token) interiors, exactly like FIELD/FILE.
 export const DATE_VARIABLE_REGEX = new RegExp(
-	/{{VDATE:([^\n\r},|]*)(?:,\s*([^\n\r}|]*))?(?:\|([^\n\r}]*))?}}/i,
+	/{{VDATE:([^\n\r},|{]*)(?:,([^\n\r}|{]*))?(?:\|([^\n\r}{]*))?}}/i,
 );
 export const LINK_TO_CURRENT_FILE_REGEX = new RegExp(/{{LINKCURRENT}}/i);
 // {{LINKSECTION}} resolves to a link to the current file at the heading the

--- a/src/formatters/vdate-redos.test.ts
+++ b/src/formatters/vdate-redos.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import { DATE_VARIABLE_REGEX } from "../constants";
+
+// Drives DATE_VARIABLE_REGEX exactly like its consumers do - a fresh global
+// regex in an exec loop (formatter.ts replaceDateVariableInString,
+// RequirementCollector.ts scanDateTokens, and the two display formatters all
+// build `new RegExp(DATE_VARIABLE_REGEX.source, "gi")`).
+function scanCount(input: string): number {
+	const re = new RegExp(DATE_VARIABLE_REGEX.source, "gi");
+	let count = 0;
+	while (re.exec(input) !== null) count++;
+	return count;
+}
+
+function parse(input: string): {
+	match: string;
+	name: string;
+	format: string;
+	options: string | null;
+} | null {
+	const m = new RegExp(DATE_VARIABLE_REGEX.source, "gi").exec(input);
+	if (!m) return null;
+	return {
+		match: m[0],
+		name: m[1]?.trim() ?? "",
+		format: m[2]?.trim() ?? "",
+		options: m[3] ?? null,
+	};
+}
+
+describe("DATE_VARIABLE_REGEX ReDoS resistance", () => {
+	// The old pattern
+	//   /{{VDATE:([^\n\r},|]*)(?:,\s*([^\n\r}|]*))?(?:\|([^\n\r}]*))?}}/i
+	// had two O(n^2) shapes when scanned with the global flag the consumers use:
+	//   - the `,\s*([^\n\r}|]*)` arm overlapped (both halves match space/tab), so
+	//     `{{VDATE:a,` + a long whitespace run with no closing `}}` retried every
+	//     split of the run;
+	//   - the interior classes accepted `{`, so a long run of unterminated
+	//     `{{VDATE:` openers made each opener re-scan the tail (FIELD #1455 shape).
+	// Both are reachable after untrusted {{CLIPBOARD}}/{{SELECTED}} content is
+	// spliced in ahead of the VDATE pass (completeFormatter.ts). The old regex took
+	// many seconds at these sizes (~12s at N=50k for the opener flood) and grew
+	// quadratically; the fixed regex stays sub-millisecond. A generous budget keeps
+	// the test non-flaky while failing hard on any regression.
+	const BUDGET_MS = 1000;
+	const N = 200_000;
+
+	it(
+		"scans a comma + whitespace flood in linear time",
+		() => {
+			const input = "{{VDATE:a," + " ".repeat(N); // no closing }}
+			const start = performance.now();
+			expect(scanCount(input)).toBe(0);
+			expect(performance.now() - start).toBeLessThan(BUDGET_MS);
+		},
+		20_000,
+	);
+
+	it(
+		"scans an unterminated `{{VDATE:` opener flood in linear time",
+		() => {
+			const input = "{{VDATE:".repeat(N);
+			const start = performance.now();
+			expect(scanCount(input)).toBe(0);
+			expect(performance.now() - start).toBeLessThan(BUDGET_MS);
+		},
+		20_000,
+	);
+
+	it(
+		"scans a `{{VDATE:a,` opener flood in linear time",
+		() => {
+			const input = "{{VDATE:a,".repeat(N);
+			const start = performance.now();
+			expect(scanCount(input)).toBe(0);
+			expect(performance.now() - start).toBeLessThan(BUDGET_MS);
+		},
+		20_000,
+	);
+});
+
+describe("DATE_VARIABLE_REGEX parses well-formed tokens unchanged", () => {
+	// Locks in that narrowing the interior classes did not change how a normal,
+	// single-line VDATE token is captured (name / trimmed format / raw options).
+	it.each([
+		[
+			"{{VDATE:due}}",
+			{ match: "{{VDATE:due}}", name: "due", format: "", options: null },
+		],
+		[
+			"{{VDATE:due,YYYY-MM-DD}}",
+			{
+				match: "{{VDATE:due,YYYY-MM-DD}}",
+				name: "due",
+				format: "YYYY-MM-DD",
+				options: null,
+			},
+		],
+		[
+			"{{VDATE:due, YYYY-MM-DD}}", // space after the comma must still trim away
+			{
+				match: "{{VDATE:due, YYYY-MM-DD}}",
+				name: "due",
+				format: "YYYY-MM-DD",
+				options: null,
+			},
+		],
+		[
+			"{{VDATE:event, MMMM Do, YYYY}}", // commas inside the format
+			{
+				match: "{{VDATE:event, MMMM Do, YYYY}}",
+				name: "event",
+				format: "MMMM Do, YYYY",
+				options: null,
+			},
+		],
+		[
+			"{{VDATE:w, [Week] ww}}", // bracket-escaped literal in the format
+			{
+				match: "{{VDATE:w, [Week] ww}}",
+				name: "w",
+				format: "[Week] ww",
+				options: null,
+			},
+		],
+		[
+			"{{VDATE:due, YYYY-MM-DD HH:mm}}",
+			{
+				match: "{{VDATE:due, YYYY-MM-DD HH:mm}}",
+				name: "due",
+				format: "YYYY-MM-DD HH:mm",
+				options: null,
+			},
+		],
+		[
+			"{{VDATE:d, YYYY|tomorrow}}", // |default value
+			{
+				match: "{{VDATE:d, YYYY|tomorrow}}",
+				name: "d",
+				format: "YYYY",
+				options: "tomorrow",
+			},
+		],
+		[
+			"{{VDATE:d, YYYY|optional}}",
+			{
+				match: "{{VDATE:d, YYYY|optional}}",
+				name: "d",
+				format: "YYYY",
+				options: "optional",
+			},
+		],
+		[
+			"{{VDATE:d, YYYY|startof:week}}", // |snap option
+			{
+				match: "{{VDATE:d, YYYY|startof:week}}",
+				name: "d",
+				format: "YYYY",
+				options: "startof:week",
+			},
+		],
+		[
+			"{{VDATE:d, YYYY|next|monday}}", // pipes survive in the options tail
+			{
+				match: "{{VDATE:d, YYYY|next|monday}}",
+				name: "d",
+				format: "YYYY",
+				options: "next|monday",
+			},
+		],
+		[
+			"{{VDATE: spaced , MMMM }}", // surrounding whitespace trims away
+			{
+				match: "{{VDATE: spaced , MMMM }}",
+				name: "spaced",
+				format: "MMMM",
+				options: null,
+			},
+		],
+	])("parses %s", (input, expected) => {
+		expect(parse(input)).toEqual(expected);
+	});
+
+	it("resolves the first of multiple tokens, leaving the rest for re-scan", () => {
+		expect(parse("a {{VDATE:x, YYYY}} b {{VDATE:y|optional}} c")).toEqual({
+			match: "{{VDATE:x, YYYY}}",
+			name: "x",
+			format: "YYYY",
+			options: null,
+		});
+	});
+});
+
+describe("DATE_VARIABLE_REGEX leaves malformed tokens literal", () => {
+	// Deliberate, documented consequences of the ReDoS hardening - both only
+	// affect inputs that never carried a meaningful VDATE value.
+	it("does not match a token that spans a newline after the comma", () => {
+		// group 1 / group 3 already excluded \n\r; this removes the lone artifact
+		// where the dropped `\s*` let a token straddle a line break.
+		expect(parse("{{VDATE:a,\nMMMM}}")).toBeNull();
+	});
+
+	it("does not consume across a nested `{` (unsupported nested token)", () => {
+		// The old regex grabbed `{{VALUE:x` as the variable name; now the opener
+		// is left literal so the inner token can resolve on its own pass.
+		expect(parse("{{VDATE:{{VALUE:x}}, YYYY}}")).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

`DATE_VARIABLE_REGEX` (the `{{VDATE:...}}` token, `src/constants.ts`) backtracked in **O(n²)** under the global flag every consumer uses. Two independent quadratic shapes lived in one pattern:

1. **Overlapping comma arm** - `,\s*([^\n\r}|]*)`: the `\s*` and the capture class both match space/tab, so `{{VDATE:a,` + a long unterminated whitespace run retries every split of the run before the missing `}}` fails.
2. **Opener flood** - all three interior classes accepted `{`, so a long run of unterminated `{{VDATE:` openers makes each opener greedily re-scan the tail to end-of-string (the same shape fixed for FIELD in #1455). The original finding missed this one; it is reachable with **no real VDATE token at all**.

## Why it matters (reachability)

`CompleteFormatter.format()` splices untrusted `{{SELECTED}}` / `{{CLIPBOARD}}` content verbatim (no length cap) into the format string immediately before the **unguarded** `replaceDateVariableInString` pass. So a webpage "copy" button, or synced / AI-generated / imported note text, can seed the payload and freeze Obsidian's main thread. The runtime Capture/Template formatters use the real clipboard/selection getters; only the display/preview formatters stub them, so the reachable path is real choice execution. Same untrusted-content-to-formatter-sink class as #1444 / #1452 / #1455.

## Fix

Mirror the documented `FIELD_VAR_REGEX_WITH_FILTERS` (#1455) defenses:

```diff
-/{{VDATE:([^\n\r},|]*)(?:,\s*([^\n\r}|]*))?(?:\|([^\n\r}]*))?}}/i
+/{{VDATE:([^\n\r},|{]*)(?:,([^\n\r}|{]*))?(?:\|([^\n\r}{]*))?}}/i
```

- **Drop the redundant `\s*`** - every consumer already `.trim()`s the captured format (`formatter.ts`, `RequirementCollector.ts`, and both display formatters), and the capture class already accepts leading spaces, so the resolved value is unchanged.
- **Exclude `{` from all three interior classes** - a match attempt can no longer consume across a following token opener. A date format escapes literals with `[...]` and never contains `{`; a variable name never contains `{`.

### Behavior change is malformed-input-only

A 2,000,000-iteration differential fuzz (old vs fixed, mirroring the consumers) found **zero** divergences across well-formed, single-line tokens (names/formats with spaces, commas, brackets, pipes, `|default`/`|optional`/`|time`/`|startof:`, multi-token strings). The only inputs that differ are already-malformed and never carried a meaningful value:
- a token literally spanning a newline after the comma (group 1 and group 3 already excluded `\n\r`, so this `\s*` artifact was the lone way a VDATE token straddled a line);
- a `{`-bearing / nested-token interior (`{{VDATE:{{VALUE:x}}, ...}}`) - now left literal, exactly like FIELD/FILE.

## Proof (red -> green)

Driven as the consumers do (`new RegExp(src,'gi')` exec loop):

| input shape | old (red) | fixed (green) |
|---|---|---|
| `{{VDATE:a,` + 120k spaces | 6815 ms | 0.17 ms |
| `{{VDATE:`.repeat(30k) | 3989 ms | 0.22 ms |
| `{{VDATE:a,`.repeat(30k) | 5349 ms | 0.29 ms |

**Live Obsidian 1.13.0** (built bundle, isolated vault):
- regression: `{{VDATE:myDate, YYYY-MM-DD}}` -> `Due: 2024-01-01`; `{{VDATE:e, MMMM Do, YYYY}}` -> `March 5th, 2024`
- fix: a 400 KB `{{VDATE:`×50000 payload formats through the full pipeline in **2 ms** (was ~11 s)
- in-runtime differential (`{{VDATE:`.repeat(N)): old 89/324/1232 ms at N=4k/8k/16k (clean quadratic) vs fixed 0 ms

## Adversarial review

An independent skeptic panel tried to refute the finding and the expanded fix from four lenses (reachability, well-formed-input equivalence, residual quadratic, blast radius). All four failed to refute (high confidence): reachability confirmed; equivalence holds for well-formed input; no fourth super-linear shape exists on the fix; running the existing suites under the patched regex gave 832/832 formatter+preflight green.

## Tests

`src/formatters/vdate-redos.test.ts`: ReDoS-resistance timing guards for the three fixed shapes (200k-char inputs, generous budget) + a well-formed-token characterization table + the two deliberate malformed-input divergences.

Gates: `tsc -noEmit`, `eslint .`, `svelte-check`, `vitest` (3543 passed / 0 failed) all green.

## Considered, not included

A fast-path guard (`if (!DATE_VARIABLE_REGEX.test(input)) return input;`) like `replaceValueInString` was suggested. Once the regex is linear it adds no security value and a redundant scan in the common has-token case, so the regex fix is kept as the clean root fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of date-style tokens so valid text is parsed more reliably.
  * Prevented malformed or nested token patterns from being misread across separators.
  * Reduced the risk of slow processing on large, tricky inputs, improving responsiveness in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->