### PR TITLE
fix: six deepsec correctness fixes (chunk gluing, capture gluing, preflight double-exec, template fan-out, proto lookups, O(H²) links)

### DIFF
--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -84,11 +84,14 @@ export interface IChoiceExecutor {
 	/**
 	 * User-script modules already loaded (and therefore already EXECUTED - loading
 	 * a CommonJS user script runs its top-level code) by a requirement-collection
-	 * pass, keyed by `command.path ?? command.id`. MacroChoiceEngine consumes an
-	 * entry (delete-on-use) instead of re-loading the script, so introspecting
-	 * `quickadd.inputs` in the one-page preflight / non-interactive CLI does not
-	 * make a script's top-level side effects run twice per trigger. Optional so
-	 * existing stubs are unaffected; absent means "no preloaded modules".
+	 * pass, keyed by `getUserScriptPreloadKey` (`command.path ?? command.id` plus
+	 * any `::` member-drill suffix - stored values are DRILLED exports, so keying
+	 * by path alone would collide different members of one file). MacroChoiceEngine
+	 * consumes an entry (delete-on-use) instead of re-loading the script, so
+	 * introspecting `quickadd.inputs` in the one-page preflight / non-interactive
+	 * CLI does not make a script's top-level side effects run twice per trigger.
+	 * Optional so existing stubs are unaffected; absent means "no preloaded
+	 * modules".
 	 */
 	preloadedUserScripts?: Map<string, unknown>;
 }

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -81,4 +81,14 @@ export interface IChoiceExecutor {
 	 * awaiting {@link execute} to determine whether the child choice stopped early.
 	 */
 	consumeAbortSignal?(): MacroAbortError | null;
+	/**
+	 * User-script modules already loaded (and therefore already EXECUTED — loading
+	 * a CommonJS user script runs its top-level code) by a requirement-collection
+	 * pass, keyed by `command.path ?? command.id`. MacroChoiceEngine consumes an
+	 * entry (delete-on-use) instead of re-loading the script, so introspecting
+	 * `quickadd.inputs` in the one-page preflight / non-interactive CLI does not
+	 * make a script's top-level side effects run twice per trigger. Optional so
+	 * existing stubs are unaffected; absent means "no preloaded modules".
+	 */
+	preloadedUserScripts?: Map<string, unknown>;
 }

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -82,7 +82,7 @@ export interface IChoiceExecutor {
 	 */
 	consumeAbortSignal?(): MacroAbortError | null;
 	/**
-	 * User-script modules already loaded (and therefore already EXECUTED — loading
+	 * User-script modules already loaded (and therefore already EXECUTED - loading
 	 * a CommonJS user script runs its top-level code) by a requirement-collection
 	 * pass, keyed by `command.path ?? command.id`. MacroChoiceEngine consumes an
 	 * entry (delete-on-use) instead of re-loading the script, so introspecting

--- a/src/ai/AIAssistant.chunkedPrompt.test.ts
+++ b/src/ai/AIAssistant.chunkedPrompt.test.ts
@@ -248,7 +248,7 @@ describe("ChunkedPrompt", () => {
 	});
 
 	// The merge path used to reassemble chunks with `combinedChunk += chunk`,
-	// dropping the separator that split() consumed — "Line one\nLine two"
+	// dropping the separator that split() consumed - "Line one\nLine two"
 	// reached the model as "Line oneLine two" (words glued across every line
 	// boundary) on the DEFAULT shouldMerge path. The consumed separators are
 	// now retained and re-inserted between merged chunks.
@@ -321,6 +321,86 @@ describe("ChunkedPrompt", () => {
 			([prompt]) => prompt as string
 		);
 		expect(sentPrompts).toEqual(["Chunk: a\nb"]);
+	});
+
+	// The group-count probe must carry the separator's own flags: u-only
+	// syntax like a code-point class range parses ONLY under /u, and a
+	// flagless probe would throw a SyntaxError that fails the whole chunked
+	// prompt for previously-working separators.
+	it("supports u-flag-only separator syntax", async () => {
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "one\u{1F600}two",
+				shouldMerge: true,
+				chunkSeparator: /[\u{1F600}-\u{1F64F}]/gu,
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		// The emoji separator is retained and re-inserted between merged chunks.
+		expect(sentPrompts).toEqual(["Chunk: one\u{1F600}two"]);
+	});
+
+	// A `\1` in a group-free pattern is a legacy octal escape (matches U+0001);
+	// wrapping it in a capture group would turn it into a backreference and
+	// change the split points. Such separators stay on the historical
+	// separator-discarding path, keeping chunk boundaries identical to split().
+	it("keeps octal-escape separators on the historical path", async () => {
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "z a\x01z tail",
+				shouldMerge: true,
+				// Built via the constructor: TS rejects the /a\1/ literal form
+				// (TS1534) for exactly the ambiguity this test pins down.
+				chunkSeparator: new RegExp("a\\1", "g"),
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		// Same chunks as "z a\x01z tail".split(/a\1/g) = ["z ", "z tail"],
+		// merged without separator re-insertion (historical behavior).
+		expect(sentPrompts).toEqual(["Chunk: z z tail"]);
+	});
+
+	// Re-inserted joiners must be budgeted at their real estimated size (the
+	// historical flat +1 only covered the default "\n"): a long separator
+	// would otherwise be re-inserted uncounted and blow a merged request far
+	// past maxChunkTokens.
+	it("budgets long re-inserted separators instead of a flat +1", async () => {
+		// Each line is 20 chars (~5 tokens); the separator is 27 chars (7
+		// tokens). Budget 16: one line + one separator + one line = 5+7+5 = 17
+		// > 16, so each line must go in its OWN request. Under the old flat +1
+		// accounting two lines merged (6+6 = 12 < 16) and the request carried
+		// ~17 estimated tokens against the 16-token budget.
+		const line = "aaaaaaaaaaaaaaaaaaaa";
+		const sep = "\n===CHUNK-BOUNDARY===\n\n\n\n\n\n";
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: [line, line, line].join(sep),
+				maxChunkTokens: 16,
+				shouldMerge: true,
+				chunkSeparator: sep as unknown as RegExp,
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(sentPrompts).toEqual([
+			`Chunk: ${line}`,
+			`Chunk: ${line}`,
+			`Chunk: ${line}`,
+		]);
 	});
 
 	// The boundary between two MERGED REQUESTS is genuinely consumed: the

--- a/src/ai/AIAssistant.chunkedPrompt.test.ts
+++ b/src/ai/AIAssistant.chunkedPrompt.test.ts
@@ -247,6 +247,110 @@ describe("ChunkedPrompt", () => {
 		expect(calls).toBeLessThan(501);
 	});
 
+	// The merge path used to reassemble chunks with `combinedChunk += chunk`,
+	// dropping the separator that split() consumed — "Line one\nLine two"
+	// reached the model as "Line oneLine two" (words glued across every line
+	// boundary) on the DEFAULT shouldMerge path. The consumed separators are
+	// now retained and re-inserted between merged chunks.
+	it("re-inserts the consumed separator between merged chunks", async () => {
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "Line one\nLine two",
+				shouldMerge: true,
+				chunkSeparator: /\n/g,
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(sentPrompts).toEqual(["Chunk: Line one\nLine two"]);
+	});
+
+	it("preserves paragraph boundaries (empty chunks) when merging", async () => {
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "A\n\nB",
+				shouldMerge: true,
+				chunkSeparator: /\n/g,
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(sentPrompts).toEqual(["Chunk: A\n\nB"]);
+	});
+
+	it("re-inserts a custom string separator between merged chunks", async () => {
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "first---second",
+				shouldMerge: true,
+				chunkSeparator: "---" as unknown as RegExp,
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(sentPrompts).toEqual(["Chunk: first---second"]);
+	});
+
+	// A separator with capturing groups already interleaves its captures into
+	// the chunk list (historical String.split behavior); no extra boundary must
+	// be re-inserted on top of that.
+	it("keeps capture-group separators unchanged (captures already survive as chunks)", async () => {
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: "a\nb",
+				shouldMerge: true,
+				chunkSeparator: /(\n)/g,
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(sentPrompts).toEqual(["Chunk: a\nb"]);
+	});
+
+	// The boundary between two MERGED REQUESTS is genuinely consumed: the
+	// separator belongs to neither request. Grouping (request count) must be
+	// unchanged by separator retention.
+	it("does not leak a separator across a merge-group boundary", async () => {
+		// budget 8 tokens ≈ 32 chars per merged group; each line is 20 chars, so
+		// exactly one line fits per group → 3 requests, none starting with \n.
+		const line = "aaaaaaaaaaaaaaaaaaaa";
+		await ChunkedPrompt(
+			makeApp(),
+			makeSettings({
+				text: [line, line, line].join("\n"),
+				maxChunkTokens: 8,
+				shouldMerge: true,
+				chunkSeparator: /\n/g,
+			}),
+			chunkFormatter
+		);
+
+		const sentPrompts = mocks.makeRequest.mock.calls.map(
+			([prompt]) => prompt as string
+		);
+		expect(sentPrompts).toEqual([
+			`Chunk: ${line}`,
+			`Chunk: ${line}`,
+			`Chunk: ${line}`,
+		]);
+	});
+
 	// Iter-2 consensus regression: VALUE modifiers (e.g. case:upper) must apply to
 	// the real chunk value — the previous sentinel approach sent the placeholder.
 	it("applies VALUE modifiers to each chunk's real text", async () => {

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -658,24 +658,89 @@ function appendSplitToBudget(
 	}
 }
 
+function countRegExpGroups(re: RegExp): number {
+	// Appending "|" makes the pattern match empty at position 0, so exec always
+	// returns a result whose length is 1 + the number of capturing groups.
+	return (new RegExp(re.source + "|").exec("") as RegExpExecArray).length - 1;
+}
+
+/**
+ * Split `text` like `text.split(separator)` while RETAINING each consumed
+ * separator, so the merge path can re-insert the boundary it split on —
+ * otherwise merged lines/paragraphs reach the model glued together
+ * ("A\nB" → "AB"). Wrapping the pattern in one capturing group makes split()
+ * interleave the matched separators without changing the chunk substrings.
+ *
+ * A separator regex that already has capturing groups keeps the historical
+ * split behavior unchanged (its captures interleave into the chunk list, so
+ * the captured text is preserved as chunks); `separators` is null there and
+ * no boundary is re-inserted, exactly as before.
+ */
+function splitTextRetainingSeparators(
+	text: string,
+	separator: RegExp | string
+): { chunks: string[]; separators: string[] | null } {
+	if (typeof separator === "string") {
+		const chunks = text.split(separator);
+		return {
+			chunks,
+			separators: new Array(Math.max(0, chunks.length - 1)).fill(separator),
+		};
+	}
+
+	if (countRegExpGroups(separator) > 0) {
+		return { chunks: text.split(separator), separators: null };
+	}
+
+	const wrapped = new RegExp(`(${separator.source})`, separator.flags);
+	const parts = text.split(wrapped);
+	const chunks: string[] = [];
+	const separators: string[] = [];
+	for (let i = 0; i < parts.length; i++) {
+		if (i % 2 === 0) chunks.push(parts[i]);
+		else separators.push(parts[i]);
+	}
+	return { chunks, separators };
+}
+
+interface PreparedChunk {
+	text: string;
+	/** The separator that preceded this chunk in the original text ("" for the
+	 * first chunk and for continuation pieces cut out of one oversized chunk). */
+	joiner: string;
+}
+
 function buildEstimatedPromptChunks(
 	chunks: string[],
+	separators: string[] | null,
 	maxEstimatedChunkTokens: number,
 	shouldMerge: boolean
 ): string[] {
-	const preparedChunks: string[] = [];
-	for (const chunk of chunks) {
-		appendSplitToBudget(chunk, maxEstimatedChunkTokens, preparedChunks);
-	}
+	const preparedChunks: PreparedChunk[] = [];
+	chunks.forEach((chunk, index) => {
+		const pieces: string[] = [];
+		appendSplitToBudget(chunk, maxEstimatedChunkTokens, pieces);
+		pieces.forEach((piece, pieceIndex) => {
+			preparedChunks.push({
+				text: piece,
+				// Only the first piece of a raw chunk was preceded by a real
+				// separator; later pieces were cut mid-text by the budget split.
+				joiner:
+					pieceIndex === 0 && index > 0
+						? (separators?.[index - 1] ?? "")
+						: "",
+			});
+		});
+	});
 
-	if (!shouldMerge) return preparedChunks;
+	if (!shouldMerge) return preparedChunks.map((chunk) => chunk.text);
 
 	const output: string[] = [];
 	let combinedChunk = "";
 	let combinedChunkSize = 0;
 
 	for (const chunk of preparedChunks) {
-		const strSize = estimateTokenCount(chunk) + 1; // +1 for the separator consumed by split().
+		const strSize = estimateTokenCount(chunk.text) + 1; // +1 for the separator consumed by split().
 
 		if (
 			combinedChunk !== "" &&
@@ -686,7 +751,11 @@ function buildEstimatedPromptChunks(
 			combinedChunkSize = 0;
 		}
 
-		combinedChunk += chunk;
+		// Re-insert the separator the text was split on so merged chunks keep
+		// their original boundaries; a chunk that opens a new request drops its
+		// leading separator (it IS the request boundary).
+		combinedChunk +=
+			combinedChunk === "" ? chunk.text : chunk.joiner + chunk.text;
 		combinedChunkSize += strSize;
 	}
 
@@ -754,7 +823,10 @@ export async function ChunkedPrompt(
 		);
 
 		const chunkSeparator = settings.chunkSeparator || /\n/g;
-		const rawChunks = text.split(chunkSeparator);
+		const { chunks: rawChunks, separators } = splitTextRetainingSeparators(
+			text,
+			chunkSeparator
+		);
 
 		// Estimate the static prompt overhead by rendering the template once with a
 		// probe chunk value. This also validates dynamic expansions: templates,
@@ -803,6 +875,7 @@ export async function ChunkedPrompt(
 
 		const chunkedText = buildEstimatedPromptChunks(
 			rawChunks,
+			separators,
 			maxEstimatedChunkTokens,
 			shouldMerge
 		);

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -660,13 +660,25 @@ function appendSplitToBudget(
 
 function countRegExpGroups(re: RegExp): number {
 	// Appending "|" makes the pattern match empty at position 0, so exec always
-	// returns a result whose length is 1 + the number of capturing groups.
-	return (new RegExp(re.source + "|").exec("") as RegExpExecArray).length - 1;
+	// returns a result whose length is 1 + the number of capturing groups. The
+	// probe must keep the source's own flags (minus the match-position ones,
+	// g/y): u- or v-only syntax like /[\u{4E00}-\u{9FFF}]/gu does not parse
+	// flagless and would throw here instead of splitting.
+	const probeFlags = re.flags.replace(/[gy]/g, "");
+	return (
+		new RegExp(re.source + "|", probeFlags).exec("") as RegExpExecArray
+	).length - 1;
 }
+
+// An unescaped `\1`-`\9` in a group-FREE pattern is a legacy octal escape;
+// wrapping the source in a capture group would silently turn it into a
+// BACKREFERENCE and change what it matches. Such separators stay on the
+// historical (separator-discarding) path.
+const UNESCAPED_DIGIT_ESCAPE_RE = /(?:^|[^\\])(?:\\\\)*\\[1-9]/;
 
 /**
  * Split `text` like `text.split(separator)` while RETAINING each consumed
- * separator, so the merge path can re-insert the boundary it split on —
+ * separator, so the merge path can re-insert the boundary it split on -
  * otherwise merged lines/paragraphs reach the model glued together
  * ("A\nB" → "AB"). Wrapping the pattern in one capturing group makes split()
  * interleave the matched separators without changing the chunk substrings.
@@ -688,7 +700,10 @@ function splitTextRetainingSeparators(
 		};
 	}
 
-	if (countRegExpGroups(separator) > 0) {
+	if (
+		countRegExpGroups(separator) > 0 ||
+		UNESCAPED_DIGIT_ESCAPE_RE.test(separator.source)
+	) {
 		return { chunks: text.split(separator), separators: null };
 	}
 
@@ -740,7 +755,14 @@ function buildEstimatedPromptChunks(
 	let combinedChunkSize = 0;
 
 	for (const chunk of preparedChunks) {
-		const strSize = estimateTokenCount(chunk.text) + 1; // +1 for the separator consumed by split().
+		// Budget the separator that is actually re-inserted, floored at the
+		// historical +1 so grouping is unchanged for the default "\n"
+		// (estimateTokenCount("\n") === 1) and for joiner-less pieces. Without
+		// this, a long custom separator (e.g. "\n\n===CHUNK===\n\n") would be
+		// re-inserted uncounted and push a merged request far over the budget.
+		const strSize =
+			estimateTokenCount(chunk.text) +
+			Math.max(1, estimateTokenCount(chunk.joiner));
 
 		if (
 			combinedChunk !== "" &&

--- a/src/choiceExecutor.preload.test.ts
+++ b/src/choiceExecutor.preload.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the heavy leaves of the executor's import graph (mirrors the mock sets
+// of MacroChoiceEngine.entry.test.ts and choiceSuggester.test.ts).
+vi.mock("./gui/choiceList/ChoiceView.svelte", () => ({}));
+vi.mock("./gui/GlobalVariables/GlobalVariablesView.svelte", () => ({}));
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+vi.mock("./main", () => ({ __esModule: true, default: class QuickAddMock {} }));
+vi.mock("./quickAddSettingsTab", () => ({
+	DEFAULT_SETTINGS: {},
+	QuickAddSettingsTab: class {},
+}));
+vi.mock("./settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({ onePageInputEnabled: false, ai: {}, disableOnlineFeatures: true }),
+	},
+}));
+vi.mock("./engine/runTemplateFromFolder", () => ({
+	runTemplateFromFolder: vi.fn(),
+}));
+vi.mock("./utils/frontmatterPropertyLinks", () => ({
+	getFocusedPropertyTarget: vi.fn(() => null),
+}));
+vi.mock("./utilityObsidian", async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>();
+	return {
+		...actual,
+		getOpenFileOriginLeaf: vi.fn(() => null),
+	};
+});
+
+const { ChoiceExecutor } = await import("./choiceExecutor");
+
+describe("ChoiceExecutor preloadedUserScripts lifecycle", () => {
+	it("clears leftover preloaded modules when the outermost execution ends", async () => {
+		const executor = new ChoiceExecutor(
+			{ workspace: { getActiveFile: () => null } } as never,
+			{} as never,
+		);
+		// Simulate a collection pass that loaded a module whose command never
+		// ran (cancelled modal / aborted macro): the entry must not survive to
+		// the NEXT trigger on a long-lived executor, where it would hand the
+		// engine a module loaded before the user's latest edits.
+		executor.preloadedUserScripts.set("stale.js", { entry: () => {} });
+
+		await executor.execute({
+			id: "unknown",
+			name: "Unknown",
+			type: "Nonexistent",
+		} as never);
+
+		expect(executor.preloadedUserScripts.size).toBe(0);
+	});
+
+	it("keeps entries alive while nested executions are still running", () => {
+		const executor = new ChoiceExecutor(
+			{ workspace: { getActiveFile: () => null } } as never,
+			{} as never,
+		);
+		executor.preloadedUserScripts.set("outer.js", {});
+
+		// Depth 2 -> 1: a nested execute() ending must NOT wipe the outer
+		// run's preloaded modules.
+		(executor as unknown as { executionDepth: number }).executionDepth = 2;
+		(executor as unknown as { endExecutionContext(): void }).endExecutionContext();
+		expect(executor.preloadedUserScripts.size).toBe(1);
+
+		// Depth 1 -> 0: the outermost end clears.
+		(executor as unknown as { endExecutionContext(): void }).endExecutionContext();
+		expect(executor.preloadedUserScripts.size).toBe(0);
+	});
+});

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -89,6 +89,13 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		if (this.executionDepth === 0) {
 			this.focusedProperty = null;
 			this.triggerContext = null;
+			// Preloaded script modules are scoped to ONE outermost execution: a
+			// cancelled/aborted run must not strand its entries, or a later
+			// trigger on a long-lived executor (api.executeChoice callers reuse
+			// one) would consume a module loaded before the user's latest edits.
+			// Cleared at the END so the CLI's collect-then-execute handoff (which
+			// populates the map before execute() begins) still works.
+			this.preloadedUserScripts.clear();
 		}
 	}
 

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -30,6 +30,11 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	// suggester) keeps its current prompt behaviour. Non-interactive callers (CLI
 	// without `ui`) flip this to false so engine prompts abort instead of hanging.
 	public interactive = true;
+	// User-script modules loaded by requirement collection (preflight / CLI),
+	// consumed once by MacroChoiceEngine so a script's top-level code runs a
+	// single time per trigger instead of once for introspection plus once for
+	// execution (see IChoiceExecutor.preloadedUserScripts).
+	public readonly preloadedUserScripts = new Map<string, unknown>();
 	public focusedProperty: FrontmatterPropertyTarget | null = null;
 	public triggerContext: QuickAddTriggerContext | null = null;
 	private pendingAbort: MacroAbortError | null = null;
@@ -290,7 +295,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			macroChoice,
 			this,
 			this.variables,
-			undefined,
+			this.preloadedUserScripts,
 			undefined,
 			originLeaf,
 		);

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -333,6 +333,10 @@ async function runResolvedChoice(
 				plugin,
 				choiceExecutor,
 				choice,
+				// Loading a user script to read quickadd.inputs executes its module
+				// body; cache it on the executor so the run below consumes this
+				// load instead of executing every script's top level twice.
+				{ preloadedUserScripts: choiceExecutor.preloadedUserScripts },
 			);
 			const unresolved = getUnresolvedRequirements(
 				requirements,

--- a/src/engine/MacroChoiceEngine.entry.test.ts
+++ b/src/engine/MacroChoiceEngine.entry.test.ts
@@ -193,6 +193,38 @@ describe("MacroChoiceEngine user script entry handling", () => {
 		expect(engine["output"]).toBe("entry-result");
 	});
 
+	// Requirement collection (one-page preflight / non-interactive CLI) already
+	// loaded — and thereby executed — the script's module body; the engine must
+	// consume that module instead of loading it again, and must consume it only
+	// ONCE so a later run of the same command loads fresh.
+	it("consumes a preloaded user-script module instead of re-loading it", async () => {
+		const entryFn = vi.fn().mockResolvedValue("entry-result");
+		const preloaded = new Map<string, unknown>([
+			["script.js", { entry: entryFn }],
+		]);
+
+		const engine = new MacroChoiceEngine(
+			app,
+			plugin,
+			macroChoice,
+			choiceExecutor,
+			variables,
+			preloaded,
+		);
+
+		await engine["executeUserScript"](userScriptCommand);
+
+		expect(mockGetUserScript).not.toHaveBeenCalled();
+		expect(entryFn).toHaveBeenCalledTimes(1);
+		// Delete-on-use: the preloaded execution is spent.
+		expect(preloaded.has("script.js")).toBe(false);
+
+		// A second execution of the same command loads (and thus runs) fresh.
+		mockGetUserScript.mockResolvedValue({ entry: entryFn });
+		await engine["executeUserScript"](userScriptCommand);
+		expect(mockGetUserScript).toHaveBeenCalledTimes(1);
+	});
+
 	it("initializes user script settings only from object-shaped settings exports", async () => {
 		const entryFn = vi.fn().mockResolvedValue("entry-result");
 		const settings = {

--- a/src/engine/MacroChoiceEngine.entry.test.ts
+++ b/src/engine/MacroChoiceEngine.entry.test.ts
@@ -194,7 +194,7 @@ describe("MacroChoiceEngine user script entry handling", () => {
 	});
 
 	// Requirement collection (one-page preflight / non-interactive CLI) already
-	// loaded — and thereby executed — the script's module body; the engine must
+	// loaded - and thereby executed - the script's module body; the engine must
 	// consume that module instead of loading it again, and must consume it only
 	// ONCE so a later run of the same command loads fresh.
 	it("consumes a preloaded user-script module instead of re-loading it", async () => {
@@ -223,6 +223,42 @@ describe("MacroChoiceEngine user script entry handling", () => {
 		mockGetUserScript.mockResolvedValue({ entry: entryFn });
 		await engine["executeUserScript"](userScriptCommand);
 		expect(mockGetUserScript).toHaveBeenCalledTimes(1);
+	});
+
+	// Preloaded values are member-DRILLED exports, so a command drilling a
+	// different `::` member of the same file must NOT consume another
+	// member's entry (path-only keying executed the wrong function).
+	it("does not consume a preloaded entry cached for a different :: member", async () => {
+		const fooEntry = vi.fn().mockResolvedValue("foo-result");
+		const barEntry = vi.fn().mockResolvedValue("bar-result");
+		const preloaded = new Map<string, unknown>([
+			["script.js::foo", { entry: fooEntry }],
+		]);
+		mockGetUserScript.mockResolvedValue({ entry: barEntry });
+
+		const engine = new MacroChoiceEngine(
+			app,
+			plugin,
+			macroChoice,
+			choiceExecutor,
+			variables,
+			preloaded,
+		);
+
+		const barCommand = { ...userScriptCommand, name: "Script::bar" };
+		await engine["executeUserScript"](barCommand);
+
+		// bar must load fresh (and run barEntry), leaving foo's entry intact.
+		expect(mockGetUserScript).toHaveBeenCalledTimes(1);
+		expect(barEntry).toHaveBeenCalledTimes(1);
+		expect(fooEntry).not.toHaveBeenCalled();
+		expect(preloaded.has("script.js::foo")).toBe(true);
+
+		const fooCommand = { ...userScriptCommand, name: "Script::foo" };
+		await engine["executeUserScript"](fooCommand);
+		expect(fooEntry).toHaveBeenCalledTimes(1);
+		expect(mockGetUserScript).toHaveBeenCalledTimes(1);
+		expect(preloaded.has("script.js::foo")).toBe(false);
 	});
 
 	it("initializes user script settings only from object-shaped settings exports", async () => {

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -50,6 +50,7 @@ import { MacroAbortError } from "../errors/MacroAbortError";
 import { UserCancelError } from "../errors/UserCancelError";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { initializeUserScriptSettings } from "../utils/userScriptSettings";
+import { getUserScriptPreloadKey } from "../utils/userScript";
 import {
 	migrateUserScriptSecretSettings,
 	resolveUserScriptSettings,
@@ -325,7 +326,10 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 	// Slightly modified from Templater's user script engine:
 	// https://github.com/SilentVoid13/Templater/blob/master/src/UserTemplates/UserTemplateParser.ts
 	protected async executeUserScript(command: IUserScript) {
-		const cacheKey = command.path ?? command.id;
+		// Member-aware key: preloaded values are DRILLED exports, so a command
+		// drilling a different `::` member of the same file must never consume
+		// another command's entry (see getUserScriptPreloadKey).
+		const cacheKey = getUserScriptPreloadKey(command);
 		let userScript: unknown;
 		if (cacheKey !== undefined) {
 			const cached = this.preloadedUserScripts.get(cacheKey);

--- a/src/formatters/capture-insert-after-linkcurrent.test.ts
+++ b/src/formatters/capture-insert-after-linkcurrent.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { LINK_TO_CURRENT_FILE_REGEX, TITLE_REGEX } from '../constants';
+import * as positioning from './helpers/insertionPositioning';
 
 // Local helper mirroring Formatter.replaceLinkToCurrentFileInString,
 // but without importing Formatter (to avoid obsidian deps in tests).
@@ -52,12 +53,12 @@ function findInsertAfterIndex(lines: string[], rawTarget: string): number {
   return partialIndex;
 }
 
+// Thin adapter over the PRODUCTION splice helper (non-task path), so these
+// simulation tests exercise the real semantics instead of a frozen local copy
+// (which had already drifted: it lacked the separator guard for text without
+// a trailing newline). Every target here is found, so pos is always >= 0.
 function insertTextAfterPositionInBody(text: string, body: string, pos: number): string {
-  if (pos === -1) return `${text}\n${body}`;
-  const split = body.split('\n');
-  const pre = split.slice(0, pos + 1).join('\n');
-  const post = split.slice(pos + 1).join('\n');
-  return `${pre}\n${text}${post}`;
+  return positioning.insertTextAfterPositionInBody(text, body, pos, false).content;
 }
 
 describe('Insert after — {{linkcurrent}} resolution', () => {

--- a/src/formatters/helpers/insertionPositioning.test.ts
+++ b/src/formatters/helpers/insertionPositioning.test.ts
@@ -216,6 +216,44 @@ describe("insertTextAfterPositionInBody", () => {
 		const r = insertTextAfterPositionInBody("- x\n", body, 0, false);
 		expect(r.content).toBe("## Log\n- x\n\n- after");
 	});
+
+	// Text without a trailing newline used to be glued straight onto the next
+	// line's content ("## Log\nnew- existing"), corrupting it — the default
+	// no-format capture ({{value}} = raw selection/clipboard) and any format
+	// not ending in \n hit this whenever the anchor is directly followed by
+	// content. Mirrors insertTextBeforePositionInBody's separator guard.
+	describe("separator guard for text without a trailing newline", () => {
+		it("does not glue onto the following content line", () => {
+			const body = "## Log\n- existing";
+			const r = insertTextAfterPositionInBody("new", body, 0, false);
+			expect(r.content).toBe("## Log\nnew\n- existing");
+			// Cursor lands at the end of the inserted text, before the separator.
+			expect(r.insertedEndOffset).toBe("## Log\n".length + "new".length);
+		});
+		it("does not glue a section-end insert onto the next heading", () => {
+			const body = "## A\n- item\n## B";
+			const r = insertTextAfterPositionInBody("x", body, 1, false);
+			expect(r.content).toBe("## A\n- item\nx\n## B");
+		});
+		it("adds nothing at end-of-file (no following content)", () => {
+			const r = insertTextAfterPositionInBody("x", "a\nb", 1, false);
+			expect(r.content).toBe("a\nb\nx");
+		});
+		it("does not treat the EOF newline artifact as content", () => {
+			const r = insertTextAfterPositionInBody("x", "a\n", 0, false);
+			expect(r.content).toBe("a\nx");
+		});
+		it("lets a blank line below absorb the text (no doubled blank)", () => {
+			const body = "## Log\n\n- after";
+			const r = insertTextAfterPositionInBody("new", body, 0, false);
+			expect(r.content).toBe("## Log\nnew\n- after");
+		});
+		it("keeps the #312 task drop intact (no separator re-added)", () => {
+			const body = "## Log\n \n- after"; // whitespace-only blank below
+			const r = insertTextAfterPositionInBody("- task\n", body, 0, true);
+			expect(r.content).toBe("## Log\n- task \n- after");
+		});
+	});
 });
 
 describe("insertTextBeforePositionInBody", () => {

--- a/src/formatters/helpers/insertionPositioning.test.ts
+++ b/src/formatters/helpers/insertionPositioning.test.ts
@@ -218,7 +218,7 @@ describe("insertTextAfterPositionInBody", () => {
 	});
 
 	// Text without a trailing newline used to be glued straight onto the next
-	// line's content ("## Log\nnew- existing"), corrupting it — the default
+	// line's content ("## Log\nnew- existing"), corrupting it - the default
 	// no-format capture ({{value}} = raw selection/clipboard) and any format
 	// not ending in \n hit this whenever the anchor is directly followed by
 	// content. Mirrors insertTextBeforePositionInBody's separator guard.

--- a/src/formatters/helpers/insertionPositioning.ts
+++ b/src/formatters/helpers/insertionPositioning.ts
@@ -355,7 +355,7 @@ export function insertTextAfterPositionInBody(
 
 	// `post` starts with the following line's CONTENT (join adds no leading
 	// "\n"), so a `text` without a trailing newline would be glued straight
-	// onto it — "## Log\n- existing" + "new" became "## Log\nnew- existing".
+	// onto it - "## Log\n- existing" + "new" became "## Log\nnew- existing".
 	// Mirror insertTextBeforePositionInBody's separator guard. Only a
 	// non-blank line below needs the separator: a blank/whitespace-only line
 	// absorbs the text instead (the #312 task-newline drop above relies on

--- a/src/formatters/helpers/insertionPositioning.ts
+++ b/src/formatters/helpers/insertionPositioning.ts
@@ -342,12 +342,13 @@ export function insertTextAfterPositionInBody(
 	// must not trigger the drop; a body WITHOUT a trailing newline has no such
 	// artifact, so its final slot is a genuine (possibly blank) last line.
 	const lineBelow = splitContent[pos + 1];
+	const lineBelowTrimmed = (lineBelow ?? "").trim();
 	const isTrailingNewlineArtifact =
 		body.endsWith("\n") && pos + 1 === splitContent.length - 1;
 	const blankLineDirectlyBelow =
 		pos + 1 < splitContent.length &&
 		!isTrailingNewlineArtifact &&
-		(lineBelow ?? "").trim() === "";
+		lineBelowTrimmed === "";
 	const text =
 		isTask && rawText.endsWith("\n") && blankLineDirectlyBelow
 			? rawText.slice(0, -1)
@@ -361,7 +362,7 @@ export function insertTextAfterPositionInBody(
 	// absorbs the text instead (the #312 task-newline drop above relies on
 	// exactly that), and the EOF artifact slot is not content.
 	const separator =
-		!text.endsWith("\n") && (lineBelow ?? "").trim() !== "" ? "\n" : "";
+		!text.endsWith("\n") && lineBelowTrimmed !== "" ? "\n" : "";
 
 	return {
 		content: `${pre}\n${text}${separator}${post}`,

--- a/src/formatters/helpers/insertionPositioning.ts
+++ b/src/formatters/helpers/insertionPositioning.ts
@@ -353,8 +353,18 @@ export function insertTextAfterPositionInBody(
 			? rawText.slice(0, -1)
 			: rawText;
 
+	// `post` starts with the following line's CONTENT (join adds no leading
+	// "\n"), so a `text` without a trailing newline would be glued straight
+	// onto it — "## Log\n- existing" + "new" became "## Log\nnew- existing".
+	// Mirror insertTextBeforePositionInBody's separator guard. Only a
+	// non-blank line below needs the separator: a blank/whitespace-only line
+	// absorbs the text instead (the #312 task-newline drop above relies on
+	// exactly that), and the EOF artifact slot is not content.
+	const separator =
+		!text.endsWith("\n") && (lineBelow ?? "").trim() !== "" ? "\n" : "";
+
 	return {
-		content: `${pre}\n${text}${post}`,
+		content: `${pre}\n${text}${separator}${post}`,
 		insertedEndOffset: pre.length + 1 + text.length,
 	};
 }

--- a/src/formatters/helpers/sectionLink.test.ts
+++ b/src/formatters/helpers/sectionLink.test.ts
@@ -115,6 +115,99 @@ describe("buildSectionSubpath", () => {
 		];
 		expect(buildSectionSubpath(twins, 9)).toBeNull();
 	});
+
+	// The chain-collision check now precomputes every heading's chain key with a
+	// forward outline-parent stack instead of re-walking ancestorChain inside a
+	// .some() (O(H^2) on duplicate-flooded notes). This property test pins the
+	// stack-based chains to the original backward-walk semantics.
+	it("matches the backward-walk reference on randomized outlines", () => {
+		// Reference: the pre-optimization ancestorChain, verbatim.
+		const referenceChain = (headings: SimpleHeading[], index: number) => {
+			const segments: string[] = [];
+			const self = sanitizeHeadingForSubpath(headings[index].heading);
+			if (self) segments.push(self);
+			let level = headings[index].level;
+			for (let i = index - 1; i >= 0 && level > 1; i--) {
+				if (headings[i].level < level) {
+					level = headings[i].level;
+					const seg = sanitizeHeadingForSubpath(headings[i].heading);
+					if (seg) segments.unshift(seg);
+				}
+			}
+			return segments;
+		};
+		const referenceSubpath = (
+			headings: SimpleHeading[],
+			cursorLine: number,
+		): string | null => {
+			if (headings.length === 0) return null;
+			let targetIndex = -1;
+			for (let i = 0; i < headings.length; i++) {
+				if (headings[i].line <= cursorLine) targetIndex = i;
+				else break;
+			}
+			if (targetIndex === -1) return null;
+			const targetText = sanitizeHeadingForSubpath(
+				headings[targetIndex].heading,
+			);
+			if (!targetText) return null;
+			const targetKey = targetText.toLowerCase();
+			const isUniqueText = !headings.some(
+				(h, i) =>
+					i !== targetIndex &&
+					sanitizeHeadingForSubpath(h.heading).toLowerCase() === targetKey,
+			);
+			if (isUniqueText) return `#${targetText}`;
+			const chain = referenceChain(headings, targetIndex);
+			if (chain.length < 2) return null;
+			const chainKey = chain.join("#");
+			const chainKeyLower = chainKey.toLowerCase();
+			const isUniqueChain = !headings.some(
+				(_h, i) =>
+					i !== targetIndex &&
+					referenceChain(headings, i).join("#").toLowerCase() ===
+						chainKeyLower,
+			);
+			if (!isUniqueChain) return null;
+			return `#${chainKey}`;
+		};
+
+		// Deterministic PRNG so failures reproduce.
+		let seed = 0x5eed;
+		const rand = () => {
+			seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+			return seed / 0x7fffffff;
+		};
+		const NAMES = ["Notes", "notes", "Log", "#", "A", "B", ""];
+		for (let round = 0; round < 2000; round++) {
+			const count = 1 + Math.floor(rand() * 12);
+			const headings: SimpleHeading[] = [];
+			for (let i = 0; i < count; i++) {
+				headings.push({
+					heading: NAMES[Math.floor(rand() * NAMES.length)],
+					level: 1 + Math.floor(rand() * 4),
+					line: i * 2,
+				});
+			}
+			const cursorLine = Math.floor(rand() * (count * 2 + 2));
+			expect(buildSectionSubpath(headings, cursorLine)).toBe(
+				referenceSubpath(headings, cursorLine),
+			);
+		}
+	});
+
+	it("resolves duplicates on a heading-flooded note in linear time", () => {
+		// 30k duplicate headings: the old O(H^2) collision check took minutes
+		// here; the stack-based precompute stays well under the budget.
+		const flood: SimpleHeading[] = [];
+		for (let i = 0; i < 15_000; i++) {
+			flood.push({ heading: `Parent ${i}`, level: 1, line: i * 4 });
+			flood.push({ heading: "Notes", level: 2, line: i * 4 + 2 });
+		}
+		const start = performance.now();
+		expect(buildSectionSubpath(flood, 42)).toBe("#Parent 10#Notes");
+		expect(performance.now() - start).toBeLessThan(1000);
+	}, 20_000);
 });
 
 describe("sanitizeHeadingForSubpath (mirrors Obsidian's anchor normalizer)", () => {

--- a/src/formatters/helpers/sectionLink.ts
+++ b/src/formatters/helpers/sectionLink.ts
@@ -227,11 +227,11 @@ export function buildSectionSubpath(
 
 /**
  * Every heading's ancestor-chain key (lowercased), computed in one forward
- * pass with the standard outline parent stack — each heading's chain is its
+ * pass with the standard outline parent stack - each heading's chain is its
  * stack-parent's chain plus itself, matching ancestorChain()'s backward walk.
  * Replaces calling the O(index) ancestorChain inside a .some() over all
  * headings, which was O(H^2) on a note flooded with duplicate headings
- * (chains are at most 6 deep — heading levels — so this is linear).
+ * (chains are at most 6 deep - heading levels - so this is linear).
  */
 function buildAllChainKeysLower(headings: SimpleHeading[]): string[] {
 	const chains: string[][] = new Array(headings.length);

--- a/src/formatters/helpers/sectionLink.ts
+++ b/src/formatters/helpers/sectionLink.ts
@@ -217,12 +217,37 @@ export function buildSectionSubpath(
 
 	const chainKey = chain.join("#");
 	const chainKeyLower = chainKey.toLowerCase();
-	const isUniqueChain = !headings.some(
-		(_h, i) =>
-			i !== targetIndex &&
-			ancestorChain(headings, i).join("#").toLowerCase() === chainKeyLower,
+	const isUniqueChain = !buildAllChainKeysLower(headings).some(
+		(key, i) => i !== targetIndex && key === chainKeyLower,
 	);
 	if (!isUniqueChain) return null; // unresolvable → whole-file fallback
 
 	return `#${chainKey}`;
+}
+
+/**
+ * Every heading's ancestor-chain key (lowercased), computed in one forward
+ * pass with the standard outline parent stack — each heading's chain is its
+ * stack-parent's chain plus itself, matching ancestorChain()'s backward walk.
+ * Replaces calling the O(index) ancestorChain inside a .some() over all
+ * headings, which was O(H^2) on a note flooded with duplicate headings
+ * (chains are at most 6 deep — heading levels — so this is linear).
+ */
+function buildAllChainKeysLower(headings: SimpleHeading[]): string[] {
+	const chains: string[][] = new Array(headings.length);
+	const stack: number[] = []; // indices with strictly increasing levels
+	for (let i = 0; i < headings.length; i++) {
+		while (
+			stack.length > 0 &&
+			headings[stack[stack.length - 1]].level >= headings[i].level
+		) {
+			stack.pop();
+		}
+		const parentChain =
+			stack.length > 0 ? chains[stack[stack.length - 1]] : [];
+		const seg = sanitizeHeadingForSubpath(headings[i].heading);
+		chains[i] = seg ? [...parentChain, seg] : parentChain;
+		stack.push(i);
+	}
+	return chains.map((chain) => chain.join("#").toLowerCase());
 }

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -81,7 +81,7 @@ export class RequirementCollector extends Formatter {
 	 * Cross-branch memo for the template-inclusion walk: template ref → the
 	 * shallowest depth it was fully scanned at during this collection.
 	 * Requirements dedupe by id, so re-scanning a template reachable through
-	 * many distinct paths adds nothing — without this memo a dense template
+	 * many distinct paths adds nothing - without this memo a dense template
 	 * DAG fans out as branching^depth (~1M scans at 4×10), freezing the UI.
 	 */
 	public readonly scannedTemplateRefDepths = new Map<string, number>();

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -77,6 +77,14 @@ export interface FieldRequirement {
 export class RequirementCollector extends Formatter {
 	public readonly requirements = new Map<string, FieldRequirement>();
 	public readonly templatesToScan = new Set<string>();
+	/**
+	 * Cross-branch memo for the template-inclusion walk: template ref → the
+	 * shallowest depth it was fully scanned at during this collection.
+	 * Requirements dedupe by id, so re-scanning a template reachable through
+	 * many distinct paths adds nothing — without this memo a dense template
+	 * DAG fans out as branching^depth (~1M scans at 4×10), freezing the UI.
+	 */
+	public readonly scannedTemplateRefDepths = new Map<string, number>();
 
 	constructor(
 		protected app: App,

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -583,7 +583,7 @@ describe("collectChoiceRequirements - template include scanning", () => {
 	});
 
 	// The walk was guarded only by the per-PATH cycle stack, so a template
-	// reachable through many distinct paths was re-scanned once per path — a
+	// reachable through many distinct paths was re-scanned once per path - a
 	// dense layered DAG fans out as branching^depth (3^6 = 729 reads here;
 	// ~1M at 4×10), freezing the UI. The cross-branch memo makes the walk
 	// linear in distinct templates while still collecting every requirement.
@@ -628,7 +628,7 @@ describe("collectChoiceRequirements - template include scanning", () => {
 	it("re-scans a template met again at a shallower depth (memo must not truncate)", async () => {
 		// Chain T1→…→T10 exhausts the inclusion depth cap, so T10's child T11 is
 		// NOT scanned on that path. The root also references T10 directly; the
-		// depth-aware memo must re-scan it there so T11's requirement surfaces —
+		// depth-aware memo must re-scan it there so T11's requirement surfaces -
 		// a naive "already seen" set would silently drop it.
 		for (let i = 1; i < 10; i++) {
 			templateBodies.set(
@@ -720,8 +720,8 @@ describe("collectChoiceRequirements - macro script metadata", () => {
 
 	// Loading a user script to read quickadd.inputs EXECUTES its module body
 	// (getUserScript runs the CommonJS wrapper). The collector must cache the
-	// loaded module in the caller's preloadedUserScripts map — and reuse an
-	// existing entry — so a single trigger never runs a script's top-level
+	// loaded module in the caller's preloadedUserScripts map - and reuse an
+	// existing entry - so a single trigger never runs a script's top-level
 	// side effects twice (introspection + MacroChoiceEngine execution).
 	it("caches loaded modules in preloadedUserScripts and reuses existing entries", async () => {
 		const exported = {
@@ -756,6 +756,49 @@ describe("collectChoiceRequirements - macro script metadata", () => {
 		expect(getUserScriptMock).toHaveBeenCalledTimes(1);
 		expect(requirements).toEqual(
 			expect.arrayContaining([expect.objectContaining({ id: "project" })]),
+		);
+	});
+
+	// getUserScript returns the `::`-member-DRILLED export, so the cache key
+	// must include the drill: two commands sharing a path but drilling
+	// different members hold different functions with different inputs, and
+	// caching by path alone made the second command reuse the first member's
+	// export (its inputs were never collected, and at runtime the wrong
+	// function could be consumed).
+	it("keys the preload cache by member drill, not just path", async () => {
+		const fooExport = {
+			quickadd: { inputs: [{ id: "fooInput", type: "text", label: "Foo" }] },
+		};
+		const barExport = {
+			quickadd: { inputs: [{ id: "barInput", type: "text", label: "Bar" }] },
+		};
+		getUserScriptMock
+			.mockResolvedValueOnce(fooExport)
+			.mockResolvedValueOnce(barExport);
+		const preloadedUserScripts = new Map<string, unknown>();
+
+		const macroChoice = createMacroChoice(scriptCommand);
+		macroChoice.macro.commands = [
+			{ ...scriptCommand, name: "Script 1::foo" },
+			{ ...scriptCommand, id: "script-2", name: "Script 1::bar" },
+		];
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			macroChoice,
+			{ preloadedUserScripts },
+		);
+
+		expect(getUserScriptMock).toHaveBeenCalledTimes(2);
+		expect(preloadedUserScripts.get("script.js::foo")).toBe(fooExport);
+		expect(preloadedUserScripts.get("script.js::bar")).toBe(barExport);
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "fooInput" }),
+				expect.objectContaining({ id: "barInput" }),
+			]),
 		);
 	});
 

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -581,6 +581,85 @@ describe("collectChoiceRequirements - template include scanning", () => {
 			]),
 		);
 	});
+
+	// The walk was guarded only by the per-PATH cycle stack, so a template
+	// reachable through many distinct paths was re-scanned once per path — a
+	// dense layered DAG fans out as branching^depth (3^6 = 729 reads here;
+	// ~1M at 4×10), freezing the UI. The cross-branch memo makes the walk
+	// linear in distinct templates while still collecting every requirement.
+	it("scans a dense template DAG once per template, not once per path", async () => {
+		const LAYERS = 6;
+		const WIDTH = 3;
+		const refsTo = (layer: number) =>
+			Array.from(
+				{ length: WIDTH },
+				(_, i) => `{{TEMPLATE:Templates/L${layer}-${i}.md}}`,
+			).join(" ");
+		for (let layer = 0; layer < LAYERS; layer++) {
+			for (let i = 0; i < WIDTH; i++) {
+				const body =
+					layer === LAYERS - 1
+						? "leaf {{VALUE:leafValue}}"
+						: refsTo(layer + 1);
+				templateBodies.set(`Templates/L${layer}-${i}.md`, body);
+			}
+		}
+		templateBodies.set("Templates/Root.md", refsTo(0));
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createTemplateChoice("Templates/Root.md"),
+		);
+
+		// Completeness: the deepest layer's requirement is still collected.
+		expect(requirements).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: "leafValue" })]),
+		);
+		// One read per distinct template (root + 18), not 3^6 per-path reads.
+		expect(cachedReadMock.mock.calls.length).toBeLessThan(2 * LAYERS * WIDTH);
+	});
+
+	it("re-scans a template met again at a shallower depth (memo must not truncate)", async () => {
+		// Chain T1→…→T10 exhausts the inclusion depth cap, so T10's child T11 is
+		// NOT scanned on that path. The root also references T10 directly; the
+		// depth-aware memo must re-scan it there so T11's requirement surfaces —
+		// a naive "already seen" set would silently drop it.
+		for (let i = 1; i < 10; i++) {
+			templateBodies.set(
+				`Templates/T${i}.md`,
+				`{{TEMPLATE:Templates/T${i + 1}.md}}`,
+			);
+		}
+		templateBodies.set("Templates/T10.md", "{{TEMPLATE:Templates/T11.md}}");
+		templateBodies.set("Templates/T11.md", "deep {{VALUE:deepEleven}}");
+		templateBodies.set(
+			"Templates/Root.md",
+			"{{TEMPLATE:Templates/T1.md}} {{TEMPLATE:Templates/T10.md}}",
+		);
+		const choiceExecutor: IChoiceExecutor = {
+			execute: vi.fn(),
+			variables: new Map<string, unknown>(),
+		};
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createTemplateChoice("Templates/Root.md"),
+		);
+
+		expect(requirements).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: "deepEleven" }),
+			]),
+		);
+	});
 });
 
 describe("collectChoiceRequirements - macro script metadata", () => {
@@ -636,6 +715,47 @@ describe("collectChoiceRequirements - macro script metadata", () => {
 					source: "script",
 				}),
 			]),
