### PR TITLE
docs: add QuickAdd sync FAQ

### DIFF
--- a/docs/docs/FAQ.md
+++ b/docs/docs/FAQ.md
@@ -4,42 +4,21 @@ title: FAQ
 
 ## Syncing QuickAdd between devices
 
-QuickAdd saves its choices and settings in
-`<vault>/.obsidian/plugins/quickadd/data.json`. If your sync setup includes
-Obsidian's configuration folder, that file carries your Template, Capture,
-Macro, Multi choices, global variables, and normal QuickAdd settings to the
-other device.
+QuickAdd keeps everything - your choices, macros, global variables, and settings - in `<vault>/.obsidian/plugins/quickadd/data.json`. As long as your sync setup includes Obsidian's configuration folder, that one file brings your whole QuickAdd setup to the other device.
 
-Two things are separate from `data.json`:
+Two things don't travel with it:
 
-- QuickAdd has to be installed and enabled on the other device. Obsidian stores
-  enabled community plugins in `<vault>/.obsidian/community-plugins.json`.
-- SecretStorage-backed values are local. If QuickAdd stores an API key or
-  script secret setting in Obsidian's SecretStorage, enter it on each device
-  that needs it.
+- **The plugin itself.** QuickAdd must be installed and enabled on the other device. Obsidian tracks enabled plugins in `<vault>/.obsidian/community-plugins.json`.
+- **Secrets.** API keys stored through Obsidian's secret storage stay on the device where you entered them, so enter them once per device.
 
-After your sync tool reports that the files have arrived, restart Obsidian on
-the receiving device, or disable and re-enable QuickAdd in **Settings ->
-Community plugins**. QuickAdd reads `data.json` when the plugin loads, so an
-already-running copy of QuickAdd will keep using the choices it loaded earlier.
+One gotcha catches almost everyone: QuickAdd reads `data.json` when it loads, so a device that's already running keeps the choices it loaded earlier. After the files have synced, restart Obsidian on the receiving device - or toggle QuickAdd off and on in **Settings -> Community plugins** - and your changes appear.
 
-If you use Obsidian Sync, also check **Settings -> Sync** on each device:
+If you use **Obsidian Sync**, also check **Settings -> Sync** on each device:
 
