### PR TITLE
fix(interactive): collect a choice's declared inputs on a remote run

### DIFF
--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -247,8 +247,14 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		// One-page preflight honoring per-choice override.
 		const globalEnabled = settingsStore.getState().onePageInputEnabled;
 		const override = choice.onePageInput;
+		// A remote interactive run (Raycast) has no in-app modal fallback, so it must
+		// collect a choice's declared inputs up front via the provider regardless of
+		// the global one-page setting - otherwise those inputs are never gathered and
+		// the run proceeds with them empty.
+		const remote = this.promptProvider != null;
 		const shouldUseOnePager =
-			override === "always" || (override !== "never" && globalEnabled);
+			override === "always" ||
+			(override !== "never" && (globalEnabled || remote));
 		if (
 			shouldUseOnePager &&
 			(choice.type === "Template" ||

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TFile, type App } from "obsidian";
 import { runOnePagePreflight } from "./runOnePagePreflight";
+import { UserCancelError } from "../errors/UserCancelError";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
@@ -186,6 +187,28 @@ describe("runOnePagePreflight selection-as-value", () => {
 		expect(requestInputs).toHaveBeenCalledTimes(1);
 		expect(modalOpenMock).not.toHaveBeenCalled();
 		expect(executor.variables.get("value")).toBe("from raycast");
+	});
+
+	it("propagates a remote form cancellation instead of continuing", async () => {
+		const choice = createChoice();
+		const executor = createExecutor();
+		const requestInputs = vi.fn(async () => {
+			throw new UserCancelError("Input cancelled by user");
+		});
+		(executor as IChoiceExecutor).promptProvider = {
+			requestInputs,
+		} as unknown as IChoiceExecutor["promptProvider"];
+		const plugin = {
+			settings: {
+				inputPrompt: "single-line",
+				globalVariables: {},
+				useSelectionAsCaptureValue: false,
+			},
+		} as any;
+
+		await expect(
+			runOnePagePreflight(createApp(null), plugin, executor, choice),
+		).rejects.toBeInstanceOf(UserCancelError);
 	});
 
 	it("does not prefill when selection usage is disabled", async () => {

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -166,6 +166,28 @@ describe("runOnePagePreflight selection-as-value", () => {
 		expect(modalOpenMock).not.toHaveBeenCalled();
 	});
 
+	it("collects via the promptProvider (not the Obsidian modal) for a remote run", async () => {
+		const choice = createChoice();
+		const executor = createExecutor();
+		const requestInputs = vi.fn(async () => ({ value: "from raycast" }));
+		(executor as IChoiceExecutor).promptProvider = {
+			requestInputs,
+		} as unknown as IChoiceExecutor["promptProvider"];
+		const plugin = {
+			settings: {
+				inputPrompt: "single-line",
+				globalVariables: {},
+				useSelectionAsCaptureValue: false,
+			},
+		} as any;
+
+		await runOnePagePreflight(createApp(null), plugin, executor, choice);
+
+		expect(requestInputs).toHaveBeenCalledTimes(1);
+		expect(modalOpenMock).not.toHaveBeenCalled();
+		expect(executor.variables.get("value")).toBe("from raycast");
+	});
+
 	it("does not prefill when selection usage is disabled", async () => {
 		const choice = createChoice();
 		const executor = createExecutor();

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -135,13 +135,24 @@ export async function runOnePagePreflight(
 			}
 		};
 
-		const modal = new OnePageInputModal(
-			app,
-			modalRequirements,
-			choiceExecutor.variables,
-			computePreview,
-		);
-		const values = await modal.waitForClose;
+		// A remote interactive session (Raycast) collects the batch form through the
+		// provider instead of the Obsidian modal; the values come back in the same
+		// id -> string shape, so the post-processing below is unchanged (the modal's
+		// per-pick multi-select map is simply absent, falling back to string parsing).
+		const provider = choiceExecutor.promptProvider;
+		let modal: OnePageInputModal | null = null;
+		let values: Record<string, string>;
+		if (provider) {
+			values = await provider.requestInputs(modalRequirements);
+		} else {
+			modal = new OnePageInputModal(
+				app,
+				modalRequirements,
+				choiceExecutor.variables,
+				computePreview,
+			);
+			values = await modal.waitForClose;
+		}
 
 		// Date inputs already store @date:ISO. FILE inputs need canonicalizing: the
 		// generic suggester stores raw typed text, so a value that isn't one of the
@@ -187,7 +198,7 @@ export async function runOnePagePreflight(
 				// Prefer the modal's unambiguous per-pick selection (survives the
 				// "a"+"b" vs literal "a, b" collision); fall back to parsing the
 				// ", "-joined text when the user manually edited the field.
-				const pickedLabels = modal.multiSelections.get(k);
+				const pickedLabels = modal?.multiSelections.get(k);
 				const items = (
 					pickedLabels ??
 					splitMultiSelectLabels(String(v), multiInfo.displayToValue)

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -5,6 +5,7 @@ import type QuickAdd from "src/main";
 import type IChoice from "src/types/choices/IChoice";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { VALUE_SYNTAX } from "src/constants";
+import { MacroAbortError } from "src/errors/MacroAbortError";
 import { OnePageInputModal } from "./OnePageInputModal";
 import {
 	canonicalizeOnePageFileValue,
@@ -227,8 +228,11 @@ export async function runOnePagePreflight(
 
 		return true;
 	} catch (error) {
-		// If user explicitly cancelled, propagate it
-		if (error === "cancelled") {
+		// Propagate an explicit cancellation/abort so the run stops instead of
+		// continuing with the inputs missing. The native modal throws the string
+		// "cancelled"; a remote provider rejects with UserCancelError (a
+		// MacroAbortError subclass).
+		if (error === "cancelled" || error instanceof MacroAbortError) {
 			throw error;
 		}
 		// For other errors, silently fail and continue


### PR DESCRIPTION
## Problem

A remote interactive run (Raycast) gathers a choice's **declared inputs** (one-page requirements, including a user script's `quickadd.inputs`) only when the `onePageInputEnabled` setting is on. With it **off**, the interactive run collected nothing, so a Macro whose script reads `variables.value` (e.g. a "brain dump" script) ran with an empty value and aborted (`no text was provided`).

The old non-interactive path always collected via `checkChoice`, so this only surfaced once runs became interactive by default - and it affected the list "Run" as well as pinned Quicklinks.

## Fix

A provider-driven run has no in-app modal fallback, so it must collect declared inputs up front through the provider:

- `runOnePagePreflightIfEnabled` runs the preflight whenever a `promptProvider` drives the run (unless the choice opts out with `onePageInput: "never"`), regardless of the global setting.
- `runOnePagePreflight` routes the batch form to `provider.requestInputs` (same `id -> string` shape, so the existing post-processing is unchanged) instead of the Obsidian modal when a provider is present.

Net effect: a remote run collects declared inputs as a batch form (like one-page-enabled) and forwards it; the front end renders it as the first prompt. In-app and non-provider runs are unchanged.

## Tests

Added a preflight test asserting the provider path collects and sets variables without opening the modal. Full suite green; `build-with-lint` clean. Validated end-to-end against a live vault (a brain-dump Macro with a `quickadd.inputs` textarea, one-page setting off) via a dev build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-page preflight input collection now also runs in remote interactive scenarios, enabling prompts even when no local input modal is displayed.

* **Bug Fixes**
  * Improved capture of returned input values, including correct handling when selection-as-value is disabled.
  * Enhanced multi-select processing for both modal-based and remote prompt flows.
  * Cancellation behavior is now more consistent, including explicit aborts.

* **Tests**
  * Added coverage for remote input collection behavior and cancellation/error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->