### PR TITLE
fix(security): kill five quadratic-regex DoS hazards over untrusted content

### DIFF
--- a/src/ai/tools/sanitizeVaultPath.test.ts
+++ b/src/ai/tools/sanitizeVaultPath.test.ts
@@ -77,6 +77,25 @@ describe("sanitizeVaultPath", () => {
 			expect(() => sanitizeVaultPath("CON/x.md")).toThrow(UnsafeVaultPathError);
 			expect(() => sanitizeVaultPath("Notes/NUL.md")).toThrow(UnsafeVaultPathError);
 		});
+		it("still derives the device-name base from the first dot", () => {
+			// NUL.tar.gz → base "NUL" must still be rejected now that the
+			// (provably no-op) trailing-dot/space replace is gone.
+			expect(() => sanitizeVaultPath("Notes/NUL.tar.gz")).toThrow(
+				UnsafeVaultPathError,
+			);
+		});
+		// The basename extraction used `.replace(/[. ]+$/u, "")` — a guaranteed
+		// no-op (the trailing-char guard above already rejected such segments)
+		// that still backtracked quadratically on a long interior dot run:
+		// ~2.8s at 80k chars, reachable from the auto-run (no-approval) read
+		// tools with a model-chosen path. This pins linear behavior; the budget
+		// is generous to stay non-flaky while failing hard on any regression.
+		it("validates a segment with a long interior dot run in linear time", () => {
+			const path = "a" + ".".repeat(200_000) + "b";
+			const start = performance.now();
+			expect(sanitizeVaultPath(path)).toBe(path);
+			expect(performance.now() - start).toBeLessThan(1000);
+		}, 20_000);
 		it("rejects empty input", () => {
 			expect(() => sanitizeVaultPath("   ")).toThrow(UnsafeVaultPathError);
 			expect(() => sanitizeVaultPath("///")).toThrow(UnsafeVaultPathError);

--- a/src/ai/tools/sanitizeVaultPath.test.ts
+++ b/src/ai/tools/sanitizeVaultPath.test.ts
@@ -84,7 +84,7 @@ describe("sanitizeVaultPath", () => {
 				UnsafeVaultPathError,
 			);
 		});
-		// The basename extraction used `.replace(/[. ]+$/u, "")` — a guaranteed
+		// The basename extraction used `.replace(/[. ]+$/u, "")` - a guaranteed
 		// no-op (the trailing-char guard above already rejected such segments)
 		// that still backtracked quadratically on a long interior dot run:
 		// ~2.8s at 80k chars, reachable from the auto-run (no-approval) read

--- a/src/ai/tools/sanitizeVaultPath.ts
+++ b/src/ai/tools/sanitizeVaultPath.ts
@@ -127,7 +127,12 @@ function validateSegment(segment: string, fullPath: string): void {
 			`Path segment "${segment}" cannot end with a space or a period: "${fullPath}".`,
 		);
 	}
-	const base = segment.replace(/[. ]+$/u, "").split(".")[0] ?? "";
+	// No trailing-dot/space trim is needed here: the guard above already threw
+	// for any segment ending in '.' or ' ', so the historical
+	// `.replace(/[. ]+$/u, "")` was a guaranteed no-op — while still costing
+	// quadratic backtracking on a long interior dot/space run reachable from
+	// the auto-run (no-approval) read tools.
+	const base = segment.split(".")[0] ?? "";
 	if (base && isReservedWindowsDeviceName(base)) {
 		throw new UnsafeVaultPathError(
 			`Path segment "${segment}" is a reserved device name: "${fullPath}".`,

--- a/src/ai/tools/sanitizeVaultPath.ts
+++ b/src/ai/tools/sanitizeVaultPath.ts
@@ -129,7 +129,7 @@ function validateSegment(segment: string, fullPath: string): void {
 	}
 	// No trailing-dot/space trim is needed here: the guard above already threw
 	// for any segment ending in '.' or ' ', so the historical
-	// `.replace(/[. ]+$/u, "")` was a guaranteed no-op — while still costing
+	// `.replace(/[. ]+$/u, "")` was a guaranteed no-op - while still costing
 	// quadratic backtracking on a long interior dot/space run reachable from
 	// the auto-run (no-approval) read tools.
 	const base = segment.split(".")[0] ?? "";

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -355,8 +355,12 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			);
 		}
 
