### PR TITLE
fix(userscript): explain loader failures

### DIFF
--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -487,6 +487,12 @@ async function collectMacroScriptRequirements(
 			const scriptPath = userScriptCommand.path ?? userScriptCommand.id;
 			const message =
 				error instanceof Error ? error.message : String(error);
+			if (error instanceof Error && error.name === "UserScriptLoadError") {
+				console.warn(
+					`QuickAdd preflight could not inspect user script '${scriptPath}': ${message}`,
+				);
+				continue;
+			}
 			log.logWarning(
 				`Preflight could not inspect user script '${scriptPath}': ${message}`,
 			);

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -24,7 +24,10 @@ import {
 	isFolder,
 } from "src/utilityObsidian";
 import { log } from "src/logger/logManager";
-import { getUserScriptPreloadKey } from "src/utils/userScript";
+import {
+	getUserScriptPreloadKey,
+	isUserScriptLoadError,
+} from "src/utils/userScript";
 import { hasTemplatePathSyntax } from "src/utils/templatePathSyntax";
 import {
 	classifyCaptureTargetScope,
@@ -487,7 +490,7 @@ async function collectMacroScriptRequirements(
 			const scriptPath = userScriptCommand.path ?? userScriptCommand.id;
 			const message =
 				error instanceof Error ? error.message : String(error);
-			if (error instanceof Error && error.name === "UserScriptLoadError") {
+			if (isUserScriptLoadError(error)) {
 				console.warn(
 					`QuickAdd preflight could not inspect user script '${scriptPath}': ${message}`,
 				);

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -491,7 +491,7 @@ async function collectMacroScriptRequirements(
 			const message =
 				error instanceof Error ? error.message : String(error);
 			if (isUserScriptLoadError(error)) {
-				console.warn(
+				log.logMessage(
 					`QuickAdd preflight could not inspect user script '${scriptPath}': ${message}`,
 				);
 				continue;

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -471,7 +471,9 @@ async function collectMacroScriptRequirements(
 					? preloadedUserScripts?.get(cacheKey)
 					: undefined;
 			if (exported === undefined) {
-				exported = await getUserScript(userScriptCommand, app);
+				exported = await getUserScript(userScriptCommand, app, {
+					reportLoadErrors: false,
+				});
 				if (cacheKey !== undefined && exported !== undefined) {
 					preloadedUserScripts?.set(cacheKey, exported);
 				}

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -274,10 +274,6 @@ describe("getUserScript", () => {
 	});
 
 	it("explains when a .js file is a saved webpage instead of raw JavaScript", async () => {
-		const noticeStub = Notice as unknown as {
-			instances: Array<{ message: string }>;
-		};
-		const before = noticeStub.instances.length;
 		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
 		const app = createUserScriptApp(
 			[
@@ -292,11 +288,10 @@ describe("getUserScript", () => {
 			"saved webpage",
 		);
 
-		const added = noticeStub.instances.slice(before);
-		expect(added).toHaveLength(1);
-		expect(added[0].message).toContain("use the Raw button");
-		expect(added[0].message).toContain("download the .js file");
-		expect(logError).toHaveBeenCalledWith(added[0].message);
+		expect(logError).toHaveBeenCalledTimes(1);
+		const reported = logError.mock.calls[0][0] as Error;
+		expect(reported.message).toContain("use the Raw button");
+		expect(reported.message).toContain("download the .js file");
 		logError.mockRestore();
 	});
 
@@ -317,10 +312,6 @@ describe("getUserScript", () => {
 	});
 
 	it("explains when an explicit default export is not runnable", async () => {
-		const noticeStub = Notice as unknown as {
-			instances: Array<{ message: string }>;
-		};
-		const before = noticeStub.instances.length;
 		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
 		const app = createUserScriptApp(
 			[
@@ -336,11 +327,10 @@ describe("getUserScript", () => {
 			"default export is not a function",
 		);
 
-		const added = noticeStub.instances.slice(before);
-		expect(added).toHaveLength(1);
-		expect(added[0].message).toContain("module.exports = async");
-		expect(added[0].message).toContain("exports.default = async");
-		expect(logError).toHaveBeenCalledWith(added[0].message);
+		expect(logError).toHaveBeenCalledTimes(1);
+		const reported = logError.mock.calls[0][0] as Error;
+		expect(reported.message).toContain("module.exports = async");
+		expect(reported.message).toContain("exports.default = async");
 		logError.mockRestore();
 	});
 
@@ -348,10 +338,6 @@ describe("getUserScript", () => {
 		const previousRequire = (window as unknown as {
 			require?: (moduleName: string) => unknown;
 		}).require;
-		const noticeStub = Notice as unknown as {
-			instances: Array<{ message: string }>;
-		};
-		const before = noticeStub.instances.length;
 		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
 		const missingModule = new Error("Cannot find module './Helper.js'");
 		(missingModule as Error & { code: string }).code = "MODULE_NOT_FOUND";
@@ -371,11 +357,10 @@ describe("getUserScript", () => {
 				getUserScript(createUserScriptCommand(), app),
 			).rejects.toThrow("could not find the required module");
 
-			const added = noticeStub.instances.slice(before);
-			expect(added).toHaveLength(1);
-			expect(added[0].message).toContain("./Helper.js");
-			expect(added[0].message).toContain("capitalization");
-			expect(logError).toHaveBeenCalledWith(added[0].message);
+			expect(logError).toHaveBeenCalledTimes(1);
+			const reported = logError.mock.calls[0][0] as Error;
+			expect(reported.message).toContain("./Helper.js");
+			expect(reported.message).toContain("capitalization");
 		} finally {
 			(window as unknown as { require?: (moduleName: string) => unknown }).require =
 				previousRequire;

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./utilityObsidian";
 import type { IUserScript } from "./types/macros/IUserScript";
 import { CommandType } from "./types/macros/CommandType";
+import { log } from "./logger/logManager";
 
 type FakeLeaf = WorkspaceLeaf & {
 	id: string;
@@ -143,6 +144,11 @@ describe("getAllFolderPathsInVault", () => {
 });
 
 describe("getUserScript", () => {
+	function noticeMessages(): string[] {
+		return (Notice as unknown as { instances: Array<{ message: string }> })
+			.instances.map((notice) => notice.message);
+	}
+
 	function createUserScriptCommand(
 		options: Partial<IUserScript> = {},
 	): IUserScript {
@@ -267,6 +273,116 @@ describe("getUserScript", () => {
 		expect((script as () => unknown)()).toBe("hi from a note");
 	});
 
+	it("explains when a .js file is a saved webpage instead of raw JavaScript", async () => {
+		const noticeStub = Notice as unknown as {
+			instances: Array<{ message: string }>;
+		};
+		const before = noticeStub.instances.length;
+		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
+		const app = createUserScriptApp(
+			[
+				"<!DOCTYPE html>",
+				"<html>",
+				"<body>GitHub page, not raw JavaScript.</body>",
+				"</html>",
+			].join("\n"),
+		);
+
+		await expect(getUserScript(createUserScriptCommand(), app)).rejects.toThrow(
+			"saved webpage",
+		);
+
+		const added = noticeStub.instances.slice(before);
+		expect(added).toHaveLength(1);
+		expect(added[0].message).toContain("use the Raw button");
+		expect(added[0].message).toContain("download the .js file");
+		expect(logError).toHaveBeenCalledWith(added[0].message);
+		logError.mockRestore();
+	});
+
+	it("can suppress user-facing load reporting during preflight", async () => {
+		const before = noticeMessages().length;
+		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
+		const app = createUserScriptApp("<html><body>not js</body></html>");
+
+		await expect(
+			getUserScript(createUserScriptCommand(), app, {
+				reportLoadErrors: false,
+			}),
+		).rejects.toThrow("saved webpage");
+
+		expect(noticeMessages()).toHaveLength(before);
+		expect(logError).not.toHaveBeenCalled();
+		logError.mockRestore();
+	});
+
+	it("explains when an explicit default export is not runnable", async () => {
+		const noticeStub = Notice as unknown as {
+			instances: Array<{ message: string }>;
+		};
+		const before = noticeStub.instances.length;
+		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
+		const app = createUserScriptApp(
+			[
+				"exports.default = {",
+				"  settings: {",
+				"    apiKey: { type: 'text', defaultValue: '' },",
+				"  },",
+				"};",
+			].join("\n"),
+		);
+
+		await expect(getUserScript(createUserScriptCommand(), app)).rejects.toThrow(
+			"default export is not a function",
+		);
+
+		const added = noticeStub.instances.slice(before);
+		expect(added).toHaveLength(1);
+		expect(added[0].message).toContain("module.exports = async");
+		expect(added[0].message).toContain("exports.default = async");
+		expect(logError).toHaveBeenCalledWith(added[0].message);
+		logError.mockRestore();
+	});
+
+	it("explains module resolution failures while loading a script", async () => {
+		const previousRequire = (window as unknown as {
+			require?: (moduleName: string) => unknown;
+		}).require;
+		const noticeStub = Notice as unknown as {
+			instances: Array<{ message: string }>;
+		};
+		const before = noticeStub.instances.length;
+		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
+		const missingModule = new Error("Cannot find module './Helper.js'");
+		(missingModule as Error & { code: string }).code = "MODULE_NOT_FOUND";
+		(window as unknown as { require?: (moduleName: string) => unknown }).require =
+			vi.fn(() => {
+				throw missingModule;
+			});
+		const app = createUserScriptApp(
+			[
+				"const helper = require('./Helper.js');",
+				"module.exports = async () => helper;",
+			].join("\n"),
+		);
+
+		try {
+			await expect(
+				getUserScript(createUserScriptCommand(), app),
+			).rejects.toThrow("could not find the required module");
+
+			const added = noticeStub.instances.slice(before);
+			expect(added).toHaveLength(1);
+			expect(added[0].message).toContain("./Helper.js");
+			expect(added[0].message).toContain("capitalization");
+			expect(logError).toHaveBeenCalledWith(added[0].message);
+		} finally {
+			(window as unknown as { require?: (moduleName: string) => unknown }).require =
+				previousRequire;
+			logError.mockRestore();
+		}
+	});
+
 	it("resolves ::member access for a note-based script", async () => {
 		const app = createUserScriptApp(
 			[
@@ -288,6 +404,30 @@ describe("getUserScript", () => {
 		await expect(
 			(script as (params: unknown) => unknown)({ token: "ok" }),
 		).resolves.toBe("ok");
+	});
+
+	it("preserves object exports with callable members", async () => {
+		const app = createUserScriptApp(
+			"module.exports = { run: async () => 'ok' };",
+		);
+
+		const script = await getUserScript(createUserScriptCommand(), app);
+
+		expect(script).toEqual({ run: expect.any(Function) });
+	});
+
+	it("allows explicit default object exports when member access selects a function", async () => {
+		const app = createUserScriptApp(
+			"exports.default = { run: async () => 'ok' };",
+		);
+		const command = createUserScriptCommand({
+			name: "Script::run",
+		});
+
+		const script = await getUserScript(command, app);
+
+		expect(typeof script).toBe("function");
+		await expect((script as () => unknown)()).resolves.toBe("ok");
 	});
 
 	it("returns undefined and shows a notice when a note has no ```js block", async () => {

--- a/src/utilityObsidian.test.ts
+++ b/src/utilityObsidian.test.ts
@@ -284,15 +284,18 @@ describe("getUserScript", () => {
 			].join("\n"),
 		);
 
-		await expect(getUserScript(createUserScriptCommand(), app)).rejects.toThrow(
-			"saved webpage",
-		);
+		try {
+			await expect(getUserScript(createUserScriptCommand(), app)).rejects.toThrow(
+				"saved webpage",
+			);
 
-		expect(logError).toHaveBeenCalledTimes(1);
-		const reported = logError.mock.calls[0][0] as Error;
-		expect(reported.message).toContain("use the Raw button");
-		expect(reported.message).toContain("download the .js file");
-		logError.mockRestore();
+			expect(logError).toHaveBeenCalledTimes(1);
+			const reported = logError.mock.calls[0][0] as Error;
+			expect(reported.message).toContain("use the Raw button");
+			expect(reported.message).toContain("download the .js file");
+		} finally {
+			logError.mockRestore();
+		}
 	});
 
 	it("can suppress user-facing load reporting during preflight", async () => {
@@ -300,15 +303,43 @@ describe("getUserScript", () => {
 		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
 		const app = createUserScriptApp("<html><body>not js</body></html>");
 
-		await expect(
-			getUserScript(createUserScriptCommand(), app, {
-				reportLoadErrors: false,
-			}),
-		).rejects.toThrow("saved webpage");
+		try {
+			await expect(
+				getUserScript(createUserScriptCommand(), app, {
+					reportLoadErrors: false,
+				}),
+			).rejects.toThrow("saved webpage");
 
+			expect(noticeMessages()).toHaveLength(before);
+			expect(logError).not.toHaveBeenCalled();
+		} finally {
+			logError.mockRestore();
+		}
+	});
+
+	it("can suppress markdown script load notices during preflight", async () => {
+		const before = noticeMessages().length;
+		const app = createUserScriptApp(
+			[
+				"# Script note",
+				"",
+				"This note has no JavaScript code block.",
+			].join("\n"),
+			"Scripts/no-code-block.md",
+		);
+
+		const script = await getUserScript(
+			createUserScriptCommand({
+				path: "Scripts/no-code-block.md",
+			}),
+			app,
+			{
+				reportLoadErrors: false,
+			},
+		);
+
+		expect(script).toBeUndefined();
 		expect(noticeMessages()).toHaveLength(before);
-		expect(logError).not.toHaveBeenCalled();
-		logError.mockRestore();
 	});
 
 	it("explains when an explicit default export is not runnable", async () => {
@@ -323,15 +354,18 @@ describe("getUserScript", () => {
 			].join("\n"),
 		);
 
-		await expect(getUserScript(createUserScriptCommand(), app)).rejects.toThrow(
-			"default export is not a function",
-		);
+		try {
+			await expect(getUserScript(createUserScriptCommand(), app)).rejects.toThrow(
+				"default export is not a function",
+			);
 
-		expect(logError).toHaveBeenCalledTimes(1);
-		const reported = logError.mock.calls[0][0] as Error;
-		expect(reported.message).toContain("module.exports = async");
-		expect(reported.message).toContain("exports.default = async");
-		logError.mockRestore();
+			expect(logError).toHaveBeenCalledTimes(1);
+			const reported = logError.mock.calls[0][0] as Error;
+			expect(reported.message).toContain("module.exports = async");
+			expect(reported.message).toContain("exports.default = async");
+		} finally {
+			logError.mockRestore();
+		}
 	});
 
 	it("explains module resolution failures while loading a script", async () => {

--- a/src/utils/userScript.ts
+++ b/src/utils/userScript.ts
@@ -5,6 +5,102 @@ import { log } from "../logger/logManager";
 import type { IUserScript } from "../types/macros/IUserScript";
 import { extractScriptFromMarkdown } from "./extractScriptFromMarkdown";
 
+type GetUserScriptOptions = {
+	reportLoadErrors?: boolean;
+};
+
+const HTML_PREFIX_LENGTH = 1024;
+
+class UserScriptLoadError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "UserScriptLoadError";
+	}
+}
+
+function stripByteOrderMark(value: string): string {
+	return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
+}
+
+function getLeadingScriptText(source: string): string {
+	return stripByteOrderMark(source)
+		.trimStart()
+		.slice(0, HTML_PREFIX_LENGTH)
+		.toLowerCase();
+}
+
+function looksLikeHtmlPayload(source: string): boolean {
+	return /^<(?:!doctype\s+html|html\b|head\b|body\b|script\b|meta\b|title\b|div\b)/.test(
+		getLeadingScriptText(source),
+	);
+}
+
+function reportAndThrowUserScriptLoadError(
+	message: string,
+	options: GetUserScriptOptions,
+): never {
+	if (options.reportLoadErrors !== false) {
+		new Notice(message);
+		log.logError(message);
+	}
+
+	throw new UserScriptLoadError(message);
+}
+
+function savedWebpageMessage(path: string): string {
+	return `QuickAdd could not load ${path}. This file looks like a saved webpage, not a JavaScript file. Open the script on GitHub, use the Raw button, then download the .js file and select that file in QuickAdd.`;
+}
+
+function defaultExportMessage(path: string): string {
+	return `QuickAdd loaded ${path}, but its default export is not a function. Change it to module.exports = async (params) => { ... } or exports.default = async (params) => { ... }. If you meant to export several functions, use module.exports = { run } and select Script::run.`;
+}
+
+function missingModuleMessage(path: string, moduleName: string | undefined): string {
+	const missing = moduleName
+		? `the required module "${moduleName}"`
+		: "a required module";
+	return `QuickAdd could not load ${path} because it could not find ${missing}. Check that the required file or package exists, and that the capitalization in require(...) matches the file name exactly.`;
+}
+
+function getMissingModuleName(error: unknown): string | undefined {
+	if (!isMissingModuleError(error)) return undefined;
+
+	const message = error instanceof Error ? error.message : String(error);
+	return message.match(/Cannot find module ['"]([^'"]+)['"]/)?.[1];
+}
+
+function isMissingModuleError(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+
+	const code = (error as { code?: unknown }).code;
+	if (code === "MODULE_NOT_FOUND") return true;
+
+	const message = error instanceof Error ? error.message : String(error);
+	return message.includes("Cannot find module");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function hasRunnableObjectMember(value: Record<string, unknown>): boolean {
+	if (typeof value.entry === "function") return true;
+
+	return Object.entries(value).some(
+		([key, member]) =>
+			key !== "settings" &&
+			key !== "quickadd" &&
+			typeof member === "function",
+	);
+}
+
+function isRunnableUserScriptExport(value: unknown): boolean {
+	if (typeof value === "function") return true;
+	if (!isRecord(value)) return false;
+
+	return hasRunnableObjectMember(value);
+}
+
 export function getUserScriptMemberAccess(fullMemberPath: string): {
 	basename: string | undefined;
 	memberAccess: string[] | undefined;
@@ -42,7 +138,11 @@ export function getUserScriptPreloadKey(
 
 // Slightly modified version of Templater's user script import implementation
 // Source: https://github.com/SilentVoid13/Templater
-export async function getUserScript(command: IUserScript, app: App) {
+export async function getUserScript(
+	command: IUserScript,
+	app: App,
+	options: GetUserScriptOptions = {},
+) {
 	// @ts-ignore
 	const file: TAbstractFile = app.vault.getAbstractFileByPath(command.path);
 	if (!file) {
@@ -78,17 +178,47 @@ export async function getUserScript(command: IUserScript, app: App) {
 		// parameters are the module globals, instead of `eval`-ing a wrapper string.
 		// This executes the (trusted, user-authored) script identically to the
 		// previous `(function(require, module, exports){ ... })` eval form.
-		const fn = new Function("require", "module", "exports", scriptSource);
+		if (looksLikeHtmlPayload(scriptSource)) {
+			reportAndThrowUserScriptLoadError(
+				savedWebpageMessage(command.path),
+				options,
+			);
+		}
 
-		fn(req, mod, exp);
+		try {
+			const fn = new Function("require", "module", "exports", scriptSource);
+
+			fn(req, mod, exp);
+		} catch (error) {
+			if (looksLikeHtmlPayload(scriptSource)) {
+				reportAndThrowUserScriptLoadError(
+					savedWebpageMessage(command.path),
+					options,
+				);
+			}
+
+			if (isMissingModuleError(error)) {
+				reportAndThrowUserScriptLoadError(
+					missingModuleMessage(
+						command.path,
+						getMissingModuleName(error),
+					),
+					options,
+				);
+			}
+
+			throw error;
+		}
 
 		// @ts-ignore
 		const userScript = exp["default"] || mod.exports;
 		if (!userScript) return;
 
 		let script = userScript;
+		const usesExplicitDefaultExport = Boolean(exp["default"]);
 
 		const { memberAccess } = getUserScriptMemberAccess(command.name);
+		const hasMemberAccess = Boolean(memberAccess && memberAccess.length > 0);
 		if (memberAccess && memberAccess.length > 0) {
 			let member: string;
 			while ((member = memberAccess.shift() as string)) {
@@ -96,6 +226,17 @@ export async function getUserScript(command: IUserScript, app: App) {
 
 				script = script[member];
 			}
+		}
+
+		if (
+			usesExplicitDefaultExport &&
+			!hasMemberAccess &&
+			!isRunnableUserScriptExport(script)
+		) {
+			reportAndThrowUserScriptLoadError(
+				defaultExportMessage(command.path),
+				options,
+			);
 		}
 
 		return script;

--- a/src/utils/userScript.ts
+++ b/src/utils/userScript.ts
@@ -18,6 +18,10 @@ class UserScriptLoadError extends Error {
 	}
 }
 
+export function isUserScriptLoadError(error: unknown): error is Error {
+	return error instanceof UserScriptLoadError;
+}
+
 function stripByteOrderMark(value: string): string {
 	return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
 }
@@ -190,13 +194,6 @@ export async function getUserScript(
 
 			fn(req, mod, exp);
 		} catch (error) {
-			if (looksLikeHtmlPayload(scriptSource)) {
-				reportAndThrowUserScriptLoadError(
-					savedWebpageMessage(command.path),
-					options,
-				);
-			}
-
 			if (isMissingModuleError(error)) {
 				reportAndThrowUserScriptLoadError(
 					missingModuleMessage(

--- a/src/utils/userScript.ts
+++ b/src/utils/userScript.ts
@@ -39,12 +39,12 @@ function reportAndThrowUserScriptLoadError(
 	message: string,
 	options: GetUserScriptOptions,
 ): never {
+	const error = new UserScriptLoadError(message);
 	if (options.reportLoadErrors !== false) {
-		new Notice(message);
-		log.logError(message);
+		log.logError(error);
 	}
 
-	throw new UserScriptLoadError(message);
+	throw error;
 }
 
 function savedWebpageMessage(path: string): string {

--- a/src/utils/userScript.ts
+++ b/src/utils/userScript.ts
@@ -172,7 +172,9 @@ export async function getUserScript(
 				// Surface a visible, actionable reason (the caller's generic "failed to
 				// load" log alone is easy to miss) and fall through to the established
 				// "return undefined" contract — do not double-log here.
-				new Notice(`QuickAdd: ${error} (${command.path})`);
+				if (options.reportLoadErrors !== false) {
+					new Notice(`QuickAdd: ${error} (${command.path})`);
+				}
 				return;
 			}
 			scriptSource = code;


### PR DESCRIPTION
Make user-script load failures explain what went wrong instead of surfacing raw JavaScript or Node errors.

This handles the recurring support patterns from these discussions:

- https://github.com/chhoumann/quickadd/discussions/429
- https://github.com/chhoumann/quickadd/discussions/553
- https://github.com/chhoumann/quickadd/discussions/570
- https://github.com/chhoumann/quickadd/discussions/652
- https://github.com/chhoumann/quickadd/discussions/710

What changed:

- Detect saved-webpage payloads before compiling user scripts and tell the user to use GitHub's Raw button and download the `.js` file.
- Detect explicit default exports that are not runnable, while preserving existing `module.exports = { run }` and `Script::run` member-access patterns.
- Convert top-level missing module failures into a message that names the missing `require(...)` target and calls out capitalization/path checks.
- Keep preflight from showing duplicate warning Notices while still leaving a console warning for diagnostics.

Before evidence from the isolated vault:

- Saved HTML `.js`: `quickadd:run` returned `Unexpected token '<'` and console only said preflight could not inspect the script.
- `exports.default = { settings: ... }`: `quickadd:run` returned the misleading non-interactive picker/export message.
- Top-level missing `require(...)`: `quickadd:run` returned `Cannot find module ... Require stack: electron/js2c/renderer_init`.

After evidence from the isolated vault `quickadd-fix-userscript-diagnostics`:

- Saved HTML `.js`: CLI, Notice, and console now say the file looks like a saved webpage and instruct the user to use Raw and download the `.js` file.
- Non-function explicit default export: CLI, Notice, and console now say the default export is not a function and show `module.exports = async (...)` / `exports.default = async (...)` fixes.
- Missing required module: CLI, Notice, and console now name the missing module and tell the user to check that the file/package exists and capitalization matches exactly.
- `pnpm run obsidian:e2e -- dev:errors` reported `No errors captured.` after the handled failure checks.

Validation:

- `pnpm exec vitest run --config vitest.config.mts src/utilityObsidian.test.ts` passed, 28 tests.
- `pnpm run test` passed, 323 files and 3639 tests.
- `pnpm run check` passed with 0 errors and 4 existing warnings.
- `pnpm run build-with-lint` passed.
- Final strict diff audit: `git diff --check origin/master...HEAD` passed.
- Design review and final review: two opposite-model adversarial reviewers challenged the design/diff. Accepted findings were folded in: preflight no longer emits duplicate warning Notices, `UserScriptLoadError` is recognized through an exported guard, and an unreachable HTML catch branch was removed.

Notes for reviewers:

- The loader still preserves existing object export behavior for callable named exports. A broader diagnostic for every non-callable `module.exports = { ... }` shape is intentionally left out to avoid changing that public scripting surface in this PR.
- The isolated-vault repro fixtures were removed after proof so repo lint does not scan intentional invalid `.js` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user-script loading with clearer guidance when a file isn’t a valid script, a module can’t be found, or an exported value isn’t runnable.
  * Enhanced handling for additional export patterns, including runnable object members and explicit default exports.
* **Bug Fixes**
  * Reduced noisy/redundant error and notice messages during preflight script inspection, with load-error reporting now suppressible.
* **Tests**
  * Expanded coverage for error messaging, notice/log behavior, and common module-export scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->