### PR TITLE
docs: add external QuickAdd trigger guide

### DIFF
--- a/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -2,12 +2,12 @@
 title: Trigger QuickAdd from outside Obsidian
 ---
 
-QuickAdd can be triggered directly from launchers, scripts, schedules, and
-dashboard notes. Use QuickAdd's native surfaces first:
+You can trigger QuickAdd from launchers, scripts, schedulers, and dashboard
+notes - no extra plugins needed. There are two built-in ways in:
 
-- Use `obsidian://quickadd` when the thing you are building can open a link.
-- Use the native Obsidian CLI when the thing you are building runs a shell
-  command, such as a scheduled job.
+- The `obsidian://quickadd` URI, for anything that can open a link.
+- The Obsidian CLI, for anything that runs a shell command, such as a
+  scheduled job.
 
 You do not need the Advanced URI plugin to run a QuickAdd choice.
 
@@ -223,9 +223,9 @@ Obsidian command for that choice.
   the choice name is encoded and spelled exactly.
 - The wrong choice runs: rename choices so the externally triggered choice name
   is unique.
-- A schedule returns missing input JSON: check the `missing` list, then copy the
-  returned `missingFlags` into the scheduled command and replace `<value>` with
-  the value you want to pass.
+- A scheduled run returns JSON instead of capturing: the choice still needs
+  input. Copy each entry from the returned `missingFlags` into your command and
+  replace `<value>` with the value you want to pass.
 - The command works in a terminal but not from a scheduler: use the full path to
   the Obsidian CLI and make sure the job runs in your user desktop session.
 - An older thread suggests `obsidian://advanced-uri?...`: replace it with

--- a/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -22,7 +22,7 @@ Before you automate a choice:
 3. Keep prompts out of scheduled jobs where possible. Scheduled jobs work best
    when every required value is passed up front.
 
-You can list choices from the CLI to confirm names and IDs:
+Using the Obsidian CLI, you can list choices to confirm names and IDs:
 
 ```bash
 obsidian vault="My Vault" quickadd:list
@@ -58,7 +58,8 @@ example `{{VALUE:entry|trim}}`.
 Unnamed values such as bare `{{VALUE}}`, `{{NAME}}`, and `{{MVALUE}}` cannot be
 filled by URI parameters. QuickAdd prompts for them inside Obsidian as usual.
 
-For callback URLs such as `x-success` and `x-error`, see
+For the full URI reference, including callback URLs such as `x-success` and
+`x-error`, see
 [Open QuickAdd from a URI](./ObsidianUri.md). Callback support is opt-in and has
 extra restrictions that ordinary triggers do not need.
 
@@ -97,13 +98,21 @@ Use `xdg-open` from a desktop session:
 xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
 ```
 
-For a `.desktop` launcher, put the command in a small shell script and point the
-launcher at that script. This avoids desktop-file escaping problems with the
-percent signs in URL-encoded values.
+For a `.desktop` launcher, put the command in a small shell script and point
+`Exec` at that script. This avoids desktop-file escaping problems with the
+percent signs in URL-encoded values:
 
 ```sh
 #!/usr/bin/env sh
 xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+```ini
+[Desktop Entry]
+Type=Application
+Name=Daily log
+Exec=/home/alice/bin/quickadd-daily-log
+Terminal=false
 ```
 
 ## Run QuickAdd on a schedule
@@ -120,7 +129,7 @@ obsidian vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled
 By default, `quickadd:run` is non-interactive. If the choice is missing required
 inputs, QuickAdd returns JSON with `missingFlags` instead of opening prompts.
 Run `quickadd:check` while building the automation to see what still needs to be
-passed:
+passed. See [QuickAdd CLI](./CLI.md) for the full command reference.
 
 ```bash
 obsidian vault="My Vault" quickadd:check choice="Daily log"
@@ -203,9 +212,9 @@ Plain Markdown links work well for dashboard notes:
 
 Clicking the link runs the choice.
 
-If you want a styled button, configure the button tool to open the same
+If you use a button plugin for styling, configure it to open the same
 `obsidian://quickadd` URI. Another QuickAdd-native option is to enable the
-command toggle on the choice, then have the button tool run the generated
+command toggle on the choice, then configure the button to run the generated
 Obsidian command for that choice.
 
 ## Troubleshooting
@@ -214,8 +223,9 @@ Obsidian command for that choice.
   the choice name is encoded and spelled exactly.
 - The wrong choice runs: rename choices so the externally triggered choice name
   is unique.
