### PR TITLE
docs(examples): add Templater folder-templates recipe

### DIFF
--- a/docs/docs/Examples/Template_TemplaterFolderTemplates.md
+++ b/docs/docs/Examples/Template_TemplaterFolderTemplates.md
@@ -1,0 +1,75 @@
+---
+title: "Template: Reuse Templater Folder Templates"
+---
+
+If you use [Templater's](https://github.com/SilentVoid13/Templater) folder
+templates, a QuickAdd Template choice normally needs its own template path -
+so you end up maintaining the folder-to-template mapping in two places.
+
+This recipe removes the duplication. A small
+[Templater user script](https://silentvoid13.github.io/Templater/user-functions/script-user-functions.html)
+reads the mapping from Templater's own settings, and a one-line shim template
+includes whichever template is configured for the destination folder. One
+QuickAdd choice then works for every folder that has a Templater folder
+template.
+
+## 1. Create the user script
+
+Save the following as `folder_template.js` in your Templater user scripts
+folder (set under Templater's "User script functions" settings). The file name
+matters: Templater exposes it as `tp.user.folder_template`.
+
+```js
+/**
+ * Resolve the Templater template configured for a given folder, via the
+ * Templater plugin's folder-template settings.
+ * @param {string} folderPath - Folder path to look up, matched exactly against `folder_templates[].folder`.
+ * @returns {string | undefined} The configured template path, or `undefined` if Templater is disabled or the folder has no mapping.
+ */
+function folderTemplate(folderPath) {
+  let templater = app.plugins.plugins["templater-obsidian"];
+  if (!templater) return;
+
+  const folderTemplates = templater.settings.folder_templates;
+  const templateByFolder = folderTemplates.find((t) => t.folder === folderPath);
+  if (!templateByFolder) return;
+  return templateByFolder.template;
+}
+
+module.exports = folderTemplate;
+```
+
+## 2. Create the shim template
+
+Create a new template file, for example `QuickAdd.md`, containing only:
+
+```
+<% tp.file.include("[[" + tp.user.folder_template(tp.file.folder(true)) + "]]") %>
+```
+
+When Templater processes the new note, this looks up the note's folder and
+includes the template configured for it.
+
+## 3. Create the Template choice
+
+Add a Template choice in QuickAdd's settings:
+
+- **Template Path**: `QuickAdd.md` (the shim template)
+- **Create in folder**: a folder that has a folder template configured in
+  Templater's settings
+
+Running the choice creates the note in that folder, and the shim pulls in the
+correct Templater template automatically. If the choice offers several
+folders, each one resolves to its own configured template.
+
+## Limitations
+
+- The lookup matches the folder path exactly against Templater's
+  folder-template list. Unlike Templater's own trigger, it does not fall back
+  to a template configured on a parent folder.
+- If the destination folder has no folder template configured, the include
+  fails with a Templater error. Only point the choice at folders that have a
+  mapping.
+
+Contributed by [@codedpalette](https://github.com/codedpalette) in
+[discussion 1105](https://github.com/chhoumann/quickadd/discussions/1105).

--- a/docs/docs/Examples/index.md
+++ b/docs/docs/Examples/index.md
@@ -14,6 +14,7 @@ from a blank choice.
 | [Add an Inbox Item](./Template_AddAnInboxItem) | Template | Beginner | Inbox folder or note | A new inbox note |
 | [Create an MOC Note with a Link Dashboard](./Template_CreateMOCNoteWithLinkDashboard) | Template | Intermediate | Base template file | A note with an embedded Base dashboard |
 | [Automatic Book Notes from Readwise](./Template_AutomaticBookNotesFromReadwise) | Template and Macro | Advanced | Readwise export script | Book notes with highlights |
+| [Reuse Templater Folder Templates](./Template_TemplaterFolderTemplates) | Template | Intermediate | Templater folder templates | A note using the folder's Templater template |
 | [Book Finder](./Macro_BookFinder) | Macro | Intermediate | Book lookup script | A populated book note |
 | [Movie and Series Script](./Macro_MovieAndSeriesScript) | Macro | Intermediate | TMDB API key | Media notes with metadata |
 | [Move Notes with a Tag](./Macro_MoveNotesWithATagToAFolder) | Macro | Intermediate | Tagged notes | Notes moved into a target folder |
@@ -32,7 +33,10 @@ your target is a Canvas card instead of a Markdown note.
 
 Start with [Add an Inbox Item](./Template_AddAnInboxItem) for a small template.
 Use [Create an MOC Note with a Link Dashboard](./Template_CreateMOCNoteWithLinkDashboard)
-when you want a generated note to include a live Base dashboard.
+when you want a generated note to include a live Base dashboard. If you
+already maintain folder templates in Templater, see
+[Reuse Templater Folder Templates](./Template_TemplaterFolderTemplates) to
+avoid duplicating that mapping in QuickAdd.
 
 ### Run scripted workflows
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -140,6 +140,7 @@ const sidebars = {
 						"Examples/Template_AddAnInboxItem",
 						"Examples/Template_CreateMOCNoteWithLinkDashboard",
 						"Examples/Template_AutomaticBookNotesFromReadwise",
+						"Examples/Template_TemplaterFolderTemplates",
 					],
 				},
 				{

--- a/docs/versioned_docs/version-2.17.2/Examples/Template_TemplaterFolderTemplates.md
+++ b/docs/versioned_docs/version-2.17.2/Examples/Template_TemplaterFolderTemplates.md
@@ -1,0 +1,75 @@
+---
+title: "Template: Reuse Templater Folder Templates"
+---
+
+If you use [Templater's](https://github.com/SilentVoid13/Templater) folder
+templates, a QuickAdd Template choice normally needs its own template path -
+so you end up maintaining the folder-to-template mapping in two places.
+
+This recipe removes the duplication. A small
+[Templater user script](https://silentvoid13.github.io/Templater/user-functions/script-user-functions.html)
+reads the mapping from Templater's own settings, and a one-line shim template
+includes whichever template is configured for the destination folder. One
+QuickAdd choice then works for every folder that has a Templater folder
+template.
+
+## 1. Create the user script
+
+Save the following as `folder_template.js` in your Templater user scripts
+folder (set under Templater's "User script functions" settings). The file name
+matters: Templater exposes it as `tp.user.folder_template`.
+
+```js
+/**
+ * Resolve the Templater template configured for a given folder, via the
+ * Templater plugin's folder-template settings.
+ * @param {string} folderPath - Folder path to look up, matched exactly against `folder_templates[].folder`.
+ * @returns {string | undefined} The configured template path, or `undefined` if Templater is disabled or the folder has no mapping.
+ */
+function folderTemplate(folderPath) {
+  let templater = app.plugins.plugins["templater-obsidian"];
+  if (!templater) return;
+
+  const folderTemplates = templater.settings.folder_templates;
+  const templateByFolder = folderTemplates.find((t) => t.folder === folderPath);
+  if (!templateByFolder) return;
+  return templateByFolder.template;
+}
+
+module.exports = folderTemplate;
+```
+
+## 2. Create the shim template
+
+Create a new template file, for example `QuickAdd.md`, containing only:
+
+```
+<% tp.file.include("[[" + tp.user.folder_template(tp.file.folder(true)) + "]]") %>
+```
+
+When Templater processes the new note, this looks up the note's folder and
+includes the template configured for it.
+
+## 3. Create the Template choice
+
+Add a Template choice in QuickAdd's settings:
+
+- **Template Path**: `QuickAdd.md` (the shim template)
+- **Create in folder**: a folder that has a folder template configured in
+  Templater's settings
+
+Running the choice creates the note in that folder, and the shim pulls in the
+correct Templater template automatically. If the choice offers several
+folders, each one resolves to its own configured template.
+
+## Limitations
+
+- The lookup matches the folder path exactly against Templater's
+  folder-template list. Unlike Templater's own trigger, it does not fall back
+  to a template configured on a parent folder.
+- If the destination folder has no folder template configured, the include
+  fails with a Templater error. Only point the choice at folders that have a
+  mapping.
+
+Contributed by [@codedpalette](https://github.com/codedpalette) in
+[discussion 1105](https://github.com/chhoumann/quickadd/discussions/1105).

--- a/docs/versioned_docs/version-2.17.2/Examples/index.md
+++ b/docs/versioned_docs/version-2.17.2/Examples/index.md
@@ -14,6 +14,7 @@ from a blank choice.
 | [Add an Inbox Item](./Template_AddAnInboxItem) | Template | Beginner | Inbox folder or note | A new inbox note |
 | [Create an MOC Note with a Link Dashboard](./Template_CreateMOCNoteWithLinkDashboard) | Template | Intermediate | Base template file | A note with an embedded Base dashboard |
 | [Automatic Book Notes from Readwise](./Template_AutomaticBookNotesFromReadwise) | Template and Macro | Advanced | Readwise export script | Book notes with highlights |
+| [Reuse Templater Folder Templates](./Template_TemplaterFolderTemplates) | Template | Intermediate | Templater folder templates | A note using the folder's Templater template |
 | [Book Finder](./Macro_BookFinder) | Macro | Intermediate | Book lookup script | A populated book note |
 | [Movie and Series Script](./Macro_MovieAndSeriesScript) | Macro | Intermediate | TMDB API key | Media notes with metadata |
 | [Move Notes with a Tag](./Macro_MoveNotesWithATagToAFolder) | Macro | Intermediate | Tagged notes | Notes moved into a target folder |
@@ -32,7 +33,10 @@ your target is a Canvas card instead of a Markdown note.
 
 Start with [Add an Inbox Item](./Template_AddAnInboxItem) for a small template.
 Use [Create an MOC Note with a Link Dashboard](./Template_CreateMOCNoteWithLinkDashboard)
-when you want a generated note to include a live Base dashboard.
+when you want a generated note to include a live Base dashboard. If you
+already maintain folder templates in Templater, see
+[Reuse Templater Folder Templates](./Template_TemplaterFolderTemplates) to
+avoid duplicating that mapping in QuickAdd.
 
 ### Run scripted workflows
 

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -110,7 +110,8 @@
           "items": [
             "Examples/Template_AddAnInboxItem",
             "Examples/Template_CreateMOCNoteWithLinkDashboard",
-            "Examples/Template_AutomaticBookNotesFromReadwise"
+            "Examples/Template_AutomaticBookNotesFromReadwise",
+            "Examples/Template_TemplaterFolderTemplates"
           ]
         },
         {


### PR DESCRIPTION
Adds a community recipe to the Examples docs: reuse Templater's folder-template configuration from a QuickAdd Template choice, so the folder-to-template mapping is not maintained in two places.

The recipe (contributed by codedpalette in discussion 1105) is a small Templater user script that reads `folder_templates` from Templater's settings, plus a one-line shim template that `tp.file.include`s the resolved template. One QuickAdd Template choice then works for every folder that has a Templater folder template. The docs page makes two things explicit that the original recipe glossed over: the user script file must be named `folder_template.js` (it is invoked as `tp.user.folder_template`), and the lookup is exact-match only (no parent-folder fallback, unlike Templater's own trigger).

Changes:
- New page `docs/docs/Examples/Template_TemplaterFolderTemplates.md`, plus a row in the Examples overview table and a mention in the "Create structured notes" section
- Sidebar entry in `sidebars.js`
- All of the above mirrored into the live `version-2.17.2` snapshot (the site root serves the frozen version; `docs/docs` is `/next/`)

Verified with a full `pnpm build` in `docs/` - the page renders in both the root and `/next/` versions.