### PR TITLE
docs: add variables and data flow guide

### DIFF
--- a/docs/docs/Choices/MacroChoice.md
+++ b/docs/docs/Choices/MacroChoice.md
@@ -276,103 +276,9 @@ module.exports = async (params) => {
 
 ## Variables and Data Flow
 
-Variables allow you to pass data between commands in a macro:
+Macro commands share one temporary variable map during the current Macro run. User scripts can write `params.variables.bookTitle`, and later Template or Capture commands can read `{{VALUE:bookTitle}}`.
 
-### Setting Variables in Scripts
-
-```javascript
-// Script 1: Set a variable
-module.exports = async (params) => {
-    const { quickAddApi, variables } = params;
-    
-    const bookName = await quickAddApi.inputPrompt("Book name:");
-    variables.bookTitle = bookName;
-    variables.readDate = new Date().toISOString();
-    
-    // Control when prompts appear:
-    variables.rating = "";        // Empty string - won't prompt
-    variables.notes = undefined;  // Undefined - will prompt for input
-};
-```
-
-### Controlling Variable Prompts
-
-When using `{{VALUE:variableName}}` in your templates, QuickAdd decides whether to prompt you for input based on how the variable was set in your script:
-
-#### Variables That Trigger Prompts
-- **Unset variables**: Variables that were never assigned a value
-- **Undefined variables**: Variables explicitly set to `undefined` in scripts
-- **Null variables**: Variables explicitly set to `null` in scripts
-
-#### Variables That Don't Trigger Prompts
-- **Empty string variables**: Variables explicitly set to `""` in scripts
-- **Variables with any other value**: Including `"0"`, `"false"`, or any non-empty string
-
-#### Practical Examples
-
-```javascript
-// Data import script example
-module.exports = async (params) => {
-    const { quickAddApi, variables } = params;
-    
-    // These will NOT prompt when used in templates:
-    variables.rating = "";        // Intentionally empty
-    variables.score = "0";        // Valid value (zero as string)
-    variables.status = "draft";   // Has content
-    variables.description = "";   // User chose to leave blank
-    
-    // These WILL prompt when used in templates:
-    variables.author = undefined; // Explicitly undefined
-    variables.reviewer = null;    // Explicitly null
-    // variables.category is never set - will prompt
-};
-```
-
-**Use Case**: This is particularly useful when importing data where some fields may be intentionally empty. For example, when importing movie data, you might want to leave the rating empty for unseen movies without being prompted to enter a rating:
-
-```javascript
-// Movie import example
-module.exports = async (params) => {
-    const { variables } = params;
-    
-    const movieData = await fetchMovieData();
-    
-    variables.title = movieData.title;
-    variables.year = movieData.year.toString();
-    
-    if (movieData.hasWatched) {
-        variables.rating = movieData.userRating || "";  // Empty if no rating
-        variables.watchDate = movieData.watchDate;
-    } else {
-        // For unwatched movies, set empty strings to avoid prompts
-        variables.rating = "";       // Don't prompt for rating
-        variables.watchDate = "";    // Don't prompt for watch date
-        variables.review = "";       // Don't prompt for review
-    }
-    
-    // This will prompt because we want user input
-    variables.personalNotes = undefined;  // Will ask for notes
-};
-```
-
-### Using Variables in Format Syntax
-
-After setting variables in a script, you can use them in subsequent commands:
-- In templates: `{{VALUE:bookTitle}}`
-- In file names: `Books/{{VALUE:bookTitle}} - Notes`
-- In captures: `Read "{{VALUE:bookTitle}}" on {{VALUE:readDate}}`
-
-### Accessing Variables in Later Scripts
-
-```javascript
-// Script 2: Use previously set variables
-module.exports = async (params) => {
-    const { variables, app } = params;
-    
-    console.log(`Processing book: ${variables.bookTitle}`);
-    // Do something with the book title
-};
-```
+For the full rules, including named `VALUE` prompts, empty values, AI Assistant output variables, and the `executeChoice` boundary, see [Variables and data flow](../VariablesDataFlow.md).
 
 ## Advanced Script Patterns
 
@@ -605,10 +511,9 @@ Break complex macros into smaller, reusable parts:
 - Ensure plugins are enabled before running the macro
 
 **Variables not passing between commands**
-- `{{VALUE}}` / `{{NAME}}` are per-template; use `{{VALUE:sharedName}}` to reuse one prompt across a macro
-- Ensure you're using the correct syntax: `{{VALUE:variableName}}`
-- Variables must be set before they're used
-- Check that variable names match exactly (case-sensitive)
+- Use a named token such as `{{VALUE:sharedName}}` or set `params.variables.sharedName` for values that later Macro steps need.
+- Make sure scripts run before the commands that read their variables.
+- See [Variables and data flow](../VariablesDataFlow.md) for the full run-variable model.
 
 **Macro not appearing in command palette**
 - Ensure the macro choice is enabled in settings

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -389,7 +389,9 @@ console.log("Enabled features:", features);
 ## Choice Execution
 
 ### `executeChoice(choiceName: string, variables?: {[key: string]: any}): Promise<void>`
-Executes another QuickAdd choice programmatically.
+Executes another QuickAdd choice programmatically. This is a one-way trigger: it passes variables into the target choice, waits for that choice to finish, and resolves with `undefined`. It does not return data from the target choice to the caller. After the target choice finishes, QuickAdd clears the temporary variable map used by that API execution. If you call it from inside a Macro script, do not expect the caller's current `params.variables` values to still be available afterward unless you saved or restored them yourself.
+
+For the Macro data-flow implications, see [`executeChoice` is a trigger](./VariablesDataFlow.md#executechoice-is-a-trigger).
 
 **Parameters:**
 - `choiceName`: Name of the choice to execute

--- a/docs/docs/UserScripts.md
+++ b/docs/docs/UserScripts.md
@@ -1089,8 +1089,9 @@ For complete working examples, see:
 
 **Variables not available in templates:**
 - Make sure you're setting them on `params.variables`
-- Variable names are case-sensitive
+- Read them with `{{VALUE:name}}`, not `{{name}}`
 - Check that the script completes successfully
+- See [Variables and data flow](./VariablesDataFlow.md) for how script variables move into later Template and Capture steps
 
 **API methods returning undefined:**
 - Ensure you're using `await` with async methods

--- a/docs/docs/VariablesDataFlow.md
+++ b/docs/docs/VariablesDataFlow.md
@@ -1,0 +1,184 @@
+---
+title: Variables and data flow
+---
+
+# Variables and data flow
+
+This page is about temporary run variables, not [Global Variables](./GlobalVariables.md). Global Variables are saved settings. Run variables live only while a Template, Capture, or Macro run is executing.
+
+QuickAdd keeps one temporary variable map for the current run. Prompts, scripts, and AI Assistant commands can write to that map. Format syntax reads from it. In a Macro, commands run in order and share the same map, so a value collected in one step can be used by later Template, Capture, script, and AI Assistant steps.
+
+Different fields still have their own rules. This page explains how values move between steps. The exact token grammar stays in [Format Syntax](./FormatSyntax.md).
+
+## Write values once
+
+Use a named `VALUE` token when one answer should appear in more than one place:
+
+```markdown
+File name format:
+Projects/{{VALUE:project}}
+
+Template body:
+# {{VALUE:project}}
+
+Capture format:
+Logged work for {{VALUE:project}}
+```
+
+If `project` is not already set, QuickAdd asks once and stores the answer under `project`. Later `{{VALUE:project}}` tokens in the same run read that stored value instead of asking again. This works across a Template file name, the Template body, Capture formats, and later Macro steps.
+
+If a script, the CLI, or the QuickAdd API supplies `project` before the token is formatted, the token uses that value and does not ask. An absent key or a key set to `undefined` is treated as missing. An empty string is a deliberate empty answer.
+
+When the prompt should be a suggester, define the options once with a name, then reuse the name:
+
+```markdown
+{{VALUE:work,home,urgent|name:category}}
+{{VALUE:category}}
+```
+
+See [`{{VALUE:<options>|name:<variable name>}}`](./FormatSyntax.md#value-name) for option lists, display labels, first-definition behavior, and reserved names.
+
+In QuickAdd 2.17.2, leading and trailing spaces around the `VALUE` name are trimmed. `{{VALUE: project }}` reads the same variable as `{{VALUE:project}}`. Still prefer the no-space form because it is easier to scan and safer in shared vaults that may have older QuickAdd versions.
+
+## The special `value` input
+
+The unnamed `{{VALUE}}` token reads the special `value` variable. It is useful for one-off input or for a trigger that already supplied content:
+
+```markdown
+{{VALUE}}
+```
+
+It is not the same as `{{VALUE:project}}`. If a value must survive across multiple Macro steps, put it under a named key and read it with `{{VALUE:name}}`:
+
+```javascript
+module.exports = async (params) => {
+    if (params.variables.value !== undefined) {
+        params.variables.project = params.variables.value;
+    }
+};
+```
+
+Then later steps can use:
+
+```markdown
+{{VALUE:project}}
+```
+
+## Scripts share the map
+
+User scripts in a Macro receive `params.variables`. That object is the shared run variable map:
+
+```javascript
+module.exports = async (params) => {
+    const title = await params.quickAddApi.inputPrompt("Title");
+
+    params.variables.title = title;
+    params.variables.slug = title.toLowerCase().replace(/\s+/g, "-");
+};
+```
+
+Later Macro steps can read those values:
+
+```markdown
+# {{VALUE:title}}
+Slug: {{VALUE:slug}}
+```
+
+Some older examples name the first script parameter `QuickAdd`:
+
+```javascript
+module.exports = async (QuickAdd) => {
+    QuickAdd.variables.title = "Inbox";
+};
+```
+
+That works because `QuickAdd` is only the local parameter name. It is the same object as `params`. New scripts should use `params` so the code matches the rest of the docs.
+
+Scripts must run before the Template, Capture, or script step that reads their variables. A local JavaScript variable is not enough:
+
+```javascript
+module.exports = async (params) => {
+    const title = "Inbox"; // Only this script can see it.
+    params.variables.title = title; // Later QuickAdd steps can see it.
+};
+```
+
+## Inline Scripts
+
+Inline scripts run before ordinary format tokens in the surrounding output. Do not expect this to read the prompted value:
+
+```javascript
+const value = "{{VALUE:project}}";
+```
+
+That string is literal JavaScript text while the inline script runs. If the script needs input-aware logic, prompt inside the script or read a variable that an earlier step already set:
+
+```javascript
+const project = this.variables.project;
+return project ? `Project: ${project}` : "";
+```
+
+## AI Assistant outputs
+
+An AI Assistant Macro command writes its response to the variable named in **Output variable name**. The default name is `output`, so later steps can read:
+
+```markdown
+{{VALUE:output}}
+```
+
+or, in a script:
+
+```javascript
+module.exports = async (params) => {
+    console.log(params.variables.output);
+};
+```
+
+QuickAdd also writes a quote-block version under `<name>-quoted`. With the default output name, use:
+
+```markdown
+{{VALUE:output-quoted}}
+```
+
+If the command's output variable name is `description`, read `{{VALUE:description}}` and `{{VALUE:description-quoted}}` instead. These variables are available to later steps in the same Macro run.
+
+## `executeChoice` is a trigger
+
+The Macro Builder's **Choice** command and the API method `quickAddApi.executeChoice` are different.
+
+A **Choice** command inside a Macro runs as part of the current Macro sequence and shares the Macro's variable map with later steps.
+
+`quickAddApi.executeChoice(choiceName, variables)` is a one-way trigger. It passes the provided variables into the target choice, waits for that choice to finish, and resolves with `undefined`. It does not return the target choice's output to the caller. After the target choice finishes, QuickAdd clears the temporary variable map used by that API execution. If you call it from inside a Macro script, do not expect the caller's current `params.variables` values to still be available afterward unless you saved or restored them yourself.
+
+Good use:
+
+```javascript
+module.exports = async (params) => {
+    await params.quickAddApi.executeChoice("Create project note", {
+        project: params.variables.project,
+    });
+};
+```
+
+Avoid this pattern:
+
+```javascript
+module.exports = async (params) => {
+    const result = await params.quickAddApi.executeChoice("Pick project");
+    params.variables.project = result; // result is undefined
+};
+```
+
+If later steps need a value, keep the workflow inside one Macro sequence, set `params.variables` directly, or call shared JavaScript helper code that returns a value to your script.
+
+## Troubleshooting
+
+**The same prompt appears more than once.** Use the same named token everywhere, such as `{{VALUE:project}}`. A bare `{{VALUE}}` and a named `{{VALUE:project}}` are different inputs.
+
+**A script value is missing in a later Template or Capture.** Set it on `params.variables`, not only in a local JavaScript variable, and make sure the script step runs before the step that reads it.
+
+**A token stayed as text.** Format syntax is `{{VALUE:name}}`. A bare `{{name}}` is not a QuickAdd token.
+
+**An AI result is missing.** Check the AI Assistant command's **Output variable name**, then read that exact variable in a later Macro step.
+
+**`executeChoice` returned `undefined`.** That is expected. Use `executeChoice` to trigger another choice with input variables, not to fetch a return value from it.

--- a/docs/docs/VariablesDataFlow.md
+++ b/docs/docs/VariablesDataFlow.md
@@ -4,11 +4,11 @@ title: Variables and data flow
 
 # Variables and data flow
 
-This page is about temporary run variables, not [Global Variables](./GlobalVariables.md). Global Variables are saved settings. Run variables live only while a Template, Capture, or Macro run is executing.
+This page covers run variables - the temporary values that live only while a Template, Capture, or Macro run is executing. For saved, reusable settings, see [Global Variables](./GlobalVariables.md).
 
 QuickAdd keeps one temporary variable map for the current run. Prompts, scripts, and AI Assistant commands can write to that map. Format syntax reads from it. In a Macro, commands run in order and share the same map, so a value collected in one step can be used by later Template, Capture, script, and AI Assistant steps.
 
-Different fields still have their own rules. This page explains how values move between steps. The exact token grammar stays in [Format Syntax](./FormatSyntax.md).
+This page explains how values move between steps; the exact token grammar lives in [Format Syntax](./FormatSyntax.md).
 
 ## Write values once
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -80,6 +80,7 @@ const sidebars = {
 					id: "FormatSyntax",
 					label: "Format Syntax",
 				},
+				{ type: "doc", id: "VariablesDataFlow", label: "Variables and data flow" },
 				{
 					type: "doc",
 					id: "ApplyTemplateToNote",

--- a/docs/versioned_docs/version-2.17.2/Choices/MacroChoice.md
+++ b/docs/versioned_docs/version-2.17.2/Choices/MacroChoice.md
@@ -276,103 +276,9 @@ module.exports = async (params) => {
 
 ## Variables and Data Flow
 
-Variables allow you to pass data between commands in a macro:
+Macro commands share one temporary variable map during the current Macro run. User scripts can write `params.variables.bookTitle`, and later Template or Capture commands can read `{{VALUE:bookTitle}}`.
 
-### Setting Variables in Scripts
-
-```javascript
-// Script 1: Set a variable
-module.exports = async (params) => {
-    const { quickAddApi, variables } = params;
-    
-    const bookName = await quickAddApi.inputPrompt("Book name:");
-    variables.bookTitle = bookName;
-    variables.readDate = new Date().toISOString();
-    
-    // Control when prompts appear:
-    variables.rating = "";        // Empty string - won't prompt
-    variables.notes = undefined;  // Undefined - will prompt for input
-};
-```
-
-### Controlling Variable Prompts
-
-When using `{{VALUE:variableName}}` in your templates, QuickAdd decides whether to prompt you for input based on how the variable was set in your script:
-
-#### Variables That Trigger Prompts
-- **Unset variables**: Variables that were never assigned a value
-- **Undefined variables**: Variables explicitly set to `undefined` in scripts
-- **Null variables**: Variables explicitly set to `null` in scripts
-
-#### Variables That Don't Trigger Prompts
-- **Empty string variables**: Variables explicitly set to `""` in scripts
-- **Variables with any other value**: Including `"0"`, `"false"`, or any non-empty string
-
-#### Practical Examples
-
-```javascript
-// Data import script example
-module.exports = async (params) => {
-    const { quickAddApi, variables } = params;
-    
-    // These will NOT prompt when used in templates:
-    variables.rating = "";        // Intentionally empty
-    variables.score = "0";        // Valid value (zero as string)
-    variables.status = "draft";   // Has content
-    variables.description = "";   // User chose to leave blank
-    
-    // These WILL prompt when used in templates:
-    variables.author = undefined; // Explicitly undefined
-    variables.reviewer = null;    // Explicitly null
-    // variables.category is never set - will prompt
-};
-```
-
-**Use Case**: This is particularly useful when importing data where some fields may be intentionally empty. For example, when importing movie data, you might want to leave the rating empty for unseen movies without being prompted to enter a rating:
-
-```javascript
-// Movie import example
-module.exports = async (params) => {
-    const { variables } = params;
-    
-    const movieData = await fetchMovieData();
-    
-    variables.title = movieData.title;
-    variables.year = movieData.year.toString();
-    
-    if (movieData.hasWatched) {
-        variables.rating = movieData.userRating || "";  // Empty if no rating
-        variables.watchDate = movieData.watchDate;
-    } else {
-        // For unwatched movies, set empty strings to avoid prompts
-        variables.rating = "";       // Don't prompt for rating
-        variables.watchDate = "";    // Don't prompt for watch date
-        variables.review = "";       // Don't prompt for review
-    }
-    
-    // This will prompt because we want user input
-    variables.personalNotes = undefined;  // Will ask for notes
-};
-```
-
-### Using Variables in Format Syntax
-
-After setting variables in a script, you can use them in subsequent commands:
-- In templates: `{{VALUE:bookTitle}}`
-- In file names: `Books/{{VALUE:bookTitle}} - Notes`
-- In captures: `Read "{{VALUE:bookTitle}}" on {{VALUE:readDate}}`
-
-### Accessing Variables in Later Scripts
-
-```javascript
-// Script 2: Use previously set variables
-module.exports = async (params) => {
-    const { variables, app } = params;
-    
-    console.log(`Processing book: ${variables.bookTitle}`);
-    // Do something with the book title
-};
-```
+For the full rules, including named `VALUE` prompts, empty values, AI Assistant output variables, and the `executeChoice` boundary, see [Variables and data flow](../VariablesDataFlow.md).
 
 ## Advanced Script Patterns
 
@@ -605,10 +511,9 @@ Break complex macros into smaller, reusable parts:
 - Ensure plugins are enabled before running the macro
 
 **Variables not passing between commands**
-- `{{VALUE}}` / `{{NAME}}` are per-template; use `{{VALUE:sharedName}}` to reuse one prompt across a macro
-- Ensure you're using the correct syntax: `{{VALUE:variableName}}`
-- Variables must be set before they're used
-- Check that variable names match exactly (case-sensitive)
+- Use a named token such as `{{VALUE:sharedName}}` or set `params.variables.sharedName` for values that later Macro steps need.
+- Make sure scripts run before the commands that read their variables.
+- See [Variables and data flow](../VariablesDataFlow.md) for the full run-variable model.
 
 **Macro not appearing in command palette**
 - Ensure the macro choice is enabled in settings

--- a/docs/versioned_docs/version-2.17.2/QuickAddAPI.md
+++ b/docs/versioned_docs/version-2.17.2/QuickAddAPI.md
@@ -389,7 +389,9 @@ console.log("Enabled features:", features);
 ## Choice Execution
 
 ### `executeChoice(choiceName: string, variables?: {[key: string]: any}): Promise<void>`
-Executes another QuickAdd choice programmatically.
+Executes another QuickAdd choice programmatically. This is a one-way trigger: it passes variables into the target choice, waits for that choice to finish, and resolves with `undefined`. It does not return data from the target choice to the caller. After the target choice finishes, QuickAdd clears the temporary variable map used by that API execution. If you call it from inside a Macro script, do not expect the caller's current `params.variables` values to still be available afterward unless you saved or restored them yourself.
+
+For the Macro data-flow implications, see [`executeChoice` is a trigger](./VariablesDataFlow.md#executechoice-is-a-trigger).
 
 **Parameters:**
 - `choiceName`: Name of the choice to execute

--- a/docs/versioned_docs/version-2.17.2/UserScripts.md
+++ b/docs/versioned_docs/version-2.17.2/UserScripts.md
@@ -1089,8 +1089,9 @@ For complete working examples, see:
 
 **Variables not available in templates:**
 - Make sure you're setting them on `params.variables`
-- Variable names are case-sensitive
+- Read them with `{{VALUE:name}}`, not `{{name}}`
 - Check that the script completes successfully
+- See [Variables and data flow](./VariablesDataFlow.md) for how script variables move into later Template and Capture steps
 
 **API methods returning undefined:**
 - Ensure you're using `await` with async methods

--- a/docs/versioned_docs/version-2.17.2/VariablesDataFlow.md
+++ b/docs/versioned_docs/version-2.17.2/VariablesDataFlow.md
@@ -1,0 +1,184 @@
+---
+title: Variables and data flow
+---
+
+# Variables and data flow
+
+This page is about temporary run variables, not [Global Variables](./GlobalVariables.md). Global Variables are saved settings. Run variables live only while a Template, Capture, or Macro run is executing.
+
+QuickAdd keeps one temporary variable map for the current run. Prompts, scripts, and AI Assistant commands can write to that map. Format syntax reads from it. In a Macro, commands run in order and share the same map, so a value collected in one step can be used by later Template, Capture, script, and AI Assistant steps.
+
+Different fields still have their own rules. This page explains how values move between steps. The exact token grammar stays in [Format Syntax](./FormatSyntax.md).
+
+## Write values once
+
+Use a named `VALUE` token when one answer should appear in more than one place:
+
+```markdown
+File name format:
+Projects/{{VALUE:project}}
+
+Template body:
+# {{VALUE:project}}
+
+Capture format:
+Logged work for {{VALUE:project}}
+```
+
+If `project` is not already set, QuickAdd asks once and stores the answer under `project`. Later `{{VALUE:project}}` tokens in the same run read that stored value instead of asking again. This works across a Template file name, the Template body, Capture formats, and later Macro steps.
+
+If a script, the CLI, or the QuickAdd API supplies `project` before the token is formatted, the token uses that value and does not ask. An absent key or a key set to `undefined` is treated as missing. An empty string is a deliberate empty answer.
+
+When the prompt should be a suggester, define the options once with a name, then reuse the name:
+
+```markdown
+{{VALUE:work,home,urgent|name:category}}
+{{VALUE:category}}
+```
+
+See [`{{VALUE:<options>|name:<variable name>}}`](./FormatSyntax.md#value-name) for option lists, display labels, first-definition behavior, and reserved names.
+
+In QuickAdd 2.17.2, leading and trailing spaces around the `VALUE` name are trimmed. `{{VALUE: project }}` reads the same variable as `{{VALUE:project}}`. Still prefer the no-space form because it is easier to scan and safer in shared vaults that may have older QuickAdd versions.
+
+## The special `value` input
+
+The unnamed `{{VALUE}}` token reads the special `value` variable. It is useful for one-off input or for a trigger that already supplied content:
+
+```markdown
+{{VALUE}}
+```
+
+It is not the same as `{{VALUE:project}}`. If a value must survive across multiple Macro steps, put it under a named key and read it with `{{VALUE:name}}`:
+
+```javascript
+module.exports = async (params) => {
+    if (params.variables.value !== undefined) {
+        params.variables.project = params.variables.value;
+    }
+};
+```
+
+Then later steps can use:
+
+```markdown
+{{VALUE:project}}
+```
+
+## Scripts share the map
+
+User scripts in a Macro receive `params.variables`. That object is the shared run variable map:
+
+```javascript
+module.exports = async (params) => {
+    const title = await params.quickAddApi.inputPrompt("Title");
+
+    params.variables.title = title;
+    params.variables.slug = title.toLowerCase().replace(/\s+/g, "-");
+};
+```
+
+Later Macro steps can read those values:
+
+```markdown
+# {{VALUE:title}}
+Slug: {{VALUE:slug}}
+```
+
+Some older examples name the first script parameter `QuickAdd`:
+
+```javascript
+module.exports = async (QuickAdd) => {
+    QuickAdd.variables.title = "Inbox";
+};
+```
+
+That works because `QuickAdd` is only the local parameter name. It is the same object as `params`. New scripts should use `params` so the code matches the rest of the docs.
+
+Scripts must run before the Template, Capture, or script step that reads their variables. A local JavaScript variable is not enough:
+
+```javascript
+module.exports = async (params) => {
+    const title = "Inbox"; // Only this script can see it.
+    params.variables.title = title; // Later QuickAdd steps can see it.
+};
+```
+
+## Inline Scripts
+
+Inline scripts run before ordinary format tokens in the surrounding output. Do not expect this to read the prompted value:
+
+```javascript
+const value = "{{VALUE:project}}";
+```
+
+That string is literal JavaScript text while the inline script runs. If the script needs input-aware logic, prompt inside the script or read a variable that an earlier step already set:
+
+```javascript
+const project = this.variables.project;
+return project ? `Project: ${project}` : "";
+```
+
+## AI Assistant outputs
+
+An AI Assistant Macro command writes its response to the variable named in **Output variable name**. The default name is `output`, so later steps can read:
+
+```markdown
+{{VALUE:output}}
+```
+
+or, in a script:
+
+```javascript
+module.exports = async (params) => {
+    console.log(params.variables.output);
+};
+```
+
+QuickAdd also writes a quote-block version under `<name>-quoted`. With the default output name, use:
+
+```markdown
+{{VALUE:output-quoted}}
+```
+
+If the command's output variable name is `description`, read `{{VALUE:description}}` and `{{VALUE:description-quoted}}` instead. These variables are available to later steps in the same Macro run.
+
+## `executeChoice` is a trigger
+
+The Macro Builder's **Choice** command and the API method `quickAddApi.executeChoice` are different.
+
+A **Choice** command inside a Macro runs as part of the current Macro sequence and shares the Macro's variable map with later steps.
+
+`quickAddApi.executeChoice(choiceName, variables)` is a one-way trigger. It passes the provided variables into the target choice, waits for that choice to finish, and resolves with `undefined`. It does not return the target choice's output to the caller. After the target choice finishes, QuickAdd clears the temporary variable map used by that API execution. If you call it from inside a Macro script, do not expect the caller's current `params.variables` values to still be available afterward unless you saved or restored them yourself.
+
+Good use:
+
+```javascript
+module.exports = async (params) => {
+    await params.quickAddApi.executeChoice("Create project note", {
+        project: params.variables.project,
+    });
+};
+```
+
+Avoid this pattern:
+
+```javascript
+module.exports = async (params) => {
+    const result = await params.quickAddApi.executeChoice("Pick project");
+    params.variables.project = result; // result is undefined
+};
+```
+
+If later steps need a value, keep the workflow inside one Macro sequence, set `params.variables` directly, or call shared JavaScript helper code that returns a value to your script.
+
+## Troubleshooting
+
+**The same prompt appears more than once.** Use the same named token everywhere, such as `{{VALUE:project}}`. A bare `{{VALUE}}` and a named `{{VALUE:project}}` are different inputs.
+
+**A script value is missing in a later Template or Capture.** Set it on `params.variables`, not only in a local JavaScript variable, and make sure the script step runs before the step that reads it.
+
+**A token stayed as text.** Format syntax is `{{VALUE:name}}`. A bare `{{name}}` is not a QuickAdd token.
+
+**An AI result is missing.** Check the AI Assistant command's **Output variable name**, then read that exact variable in a later Macro step.
+
+**`executeChoice` returned `undefined`.** That is expected. Use `executeChoice` to trigger another choice with input variables, not to fetch a return value from it.

--- a/docs/versioned_docs/version-2.17.2/VariablesDataFlow.md
+++ b/docs/versioned_docs/version-2.17.2/VariablesDataFlow.md
@@ -4,11 +4,11 @@ title: Variables and data flow
 
 # Variables and data flow
 
-This page is about temporary run variables, not [Global Variables](./GlobalVariables.md). Global Variables are saved settings. Run variables live only while a Template, Capture, or Macro run is executing.
+This page covers run variables - the temporary values that live only while a Template, Capture, or Macro run is executing. For saved, reusable settings, see [Global Variables](./GlobalVariables.md).
 
 QuickAdd keeps one temporary variable map for the current run. Prompts, scripts, and AI Assistant commands can write to that map. Format syntax reads from it. In a Macro, commands run in order and share the same map, so a value collected in one step can be used by later Template, Capture, script, and AI Assistant steps.
 
-Different fields still have their own rules. This page explains how values move between steps. The exact token grammar stays in [Format Syntax](./FormatSyntax.md).
+This page explains how values move between steps; the exact token grammar lives in [Format Syntax](./FormatSyntax.md).
 
 ## Write values once
 

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -51,6 +51,7 @@
           "id": "FormatSyntax",
           "label": "Format Syntax"
         },
+        { "type": "doc", "id": "VariablesDataFlow", "label": "Variables and data flow" },
         {
           "type": "doc",
           "id": "ApplyTemplateToNote",


### PR DESCRIPTION
## Summary
- Add a canonical Variables and data flow page to current and 2.17.2 docs.
- Document named VALUE reuse across file names, bodies, captures, scripts, and macros.
- Document params.variables / QuickAdd.variables, executeChoice as a no-return trigger, AI Assistant output variables, and the current 2.17.2 whitespace behavior.
- Replace duplicate variable-flow guidance in Macro Choice, User Scripts, and QuickAdd API with links to the canonical page.

Refs #217, #315, #452, #500, #515, #537, #573, #630, #679, #697, #759, #825.

## Verification
- pnpm run build
- pnpm run provision:e2e-vault
- pnpm run obsidian:e2e -- quickadd:list
- pnpm run obsidian:e2e -- quickadd:run choice=__qa-doc-vars-main vars='{"project":"Alpha Project"}'
- pnpm run obsidian:e2e -- quickadd:run choice=__qa-doc-vars-execute
- pnpm run obsidian:e2e -- quickadd:run choice=__qa-doc-vars-bare vars='{"value":"Selected from value"}'
- pnpm run obsidian:e2e -- quickadd:run choice=__qa-doc-vars-ai-default vars='{"project":"Alpha Project"}'
- pnpm run obsidian:e2e -- dev:errors
- cd docs && pnpm install
- cd docs && pnpm build
- git diff --check

## Review
- Design reviewed before writing with two adversarial reviewers.
- Final draft reviewed with two adversarial reviewers.
- Local strict review confirmed current/versioned page parity, no em dash in the new canonical page, and no Templater bridge recipe.

## Notes
- Discussion #825 described whitespace as a gotcha, but current 2.17.2 behavior trims leading and trailing spaces around VALUE names. The page documents the current behavior and recommends the no-space form for readability and older-version safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Variables and data flow” documentation page.
  * Added sidebar navigation to the new guide.

* **Documentation**
  * Clarified how values move between steps in macros, templates, and captures.
  * Updated troubleshooting tips for variable references and missing values.
  * Improved guidance for choice execution behavior and variable lifetime.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->