-- A schedule returns missing input JSON: copy the returned `missingFlags` into
-  the scheduled command and replace `<value>` with the value you want to pass.
+- A schedule returns missing input JSON: check the `missing` list, then copy the
+  returned `missingFlags` into the scheduled command and replace `<value>` with
+  the value you want to pass.
 - The command works in a terminal but not from a scheduler: use the full path to
   the Obsidian CLI and make sure the job runs in your user desktop session.
 - An older thread suggests `obsidian://advanced-uri?...`: replace it with

--- a/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -1,0 +1,222 @@
+---
+title: Trigger QuickAdd from outside Obsidian
+---
+
+QuickAdd can be triggered directly from launchers, scripts, schedules, and
+dashboard notes. Use QuickAdd's native surfaces first:
+
+- Use `obsidian://quickadd` when the thing you are building can open a link.
+- Use the native Obsidian CLI when the thing you are building runs a shell
+  command, such as a scheduled job.
+
+You do not need the Advanced URI plugin to run a QuickAdd choice.
+
+## Prepare the choice
+
+Before you automate a choice:
+
+1. Give the choice a unique name. URI triggers select by choice name, and if more
+   than one choice has that name, QuickAdd runs the first match it finds.
+2. Use named values for anything you want to pass from outside Obsidian, for
+   example `{{VALUE:entry}}` or `{{VALUE:project}}`.
+3. Keep prompts out of scheduled jobs where possible. Scheduled jobs work best
+   when every required value is passed up front.
+
+You can list choices from the CLI to confirm names and IDs:
+
+```bash
+obsidian vault="My Vault" quickadd:list
+```
+
+## Native URI syntax
+
+Use this URI shape:
+
+```text
+obsidian://quickadd?choice=<encoded choice name>[&value-<name>=<encoded value>]
+```
+
+Example:
+
+```text
+obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-entry=Finished%20review
+```
+
+The URI parameters are:
+
+- `choice` - the exact choice name to run. Encode spaces and special characters,
+  for example `Daily log` becomes `Daily%20log`.
+- `value-<name>` - sets a named QuickAdd value. `value-entry=Done` fills
+  `{{VALUE:entry}}`; `value-log%20notes=Done` fills `{{VALUE:log notes}}`.
+- `vault` - the Obsidian vault selector. This is handled by Obsidian before
+  QuickAdd receives the URI.
+
+Values are used exactly as passed. If a choice should ignore accidental leading
+or trailing whitespace for a value, use `|trim` in the choice format, for
+example `{{VALUE:entry|trim}}`.
+
+Unnamed values such as bare `{{VALUE}}`, `{{NAME}}`, and `{{MVALUE}}` cannot be
+filled by URI parameters. QuickAdd prompts for them inside Obsidian as usual.
+
+For callback URLs such as `x-success` and `x-error`, see
+[Open QuickAdd from a URI](./ObsidianUri.md). Callback support is opt-in and has
+extra restrictions that ordinary triggers do not need.
+
+## Desktop shortcuts
+
+Any desktop shortcut or launcher that can open a URL can open
+`obsidian://quickadd`.
+
+### macOS
+
+Use Shortcuts with an **Open URLs** action, or run:
+
+```bash
+/usr/bin/open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+If you use a shell command, quote the whole URI. The `&` character has special
+meaning in shells unless it is quoted.
+
+### Windows
+
+For a desktop shortcut target or launcher command, use:
+
+```bat
+cmd.exe /c start "" "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
+```
+
+The empty `""` is intentional. In `cmd.exe start`, the first quoted string is the
+window title, not the command to run.
+
+### Linux
+
+Use `xdg-open` from a desktop session:
+
+```bash
+xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+For a `.desktop` launcher, put the command in a small shell script and point the
+launcher at that script. This avoids desktop-file escaping problems with the
+percent signs in URL-encoded values.
+
+```sh
+#!/usr/bin/env sh
+xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+## Run QuickAdd on a schedule
+
+QuickAdd does not include a background scheduler. Use your operating system's
+scheduler to run Obsidian's native CLI command.
+
+Scheduled jobs should use `quickadd:run`:
+
+```bash
+obsidian vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled check"
+```
+
+By default, `quickadd:run` is non-interactive. If the choice is missing required
+inputs, QuickAdd returns JSON with `missingFlags` instead of opening prompts.
+Run `quickadd:check` while building the automation to see what still needs to be
+passed:
+
+```bash
+obsidian vault="My Vault" quickadd:check choice="Daily log"
+```
+
+If you intentionally want Obsidian prompts, add `ui`, but only do this for jobs
+that run while you are logged in and able to answer the prompts:
+
+```bash
+obsidian vault="My Vault" quickadd:run choice="Daily log" ui
+```
+
+Use full paths in schedulers. They usually do not load the same `PATH` as your
+terminal.
+
+### macOS launchd
+
+Use the full path from `command -v obsidian`. In a launchd plist, pass each
+argument as its own string:
+
+```xml
+<key>ProgramArguments</key>
+<array>
+  <string>/opt/homebrew/bin/obsidian</string>
+  <string>vault=My Vault</string>
+  <string>quickadd:run</string>
+  <string>choice=Daily log</string>
+  <string>value-entry=Scheduled check</string>
+</array>
+```
+
+Depending on your install, the Obsidian CLI path may be
+`/usr/local/bin/obsidian` instead.
+
+### Windows Task Scheduler
+
+Use `Obsidian.com`, not `Obsidian.exe`, for CLI commands:
+
+```text
+Program/script:
+C:\Users\alice\AppData\Local\Obsidian\Obsidian.com
+
+Arguments:
+vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled check"
+```
+
+For a scheduled URI action instead, run:
+
+```text
+Program/script:
+cmd.exe
+
+Arguments:
+/c start "" "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
+```
+
+URI actions need a logged-in desktop session. In Task Scheduler, use "Run only
+when user is logged on" for URL-opening tasks.
+
+### Linux cron or systemd user timers
+
+Use the full CLI path:
+
+```cron
+0 9 * * * /home/alice/.local/bin/obsidian vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled check"
+```
+
+Run GUI-related jobs only from your user desktop session. If a cron job cannot
+reach your desktop session, prefer a systemd user timer or run the command from
+your desktop environment's scheduler.
+
+## In-note links and buttons
+
+Plain Markdown links work well for dashboard notes:
+
+```markdown
+[New idea](obsidian://quickadd?vault=My%20Vault&choice=New%20idea)
+[Log work](obsidian://quickadd?vault=My%20Vault&choice=Work%20log&value-project=QuickAdd)
+```
+
+Clicking the link runs the choice.
+
+If you want a styled button, configure the button tool to open the same
+`obsidian://quickadd` URI. Another QuickAdd-native option is to enable the
+command toggle on the choice, then have the button tool run the generated
+Obsidian command for that choice.
+
+## Troubleshooting
+
+- Nothing happens: make sure QuickAdd is enabled in the selected vault and that
+  the choice name is encoded and spelled exactly.
+- The wrong choice runs: rename choices so the externally triggered choice name
+  is unique.
+- A schedule returns missing input JSON: copy the returned `missingFlags` into
+  the scheduled command and replace `<value>` with the value you want to pass.
+- The command works in a terminal but not from a scheduler: use the full path to
+  the Obsidian CLI and make sure the job runs in your user desktop session.
+- An older thread suggests `obsidian://advanced-uri?...`: replace it with
+  `obsidian://quickadd?...`. QuickAdd has its own URI handler.

--- a/docs/docs/Misc/AHK_OpenQuickAddFromDesktop.md
+++ b/docs/docs/Misc/AHK_OpenQuickAddFromDesktop.md
@@ -13,11 +13,14 @@ QuickAdd now has a native URI handler, so AutoHotkey can open QuickAdd directly:
 #SingleInstance, Force
 SendMode Input
 SetWorkingDir, %A_ScriptDir%
+SetTitleMatchMode, RegEx
 
 !^+g::
+    WinActivate, i) Obsidian
     Run "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
 Return
 ```
 
 Replace `My%20Vault` and `Daily%20log` with your URL-encoded vault and choice
-names.
+names. Remove `WinActivate` if you do not want AutoHotkey to focus Obsidian
+before opening the URI.

--- a/docs/docs/Misc/AHK_OpenQuickAddFromDesktop.md
+++ b/docs/docs/Misc/AHK_OpenQuickAddFromDesktop.md
@@ -3,63 +3,21 @@ hidden: true
 title: Open QuickAdd from your Desktop
 ---
 
-**UPDATE: A more reliable method is to use the [Global Hotkeys](https://github.com/mjessome/obsidian-global-hotkeys) plugin for Obsidian.**
+This older page is kept for existing links. For current desktop shortcuts,
+launchers, scheduled jobs, and dashboard links, use
+[Trigger QuickAdd from outside Obsidian](../Advanced/TriggerQuickAddFromOutsideObsidian.md).
 
-This is an [AutoHotkey](https://www.autohotkey.com/) script which unminimizes/focuses Obsidian and sends some keypresses to it.
-
-I've bound this to my QuickAdd activation hotkey, so this script automatically brings Obsidian to the front of my screen with QuickAdd open.
+QuickAdd now has a native URI handler, so AutoHotkey can open QuickAdd directly:
 
 ```ahk
 #SingleInstance, Force
 SendMode Input
 SetWorkingDir, %A_ScriptDir%
-SetTitleMatchMode, RegEx
 
 !^+g::
-    WinActivate, i) Obsidian
-    ControlSend,, {CtrlDown}{AltDown}{ShiftDown}G{CtrlUp}{CtrlUp}{ShiftUp}, i)Obsidian
+    Run "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
 Return
 ```
 
-I'm using CTRL+SHIFT+ALT+G as my shortcut, both in Obsidian and for the AHK script to activate. I use a keyboard shortcut to send those keys (lol, I know - but it's to avoid potential conflicts).
-Here's a guide to what the `!^+` mean, and how you can customize it: https://www.autohotkey.com/docs/Hotkeys.htm
-
-#### Update
-
-If you are willing to install the `Obsidian Advanced URI` plugin, this script is much easier for you to use.
-
-```ahk
-SendMode Input
-SetWorkingDir, %A_ScriptDir%
-SetTitleMatchMode, RegEx
-
-!^+g::
-    WinActivate, i) Obsidian
-
-    Run "obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd"
-Return
-```
-
-Simply replace `<YOUR_VAULT_NAME>` with the name of your vault.
-
-**This version is more reliable**, as the other one can fail to activate occasionally.
-
-It uses the same hotkey to activate as above (`CTRL+SHIFT+ALT+G`). If you wish to change it:
-
--   `!` means `Alt`
--   `^` means `Ctrl`
--   `+` means `Shift`
-
-So, you can replace the `!^+g` with any hotkey of your choosing.
-
-#### macOS
-
-You can trigger QuickAdd via the Advanced URI using any launcher or automation tool you prefer:
-
-- Open URL: `obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd`
-
-Examples:
-- macOS Shortcuts: add an “Open URLs” action with the URI; assign a keyboard shortcut.
-- Alfred: create a workflow that opens the URI.
-- Raycast: optional — create a Quicklink with the URI.
-- Keyboard Maestro or Hammerspoon: bind a hotkey that runs `open "obsidian://advanced-uri?..."`.
+Replace `My%20Vault` and `Daily%20log` with your URL-encoded vault and choice
+names.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -201,13 +201,13 @@ const sidebars = {
 				},
 				{
 					type: "doc",
-					id: "Advanced/TriggerQuickAddFromOutsideObsidian",
-					label: "Trigger QuickAdd Externally",
+					id: "Advanced/CLI",
+					label: "QuickAdd CLI",
 				},
 				{
 					type: "doc",
-					id: "Advanced/CLI",
-					label: "QuickAdd CLI",
+					id: "Advanced/TriggerQuickAddFromOutsideObsidian",
+					label: "Trigger QuickAdd from outside Obsidian",
 				},
 			],
 		},

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -201,6 +201,11 @@ const sidebars = {
 				},
 				{
 					type: "doc",
+					id: "Advanced/TriggerQuickAddFromOutsideObsidian",
+					label: "Trigger QuickAdd Externally",
+				},
+				{
+					type: "doc",
 					id: "Advanced/CLI",
 					label: "QuickAdd CLI",
 				},

--- a/docs/versioned_docs/version-2.17.2/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/versioned_docs/version-2.17.2/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -2,12 +2,12 @@
 title: Trigger QuickAdd from outside Obsidian
 ---
 
-QuickAdd can be triggered directly from launchers, scripts, schedules, and
-dashboard notes. Use QuickAdd's native surfaces first:
+You can trigger QuickAdd from launchers, scripts, schedulers, and dashboard
+notes - no extra plugins needed. There are two built-in ways in:
 
-- Use `obsidian://quickadd` when the thing you are building can open a link.
-- Use the native Obsidian CLI when the thing you are building runs a shell
-  command, such as a scheduled job.
+- The `obsidian://quickadd` URI, for anything that can open a link.
+- The Obsidian CLI, for anything that runs a shell command, such as a
+  scheduled job.
 
 You do not need the Advanced URI plugin to run a QuickAdd choice.
 
