### PR TITLE
feat(cli): expose full field metadata and verified run outcomes

### DIFF
--- a/docs/docs/Advanced/CLI.md
+++ b/docs/docs/Advanced/CLI.md
@@ -85,6 +85,20 @@ obsidian vault=dev quickadd \
 
 Values are passed through exactly as provided. If a choice should ignore accidental leading or trailing whitespace for a specific token, use `|trim` in that format string, for example `{{VALUE:project|trim}}`.
 
+### Reserved flag names
+
+The bare `key=value` form (pattern 2) ignores names that a command already uses
+as flags or selectors: `choice`, `id`, `vars`, `ui`, `verify` (on `quickadd` /
+`quickadd:run`), `fields` (on `quickadd:check`), and `path` (on
+`quickadd:run-template`). If a choice has a variable named after one of these
+(for example `{{VALUE:verify}}`), pass it with the `value-` prefix or via `vars`
+instead, both of which are never treated as flags:
+
+```bash
+obsidian vault=dev quickadd choice="My choice" value-verify="a value"
+obsidian vault=dev quickadd choice="My choice" vars='{"verify":"a value"}'
+```
+
 ## Non-interactive behavior
 
 By default, `quickadd` and `quickadd:run` are non-interactive. If QuickAdd

--- a/src/cli/registerQuickAddCliHandlers.test.ts
+++ b/src/cli/registerQuickAddCliHandlers.test.ts
@@ -207,6 +207,49 @@ describe("registerQuickAddCliHandlers", () => {
 		expect(executors[0].variables.get("team")).toBe("Core");
 	});
 
