### PR TITLE
feat(interactive): forward multi-select, FIELD/FILE, and AI pickers to a remote client

### DIFF
--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -3,6 +3,7 @@ import { TFile } from "obsidian";
 import { UserCancelError } from "src/errors/UserCancelError";
 import { ChoiceAbortError } from "src/errors/ChoiceAbortError";
 import GenericSuggester from "src/gui/GenericSuggester/genericSuggester";
+import type { PromptProvider } from "src/interactive/promptProvider";
 import { settingsStore } from "src/settingsStore";
 import { getMarkdownFilesInFolder } from "src/utilityObsidian";
 import invariant from "src/utils/invariant";
@@ -178,7 +179,8 @@ async function getTargetPromptTemplate(
 	app: App,
 	userDefinedPromptTemplate: Params["promptTemplate"],
 	promptTemplates: TFile[],
-	interactive = true
+	interactive = true,
+	promptProvider?: PromptProvider
 ): Promise<[string, string]> {
 	let targetFile;
 
@@ -187,22 +189,31 @@ async function getTargetPromptTemplate(
 			item.path.endsWith(userDefinedPromptTemplate.name)
 		);
 	} else {
-		// Non-interactive run (CLI without `ui`): the prompt-template picker has no
-		// one to answer it, so opening it would hang. Abort with an actionable error.
-		if (!interactive) {
+		const basenames = promptTemplates.map((f) => f.basename);
+
+		if (promptProvider) {
+			// Route the picker to a remote interactive session (Raycast). The
+			// suggester returns the selected actualItems entry (the TFile).
+			targetFile = (await promptProvider.suggester(
+				basenames,
+				promptTemplates as unknown as string[],
+				"Select a prompt template"
+			)) as TFile | undefined;
+		} else if (!interactive) {
+			// Non-interactive run (CLI without `ui`): the prompt-template picker has
+			// no one to answer it, so opening it would hang. Abort with an actionable
+			// error.
 			throw new ChoiceAbortError(
 				"This AI command asks which prompt template to use, but this run is non-interactive. " +
 					"Enable a specific prompt template in the command, or re-run with the ui flag."
 			);
+		} else {
+			targetFile = await GenericSuggester.Suggest(
+				app,
+				basenames,
+				promptTemplates
+			);
 		}
-
-		const basenames = promptTemplates.map((f) => f.basename);
-
-		targetFile = await GenericSuggester.Suggest(
-			app,
-			basenames,
-			promptTemplates
-		);
 	}
 
 	invariant(targetFile, "Prompt template does not exist");
@@ -235,6 +246,11 @@ interface Params {
 	 * (api.ai) are unaffected.
 	 */
 	interactive?: boolean;
+	/**
+	 * When set (a remote interactive session, e.g. Raycast), the prompt-template
+	 * picker is forwarded to it instead of opening an Obsidian modal.
+	 */
+	promptProvider?: PromptProvider;
 }
 
 export async function runAIAssistant(
@@ -266,7 +282,8 @@ export async function runAIAssistant(
 			app,
 			promptTemplate,
 			promptTemplates,
-			settings.interactive ?? true
+			settings.interactive ?? true,
+			settings.promptProvider
 		);
 
 		notice.setMessage(

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -634,21 +634,28 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 		const options = getModelNames();
 		let modelName: string;
 		if (command.model === "Ask me") {
-			// Non-interactive run (CLI without `ui`): the "Ask me" model picker has no
-			// one to answer it. Abort with an actionable error instead of hanging.
-			if (this.choiceExecutor.interactive === false) {
+			// Route to a remote interactive session (Raycast) when one is driving.
+			const provider = this.choiceExecutor.promptProvider;
+			if (provider) {
+				modelName = String(
+					await provider.suggester(options, options, "Select a model"),
+				);
+			} else if (this.choiceExecutor.interactive === false) {
+				// Non-interactive run (CLI without `ui`): the "Ask me" model picker has
+				// no one to answer it. Abort with an actionable error instead of hanging.
 				throw new ChoiceAbortError(
 					"This AI command is set to \"Ask me\" for the model, but this run is non-interactive. " +
 						"Pick a specific model in the command, or re-run with the ui flag.",
 				);
-			}
-			try {
-				modelName = await GenericSuggester.Suggest(this.app, options, options);
-			} catch (error) {
-				if (isCancellationError(error)) {
-					throw new UserCancelError("Input cancelled by user");
+			} else {
+				try {
+					modelName = await GenericSuggester.Suggest(this.app, options, options);
+				} catch (error) {
+					if (isCancellationError(error)) {
+						throw new UserCancelError("Input cancelled by user");
+					}
+					throw error;
 				}
-				throw error;
 			}
 		} else {
 			modelName = command.model;

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -695,6 +695,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 				showAssistantMessages: aiSettings.showAssistant,
 				modelOptions: command.modelParameters,
 				interactive: this.choiceExecutor.interactive,
+				promptProvider: this.choiceExecutor.promptProvider,
 			},
 			async (input: string) => {
 				return formatter.formatFileContent(input);

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1551,6 +1551,19 @@ describe("CompleteFormatter - remote prompt provider routing", () => {
 		expect(mocks.inputPromptPrompt).not.toHaveBeenCalled();
 	});
 
+	it("routes {{VALUE:a,b,c|multi}} to the provider's suggesterMulti, not the Obsidian modal", async () => {
+		const suggesterMulti = vi.fn(
+			async (_display: string[], _actual: string[]) => ["a", "c"],
+		);
+		const f = providerFormatter({ suggesterMulti });
+		const out = await f.formatFileContent("{{VALUE:a,b,c|multi}}");
+		expect(suggesterMulti).toHaveBeenCalledTimes(1);
+		expect(suggesterMulti.mock.calls[0][0]).toEqual(["a", "b", "c"]);
+		expect(suggesterMulti.mock.calls[0][1]).toEqual(["a", "b", "c"]);
+		expect(out).toContain("a");
+		expect(out).toContain("c");
+	});
+
 	it("routes anonymous {{VALUE|type:checkbox}} to the provider's suggester, not the Obsidian modal", async () => {
 		mocks.genericSuggesterSuggest.mockResolvedValue("false"); // modal answer (should be unused)
 		const suggester = vi.fn(async () => "true");

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -696,13 +696,21 @@ export class CompleteFormatter extends Formatter {
 			optional?: boolean;
 		},
 	): Promise<string[]> {
+		const displayValues = context?.displayValues ?? suggestedValues;
+		// Route to a remote interactive session (Raycast) when one is driving.
+		const provider = this.choiceExecutor?.promptProvider;
+		if (provider) {
+			return await provider.suggesterMulti(displayValues, suggestedValues, {
+				placeholder: context?.placeholder,
+				allowCustomInput,
+			});
+		}
 		this.assertInteractivePrompt(
 			context?.variableKey
 				? `{{VALUE:${context.variableKey}}}`
 				: "a multi-select value",
 		);
 		try {
-			const displayValues = context?.displayValues ?? suggestedValues;
 			return await MultiSuggester.Suggest(
 				this.app,
 				displayValues,
@@ -725,6 +733,9 @@ export class CompleteFormatter extends Formatter {
 
 	protected async suggestForField(fieldInput: string): Promise<string | string[]> {
 		this.assertInteractivePrompt(`{{FIELD:${fieldInput}}}`);
+		// Route the final picker to a remote interactive session (Raycast) when one
+		// is driving; the vault-side value collection below still runs unchanged.
+		const provider = this.choiceExecutor?.promptProvider;
 		try {
 			// Parse the field input to extract field name and filters. Do NOT warn
 			// on unknown keys here: the field replacer in formatter.ts already parses
@@ -822,6 +833,15 @@ export class CompleteFormatter extends Formatter {
 									filters.caseSensitive,
 								),
 							);
+				// Route to a remote interactive session (Raycast) when one is driving.
+				if (provider) {
+					return await provider.suggesterMulti(multiValues, multiValues, {
+						placeholder,
+						allowCustomInput: true,
+						preselected:
+							preselected && preselected.length > 0 ? preselected : undefined,
+					});
+				}
 				return await MultiSuggester.Suggest(this.app, multiValues, multiValues, {
 					placeholder,
 					allowCustomValue: true,
@@ -846,6 +866,12 @@ export class CompleteFormatter extends Formatter {
 					}
 				}
 
+				if (provider) {
+					return await provider.inputPrompt(
+						`Enter value for ${fieldName}`,
+						fallbackPrompt,
+					);
+				}
 				return await GenericInputPrompt.PromptWithContext(
 					this.app,
 					`Enter value for ${fieldName}`,
@@ -855,6 +881,11 @@ export class CompleteFormatter extends Formatter {
 				);
 			}
 
+			if (provider) {
+				return String(
+					await provider.suggester(values, values, placeholder, true),
+				);
+			}
 			return await InputSuggester.Suggest(this.app, values, values, {
 				placeholder,
 			});
@@ -874,6 +905,9 @@ export class CompleteFormatter extends Formatter {
 		this.assertInteractivePrompt(
 			`{{FILE}} (pick a file from ${parsed.folderPath})`,
 		);
+		// Route the final picker to a remote interactive session (Raycast) when one
+		// is driving; the vault-side file filtering below still runs unchanged.
+		const provider = this.choiceExecutor?.promptProvider;
 		try {
 			const files = EnhancedFieldSuggestionFileFilter.filterFiles(
 				this.app.vault.getMarkdownFiles(),
@@ -888,14 +922,17 @@ export class CompleteFormatter extends Formatter {
 			// dead-ends, mirroring suggestForField. A typed value is stored as custom
 			// (never resolved to a real file); an empty/skip stays "".
 			if (files.length === 0) {
-				const typed = await GenericInputPrompt.Prompt(
-					this.app,
-					placeholder,
-					`No markdown files found in "${parsed.folderPath}". Type a value or leave empty.`,
-					undefined,
-					undefined,
-					parsed.optional ? { optional: true } : undefined,
-				);
+				const description = `No markdown files found in "${parsed.folderPath}". Type a value or leave empty.`;
+				const typed = provider
+					? await provider.inputPrompt(placeholder, description)
+					: await GenericInputPrompt.Prompt(
+							this.app,
+							placeholder,
+							description,
+							undefined,
+							undefined,
+							parsed.optional ? { optional: true } : undefined,
+						);
 				if (parsed.multiSelect) {
 					return typed ? [`${FILE_CUSTOM_PREFIX}${typed}`] : [];
 				}
@@ -909,19 +946,34 @@ export class CompleteFormatter extends Formatter {
 			const items = files.map((file) => `${FILE_PICK_PREFIX}${file.path}`);
 
 			if (parsed.multiSelect) {
-				const result = await MultiSuggester.Suggest(
-					this.app,
-					displayItems,
-					items,
-					{
-						placeholder,
-						allowCustomValue: parsed.allowCustomInput,
-						...(parsed.optional ? { skippable: true } : {}),
-					},
-				);
+				const result = provider
+					? await provider.suggesterMulti(displayItems, items, {
+							placeholder,
+							allowCustomInput: parsed.allowCustomInput,
+						})
+					: await MultiSuggester.Suggest(this.app, displayItems, items, {
+							placeholder,
+							allowCustomValue: parsed.allowCustomInput,
+							...(parsed.optional ? { skippable: true } : {}),
+						});
 				return result.map((item) =>
 					items.includes(item) ? item : `${FILE_CUSTOM_PREFIX}${item}`,
 				);
+			}
+
+			if (provider) {
+				const result = String(
+					await provider.suggester(
+						displayItems,
+						items,
+						placeholder,
+						parsed.allowCustomInput,
+					),
+				);
+				if (!result) return "";
+				return items.includes(result)
+					? result
+					: `${FILE_CUSTOM_PREFIX}${result}`;
 			}
 
 			if (parsed.allowCustomInput) {

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-cleanup.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-cleanup.test.ts
@@ -136,3 +136,59 @@ describe("AIAssistantCommandSettingsModal Model dropdown missing-model handling"
 		modal.close();
 	});
 });
+
+function getPromptTemplateControls(modal: AIAssistantCommandSettingsModal): {
+	toggle: HTMLInputElement;
+	text: HTMLInputElement;
+} {
+	// The stub's Setting has no CSS classes: nameEl (a <div> whose textContent is
+	// exactly the setting name) sits under infoEl under settingEl (which also holds
+	// controlEl with the toggle + text input).
+	const nameEl = Array.from(
+		modal.contentEl.querySelectorAll<HTMLElement>("div")
+	).find(
+		(el) => el.children.length === 0 && el.textContent === "Prompt Template"
+	);
+	const settingEl = nameEl?.parentElement?.parentElement;
+	if (!settingEl) throw new Error("Prompt Template setting not found");
+	const toggle = settingEl.querySelector<HTMLInputElement>(
+		'input[type="checkbox"]'
+	);
+	const text = settingEl.querySelector<HTMLInputElement>(
+		'input:not([type="checkbox"])'
+	);
+	if (!toggle || !text) throw new Error("Prompt Template controls not found");
+	return { toggle, text };
+}
+
+function clickSave(modal: AIAssistantCommandSettingsModal): void {
+	const save = Array.from(
+		modal.contentEl.querySelectorAll<HTMLButtonElement>("button")
+	).find((b) => b.textContent === "Save");
+	if (!save) throw new Error("Save button not found");
+	save.click();
+}
+
+describe("AIAssistantCommandSettingsModal prompt-template persistence", () => {
+	beforeAll(() => {
+		const modalProto = Object.getPrototypeOf(
+			AIAssistantCommandSettingsModal.prototype
+		) as { onClose?: () => void };
+		modalProto.onClose ??= function onClose() {};
+	});
+
+	it("persists an enabled prompt template through Save", () => {
+		const command = makeCommand("gpt-test");
+		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
+
+		const { toggle, text } = getPromptTemplateControls(modal);
+		toggle.click(); // enable
+		text.value = "MyTemplate.md";
+		text.dispatchEvent(new Event("input"));
+
+		clickSave(modal);
+
+		expect(command.promptTemplate.enable).toBe(true);
+		expect(command.promptTemplate.name).toBe("MyTemplate.md");
+	});
+});

--- a/src/interactive/interactivePromptServer.ts
+++ b/src/interactive/interactivePromptServer.ts
@@ -78,6 +78,14 @@ export type PromptSpec =
 			items: SuggesterItem[];
 	  }
 	| {
+			type: "multiselect";
+			placeholder?: string;
+			allowCustomInput: boolean;
+			items: SuggesterItem[];
+			/** `value`s (wire tokens) that start pre-selected. */
+			preselected: string[];
+	  }
+	| {
 			type: "input";
 			header: string;
 			placeholder?: string;

--- a/src/interactive/promptProvider.test.ts
+++ b/src/interactive/promptProvider.test.ts
@@ -143,6 +143,30 @@ describe("RemotePromptProvider suggester marshaling", () => {
 		expect(spec.items[0].title).toBe("A");
 	});
 
+	it("suggesterMulti keeps a preselected value that isn't in the item list (adds it as a pre-checked custom item)", async () => {
+		let spec: { items: { title: string; value: string }[]; preselected: string[] } =
+			{ items: [], preselected: [] };
+		const server = {
+			emitPrompt: vi.fn(async (_id: string, s: unknown) => {
+				spec = s as typeof spec;
+				// Accept the defaults (return exactly what was preselected).
+				return spec.preselected;
+			}),
+		} as unknown as ServerLike;
+		const provider = new RemotePromptProvider("s", server);
+
+		// "active" is a default-from-active value not among the collected options.
+		const result = await provider.suggesterMulti(["a", "b"], ["a", "b"], {
+			preselected: ["a", "active"],
+			allowCustomInput: true,
+		});
+
+		expect(result).toEqual(["a", "active"]);
+		// "active" was appended as its own pre-checked item, not dropped.
+		expect(spec.items.map((i) => i.title)).toContain("active");
+		expect(spec.preselected).toHaveLength(2);
+	});
+
 	it("suggesterMulti keeps custom-typed values verbatim", async () => {
 		const server = {
 			emitPrompt: vi.fn(async () => ["custom-x"]),

--- a/src/interactive/promptProvider.test.ts
+++ b/src/interactive/promptProvider.test.ts
@@ -118,4 +118,39 @@ describe("RemotePromptProvider suggester marshaling", () => {
 		const result = await provider.suggester(["a"], ["a"], undefined, true);
 		expect(result).toBe("typed custom");
 	});
+
+	it("suggesterMulti returns the selected actualItems entries and maps preselected to tokens", async () => {
+		let spec: { items: { title: string; value: string }[]; preselected: string[] } =
+			{ items: [], preselected: [] };
+		const server = {
+			emitPrompt: vi.fn(async (_id: string, s: unknown) => {
+				spec = s as typeof spec;
+				// Client selects the first and third items by their wire tokens.
+				return [spec.items[0].value, spec.items[2].value];
+			}),
+		} as unknown as ServerLike;
+		const provider = new RemotePromptProvider("s", server);
+
+		const result = await provider.suggesterMulti(
+			["A", "B", "C"],
+			["a", "b", "c"],
+			{ preselected: ["b"], placeholder: "pick" },
+		);
+
+		expect(result).toEqual(["a", "c"]);
+		// Preselected "b" (index 1) is mapped to that item's opaque token.
+		expect(spec.preselected).toEqual([spec.items[1].value]);
+		expect(spec.items[0].title).toBe("A");
+	});
+
+	it("suggesterMulti keeps custom-typed values verbatim", async () => {
+		const server = {
+			emitPrompt: vi.fn(async () => ["custom-x"]),
+		} as unknown as ServerLike;
+		const provider = new RemotePromptProvider("s", server);
+		const result = await provider.suggesterMulti(["A"], ["a"], {
+			allowCustomInput: true,
+		});
+		expect(result).toEqual(["custom-x"]);
+	});
 });

--- a/src/interactive/promptProvider.ts
+++ b/src/interactive/promptProvider.ts
@@ -136,12 +136,22 @@ export class RemotePromptProvider implements PromptProvider {
 			title: displayItems[index] ?? String(value),
 			value: `${SUGGESTER_INDEX_PREFIX}${index}`,
 		}));
-		// Map preselected actual values to their wire tokens so the client can
-		// pre-check them.
-		const preselected = (options?.preselected ?? [])
-			.map((value) => actualItems.indexOf(value))
-			.filter((index) => index >= 0)
-			.map((index) => `${SUGGESTER_INDEX_PREFIX}${index}`);
+		// Map preselected values to wire tokens so the client pre-checks them. A
+		// preselected value the item list doesn't contain (e.g. a FIELD
+		// default-from:active value the vault scan didn't surface) is appended as a
+		// pre-checked custom item instead of being dropped - mirroring
+		// MultiSuggester, which adds such defaults as custom rows.
+		const preselected: string[] = [];
+		for (const value of options?.preselected ?? []) {
+			const index = actualItems.indexOf(value);
+			if (index >= 0) {
+				preselected.push(`${SUGGESTER_INDEX_PREFIX}${index}`);
+			} else {
+				const token = String(value);
+				items.push({ title: token, value: token });
+				preselected.push(token);
+			}
+		}
 
 		const answer = await this.server.emitPrompt(this.sessionId, {
 			type: "multiselect",

--- a/src/interactive/promptProvider.ts
+++ b/src/interactive/promptProvider.ts
@@ -34,6 +34,19 @@ export interface PromptProvider {
 		placeholder?: string,
 		allowCustomInput?: boolean,
 	): Promise<unknown>;
+	/**
+	 * Multi-select over a fixed list (`{{VALUE:a,b|multi}}`, `{{FIELD|multi}}`,
+	 * `{{FILE|multi}}`). Returns the selected `actualItems` entries in list order.
+	 */
+	suggesterMulti(
+		displayItems: string[],
+		actualItems: string[],
+		options?: {
+			placeholder?: string;
+			allowCustomInput?: boolean;
+			preselected?: string[];
+		},
+	): Promise<string[]>;
 	inputPrompt(
 		header: string,
 		placeholder?: string,
@@ -108,6 +121,51 @@ export class RemotePromptProvider implements PromptProvider {
 		}
 		// A custom-typed value (allowCustomInput) is returned verbatim.
 		return raw;
+	}
+
+	async suggesterMulti(
+		displayItems: string[],
+		actualItems: string[],
+		options?: {
+			placeholder?: string;
+			allowCustomInput?: boolean;
+			preselected?: string[];
+		},
+	): Promise<string[]> {
+		const items = actualItems.map((value, index) => ({
+			title: displayItems[index] ?? String(value),
+			value: `${SUGGESTER_INDEX_PREFIX}${index}`,
+		}));
+		// Map preselected actual values to their wire tokens so the client can
+		// pre-check them.
+		const preselected = (options?.preselected ?? [])
+			.map((value) => actualItems.indexOf(value))
+			.filter((index) => index >= 0)
+			.map((index) => `${SUGGESTER_INDEX_PREFIX}${index}`);
+
+		const answer = await this.server.emitPrompt(this.sessionId, {
+			type: "multiselect",
+			placeholder: options?.placeholder,
+			allowCustomInput: options?.allowCustomInput ?? false,
+			items,
+			preselected,
+		});
+		if (!Array.isArray(answer)) return [];
+		return answer.map((raw) => {
+			const value = String(raw);
+			if (value.startsWith(SUGGESTER_INDEX_PREFIX)) {
+				const index = Number(value.slice(SUGGESTER_INDEX_PREFIX.length));
+				if (
+					Number.isInteger(index) &&
+					index >= 0 &&
+					index < actualItems.length
+				) {
+					return actualItems[index];
+				}
+			}
+			// A custom-typed value (allowCustomInput) is returned verbatim.
+			return value;
+		});
 	}
 
 	async inputPrompt(


### PR DESCRIPTION
## What

Phase 2 of the interactive prompt bridge. Removes the remaining prompts that still opened an Obsidian modal during a remote (Raycast) interactive run, so more workflows run end-to-end from an external front end.

Now forwarded to the provider:
- **`{{VALUE:a,b|multi}}`** (`suggestForValueMulti`) — multi-select.
- **`{{FIELD:…}}`** single and `|multi` (`suggestForField`) — vault value collection, defaults, and preselection are unchanged; only the final picker is routed.
- **`{{FILE:…}}`** single and `|multi` (`suggestForFile`) — `@file:`/custom encoding preserved.
- **AI Assistant "Ask me" model picker** (`MacroChoiceEngine`).
- **AI Assistant prompt-template picker** (`AIAssistant.getTargetPromptTemplate`) — when no template is pinned, the chooser now forwards instead of hanging the remote run.

## How

- New provider surface: a `suggesterMulti` method (multi-select) plus a `multiselect` server prompt spec; single-selects reuse the existing `suggester`. Selections are wired as opaque index tokens mapped back to the original items (so object values keep identity), and custom-typed values pass through verbatim.
- The AI pickers thread `choiceExecutor.promptProvider` into `runAIAssistant`.

Nothing changes for in-app or mobile runs — the provider seam stays inert unless a remote session drives execution. The non-interactive-CLI abort guards are unchanged.

## Limitation

Multi-select uses the remote client's TagPicker, which only selects predefined items, so **typed-custom values in a multi-select aren't forwarded** (rare; single-select custom still works).

## Tests

Provider tests for `suggesterMulti` (index mapping, preselection, custom passthrough), a `{{VALUE:…|multi}}` routing test, and a regression test asserting the AI command settings modal's Save persists the prompt template. Full suite green; `build-with-lint` clean.

## Testing

Validated end-to-end against a live vault via a dev build: multi-select TagPicker, single `{{FIELD}}`/`{{FILE}}` lists, the model picker, and the template picker all render natively in Raycast.

Also verified with no change needed: nested `quickAddApi.executeChoice` already propagates the provider (it reuses the executor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote prompt-provider support for assistant prompts, including remote multi-select and preselected values.
  * Routed multi-value and file/prompt selections to the remote provider when available (with automatic fallback to local UI).

* **Bug Fixes**
  * Non-interactive runs now abort cleanly when no prompt provider is available, instead of opening a picker.
  * Improved support for custom selections and empty-result handling in provider-routed flows.

* **Tests**
  * Added/expanded test coverage for prompt-template saving and remote multi-select routing and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->