@@ -223,9 +223,9 @@ Obsidian command for that choice.
   the choice name is encoded and spelled exactly.
 - The wrong choice runs: rename choices so the externally triggered choice name
   is unique.
-- A schedule returns missing input JSON: check the `missing` list, then copy the
-  returned `missingFlags` into the scheduled command and replace `<value>` with
-  the value you want to pass.
+- A scheduled run returns JSON instead of capturing: the choice still needs
+  input. Copy each entry from the returned `missingFlags` into your command and
+  replace `<value>` with the value you want to pass.
 - The command works in a terminal but not from a scheduler: use the full path to
   the Obsidian CLI and make sure the job runs in your user desktop session.
 - An older thread suggests `obsidian://advanced-uri?...`: replace it with

--- a/docs/versioned_docs/version-2.17.2/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/versioned_docs/version-2.17.2/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -22,7 +22,7 @@ Before you automate a choice:
 3. Keep prompts out of scheduled jobs where possible. Scheduled jobs work best
    when every required value is passed up front.
 
-You can list choices from the CLI to confirm names and IDs:
+Using the Obsidian CLI, you can list choices to confirm names and IDs:
 
 ```bash
 obsidian vault="My Vault" quickadd:list
@@ -58,7 +58,8 @@ example `{{VALUE:entry|trim}}`.
 Unnamed values such as bare `{{VALUE}}`, `{{NAME}}`, and `{{MVALUE}}` cannot be
 filled by URI parameters. QuickAdd prompts for them inside Obsidian as usual.
 
-For callback URLs such as `x-success` and `x-error`, see
+For the full URI reference, including callback URLs such as `x-success` and
+`x-error`, see
 [Open QuickAdd from a URI](./ObsidianUri.md). Callback support is opt-in and has
 extra restrictions that ordinary triggers do not need.
 
@@ -97,13 +98,21 @@ Use `xdg-open` from a desktop session:
 xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
 ```
 
