### PR TITLE
docs: add daily note capture cookbook

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -388,7 +388,7 @@ When `Create line if not found` is enabled and its location dropdown is set to *
 This is the recipe for the classic "daily log, newest first" note (issue [#481](https://github.com/chhoumann/quickadd/issues/481)):
 
 -   **Capture to**: your log note (enable `Create file if it doesn't exist` if you want it auto-created).
--   **Format**: the entry, ending with a newline, e.g. `- {{TIME:HH:mm}} {{VALUE}}\n`. The trailing newline (or enabling `Capture as task`) is what keeps multiple entries on the same day on separate lines — without it, repeated same-day captures run together on one line.
+-   **Format**: the entry, ending with a newline, e.g. `- {{DATE:HH:mm}} {{VALUE}}\n`. Use a trailing newline for non-task line formats so each capture is a complete Markdown line. Task captures add their own newline.
 -   **Insert after**: the day heading, `## {{DATE:YYYY-MM-DD}}`.
 -   **Insert at end of section**: off, so each new entry lands directly under the day heading (newest entry on top within the day).
 -   **Create line if not found**: on, with the location set to **Ordered**, **Sort sections by** = `Date`, and **Section order** = `Newest / highest first`.

--- a/docs/docs/Examples/Capture_AddJournalEntry.md
+++ b/docs/docs/Examples/Capture_AddJournalEntry.md
@@ -6,7 +6,7 @@ For the current step-by-step daily-note setup, use [Capture: Add entries to your
 
 Compact reference for the journal entry format:
 
-- **File path / format**: `bins/daily/{{DATE:gggg-MM-DD - ddd MMM D}}.md`
+- **File path / format**: `bins/daily/{{DATE:YYYY-MM-DD - ddd MMM D}}.md`
 - **Write position**: **After line...**
 - **Insert after**: `## What did I do today?`
 - **Capture format**:

--- a/docs/docs/Examples/Capture_AddJournalEntry.md
+++ b/docs/docs/Examples/Capture_AddJournalEntry.md
@@ -2,16 +2,15 @@
 title: "Capture: Add journal entry"
 ---
 
-This captures a new journal entry in my daily journal under the `What did I do today` header.
+For the current step-by-step daily-note setup, use [Capture: Add entries to your daily note](./Capture_ToDailyNote). That cookbook covers this journal entry pattern plus creating today's note, inserting under a heading, tasks, quotes, callouts, table rows, and newline gotchas.
 
-Capture To: `bins/daily/{{DATE:gggg-MM-DD - ddd MMM D}}.md`
+Compact reference for the journal entry format:
 
-Insert after: `## What did I do today?`
+- **File path / format**: `bins/daily/{{DATE:gggg-MM-DD - ddd MMM D}}.md`
+- **Write position**: **After line...**
+- **Insert after**: `## What did I do today?`
+- **Capture format**:
 
-Capture format:
-
-```
+```markdown
 - {{DATE:HH:mm}} {{VALUE}}\n
 ```
-
-![A Capture choice configured to add a timestamped journal entry](../Images/choices/capture-builder.png)

--- a/docs/docs/Examples/Capture_ToDailyNote.md
+++ b/docs/docs/Examples/Capture_ToDailyNote.md
@@ -1,0 +1,149 @@
+---
+title: "Capture: Add entries to your daily note"
+---
+
+Use this cookbook when you want one QuickAdd choice to add text to today's daily note, even if the note or target heading does not exist yet.
+
+All recipes start from the same Capture choice. Change the **Capture format** and the target heading for the result you want.
+
+## Base setup
+
+1. In QuickAdd settings, add a new **Capture** choice.
+2. Name it (for example, `Daily entry`) and open its settings.
+3. Disable **Capture to active file**.
+4. Set **File path / format** to match your vault's daily-note path and date pattern, for example `Daily/{{DATE:YYYY-MM-DD}}.md`.
+5. Enable **Create file if it doesn't exist**.
+6. Set **Write position** to **After line...**.
+7. In the **Insert after** field, enter the heading you want entries placed under, for example `## Journal`.
+8. Enable **Insert at end of section** so each capture appends at the bottom of the section.
+9. Enable **Create line if not found** and set its placement to **Top** so the heading is inserted when a fresh note does not have it yet.
+10. Leave **Link to captured file** disabled.
+11. Enable **Capture format** and use one of the recipes below.
+
+## Recipes
+
+Each recipe shows what to change from the base setup.
+
+### Timestamped journal line
+
+Keep **Insert after** set to `## Journal`.
+
+**Capture format:**
+
+```
+- {{DATE:HH:mm}} {{VALUE}}\n
+```
+
+Produces:
+
+```markdown
+## Journal
+- 18:54 first journal entry
+- 18:55 second journal entry
+```
+
+End non-task line formats with `\n` so the capture is an explicit complete Markdown line.
+
+### Task line
+
+Change **Insert after** to `## Tasks`.
+
+**Task:** on (in the **Content** section).
+
+**Capture format:**
+
+```
+{{VALUE}}
+```
+
+**Task** wraps the value in `- [ ] ...` automatically. Do not add `- [ ]` to the format manually.
+
+### Task with a date prompt
+
+**Task:** on.
+
+**Capture format:**
+
+```
+{{VALUE}} due {{VDATE:due,YYYY-MM-DD}}
+```
+
+QuickAdd prompts for the task text and then for `due`. You can enter an exact date or a natural-language date such as `tomorrow`. Result: `- [ ] pay rent due 2026-07-07`.
+
+### Callout line
+
+Change **Insert after** to the callout opener, for example:
+
+```
+> [!info]- Captured today
+```
+
+**Capture format:**
+
+```
+> {{VALUE}}\n
+```
+
+On first use, **Create line if not found** inserts the callout opener at the position you chose. Each subsequent capture appends before the next blank line or heading, so keep the callout as one contiguous quoted block. The `>` prefix is required to keep the entry inside the callout block.
+
+### Quote
+
+Change **Insert after** to `## Quotes`.
+
+**Capture format:**
+
+```
+> {{VALUE}}\n
+```
+
+Same format as the callout recipe but targeting a regular heading. Produces a blockquote line under the section.
+
+### Table row
+
+Use this when the daily note already has a table under a heading and the table is the last block in that section. Keep **Write position** as **After line...**, set **Insert after** to the heading above the table, and keep **Insert at end of section** enabled. If more content follows the table in the same section, target the table separator row instead.
+
+**Capture format:**
+
+```
+| {{DATE:HH:mm}} | {{VALUE}} |\n
+```
+
+This keeps the row attached to the table:
+
+```markdown
+## Log
+| When | What |
+| --- | --- |
+| 09:00 | existing |
+| 18:55 | section row |
+```
+
+### Tomorrow's daily note
+
+Change **File path / format** to:
+
+```
+Daily/{{DATE:YYYY-MM-DD+1}}.md
+```
+
+The `+1` shifts the target date one day forward. Combine with any of the formats above.
+
+## Troubleshooting
+
+**Captures run together on one line.**
+For non-task formats, end the capture format with `\n` or press Enter at the end of the format field. Formats that use **Task** do not need one; QuickAdd inserts that line break.
+
+**Pasted multiple lines became one task.**
+The **Task** setting wraps the whole capture once. Capture one task at a time, or use an advanced macro or userscript if you need to split pasted lines into separate tasks.
+
+**The heading is not found and capture fails.**
+Enable **Create line if not found** with placement **Top** (or **Bottom**). QuickAdd inserts the heading on first use and places new content after it.
+
+**You need to insert above a placeholder.**
+Use **Before line...** instead of **After line...** and target the placeholder, such as `<!-- quickadd:notes -->`. See [Insert before](../Choices/CaptureChoice#insert-before) for the full setting.
+
+**Capture writes to the wrong file.**
+The date pattern in **File path / format** must match your vault's daily-note naming exactly. If your notes are named `2025.01.15.md` inside `Journal/`, use `Journal/{{DATE:YYYY.MM.DD}}.md`.
+
+**Table rows or callout content breaks when using bottom-of-file placement.**
+Use **After line...** with **Insert at end of section** instead of **Bottom of file**. Bottom-of-file placement starts non-task captures on a new line, and when the file already ends with a newline that leaves a blank line before the captured content. That blank line splits table rows and callout blocks.

--- a/docs/docs/Examples/Capture_ToDailyNote.md
+++ b/docs/docs/Examples/Capture_ToDailyNote.md
@@ -2,9 +2,9 @@
 title: "Capture: Add entries to your daily note"
 ---
 
-Use this cookbook when you want one QuickAdd choice to add text to today's daily note, even if the note or target heading does not exist yet.
+This cookbook gives you one QuickAdd choice that adds text to today's daily note - even when the note or the target heading doesn't exist yet.
 
-All recipes start from the same Capture choice. Change the **Capture format** and the target heading for the result you want.
+Every recipe starts from the same base Capture choice; you only change the **Capture format** and the target heading.
 
 ## Base setup
 
@@ -42,7 +42,7 @@ Produces:
 - 18:55 second journal entry
 ```
 
-End non-task line formats with `\n` so the capture is an explicit complete Markdown line.
+End non-task formats with `\n` so each capture lands as its own complete line.
 
 ### Task line
 

--- a/docs/docs/Examples/index.md
+++ b/docs/docs/Examples/index.md
@@ -7,7 +7,7 @@ from a blank choice.
 
 | Workflow | Choice type | Setup | Prerequisites | What it creates |
 | --- | --- | --- | --- | --- |
-| [Add Journal Entry](./Capture_AddJournalEntry) | Capture | Beginner | Daily note or journal file | A timestamped journal entry |
+| [Capture to Your Daily Note](./Capture_ToDailyNote) | Capture | Beginner | Daily note path | Timestamped entries, tasks, quotes, callouts, and table rows |
 | [Add a Task to a Kanban Board](./Capture_AddTaskToKanbanBoard) | Capture | Beginner | Obsidian Kanban plugin | A task in a board section |
 | [Fetch Tasks from Todoist](./Capture_FetchTasksFromTodoist) | Capture and Macro | Intermediate | Todoist API token | Imported Todoist tasks |
 | [Canvas Capture](./Capture_CanvasCapture) | Capture | Intermediate | An Obsidian Canvas file | Text added to a selected or targeted card |
@@ -24,9 +24,9 @@ from a blank choice.
 
 ### Capture information faster
 
-Start with [Add Journal Entry](./Capture_AddJournalEntry) if you want the
-simplest capture flow. Move to [Canvas Capture](./Capture_CanvasCapture) when
-your target is a Canvas card instead of a Markdown note.
+Start with [Capture to Your Daily Note](./Capture_ToDailyNote) for daily-note
+captures. Move to [Canvas Capture](./Capture_CanvasCapture) when your target is
+a Canvas card instead of a Markdown note.
 
 ### Create structured notes
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -127,6 +127,7 @@ const sidebars = {
 					label: "Capture Examples",
 					items: [
 						"Examples/Capture_AddJournalEntry",
+						"Examples/Capture_ToDailyNote",
 						"Examples/Capture_AddTaskToKanbanBoard",
 						"Examples/Capture_FetchTasksFromTodoist",
 						"Examples/Capture_InsertBaseTemplateIntoActiveFile",

--- a/docs/versioned_docs/version-2.17.2/Choices/CaptureChoice.md
+++ b/docs/versioned_docs/version-2.17.2/Choices/CaptureChoice.md
@@ -388,7 +388,7 @@ When `Create line if not found` is enabled and its location dropdown is set to *
 This is the recipe for the classic "daily log, newest first" note (issue [#481](https://github.com/chhoumann/quickadd/issues/481)):
 
 -   **Capture to**: your log note (enable `Create file if it doesn't exist` if you want it auto-created).
--   **Format**: the entry, ending with a newline, e.g. `- {{TIME:HH:mm}} {{VALUE}}\n`. The trailing newline (or enabling `Capture as task`) is what keeps multiple entries on the same day on separate lines — without it, repeated same-day captures run together on one line.
+-   **Format**: the entry, ending with a newline, e.g. `- {{DATE:HH:mm}} {{VALUE}}\n`. Use a trailing newline for non-task line formats so each capture is a complete Markdown line. Task captures add their own newline.
 -   **Insert after**: the day heading, `## {{DATE:YYYY-MM-DD}}`.
 -   **Insert at end of section**: off, so each new entry lands directly under the day heading (newest entry on top within the day).
 -   **Create line if not found**: on, with the location set to **Ordered**, **Sort sections by** = `Date`, and **Section order** = `Newest / highest first`.

--- a/docs/versioned_docs/version-2.17.2/Examples/Capture_AddJournalEntry.md
+++ b/docs/versioned_docs/version-2.17.2/Examples/Capture_AddJournalEntry.md
@@ -6,7 +6,7 @@ For the current step-by-step daily-note setup, use [Capture: Add entries to your
 
 Compact reference for the journal entry format:
 
-- **File path / format**: `bins/daily/{{DATE:gggg-MM-DD - ddd MMM D}}.md`
+- **File path / format**: `bins/daily/{{DATE:YYYY-MM-DD - ddd MMM D}}.md`
 - **Write position**: **After line...**
 - **Insert after**: `## What did I do today?`
 - **Capture format**:

--- a/docs/versioned_docs/version-2.17.2/Examples/Capture_AddJournalEntry.md
+++ b/docs/versioned_docs/version-2.17.2/Examples/Capture_AddJournalEntry.md
@@ -2,16 +2,15 @@
 title: "Capture: Add journal entry"
 ---
 
-This captures a new journal entry in my daily journal under the `What did I do today` header.
+For the current step-by-step daily-note setup, use [Capture: Add entries to your daily note](./Capture_ToDailyNote). That cookbook covers this journal entry pattern plus creating today's note, inserting under a heading, tasks, quotes, callouts, table rows, and newline gotchas.
 
-Capture To: `bins/daily/{{DATE:gggg-MM-DD - ddd MMM D}}.md`
+Compact reference for the journal entry format:
 
-Insert after: `## What did I do today?`
+- **File path / format**: `bins/daily/{{DATE:gggg-MM-DD - ddd MMM D}}.md`
+- **Write position**: **After line...**
+- **Insert after**: `## What did I do today?`
+- **Capture format**:
 
-Capture format:
-
-```
+```markdown
 - {{DATE:HH:mm}} {{VALUE}}\n
 ```
-
-![A Capture choice configured to add a timestamped journal entry](../Images/choices/capture-builder.png)

--- a/docs/versioned_docs/version-2.17.2/Examples/Capture_ToDailyNote.md
+++ b/docs/versioned_docs/version-2.17.2/Examples/Capture_ToDailyNote.md
@@ -1,0 +1,149 @@
+---
+title: "Capture: Add entries to your daily note"
+---
+
+Use this cookbook when you want one QuickAdd choice to add text to today's daily note, even if the note or target heading does not exist yet.
+
+All recipes start from the same Capture choice. Change the **Capture format** and the target heading for the result you want.
+
+## Base setup
+
+1. In QuickAdd settings, add a new **Capture** choice.
+2. Name it (for example, `Daily entry`) and open its settings.
+3. Disable **Capture to active file**.
+4. Set **File path / format** to match your vault's daily-note path and date pattern, for example `Daily/{{DATE:YYYY-MM-DD}}.md`.
+5. Enable **Create file if it doesn't exist**.
+6. Set **Write position** to **After line...**.
+7. In the **Insert after** field, enter the heading you want entries placed under, for example `## Journal`.
+8. Enable **Insert at end of section** so each capture appends at the bottom of the section.
+9. Enable **Create line if not found** and set its placement to **Top** so the heading is inserted when a fresh note does not have it yet.
+10. Leave **Link to captured file** disabled.
+11. Enable **Capture format** and use one of the recipes below.
+
+## Recipes
+
+Each recipe shows what to change from the base setup.
+
+### Timestamped journal line
+
+Keep **Insert after** set to `## Journal`.
+
+**Capture format:**
+
+```
+- {{DATE:HH:mm}} {{VALUE}}\n
+```
+
+Produces:
+
+```markdown
+## Journal
+- 18:54 first journal entry
+- 18:55 second journal entry
+```
+
+End non-task line formats with `\n` so the capture is an explicit complete Markdown line.
+
+### Task line
+
+Change **Insert after** to `## Tasks`.
+
+**Task:** on (in the **Content** section).
+
+**Capture format:**
+
+```
+{{VALUE}}
+```
+
+**Task** wraps the value in `- [ ] ...` automatically. Do not add `- [ ]` to the format manually.
+
+### Task with a date prompt
+
+**Task:** on.
+
+**Capture format:**
+
+```
+{{VALUE}} due {{VDATE:due,YYYY-MM-DD}}
+```
+
+QuickAdd prompts for the task text and then for `due`. You can enter an exact date or a natural-language date such as `tomorrow`. Result: `- [ ] pay rent due 2026-07-07`.
+
+### Callout line
+
+Change **Insert after** to the callout opener, for example:
+
+```
+> [!info]- Captured today
+```
+
+**Capture format:**
+
+```
+> {{VALUE}}\n
+```
+
+On first use, **Create line if not found** inserts the callout opener at the position you chose. Each subsequent capture appends before the next blank line or heading, so keep the callout as one contiguous quoted block. The `>` prefix is required to keep the entry inside the callout block.
+
+### Quote
+
+Change **Insert after** to `## Quotes`.
+
+**Capture format:**
+
+```
+> {{VALUE}}\n
+```
+
+Same format as the callout recipe but targeting a regular heading. Produces a blockquote line under the section.
+
+### Table row
+
+Use this when the daily note already has a table under a heading and the table is the last block in that section. Keep **Write position** as **After line...**, set **Insert after** to the heading above the table, and keep **Insert at end of section** enabled. If more content follows the table in the same section, target the table separator row instead.
+
+**Capture format:**
+
+```
+| {{DATE:HH:mm}} | {{VALUE}} |\n
+```
+
+This keeps the row attached to the table:
+
+```markdown
+## Log
+| When | What |
+| --- | --- |
+| 09:00 | existing |
+| 18:55 | section row |
+```
+
+### Tomorrow's daily note
+
+Change **File path / format** to:
+
+```
+Daily/{{DATE:YYYY-MM-DD+1}}.md
+```
+
+The `+1` shifts the target date one day forward. Combine with any of the formats above.
+
+## Troubleshooting
+
+**Captures run together on one line.**
+For non-task formats, end the capture format with `\n` or press Enter at the end of the format field. Formats that use **Task** do not need one; QuickAdd inserts that line break.
+
+**Pasted multiple lines became one task.**
+The **Task** setting wraps the whole capture once. Capture one task at a time, or use an advanced macro or userscript if you need to split pasted lines into separate tasks.
+
+**The heading is not found and capture fails.**
+Enable **Create line if not found** with placement **Top** (or **Bottom**). QuickAdd inserts the heading on first use and places new content after it.
+
+**You need to insert above a placeholder.**
+Use **Before line...** instead of **After line...** and target the placeholder, such as `<!-- quickadd:notes -->`. See [Insert before](../Choices/CaptureChoice#insert-before) for the full setting.
+
+**Capture writes to the wrong file.**
+The date pattern in **File path / format** must match your vault's daily-note naming exactly. If your notes are named `2025.01.15.md` inside `Journal/`, use `Journal/{{DATE:YYYY.MM.DD}}.md`.
+
+**Table rows or callout content breaks when using bottom-of-file placement.**
+Use **After line...** with **Insert at end of section** instead of **Bottom of file**. Bottom-of-file placement starts non-task captures on a new line, and when the file already ends with a newline that leaves a blank line before the captured content. That blank line splits table rows and callout blocks.

--- a/docs/versioned_docs/version-2.17.2/Examples/Capture_ToDailyNote.md
+++ b/docs/versioned_docs/version-2.17.2/Examples/Capture_ToDailyNote.md
@@ -2,9 +2,9 @@
 title: "Capture: Add entries to your daily note"
 ---
 
-Use this cookbook when you want one QuickAdd choice to add text to today's daily note, even if the note or target heading does not exist yet.
+This cookbook gives you one QuickAdd choice that adds text to today's daily note - even when the note or the target heading doesn't exist yet.
 
-All recipes start from the same Capture choice. Change the **Capture format** and the target heading for the result you want.
+Every recipe starts from the same base Capture choice; you only change the **Capture format** and the target heading.
 
 ## Base setup
 
@@ -42,7 +42,7 @@ Produces:
 - 18:55 second journal entry
 ```
 
-End non-task line formats with `\n` so the capture is an explicit complete Markdown line.
+End non-task formats with `\n` so each capture lands as its own complete line.
 
 ### Task line
 

--- a/docs/versioned_docs/version-2.17.2/Examples/index.md
+++ b/docs/versioned_docs/version-2.17.2/Examples/index.md
@@ -7,7 +7,7 @@ from a blank choice.
 
 | Workflow | Choice type | Setup | Prerequisites | What it creates |
 | --- | --- | --- | --- | --- |
-| [Add Journal Entry](./Capture_AddJournalEntry) | Capture | Beginner | Daily note or journal file | A timestamped journal entry |
+| [Capture to Your Daily Note](./Capture_ToDailyNote) | Capture | Beginner | Daily note path | Timestamped entries, tasks, quotes, callouts, and table rows |
 | [Add a Task to a Kanban Board](./Capture_AddTaskToKanbanBoard) | Capture | Beginner | Obsidian Kanban plugin | A task in a board section |
 | [Fetch Tasks from Todoist](./Capture_FetchTasksFromTodoist) | Capture and Macro | Intermediate | Todoist API token | Imported Todoist tasks |
 | [Canvas Capture](./Capture_CanvasCapture) | Capture | Intermediate | An Obsidian Canvas file | Text added to a selected or targeted card |
@@ -24,9 +24,9 @@ from a blank choice.
 
 ### Capture information faster
 
-Start with [Add Journal Entry](./Capture_AddJournalEntry) if you want the
-simplest capture flow. Move to [Canvas Capture](./Capture_CanvasCapture) when
-your target is a Canvas card instead of a Markdown note.
+Start with [Capture to Your Daily Note](./Capture_ToDailyNote) for daily-note
+captures. Move to [Canvas Capture](./Capture_CanvasCapture) when your target is
+a Canvas card instead of a Markdown note.
 
 ### Create structured notes
 

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -98,6 +98,7 @@
           "label": "Capture Examples",
           "items": [
             "Examples/Capture_AddJournalEntry",
+            "Examples/Capture_ToDailyNote",
             "Examples/Capture_AddTaskToKanbanBoard",
             "Examples/Capture_FetchTasksFromTodoist",
             "Examples/Capture_InsertBaseTemplateIntoActiveFile",


### PR DESCRIPTION
## Summary
- add a canonical daily-note Capture cookbook in both Next and 2.17.2 docs
- cover `{{DATE}}` daily-note paths, Insert After with Create line if not found, timestamped lines, tasks, date prompts, callouts, quotes, table rows, tomorrow offsets, and bottom-of-file/newline gotchas
- point the old journal-entry example and examples overview at the new canonical daily-note guide

## Motivating discussions
References discussions #91, #278, #315, #437, #532, #689, #743, #778, and #1008.

## Validation
- `pnpm run build`
- `pnpm run provision:e2e-vault`
- `pnpm run obsidian:e2e -- quickadd:list`
- live-ran timestamped journal, no-newline comparison, task, VDATE task, callout, quote, tomorrow note, table bottom, table Insert After, multi-line task, and Insert Before placeholder captures through `pnpm run obsidian:e2e -- quickadd:run ... verify=true`
- `pnpm run obsidian:e2e -- dev:errors` reported no errors
- `cd docs && pnpm install`
- `cd docs && pnpm build`
- `pnpm run build-with-lint`
- `pnpm run test`

## Review
- ran one strict docs/code-quality review and two adversarial reviews before opening the PR
- addressed review findings around the Task label, callout/table placement limits, old journal-example duplication, multi-line task caveat, and placeholder Insert Before workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Capture to Your Daily Note” guide with step-by-step setup examples for journal entries, tasks, callouts, quotes, and table rows.
  * Expanded the examples index and sidebar to make the daily-note capture workflow easier to find.

* **Documentation**
  * Updated capture guidance to clarify newline behavior for non-task entries and note that task captures include their own newline.
  * Replaced older journal-entry wording with a clearer reference to the daily-note workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->