### PR TITLE
fix(example-scripts): three deepsec robustness/data-integrity fixes

### DIFF
--- a/docs/docs/Examples/Template_AutomaticBookNotesFromReadwise.md
+++ b/docs/docs/Examples/Template_AutomaticBookNotesFromReadwise.md
@@ -185,7 +185,11 @@ function formatDailyQuote(sourceText, sourceItem) {
 	return `${quote}${attr}`;
 }
 
-function textFormatter(sourceText, sourceNote) {
+function textFormatter(sourceText, rawSourceNote) {
+	// Readwise can return a highlight without a note (null/undefined rather
+	// than ""); normalize once so the .includes probe below can't throw and
+	// abort the whole import on a single note-less highlight.
+	const sourceNote = rawSourceNote ?? "";
 	let quote = sourceText
 		.split("\n")
 		.filter((line) => line != "")

--- a/docs/static/scripts/EzImport.js
+++ b/docs/static/scripts/EzImport.js
@@ -314,7 +314,11 @@ function formatHighlights(highlights) {
 		.join("\n\n");
 }
 
-function textFormatter(sourceText, sourceNote) {
+function textFormatter(sourceText, rawSourceNote) {
+	// Readwise can return a highlight without a note (null/undefined rather
+	// than ""); normalize once so the .includes probes below can't throw and
+	// abort the whole import on a single note-less highlight.
+	const sourceNote = rawSourceNote ?? "";
 	const quote = sourceText
 		.split("\n")
 		.filter((line) => line !== "")

--- a/docs/static/scripts/migrateDataviewToFrontmatter.js
+++ b/docs/static/scripts/migrateDataviewToFrontmatter.js
@@ -332,8 +332,15 @@ function parseInlineFieldsWithWikilinks(content, allowedProperties = [], migrate
 
                     if (fieldName && fieldValue) {
                         const fieldNameLower = fieldName.toLowerCase();
-                        const shouldMigrate = migrateAll ||
-                            (allowedPropertiesLower.length > 0 && allowedPropertiesLower.includes(fieldNameLower));
+                        // `frontmatter['__proto__'] = value` hits the Object.prototype
+                        // accessor instead of creating an own property, so the value
+                        // would be silently dropped while the body line is deleted -
+                        // data loss. Leave such a line in the body verbatim instead
+                        // (mirrors the core plugin's dunder-key guard, which blocks
+                        // __proto__ in any position).
+                        const isUnwritableName = fieldName === '__proto__';
+                        const shouldMigrate = !isUnwritableName && (migrateAll ||
+                            (allowedPropertiesLower.length > 0 && allowedPropertiesLower.includes(fieldNameLower)));
 
                         if (shouldMigrate) {
                             // This line should be removed (moved to frontmatter).

--- a/docs/static/scripts/togglManager.js
+++ b/docs/static/scripts/togglManager.js
@@ -40,7 +40,7 @@ module.exports = async function togglManager(params) {
     // missing/disabled Toggl integration throws an opaque TypeError here.
     const togglPlugin = params.app.plugins.plugins["obsidian-toggl-integration"];
     if (!togglPlugin || !togglPlugin.toggl || !togglPlugin.toggl._apiManager) {
-        new Notice("Toggl Track integration plugin is not installed or enabled.", 5000);
+        new Notice("Toggl Track integration plugin is not installed, enabled, or connected to your Toggl account.", 5000);
         throw new Error("Toggl Track integration plugin not found.");
     }
     togglApi = togglPlugin.toggl._apiManager;

--- a/docs/static/scripts/togglManager.js
+++ b/docs/static/scripts/togglManager.js
@@ -36,7 +36,14 @@ const menu = {
 };
 
 module.exports = async function togglManager(params) {
-    togglApi = params.app.plugins.plugins["obsidian-toggl-integration"].toggl._apiManager;
+    // Guard the plugin lookup (mirrors citationsManager.js): without it, a
+    // missing/disabled Toggl integration throws an opaque TypeError here.
+    const togglPlugin = params.app.plugins.plugins["obsidian-toggl-integration"];
+    if (!togglPlugin || !togglPlugin.toggl || !togglPlugin.toggl._apiManager) {
+        new Notice("Toggl Track integration plugin is not installed or enabled.", 5000);
+        throw new Error("Toggl Track integration plugin not found.");
+    }
+    togglApi = togglPlugin.toggl._apiManager;
     quickAddApi = params.quickAddApi;
     projects = await togglApi.getProjects();
 

--- a/docs/versioned_docs/version-2.13.1/Examples/Template_AutomaticBookNotesFromReadwise.md
+++ b/docs/versioned_docs/version-2.13.1/Examples/Template_AutomaticBookNotesFromReadwise.md
@@ -185,7 +185,11 @@ function formatDailyQuote(sourceText, sourceItem) {
 	return `${quote}${attr}`;
 }
 
-function textFormatter(sourceText, sourceNote) {
+function textFormatter(sourceText, rawSourceNote) {
+	// Readwise can return a highlight without a note (null/undefined rather
+	// than ""); normalize once so the .includes probe below can't throw and
+	// abort the whole import on a single note-less highlight.
+	const sourceNote = rawSourceNote ?? "";
 	let quote = sourceText
 		.split("\n")
 		.filter((line) => line != "")


### PR DESCRIPTION
Fixes the three open deepsec BUG findings in the bundled example scripts, plus the review-panel follow-ups.

- **EzImport.js**: `textFormatter` dereferenced the highlight note (`.includes` probes) BEFORE its own falsy guard, so a single Readwise highlight with a null/undefined note threw a TypeError that aborted the entire import. The note is normalized once at the top; a missing note now degrades to plain `> quote` rendering - which is what the later guard already intended. The review panel found the same crash in the inline script copy embedded in the Book Notes docs page (which users are told to copy-paste), so both `docs/docs` and the served `version-2.13.1` snapshot get the same normalization.

- **migrateDataviewToFrontmatter.js**: with "Migrate All Properties" on, a body line `__proto__:: value` was written as `frontmatter['__proto__']`, which hits the Object.prototype accessor instead of creating an own property - the value silently vanished while the body line was deleted (data loss; not exploitable pollution). Such a line is now left in the body verbatim, mirroring the core plugin's dunder-key guard (#1431). Only the exact `__proto__` key is affected; `constructor`/`prototype` are safe as terminal own-property writes and keep migrating.

- **togglManager.js**: the Toggl integration plugin lookup was unguarded, so a missing/disabled plugin threw an opaque TypeError. Guarded with a Notice + clear error, matching citationsManager.js and the `projects.find` guard already in this file (#1454). The message also covers the installed-but-not-connected case (the integration only exposes its API manager after a token is configured).

No tests, per the maintainer's standing preference that example scripts stay out of the test suite; all scripts pass `node --check`, and the `__proto__` accessor drop was verified empirically (plus an 80k-case master-vs-branch differential fuzz by the review panel showing the guard changes behavior ONLY on `__proto__` lines).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when imported highlights or notes are missing, so note formatting now works more reliably.
  * Improved safety when migrating inline fields, avoiding unexpected handling of special field names.
  * Added a clearer error and warning when required tracking integration components aren’t available.

* **Documentation**
  * Updated example documentation to reflect the latest note-import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->