-For a `.desktop` launcher, put the command in a small shell script and point the
-launcher at that script. This avoids desktop-file escaping problems with the
-percent signs in URL-encoded values.
+For a `.desktop` launcher, put the command in a small shell script and point
+`Exec` at that script. This avoids desktop-file escaping problems with the
+percent signs in URL-encoded values:
 
 ```sh
 #!/usr/bin/env sh
 xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+```ini
+[Desktop Entry]
+Type=Application
+Name=Daily log
+Exec=/home/alice/bin/quickadd-daily-log
+Terminal=false
 ```
 
 ## Run QuickAdd on a schedule
@@ -120,7 +129,7 @@ obsidian vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled
 By default, `quickadd:run` is non-interactive. If the choice is missing required
 inputs, QuickAdd returns JSON with `missingFlags` instead of opening prompts.
 Run `quickadd:check` while building the automation to see what still needs to be
-passed:
+passed. See [QuickAdd CLI](./CLI.md) for the full command reference.
 
 ```bash
 obsidian vault="My Vault" quickadd:check choice="Daily log"
@@ -203,9 +212,9 @@ Plain Markdown links work well for dashboard notes:
 
 Clicking the link runs the choice.
 
-If you want a styled button, configure the button tool to open the same
+If you use a button plugin for styling, configure it to open the same
 `obsidian://quickadd` URI. Another QuickAdd-native option is to enable the
