### PR TITLE
feat(interactive): forward runtime prompts to a remote front end (Raycast)

### DIFF
--- a/docs/docs/Advanced/CLI.md
+++ b/docs/docs/Advanced/CLI.md
@@ -141,7 +141,9 @@ background. Attach to the session and drive it:
 
 Prompt `type`s and the `value` you reply with: `suggester`/`input`/`date` →
 string, `confirm` → boolean, `checkbox` → string array, `info` →
-acknowledgement. The run's outcome arrives as the `done`/`error` poll event.
+acknowledgement, `form` → an object mapping each field's `id` to its string
+value (date fields use the `@date:ISO` format). The run's outcome arrives as the
+`done`/`error` poll event.
 
 Notes:
 

--- a/docs/docs/Advanced/CLI.md
+++ b/docs/docs/Advanced/CLI.md
@@ -113,3 +113,43 @@ Use `ui` to allow interactive prompts:
 ```bash
 obsidian vault=dev quickadd choice="Daily log" ui
 ```
+
+## Interactive runs (`quickadd:interactive`)
+
+Some choices prompt at *run time* for inputs that can't be collected up front -
+a macro's `quickAddApi.suggester` over data it just fetched, an `inputPrompt`,
+`yesNoPrompt`, `checkboxPrompt`, and so on. `quickadd:interactive` runs a choice
+and **forwards those prompts to you over a local HTTP bridge** so an external
+front end (Raycast, a script) can render them and answer, instead of the prompts
+opening in Obsidian.
+
+```bash
+obsidian vault=dev quickadd:interactive choice="Import from Readwise"
+# -> {"ok":true,"host":"127.0.0.1","port":51789,"sessionId":"…","token":"…"}
+```
+
+The command returns connection details immediately and runs the choice in the
+background. Attach to the session and drive it:
+
+- `GET  http://127.0.0.1:<port>/poll?session=<id>&token=<token>` - long-polls for
+  the next event: `{"kind":"prompt","requestId":…,"prompt":{…}}`,
+  `{"kind":"done","result":…}`, `{"kind":"error","error":…}`, or a periodic
+  `{"kind":"idle"}` keepalive (just poll again).
+- `POST http://127.0.0.1:<port>/reply?session=<id>&token=<token>` with body
+  `{"requestId":…,"value":…}` to answer, or `{"requestId":…,"cancelled":true}`
+  to cancel (which aborts the run).
+
+Prompt `type`s and the `value` you reply with: `suggester`/`input`/`date` →
+string, `confirm` → boolean, `checkbox` → string array, `info` →
+acknowledgement. The run's outcome arrives as the `done`/`error` poll event.
+
+Notes:
+
+- **Desktop only.** The bridge binds to `127.0.0.1`, is gated by the per-session
+  `token`, rejects browser (`Origin`/`Referer`) and non-loopback `Host`
+  requests, and the server is ephemeral - it starts on the first session and
+  stops when the last one ends.
+- **Concurrency.** Each run gets its own `sessionId` + `token`; many can run at
+  once without interfering.
+- If no client attaches within ~30s the run is aborted so a prompt can't hang
+  forever.

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -5,6 +5,7 @@ import type { MacroAbortError } from "./errors/MacroAbortError";
 import type { ChoiceOutcome } from "./types/ChoiceOutcome";
 import type { FrontmatterPropertyTarget } from "./utils/frontmatterPropertyLinks";
 import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
