### PR TITLE
fix(capture): keep linebreak expansion out of inline script fences

### DIFF
--- a/src/formatters/captureChoiceFormatter-linebreak.test.ts
+++ b/src/formatters/captureChoiceFormatter-linebreak.test.ts
@@ -52,12 +52,15 @@ vi.mock("../gui/MathModal", () => ({
 	},
 }));
 
+const inlineScriptCalls = vi.hoisted(() => [] as string[]);
+
 vi.mock("../engine/SingleInlineScriptEngine", () => ({
 	__esModule: true,
 	SingleInlineScriptEngine: class {
 		public params = { variables: {} as Record<string, unknown> };
 		constructor() {}
-		async runAndGetOutput() {
+		async runAndGetOutput(code: string) {
+			inlineScriptCalls.push(code);
 			return "";
 		}
 	},
@@ -107,6 +110,8 @@ vi.mock("../main", () => ({
 }));
 
 import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+import { findInlineScriptSpans } from "./formatter";
+import { INLINE_JAVASCRIPT_REGEX } from "../constants";
 
 const createChoice = (
 	overrides: Partial<ICaptureChoice> = {},
@@ -368,6 +373,107 @@ describe("capture linebreak escapes only apply to the format string (issue #527)
 			);
 
 			expect(result).toBe("\\n{{DATE}}{{TIME}}\n");
+		});
+	});
+
+	describe("inline script fences (issue #1467)", () => {
+		const fence =
+			'```js quickadd\nconst parts = "one\\ntwo".split("\\n");\nreturn parts.length;\n```';
+
+		it("leaves inline script fences verbatim while expanding around them", () => {
+			const formatter = createFormatter(null);
+
+			const result = formatter.expandOutsideTokens(
+				`before\\n${fence}\\nafter\\n`,
+			);
+
+			expect(result).toBe(`before\n${fence}\nafter\n`);
+		});
+
+		it("does not let an unclosed {{ swallow the start of a script fence", () => {
+			const formatter = createFormatter(null);
+			const fenceWithBraces =
+				'```js quickadd\nconst map = {a: {b: 1}};\nreturn "x\\ny".split("\\n").length;\n```';
+
+			const result = formatter.expandOutsideTokens(
+				`{{oops \\n${fenceWithBraces}`,
+			);
+
+			expect(result).toBe(`{{oops \n${fenceWithBraces}`);
+		});
+
+		it("passes uncorrupted script source to the inline script engine", async () => {
+			inlineScriptCalls.length = 0;
+			const formatter = createFormatter(null);
+
+			await formatter.formatContentOnly(`${fence}\\n`);
+
+			expect(inlineScriptCalls).toHaveLength(1);
+			expect(inlineScriptCalls[0]).toBe(
+				'const parts = "one\\ntwo".split("\\n");\nreturn parts.length;',
+			);
+		});
+
+		it("does not let an unclosed {{ whose first }} sits in a LATER fence cut that fence open", () => {
+			const formatter = createFormatter(null);
+			const fenceOne = '```js quickadd\nconst first = "a\\nb";\n```';
+			const fenceTwo =
+				'```js quickadd\nconst map = {a: {b: 1}};\nreturn "x\\ny".split("\\n").length;\n```';
+			const input = `{{oops \\n${fenceOne}\\n${fenceTwo}`;
+
+			const result = formatter.expandOutsideTokens(input);
+
+			expect(result).toBe(`{{oops \n${fenceOne}\n${fenceTwo}`);
+		});
+
+		it("finds spans identical to INLINE_JAVASCRIPT_REGEX (fuzz)", () => {
+			const regexSpans = (input: string) => {
+				const re = new RegExp(INLINE_JAVASCRIPT_REGEX.source, "g");
+				const out: string[] = [];
+				let m: RegExpExecArray | null;
+				while ((m = re.exec(input)) !== null) {
+					out.push(`${m.index}:${m.index + m[0].length}`);
+				}
+				return out.join(",");
+			};
+			const scanSpans = (input: string) =>
+				findInlineScriptSpans(input)
+					.map((s) => `${s.start}:${s.end}`)
+					.join(",");
+
+			// Deterministic LCG so failures reproduce.
+			let seed = 42;
+			const rnd = (max: number) => {
+				seed = (seed * 1103515245 + 12345) % 2147483648;
+				return seed % max;
+			};
+			const alphabet = [
+				"`",
+				"``",
+				"```",
+				"````",
+				"js quickadd",
+				"```js quickadd",
+				"j",
+				"s",
+				" ",
+				"\n",
+				"\\n",
+				"x",
+				"{{",
+				"}}",
+			];
+
+			for (let t = 0; t < 5000; t++) {
+				let input = "";
+				const len = rnd(30);
+				for (let k = 0; k < len; k++) {
+					input += alphabet[rnd(alphabet.length)];
+				}
+				expect(scanSpans(input), JSON.stringify(input)).toBe(
+					regexSpans(input),
+				);
+			}
 		});
 	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -78,6 +78,65 @@ export interface TemplateInclusionState {
 
 export const MAX_TEMPLATE_INCLUSION_DEPTH = 10;
 
+const INLINE_SCRIPT_FENCE_LANG = "js quickadd";
+
+/**
+ * Locates every inline script fence (```js quickadd ... ```) in the input so
+ * escape expansion can copy those spans verbatim. Single-pass replica of
+ * INLINE_JAVASCRIPT_REGEX (see constants.ts): an opener is a run of 3+
+ * backticks immediately followed by "js quickadd", and the first following
+ * run of 3+ backticks closes it (consumed whole, like the regex's greedy
+ * closer). The lazy regex is quadratic on backtick floods, and this runs on
+ * every keystroke of the format-editor preview — hence the linear scan.
+ * Span-for-span equivalence with the regex is pinned by a fuzz test in
+ * captureChoiceFormatter-linebreak.test.ts.
+ */
+export function findInlineScriptSpans(
+	input: string,
+): Array<{ start: number; end: number }> {
+	const spans: Array<{ start: number; end: number }> = [];
+	const n = input.length;
+	let i = 0;
+
+	while (i < n) {
+		const runStart = input.indexOf("`", i);
+		if (runStart === -1) break;
+		let runEnd = runStart;
+		while (runEnd < n && input[runEnd] === "`") runEnd++;
+
+		if (
+			runEnd - runStart < 3 ||
+			!input.startsWith(INLINE_SCRIPT_FENCE_LANG, runEnd)
+		) {
+			i = runEnd;
+			continue;
+		}
+
+		// Opener found — the next 3+ backtick run closes it. If none exists,
+		// no later opener can match either (its backticks would have served
+		// as this fence's closer), so scanning is done.
+		let j = runEnd + INLINE_SCRIPT_FENCE_LANG.length;
+		let end = -1;
+		while (j < n) {
+			const tick = input.indexOf("`", j);
+			if (tick === -1) break;
+			let tickRunEnd = tick;
+			while (tickRunEnd < n && input[tickRunEnd] === "`") tickRunEnd++;
+			if (tickRunEnd - tick >= 3) {
+				end = tickRunEnd;
+				break;
+			}
+			j = tickRunEnd;
+		}
+		if (end === -1) break;
+
+		spans.push({ start: runStart, end });
+		i = end;
+	}
+
+	return spans;
+}
+
 export abstract class Formatter {
 	protected value: string;
 	protected variables: Map<string, unknown> = new Map<string, unknown>();
@@ -1385,19 +1444,52 @@ export abstract class Formatter {
 	}
 
 	/**
-		* Like replaceLinebreakInString, but leaves `{{...}}` token spans untouched.
-		* Format-token regexes cannot match across real linebreaks (see constants.ts),
-		* so expanding `\n` inside token options (e.g. `{{VALUE:x|default:a\nb}}`)
-		* would render the token unparseable and dump it literally into the output.
+		* Like replaceLinebreakInString, but leaves `{{...}}` token spans and inline
+		* script fences untouched. Format-token regexes cannot match across real
+		* linebreaks (see constants.ts), so expanding `\n` inside token options
+		* (e.g. `{{VALUE:x|default:a\nb}}`) would render the token unparseable and
+		* dump it literally into the output. Inline script fences are verbatim
+		* JavaScript source: expanding `\n` there puts a raw newline inside string
+		* literals and the script dies with "Invalid or unexpected token" (#1467).
 		*/
 	protected expandLinebreakEscapesOutsideTokens(input: string): string {
+		const scriptSpans = findInlineScriptSpans(input);
 		let output = "";
 		let i = 0;
+		let spanIdx = 0;
 
 		while (i < input.length) {
+			while (spanIdx < scriptSpans.length && scriptSpans[spanIdx].end <= i) {
+				spanIdx++;
+			}
+			const nextSpan = scriptSpans[spanIdx];
+			if (nextSpan && nextSpan.start === i) {
+				output += input.slice(nextSpan.start, nextSpan.end);
+				i = nextSpan.end;
+				continue;
+			}
+
 			if (input[i] === "{" && input[i + 1] === "{") {
 				const close = input.indexOf("}}", i + 2);
+				// A `}}` that sits inside a script fence belongs to the script's
+				// code, not to this token — the fence wins and the `{{` is plain
+				// text. Otherwise the token skip would end mid-fence and the rest
+				// of the script would get its `\n` escapes expanded. Any fence can
+				// be the victim (the first `}}` may fall in a later fence), so
+				// check every span the skip could end inside of.
+				let cutsIntoScript = false;
 				if (close !== -1) {
+					const skipEnd = close + 2;
+					for (let k = spanIdx; k < scriptSpans.length; k++) {
+						const span = scriptSpans[k];
+						if (span.start >= skipEnd) break;
+						if (skipEnd < span.end && skipEnd > span.start) {
+							cutsIntoScript = true;
+							break;
+						}
+					}
+				}
+				if (close !== -1 && !cutsIntoScript) {
 					output += input.slice(i, close + 2);
 					i = close + 2;
 					continue;


### PR DESCRIPTION
## What

Captures with an inline script (` ```js quickadd ` fence) in their format failed with `SyntaxError: Invalid or unexpected token` whenever the script contained a `\n` escape in a string literal (e.g. `content.split('\n')`), and the capture wrote nothing.

## Why

`expandLinebreakEscapesOutsideTokens` runs on the raw format template before `format()` extracts and evaluates the inline script. It skipped `{{...}}` token spans but not script fences, so the `\n` inside the fence became a raw newline inside a JS string literal - exactly the reported SyntaxError. Reproduced live in an isolated Obsidian 1.13 instance (byte-for-byte the reported console error) before fixing; the same repro is green after the fix.

## How

- `expandLinebreakEscapesOutsideTokens` now copies inline-script fence spans verbatim.
- Fence spans are located by a linear run-scanner (`findInlineScriptSpans`) instead of the lazy `INLINE_JAVASCRIPT_REGEX`, which is quadratic on backtick floods (~22s at 160k backticks) and would newly run on every keystroke of the format-editor preview. The scanner is span-identical to the regex - pinned by a deterministic 5k-case fuzz test in-repo (200k cases probed locally), and takes ~0.4ms on the same flood.
- The `{{...}}` token skip is guarded: an unclosed `{{` whose first `}}` falls inside **any** fence treats the `{{` as plain text instead of cutting the fence open (adversarial review caught the multi-fence variant; the new test is proven red against the unguarded version).

Unclosed fences keep their old behavior (still expanded) - the script extractor never matches those, so they are inert text either way.

## Review notes

- Pre-existing, not addressed here: `replaceInlineJavascriptInString` (completeFormatter.ts) runs the lazy `INLINE_JAVASCRIPT_REGEX` over post-substitution text (clipboard/VALUE-tainted), so the quadratic hazard exists there independently - candidate for a deepsec other-redos follow-up.
- `replaceLinebreakInString` (the non-token-aware sibling) has no production callers; left untouched.

Fixes #1467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of line breaks around template tokens and inline script fences, preventing fenced content from being altered or truncated.
  * Fixed cases where an unclosed template token could incorrectly affect later fenced script content.
  * Made inline script processing more reliable so the original fenced source is preserved.

* **Tests**
  * Added broader coverage for inline script fence edge cases and span detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->