-command toggle on the choice, then have the button tool run the generated
+command toggle on the choice, then configure the button to run the generated
 Obsidian command for that choice.
 
 ## Troubleshooting
@@ -214,8 +223,9 @@ Obsidian command for that choice.
   the choice name is encoded and spelled exactly.
 - The wrong choice runs: rename choices so the externally triggered choice name
   is unique.
-- A schedule returns missing input JSON: copy the returned `missingFlags` into
-  the scheduled command and replace `<value>` with the value you want to pass.
+- A schedule returns missing input JSON: check the `missing` list, then copy the
+  returned `missingFlags` into the scheduled command and replace `<value>` with
+  the value you want to pass.
 - The command works in a terminal but not from a scheduler: use the full path to
   the Obsidian CLI and make sure the job runs in your user desktop session.
 - An older thread suggests `obsidian://advanced-uri?...`: replace it with

--- a/docs/versioned_docs/version-2.17.2/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/versioned_docs/version-2.17.2/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -1,0 +1,222 @@
+---
+title: Trigger QuickAdd from outside Obsidian
+---
+
+QuickAdd can be triggered directly from launchers, scripts, schedules, and
+dashboard notes. Use QuickAdd's native surfaces first:
+
+- Use `obsidian://quickadd` when the thing you are building can open a link.
+- Use the native Obsidian CLI when the thing you are building runs a shell
+  command, such as a scheduled job.
+
+You do not need the Advanced URI plugin to run a QuickAdd choice.
+
+## Prepare the choice
+
+Before you automate a choice:
+
+1. Give the choice a unique name. URI triggers select by choice name, and if more
+   than one choice has that name, QuickAdd runs the first match it finds.
+2. Use named values for anything you want to pass from outside Obsidian, for
+   example `{{VALUE:entry}}` or `{{VALUE:project}}`.
+3. Keep prompts out of scheduled jobs where possible. Scheduled jobs work best
+   when every required value is passed up front.
+
+You can list choices from the CLI to confirm names and IDs:
+
+```bash
+obsidian vault="My Vault" quickadd:list
+```
+
+## Native URI syntax
+
+Use this URI shape:
+
+```text
+obsidian://quickadd?choice=<encoded choice name>[&value-<name>=<encoded value>]
+```
+
+Example:
+
+```text
+obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-entry=Finished%20review
+```
+
+The URI parameters are:
+
+- `choice` - the exact choice name to run. Encode spaces and special characters,
+  for example `Daily log` becomes `Daily%20log`.
+- `value-<name>` - sets a named QuickAdd value. `value-entry=Done` fills
+  `{{VALUE:entry}}`; `value-log%20notes=Done` fills `{{VALUE:log notes}}`.
+- `vault` - the Obsidian vault selector. This is handled by Obsidian before
+  QuickAdd receives the URI.
+
+Values are used exactly as passed. If a choice should ignore accidental leading
+or trailing whitespace for a value, use `|trim` in the choice format, for
+example `{{VALUE:entry|trim}}`.
+
+Unnamed values such as bare `{{VALUE}}`, `{{NAME}}`, and `{{MVALUE}}` cannot be
+filled by URI parameters. QuickAdd prompts for them inside Obsidian as usual.
+
+For callback URLs such as `x-success` and `x-error`, see
+[Open QuickAdd from a URI](./ObsidianUri.md). Callback support is opt-in and has
+extra restrictions that ordinary triggers do not need.
+
+## Desktop shortcuts
+
+Any desktop shortcut or launcher that can open a URL can open
+`obsidian://quickadd`.
+
+### macOS
+
+Use Shortcuts with an **Open URLs** action, or run:
+
+```bash
+/usr/bin/open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+If you use a shell command, quote the whole URI. The `&` character has special
+meaning in shells unless it is quoted.
+
+### Windows
+
+For a desktop shortcut target or launcher command, use:
+
+```bat
+cmd.exe /c start "" "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
+```
+
+The empty `""` is intentional. In `cmd.exe start`, the first quoted string is the
+window title, not the command to run.
+
+### Linux
+
+Use `xdg-open` from a desktop session:
+
+```bash
+xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+For a `.desktop` launcher, put the command in a small shell script and point the
+launcher at that script. This avoids desktop-file escaping problems with the
+percent signs in URL-encoded values.
+
+```sh
+#!/usr/bin/env sh
+xdg-open 'obsidian://quickadd?vault=My%20Vault&choice=Daily%20log'
+```
+
+## Run QuickAdd on a schedule
+
+QuickAdd does not include a background scheduler. Use your operating system's
+scheduler to run Obsidian's native CLI command.
+
+Scheduled jobs should use `quickadd:run`:
+
+```bash
+obsidian vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled check"
+```
+
+By default, `quickadd:run` is non-interactive. If the choice is missing required
+inputs, QuickAdd returns JSON with `missingFlags` instead of opening prompts.
+Run `quickadd:check` while building the automation to see what still needs to be
+passed:
+
+```bash
+obsidian vault="My Vault" quickadd:check choice="Daily log"
+```
+
+If you intentionally want Obsidian prompts, add `ui`, but only do this for jobs
+that run while you are logged in and able to answer the prompts:
+
+```bash
+obsidian vault="My Vault" quickadd:run choice="Daily log" ui
+```
+
+Use full paths in schedulers. They usually do not load the same `PATH` as your
+terminal.
+
+### macOS launchd
+
+Use the full path from `command -v obsidian`. In a launchd plist, pass each
+argument as its own string:
+
+```xml
+<key>ProgramArguments</key>
+<array>
+  <string>/opt/homebrew/bin/obsidian</string>
+  <string>vault=My Vault</string>
+  <string>quickadd:run</string>
+  <string>choice=Daily log</string>
+  <string>value-entry=Scheduled check</string>
+</array>
+```
+
+Depending on your install, the Obsidian CLI path may be
+`/usr/local/bin/obsidian` instead.
+
+### Windows Task Scheduler
+
+Use `Obsidian.com`, not `Obsidian.exe`, for CLI commands:
+
+```text
+Program/script:
+C:\Users\alice\AppData\Local\Obsidian\Obsidian.com
+
+Arguments:
+vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled check"
+```
+
+For a scheduled URI action instead, run:
+
+```text
+Program/script:
+cmd.exe
+
+Arguments:
+/c start "" "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
+```
+
+URI actions need a logged-in desktop session. In Task Scheduler, use "Run only
+when user is logged on" for URL-opening tasks.
+
+### Linux cron or systemd user timers
+
+Use the full CLI path:
+
+```cron
+0 9 * * * /home/alice/.local/bin/obsidian vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled check"
+```
+
+Run GUI-related jobs only from your user desktop session. If a cron job cannot
+reach your desktop session, prefer a systemd user timer or run the command from
+your desktop environment's scheduler.
+
+## In-note links and buttons
+
+Plain Markdown links work well for dashboard notes:
+
+```markdown
+[New idea](obsidian://quickadd?vault=My%20Vault&choice=New%20idea)
+[Log work](obsidian://quickadd?vault=My%20Vault&choice=Work%20log&value-project=QuickAdd)
+```
+
+Clicking the link runs the choice.
+
+If you want a styled button, configure the button tool to open the same
+`obsidian://quickadd` URI. Another QuickAdd-native option is to enable the
+command toggle on the choice, then have the button tool run the generated
+Obsidian command for that choice.
+
+## Troubleshooting
+
+- Nothing happens: make sure QuickAdd is enabled in the selected vault and that
+  the choice name is encoded and spelled exactly.
+- The wrong choice runs: rename choices so the externally triggered choice name
+  is unique.
+- A schedule returns missing input JSON: copy the returned `missingFlags` into
+  the scheduled command and replace `<value>` with the value you want to pass.
+- The command works in a terminal but not from a scheduler: use the full path to
+  the Obsidian CLI and make sure the job runs in your user desktop session.
+- An older thread suggests `obsidian://advanced-uri?...`: replace it with
+  `obsidian://quickadd?...`. QuickAdd has its own URI handler.