-		const normalized = segment.replace(/[. ]+$/u, "");
-		const base = normalized.split(".")[0] ?? "";
+		// No trailing-dot/space trim is needed here: the guard above already
+		// threw for any segment ending in '.' or ' ', so the historical
+		// `.replace(/[. ]+$/u, "")` was a guaranteed no-op - while still costing
+		// quadratic backtracking on a long interior dot/space run in a
+		// format-resolved folder name (same shape as sanitizeVaultPath's).
+		const base = segment.split(".")[0] ?? "";
 		if (base && isReservedWindowsDeviceName(base)) {
 			throw new InvalidFolderPathError(
 				"Folder name cannot be a reserved name like CON, PRN, AUX, NUL, COM1-9, or LPT1-9.",

--- a/src/formatters/helpers/insertionPositioning.test.ts
+++ b/src/formatters/helpers/insertionPositioning.test.ts
@@ -72,6 +72,22 @@ describe("findMultiLineRange", () => {
 			end: -1,
 		});
 	});
+
+	// The old stripTrailingWhitespace used /\s+$/, which backtracks
+	// quadratically on a line holding a long interior whitespace run
+	// (" ".repeat(n) + "x"): ~3.2s at n=80k, frozen UI during a multi-line
+	// insert-after capture over an untrusted (synced/pasted/AI-written) note.
+	// trimEnd() is linear; the budget is generous to stay non-flaky while
+	// failing hard on any quadratic regression.
+	it("normalizes a pathological whitespace-run line in linear time", () => {
+		const lines = [" ".repeat(200_000) + "x", "## D", "**Tasks**"];
+		const start = performance.now();
+		expect(findMultiLineRange(lines, ["## D", "**Tasks**"])).toEqual({
+			start: 1,
+			end: 2,
+		});
+		expect(performance.now() - start).toBeLessThan(1000);
+	}, 20_000);
 });
 
 describe("findInsertAfterRange", () => {

--- a/src/formatters/helpers/insertionPositioning.ts
+++ b/src/formatters/helpers/insertionPositioning.ts
@@ -158,7 +158,12 @@ export function findMultiLineRange(
 }
 
 function stripTrailingWhitespace(line: string): string {
-	return line.replace(/\s+$/, "");
+	// trimEnd() strips exactly the same character set as the historical
+	// /\s+$/ replace (ECMAScript WhiteSpace + LineTerminator) but in linear
+	// time. The unanchored regex backtracked quadratically on a note line
+	// holding a long interior whitespace run (" ".repeat(n) + "x"), freezing
+	// the UI during a multi-line insert-after/-before capture search.
+	return line.trimEnd();
 }
 
 /**

--- a/src/gui/suggesters/headingSanitizer.test.ts
+++ b/src/gui/suggesters/headingSanitizer.test.ts
@@ -46,8 +46,51 @@ describe('sanitizeHeading', () => {
 		['Heading with [[ leftover', 'Heading with  leftover'],
 		['Heading with ]] brackets', 'Heading with  brackets'],
 		['[[Link]] with ]] stray', 'Link with  stray'],
+
+		// Scanner-edge cases pinned against the historical regex pipeline
+		// (differentially fuzzed byte-identical; these are the trickiest shapes)
+		['[[a]b]]', 'a]b'],           // single ] inside link → no wiki match, strays stripped
+		['[[a|b]c]]', 'a|b]c'],       // alias broken by single ] → no wiki match
+		['[[a|b|c]]', 'b|c'],         // second | belongs to the alias
+		['[[a[[b]]', 'ab'],           // nested opener consumed into the target
+		['![[a![[b]]', ''],           // nested image opener consumed into the embed
+		['[[|x]]', 'x'],              // empty target, alias wins
+		['![[a]b]]', '!a]b'],         // broken image embed leaves the bang literal
+		['  ## x', '## x'],           // leading hashes after whitespace are NOT ATX-trimmed
+		['a#  ##', 'a#'],             // only the trailing whitespace+hash run trims
+		['x ### y', 'x ### y'],       // interior hash run untouched
+		['abc ### ', 'abc ###'],      // trailing hashes not at end-of-string stay
+		['a ## b ##', 'a ## b'],
+		['#x#', 'x'],
+		['# #', ''],
+		['##  ##', ''],
 	])('sanitizes "%s" to "%s"', (input, expected) => {
 		expect(sanitizeHeading(input)).toBe(expected);
+	});
+
+	// The old chained regexes backtracked quadratically on adversarial headings
+	// (any single `#`-prefixed note line, unbounded length, reaches this via
+	// FileIndex.createIndexedFile for every heading of every file — full reindex
+	// AND every metadataCache 'changed' event). wikiRE was O(n^2) on a "["
+	// flood, imgRE on a "![[" flood, and trimHashRE on interior "#"/whitespace
+	// runs. The linear scanners stay in single-digit milliseconds at these
+	// sizes; a generous budget keeps the test non-flaky while failing hard on
+	// any quadratic regression (the old code took seconds here).
+	describe('ReDoS resistance', () => {
+		const BUDGET_MS = 1000;
+		const N = 200_000;
+
+		it.each([
+			['wikilink opener flood', '['.repeat(N), ''],
+			['image opener flood', '![['.repeat(Math.floor(N / 3)), '!'.repeat(Math.floor(N / 3))],
+			['alias opener flood', '[[a|'.repeat(Math.floor(N / 4)), 'a|'.repeat(Math.floor(N / 4))],
+			['interior hash run', 'x' + '#'.repeat(N) + 'y', 'x' + '#'.repeat(N) + 'y'],
+			['interior whitespace run', 'x' + ' '.repeat(N) + 'y', 'x' + ' '.repeat(N) + 'y'],
+		])('sanitizes a %s in linear time', (_name, input, expected) => {
+			const start = performance.now();
+			expect(sanitizeHeading(input)).toBe(expected);
+			expect(performance.now() - start).toBeLessThan(BUDGET_MS);
+		}, 20_000);
 	});
 	
 	// Performance test - ensure regex caching works

--- a/src/gui/suggesters/headingSanitizer.test.ts
+++ b/src/gui/suggesters/headingSanitizer.test.ts
@@ -70,7 +70,7 @@ describe('sanitizeHeading', () => {
 
 	// The old chained regexes backtracked quadratically on adversarial headings
 	// (any single `#`-prefixed note line, unbounded length, reaches this via
-	// FileIndex.createIndexedFile for every heading of every file — full reindex
+	// FileIndex.createIndexedFile for every heading of every file - full reindex
 	// AND every metadataCache 'changed' event). wikiRE was O(n^2) on a "["
 	// flood, imgRE on a "![[" flood, and trimHashRE on interior "#"/whitespace
 	// runs. The linear scanners stay in single-digit milliseconds at these

--- a/src/gui/suggesters/headingSanitizer.ts
+++ b/src/gui/suggesters/headingSanitizer.ts
@@ -32,7 +32,7 @@ function isWhitespaceCodeUnit(text: string, index: number): boolean {
 }
 
 /**
- * Pass 1 — remove image embeds. Equivalent to
+ * Pass 1 - remove image embeds. Equivalent to
  * `replace(/!\[\[[^\]]*\]\]/g, "")`: at each `![[`, the greedy `[^\]]*` runs to
  * the FIRST `]`, which must start a `]]` pair for the whole embed to match.
  * `close` only ever moves forward, so failed openers sharing one long
@@ -64,7 +64,7 @@ function stripImageEmbeds(text: string): string {
 }
 
 /**
- * Pass 2 — resolve wikilinks to their alias (or target). Equivalent to
+ * Pass 2 - resolve wikilinks to their alias (or target). Equivalent to
  * `replace(/\[\[([^\]|]*?)(\|([^\]]*?))?\]\]/g, (_, p1, _p2, alias) => alias ?? p1)`:
  * after `[[`, the target runs to the first `]` or `|`; a `]` must start `]]`
  * (emit the target), a `|` starts an alias that runs to the first `]`, which
@@ -113,10 +113,10 @@ function resolveWikiLinks(text: string): string {
 }
 
 /**
- * Pass 4 — strip ATX heading markers. Equivalent to
+ * Pass 4 - strip ATX heading markers. Equivalent to
  * `replace(/^#+\s*|\s*#+$/g, "")`: a leading `#` run plus following whitespace,
  * and (independently, on what remains) a trailing `#` run plus the whitespace
- * run directly before it — the trailing alternative only fires when the string
+ * run directly before it - the trailing alternative only fires when the string
  * actually ENDS with `#`. The old regex backtracked quadratically on interior
  * `#`/whitespace runs ("x" + "#".repeat(n) + "y").
  */
@@ -137,7 +137,7 @@ function trimAtxHashMarkers(text: string): string {
 }
 
 /**
- * Pass 5 — drop stray `[[` / `]]` pairs left by unmatched links. Equivalent to
+ * Pass 5 - drop stray `[[` / `]]` pairs left by unmatched links. Equivalent to
  * `replace(/\[\[|\]\]/g, "")` (leftmost, non-overlapping).
  */
 function stripStrayBrackets(text: string): string {
@@ -158,7 +158,7 @@ function stripStrayBrackets(text: string): string {
 	return out;
 }
 
-// Pass 3 — a bare single-character class has no quantifier to backtrack, so
+// Pass 3 - a bare single-character class has no quantifier to backtrack, so
 // this one regex pass is already linear and stays.
 const MD_CHARS_RE = /[*_`~]/g;
 

--- a/src/gui/suggesters/headingSanitizer.ts
+++ b/src/gui/suggesters/headingSanitizer.ts
@@ -1,0 +1,171 @@
+/**
+ * Single-source heading sanitizer. Removes image embeds, wikilinks, markdown
+ * formatting, and ATX heading markers from heading text for display/search.
+ *
+ * Implemented as linear single-pass scanners instead of the historical chained
+ * regexes. Three of those regexes backtracked quadratically on adversarial
+ * headings (a markdown heading is any single `#`-prefixed line, of unbounded
+ * length, and FileIndex runs this over every heading of every note):
+ *
+ *   - /\[\[([^\]|]*?)(\|([^\]]*?))?\]\]/g  on "[".repeat(n)        (wikilinks)
+ *   - /!\[\[[^\]]*\]\]/g                   on "![[".repeat(n)      (images)
+ *   - /^#+\s*|\s*#+$/g                     on interior "#"/space runs (hashes)
+ *
+ * Each scanner below is byte-for-byte equivalent to the regex pass it replaced
+ * (differentially fuzzed against the old pipeline); the pass ORDER is part of
+ * the contract: images → wikilinks → md chars → hashes → stray brackets → trim.
+ *
+ * This module is dependency-free on purpose so it can be exercised standalone
+ * (fuzz harnesses, node scripts) without pulling in Obsidian imports.
+ */
+
+const BANG = 0x21; /* ! */
+const HASH = 0x23; /* # */
+const OPEN = 0x5b; /* [ */
+const CLOSE = 0x5d; /* ] */
+const PIPE = 0x7c; /* | */
+
+const SINGLE_WHITESPACE_RE = /^\s$/;
+
+function isWhitespaceCodeUnit(text: string, index: number): boolean {
+	return SINGLE_WHITESPACE_RE.test(text[index]);
+}
+
+/**
+ * Pass 1 — remove image embeds. Equivalent to
+ * `replace(/!\[\[[^\]]*\]\]/g, "")`: at each `![[`, the greedy `[^\]]*` runs to
+ * the FIRST `]`, which must start a `]]` pair for the whole embed to match.
+ * `close` only ever moves forward, so failed openers sharing one long
+ * bracket-free tail cost O(n) total instead of O(n) each.
+ */
+function stripImageEmbeds(text: string): string {
+	let out = "";
+	let i = 0;
+	let close = 0;
+	while (i < text.length) {
+		if (
+			text.charCodeAt(i) === BANG &&
+			text.charCodeAt(i + 1) === OPEN &&
+			text.charCodeAt(i + 2) === OPEN
+		) {
+			if (close < i + 3) close = i + 3;
+			while (close < text.length && text.charCodeAt(close) !== CLOSE) {
+				close++;
+			}
+			if (close < text.length && text.charCodeAt(close + 1) === CLOSE) {
+				i = close + 2; // drop the whole ![[...]] embed
+				continue;
+			}
+		}
+		out += text[i];
+		i++;
+	}
+	return out;
+}
+
+/**
+ * Pass 2 — resolve wikilinks to their alias (or target). Equivalent to
+ * `replace(/\[\[([^\]|]*?)(\|([^\]]*?))?\]\]/g, (_, p1, _p2, alias) => alias ?? p1)`:
+ * after `[[`, the target runs to the first `]` or `|`; a `]` must start `]]`
+ * (emit the target), a `|` starts an alias that runs to the first `]`, which
+ * must start `]]` (emit the alias). Anything else leaves the opener literal.
+ * Both search cursors are monotonic, keeping the scan linear on opener floods.
+ */
+function resolveWikiLinks(text: string): string {
+	let out = "";
+	let i = 0;
+	let stop = 0; // first `]` or `|` at/after the link target
+	let close = 0; // first `]` at/after the alias
+	while (i < text.length) {
+		if (
+			text.charCodeAt(i) === OPEN &&
+			text.charCodeAt(i + 1) === OPEN
+		) {
+			if (stop < i + 2) stop = i + 2;
+			while (stop < text.length) {
+				const code = text.charCodeAt(stop);
+				if (code === CLOSE || code === PIPE) break;
+				stop++;
+			}
+			if (stop < text.length && text.charCodeAt(stop) === CLOSE) {
+				if (text.charCodeAt(stop + 1) === CLOSE) {
+					out += text.slice(i + 2, stop); // [[target]] → target
+					i = stop + 2;
+					continue;
+				}
+			} else if (stop < text.length) {
+				// text.charCodeAt(stop) === PIPE
+				if (close < stop + 1) close = stop + 1;
+				while (close < text.length && text.charCodeAt(close) !== CLOSE) {
+					close++;
+				}
+				if (close < text.length && text.charCodeAt(close + 1) === CLOSE) {
+					out += text.slice(stop + 1, close); // [[target|alias]] → alias
+					i = close + 2;
+					continue;
+				}
+			}
+		}
+		out += text[i];
+		i++;
+	}
+	return out;
+}
+
+/**
+ * Pass 4 — strip ATX heading markers. Equivalent to
+ * `replace(/^#+\s*|\s*#+$/g, "")`: a leading `#` run plus following whitespace,
+ * and (independently, on what remains) a trailing `#` run plus the whitespace
+ * run directly before it — the trailing alternative only fires when the string
+ * actually ENDS with `#`. The old regex backtracked quadratically on interior
+ * `#`/whitespace runs ("x" + "#".repeat(n) + "y").
+ */
+function trimAtxHashMarkers(text: string): string {
+	let start = 0;
+	if (text.charCodeAt(0) === HASH) {
+		while (text.charCodeAt(start) === HASH) start++;
+		while (start < text.length && isWhitespaceCodeUnit(text, start)) {
+			start++;
+		}
+	}
+	let end = text.length;
+	if (end > start && text.charCodeAt(end - 1) === HASH) {
+		while (end > start && text.charCodeAt(end - 1) === HASH) end--;
+		while (end > start && isWhitespaceCodeUnit(text, end - 1)) end--;
+	}
+	return text.slice(start, end);
+}
+
+/**
+ * Pass 5 — drop stray `[[` / `]]` pairs left by unmatched links. Equivalent to
+ * `replace(/\[\[|\]\]/g, "")` (leftmost, non-overlapping).
+ */
+function stripStrayBrackets(text: string): string {
+	let out = "";
+	let i = 0;
+	while (i < text.length) {
+		const code = text.charCodeAt(i);
+		if (
+			(code === OPEN && text.charCodeAt(i + 1) === OPEN) ||
+			(code === CLOSE && text.charCodeAt(i + 1) === CLOSE)
+		) {
+			i += 2;
+			continue;
+		}
+		out += text[i];
+		i++;
+	}
+	return out;
+}
+
+// Pass 3 — a bare single-character class has no quantifier to backtrack, so
+// this one regex pass is already linear and stays.
+const MD_CHARS_RE = /[*_`~]/g;
+
+export function sanitizeHeading(heading: string): string {
+	return stripStrayBrackets(
+		trimAtxHashMarkers(
+			resolveWikiLinks(stripImageEmbeds(heading)).replace(MD_CHARS_RE, ""),
+		),
+	).trim();
+}

--- a/src/gui/suggesters/headingSanitizer.ts
+++ b/src/gui/suggesters/headingSanitizer.ts
@@ -39,7 +39,12 @@ function isWhitespaceCodeUnit(text: string, index: number): boolean {
  * bracket-free tail cost O(n) total instead of O(n) each.
  */
 function stripImageEmbeds(text: string): string {
+	// Fast path: without an opener nothing can match, and the output is the
+	// input verbatim (headings are unbounded note content on the index hot
+	// path, so a large PLAIN heading must not pay for a rebuild).
+	if (!text.includes("![[")) return text;
 	let out = "";
+	let copyFrom = 0; // start of the pending verbatim span
 	let i = 0;
 	let close = 0;
 	while (i < text.length) {
@@ -53,14 +58,15 @@ function stripImageEmbeds(text: string): string {
 				close++;
 			}
 			if (close < text.length && text.charCodeAt(close + 1) === CLOSE) {
+				out += text.slice(copyFrom, i); // flush the verbatim span
 				i = close + 2; // drop the whole ![[...]] embed
+				copyFrom = i;
 				continue;
 			}
 		}
-		out += text[i];
 		i++;
 	}
-	return out;
+	return out + text.slice(copyFrom);
 }
 
 /**
@@ -72,7 +78,10 @@ function stripImageEmbeds(text: string): string {
  * Both search cursors are monotonic, keeping the scan linear on opener floods.
  */
 function resolveWikiLinks(text: string): string {
+	// Fast path: no opener, no match, output verbatim.
+	if (!text.includes("[[")) return text;
 	let out = "";
+	let copyFrom = 0; // start of the pending verbatim span
 	let i = 0;
 	let stop = 0; // first `]` or `|` at/after the link target
 	let close = 0; // first `]` at/after the alias
@@ -89,8 +98,10 @@ function resolveWikiLinks(text: string): string {
 			}
 			if (stop < text.length && text.charCodeAt(stop) === CLOSE) {
 				if (text.charCodeAt(stop + 1) === CLOSE) {
-					out += text.slice(i + 2, stop); // [[target]] → target
+					// [[target]] → target
+					out += text.slice(copyFrom, i) + text.slice(i + 2, stop);
 					i = stop + 2;
+					copyFrom = i;
 					continue;
 				}
 			} else if (stop < text.length) {
@@ -100,16 +111,17 @@ function resolveWikiLinks(text: string): string {
 					close++;
 				}
 				if (close < text.length && text.charCodeAt(close + 1) === CLOSE) {
-					out += text.slice(stop + 1, close); // [[target|alias]] → alias
+					// [[target|alias]] → alias
+					out += text.slice(copyFrom, i) + text.slice(stop + 1, close);
 					i = close + 2;
+					copyFrom = i;
 					continue;
 				}
 			}
 		}
-		out += text[i];
 		i++;
 	}
-	return out;
+	return out + text.slice(copyFrom);
 }
 
 /**
@@ -141,7 +153,10 @@ function trimAtxHashMarkers(text: string): string {
  * `replace(/\[\[|\]\]/g, "")` (leftmost, non-overlapping).
  */
 function stripStrayBrackets(text: string): string {
+	// Fast path: neither pair present, output verbatim.
+	if (!text.includes("[[") && !text.includes("]]")) return text;
 	let out = "";
+	let copyFrom = 0; // start of the pending verbatim span
 	let i = 0;
 	while (i < text.length) {
 		const code = text.charCodeAt(i);
@@ -149,13 +164,14 @@ function stripStrayBrackets(text: string): string {
 			(code === OPEN && text.charCodeAt(i + 1) === OPEN) ||
 			(code === CLOSE && text.charCodeAt(i + 1) === CLOSE)
 		) {
+			out += text.slice(copyFrom, i); // flush the verbatim span
 			i += 2;
+			copyFrom = i;
 			continue;
 		}
-		out += text[i];
 		i++;
 	}
-	return out;
+	return out + text.slice(copyFrom);
 }
 
 // Pass 3 - a bare single-character class has no quantifier to backtrack, so

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -232,6 +232,6 @@ export function renderFuzzyHighlight(el: HTMLElement, text: string, query: strin
 }
 
 // Single-source heading sanitizer; lives in its own dependency-free module
-// (linear scanners — the old chained regexes were quadratic on adversarial
+// (linear scanners - the old chained regexes were quadratic on adversarial
 // headings). Re-exported here so existing imports keep working.
 export { sanitizeHeading } from "./headingSanitizer";

--- a/src/gui/suggesters/utils.ts
+++ b/src/gui/suggesters/utils.ts
@@ -231,23 +231,7 @@ export function renderFuzzyHighlight(el: HTMLElement, text: string, query: strin
 	}
 }
 
-/**
- * Single-source heading sanitizer with cached regex patterns.
- * Removes wikilinks, images, and markdown formatting from heading text.
- */
-export const sanitizeHeading = (() => {
-	const imgRE     = /!\[\[[^\]]*\]\]/g;                   // ![[img.png]] - process first
-	const wikiRE    = /\[\[([^\]|]*?)(\|([^\]]*?))?\]\]/g;  // [[page]] or [[page|alias]]
-	const mdRE      = /[*_`~]/g;                            // *, _, `, ~ (global flag for all occurrences)
-	const trimHashRE = /^#+\s*|\s*#+$/g;                    // leading/trailing # from ATX headings
-	const strayRE   = /\[\[|\]\]/g;                         // any leftover [[ ]]
-
-	return (heading: string): string =>
-		heading
-			.replace(imgRE,     '')                         // Remove images first
-			.replace(wikiRE,    (_, p1, _p2, alias) => alias ?? p1) // Then handle wikilinks
-			.replace(mdRE,      '')                         // Remove markdown formatting
-			.replace(trimHashRE, '')                        // Remove ATX heading markers
-			.replace(strayRE,   '')                         // Clean up stray brackets
-			.trim();
-})();
+// Single-source heading sanitizer; lives in its own dependency-free module
+// (linear scanners — the old chained regexes were quadratic on adversarial
+// headings). Re-exported here so existing imports keep working.
+export { sanitizeHeading } from "./headingSanitizer";