+	it("routes quickadd:run through executeWithOutcome when the verify flag is set", async () => {
+		const { plugin, handlers } = createPlugin([templateChoice]);
+		registerQuickAddCliHandlers(plugin);
+		const run = handlers.find(
+			(handler) => handler.command === "quickadd:run",
+		);
+		expect(run).toBeDefined();
+
+		const verified = JSON.parse(
+			String(
+				await Promise.resolve(
+					run!.handler({
+						choice: templateChoice.name,
+						verify: "true",
+					}),
+				),
+			),
+		);
+		expect(verified.ok).toBe(true);
+		expect(verified.verified).toBe(true);
+		expect(verified.file).toBe("Created Note.md");
+		expect(executors[0].executeWithOutcome).toHaveBeenCalledWith(
+			templateChoice,
+		);
+		expect(executors[0].execute).not.toHaveBeenCalled();
+		// The verify flag must not leak into the executor's variables.
+		expect(executors[0].variables.has("verify")).toBe(false);
+
+		const legacy = JSON.parse(
+			String(
+				await Promise.resolve(
+					run!.handler({
+						choice: templateChoice.name,
+					}),
+				),
+			),
+		);
+		expect(legacy.ok).toBe(true);
+		expect(legacy.verified).toBe(false);
+		expect(legacy.file).toBeUndefined();
+		expect(executors[1].execute).toHaveBeenCalledWith(templateChoice);
+	});
+
 	it("returns missing inputs for non-interactive runs", async () => {
 		const { plugin, handlers } = createPlugin([
 			templateChoice,
@@ -600,5 +643,72 @@ describe("registerQuickAddCliHandlers", () => {
 		expect(payload.requiredInputCount).toBe(1);
 		expect(payload.missingInputCount).toBe(1);
 		expect(executors[0].execute).not.toHaveBeenCalled();
+	});
+
+	it("includes full field metadata in quickadd:check when the fields flag is set", async () => {
+		const { plugin, handlers } = createPlugin([templateChoice]);
+		registerQuickAddCliHandlers(plugin);
+		const check = handlers.find(
+			(handler) => handler.command === "quickadd:check",
+		);
+		expect(check).toBeDefined();
+
+		const requirement = {
+			id: "priority",
+			label: "Priority",
+			type: "dropdown",
+			options: ["low", "medium", "high"],
+			displayOptions: ["Low", "Medium", "High"],
+			defaultValue: "medium",
+			optional: true,
+			suggesterConfig: {
+				allowCustomInput: false,
+				caseSensitive: false,
+				multiSelect: false,
+			},
+		};
+		collectChoiceRequirementsMock.mockResolvedValue([requirement]);
+		getUnresolvedRequirementsMock.mockReturnValue([requirement]);
+
+		const withFields = JSON.parse(
+			String(
+				await Promise.resolve(
+					check!.handler({
+						choice: templateChoice.name,
+						fields: "true",
+					}),
+				),
+			),
+		);
+		expect(withFields.missing).toEqual([
+			expect.objectContaining({
+				id: "priority",
+				type: "dropdown",
+				optionCount: 3,
+				options: ["low", "medium", "high"],
+				displayOptions: ["Low", "Medium", "High"],
+				defaultValue: "medium",
+				optional: true,
+				suggesterConfig: {
+					allowCustomInput: false,
+					caseSensitive: false,
+					multiSelect: false,
+				},
+			}),
+		]);
+		// The fields flag must not leak into the executor's variables.
+		expect(executors[0].variables.has("fields")).toBe(false);
+
+		const withoutFields = JSON.parse(
+			String(
+				await Promise.resolve(
+					check!.handler({
+						choice: templateChoice.name,
+					}),
+				),
+			),
+		);
+		expect(withoutFields.missing[0].options).toBeUndefined();
+		expect(withoutFields.missing[0].optionCount).toBe(3);
 	});
 });

--- a/src/cli/registerQuickAddCliHandlers.test.ts
+++ b/src/cli/registerQuickAddCliHandlers.test.ts
@@ -661,6 +661,7 @@ describe("registerQuickAddCliHandlers", () => {
 			displayOptions: ["Low", "Medium", "High"],
 			defaultValue: "medium",
 			optional: true,
+			filters: "tags:#project",
 			suggesterConfig: {
 				allowCustomInput: false,
 				caseSensitive: false,
@@ -689,6 +690,7 @@ describe("registerQuickAddCliHandlers", () => {
 				displayOptions: ["Low", "Medium", "High"],
 				defaultValue: "medium",
 				optional: true,
+				filters: "tags:#project",
 				suggesterConfig: {
 					allowCustomInput: false,
 					caseSensitive: false,

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -9,6 +9,7 @@ import {
 	collectChoiceRequirements,
 	getUnresolvedRequirements,
 } from "../preflight/collectChoiceRequirements";
+import type { FieldRequirement } from "../preflight/RequirementCollector";
 import type IChoice from "../types/choices/IChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
@@ -70,6 +71,10 @@ const RUN_FLAGS: CliFlags = {
 	ui: {
 		description: "Allow interactive prompts",
 	},
+	verify: {
+		description:
+			"Report the verified outcome for Template/Capture choices (file path on success, honest failure when the engine swallows an error)",
+	},
 };
 
 const LIST_FLAGS: CliFlags = {
@@ -109,6 +114,10 @@ const CHECK_FLAGS: CliFlags = {
 		value: "<json>",
 		description: "Variables object as JSON",
 	},
+	fields: {
+		description:
+			"Include full field metadata (options, defaults, widget config)",
+	},
 };
 
 const PREVIEW_FLAGS: CliFlags = {
@@ -121,9 +130,15 @@ const PREVIEW_FLAGS: CliFlags = {
 	},
 };
 
-const RESERVED_RUN_PARAMS = new Set<string>(["choice", "id", "vars", "ui"]);
+const RESERVED_RUN_PARAMS = new Set<string>([
+	"choice",
+	"id",
+	"vars",
+	"ui",
+	"verify",
+]);
 const RESERVED_RUN_TEMPLATE_PARAMS = new Set<string>(["path", "vars", "ui"]);
-const RESERVED_CHECK_PARAMS = new Set<string>(["choice", "id", "vars"]);
+const RESERVED_CHECK_PARAMS = new Set<string>(["choice", "id", "vars", "fields"]);
 
 const CLI_COMMANDS = {
 	runDefault: "quickadd",
@@ -243,16 +258,7 @@ function resolveChoiceFromParams(plugin: QuickAdd, params: CliData): IChoice {
 	throw new Error("Missing choice selector. Provide either choice=<name> or id=<id>");
 }
 
-function toMissingFieldSummary(requirement: {
-	id: string;
-	label: string;
-	type: string;
-	placeholder?: string;
-	defaultValue?: string;
-	description?: string;
-	source?: string;
-	options?: string[];
-}) {
+function toMissingFieldSummary(requirement: FieldRequirement) {
 	return {
 		id: requirement.id,
 		label: requirement.label,
@@ -262,6 +268,28 @@ function toMissingFieldSummary(requirement: {
 		defaultValue: requirement.defaultValue,
 		description: requirement.description,
 		optionCount: requirement.options?.length ?? 0,
+	};
+}
+
+/**
+ * Full field metadata for external front ends (Raycast, scripts) that render
+ * their own input controls instead of QuickAdd's modals. Superset of
+ * toMissingFieldSummary; opt-in via the `fields` flag so the default envelope
+ * stays compact (a file-picker's options can span a whole folder).
+ */
+function toDetailedFieldSummary(requirement: FieldRequirement) {
+	return {
+		...toMissingFieldSummary(requirement),
+		options: requirement.options,
+		displayOptions: requirement.displayOptions,
+		dateFormat: requirement.dateFormat,
+		withTime: requirement.withTime,
+		optional: requirement.optional,
+		runtimeOnly: requirement.runtimeOnly,
+		multiEmit: requirement.multiEmit,
+		numericConfig: requirement.numericConfig,
+		sliderConfig: requirement.sliderConfig,
+		suggesterConfig: requirement.suggesterConfig,
 	};
 }
 
@@ -463,6 +491,10 @@ async function runChoiceHandler(
 		command,
 		choice,
 		RESERVED_RUN_PARAMS,
+		// Opt-in (`verify`) so existing scripts keying off the legacy envelope
+		// keep their behavior; run-template made the outcome path the default
+		// from the start, quickadd:run could not.
+		/* useOutcome */ isTruthy(params.verify),
 	);
 }
 
@@ -622,6 +654,9 @@ async function checkChoiceHandler(
 			requirements,
 			choiceExecutor.variables,
 		);
+		const summarize = isTruthy(params.fields)
+			? toDetailedFieldSummary
+			: toMissingFieldSummary;
 
 		return serialize({
 			ok: unresolved.length === 0,
@@ -629,7 +664,7 @@ async function checkChoiceHandler(
 			choice: describeChoice(choice),
 			requiredInputCount: requirements.length,
 			missingInputCount: unresolved.length,
-			missing: unresolved.map(toMissingFieldSummary),
+			missing: unresolved.map(summarize),
 			missingFlags: unresolved.map(
 				(requirement) => `value-${requirement.id}=<value>`,
 			),

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -130,6 +130,12 @@ const PREVIEW_FLAGS: CliFlags = {
 	},
 };
 
+// Reserved param names are consumed as command flags/selectors and NOT passed
+// through as choice variables (extractVariables skips them). A choice whose
+// variable is literally named after a flag (e.g. `{{VALUE:verify}}`,
+// `{{VALUE:fields}}`, `{{VALUE:ui}}`) can't receive it via the bare
+// `name=value` form; supply it with the unreserved `value-<name>=...` prefix or
+// `vars=<json>` instead (see docs/docs/Advanced/CLI.md#reserved-flag-names).
 const RESERVED_RUN_PARAMS = new Set<string>([
 	"choice",
 	"id",
@@ -287,6 +293,7 @@ function toDetailedFieldSummary(requirement: FieldRequirement) {
 		optional: requirement.optional,
 		runtimeOnly: requirement.runtimeOnly,
 		multiEmit: requirement.multiEmit,
+		filters: requirement.filters,
 		numericConfig: requirement.numericConfig,
 		sliderConfig: requirement.sliderConfig,
 		suggesterConfig: requirement.suggesterConfig,


### PR DESCRIPTION
## Summary

Two opt-in, backward-compatible flags on the QuickAdd CLI so external front ends (Raycast, Shortcuts, scripts) can build faithful UI on top of it and report truthful results.

- **`quickadd:check ... fields`** — each `missing[]` entry carries the full `FieldRequirement` (`options`, `displayOptions`, `dateFormat`/`withTime`, `numericConfig`, `sliderConfig`, `suggesterConfig`, `optional`, `runtimeOnly`, `multiEmit`) instead of just `optionCount`. Without the flag the compact summary is unchanged, so a client can render a real dropdown / date picker / slider from a choice's requirements.
- **`quickadd:run ... verify`** — routes Template/Capture through `executeWithOutcome`, returning the created `file` path on success and an honest `aborted` error on failure (mirroring `quickadd:run-template`). Fixes the case where the legacy void-execute path reports `ok:true` while the engine silently swallowed a runtime failure (missing target file/heading, empty file name). Default keeps the legacy envelope.

Both flags are added to their command's reserved-params set (`RESERVED_CHECK_PARAMS` / `RESERVED_RUN_PARAMS`) so they never leak into the executor's variables.

## Why

I built a Raycast extension that drives QuickAdd choices end to end through the CLI. `fields` is what lets it render native form controls from a choice's requirements; `verify` is what lets it show truthful success/failure and link to the created note.

## Testing

- New regression tests in `registerQuickAddCliHandlers.test.ts`: detailed-vs-compact `check` output, `verify` routing through `executeWithOutcome` vs the legacy path, and both flags not leaking into executor variables.
- `pnpm run build-with-lint` clean; full suite green (`pnpm run test`).
- Verified end to end against a live vault via the Obsidian CLI: `check fields` returns dropdown `options` and VDATE `dateFormat`; `run verify` returns `verified:true` with the created `file` and an honest abort otherwise.

## Compatibility / release impact

Additive and backward compatible — no behavior change without the flags. Minor version bump (new `feat`).

Closes #1469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in verified run mode for QuickAdd CLI actions, returning a verification-oriented success envelope.
  * Added an opt-in detailed mode for QuickAdd `check`, including richer missing-field metadata.

* **Bug Fixes**
  * Prevented the `verify` and `fields` flags from being treated as normal execution variables.

* **Documentation**
  * Documented reserved flag names and how to pass reserved tokens when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->