--- a/docs/versioned_docs/version-2.17.2/Misc/AHK_OpenQuickAddFromDesktop.md
+++ b/docs/versioned_docs/version-2.17.2/Misc/AHK_OpenQuickAddFromDesktop.md
@@ -13,11 +13,14 @@ QuickAdd now has a native URI handler, so AutoHotkey can open QuickAdd directly:
 #SingleInstance, Force
 SendMode Input
 SetWorkingDir, %A_ScriptDir%
+SetTitleMatchMode, RegEx
 
 !^+g::
+    WinActivate, i) Obsidian
     Run "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
 Return
 ```
 
 Replace `My%20Vault` and `Daily%20log` with your URL-encoded vault and choice
-names.
+names. Remove `WinActivate` if you do not want AutoHotkey to focus Obsidian
+before opening the URI.

--- a/docs/versioned_docs/version-2.17.2/Misc/AHK_OpenQuickAddFromDesktop.md
+++ b/docs/versioned_docs/version-2.17.2/Misc/AHK_OpenQuickAddFromDesktop.md
@@ -3,63 +3,21 @@ hidden: true
 title: Open QuickAdd from your Desktop
 ---
 
-**UPDATE: A more reliable method is to use the [Global Hotkeys](https://github.com/mjessome/obsidian-global-hotkeys) plugin for Obsidian.**
+This older page is kept for existing links. For current desktop shortcuts,
+launchers, scheduled jobs, and dashboard links, use
+[Trigger QuickAdd from outside Obsidian](../Advanced/TriggerQuickAddFromOutsideObsidian.md).
 
-This is an [AutoHotkey](https://www.autohotkey.com/) script which unminimizes/focuses Obsidian and sends some keypresses to it.
-
-I've bound this to my QuickAdd activation hotkey, so this script automatically brings Obsidian to the front of my screen with QuickAdd open.
+QuickAdd now has a native URI handler, so AutoHotkey can open QuickAdd directly:
 
 ```ahk
 #SingleInstance, Force
 SendMode Input
 SetWorkingDir, %A_ScriptDir%