+		);
+	});
+
+	// Loading a user script to read quickadd.inputs EXECUTES its module body
+	// (getUserScript runs the CommonJS wrapper). The collector must cache the
+	// loaded module in the caller's preloadedUserScripts map — and reuse an
+	// existing entry — so a single trigger never runs a script's top-level
+	// side effects twice (introspection + MacroChoiceEngine execution).
+	it("caches loaded modules in preloadedUserScripts and reuses existing entries", async () => {
+		const exported = {
+			quickadd: {
+				inputs: [{ id: "project", type: "text", label: "Project" }],
+			},
+		};
+		getUserScriptMock.mockResolvedValue(exported);
+		const preloadedUserScripts = new Map<string, unknown>();
+
+		await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createMacroChoice(scriptCommand),
+			{ preloadedUserScripts },
+		);
+
+		expect(getUserScriptMock).toHaveBeenCalledTimes(1);
+		expect(preloadedUserScripts.get("script.js")).toBe(exported);
+
+		// A second collection pass (e.g. CLI collect followed by the one-page
+		// preflight) must reuse the cached module, not execute it again.
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			choiceExecutor,
+			createMacroChoice(scriptCommand),
+			{ preloadedUserScripts },
+		);
+
+		expect(getUserScriptMock).toHaveBeenCalledTimes(1);
+		expect(requirements).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: "project" })]),
 		);
 	});
 

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -24,6 +24,7 @@ import {
 	isFolder,
 } from "src/utilityObsidian";
 import { log } from "src/logger/logManager";