--- a/src/utils/generatedFilePath.test.ts
+++ b/src/utils/generatedFilePath.test.ts
@@ -87,4 +87,28 @@ describe("normalizeGeneratedFilePath", () => {
 			"a/b/Line Break",
 		);
 	});
+
+	// The historical control-run collapse (` *[<control>]+ *` global) and the
+	// two trailing trims (/ +$/u, /[. ]+$/u) all backtracked quadratically on
+	// long interior space/dot runs - and these names embed untrusted format
+	// output ({{VALUE}}/{{CLIPBOARD}}). The linear scanners were proven
+	// byte-identical by a 3.36M-case differential fuzz (incl. exhaustive
+	// coverage of all strings up to length 6 over the control/space/dot
+	// alphabet, comparing thrown messages too). These pin the linear-time
+	// behavior; budgets are generous to stay non-flaky (the old code took
+	// seconds at these sizes).
+	describe("ReDoS resistance", () => {
+		const BUDGET_MS = 1000;
+		const N = 200_000;
+
+		it.each([
+			["interior space run", "a" + " ".repeat(N) + "b"],
+			["interior dot run", "a" + ".".repeat(N) + "b"],
+			["interior dot/space mix", "a" + ". ".repeat(N / 2) + "b"],
+		])("normalizes a %s in linear time", (_name, input) => {
+			const start = performance.now();
+			expect(normalizeGeneratedFilePath(input)).toBe(input);
+			expect(performance.now() - start).toBeLessThan(BUDGET_MS);
+		}, 20_000);
+	});
 });