-SetTitleMatchMode, RegEx
 
 !^+g::
-    WinActivate, i) Obsidian
-    ControlSend,, {CtrlDown}{AltDown}{ShiftDown}G{CtrlUp}{CtrlUp}{ShiftUp}, i)Obsidian
+    Run "obsidian://quickadd?vault=My%20Vault&choice=Daily%20log"
 Return
 ```
 
-I'm using CTRL+SHIFT+ALT+G as my shortcut, both in Obsidian and for the AHK script to activate. I use a keyboard shortcut to send those keys (lol, I know - but it's to avoid potential conflicts).
-Here's a guide to what the `!^+` mean, and how you can customize it: https://www.autohotkey.com/docs/Hotkeys.htm
-
-#### Update
-
-If you are willing to install the `Obsidian Advanced URI` plugin, this script is much easier for you to use.
-
-```ahk
-SendMode Input
-SetWorkingDir, %A_ScriptDir%
-SetTitleMatchMode, RegEx
-
-!^+g::
-    WinActivate, i) Obsidian
-
-    Run "obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd"
-Return
-```
-
-Simply replace `<YOUR_VAULT_NAME>` with the name of your vault.
-
-**This version is more reliable**, as the other one can fail to activate occasionally.
-
-It uses the same hotkey to activate as above (`CTRL+SHIFT+ALT+G`). If you wish to change it:
-
--   `!` means `Alt`
--   `^` means `Ctrl`
--   `+` means `Shift`
-
-So, you can replace the `!^+g` with any hotkey of your choosing.
-
-#### macOS
-
-You can trigger QuickAdd via the Advanced URI using any launcher or automation tool you prefer:
-
-- Open URL: `obsidian://advanced-uri?vault=<YOUR_VAULT_NAME>&commandname=QuickAdd:%20Run%20QuickAdd`
-
-Examples:
-- macOS Shortcuts: add an “Open URLs” action with the URI; assign a keyboard shortcut.
-- Alfred: create a workflow that opens the URI.
-- Raycast: optional — create a Quicklink with the URI.
-- Keyboard Maestro or Hammerspoon: bind a hotkey that runs `open "obsidian://advanced-uri?..."`.
+Replace `My%20Vault` and `Daily%20log` with your URL-encoded vault and choice
+names.

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -172,6 +172,11 @@
         },
         {
           "type": "doc",
+          "id": "Advanced/TriggerQuickAddFromOutsideObsidian",
+          "label": "Trigger QuickAdd Externally"
+        },
+        {
+          "type": "doc",
           "id": "Advanced/CLI",
           "label": "QuickAdd CLI"
         }

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -172,13 +172,13 @@
         },
         {
           "type": "doc",
-          "id": "Advanced/TriggerQuickAddFromOutsideObsidian",
-          "label": "Trigger QuickAdd Externally"
+          "id": "Advanced/CLI",
+          "label": "QuickAdd CLI"
         },
         {
           "type": "doc",
-          "id": "Advanced/CLI",
-          "label": "QuickAdd CLI"
+          "id": "Advanced/TriggerQuickAddFromOutsideObsidian",
+          "label": "Trigger QuickAdd from outside Obsidian"
         }
       ]
     },