+import type { PromptProvider } from "./interactive/promptProvider";
 
 export interface IChoiceExecutor {
 	execute(choice: IChoice): Promise<void>;
@@ -46,6 +47,14 @@ export interface IChoiceExecutor {
 	 * on an unanswerable modal.
 	 */
 	interactive?: boolean;
+	/**
+	 * When set, runtime prompts a script raises (`quickAddApi.suggester` and, over
+	 * time, the rest of the prompt seam) are routed to this provider — a remote
+	 * interactive session driven by an external front end (Raycast) — instead of
+	 * opening an Obsidian modal. Absent means the normal in-app prompt behaviour.
+	 * Independent of {@link interactive}, which still gates engine-level prompts.
+	 */
+	promptProvider?: PromptProvider;
 	/**
 	 * Frontmatter property value focused when the outermost choice execution began.
 	 * Append Link uses this to avoid the stale CodeMirror cursor Obsidian reports

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -8,6 +8,7 @@ import { TemplateChoiceEngine } from "./engine/TemplateChoiceEngine";
 import { CaptureChoiceEngine } from "./engine/CaptureChoiceEngine";
 import { MacroChoiceEngine } from "./engine/MacroChoiceEngine";
 import type { IChoiceExecutor } from "./IChoiceExecutor";
+import type { PromptProvider } from "./interactive/promptProvider";
 import type IMultiChoice from "./types/choices/IMultiChoice";
 import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
 import { settingsStore } from "./settingsStore";
@@ -30,6 +31,10 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	// suggester) keeps its current prompt behaviour. Non-interactive callers (CLI
 	// without `ui`) flip this to false so engine prompts abort instead of hanging.
 	public interactive = true;
+	// When set, script prompts route to this remote provider (interactive session
+	// driven by an external front end) instead of Obsidian modals. See
+	// IChoiceExecutor.promptProvider.
+	public promptProvider?: PromptProvider;
 	// User-script modules loaded by requirement collection (preflight / CLI),
 	// consumed once by MacroChoiceEngine so a script's top-level code runs a
 	// single time per trigger instead of once for introspection plus once for

--- a/src/cli/registerQuickAddCliHandlers.test.ts
+++ b/src/cli/registerQuickAddCliHandlers.test.ts
@@ -169,6 +169,7 @@ describe("registerQuickAddCliHandlers", () => {
 			"quickadd:list",
 			"quickadd:check",
 			"quickadd:package-preview",
+			"quickadd:interactive",
 		]);
 	});
 

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -10,6 +10,8 @@ import {
 	getUnresolvedRequirements,
 } from "../preflight/collectChoiceRequirements";
 import type { FieldRequirement } from "../preflight/RequirementCollector";
+import { interactivePromptServer } from "../interactive/interactivePromptServer";
+import { RemotePromptProvider } from "../interactive/promptProvider";
 import type IChoice from "../types/choices/IChoice";
 import type IMultiChoice from "../types/choices/IMultiChoice";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
@@ -120,6 +122,21 @@ const CHECK_FLAGS: CliFlags = {
 	},
 };
 
+const INTERACTIVE_FLAGS: CliFlags = {
+	choice: {
+		value: "<name>",
+		description: "Choice name",
+	},
+	id: {
+		value: "<id>",
+		description: "Choice id",
+	},
+	vars: {
+		value: "<json>",
+		description: "Variables object as JSON (pre-seeded inputs)",
+	},
+};
+
 const PREVIEW_FLAGS: CliFlags = {
 	path: {
 		value: "<vault-path>",
@@ -145,6 +162,7 @@ const RESERVED_RUN_PARAMS = new Set<string>([
 ]);
 const RESERVED_RUN_TEMPLATE_PARAMS = new Set<string>(["path", "vars", "ui"]);
 const RESERVED_CHECK_PARAMS = new Set<string>(["choice", "id", "vars", "fields"]);
+const RESERVED_INTERACTIVE_PARAMS = new Set<string>(["choice", "id", "vars"]);
 
 const CLI_COMMANDS = {
 	runDefault: "quickadd",
@@ -153,6 +171,7 @@ const CLI_COMMANDS = {
 	list: "quickadd:list",
 	check: "quickadd:check",
 	preview: "quickadd:package-preview",
+	interactive: "quickadd:interactive",
 } as const;
 
 const SUPPORTED_LIST_TYPES = new Set(["template", "capture", "macro", "multi"]);
@@ -685,6 +704,98 @@ async function checkChoiceHandler(
 	}
 }
 
+/**
+ * Starts an *interactive* run: the choice executes immediately with a remote
+ * prompt provider, and any runtime prompt (currently `quickAddApi.suggester`) is
+ * forwarded to the caller over the interactive server instead of an Obsidian
+ * modal. Returns the connection details right away — {port, sessionId, token} —
+ * so the caller can attach and drive the prompts; the run's final outcome is
+ * delivered over the server (a `done`/`error` poll event), not this response.
+ */
+async function interactiveHandler(
+	plugin: QuickAdd,
+	params: CliData,
+): Promise<string> {
+	const command = CLI_COMMANDS.interactive;
+	let choice: IChoice;
+	try {
+		choice = resolveChoiceFromParams(plugin, params);
+	} catch (error) {
+		return serialize({
+			ok: false,
+			command,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+
+	if (choice.type === "Multi") {
+		return serialize({
+			ok: false,
+			command,
+			error: "Multi choices cannot be run interactively via CLI.",
+			choice: describeChoice(choice),
+		});
+	}
+
+	try {
+		const port = await interactivePromptServer.ensureStarted();
+		const { id: sessionId, token } = interactivePromptServer.createSession();
+
+		const choiceExecutor = new ChoiceExecutor(
+			plugin.app,
+			plugin,
+		) as IChoiceExecutor;
+		setExecutorVariables(
+			choiceExecutor,
+			extractVariables(params, RESERVED_INTERACTIVE_PARAMS),
+		);
+		choiceExecutor.interactive = true;
+		choiceExecutor.promptProvider = new RemotePromptProvider(sessionId);
+
+		// Fire-and-forget: the run proceeds while the caller attaches and answers
+		// prompts. Its result/error is delivered to the caller via the server, so
+		// this handler must not await it.
+		void (async () => {
+			try {
+				await choiceExecutor.execute(choice);
+				const aborted = choiceExecutor.consumeAbortSignal?.();
+				if (aborted) {
+					interactivePromptServer.finish(sessionId, {
+						kind: "error",
+						error: aborted.message || "Choice execution aborted",
+					});
+					return;
+				}
+				interactivePromptServer.finish(sessionId, {
+					kind: "done",
+					result: { ok: true, choice: describeChoice(choice) },
+				});
+			} catch (error) {
+				interactivePromptServer.finish(sessionId, {
+					kind: "error",
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		})();
+
+		return serialize({
+			ok: true,
+			command,
+			choice: describeChoice(choice),
+			host: "127.0.0.1",
+			port,
+			sessionId,
+			token,
+		});
+	} catch (error) {
+		return serialize({
+			ok: false,
+			command,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
 async function previewPackageHandler(
 	plugin: QuickAdd,
 	params: CliData,
@@ -777,6 +888,12 @@ export function registerQuickAddCliHandlers(plugin: QuickAdd): boolean {
 		"Preview a QuickAdd package before importing (files + capabilities)",
 		PREVIEW_FLAGS,
 		(params: CliData) => previewPackageHandler(plugin, params),
+	);
+	register(
+		CLI_COMMANDS.interactive,
+		"Run a choice interactively: forwards its runtime prompts to the caller over a local server (returns host/port/sessionId/token to attach)",
+		INTERACTIVE_FLAGS,
+		(params: CliData) => interactiveHandler(plugin, params),
 	);
 
 	log.logMessage("Registered QuickAdd CLI handlers.");

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -757,6 +757,41 @@ async function interactiveHandler(
 		// this handler must not await it.
 		void (async () => {
 			try {
+				// Template/Capture engines can swallow a runtime failure on the void
+				// execute() path, so use the verified-outcome path (mirrors run-choice)
+				// to avoid reporting a failed file create as success.
+				if (
+					(choice.type === "Template" || choice.type === "Capture") &&
+					typeof choiceExecutor.executeWithOutcome === "function"
+				) {
+					const outcome = await choiceExecutor.executeWithOutcome(
+						choice as ITemplateChoice | ICaptureChoice,
+					);
+					if (outcome.status === "success") {
+						interactivePromptServer.finish(sessionId, {
+							kind: "done",
+							result: {
+								ok: true,
+								choice: describeChoice(choice),
+								file: outcome.file?.path,
+								verified: true,
+							},
+						});
+						return;
+					}
+					interactivePromptServer.finish(sessionId, {
+						kind: "error",
+						error:
+							outcome.status === "cancelled"
+								? outcome.reason ||
+									(outcome.cancelKind === "user"
+										? "Execution cancelled by user"
+										: "Execution aborted")
+								: "Choice execution failed; no file was created.",
+					});
+					return;
+				}
+
 				await choiceExecutor.execute(choice);
 				const aborted = choiceExecutor.consumeAbortSignal?.();
 				if (aborted) {

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1550,4 +1550,20 @@ describe("CompleteFormatter - remote prompt provider routing", () => {
 		expect(inputPrompt).toHaveBeenCalled();
 		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
 	});
+
+	it("routes anonymous {{VALUE|type:checkbox}} to the provider's suggester, not the Obsidian modal", async () => {
+		mocks.genericSuggesterSuggest.mockResolvedValue("false"); // modal answer (should be unused)
+		const suggester = vi.fn(async () => "true");
+		const f = providerFormatter({ suggester });
+		await expect(
+			f.formatFileContent("[{{VALUE|type:checkbox}}]"),
+		).resolves.toBe("[true]");
+		expect(suggester).toHaveBeenCalledWith(
+			["true", "false"],
+			["true", "false"],
+			expect.anything(),
+			false,
+		);
+		expect(mocks.genericSuggesterSuggest).not.toHaveBeenCalled();
+	});
 });

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1499,3 +1499,55 @@ describe("CompleteFormatter {{linksection}} runtime resolution", () => {
 		);
 	});
 });
+
+describe("CompleteFormatter - remote prompt provider routing", () => {
+	// An interactive run driven by a remote provider (Raycast): token prompts the
+	// requirement collector didn't pre-satisfy must go to the provider, not a modal.
+	const providerFormatter = (
+		provider: Record<string, unknown>,
+		variables: Map<string, unknown> = new Map(),
+	) => {
+		const app = makeApp({ activeFile: null, selection: null, generatedLink: "" });
+		const plugin = makePlugin({});
+		return new CompleteFormatter(app as any, plugin as any, {
+			variables,
+			interactive: true,
+			promptProvider: provider,
+			execute: vi.fn(),
+		} as any);
+	};
+
+	it("routes {{VALUE:opts}} to the provider's suggester, not the Obsidian modal", async () => {
+		mocks.genericSuggesterSuggest.mockResolvedValue("a"); // modal answer (should be unused)
+		const suggester = vi.fn(async () => "b");
+		const f = providerFormatter({ suggester });
+		await expect(f.formatFolderPath("{{VALUE:a,b,c}}")).resolves.toBe("b");
+		expect(suggester).toHaveBeenCalledWith(
+			["a", "b", "c"],
+			["a", "b", "c"],
+			undefined,
+			false,
+		);
+		expect(mocks.genericSuggesterSuggest).not.toHaveBeenCalled();
+	});
+
+	it("routes anonymous {{VALUE}} to the provider's inputPrompt", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("modal");
+		const inputPrompt = vi.fn(async () => "remote");
+		const f = providerFormatter({ inputPrompt });
+		await expect(f.formatFolderPath("{{VALUE}}")).resolves.toBe("remote");
+		expect(inputPrompt).toHaveBeenCalled();
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
+	});
+
+	it("routes named {{VALUE:name}} to the provider's inputPrompt", async () => {
+		mocks.inputPromptPrompt.mockResolvedValue("modal");
+		const inputPrompt = vi.fn(async () => "remote-name");
+		const f = providerFormatter({ inputPrompt });
+		await expect(f.formatFolderPath("{{VALUE:name}}")).resolves.toBe(
+			"remote-name",
+		);
+		expect(inputPrompt).toHaveBeenCalled();
+		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
+	});
+});

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -520,6 +520,9 @@ export class CompleteFormatter extends Formatter {
 					{
 						defaultValue: context.defaultValue,
 						dateFormat: context.dateFormat ?? "YYYY-MM-DD",
+						// Carry |time/|datetime so the remote client renders a time
+						// picker; otherwise the picked time is silently dropped.
+						withTime: context.withTime,
 					},
 				);
 			}

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -397,13 +397,15 @@ export class CompleteFormatter extends Formatter {
 				// mirroring promptForVariable's named {{VALUE:x|type:checkbox}} path.
 				const checkboxProvider = this.choiceExecutor?.promptProvider;
 				if (checkboxProvider) {
-					this.value = await checkboxProvider.suggester(
-						["true", "false"],
-						["true", "false"],
-						this.valuePromptContext.description ??
-							this.valueHeader ??
-							"Choose value",
-						false,
+					this.value = String(
+						await checkboxProvider.suggester(
+							["true", "false"],
+							["true", "false"],
+							this.valuePromptContext.description ??
+								this.valueHeader ??
+								"Choose value",
+							false,
+						),
 					);
 					return this.value;
 				}
@@ -541,11 +543,13 @@ export class CompleteFormatter extends Formatter {
 				);
 			}
 			if (context?.inputTypeOverride === "checkbox") {
-				return await provider.suggester(
-					["true", "false"],
-					["true", "false"],
-					context.description ?? header ?? context.label ?? "Choose value",
-					false,
+				return String(
+					await provider.suggester(
+						["true", "false"],
+						["true", "false"],
+						context.description ?? header ?? context.label ?? "Choose value",
+						false,
+					),
 				);
 			}
 			return await provider.inputPrompt(
@@ -637,11 +641,15 @@ export class CompleteFormatter extends Formatter {
 		// (e.g. a rating field) that the requirement collector didn't pre-satisfy.
 		const provider = this.choiceExecutor?.promptProvider;
 		if (provider) {
-			return await provider.suggester(
-				context?.displayValues ?? suggestedValues,
-				suggestedValues,
-				context?.placeholder,
-				allowCustomInput,
+			// Formatter tokens resolve to strings; the provider hands back the
+			// selected actualItems entry (here always a string) or a custom value.
+			return String(
+				await provider.suggester(
+					context?.displayValues ?? suggestedValues,
+					suggestedValues,
+					context?.placeholder,
+					allowCustomInput,
+				),
 			);
 		}
 		this.assertInteractivePrompt(

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -414,6 +414,16 @@ export class CompleteFormatter extends Formatter {
 					throw error;
 				}
 			}
+			// Route to a remote interactive session (Raycast) when one is driving.
+			const valueProvider = this.choiceExecutor?.promptProvider;
+			if (valueProvider) {
+				this.value = await valueProvider.inputPrompt(
+					this.valueHeader ?? "Enter value",
+					this.valuePromptContext?.placeholder,
+					this.valuePromptContext?.defaultValue,
+				);
+				return this.value;
+			}
 			try {
 				const linkSourcePath = this.getLinkSourcePath();
 				const promptFactory = new InputPrompt().factory(
@@ -501,6 +511,32 @@ export class CompleteFormatter extends Formatter {
 		header?: string,
 		context?: PromptContext,
 	): Promise<string> {
+		// Route to a remote interactive session (Raycast) when one is driving.
+		const provider = this.choiceExecutor?.promptProvider;
+		if (provider) {
+			if (context?.type === "VDATE") {
+				return await provider.datePrompt(
+					header ?? context.label ?? "Enter date",
+					{
+						defaultValue: context.defaultValue,
+						dateFormat: context.dateFormat ?? "YYYY-MM-DD",
+					},
+				);
+			}
+			if (context?.inputTypeOverride === "checkbox") {
+				return await provider.suggester(
+					["true", "false"],
+					["true", "false"],
+					context.description ?? header ?? context.label ?? "Choose value",
+					false,
+				);
+			}
+			return await provider.inputPrompt(
+				header ?? context?.label ?? "Enter value",
+				context?.placeholder,
+				context?.defaultValue,
+			);
+		}
 		this.assertInteractivePrompt(
 			header ? `{{VALUE:${header}}}` : "a template variable",
 		);
@@ -554,6 +590,10 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async promptForMathValue(): Promise<string> {
+		const provider = this.choiceExecutor?.promptProvider;
+		if (provider) {
+			return await provider.inputPrompt("Enter a math expression");
+		}
 		this.assertInteractivePrompt("a {{MATH}} expression");
 		try {
 			return await MathModal.Prompt();
@@ -575,6 +615,18 @@ export class CompleteFormatter extends Formatter {
 			optional?: boolean;
 		},
 	) {
+		// Route to a remote interactive session (Raycast) when one is driving this
+		// run - covers `{{VALUE:a,b,c}}` option lists in a template/capture format
+		// (e.g. a rating field) that the requirement collector didn't pre-satisfy.
+		const provider = this.choiceExecutor?.promptProvider;
+		if (provider) {
+			return await provider.suggester(
+				context?.displayValues ?? suggestedValues,
+				suggestedValues,
+				context?.placeholder,
+				allowCustomInput,
+			);
+		}
 		this.assertInteractivePrompt(
 			context?.variableKey ? `{{VALUE:${context.variableKey}}}` : "a value choice",
 		);

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -393,6 +393,20 @@ export class CompleteFormatter extends Formatter {
 			// Anonymous {{VALUE|type:checkbox}} gets the same forced true/false
 			// picker as the named form (resolved before the InputPrompt factory).
 			if (this.valuePromptContext?.inputTypeOverride === "checkbox") {
+				// Route to a remote interactive session (Raycast) when one is driving,
+				// mirroring promptForVariable's named {{VALUE:x|type:checkbox}} path.
+				const checkboxProvider = this.choiceExecutor?.promptProvider;
+				if (checkboxProvider) {
+					this.value = await checkboxProvider.suggester(
+						["true", "false"],
+						["true", "false"],
+						this.valuePromptContext.description ??
+							this.valueHeader ??
+							"Choose value",
+						false,
+					);
+					return this.value;
+				}
 				try {
 					this.value = await GenericSuggester.Suggest(
 						this.app,

--- a/src/interactive/interactivePromptServer.test.ts
+++ b/src/interactive/interactivePromptServer.test.ts
@@ -92,6 +92,11 @@ describe("interactivePromptServer long-poll waiter", () => {
 		await vi.advanceTimersByTimeAsync(75_000 + 10);
 		await rejected;
 		expect(srv.sessions.get(s.id)?.finished).toBe(true);
+
+		// finish() scheduled a cleanup timeout; flush it so the session doesn't
+		// linger in the map (and leak into later tests) once real timers resume.
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(srv.sessions.has(s.id)).toBe(false);
 	});
 });
 

--- a/src/interactive/interactivePromptServer.test.ts
+++ b/src/interactive/interactivePromptServer.test.ts
@@ -4,6 +4,7 @@ import {
 	isLoopbackClient,
 	safeEqual,
 } from "./interactivePromptServer";
+import { UserCancelError } from "../errors/UserCancelError";
 
 describe("safeEqual", () => {
 	it("matches equal strings and rejects different or different-length ones", () => {
@@ -24,6 +25,44 @@ describe("isLoopbackClient", () => {
 		expect(isLoopbackClient({ host: "127.0.0.1:5000", referer: "https://evil.test/x" })).toBe(false);
 		expect(isLoopbackClient({ host: "evil.test:5000" })).toBe(false);
 		expect(isLoopbackClient({})).toBe(false);
+	});
+});
+
+describe("interactivePromptServer long-poll waiter", () => {
+	it("parks a single waiter and hands a concurrent poll an immediate idle", async () => {
+		const s = interactivePromptServer.createSession();
+		const srv = interactivePromptServer as unknown as {
+			handlePoll(session: unknown, res: unknown): void;
+			sessions: Map<string, unknown>;
+		};
+		const session = srv.sessions.get(s.id);
+
+		const first = fakeRes();
+		const second = fakeRes();
+
+		// First poll parks (nothing queued yet) — no response written.
+		srv.handlePoll(session, first.res);
+		expect(first.events).toHaveLength(0);
+
+		// A concurrent/overlapping poll must not overwrite the parked waiter;
+		// it gets an immediate idle so the client simply re-polls.
+		srv.handlePoll(session, second.res);
+		expect(second.events).toEqual([{ kind: "idle" }]);
+
+		// Emitting a prompt fires the *parked* (first) waiter, not the second.
+		const prompt = interactivePromptServer.emitPrompt(s.id, {
+			type: "confirm",
+			header: "Proceed?",
+		});
+		expect(first.events).toHaveLength(1);
+		expect((first.events[0] as { kind: string }).kind).toBe("prompt");
+
+		// A stale close from the already-fired first poll must not disturb state.
+		first.close();
+
+		interactivePromptServer.submitReply(s.id, pendingRequestId(s.id), true);
+		await expect(prompt).resolves.toBe(true);
+		interactivePromptServer.finish(s.id, { kind: "done", result: {} });
 	});
 });
 
@@ -72,6 +111,33 @@ describe("interactivePromptServer session multiplexing", () => {
 		await expect(prompt).rejects.toThrow(/ended/i);
 	});
 
+	it("rejects a prompt raised after the session already finished (no hang)", async () => {
+		const s = interactivePromptServer.createSession();
+		interactivePromptServer.finish(s.id, { kind: "done", result: {} });
+		// Without the finished-guard this promise would park forever.
+		await expect(
+			interactivePromptServer.emitPrompt(s.id, {
+				type: "confirm",
+				header: "Late?",
+			}),
+		).rejects.toThrow(/ended/i);
+	});
+
+	it("rejects a cancelled reply with UserCancelError so the run aborts as a user cancel", async () => {
+		const s = interactivePromptServer.createSession();
+		const prompt = interactivePromptServer.emitPrompt(s.id, {
+			type: "input",
+			header: "Name",
+			multiline: false,
+		});
+		const rid = pendingRequestId(s.id);
+		expect(
+			interactivePromptServer.submitReply(s.id, rid, undefined, true),
+		).toBe(true);
+		await expect(prompt).rejects.toBeInstanceOf(UserCancelError);
+		interactivePromptServer.finish(s.id, { kind: "done", result: {} });
+	});
+
 	it("caps the number of concurrent sessions", () => {
 		const created: string[] = [];
 		try {
@@ -86,6 +152,31 @@ describe("interactivePromptServer session multiplexing", () => {
 		}
 	});
 });
+
+/** Minimal ServerResponse stand-in capturing what `send()` writes. */
+function fakeRes(): {
+	res: unknown;
+	events: unknown[];
+	close: () => void;
+} {
+	const events: unknown[] = [];
+	let closeHandler: (() => void) | null = null;
+	return {
+		res: {
+			writeHead() {},
+			end(payload?: string) {
+				if (payload) events.push(JSON.parse(payload));
+			},
+			on(event: string, cb: () => void) {
+				if (event === "close") closeHandler = cb;
+			},
+		},
+		events,
+		close() {
+			closeHandler?.();
+		},
+	};
+}
 
 /** Reads the single pending requestId for a session (test helper). */
 function pendingRequestId(sessionId: string): string {

--- a/src/interactive/interactivePromptServer.test.ts
+++ b/src/interactive/interactivePromptServer.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+	interactivePromptServer,
+	isLoopbackClient,
+	safeEqual,
+} from "./interactivePromptServer";
+
+describe("safeEqual", () => {
+	it("matches equal strings and rejects different or different-length ones", () => {
+		expect(safeEqual("abc123", "abc123")).toBe(true);
+		expect(safeEqual("abc123", "abc124")).toBe(false);
+		expect(safeEqual("abc", "abcd")).toBe(false);
+		expect(safeEqual("", "")).toBe(true);
+	});
+});
+
+describe("isLoopbackClient", () => {
+	it("allows loopback hosts with no browser origin", () => {
+		expect(isLoopbackClient({ host: "127.0.0.1:5000" })).toBe(true);
+		expect(isLoopbackClient({ host: "localhost:5000" })).toBe(true);
+	});
+	it("rejects browser origins and non-loopback hosts (DNS-rebinding)", () => {
+		expect(isLoopbackClient({ host: "127.0.0.1:5000", origin: "https://evil.test" })).toBe(false);
+		expect(isLoopbackClient({ host: "127.0.0.1:5000", referer: "https://evil.test/x" })).toBe(false);
+		expect(isLoopbackClient({ host: "evil.test:5000" })).toBe(false);
+		expect(isLoopbackClient({})).toBe(false);
+	});
+});
+
+describe("interactivePromptServer session multiplexing", () => {
+	it("resolves each prompt with the reply for its own session and requestId", async () => {
+		const a = interactivePromptServer.createSession();
+		const b = interactivePromptServer.createSession();
+		expect(a.id).not.toBe(b.id);
+		expect(a.token).not.toBe(b.token);
+
+		const promptA = interactivePromptServer.emitPrompt(a.id, {
+			type: "input",
+			header: "A",
+			multiline: false,
+		});
+		const promptB = interactivePromptServer.emitPrompt(b.id, {
+			type: "input",
+			header: "B",
+			multiline: false,
+		});
+
+		// A reply for one session must not resolve the other's prompt.
+		const rid = crypto.randomUUID();
+		expect(interactivePromptServer.submitReply(a.id, rid, "wrong-request")).toBe(false);
+
+		// Reply to each with its actual pending requestId (the only pending one).
+		const ridA = pendingRequestId(a.id);
+		const ridB = pendingRequestId(b.id);
+		expect(interactivePromptServer.submitReply(a.id, ridA, "answer-A")).toBe(true);
+		expect(interactivePromptServer.submitReply(b.id, ridB, "answer-B")).toBe(true);
+
+		await expect(promptA).resolves.toBe("answer-A");
+		await expect(promptB).resolves.toBe("answer-B");
+
+		interactivePromptServer.finish(a.id, { kind: "done", result: {} });
+		interactivePromptServer.finish(b.id, { kind: "done", result: {} });
+	});
+
+	it("rejects a still-open prompt when the session finishes", async () => {
+		const s = interactivePromptServer.createSession();
+		const prompt = interactivePromptServer.emitPrompt(s.id, {
+			type: "confirm",
+			header: "Proceed?",
+		});
+		interactivePromptServer.finish(s.id, { kind: "error", error: "boom" });
+		await expect(prompt).rejects.toThrow(/ended/i);
+	});
+
+	it("caps the number of concurrent sessions", () => {
+		const created: string[] = [];
+		try {
+			// Already have some sessions from earlier tests may have been cleaned up;
+			// create until it throws to prove the cap is enforced.
+			for (let i = 0; i < 64; i++) created.push(interactivePromptServer.createSession().id);
+			throw new Error("expected the session cap to be hit");
+		} catch (error) {
+			expect((error as Error).message).toMatch(/too many/i);
+		} finally {
+			for (const id of created) interactivePromptServer.finish(id, { kind: "done", result: {} });
+		}
+	});
+});
+
+/** Reads the single pending requestId for a session (test helper). */
+function pendingRequestId(sessionId: string): string {
+	const sessions = (
+		interactivePromptServer as unknown as {
+			sessions: Map<string, { pending: Map<string, unknown> }>;
+		}
+	).sessions;
+	const pending = sessions.get(sessionId)?.pending;
+	const first = pending ? [...pending.keys()][0] : undefined;
+	if (!first) throw new Error("no pending prompt");
+	return first;
+}

--- a/src/interactive/interactivePromptServer.test.ts
+++ b/src/interactive/interactivePromptServer.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	interactivePromptServer,
 	isLoopbackClient,
 	safeEqual,
 } from "./interactivePromptServer";
 import { UserCancelError } from "../errors/UserCancelError";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe("safeEqual", () => {
 	it("matches equal strings and rejects different or different-length ones", () => {
@@ -63,6 +67,31 @@ describe("interactivePromptServer long-poll waiter", () => {
 		interactivePromptServer.submitReply(s.id, pendingRequestId(s.id), true);
 		await expect(prompt).resolves.toBe(true);
 		interactivePromptServer.finish(s.id, { kind: "done", result: {} });
+	});
+
+	it("aborts the run when an attached client stops polling (disconnect watchdog)", async () => {
+		vi.useFakeTimers();
+		const s = interactivePromptServer.createSession();
+		const srv = interactivePromptServer as unknown as {
+			handlePoll(session: unknown, res: unknown): void;
+			sessions: Map<string, { finished: boolean }>;
+		};
+		const session = srv.sessions.get(s.id);
+
+		// Client attaches (arms the watchdog), receives a prompt, then goes silent.
+		srv.handlePoll(session, fakeRes().res);
+		const prompt = interactivePromptServer.emitPrompt(s.id, {
+			type: "confirm",
+			header: "Proceed?",
+		});
+		// Attach the rejection handler before advancing timers so the abort isn't
+		// briefly seen as an unhandled rejection.
+		const rejected = expect(prompt).rejects.toThrow(/ended/i);
+
+		// No further polls: the watchdog must fire and abort the awaiting prompt.
+		await vi.advanceTimersByTimeAsync(75_000 + 10);
+		await rejected;
+		expect(srv.sessions.get(s.id)?.finished).toBe(true);
 	});
 });
 

--- a/src/interactive/interactivePromptServer.ts
+++ b/src/interactive/interactivePromptServer.ts
@@ -26,13 +26,44 @@ export interface SuggesterItem {
 	value: string;
 }
 
-/** A prompt the running script is blocked on. Extend with new `type`s over time. */
-export type PromptSpec = {
-	type: "suggester";
-	placeholder?: string;
-	allowCustomInput: boolean;
-	items: SuggesterItem[];
-};
+export interface CheckboxItem {
+	title: string;
+	value: string;
+	checked: boolean;
+}
+
+/**
+ * A prompt the running script is blocked on. Mirrors the QuickAdd API prompt
+ * seam (suggester / inputPrompt / wideInputPrompt / datePrompt / yesNoPrompt /
+ * checkboxPrompt / infoDialog). The reply `value` type per prompt:
+ *  - suggester/input/date -> string   - confirm -> boolean
+ *  - checkbox -> string[]             - info -> acknowledgement (any)
+ */
+export type PromptSpec =
+	| {
+			type: "suggester";
+			placeholder?: string;
+			allowCustomInput: boolean;
+			items: SuggesterItem[];
+	  }
+	| {
+			type: "input";
+			header: string;
+			placeholder?: string;
+			defaultValue?: string;
+			/** Render a multi-line field (wideInputPrompt). */
+			multiline: boolean;
+	  }
+	| {
+			type: "date";
+			header: string;
+			placeholder?: string;
+			defaultValue?: string;
+			dateFormat?: string;
+	  }
+	| { type: "confirm"; header: string; text?: string }
+	| { type: "checkbox"; header?: string; items: CheckboxItem[] }
+	| { type: "info"; header: string; text: string[] };
 
 /** Events streamed to the polling client. */
 type ServerEvent =
@@ -53,11 +84,41 @@ interface Session {
 	>;
 	finished: boolean;
 	cleanupTimer: ReturnType<typeof setTimeout> | null;
+	/** True once a client has polled at least once. */
+	attached: boolean;
+	/** Aborts the run if no client attaches in time (avoids a hung executor). */
+	attachTimer: ReturnType<typeof setTimeout> | null;
 }
 
 const LONG_POLL_MS = 25_000;
 /** Keep a finished session around briefly so the client can still poll its final event. */
 const SESSION_TTL_MS = 60_000;
+/** Abort a run whose caller never attached, so a prompt can't park forever. */
+const ATTACH_TIMEOUT_MS = 30_000;
+/** Bound concurrent sessions so a runaway caller can't exhaust memory. */
+const MAX_SESSIONS = 32;
+
+/** Length-independent, constant-time string comparison (localhost, but cheap to be safe). */
+export function safeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let diff = 0;
+	for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	return diff === 0;
+}
+
+/**
+ * True only for a request that looks like our own loopback client: no browser
+ * Origin/Referer, and a Host of 127.0.0.1/localhost (DNS-rebinding guard).
+ */
+export function isLoopbackClient(headers: {
+	origin?: string;
+	referer?: string;
+	host?: string;
+}): boolean {
+	if (headers.origin || headers.referer) return false;
+	const hostname = (headers.host ?? "").split(":")[0];
+	return hostname === "127.0.0.1" || hostname === "localhost";
+}
 
 function nodeRequire<T>(mod: string): T | null {
 	try {
@@ -110,9 +171,12 @@ class InteractivePromptServer {
 	}
 
 	createSession(): { id: string; token: string } {
+		if (this.sessions.size >= MAX_SESSIONS) {
+			throw new Error("Too many active interactive sessions.");
+		}
 		const id = randomId();
 		const token = randomId() + randomId();
-		this.sessions.set(id, {
+		const session: Session = {
 			id,
 			token,
 			queue: [],
@@ -121,7 +185,18 @@ class InteractivePromptServer {
 			pending: new Map(),
 			finished: false,
 			cleanupTimer: null,
-		});
+			attached: false,
+			attachTimer: null,
+		};
+		session.attachTimer = setTimeout(() => {
+			if (!session.attached && !session.finished) {
+				this.finish(session.id, {
+					kind: "error",
+					error: "No client attached to the interactive session.",
+				});
+			}
+		}, ATTACH_TIMEOUT_MS);
+		this.sessions.set(id, session);
 		return { id, token };
 	}
 
@@ -144,6 +219,10 @@ class InteractivePromptServer {
 		const session = this.sessions.get(sessionId);
 		if (!session || session.finished) return;
 		session.finished = true;
+		if (session.attachTimer) {
+			clearTimeout(session.attachTimer);
+			session.attachTimer = null;
+		}
 		for (const [, pending] of session.pending) {
 			pending.reject(new Error("Interactive session ended"));
 		}
@@ -160,6 +239,7 @@ class InteractivePromptServer {
 		for (const session of this.sessions.values()) {
 			if (session.waiterTimer) clearTimeout(session.waiterTimer);
 			if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
+			if (session.attachTimer) clearTimeout(session.attachTimer);
 			for (const [, pending] of session.pending) {
 				pending.reject(new Error("QuickAdd unloaded"));
 			}
@@ -187,6 +267,7 @@ class InteractivePromptServer {
 	private destroySession(session: Session): void {
 		if (session.waiterTimer) clearTimeout(session.waiterTimer);
 		if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
+		if (session.attachTimer) clearTimeout(session.attachTimer);
 		this.sessions.delete(session.id);
 		if (this.sessions.size === 0) {
 			this.server?.close();
@@ -196,7 +277,42 @@ class InteractivePromptServer {
 	}
 
 	private authed(session: Session | undefined, token: string | null): session is Session {
-		return !!session && !!token && session.token === token;
+		return !!session && !!token && safeEqual(session.token, token);
+	}
+
+	/**
+	 * Reject anything that doesn't look like our own loopback client: a browser
+	 * (sends Origin/Referer) or a Host header that isn't 127.0.0.1/localhost
+	 * (DNS-rebinding). The server is bound to loopback, but these headers are the
+	 * cheap defence against a drive-by page probing the port.
+	 */
+	private originAllowed(req: IncomingMessage): boolean {
+		return isLoopbackClient({
+			origin: req.headers.origin,
+			referer: req.headers.referer,
+			host: req.headers.host,
+		});
+	}
+
+	/**
+	 * Deliver an answer (or a cancel) to the prompt a session is blocked on.
+	 * Public so the HTTP layer and tests share one path. Returns true if a
+	 * matching pending prompt was found.
+	 */
+	submitReply(
+		sessionId: string,
+		requestId: string,
+		value: unknown,
+		cancelled = false,
+	): boolean {
+		const session = this.sessions.get(sessionId);
+		if (!session) return false;
+		const pending = session.pending.get(requestId);
+		if (!pending) return false;
+		session.pending.delete(requestId);
+		if (cancelled) pending.reject(new Error("Prompt cancelled"));
+		else pending.resolve(value);
+		return true;
 	}
 
 	private send(res: ServerResponse, status: number, body: unknown): void {
@@ -223,6 +339,10 @@ class InteractivePromptServer {
 
 	private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
 		try {
+			if (!this.originAllowed(req)) {
+				this.send(res, 403, { ok: false, error: "Forbidden" });
+				return;
+			}
 			const url = new URL(req.url ?? "/", "http://127.0.0.1");
 			const sessionId = url.searchParams.get("session");
 			const token = url.searchParams.get("token");
@@ -260,6 +380,14 @@ class InteractivePromptServer {
 	}
 
 	private handlePoll(session: Session, res: ServerResponse): void {
+		// First poll = the caller attached; cancel the no-attach abort.
+		if (!session.attached) {
+			session.attached = true;
+			if (session.attachTimer) {
+				clearTimeout(session.attachTimer);
+				session.attachTimer = null;
+			}
+		}
 		const queued = session.queue.shift();
 		if (queued) {
 			this.send(res, 200, queued);
@@ -285,14 +413,7 @@ class InteractivePromptServer {
 		body: { requestId?: string; value?: unknown; cancelled?: boolean },
 	): void {
 		if (!body.requestId) return;
-		const pending = session.pending.get(body.requestId);
-		if (!pending) return;
-		session.pending.delete(body.requestId);
-		if (body.cancelled) {
-			pending.reject(new Error("Prompt cancelled"));
-		} else {
-			pending.resolve(body.value);
-		}
+		this.submitReply(session.id, body.requestId, body.value, body.cancelled);
 	}
 }
 

--- a/src/interactive/interactivePromptServer.ts
+++ b/src/interactive/interactivePromptServer.ts
@@ -1,0 +1,299 @@
+/**
+ * Localhost HTTP bridge that lets an external front end (Raycast, scripts) drive
+ * QuickAdd's *interactive* prompts — the ones a script raises at runtime and the
+ * requirement collector therefore cannot pre-satisfy (e.g. a Readwise importer's
+ * `quickAddApi.suggester(...)`).
+ *
+ * Transport: HTTP long-poll on 127.0.0.1 with an ephemeral random port. Chosen
+ * over a WebSocket so it needs no dependency (Node's built-in `http`, required
+ * lazily via `window.require` so the mobile bundle is untouched — desktop only).
+ *
+ * Concurrency: every run gets its own `sessionId` + per-session `token`; the
+ * server multiplexes any number of concurrent sessions and correlates each
+ * prompt to its answer by `requestId`. A caller can only ever see its own
+ * session (unknown/mismatched token → 401/404).
+ *
+ * Lifecycle: the server starts on the first session and stops once the last
+ * session is cleaned up, so nothing listens when no interactive run is active.
+ */
+
+import type { Server, IncomingMessage, ServerResponse } from "http";
+
+export interface SuggesterItem {
+	/** Text shown to the user. */
+	title: string;
+	/** The value handed back to the script when this item is chosen. */
+	value: string;
+}
+
+/** A prompt the running script is blocked on. Extend with new `type`s over time. */
+export type PromptSpec = {
+	type: "suggester";
+	placeholder?: string;
+	allowCustomInput: boolean;
+	items: SuggesterItem[];
+};
+
+/** Events streamed to the polling client. */
+type ServerEvent =
+	| { kind: "prompt"; requestId: string; prompt: PromptSpec }
+	| { kind: "done"; result: unknown }
+	| { kind: "error"; error: string }
+	| { kind: "idle" };
+
+interface Session {
+	id: string;
+	token: string;
+	queue: ServerEvent[];
+	waiter: ((event: ServerEvent) => void) | null;
+	waiterTimer: ReturnType<typeof setTimeout> | null;
+	pending: Map<
+		string,
+		{ resolve: (value: unknown) => void; reject: (error: Error) => void }
+	>;
+	finished: boolean;
+	cleanupTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const LONG_POLL_MS = 25_000;
+/** Keep a finished session around briefly so the client can still poll its final event. */
+const SESSION_TTL_MS = 60_000;
+
+function nodeRequire<T>(mod: string): T | null {
+	try {
+		const req = (window as unknown as { require?: (m: string) => unknown })
+			.require;
+		return req ? (req(mod) as T) : null;
+	} catch {
+		return null;
+	}
+}
+
+function randomId(): string {
+	const c = (globalThis as { crypto?: Crypto }).crypto;
+	if (c?.randomUUID) return c.randomUUID();
+	// Fallback: two random segments (localhost-only, non-cryptographic use is fine).
+	return (
+		Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)
+	);
+}
+
+class InteractivePromptServer {
+	private server: Server | null = null;
+	private port = 0;
+	private readonly sessions = new Map<string, Session>();
+
+	/** Start the server if needed and return the bound port. */
+	async ensureStarted(): Promise<number> {
+		if (this.server) return this.port;
+		const http = nodeRequire<typeof import("http")>("http");
+		if (!http) {
+			throw new Error(
+				"Interactive prompts require desktop Obsidian (Node http is unavailable).",
+			);
+		}
+		return await new Promise<number>((resolve, reject) => {
+			const server = http.createServer(
+				(req: IncomingMessage, res: ServerResponse) =>
+					void this.handle(req, res),
+			);
+			server.on("error", reject);
+			// Port 0 → OS picks a free port. Bind to loopback only.
+			server.listen(0, "127.0.0.1", () => {
+				const address = server.address();
+				this.port =
+					typeof address === "object" && address ? address.port : 0;
+				this.server = server;
+				resolve(this.port);
+			});
+		});
+	}
+
+	createSession(): { id: string; token: string } {
+		const id = randomId();
+		const token = randomId() + randomId();
+		this.sessions.set(id, {
+			id,
+			token,
+			queue: [],
+			waiter: null,
+			waiterTimer: null,
+			pending: new Map(),
+			finished: false,
+			cleanupTimer: null,
+		});
+		return { id, token };
+	}
+
+	/** Raise a prompt for a session and resolve when the client replies. */
+	emitPrompt(sessionId: string, prompt: PromptSpec): Promise<unknown> {
+		const session = this.sessions.get(sessionId);
+		if (!session) return Promise.reject(new Error("Unknown session"));
+		const requestId = randomId();
+		return new Promise<unknown>((resolve, reject) => {
+			session.pending.set(requestId, { resolve, reject });
+			this.push(session, { kind: "prompt", requestId, prompt });
+		});
+	}
+
+	/** Deliver the run's final outcome and schedule the session for cleanup. */
+	finish(
+		sessionId: string,
+		event: { kind: "done"; result: unknown } | { kind: "error"; error: string },
+	): void {
+		const session = this.sessions.get(sessionId);
+		if (!session || session.finished) return;
+		session.finished = true;
+		for (const [, pending] of session.pending) {
+			pending.reject(new Error("Interactive session ended"));
+		}
+		session.pending.clear();
+		this.push(session, event);
+		session.cleanupTimer = setTimeout(
+			() => this.destroySession(session),
+			SESSION_TTL_MS,
+		);
+	}
+
+	/** Stop the server and drop all sessions (plugin unload). */
+	stop(): void {
+		for (const session of this.sessions.values()) {
+			if (session.waiterTimer) clearTimeout(session.waiterTimer);
+			if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
+			for (const [, pending] of session.pending) {
+				pending.reject(new Error("QuickAdd unloaded"));
+			}
+		}
+		this.sessions.clear();
+		this.server?.close();
+		this.server = null;
+		this.port = 0;
+	}
+
+	private push(session: Session, event: ServerEvent): void {
+		if (session.waiter) {
+			const waiter = session.waiter;
+			session.waiter = null;
+			if (session.waiterTimer) {
+				clearTimeout(session.waiterTimer);
+				session.waiterTimer = null;
+			}
+			waiter(event);
+		} else {
+			session.queue.push(event);
+		}
+	}
+
+	private destroySession(session: Session): void {
+		if (session.waiterTimer) clearTimeout(session.waiterTimer);
+		if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
+		this.sessions.delete(session.id);
+		if (this.sessions.size === 0) {
+			this.server?.close();
+			this.server = null;
+			this.port = 0;
+		}
+	}
+
+	private authed(session: Session | undefined, token: string | null): session is Session {
+		return !!session && !!token && session.token === token;
+	}
+
+	private send(res: ServerResponse, status: number, body: unknown): void {
+		const payload = JSON.stringify(body);
+		res.writeHead(status, {
+			"content-type": "application/json",
+			"cache-control": "no-store",
+		});
+		res.end(payload);
+	}
+
+	private async readBody(req: IncomingMessage): Promise<unknown> {
+		const chunks: Buffer[] = [];
+		let size = 0;
+		for await (const chunk of req) {
+			size += (chunk as Buffer).length;
+			// Interactive replies are tiny; cap to avoid buffering junk.
+			if (size > 1_000_000) throw new Error("Request body too large");
+			chunks.push(chunk as Buffer);
+		}
+		if (chunks.length === 0) return {};
+		return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+	}
+
+	private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+		try {
+			const url = new URL(req.url ?? "/", "http://127.0.0.1");
+			const sessionId = url.searchParams.get("session");
+			const token = url.searchParams.get("token");
+			const session = sessionId
+				? this.sessions.get(sessionId)
+				: undefined;
+
+			if (!this.authed(session, token)) {
+				this.send(res, 404, { ok: false, error: "Unknown session or token" });
+				return;
+			}
+
+			if (req.method === "GET" && url.pathname === "/poll") {
+				this.handlePoll(session, res);
+				return;
+			}
+			if (req.method === "POST" && url.pathname === "/reply") {
+				const body = (await this.readBody(req)) as {
+					requestId?: string;
+					value?: unknown;
+					cancelled?: boolean;
+				};
+				this.handleReply(session, body);
+				this.send(res, 200, { ok: true });
+				return;
+			}
+
+			this.send(res, 404, { ok: false, error: "Not found" });
+		} catch (error) {
+			this.send(res, 400, {
+				ok: false,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	private handlePoll(session: Session, res: ServerResponse): void {
+		const queued = session.queue.shift();
+		if (queued) {
+			this.send(res, 200, queued);
+			return;
+		}
+		// Long-poll: hold the request until the next event or a keepalive timeout.
+		session.waiter = (event) => this.send(res, 200, event);
+		session.waiterTimer = setTimeout(() => {
+			session.waiter = null;
+			session.waiterTimer = null;
+			this.send(res, 200, { kind: "idle" } satisfies ServerEvent);
+		}, LONG_POLL_MS);
+		res.on("close", () => {
+			// Client hung up mid-poll; drop the waiter so we don't write to a dead socket.
+			if (session.waiterTimer) clearTimeout(session.waiterTimer);
+			session.waiter = null;
+			session.waiterTimer = null;
+		});
+	}
+
+	private handleReply(
+		session: Session,
+		body: { requestId?: string; value?: unknown; cancelled?: boolean },
+	): void {
+		if (!body.requestId) return;
+		const pending = session.pending.get(body.requestId);
+		if (!pending) return;
+		session.pending.delete(body.requestId);
+		if (body.cancelled) {
+			pending.reject(new Error("Prompt cancelled"));
+		} else {
+			pending.resolve(body.value);
+		}
+	}
+}
+
+export const interactivePromptServer = new InteractivePromptServer();

--- a/src/interactive/interactivePromptServer.ts
+++ b/src/interactive/interactivePromptServer.ts
@@ -18,6 +18,14 @@
  */
 
 import type { Server, IncomingMessage, ServerResponse } from "http";
+import { UserCancelError } from "../errors/UserCancelError";
+
+/** The sliver of Node's `http` module we use (required lazily, desktop only). */
+type HttpModule = {
+	createServer: (
+		listener: (req: IncomingMessage, res: ServerResponse) => void,
+	) => Server;
+};
 
 export interface SuggesterItem {
 	/** Text shown to the user. */
@@ -83,6 +91,8 @@ export type PromptSpec =
 			placeholder?: string;
 			defaultValue?: string;
 			dateFormat?: string;
+			/** Render a date *and time* picker (VDATE `|time`/`|datetime`). */
+			withTime?: boolean;
 	  }
 	| { type: "confirm"; header: string; text?: string }
 	| { type: "checkbox"; header?: string; items: CheckboxItem[] }
@@ -157,9 +167,14 @@ function nodeRequire<T>(mod: string): T | null {
 function randomId(): string {
 	const c = (globalThis as { crypto?: Crypto }).crypto;
 	if (c?.randomUUID) return c.randomUUID();
-	// Fallback: two random segments (localhost-only, non-cryptographic use is fine).
-	return (
-		Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)
+	// The bearer token is the only local auth secret, so never fall back to a
+	// non-cryptographic source: use getRandomValues, else fail closed.
+	if (c?.getRandomValues) {
+		const bytes = c.getRandomValues(new Uint8Array(16));
+		return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+	}
+	throw new Error(
+		"Interactive prompts require a secure random source (crypto), which is unavailable here.",
 	);
 }
 
@@ -167,24 +182,42 @@ class InteractivePromptServer {
 	private server: Server | null = null;
 	private port = 0;
 	private readonly sessions = new Map<string, Session>();
+	// Memoized so concurrent ensureStarted() calls share one listen (no leaked
+	// duplicate servers on a race between two interactive runs).
+	private startPromise: Promise<number> | null = null;
+	// Bumped by stop(). A listen() callback that resolves after a stop() belongs
+	// to a torn-down generation and must discard its server, never install it —
+	// otherwise unloading QuickAdd mid-startup leaves a live listener behind.
+	private generation = 0;
 
 	/** Start the server if needed and return the bound port. */
 	async ensureStarted(): Promise<number> {
 		if (this.server) return this.port;
-		const http = nodeRequire<typeof import("http")>("http");
+		if (this.startPromise) return this.startPromise;
+		const http = nodeRequire<HttpModule>("http");
 		if (!http) {
 			throw new Error(
 				"Interactive prompts require desktop Obsidian (Node http is unavailable).",
 			);
 		}
-		return await new Promise<number>((resolve, reject) => {
+		const generation = this.generation;
+		this.startPromise = new Promise<number>((resolve, reject) => {
 			const server = http.createServer(
 				(req: IncomingMessage, res: ServerResponse) =>
 					void this.handle(req, res),
 			);
-			server.on("error", reject);
+			server.on("error", (error) => {
+				if (this.generation === generation) this.startPromise = null;
+				reject(error);
+			});
 			// Port 0 → OS picks a free port. Bind to loopback only.
 			server.listen(0, "127.0.0.1", () => {
+				if (this.generation !== generation) {
+					// stop() ran while we were binding — discard this listener.
+					server.close();
+					reject(new Error("Interactive server stopped during startup."));
+					return;
+				}
 				const address = server.address();
 				this.port =
 					typeof address === "object" && address ? address.port : 0;
@@ -192,6 +225,7 @@ class InteractivePromptServer {
 				resolve(this.port);
 			});
 		});
+		return this.startPromise;
 	}
 
 	createSession(): { id: string; token: string } {
@@ -228,6 +262,12 @@ class InteractivePromptServer {
 	emitPrompt(sessionId: string, prompt: PromptSpec): Promise<unknown> {
 		const session = this.sessions.get(sessionId);
 		if (!session) return Promise.reject(new Error("Unknown session"));
+		// A prompt raised after the session ended (e.g. the no-attach timeout
+		// already fired finish()) must reject, not park forever, so the executor
+		// aborts instead of hanging.
+		if (session.finished) {
+			return Promise.reject(new Error("Interactive session ended"));
+		}
 		const requestId = randomId();
 		return new Promise<unknown>((resolve, reject) => {
 			session.pending.set(requestId, { resolve, reject });
@@ -260,6 +300,9 @@ class InteractivePromptServer {
 
 	/** Stop the server and drop all sessions (plugin unload). */
 	stop(): void {
+		// Invalidate any in-flight ensureStarted() so its listen() callback
+		// discards the server instead of installing it after unload.
+		this.generation++;
 		for (const session of this.sessions.values()) {
 			if (session.waiterTimer) clearTimeout(session.waiterTimer);
 			if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
@@ -272,6 +315,7 @@ class InteractivePromptServer {
 		this.server?.close();
 		this.server = null;
 		this.port = 0;
+		this.startPromise = null;
 	}
 
 	private push(session: Session, event: ServerEvent): void {
@@ -292,11 +336,18 @@ class InteractivePromptServer {
 		if (session.waiterTimer) clearTimeout(session.waiterTimer);
 		if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
 		if (session.attachTimer) clearTimeout(session.attachTimer);
+		// Reject any still-pending prompt so a caller awaiting it aborts rather
+		// than hanging (finish() normally clears these, but be defensive).
+		for (const [, pending] of session.pending) {
+			pending.reject(new Error("Interactive session ended"));
+		}
+		session.pending.clear();
 		this.sessions.delete(session.id);
 		if (this.sessions.size === 0) {
 			this.server?.close();
 			this.server = null;
 			this.port = 0;
+			this.startPromise = null;
 		}
 	}
 
@@ -334,7 +385,11 @@ class InteractivePromptServer {
 		const pending = session.pending.get(requestId);
 		if (!pending) return false;
 		session.pending.delete(requestId);
-		if (cancelled) pending.reject(new Error("Prompt cancelled"));
+		// A remote cancel must abort the run exactly like dismissing the Obsidian
+		// modal: reject with UserCancelError so downstream abort handling classifies
+		// it as a user cancellation (x-cancel, suppressed notice) rather than an error.
+		if (cancelled)
+			pending.reject(new UserCancelError("Input cancelled by user"));
 		else pending.resolve(value);
 		return true;
 	}
@@ -389,8 +444,15 @@ class InteractivePromptServer {
 					value?: unknown;
 					cancelled?: boolean;
 				};
-				this.handleReply(session, body);
-				this.send(res, 200, { ok: true });
+				const accepted = this.handleReply(session, body);
+				// A missing/stale requestId matched no pending prompt: tell the
+				// client so it doesn't believe a blocked run was answered.
+				if (accepted) this.send(res, 200, { ok: true });
+				else
+					this.send(res, 409, {
+						ok: false,
+						error: "No pending prompt for that requestId",
+					});
 				return;
 			}
 
@@ -417,15 +479,27 @@ class InteractivePromptServer {
 			this.send(res, 200, queued);
 			return;
 		}
+		// Only one poll may park at a time. A concurrent/overlapping poll (a
+		// misbehaving or double-mounted client) gets an immediate idle instead
+		// of overwriting - and cross-wiring - the parked waiter.
+		if (session.waiter) {
+			this.send(res, 200, { kind: "idle" } satisfies ServerEvent);
+			return;
+		}
 		// Long-poll: hold the request until the next event or a keepalive timeout.
-		session.waiter = (event) => this.send(res, 200, event);
+		// The identity checks below ensure a stale timeout/close only clears the
+		// waiter it created, never a newer one.
+		const waiter = (event: ServerEvent) => this.send(res, 200, event);
+		session.waiter = waiter;
 		session.waiterTimer = setTimeout(() => {
+			if (session.waiter !== waiter) return;
 			session.waiter = null;
 			session.waiterTimer = null;
 			this.send(res, 200, { kind: "idle" } satisfies ServerEvent);
 		}, LONG_POLL_MS);
 		res.on("close", () => {
 			// Client hung up mid-poll; drop the waiter so we don't write to a dead socket.
+			if (session.waiter !== waiter) return;
 			if (session.waiterTimer) clearTimeout(session.waiterTimer);
 			session.waiter = null;
 			session.waiterTimer = null;
@@ -435,9 +509,14 @@ class InteractivePromptServer {
 	private handleReply(
 		session: Session,
 		body: { requestId?: string; value?: unknown; cancelled?: boolean },
-	): void {
-		if (!body.requestId) return;
-		this.submitReply(session.id, body.requestId, body.value, body.cancelled);
+	): boolean {
+		if (!body.requestId) return false;
+		return this.submitReply(
+			session.id,
+			body.requestId,
+			body.value,
+			body.cancelled,
+		);
 	}
 }
 

--- a/src/interactive/interactivePromptServer.ts
+++ b/src/interactive/interactivePromptServer.ts
@@ -122,6 +122,8 @@ interface Session {
 	attached: boolean;
 	/** Aborts the run if no client attaches in time (avoids a hung executor). */
 	attachTimer: ReturnType<typeof setTimeout> | null;
+	/** Aborts the run if an attached client stops polling (disconnect/crash). */
+	pollWatchdog: ReturnType<typeof setTimeout> | null;
 }
 
 const LONG_POLL_MS = 25_000;
@@ -129,6 +131,13 @@ const LONG_POLL_MS = 25_000;
 const SESSION_TTL_MS = 60_000;
 /** Abort a run whose caller never attached, so a prompt can't park forever. */
 const ATTACH_TIMEOUT_MS = 30_000;
+/**
+ * Abort a run whose attached client stopped polling. A healthy client re-polls
+ * at least every LONG_POLL_MS (25s), so this generous multiple only fires on a
+ * genuine disconnect/crash — otherwise a prompt awaiting a reply would hang the
+ * executor and leak the session forever.
+ */
+const POLL_TIMEOUT_MS = 75_000;
 /** Bound concurrent sessions so a runaway caller can't exhaust memory. */
 const MAX_SESSIONS = 32;
 
@@ -245,6 +254,7 @@ class InteractivePromptServer {
 			cleanupTimer: null,
 			attached: false,
 			attachTimer: null,
+			pollWatchdog: null,
 		};
 		session.attachTimer = setTimeout(() => {
 			if (!session.attached && !session.finished) {
@@ -287,6 +297,10 @@ class InteractivePromptServer {
 			clearTimeout(session.attachTimer);
 			session.attachTimer = null;
 		}
+		if (session.pollWatchdog) {
+			clearTimeout(session.pollWatchdog);
+			session.pollWatchdog = null;
+		}
 		for (const [, pending] of session.pending) {
 			pending.reject(new Error("Interactive session ended"));
 		}
@@ -307,8 +321,16 @@ class InteractivePromptServer {
 			if (session.waiterTimer) clearTimeout(session.waiterTimer);
 			if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
 			if (session.attachTimer) clearTimeout(session.attachTimer);
+			if (session.pollWatchdog) clearTimeout(session.pollWatchdog);
 			for (const [, pending] of session.pending) {
 				pending.reject(new Error("QuickAdd unloaded"));
+			}
+			// Close any parked long-poll response so it isn't orphaned after
+			// server.close() (which won't terminate in-flight connections).
+			if (session.waiter) {
+				const waiter = session.waiter;
+				session.waiter = null;
+				waiter({ kind: "error", error: "QuickAdd unloaded" });
 			}
 		}
 		this.sessions.clear();
@@ -336,6 +358,7 @@ class InteractivePromptServer {
 		if (session.waiterTimer) clearTimeout(session.waiterTimer);
 		if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
 		if (session.attachTimer) clearTimeout(session.attachTimer);
+		if (session.pollWatchdog) clearTimeout(session.pollWatchdog);
 		// Reject any still-pending prompt so a caller awaiting it aborts rather
 		// than hanging (finish() normally clears these, but be defensive).
 		for (const [, pending] of session.pending) {
@@ -474,6 +497,16 @@ class InteractivePromptServer {
 				session.attachTimer = null;
 			}
 		}
+		// Reset the disconnect watchdog on every poll: while the client keeps
+		// polling the run stays alive; if it goes silent, abort so a pending
+		// prompt doesn't hang the executor and leak the session.
+		if (session.pollWatchdog) clearTimeout(session.pollWatchdog);
+		session.pollWatchdog = setTimeout(() => {
+			this.finish(session.id, {
+				kind: "error",
+				error: "Interactive client disconnected.",
+			});
+		}, POLL_TIMEOUT_MS);
 		const queued = session.queue.shift();
 		if (queued) {
 			this.send(res, 200, queued);

--- a/src/interactive/interactivePromptServer.ts
+++ b/src/interactive/interactivePromptServer.ts
@@ -32,6 +32,29 @@ export interface CheckboxItem {
 	checked: boolean;
 }
 
+/** One field of a batch `requestInputs` form (a subset of QuickAdd's FieldRequirement). */
+export interface FormField {
+	id: string;
+	label: string;
+	type:
+		| "text"
+		| "number"
+		| "textarea"
+		| "dropdown"
+		| "date"
+		| "suggester"
+		| "slider"
+		| "field-suggest";
+	placeholder?: string;
+	defaultValue?: string;
+	description?: string;
+	options?: string[];
+	dateFormat?: string;
+	optional?: boolean;
+	numericConfig?: { min?: number; max?: number; step?: number };
+	suggesterConfig?: { allowCustomInput?: boolean; multiSelect?: boolean };
+}
+
 /**
  * A prompt the running script is blocked on. Mirrors the QuickAdd API prompt
  * seam (suggester / inputPrompt / wideInputPrompt / datePrompt / yesNoPrompt /
@@ -63,7 +86,8 @@ export type PromptSpec =
 	  }
 	| { type: "confirm"; header: string; text?: string }
 	| { type: "checkbox"; header?: string; items: CheckboxItem[] }
-	| { type: "info"; header: string; text: string[] };
+	| { type: "info"; header: string; text: string[] }
+	| { type: "form"; fields: FormField[] };
 
 /** Events streamed to the polling client. */
 type ServerEvent =

--- a/src/interactive/promptProvider.test.ts
+++ b/src/interactive/promptProvider.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RemotePromptProvider } from "./promptProvider";
+import type { FieldRequirement } from "../preflight/RequirementCollector";
+import type { interactivePromptServer } from "./interactivePromptServer";
+
+type ServerLike = typeof interactivePromptServer;
+
+/** A server stub that resolves every emitPrompt with a canned answer. */
+function fakeServer(answer: unknown): ServerLike {
+	return {
+		emitPrompt: vi.fn(async () => answer),
+	} as unknown as ServerLike;
+}
+
+function dateField(id: string): FieldRequirement {
+	return { id, label: id, type: "date" };
+}
+
+afterEach(() => {
+	delete (window as Window & { moment?: unknown }).moment;
+	vi.clearAllMocks();
+});
+
+describe("RemotePromptProvider date marshaling", () => {
+	it("datePrompt returns the full ISO when no dateFormat (matches QuickAddApi.datePrompt)", async () => {
+		const provider = new RemotePromptProvider(
+			"s",
+			fakeServer("2025-12-10T15:41:11.393Z"),
+		);
+		expect(await provider.datePrompt("When")).toBe(
+			"2025-12-10T15:41:11.393Z",
+		);
+	});
+
+	it("datePrompt strips a leading @date: from the client answer", async () => {
+		const provider = new RemotePromptProvider(
+			"s",
+			fakeServer("@date:2025-12-10T15:41:11.393Z"),
+		);
+		expect(await provider.datePrompt("When")).toBe(
+			"2025-12-10T15:41:11.393Z",
+		);
+	});
+
+	it("datePrompt formats with dateFormat when provided", async () => {
+		(window as Window & { moment?: unknown }).moment = (iso: string) => ({
+			isValid: () => Boolean(iso),
+			format: (fmt: string) =>
+				fmt === "YYYY-MM-DD" ? "2025-12-10" : `fmt-${fmt}`,
+		});
+		const provider = new RemotePromptProvider(
+			"s",
+			fakeServer("2025-12-10T15:41:11.393Z"),
+		);
+		expect(
+			await provider.datePrompt("When", { dateFormat: "YYYY-MM-DD" }),
+		).toBe("2025-12-10");
+	});
+
+	it("requestInputs wraps a date-field answer as @date:ISO, leaving other fields untouched", async () => {
+		const provider = new RemotePromptProvider(
+			"s",
+			fakeServer({ d: "2025-12-10T15:41:11.393Z", name: "hi" }),
+		);
+		const out = await provider.requestInputs([
+			dateField("d"),
+			{ id: "name", label: "Name", type: "text" },
+		]);
+		expect(out.d).toBe("@date:2025-12-10T15:41:11.393Z");
+		expect(out.name).toBe("hi");
+	});
+
+	it("requestInputs does not double-wrap an answer already prefixed with @date:", async () => {
+		const provider = new RemotePromptProvider(
+			"s",
+			fakeServer({ d: "@date:2025-12-10T15:41:11.393Z" }),
+		);
+		const out = await provider.requestInputs([dateField("d")]);
+		expect(out.d).toBe("@date:2025-12-10T15:41:11.393Z");
+	});
+});

--- a/src/interactive/promptProvider.test.ts
+++ b/src/interactive/promptProvider.test.ts
@@ -79,3 +79,43 @@ describe("RemotePromptProvider date marshaling", () => {
 		expect(out.d).toBe("@date:2025-12-10T15:41:11.393Z");
 	});
 });
+
+describe("RemotePromptProvider suggester marshaling", () => {
+	it("returns the original actualItems entry (object identity), not a stringified copy", async () => {
+		const file = { basename: "note", path: "a/note.md" };
+		const other = { basename: "x", path: "x.md" };
+		let sentItems: { title: string; value: string }[] = [];
+		const server = {
+			emitPrompt: vi.fn(async (_id: string, spec: unknown) => {
+				sentItems = (spec as { items: { title: string; value: string }[] })
+					.items;
+				// Client selects the first item by its opaque wire token.
+				return sentItems[0].value;
+			}),
+		} as unknown as ServerLike;
+		const provider = new RemotePromptProvider("s", server);
+
+		const result = await provider.suggester(
+			(f: unknown) => (f as { basename: string }).basename,
+			[file, other] as unknown as string[],
+			undefined,
+			false,
+		);
+
+		// Same object reference back, exactly like GenericSuggester.
+		expect(result).toBe(file);
+		// Display function drives the title; the wire value is an opaque token,
+		// never the stringified object.
+		expect(sentItems[0].title).toBe("note");
+		expect(sentItems[0].value).not.toBe("[object Object]");
+	});
+
+	it("returns a custom-typed value verbatim when allowCustomInput is set", async () => {
+		const provider = new RemotePromptProvider(
+			"s",
+			fakeServer("typed custom"),
+		);
+		const result = await provider.suggester(["a"], ["a"], undefined, true);
+		expect(result).toBe("typed custom");
+	});
+});

--- a/src/interactive/promptProvider.ts
+++ b/src/interactive/promptProvider.ts
@@ -16,6 +16,13 @@ import {
 	interactivePromptServer,
 } from "./interactivePromptServer";
 
+/**
+ * Prefix for the opaque token a suggester reply carries for a *selected* item
+ * (as opposed to a custom-typed value). The NUL char makes a collision with real
+ * user input effectively impossible.
+ */
+const SUGGESTER_INDEX_PREFIX = "\u0000qa-idx:";
+
 export interface PromptProvider {
 	/** Batch multi-field prompt (`quickAddApi.requestInputs`). Returns id -> value. */
 	requestInputs(fields: FieldRequirement[]): Promise<Record<string, string>>;
@@ -26,7 +33,7 @@ export interface PromptProvider {
 		actualItems: string[],
 		placeholder?: string,
 		allowCustomInput?: boolean,
-	): Promise<string>;
+	): Promise<unknown>;
 	inputPrompt(
 		header: string,
 		placeholder?: string,
@@ -69,7 +76,7 @@ export class RemotePromptProvider implements PromptProvider {
 		actualItems: string[],
 		placeholder?: string,
 		allowCustomInput = false,
-	): Promise<string> {
+	): Promise<unknown> {
 		const displays =
 			typeof displayItems === "function"
 				? actualItems.map((value, index, arr) =>
@@ -77,9 +84,12 @@ export class RemotePromptProvider implements PromptProvider {
 					)
 				: displayItems.map((label) => String(label));
 
+		// Wire the reply as an opaque index token so we can map it back to the
+		// ORIGINAL actualItems entry, preserving object identity exactly like
+		// GenericSuggester (scripts that suggest TFiles/records read .basename etc.).
 		const items = actualItems.map((value, index) => ({
 			title: displays[index] ?? String(value),
-			value: String(value),
+			value: `${SUGGESTER_INDEX_PREFIX}${index}`,
 		}));
 
 		const answer = await this.server.emitPrompt(this.sessionId, {
@@ -88,7 +98,16 @@ export class RemotePromptProvider implements PromptProvider {
 			allowCustomInput,
 			items,
 		});
-		return answer == null ? "" : String(answer);
+		if (answer == null) return "";
+		const raw = String(answer);
+		if (raw.startsWith(SUGGESTER_INDEX_PREFIX)) {
+			const index = Number(raw.slice(SUGGESTER_INDEX_PREFIX.length));
+			if (Number.isInteger(index) && index >= 0 && index < actualItems.length) {
+				return actualItems[index];
+			}
+		}
+		// A custom-typed value (allowCustomInput) is returned verbatim.
+		return raw;
 	}
 
 	async inputPrompt(

--- a/src/interactive/promptProvider.ts
+++ b/src/interactive/promptProvider.ts
@@ -39,7 +39,12 @@ export interface PromptProvider {
 	): Promise<string>;
 	datePrompt(
 		header: string,
-		options?: { placeholder?: string; defaultValue?: string; dateFormat?: string },
+		options?: {
+			placeholder?: string;
+			defaultValue?: string;
+			dateFormat?: string;
+			withTime?: boolean;
+		},
 	): Promise<string>;
 	yesNoPrompt(header: string, text?: string): Promise<boolean>;
 	checkboxPrompt(
@@ -120,7 +125,12 @@ export class RemotePromptProvider implements PromptProvider {
 
 	async datePrompt(
 		header: string,
-		options?: { placeholder?: string; defaultValue?: string; dateFormat?: string },
+		options?: {
+			placeholder?: string;
+			defaultValue?: string;
+			dateFormat?: string;
+			withTime?: boolean;
+		},
 	): Promise<string> {
 		const answer = await this.server.emitPrompt(this.sessionId, {
 			type: "date",
@@ -128,14 +138,17 @@ export class RemotePromptProvider implements PromptProvider {
 			placeholder: options?.placeholder,
 			defaultValue: options?.defaultValue,
 			dateFormat: options?.dateFormat,
+			withTime: options?.withTime,
 		});
-		const iso = String(answer ?? "");
-		if (!iso) return "";
-		// Match VDateInputPrompt's output: format the picked ISO date with the
-		// requested format, falling back to the date part of the ISO string.
+		const raw = String(answer ?? "");
+		if (!raw) return "";
+		// The client may send a bare ISO or an `@date:ISO`; normalize to the ISO.
+		const iso = raw.startsWith("@date:") ? raw.slice(6) : raw;
+		// Match QuickAddApi.datePrompt exactly: format with the requested format,
+		// else return the full ISO string (not just its date part).
 		const format = options?.dateFormat;
 		const formatted = format ? formatISODate(iso, format) : null;
-		return formatted ?? (iso.length >= 10 ? iso.slice(0, 10) : iso);
+		return formatted ?? iso;
 	}
 
 	async yesNoPrompt(header: string, text?: string): Promise<boolean> {
@@ -201,9 +214,19 @@ export class RemotePromptProvider implements PromptProvider {
 			fields: formFields,
 		});
 		if (!answer || typeof answer !== "object") return {};
+		// Date fields must come back as `@date:ISO`, matching OnePageInputModal, so
+		// QuickAddApi.requestInputs' shared post-processing stores the raw ISO and
+		// applies dateFormat identically to the in-app path.
+		const dateFieldIds = new Set(
+			fields.filter((field) => field.type === "date").map((field) => field.id),
+		);
 		const result: Record<string, string> = {};
 		for (const [key, value] of Object.entries(answer as Record<string, unknown>)) {
-			result[key] = value == null ? "" : String(value);
+			let str = value == null ? "" : String(value);
+			if (str && dateFieldIds.has(key) && !str.startsWith("@date:")) {
+				str = `@date:${str}`;
+			}
+			result[key] = str;
 		}
 		return result;
 	}

--- a/src/interactive/promptProvider.ts
+++ b/src/interactive/promptProvider.ts
@@ -3,20 +3,45 @@
  * modal. When a choice executor carries a provider (a remote interactive session
  * driven by an external front end), prompts are routed to it instead of the app.
  *
- * Spike scope: `suggester`. The interface will grow to cover the rest of the
- * prompt seam (inputPrompt / yesNoPrompt / checkboxPrompt / ...) as they are
- * forwarded.
+ * Covers the full script prompt seam: suggester / inputPrompt / wideInputPrompt /
+ * datePrompt / yesNoPrompt / checkboxPrompt / infoDialog. Each method returns
+ * exactly what its in-app counterpart returns, so a script cannot tell it was
+ * driven remotely.
  */
 
+import { formatISODate } from "../utils/dateParser";
 import { interactivePromptServer } from "./interactivePromptServer";
 
 export interface PromptProvider {
 	suggester(
-		displayItems: string[] | ((value: string, index?: number, arr?: string[]) => string),
+		displayItems:
+			| string[]
+			| ((value: string, index?: number, arr?: string[]) => string),
 		actualItems: string[],
 		placeholder?: string,
 		allowCustomInput?: boolean,
 	): Promise<string>;
+	inputPrompt(
+		header: string,
+		placeholder?: string,
+		value?: string,
+	): Promise<string>;
+	wideInputPrompt(
+		header: string,
+		placeholder?: string,
+		value?: string,
+	): Promise<string>;
+	datePrompt(
+		header: string,
+		options?: { placeholder?: string; defaultValue?: string; dateFormat?: string },
+	): Promise<string>;
+	yesNoPrompt(header: string, text?: string): Promise<boolean>;
+	checkboxPrompt(
+		items: string[],
+		selectedItems?: string[],
+		header?: string,
+	): Promise<string[]>;
+	infoDialog(header: string, text: string[] | string): Promise<void>;
 }
 
 /** Routes prompts to a connected front end over the interactive server session. */
@@ -52,9 +77,93 @@ export class RemotePromptProvider implements PromptProvider {
 			allowCustomInput,
 			items,
 		});
-
-		// A rejected reply (cancel) throws upstream in emitPrompt; here `answer` is
-		// the chosen item's value, or free text when allowCustomInput is set.
 		return answer == null ? "" : String(answer);
+	}
+
+	async inputPrompt(
+		header: string,
+		placeholder?: string,
+		value?: string,
+	): Promise<string> {
+		return this.textPrompt(header, placeholder, value, false);
+	}
+
+	async wideInputPrompt(
+		header: string,
+		placeholder?: string,
+		value?: string,
+	): Promise<string> {
+		return this.textPrompt(header, placeholder, value, true);
+	}
+
+	private async textPrompt(
+		header: string,
+		placeholder: string | undefined,
+		value: string | undefined,
+		multiline: boolean,
+	): Promise<string> {
+		const answer = await this.server.emitPrompt(this.sessionId, {
+			type: "input",
+			header,
+			placeholder,
+			defaultValue: value,
+			multiline,
+		});
+		return answer == null ? "" : String(answer);
+	}
+
+	async datePrompt(
+		header: string,
+		options?: { placeholder?: string; defaultValue?: string; dateFormat?: string },
+	): Promise<string> {
+		const answer = await this.server.emitPrompt(this.sessionId, {
+			type: "date",
+			header,
+			placeholder: options?.placeholder,
+			defaultValue: options?.defaultValue,
+			dateFormat: options?.dateFormat,
+		});
+		const iso = String(answer ?? "");
+		if (!iso) return "";
+		// Match VDateInputPrompt's output: format the picked ISO date with the
+		// requested format, falling back to the date part of the ISO string.
+		const format = options?.dateFormat;
+		const formatted = format ? formatISODate(iso, format) : null;
+		return formatted ?? (iso.length >= 10 ? iso.slice(0, 10) : iso);
+	}
+
+	async yesNoPrompt(header: string, text?: string): Promise<boolean> {
+		const answer = await this.server.emitPrompt(this.sessionId, {
+			type: "confirm",
+			header,
+			text,
+		});
+		return answer === true || answer === "true";
+	}
+
+	async checkboxPrompt(
+		items: string[],
+		selectedItems?: string[],
+		header?: string,
+	): Promise<string[]> {
+		const selected = new Set(selectedItems ?? []);
+		const answer = await this.server.emitPrompt(this.sessionId, {
+			type: "checkbox",
+			header,
+			items: items.map((value) => ({
+				title: String(value),
+				value: String(value),
+				checked: selected.has(value),
+			})),
+		});
+		return Array.isArray(answer) ? answer.map((v) => String(v)) : [];
+	}
+
+	async infoDialog(header: string, text: string[] | string): Promise<void> {
+		await this.server.emitPrompt(this.sessionId, {
+			type: "info",
+			header,
+			text: Array.isArray(text) ? text : [text],
+		});
 	}
 }

--- a/src/interactive/promptProvider.ts
+++ b/src/interactive/promptProvider.ts
@@ -1,0 +1,60 @@
+/**
+ * Abstraction the QuickAdd API prompt methods consult before opening an Obsidian
+ * modal. When a choice executor carries a provider (a remote interactive session
+ * driven by an external front end), prompts are routed to it instead of the app.
+ *
+ * Spike scope: `suggester`. The interface will grow to cover the rest of the
+ * prompt seam (inputPrompt / yesNoPrompt / checkboxPrompt / ...) as they are
+ * forwarded.
+ */
+
+import { interactivePromptServer } from "./interactivePromptServer";
+
+export interface PromptProvider {
+	suggester(
+		displayItems: string[] | ((value: string, index?: number, arr?: string[]) => string),
+		actualItems: string[],
+		placeholder?: string,
+		allowCustomInput?: boolean,
+	): Promise<string>;
+}
+
+/** Routes prompts to a connected front end over the interactive server session. */
+export class RemotePromptProvider implements PromptProvider {
+	constructor(
+		private readonly sessionId: string,
+		private readonly server = interactivePromptServer,
+	) {}
+
+	async suggester(
+		displayItems:
+			| string[]
+			| ((value: string, index?: number, arr?: string[]) => string),
+		actualItems: string[],
+		placeholder?: string,
+		allowCustomInput = false,
+	): Promise<string> {
+		const displays =
+			typeof displayItems === "function"
+				? actualItems.map((value, index, arr) =>
+						String(displayItems(value, index, arr)),
+					)
+				: displayItems.map((label) => String(label));
+
+		const items = actualItems.map((value, index) => ({
+			title: displays[index] ?? String(value),
+			value: String(value),
+		}));
+
+		const answer = await this.server.emitPrompt(this.sessionId, {
+			type: "suggester",
+			placeholder,
+			allowCustomInput,
+			items,
+		});
+
+		// A rejected reply (cancel) throws upstream in emitPrompt; here `answer` is
+		// the chosen item's value, or free text when allowCustomInput is set.
+		return answer == null ? "" : String(answer);
+	}
+}

--- a/src/interactive/promptProvider.ts
+++ b/src/interactive/promptProvider.ts
@@ -10,9 +10,15 @@
  */
 
 import { formatISODate } from "../utils/dateParser";
-import { interactivePromptServer } from "./interactivePromptServer";
+import type { FieldRequirement } from "../preflight/RequirementCollector";
+import {
+	type FormField,
+	interactivePromptServer,
+} from "./interactivePromptServer";
 
 export interface PromptProvider {
+	/** Batch multi-field prompt (`quickAddApi.requestInputs`). Returns id -> value. */
+	requestInputs(fields: FieldRequirement[]): Promise<Record<string, string>>;
 	suggester(
 		displayItems:
 			| string[]
@@ -165,5 +171,40 @@ export class RemotePromptProvider implements PromptProvider {
 			header,
 			text: Array.isArray(text) ? text : [text],
 		});
+	}
+
+	async requestInputs(
+		fields: FieldRequirement[],
+	): Promise<Record<string, string>> {
+		const formFields: FormField[] = fields.map((field) => ({
+			id: field.id,
+			label: field.label ?? field.id,
+			type:
+				field.type === "file-picker" ? "suggester" : (field.type as FormField["type"]),
+			placeholder: field.placeholder,
+			defaultValue: field.defaultValue,
+			description: field.description,
+			options: field.options,
+			dateFormat: field.dateFormat,
+			optional: field.optional,
+			numericConfig: field.numericConfig,
+			suggesterConfig: field.suggesterConfig
+				? {
+						allowCustomInput: field.suggesterConfig.allowCustomInput,
+						multiSelect: field.suggesterConfig.multiSelect,
+					}
+				: undefined,
+		}));
+
+		const answer = await this.server.emitPrompt(this.sessionId, {
+			type: "form",
+			fields: formFields,
+		});
+		if (!answer || typeof answer !== "object") return {};
+		const result: Record<string, string> = {};
+		for (const [key, value] of Object.entries(answer as Record<string, unknown>)) {
+			result[key] = value == null ? "" : String(value);
+		}
+		return result;
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import { UpdateModal } from "./gui/UpdateModal/UpdateModal";
 import { CommandType } from "./types/macros/CommandType";
 import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
+import { interactivePromptServer } from "./interactive/interactivePromptServer";
 import { parseSemver } from "./utils/semver";
 import { dedupeChoicesById, resolveChoiceIcon } from "./utils/choiceUtils";
 import { isReservedVariableKey } from "./utils/reservedVariableKeys";
@@ -438,6 +439,10 @@ export default class QuickAdd extends Plugin {
 		// Clean up field suggestion cache
 		const cache = FieldSuggestionCache.getInstance();
 		cache.destroy();
+
+		// Stop the interactive-prompt bridge (closes the localhost server and drops
+		// any in-flight sessions) so nothing keeps listening after unload.
+		interactivePromptServer.stop();
 	}
 
 	async loadSettings() {

--- a/src/quickAddApi.requestInputs.test.ts
+++ b/src/quickAddApi.requestInputs.test.ts
@@ -83,4 +83,44 @@ describe("QuickAddApi.requestInputs", () => {
 		expect(result["raw-date"]).toBe("@date:2025-12-10T15:41:11.393Z");
 		expect(choiceExecutor.variables.get("raw-date")).toBe("@date:2025-12-10T15:41:11.393Z");
 	});
+
+	it("routes to a remote prompt provider instead of the modal when one is set", async () => {
+		// The modal would return {} (empty) here; the provider returns rating=8, so
+		// seeing 8 proves the provider path ran, not the modal.
+		modalReturnValue = {};
+		const providerRequestInputs = vi.fn(
+			async (_fields: Array<Record<string, unknown>>) => ({ rating: "8" }),
+		);
+		(choiceExecutor as IChoiceExecutor).promptProvider = {
+			requestInputs: providerRequestInputs,
+		} as unknown as IChoiceExecutor["promptProvider"];
+
+		const api = QuickAddApi.GetApi({} as App, plugin, choiceExecutor);
+		const result = await api.requestInputs([
+			{ id: "rating", type: "suggester", options: ["10", "9", "8"] },
+		]);
+
+		expect(providerRequestInputs).toHaveBeenCalledTimes(1);
+		expect(providerRequestInputs.mock.calls[0][0][0]).toMatchObject({
+			id: "rating",
+			type: "suggester",
+			options: ["10", "9", "8"],
+		});
+		expect(result.rating).toBe("8");
+		expect(choiceExecutor.variables.get("rating")).toBe("8");
+	});
+
+	it("does not re-ask (nor call the provider) for inputs already in variables", async () => {
+		const providerRequestInputs = vi.fn(async () => ({ x: "asked" }));
+		(choiceExecutor as IChoiceExecutor).promptProvider = {
+			requestInputs: providerRequestInputs,
+		} as unknown as IChoiceExecutor["promptProvider"];
+		choiceExecutor.variables.set("x", "preset");
+
+		const api = QuickAddApi.GetApi({} as App, plugin, choiceExecutor);
+		const result = await api.requestInputs([{ id: "x", type: "text" }]);
+
+		expect(providerRequestInputs).not.toHaveBeenCalled();
+		expect(result.x).toBe("preset");
+	});
 });

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -279,6 +279,8 @@ export class QuickAddApi {
 				value?: string,
 				options?: InputPromptOptions,
 			) => {
+				const provider = choiceExecutor?.promptProvider;
+				if (provider) return provider.inputPrompt(header, placeholder, value);
 				return QuickAddApi.inputPrompt(app, header, placeholder, value, options);
 			},
 			datePrompt: (
@@ -289,6 +291,8 @@ export class QuickAddApi {
 					dateFormat?: string;
 				},
 			) => {
+				const provider = choiceExecutor?.promptProvider;
+				if (provider) return provider.datePrompt(header, options);
 				return QuickAddApi.datePrompt(app, header, options);
 			},
 			wideInputPrompt: (
@@ -297,6 +301,8 @@ export class QuickAddApi {
 				value?: string,
 				options?: InputPromptOptions,
 			) => {
+				const provider = choiceExecutor?.promptProvider;
+				if (provider) return provider.wideInputPrompt(header, placeholder, value);
 				return QuickAddApi.wideInputPrompt(
 					app,
 					header,
@@ -306,9 +312,13 @@ export class QuickAddApi {
 				);
 			},
 			yesNoPrompt: (header: string, text?: string) => {
+				const provider = choiceExecutor?.promptProvider;
+				if (provider) return provider.yesNoPrompt(header, text);
 				return QuickAddApi.yesNoPrompt(app, header, text);
 			},
 			infoDialog: (header: string, text: string[] | string) => {
+				const provider = choiceExecutor?.promptProvider;
+				if (provider) return provider.infoDialog(header, text);
 				return QuickAddApi.infoDialog(app, header, text);
 			},
 			suggester: (
@@ -345,6 +355,10 @@ export class QuickAddApi {
 				selectedItems?: string[],
 				header?: string,
 			) => {
+				const provider = choiceExecutor?.promptProvider;
+				if (provider) {
+					return provider.checkboxPrompt(items, selectedItems, header);
+				}
 				return QuickAddApi.checkboxPrompt(
 					app,
 					items,

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -320,6 +320,17 @@ export class QuickAddApi {
 				allowCustomInput = false,
 				options?: { renderItem?: (value: string, el: HTMLElement) => void; },
 			) => {
+				// Route to a remote interactive session (Raycast) when one is driving
+				// this execution; otherwise open the Obsidian suggester modal.
+				const provider = choiceExecutor?.promptProvider;
+				if (provider) {
+					return provider.suggester(
+						displayItems,
+						actualItems,
+						placeholder,
+						allowCustomInput,
+					);
+				}
 				return QuickAddApi.suggester(
 					app,
 					displayItems,

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -222,16 +222,28 @@ export class QuickAddApi {
 
 				let collected: Record<string, string> = {};
 				if (missing.length > 0) {
-					const modal = new OnePageInputModal(
-						app,
-						missing,
-						choiceExecutor.variables,
-					);
-					try {
-						collected = await modal.waitForClose;
-					} catch (error) {
-						throwIfPromptCancelled(error);
-						throw error;
+					// Route the batch form to a remote interactive session (Raycast)
+					// when one is driving this run; otherwise open the Obsidian modal.
+					const provider = choiceExecutor?.promptProvider;
+					if (provider) {
+						try {
+							collected = await provider.requestInputs(missing);
+						} catch (error) {
+							throwIfPromptCancelled(error);
+							throw error;
+						}
+					} else {
+						const modal = new OnePageInputModal(
+							app,
+							missing,
+							choiceExecutor.variables,
+						);
+						try {
+							collected = await modal.waitForClose;
+						} catch (error) {
+							throwIfPromptCancelled(error);
+							throw error;
+						}
 					}
 				}
 


### PR DESCRIPTION
## What

Adds an **interactive prompt bridge**: a QuickAdd choice's *runtime* prompts - the ones a script raises mid-execution that the requirement collector can't pre-satisfy - can be driven from an external front end (a Raycast extension) instead of Obsidian's native modals. This is the last gap in running arbitrary QuickAdd workflows headlessly: a real Readwise importer (interactive suggester + `requestInputs` form + a `{{VALUE:...}}` rating in its template) now runs end-to-end from Raycast.

Nothing changes for normal in-app or mobile runs. The whole mechanism is inert unless a remote session is explicitly driving execution.

## How

- **`src/interactive/interactivePromptServer.ts`** - a localhost HTTP long-poll server, started on demand via `window.require("http")` (desktop-only Node, so the mobile bundle is untouched), bound to `127.0.0.1` on an OS-assigned port. Multiplexes concurrent sessions by `sessionId` + a per-session bearer token, correlates each prompt to its reply by `requestId`, and stops when the last session is cleaned up.
- **`src/interactive/promptProvider.ts`** - a `PromptProvider` seam on `IChoiceExecutor`. When set, `quickAddApi.*` prompts and `CompleteFormatter` token prompts (`{{VALUE:...}}`, `{{VDATE}}`, `{{MATH}}`) delegate to a `RemotePromptProvider`; when unset they fall through to the Obsidian modal unchanged. Return values are marshaled to be byte-identical to the in-app path, so a script can't tell it was driven remotely.
- **`quickadd:interactive` CLI handler** - returns `{host,port,sessionId,token}` immediately and runs the choice async, delivering the final outcome as a `done`/`error` poll event. Uses `executeWithOutcome()` for Template/Capture so a swallowed engine failure isn't reported as success.
- Docs in `docs/docs/Advanced/CLI.md`.

## Security

This introduces a new listening socket, so it got a deliberate review pass (self-review + an independent adversarial review). Defenses:

- Loopback-only bind; **DNS-rebinding guard** (Host header must be `127.0.0.1`/`localhost`); **Origin/Referer rejected** (blocks a drive-by page probing the port).
- Per-session **bearer token**, constant-time compared; token uses `crypto.randomUUID`/`getRandomValues` and **fails closed** rather than falling back to `Math.random`. Both `/poll` and `/reply` are gated by session + token.
- `MAX_SESSIONS` cap, a no-attach abort timeout, and a session TTL so nothing lingers or can be exhausted.
- Lifecycle hardening: `ensureStarted()` is memoized with a generation guard so a `stop()` during startup can't leave a listener alive after unload; a prompt raised on a finished session rejects (no hung executor); the long-poll waiter is single-parked with identity-guarded cleanup.
- A remote cancel rejects with `UserCancelError`, so cancellation aborts the run exactly like dismissing a modal.

## Tests

Unit tests for the server (session isolation, token/host gating, single-waiter guard, finished-session and cancel paths), the provider date marshaling, and the `requestInputs`/formatter routing. Full suite green; `build-with-lint` clean.

## Notes

The Raycast extension that consumes this is a separate repo. Mobile safety was verified on a physical/emulated Android device: with no `window.require`, the provider seam stays unset and every prompt uses the normal modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `quickadd:interactive` CLI mode that runs interactive prompts via a local HTTP bridge and returns `host`, `port`, `sessionId`, and `token` immediately.
  * Enabled remote interactive prompting through the QuickAdd prompt flows (including value/input/variables, suggestions, dates, checkboxes, confirmations, and form inputs) when a prompt provider is configured.
* **Bug Fixes**
  * Improved interactive session lifecycle, including cleanup on unload, long-poll behavior, session multiplexing, timeouts, and reliable cancellation.
* **Documentation**
  * Documented the new CLI interactive mode, bridge endpoints, reply formats, and operational constraints.
* **Tests**
  * Added coverage for prompt-provider routing, prompt server behavior, and request/formatter routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->