+import { getUserScriptPreloadKey } from "src/utils/userScript";
 import { hasTemplatePathSyntax } from "src/utils/templatePathSyntax";
 import {
 	classifyCaptureTargetScope,
@@ -212,7 +213,7 @@ async function scanContentWithTemplateIncludes(
 		// Skip a template already fully scanned at an equal-or-shallower depth:
 		// same content, and its children were explored at least as deep, so a
 		// re-scan can only repeat work (the per-path `templateStack` alone lets
-		// a dense DAG re-scan each template once per PATH — up to
+		// a dense DAG re-scan each template once per PATH - up to
 		// branching^depth invocations). A ref first seen NEAR the depth cap is
 		// re-scanned if met again shallower, so the memo never truncates a
 		// subtree the old walk would have explored.
@@ -461,7 +462,9 @@ async function collectMacroScriptRequirements(
 			// Reuse an already-loaded module (loading executes the script's
 			// top-level code); cache what we load so the runtime engine consumes
 			// this execution instead of running the module body a second time.
-			const cacheKey = userScriptCommand.path ?? userScriptCommand.id;
+			// The key is member-aware (path + `::` drill) because getUserScript
+			// returns the drilled export.
+			const cacheKey = getUserScriptPreloadKey(userScriptCommand);
 			let exported =
 				cacheKey !== undefined
 					? preloadedUserScripts?.get(cacheKey)

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -42,6 +42,15 @@ import type { NumericInputConfig, SliderConfig } from "src/utils/valueSyntax";
 
 interface CollectChoiceRequirementsOptions {
 	seedCaptureSelectionAsValue?: boolean;
+	/**
+	 * When provided, user-script modules loaded to read `quickadd.inputs` are
+	 * cached here (keyed by `command.path ?? command.id`) and reused across
+	 * collection passes. Loading a CommonJS user script EXECUTES its top-level
+	 * code, so without this cache a single trigger runs every script's module
+	 * body twice: once here for introspection and once in MacroChoiceEngine.
+	 * The engine consumes these entries instead of re-loading (delete-on-use).
+	 */
+	preloadedUserScripts?: Map<string, unknown>;
 }
 
 const VALID_FIELD_TYPES: FieldType[] = [
@@ -200,6 +209,16 @@ async function scanContentWithTemplateIncludes(
 
 	for (const ref of nested) {
 		if (templateStack.has(ref)) continue;
+		// Skip a template already fully scanned at an equal-or-shallower depth:
+		// same content, and its children were explored at least as deep, so a
+		// re-scan can only repeat work (the per-path `templateStack` alone lets
+		// a dense DAG re-scan each template once per PATH — up to
+		// branching^depth invocations). A ref first seen NEAR the depth cap is
+		// re-scanned if met again shallower, so the memo never truncates a
+		// subtree the old walk would have explored.
+		const scannedDepth = collector.scannedTemplateRefDepths.get(ref);
+		if (scannedDepth !== undefined && scannedDepth <= depth) continue;
+		collector.scannedTemplateRefDepths.set(ref, depth);
 		templateStack.add(ref);
 		try {
 			await scanContentWithTemplateIncludes(
@@ -430,6 +449,7 @@ async function collectForCaptureChoice(
 async function collectMacroScriptRequirements(
 	app: App,
 	choice: IMacroChoice,
+	preloadedUserScripts?: Map<string, unknown>,
 ): Promise<FieldRequirement[]> {
 	const requirements: FieldRequirement[] = [];
 	const commands: ICommand[] = choice?.macro?.commands ?? [];
@@ -438,7 +458,20 @@ async function collectMacroScriptRequirements(
 		if (command?.type !== CommandType.UserScript) continue;
 		const userScriptCommand = command as IUserScript;
 		try {
-			const exported = await getUserScript(userScriptCommand, app);
+			// Reuse an already-loaded module (loading executes the script's
+			// top-level code); cache what we load so the runtime engine consumes
+			// this execution instead of running the module body a second time.
+			const cacheKey = userScriptCommand.path ?? userScriptCommand.id;
+			let exported =
+				cacheKey !== undefined
+					? preloadedUserScripts?.get(cacheKey)
+					: undefined;
+			if (exported === undefined) {
+				exported = await getUserScript(userScriptCommand, app);
+				if (cacheKey !== undefined && exported !== undefined) {
+					preloadedUserScripts?.set(cacheKey, exported);
+				}
+			}
 			const scriptInputs = getQuickAddScriptInputs(exported);
 			for (const input of scriptInputs) {
 				const requirement = toFieldRequirement(input);
@@ -486,6 +519,7 @@ export async function collectChoiceRequirements(
 		scriptRequirements = await collectMacroScriptRequirements(
 			app,
 			choice as IMacroChoice,
+			options?.preloadedUserScripts,
 		);
 	} else {
 		return [];

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -45,7 +45,8 @@ interface CollectChoiceRequirementsOptions {
 	seedCaptureSelectionAsValue?: boolean;
 	/**
 	 * When provided, user-script modules loaded to read `quickadd.inputs` are
-	 * cached here (keyed by `command.path ?? command.id`) and reused across
+	 * cached here (keyed via `getUserScriptPreloadKey`: `command.path ??
+	 * command.id` plus any `::` member-drill suffix) and reused across
 	 * collection passes. Loading a CommonJS user script EXECUTES its top-level
 	 * code, so without this cache a single trigger runs every script's module
 	 * body twice: once here for introspection and once in MacroChoiceEngine.

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -87,7 +87,13 @@ export async function runOnePagePreflight(
 			plugin,
 			choiceExecutor,
 			choice,
-			{ seedCaptureSelectionAsValue: true },
+			{
+				seedCaptureSelectionAsValue: true,
+				// Hand loaded user-script modules to the executor so the runtime
+				// engine consumes THIS load instead of executing each script's
+				// top-level code a second time.
+				preloadedUserScripts: choiceExecutor.preloadedUserScripts,
+			},
 		);
 		if (requirements.length === 0) return false; // Nothing to collect
 

--- a/src/utils/dateAliases.test.ts
+++ b/src/utils/dateAliases.test.ts
@@ -44,6 +44,19 @@ describe("dateAliases", () => {
 		).toBe("tomorrow");
 	});
 
+	it("round-trips a '__proto__' alias line through parse and lookup", () => {
+		// The old `result[key] = value` write hit the Object.prototype accessor
+		// for this key: no own property was created and the alias silently
+		// vanished from the settings textarea on the next open.
+		const parsed = parseDateAliasLines("__proto__ = tomorrow");
+		expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(
+			true,
+		);
+		expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+		expect(formatDateAliasLines(parsed)).toBe("__proto__ = tomorrow");
+		expect(normalizeDateInput("__proto__", parsed)).toBe("tomorrow");
+	});
+
 	it("parses alias lines into a map", () => {
 		const parsed = parseDateAliasLines("tm = tomorrow\n# comment\nyd=yesterday");
 		expect(parsed).toEqual({ tm: "tomorrow", yd: "yesterday" });

--- a/src/utils/dateAliases.test.ts
+++ b/src/utils/dateAliases.test.ts
@@ -23,6 +23,27 @@ describe("dateAliases", () => {
 		expect(result).toBe("next friday");
 	});
 
+	it("does not resolve Object.prototype members as aliases", () => {
+		// A bare bracket lookup on the plain-object alias map walked the
+		// prototype chain: "constructor" resolved to the Object function (a
+		// truthy non-string) instead of falling through to the raw input.
+		expect(normalizeDateInput("constructor", { tm: "tomorrow" })).toBe(
+			"constructor",
+		);
+		expect(normalizeDateInput("__proto__", { tm: "tomorrow" })).toBe(
+			"__proto__",
+		);
+		expect(normalizeDateInput("constructor 5pm", { tm: "tomorrow" })).toBe(
+			"constructor 5pm",
+		);
+	});
+
+	it("still resolves a user-defined alias that shadows a magic name", () => {
+		expect(
+			normalizeDateInput("constructor", { constructor: "tomorrow" }),
+		).toBe("tomorrow");
+	});
+
 	it("parses alias lines into a map", () => {
 		const parsed = parseDateAliasLines("tm = tomorrow\n# comment\nyd=yesterday");
 		expect(parsed).toEqual({ tm: "tomorrow", yd: "yesterday" });

--- a/src/utils/dateAliases.ts
+++ b/src/utils/dateAliases.ts
@@ -12,6 +12,17 @@ export const DEFAULT_DATE_ALIASES: DateAliasMap = {
 	ly: "last year",
 };
 
+// The alias map is a plain object literal, so a bare bracket lookup walks the
+// prototype chain: an input of "constructor" or "__proto__" (never defined as
+// an alias) would resolve to an inherited built-in instead of falling through
+// to the raw input. Own-property membership keeps magic names deterministic
+// (same guard as the #1442 FIELD-default / legacy-mode lookups).
+function lookupAlias(aliases: DateAliasMap, key: string): string | undefined {
+	return Object.prototype.hasOwnProperty.call(aliases, key)
+		? aliases[key]
+		: undefined;
+}
+
 export function normalizeDateInput(
 	input: string,
 	aliases: DateAliasMap = DEFAULT_DATE_ALIASES,
@@ -19,11 +30,11 @@ export function normalizeDateInput(
 	const trimmed = input.trim();
 	if (!trimmed) return input;
 
-	const direct = aliases[trimmed.toLowerCase()];
+	const direct = lookupAlias(aliases, trimmed.toLowerCase());
 	if (direct) return direct;
 
 	const [first, ...rest] = trimmed.split(/\s+/);
-	const replacement = aliases[first.toLowerCase()];
+	const replacement = lookupAlias(aliases, first.toLowerCase());
 	if (!replacement) return input;
 
 	return [replacement, ...rest].join(" ");

--- a/src/utils/dateAliases.ts
+++ b/src/utils/dateAliases.ts
@@ -55,7 +55,18 @@ export function parseDateAliasLines(text: string): DateAliasMap {
 		const value = trimmed.slice(separatorIndex + 1).trim();
 
 		if (!key || !value) continue;
-		result[key] = value;
+		// defineProperty, not `result[key] = value`: a bare assignment for the
+		// key "__proto__" hits the Object.prototype accessor instead of creating
+		// an own property, so that alias silently vanished on the next settings
+		// round-trip. defineProperty always creates the own (enumerable,
+		// serializable) entry, which the hasOwnProperty-guarded lookup then
+		// resolves like any other alias.
+		Object.defineProperty(result, key, {
+			value,
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
 	}
 
 	return result;

--- a/src/utils/userScript.ts
+++ b/src/utils/userScript.ts
@@ -21,6 +21,25 @@ export function getUserScriptMemberAccess(fullMemberPath: string): {
 	};
 }
 
+/**
+ * Cache key for a preloaded user-script module (the map shared between the
+ * requirement collector and MacroChoiceEngine). It must include the `::`
+ * member drill from `command.name`, because getUserScript returns the
+ * DRILLED value: two commands sharing one path but drilling different
+ * members (`lib::foo` vs `lib::bar`) hold different functions and must
+ * never consume each other's preloaded entry.
+ */
+export function getUserScriptPreloadKey(
+	command: IUserScript,
+): string | undefined {
+	const base = command.path ?? command.id;
+	if (base === undefined) return undefined;
+	const { memberAccess } = getUserScriptMemberAccess(command.name ?? "");
+	return memberAccess && memberAccess.length > 0
+		? `${base}::${memberAccess.join("::")}`
+		: base;
+}
+
 // Slightly modified version of Templater's user script import implementation
 // Source: https://github.com/SilentVoid13/Templater
 export async function getUserScript(command: IUserScript, app: App) {


### PR DESCRIPTION
Fixes six open deepsec BUG findings, all independently revalidated as real before fixing. Every behavioral fix has a regression test proven RED against the pre-fix code, and the capture-gluing fix is additionally proven live in Obsidian (RED on the master build, GREEN on this branch, same scenario).

- **ChunkedPrompt merge gluing** (`AIAssistant.ts`): the merge path reassembled chunks with bare concatenation, so the separators `split()` consumed never came back - `"Line one\nLine two"` reached the model as `"Line oneLine two"` on the DEFAULT `shouldMerge` path. Separators are now retained (single-capture wrap of the separator pattern keeps split semantics byte-identical) and re-inserted between merged chunks. Grouping for the default `\n` separator is byte-identical; long custom separators are now budgeted at their real estimated size. Hardened per review: the group-count probe carries the separator's own flags (u-only syntax previously threw), and group-free patterns with legacy octal escapes stay on the historical path (wrapping would turn them into backreferences).

- **Capture gluing** (`insertionPositioning.ts`): text without a trailing newline was glued straight onto the next line's content - `"## Log\n- existing"` + `"new"` produced `"## Log\nnew- existing"`, corrupting the list item, for default no-format captures ({{value}} = raw selection/clipboard) and any format not ending in `\n`. Now mirrors the sibling insert-before separator guard; the #312 task-newline drop and EOF-artifact handling are pinned by tests. Live-verified end-to-end in Obsidian 1.13.0.

- **Preflight/CLI double script execution** (`collectChoiceRequirements.ts` + executor/engine wiring): reading `quickadd.inputs` loads - and thereby EXECUTES - each user script's module body, and the runtime engine then loaded it again, so one trigger ran top-level side effects twice (one-page preflight or non-interactive `quickadd:run`). Collection passes now cache the loaded module on the executor's `preloadedUserScripts` map, which the engine's existing consume-once path (previously never fed) consumes. Per review: the cache key includes the `::` member drill (getUserScript returns the DRILLED export - path-only keying could execute the wrong member), and leftover entries are cleared when the outermost execution ends so a cancelled run can never hand a later trigger a stale module. Known, inherent semantics note: the consumed module's top level runs at collection time rather than command time.

- **Template-inclusion fan-out** (`collectChoiceRequirements.ts`): the walk was guarded only by the per-path cycle stack, so a dense template DAG re-scanned each template once per PATH (branching^depth, ~1M scans at 4×10 - a UI freeze from a malicious imported package). A depth-aware cross-branch memo makes the walk linear in distinct templates; a ref met again at a shallower depth is re-scanned, so the depth cap never silently drops requirements (test-pinned; the panel's cycle-pruning refutation attempt failed to produce a divergence in 2.15M randomized graphs).

- **Prototype-chain alias lookups** (`dateAliases.ts`): `aliases["constructor"]`/`["__proto__"]` resolved to inherited built-ins instead of falling through to the raw input (same class as the #1442 fixes) - own-property guard. Also fixes the sibling WRITE site the panel found: a `__proto__ = x` alias line hit the prototype accessor and silently vanished from settings; entries are now written with defineProperty.

- **O(H²) duplicate-heading disambiguation** (`sectionLink.ts`): the chain-collision check called the O(index) ancestorChain inside `.some()`. Chain keys are now precomputed in one forward outline-stack pass; a 2000-round randomized property test pins the new chains to the old backward-walk semantics (the panel independently fuzzed 100k+ level sequences with zero divergence).

A 13-agent adversarial workflow reviewed the initial fixes; its one must-fix (member-drill cache key) and all should-fixes are folded in with their own RED-proven tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of preloaded user scripts across setup and execution, including correct reuse for member-drilled script commands (avoids re-running script top-level code unnecessarily).

* **Bug Fixes**
  * Fixed prompt splitting/merging to preserve separators and line breaks more accurately.
  * Improved text insertion so content doesn’t get accidentally glued to following sections.
  * Hardened date alias parsing to safely handle special names like `__proto__` and `constructor`.

* **Performance**
  * Improved section link lookup performance for large documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->