### PR DESCRIPTION
Adds a user-facing guide for triggering QuickAdd from outside Obsidian, covering the native `obsidian://quickadd` URI, desktop shortcuts on macOS/Windows/Linux, scheduled runs through the Obsidian CLI, and dashboard-note links/buttons.

This also retires the hidden desktop/AHK page's stale key-send and Advanced URI workaround, replacing it with the native QuickAdd URI path while preserving the old page URL for existing links.

Refs discussions #340, #451, #551, #691, #792, #1069.

Validation:
- `pnpm run build`
- `pnpm run provision:e2e-vault`
- `pnpm run obsidian:e2e -- quickadd:list`
- `pnpm run obsidian:e2e -- quickadd:check choice='External Trigger Capture'` returned `missingFlags:["value-entry=<value>"]`
- `pnpm run obsidian:e2e -- quickadd:run choice='External Trigger Capture' value-entry='CLI scheduled proof' verify` returned `verified:true` and wrote `External Trigger Proof.md`
- `pnpm run obsidian:e2e -- eval ... app.workspace.protocolHandlers.get("quickadd")({ choice, "value-entry": ... })` appended `URI handler proof` through the live registered protocol handler
- `pnpm run obsidian:e2e -- eval ... app.commands.commands["quickadd:choice:__qa-external-trigger-capture"]` confirmed the generated Obsidian command is `QuickAdd: External Trigger Capture`
- `pnpm run obsidian:e2e -- dev:errors` returned no captured errors
- `cd docs && pnpm install && pnpm build`
- `cd docs && pnpm build` after review fixes
- `pnpm run build-with-lint`

Review notes:
- `ultracode` was not installed on this machine, so that exact review tool could not be run.
- Opposite-model `claude` review was attempted before editing and after drafting. The pre-edit default model was quota-blocked, bare mode was unauthenticated, and Sonnet did not return in the bounded windows. One final Sonnet architect review did return findings; the actionable docs-shape findings were addressed in `docs: address external trigger guide review`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new guide for triggering QuickAdd from outside Obsidian, including URI-based and CLI-based automation.
  * Included examples for desktop shortcuts, schedulers, and in-note links/buttons across major operating systems.

* **Documentation**
  * Updated an older desktop automation page to point readers to the newer guide.
  * Added the new guide to the app’s documentation navigation, including versioned docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->