-- Under **Vault configuration sync**, enable **Active community plugin list**
-  and **Installed community plugin list** if you want Obsidian Sync to install
-  and enable QuickAdd for you.
-- If a macro calls a standalone `.js` user script, enable **Sync all other
-  types**. Obsidian's [Sync settings](https://obsidian.md/help/sync/settings)
-  treat `.js` as an additional file type. Without the script file at the same
-  vault path, the macro configuration can appear but the script will not run.
-- Note-based user scripts in Markdown notes avoid the `.js` file-type toggle.
-  See [User Scripts](./UserScripts) for the two script forms and mobile limits.
+- Enable **Active community plugin list** and **Installed community plugin list** under **Vault configuration sync** if you want Obsidian Sync to install and enable QuickAdd for you.
+- If a macro runs a standalone `.js` user script, enable **Sync all other types**. Obsidian Sync skips `.js` files unless that setting is on (see [Sync settings](https://obsidian.md/help/sync/settings)) - which is why a macro can arrive on the other device with its script missing: the configuration syncs, the script doesn't, and the macro fails.
+- Scripts kept in Markdown notes sync like any other note and sidestep the file-type toggle entirely. See [User Scripts](./UserScripts) for both script forms.
 
-If you use iCloud, Dropbox, Git, Syncthing, or another file-sync tool, the
-`.js` toggle does not apply. Make sure the tool syncs the whole `.obsidian`
-configuration folder and the script files in your vault, then restart or
-re-enable QuickAdd on the other device.
+With iCloud, Dropbox, Git, Syncthing, or any other file-sync tool, the file-type toggle doesn't apply - just make sure the tool syncs the whole `.obsidian` folder plus your script files, then restart or re-enable QuickAdd on the other device.
 
-For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and
-import it on the other device. Packages move the QuickAdd configuration, but not
-referenced `.js` files, note-script files, or local secrets.
+For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and import it on the other device. A package moves your QuickAdd configuration, but not referenced `.js` files, note scripts, or secrets.

--- a/docs/docs/FAQ.md
+++ b/docs/docs/FAQ.md
@@ -1,0 +1,45 @@
+---
+title: FAQ
+---
+
+## Syncing QuickAdd between devices
+
+QuickAdd saves its choices and settings in
+`<vault>/.obsidian/plugins/quickadd/data.json`. If your sync setup includes
+Obsidian's configuration folder, that file carries your Template, Capture,
+Macro, Multi choices, global variables, and normal QuickAdd settings to the
+other device.
+
+Two things are separate from `data.json`:
+
+- QuickAdd has to be installed and enabled on the other device. Obsidian stores
+  enabled community plugins in `<vault>/.obsidian/community-plugins.json`.
+- SecretStorage-backed values are local. If QuickAdd stores an API key or
+  script secret setting in Obsidian's SecretStorage, enter it on each device
+  that needs it.
+
+After your sync tool reports that the files have arrived, restart Obsidian on
+the receiving device, or disable and re-enable QuickAdd in **Settings ->
+Community plugins**. QuickAdd reads `data.json` when the plugin loads, so an
+already-running copy of QuickAdd will keep using the choices it loaded earlier.
+
+If you use Obsidian Sync, also check **Settings -> Sync** on each device:
+
+- Under **Vault configuration sync**, enable **Active community plugin list**
+  and **Installed community plugin list** if you want Obsidian Sync to install
+  and enable QuickAdd for you.
+- If a macro calls a standalone `.js` user script, enable **Sync all other
+  types**. Obsidian's [Sync settings](https://obsidian.md/help/sync/settings)
+  treat `.js` as an additional file type. Without the script file at the same
+  vault path, the macro configuration can appear but the script will not run.
+- Note-based user scripts in Markdown notes avoid the `.js` file-type toggle.
+  See [User Scripts](./UserScripts) for the two script forms and mobile limits.
+
+If you use iCloud, Dropbox, Git, Syncthing, or another file-sync tool, the
+`.js` toggle does not apply. Make sure the tool syncs the whole `.obsidian`
+configuration folder and the script files in your vault, then restart or
+re-enable QuickAdd on the other device.
+
+For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and
+import it on the other device. Packages move the QuickAdd configuration, but not
+referenced `.js` files, note-script files, or local secrets.

--- a/docs/docs/FAQ.md
+++ b/docs/docs/FAQ.md
@@ -21,4 +21,4 @@ If you use **Obsidian Sync**, also check **Settings -> Sync** on each device:
 
 With iCloud, Dropbox, Git, Syncthing, or any other file-sync tool, the file-type toggle doesn't apply - just make sure the tool syncs the whole `.obsidian` folder plus your script files, then restart or re-enable QuickAdd on the other device.
 
-For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and import it on the other device. A package moves your QuickAdd configuration, but not referenced `.js` files, note scripts, or secrets.
+For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and import it on the other device. A package moves your QuickAdd configuration and bundled dependent scripts. Secrets still stay local, so enter those on each device.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -211,6 +211,7 @@ const sidebars = {
 			label: "Other",
 			collapsed: true,
 			items: [
+				"FAQ",
 				{
 					type: "doc",
 					id: "ManualInstallation",

--- a/docs/versioned_docs/version-2.17.2/FAQ.md
+++ b/docs/versioned_docs/version-2.17.2/FAQ.md
@@ -4,42 +4,21 @@ title: FAQ
 
 ## Syncing QuickAdd between devices
 
-QuickAdd saves its choices and settings in
-`<vault>/.obsidian/plugins/quickadd/data.json`. If your sync setup includes
-Obsidian's configuration folder, that file carries your Template, Capture,
-Macro, Multi choices, global variables, and normal QuickAdd settings to the
-other device.
+QuickAdd keeps everything - your choices, macros, global variables, and settings - in `<vault>/.obsidian/plugins/quickadd/data.json`. As long as your sync setup includes Obsidian's configuration folder, that one file brings your whole QuickAdd setup to the other device.
 
-Two things are separate from `data.json`:
+Two things don't travel with it:
 
-- QuickAdd has to be installed and enabled on the other device. Obsidian stores
-  enabled community plugins in `<vault>/.obsidian/community-plugins.json`.
-- SecretStorage-backed values are local. If QuickAdd stores an API key or
-  script secret setting in Obsidian's SecretStorage, enter it on each device
-  that needs it.
+- **The plugin itself.** QuickAdd must be installed and enabled on the other device. Obsidian tracks enabled plugins in `<vault>/.obsidian/community-plugins.json`.
+- **Secrets.** API keys stored through Obsidian's secret storage stay on the device where you entered them, so enter them once per device.
 
-After your sync tool reports that the files have arrived, restart Obsidian on
-the receiving device, or disable and re-enable QuickAdd in **Settings ->
-Community plugins**. QuickAdd reads `data.json` when the plugin loads, so an
-already-running copy of QuickAdd will keep using the choices it loaded earlier.
+One gotcha catches almost everyone: QuickAdd reads `data.json` when it loads, so a device that's already running keeps the choices it loaded earlier. After the files have synced, restart Obsidian on the receiving device - or toggle QuickAdd off and on in **Settings -> Community plugins** - and your changes appear.
 
-If you use Obsidian Sync, also check **Settings -> Sync** on each device:
+If you use **Obsidian Sync**, also check **Settings -> Sync** on each device:
 
-- Under **Vault configuration sync**, enable **Active community plugin list**
-  and **Installed community plugin list** if you want Obsidian Sync to install
-  and enable QuickAdd for you.
-- If a macro calls a standalone `.js` user script, enable **Sync all other
-  types**. Obsidian's [Sync settings](https://obsidian.md/help/sync/settings)
-  treat `.js` as an additional file type. Without the script file at the same
-  vault path, the macro configuration can appear but the script will not run.
-- Note-based user scripts in Markdown notes avoid the `.js` file-type toggle.
-  See [User Scripts](./UserScripts) for the two script forms and mobile limits.
+- Enable **Active community plugin list** and **Installed community plugin list** under **Vault configuration sync** if you want Obsidian Sync to install and enable QuickAdd for you.
+- If a macro runs a standalone `.js` user script, enable **Sync all other types**. Obsidian Sync skips `.js` files unless that setting is on (see [Sync settings](https://obsidian.md/help/sync/settings)) - which is why a macro can arrive on the other device with its script missing: the configuration syncs, the script doesn't, and the macro fails.
+- Scripts kept in Markdown notes sync like any other note and sidestep the file-type toggle entirely. See [User Scripts](./UserScripts) for both script forms.
 
-If you use iCloud, Dropbox, Git, Syncthing, or another file-sync tool, the
-`.js` toggle does not apply. Make sure the tool syncs the whole `.obsidian`
-configuration folder and the script files in your vault, then restart or
-re-enable QuickAdd on the other device.
+With iCloud, Dropbox, Git, Syncthing, or any other file-sync tool, the file-type toggle doesn't apply - just make sure the tool syncs the whole `.obsidian` folder plus your script files, then restart or re-enable QuickAdd on the other device.
 
-For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and
-import it on the other device. Packages move the QuickAdd configuration, but not
-referenced `.js` files, note-script files, or local secrets.
+For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and import it on the other device. A package moves your QuickAdd configuration, but not referenced `.js` files, note scripts, or secrets.

--- a/docs/versioned_docs/version-2.17.2/FAQ.md
+++ b/docs/versioned_docs/version-2.17.2/FAQ.md
@@ -1,0 +1,45 @@
+---
+title: FAQ
+---
+
+## Syncing QuickAdd between devices
+
+QuickAdd saves its choices and settings in
+`<vault>/.obsidian/plugins/quickadd/data.json`. If your sync setup includes
+Obsidian's configuration folder, that file carries your Template, Capture,
+Macro, Multi choices, global variables, and normal QuickAdd settings to the
+other device.
+
+Two things are separate from `data.json`:
+
+- QuickAdd has to be installed and enabled on the other device. Obsidian stores
+  enabled community plugins in `<vault>/.obsidian/community-plugins.json`.
+- SecretStorage-backed values are local. If QuickAdd stores an API key or
+  script secret setting in Obsidian's SecretStorage, enter it on each device
+  that needs it.
+
+After your sync tool reports that the files have arrived, restart Obsidian on
+the receiving device, or disable and re-enable QuickAdd in **Settings ->
+Community plugins**. QuickAdd reads `data.json` when the plugin loads, so an
+already-running copy of QuickAdd will keep using the choices it loaded earlier.
+
+If you use Obsidian Sync, also check **Settings -> Sync** on each device:
+
+- Under **Vault configuration sync**, enable **Active community plugin list**
+  and **Installed community plugin list** if you want Obsidian Sync to install
+  and enable QuickAdd for you.
+- If a macro calls a standalone `.js` user script, enable **Sync all other
+  types**. Obsidian's [Sync settings](https://obsidian.md/help/sync/settings)
+  treat `.js` as an additional file type. Without the script file at the same
+  vault path, the macro configuration can appear but the script will not run.
+- Note-based user scripts in Markdown notes avoid the `.js` file-type toggle.
+  See [User Scripts](./UserScripts) for the two script forms and mobile limits.
+
+If you use iCloud, Dropbox, Git, Syncthing, or another file-sync tool, the
+`.js` toggle does not apply. Make sure the tool syncs the whole `.obsidian`
+configuration folder and the script files in your vault, then restart or
+re-enable QuickAdd on the other device.
+
+For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and
+import it on the other device. Packages move the QuickAdd configuration, but not
+referenced `.js` files, note-script files, or local secrets.

--- a/docs/versioned_docs/version-2.17.2/FAQ.md
+++ b/docs/versioned_docs/version-2.17.2/FAQ.md
@@ -21,4 +21,4 @@ If you use **Obsidian Sync**, also check **Settings -> Sync** on each device:
 
 With iCloud, Dropbox, Git, Syncthing, or any other file-sync tool, the file-type toggle doesn't apply - just make sure the tool syncs the whole `.obsidian` folder plus your script files, then restart or re-enable QuickAdd on the other device.
 
-For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and import it on the other device. A package moves your QuickAdd configuration, but not referenced `.js` files, note scripts, or secrets.
+For a one-time transfer, [export a QuickAdd package](./Choices/Packages) and import it on the other device. A package moves your QuickAdd configuration and bundled dependent scripts. Secrets still stay local, so enter those on each device.

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -182,6 +182,7 @@
       "label": "Other",
       "collapsed": true,
       "items": [
+        "FAQ",
         {
           "type": "doc",
           "id": "ManualInstallation",


### PR DESCRIPTION
Add a concise FAQ entry for syncing QuickAdd between devices in both the current docs tree and the latest stable 2.17.2 docs.

The FAQ explains that QuickAdd choices and normal settings live in `.obsidian/plugins/quickadd/data.json`, that receiving devices need a QuickAdd disable/re-enable or Obsidian restart before synced settings are read, and that standalone `.js` user scripts need separate file sync attention. It also calls out plugin enablement, SecretStorage-backed values, third-party sync tools, and package export/import limits.

I verified the Obsidian Sync file-type and settings-reload guidance against the current official Obsidian docs on July 6, 2026, and scoped the `.js` caveat to Obsidian Sync's `Sync all other types` behavior.

Refs discussions #590, #610, #723, #797, #824.

Validation:
- `pnpm run build`
- `pnpm run provision:e2e-vault`
- `pnpm run obsidian:e2e -- eval code='JSON.stringify({vault: app.vault.getName(), basePath: app.vault.adapter.getBasePath?.() ?? null})'`
- `pnpm run obsidian:e2e -- quickadd:list`
- `pnpm run obsidian:e2e -- dev:errors`
- Live reload proof in the isolated vault: wrote a marker choice directly to `.obsidian/plugins/quickadd/data.json`, confirmed the running QuickAdd instance did not see it until `pnpm run obsidian:e2e -- plugin:reload id=quickadd`, then restored the original vault data.
- `cd docs && pnpm install && pnpm build`
- Final Docusaurus rebuild after review fixes: `cd docs && pnpm build`
- Pre-edit design review plus final two-reviewer adversarial diff review via Claude Sonnet.

Review notes:
- Sidebar edits are intentionally one additive entry per manual sidebar.
- This does not document Templater settings or bridge recipes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ section on syncing QuickAdd between devices, including what is transferred (choices, macros, globals, settings) and what is not (plugin install/enabled state and per-device secrets).
  * Included instructions for Obsidian Sync and other file-sync tools, plus the need to restart or re-toggle QuickAdd after syncing.
  * Added guidance for one-time export/import via QuickAdd packages.

* **Documentation**
  * Added the FAQ entry to the documentation sidebar for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->