--- a/src/utils/generatedFilePath.ts
+++ b/src/utils/generatedFilePath.ts
@@ -1,8 +1,4 @@
 const CONTROL_OR_LINE_SEPARATOR_CHARS = `${String.fromCharCode(0x00)}-${String.fromCharCode(0x1f)}${String.fromCharCode(0x7f)}\u2028\u2029`;
-const CONTROL_OR_LINE_SEPARATOR_WITH_SPACES = new RegExp(
-	` *[${CONTROL_OR_LINE_SEPARATOR_CHARS}]+ *`,
-	"gu",
-);
 const STARTS_WITH_CONTROL_OR_LINE_SEPARATOR = new RegExp(
 	`^ *[${CONTROL_OR_LINE_SEPARATOR_CHARS}]`,
 	"u",
@@ -11,6 +7,61 @@ const ENDS_WITH_CONTROL_OR_LINE_SEPARATOR = new RegExp(
 	`[${CONTROL_OR_LINE_SEPARATOR_CHARS}] *$`,
 	"u",
 );
+
+function isControlOrLineSeparator(code: number): boolean {
+	return (
+		code <= 0x1f || code === 0x7f || code === 0x2028 || code === 0x2029
+	);
+}
+
+// Linear replacement for the historical global regex
+// ` *[<control>]+ *` -> " ": each run of control/line-separator characters,
+// together with the spaces directly around it, collapses to a single space.
+// The regex backtracked quadratically on a long interior space run with no
+// control character after it (each start position re-scanned the run), and
+// these names embed untrusted format output ({{VALUE}}/clipboard). When the
+// space run is not followed by a control character the regex left it
+// untouched, so the scanner copies it verbatim and jumps past it.
+function collapseControlRunsWithSpaces(value: string): string {
+	let out = "";
+	let i = 0;
+	while (i < value.length) {
+		let j = i;
+		while (j < value.length && value.charCodeAt(j) === 0x20 /* space */) {
+			j++;
+		}
+		if (j < value.length && isControlOrLineSeparator(value.charCodeAt(j))) {
+			while (
+				j < value.length &&
+				isControlOrLineSeparator(value.charCodeAt(j))
+			) {
+				j++;
+			}
+			while (j < value.length && value.charCodeAt(j) === 0x20) {
+				j++;
+			}
+			out += " ";
+			i = j;
+			continue;
+		}
+		// No control char after the space run: nothing here can start a match,
+		// so copy [i, j] verbatim (run + the non-matching char) and move on.
+		out += value.slice(i, Math.min(j + 1, value.length));
+		i = j + 1;
+	}
+	return out;
+}
+
+/**
+ * Linear trailing-trim for a small character set. The historical
+ * `/ +$/u` / `/[. ]+$/u` replaces backtracked quadratically on a long
+ * interior run of the trimmed characters ("a" + ".".repeat(n) + "b").
+ */
+function trimTrailingCharsLinear(value: string, chars: string): string {
+	let end = value.length;
+	while (end > 0 && chars.includes(value[end - 1])) end--;
+	return value.slice(0, end);
+}
 
 export function normalizeGeneratedFilePath(
 	path: string,
@@ -53,17 +104,17 @@ function normalizeGeneratedFilePathSegment(
 	const startsWithControl =
 		STARTS_WITH_CONTROL_OR_LINE_SEPARATOR.test(segment);
 	const endsWithControl = ENDS_WITH_CONTROL_OR_LINE_SEPARATOR.test(segment);
-	let normalized = segment.replace(CONTROL_OR_LINE_SEPARATOR_WITH_SPACES, " ");
+	let normalized = collapseControlRunsWithSpaces(segment);
 
 	if (startsWithControl) normalized = normalized.replace(/^ /u, "");
 	if (endsWithControl) normalized = normalized.replace(/ $/u, "");
 
-	const withoutTrailingSpaces = normalized.replace(/ +$/u, "");
+	const withoutTrailingSpaces = trimTrailingCharsLinear(normalized, " ");
 	if (withoutTrailingSpaces === "." || withoutTrailingSpaces === "..") {
 		throw new Error(`${label} cannot contain "." or ".." path segments.`);
 	}
 
-	normalized = normalized.replace(/[. ]+$/u, "");
+	normalized = trimTrailingCharsLinear(normalized, ". ");
 
 	if (!normalized) {
 		throw new Error(`${label} contains an empty path segment after formatting.`);


### PR DESCRIPTION
Fixes the two open deepsec MEDIUM ReDoS findings plus three sibling quadratics of the same class found during verification - all empirically confirmed quadratic and reachable from untrusted content (synced/pasted/AI-written notes, format-resolved names).

**Flagged by deepsec:**

- `sanitizeHeading` (gui/suggesters): the chained wikilink/image regexes were O(n²) on unclosed-opener floods. FileIndex runs this over every heading of every note (full reindex + every metadataCache `changed` event), so one crafted heading line of `[`s froze the renderer for seconds-to-minutes. Rewritten as linear single-pass scanners in a new dependency-free `headingSanitizer.ts`. The flagged finding was incomplete: the ATX-hash trim regex (`/^#+\s*|\s*#+$/g`) was independently quadratic on interior hash/whitespace runs and is fixed too.
- `stripTrailingWhitespace` in `findMultiLineRange` (insertionPositioning): `/\s+$/` took 3.2s at 80k chars on an interior whitespace run, hit for every file line during a multi-line insert-after/-before capture. `trimEnd()` strips the identical character set (spec: both are WhiteSpace + LineTerminator) in linear time.
- `sanitizeVaultPath.validateSegment` kept a provably dead `.replace(/[. ]+$/u, "")` (the trailing-char guard above it already threw for anything it could match) that still backtracked quadratically - 2.8s at 80k chars, reachable from the auto-run (no-approval) AI read tools with a model-chosen path.

**Siblings surfaced by the adversarial review panel:**

- `TemplateEngine.validateFolderSegment`: exact structural clone of the sanitizeVaultPath dead replace; dropped the same way.
- `normalizeGeneratedFilePath`: three LIVE quadratic shapes over format-generated file names (which embed `{{VALUE}}`/`{{CLIPBOARD}}` content) - the control-run collapse and both trailing trims. Replaced with linear scanners.

**Verification**

- Differential fuzz, new vs old implementations as oracle: sanitizeHeading 4.3M cases here + an independent 14.1M-case fuzz by the review panel (exhaustive short-string coverage over the delimiter alphabets, full-BMP sweeps, lone surrogates) - zero mismatches; trimEnd equivalence proven over the full BMP + astral range on both V8 and JavaScriptCore; generatedFilePath 3.36M cases including thrown-message equality - zero mismatches.
- All ten new linear-time regression tests fail against the old code (8-21s each) and pass in single-digit milliseconds now.
- A 13-agent adversarial workflow tried to refute each fix and upheld all of them.

Deliberately unchanged (pre-existing, noted for the record): `NUL  .md` (spaces before the extension dot) still passes the reserved-device check exactly as on master; the new scanner is ~2.6x slower than the regexes on short headings (sub-microsecond absolute cost, traded for the quadratic worst case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heading cleanup for pasted/linked content, including wikilinks/images and ATX heading marker trimming.
  * Hardened generated path, segment, and vault-path sanitization rules for edge-case filenames and segments.
  * Improved whitespace handling to avoid slowdowns on large trailing/interior whitespace inputs.

* **Tests**
  * Added regression coverage for tricky path and heading sanitization cases.
  * Added performance/linear-time checks to catch future ReDoS-style regressions across path normalization, heading sanitization, and insertion positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->