### PR TITLE
docs: graduate one-page inputs out of Beta and add a Controlling Prompts page

### DIFF
--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -7,6 +7,7 @@ description: Collect all QuickAdd inputs in a single dynamic form
 # One-page Inputs
 
 QuickAdd can collect all inputs in a single, dynamic form before running your choice.
+For a task-oriented overview of prompts in general, see [Controlling Prompts](../ControllingPrompts.md).
 
 ## Enable
 - Settings → QuickAdd → toggle “One-page input for choices”.

--- a/docs/docs/Advanced/onePageInputs.md
+++ b/docs/docs/Advanced/onePageInputs.md
@@ -1,21 +1,19 @@
 ---
 sidebar_position: 50
 title: One-page Inputs
-description: Collect all QuickAdd inputs in a single dynamic form (Beta)
+description: Collect all QuickAdd inputs in a single dynamic form
 ---
 
 # One-page Inputs
 
 QuickAdd can collect all inputs in a single, dynamic form before running your choice.
-This feature is currently in Beta.
 
 ## Enable
 - Settings → QuickAdd → toggle “One-page input for choices”.
-- Works with Template and Capture choices. Macros get partial support (see User Scripts below).
- - Note: Beta – please report issues and edge cases.
+- Works with Template, Capture, and Macro choices. For Macros, only script-declared inputs are collected (see User Scripts below).
 
 ## Per-choice override
-Each choice builder has a **One-page input override** dropdown that lets you override the global setting for that choice:
+Template and Capture choice builders have a **One-page input override** dropdown that lets you override the global setting for that choice:
 - **Follow global setting** – use whatever the global toggle is set to (default).
 - **Always** – force the one-page modal for this choice even if disabled globally.
 - **Never** – disable the one-page modal for this choice even if enabled globally.
@@ -52,7 +50,8 @@ Each choice builder has a **One-page input override** dropdown that lets you ove
 Note: For **required** date fields with a default, leaving the input blank will apply the default automatically at submit time. A **required** date field left blank without a usable default is re-asked by the sequential date prompt after submit. Optional date fields left blank stay empty.
 
 ### Cancel behavior
-- If you press Cancel in the one-page modal, the preflight is aborted and the choice proceeds with the standard step-by-step prompts at runtime.
+- Cancelling the one-page modal (Cancel button or Esc) cancels the whole run. QuickAdd does not fall back to the step-by-step prompts.
+- If the form fails to open for another reason (for example, a requirement could not be collected), QuickAdd logs a warning and the choice runs with the standard step-by-step prompts instead.
 
 ### Internals and reserved variables
 - QuickAdd uses reserved variable ids prefixed with `__qa.` for internal wiring during preflight/runtime.
@@ -204,4 +203,4 @@ Behavior:
 - Preflight may import user script modules to statically read `quickadd.inputs`. This can execute module top-level code.
 - Inline scripts aren’t scanned for input declarations yet.
 - If needed, you can still prompt ad-hoc (e.g., using inputPrompt or suggester) and those values will skip future one-page prompts due to being prefilled.
-- Closing the modal without submitting triggers `MacroAbortError("Input cancelled by user")`, which stops the macro unless you catch it.
+- Closing the `requestInputs` modal without submitting rejects with `MacroAbortError("Input cancelled by user")`, which stops the macro unless you catch it.

--- a/docs/docs/ControllingPrompts.md
+++ b/docs/docs/ControllingPrompts.md
@@ -1,0 +1,109 @@
+---
+title: Controlling Prompts
+description: How QuickAdd decides what to ask and in which order, and how to label, shape, skip, or combine prompts - including every keyboard shortcut.
+---
+
+# Controlling Prompts
+
+When QuickAdd runs a choice, every format token that needs input becomes a prompt: `{{VALUE:title}}` in a file name, `{{VDATE:due,YYYY-MM-DD}}` in a template, the target file of a Capture, and so on. This page is the overview of everything you control about those prompts: the order they appear in, per-prompt labels and widgets, optional prompts, the keys that submit or skip them, and the one-page form that collects every input at once.
+
+For the full syntax of each token and flag, see [Format Syntax](./FormatSyntax.md). For the one-page form in depth, see [One-page Inputs](./Advanced/onePageInputs.md).
+
+## Where prompts come from
+
+QuickAdd prompts whenever it meets a token it cannot resolve on its own:
+
+- [`{{VALUE}}` / `{{VALUE:name}}`](./FormatSyntax.md#value) ask for text, or show a pick list when you give them options.
+- [`{{VDATE:name,format}}`](./FormatSyntax.md#vdate) asks for a date, with natural language support.
+- [`{{FIELD:name}}`](./FormatSyntax.md#field) suggests values that already exist in your vault's properties.
+- [`{{FILE:folder}}`](./FormatSyntax.md#file) asks you to pick a note from a folder.
+- Template choices may also ask for a file name or folder; Capture choices may ask which file to capture to.
+
+A variable prompts once per run. If `{{VALUE:title}}` appears in both the file name and the template body, you are asked once and the answer is reused. This also means prefilled variables (from a macro step, [the API](./QuickAddAPI.md), or the [CLI](./Advanced/CLI.md)) skip their prompts entirely - an empty string counts as an answer.
+
+## Prompt order
+
+Prompts follow the structure of the choice, not the position of tokens in your text:
+
+1. **Template choices** resolve the template path first, then the folder, then the file name, and finally the template's content. A token in the file name always prompts before anything in the template body.
+2. **Capture choices** resolve the capture target first, then the capture format.
+3. **Within one piece of text** (a file name, a template, a capture format), prompts are grouped by token kind, and only within a kind do they follow the order they appear in. Dates (`{{VDATE}}`) are asked before named values (`{{VALUE:name}}`), which are asked before fields (`{{FIELD}}`) and file pickers (`{{FILE}}`).
+
+For example, in this template:
+
+```markdown
+Attendees: {{VALUE:attendees}}
+Due: {{VDATE:due,YYYY-MM-DD}}
+```
+
+the `due` prompt appears first, even though `attendees` comes first in the text.
+
+There is no flag that reorders individual prompts. If the sequence bothers you, use the [one-page input form](#one-form-instead-of-many-prompts): it shows all inputs in a single form, and you fill them in any order you like.
+
+:::note
+A suggester shared across fields with [`|name:`](./FormatSyntax.md#value-name) is resolved before the surrounding field's other prompts.
+:::
+
+## Shape an individual prompt
+
+Each control is a flag on the token. The reference for every flag lives in [Format Syntax](./FormatSyntax.md); the ones you will reach for most:
+
+| You want | Flag | Example |
+| --- | --- | --- |
+| Helper text on the prompt | [`\|label:`](./FormatSyntax.md#value-label) | `{{VALUE:attendees\|label:Comma-separated names}}` |
+| A pre-filled default | [`\|default:`](./FormatSyntax.md#value-default-option) | `{{VALUE:status\|default:open}}` |
+| A large, multi-line text box | [`\|type:multiline`](./FormatSyntax.md#value-multiline) | `{{VALUE:notes\|type:multiline}}` |
+| A number, slider, or checkbox | [`\|type:number` and friends](./FormatSyntax.md#value-property-types) | `{{VALUE:rating\|type:slider\|min:0\|max:10}}` |
+| A pick list | [comma-separated options](./FormatSyntax.md#named-value) | `{{VALUE:low,medium,high}}` |
+| A pick list that accepts custom text | [`\|custom`](./FormatSyntax.md#value-custom) | `{{VALUE:home,work\|custom}}` |
+| Multiple selections | [`\|multi`](./FormatSyntax.md#value-multi) | `{{VALUE:a,b,c\|multi}}` |
+
+Good to know:
+
+- Among the input tokens, `|label:` works on `{{VALUE}}` tokens and [`{{FILE:...}}`](./FormatSyntax.md#file) pickers (not on `{{VDATE}}` or `{{FIELD}}`). On a plain text prompt the label renders as helper text below the title; on a pick list it becomes the placeholder.
+- `|type:multiline` upgrades a single token to the large prompt and overrides the global **Use Multi-line Input Prompt** setting. The reverse does not exist: with the global setting on, every plain text prompt is multi-line.
+- `|type:` flags only work on single-value tokens - a pick list ignores them.
+
+## Optional prompts
+
+Add [`|optional`](./FormatSyntax.md#optional-fields) to let a prompt be skipped, resolving to nothing:
+
+```markdown
+- [ ] {{VALUE:task}} {{VDATE:due,[📅 ]YYYY-MM-DD|optional}}
+```
+
+Optional prompts gain a **Skip** button and accept an empty submission as the answer; you are not re-asked later in the run. Skipping is an answer - pressing Esc still cancels the whole choice. `|optional` works on `{{VALUE}}` tokens, option lists, `{{VDATE}}`, and `{{FILE}}`.
+
+If a variable appears in several places, put `|optional` on every occurrence. The sequential prompts and the one-page form combine repeated flags differently, and flagging every occurrence is the only spelling that behaves the same everywhere.
+
+## Submit keys
+
+| Prompt | Submit | Also useful |
+| --- | --- | --- |
+| Single-line input (also number, slider, and date prompts) | `Enter` | |
+| Multi-line input | `Ctrl/Cmd+Enter` (`Enter` inserts a newline) | `Tab` indents; `Shift+Tab` moves focus out |
+| Pick list / suggester | `Enter` picks the highlighted option | |
+| Math prompt ([`{{MVALUE}}`](./FormatSyntax.md#mvalue)) | `Ctrl+Enter` | |
+| One-page input form | `Ctrl/Cmd+Enter` | `Tab` moves between fields |
+| Any optional prompt | | `Ctrl/Cmd+Shift+Enter` skips |
+
+`Esc` cancels the prompt and with it the whole run - nothing is created or captured. If you want a notice when that happens, enable **Show Input Cancellation Notifications** in [settings](./Settings.md#notifications).
+
+## Autocomplete inside prompts
+
+While typing in a prompt, `#` searches your vault's tags and `[[` searches your files (headings, blocks, and relative paths work too). See [Suggester System](./SuggesterSystem.md) for all triggers and keys. These triggers work in the single-line and multi-line prompts; the one-page form's text fields do not offer them, though its field and pick-list inputs have their own inline suggestions.
+
+## One form instead of many prompts
+
+Instead of answering prompts one at a time, QuickAdd can collect everything in a single form before the choice runs: every unanswered variable, rendered as the right widget (text, textarea, date with a calendar, dropdown, slider), with optional fields badged and a live file name preview.
+
+- Enable it globally with **One-page input for choices** under [Settings → Input](./Settings.md#input).
+- Template and Capture choices each have a **One-page input override** dropdown in their builder (**Follow global setting**, **Always**, **Never**), so you can turn the form on or off per choice.
+- A few inputs still run as follow-up steps after the form, such as [`{{FIELD:...|multi}}`](./FormatSyntax.md#field-multi) pickers and Capture's insert-after heading picker.
+- Cancelling the form cancels the whole run, exactly like cancelling a sequential prompt.
+
+The full behavior - what is collected, date parsing, defaults, and script-declared inputs - is documented in [One-page Inputs](./Advanced/onePageInputs.md).
+
+## For script authors
+
+User scripts can declare their inputs so they appear in the one-page form (`quickadd.inputs`), and can open a one-page form of their own at runtime with [`quickAddApi.requestInputs`](./QuickAddAPI.md). Both are covered in [One-page Inputs](./Advanced/onePageInputs.md#user-scripts-declare-inputs-optional).

--- a/docs/docs/ControllingPrompts.md
+++ b/docs/docs/ControllingPrompts.md
@@ -27,7 +27,7 @@ Prompts follow the structure of the choice, not the position of tokens in your t
 
 1. **Template choices** resolve the template path first, then the folder, then the file name, and finally the template's content. A token in the file name always prompts before anything in the template body.
 2. **Capture choices** resolve the capture target first, then the capture format.
-3. **Within one piece of text** (a file name, a template, a capture format), prompts are grouped by token kind, and only within a kind do they follow the order they appear in. Dates (`{{VDATE}}`) are asked before named values (`{{VALUE:name}}`), which are asked before fields (`{{FIELD}}`) and file pickers (`{{FILE}}`).
+3. **Within one piece of text** (a file name, a template, a capture format), prompts are grouped by token kind, and only within a kind do they follow the order they appear in. A plain `{{VALUE}}`/`{{NAME}}` is asked first of all, then dates (`{{VDATE}}`), then named values (`{{VALUE:name}}`), then fields (`{{FIELD}}`) and file pickers (`{{FILE}}`), with the math prompt (`{{MVALUE}}`) last.
 
 For example, in this template:
 
@@ -38,10 +38,10 @@ Due: {{VDATE:due,YYYY-MM-DD}}
 
 the `due` prompt appears first, even though `attendees` comes first in the text.
 
-There is no flag that reorders individual prompts. If the sequence bothers you, use the [one-page input form](#one-form-instead-of-many-prompts): it shows all inputs in a single form, and you fill them in any order you like.
+There is no flag that reorders individual prompts. If the sequence bothers you, use the [one-page input form](#one-form-instead-of-many-prompts): it lists all inputs in a single form (in the same resolution order), and you fill them in any order you like.
 
 :::note
-A suggester shared across fields with [`|name:`](./FormatSyntax.md#value-name) is resolved before the surrounding field's other prompts.
+A suggester defined with [`|name:`](./FormatSyntax.md#value-name) and its reuses can appear in any order within one piece of text - when a reuse comes before the definition, QuickAdd resolves the definition early so you are asked once.
 :::
 
 ## Shape an individual prompt
@@ -83,11 +83,11 @@ If a variable appears in several places, put `|optional` on every occurrence. Th
 | Single-line input (also number, slider, and date prompts) | `Enter` | |
 | Multi-line input | `Ctrl/Cmd+Enter` (`Enter` inserts a newline) | `Tab` indents; `Shift+Tab` moves focus out |
 | Pick list / suggester | `Enter` picks the highlighted option | |
-| Math prompt ([`{{MVALUE}}`](./FormatSyntax.md#mvalue)) | `Ctrl+Enter` | |
+| Math prompt ([`{{MVALUE}}`](./FormatSyntax.md#mvalue)) | `Ctrl/Cmd+Enter` | `Tab` jumps to the cursor marker |
 | One-page input form | `Ctrl/Cmd+Enter` | `Tab` moves between fields |
 | Any optional prompt | | `Ctrl/Cmd+Shift+Enter` skips |
 
-`Esc` cancels the prompt and with it the whole run - nothing is created or captured. If you want a notice when that happens, enable **Show Input Cancellation Notifications** in [settings](./Settings.md#notifications).
+`Esc` cancels the prompt and with it the whole run - nothing is created or captured by the cancelled choice (in a macro, steps that already ran are not undone). If you want a notice when that happens, enable **Show Input Cancellation Notifications** in [settings](./Settings.md#notifications).
 
 ## Autocomplete inside prompts
 
@@ -95,7 +95,7 @@ While typing in a prompt, `#` searches your vault's tags and `[[` searches your 
 
 ## One form instead of many prompts
 
-Instead of answering prompts one at a time, QuickAdd can collect everything in a single form before the choice runs: every unanswered variable, rendered as the right widget (text, textarea, date with a calendar, dropdown, slider), with optional fields badged and a live file name preview.
+Instead of answering prompts one at a time, QuickAdd can collect everything in a single form before the choice runs: every unanswered variable, rendered as the right widget (text, textarea, date with a calendar, dropdown, slider), with optional fields badged and, for Template choices with a file name format, a live file name preview.
 
 - Enable it globally with **One-page input for choices** under [Settings → Input](./Settings.md#input).
 - Template and Capture choices each have a **One-page input override** dropdown in their builder (**Follow global setting**, **Always**, **Never**), so you can turn the form on or off per choice.

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -268,7 +268,7 @@ Notes:
 
 ## Optional fields: `|optional` {#optional-fields}
 
-Marks a prompt as optional, so it can be skipped and resolve to nothing. Works on `{{VALUE}}`/`{{NAME}}`, `{{VALUE:<variable>}}`, option lists, and `{{VDATE:...}}`.
+Marks a prompt as optional, so it can be skipped and resolve to nothing. Works on `{{VALUE}}`/`{{NAME}}`, `{{VALUE:<variable>}}`, option lists, `{{VDATE:...}}`, and `{{FILE:...}}`.
 
 ```markdown
 {{VALUE:reminder|optional}}
@@ -365,7 +365,7 @@ Example: `{{GLOBAL_VAR:Meeting Header}}`.
 
 ## `{{MVALUE}}` {#mvalue}
 
-Math modal for writing LaTeX. Use CTRL + Enter to submit.
+Math modal for writing LaTeX. Use Ctrl/Cmd + Enter to submit.
 
 Example: `Equation: ${{MVALUE}}$`.
 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -164,7 +164,7 @@ Example:
 {{VALUE:summary|type:multiline|label:Summary}}
 ```
 
-**Keyboard:** In the multi-line prompt, pressing **Tab** inserts a tab character at the cursor (handy for nested Markdown lists) instead of moving focus; with text selected, Tab indents every line the selection touches. **Shift+Tab** is left unbound, so it still moves focus out of the field.
+**Keyboard:** Submit the multi-line prompt with **Ctrl/Cmd+Enter** - plain **Enter** inserts a newline. Pressing **Tab** inserts a tab character at the cursor (handy for nested Markdown lists) instead of moving focus; with text selected, Tab indents every line the selection touches. **Shift+Tab** is left unbound, so it still moves focus out of the field. See [Controlling Prompts](./ControllingPrompts.md#submit-keys) for all prompt shortcuts.
 
 ## `{{VALUE:<variable>|type:number}}` / `|type:slider` / `|type:checkbox` / `|type:text` {#value-property-types}
 

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -19,7 +19,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 - **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt.
 - **Persist Input Prompt Drafts** — Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.
 - **Use editor selection as default Capture value** — When enabled, Capture uses the current editor selection as `{{VALUE}}` and may skip the prompt. When disabled, Capture always prompts for `{{VALUE}}`.
-- **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs).
+- **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs) and [Controlling Prompts](./ControllingPrompts).
 - **Date aliases** — Shortcodes for natural language date parsing. One per line: `alias = phrase`. Example: `tm = tomorrow`. Use **Reset to defaults** to restore the built-in aliases.
 
 ## Templates & Properties

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -19,7 +19,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 - **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt.
 - **Persist Input Prompt Drafts** — Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.
 - **Use editor selection as default Capture value** — When enabled, Capture uses the current editor selection as `{{VALUE}}` and may skip the prompt. When disabled, Capture always prompts for `{{VALUE}}`.
-- **One-page input for choices (Beta)** — Experimental. Resolve variables up front and show a single dynamic form before executing Template/Capture choices. See [One-page Inputs](./Advanced/onePageInputs).
+- **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs).
 - **Date aliases** — Shortcodes for natural language date parsing. One per line: `alias = phrase`. Example: `tm = tomorrow`. Use **Reset to defaults** to restore the built-in aliases.
 
 ## Templates & Properties

--- a/docs/docs/Settings.md
+++ b/docs/docs/Settings.md
@@ -16,7 +16,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 ## Input
 
-- **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt.
+- **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt. Multi-line prompts submit with Ctrl/Cmd+Enter (Enter inserts a newline). See [Controlling Prompts](./ControllingPrompts#submit-keys).
 - **Persist Input Prompt Drafts** — Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.
 - **Use editor selection as default Capture value** — When enabled, Capture uses the current editor selection as `{{VALUE}}` and may skip the prompt. When disabled, Capture always prompts for `{{VALUE}}`.
 - **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs) and [Controlling Prompts](./ControllingPrompts).

--- a/docs/docs/SuggesterSystem.md
+++ b/docs/docs/SuggesterSystem.md
@@ -6,6 +6,8 @@ title: Suggester System
 
 QuickAdd's suggester system provides intelligent, context-aware suggestions when selecting files, tags, headings, and other content in your vault.
 
+The `#` and `[[` triggers below work in QuickAdd's single-line and multi-line input prompts. The [one-page input form](./ControllingPrompts.md#one-form-instead-of-many-prompts)'s text fields do not offer them; its field and pick-list inputs have their own inline suggestions.
+
 ![Obsidian_kKQxHJal6p](https://github.com/user-attachments/assets/cc89f672-3451-42c0-89b8-89e0a1ebc780)
 
 ## Special Search Modes

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -83,6 +83,11 @@ const sidebars = {
 				{ type: "doc", id: "VariablesDataFlow", label: "Variables and data flow" },
 				{
 					type: "doc",
+					id: "ControllingPrompts",
+					label: "Controlling Prompts",
+				},
+				{
+					type: "doc",
 					id: "ApplyTemplateToNote",
 					label: "Apply Template to Note",
 				},

--- a/docs/versioned_docs/version-2.17.2/Advanced/onePageInputs.md
+++ b/docs/versioned_docs/version-2.17.2/Advanced/onePageInputs.md
@@ -7,6 +7,7 @@ description: Collect all QuickAdd inputs in a single dynamic form
 # One-page Inputs
 
 QuickAdd can collect all inputs in a single, dynamic form before running your choice.
+For a task-oriented overview of prompts in general, see [Controlling Prompts](../ControllingPrompts.md).
 
 ## Enable
 - Settings → QuickAdd → toggle “One-page input for choices”.

--- a/docs/versioned_docs/version-2.17.2/Advanced/onePageInputs.md
+++ b/docs/versioned_docs/version-2.17.2/Advanced/onePageInputs.md
@@ -1,21 +1,19 @@
 ---
 sidebar_position: 50
 title: One-page Inputs
-description: Collect all QuickAdd inputs in a single dynamic form (Beta)
+description: Collect all QuickAdd inputs in a single dynamic form
 ---
 
 # One-page Inputs
 
 QuickAdd can collect all inputs in a single, dynamic form before running your choice.
-This feature is currently in Beta.
 
 ## Enable
 - Settings → QuickAdd → toggle “One-page input for choices”.
-- Works with Template and Capture choices. Macros get partial support (see User Scripts below).
- - Note: Beta – please report issues and edge cases.
+- Works with Template, Capture, and Macro choices. For Macros, only script-declared inputs are collected (see User Scripts below).
 
 ## Per-choice override
-Each choice builder has a **One-page input override** dropdown that lets you override the global setting for that choice:
+Template and Capture choice builders have a **One-page input override** dropdown that lets you override the global setting for that choice:
 - **Follow global setting** – use whatever the global toggle is set to (default).
 - **Always** – force the one-page modal for this choice even if disabled globally.
 - **Never** – disable the one-page modal for this choice even if enabled globally.
@@ -52,7 +50,8 @@ Each choice builder has a **One-page input override** dropdown that lets you ove
 Note: For **required** date fields with a default, leaving the input blank will apply the default automatically at submit time. A **required** date field left blank without a usable default is re-asked by the sequential date prompt after submit. Optional date fields left blank stay empty.
 
 ### Cancel behavior
-- If you press Cancel in the one-page modal, the preflight is aborted and the choice proceeds with the standard step-by-step prompts at runtime.
+- Cancelling the one-page modal (Cancel button or Esc) cancels the whole run. QuickAdd does not fall back to the step-by-step prompts.
+- If the form fails to open for another reason (for example, a requirement could not be collected), QuickAdd logs a warning and the choice runs with the standard step-by-step prompts instead.
 
 ### Internals and reserved variables
 - QuickAdd uses reserved variable ids prefixed with `__qa.` for internal wiring during preflight/runtime.
@@ -204,4 +203,4 @@ Behavior:
 - Preflight may import user script modules to statically read `quickadd.inputs`. This can execute module top-level code.
 - Inline scripts aren’t scanned for input declarations yet.
 - If needed, you can still prompt ad-hoc (e.g., using inputPrompt or suggester) and those values will skip future one-page prompts due to being prefilled.
-- Closing the modal without submitting triggers `MacroAbortError("Input cancelled by user")`, which stops the macro unless you catch it.
+- Closing the `requestInputs` modal without submitting rejects with `MacroAbortError("Input cancelled by user")`, which stops the macro unless you catch it.

--- a/docs/versioned_docs/version-2.17.2/ControllingPrompts.md
+++ b/docs/versioned_docs/version-2.17.2/ControllingPrompts.md
@@ -1,0 +1,109 @@
+---
+title: Controlling Prompts
+description: How QuickAdd decides what to ask and in which order, and how to label, shape, skip, or combine prompts - including every keyboard shortcut.
+---
+
+# Controlling Prompts
+
+When QuickAdd runs a choice, every format token that needs input becomes a prompt: `{{VALUE:title}}` in a file name, `{{VDATE:due,YYYY-MM-DD}}` in a template, the target file of a Capture, and so on. This page is the overview of everything you control about those prompts: the order they appear in, per-prompt labels and widgets, optional prompts, the keys that submit or skip them, and the one-page form that collects every input at once.
+
+For the full syntax of each token and flag, see [Format Syntax](./FormatSyntax.md). For the one-page form in depth, see [One-page Inputs](./Advanced/onePageInputs.md).
+
+## Where prompts come from
+
+QuickAdd prompts whenever it meets a token it cannot resolve on its own:
+
+- [`{{VALUE}}` / `{{VALUE:name}}`](./FormatSyntax.md#value) ask for text, or show a pick list when you give them options.
+- [`{{VDATE:name,format}}`](./FormatSyntax.md#vdate) asks for a date, with natural language support.
+- [`{{FIELD:name}}`](./FormatSyntax.md#field) suggests values that already exist in your vault's properties.
+- [`{{FILE:folder}}`](./FormatSyntax.md#file) asks you to pick a note from a folder.
+- Template choices may also ask for a file name or folder; Capture choices may ask which file to capture to.
+
+A variable prompts once per run. If `{{VALUE:title}}` appears in both the file name and the template body, you are asked once and the answer is reused. This also means prefilled variables (from a macro step, [the API](./QuickAddAPI.md), or the [CLI](./Advanced/CLI.md)) skip their prompts entirely - an empty string counts as an answer.
+
+## Prompt order
+
+Prompts follow the structure of the choice, not the position of tokens in your text:
+
+1. **Template choices** resolve the template path first, then the folder, then the file name, and finally the template's content. A token in the file name always prompts before anything in the template body.
+2. **Capture choices** resolve the capture target first, then the capture format.
+3. **Within one piece of text** (a file name, a template, a capture format), prompts are grouped by token kind, and only within a kind do they follow the order they appear in. Dates (`{{VDATE}}`) are asked before named values (`{{VALUE:name}}`), which are asked before fields (`{{FIELD}}`) and file pickers (`{{FILE}}`).
+
+For example, in this template:
+
+```markdown
+Attendees: {{VALUE:attendees}}
+Due: {{VDATE:due,YYYY-MM-DD}}
+```
+
+the `due` prompt appears first, even though `attendees` comes first in the text.
+
+There is no flag that reorders individual prompts. If the sequence bothers you, use the [one-page input form](#one-form-instead-of-many-prompts): it shows all inputs in a single form, and you fill them in any order you like.
+
+:::note
+A suggester shared across fields with [`|name:`](./FormatSyntax.md#value-name) is resolved before the surrounding field's other prompts.
+:::
+
+## Shape an individual prompt
+
+Each control is a flag on the token. The reference for every flag lives in [Format Syntax](./FormatSyntax.md); the ones you will reach for most:
+
+| You want | Flag | Example |
+| --- | --- | --- |
+| Helper text on the prompt | [`\|label:`](./FormatSyntax.md#value-label) | `{{VALUE:attendees\|label:Comma-separated names}}` |
+| A pre-filled default | [`\|default:`](./FormatSyntax.md#value-default-option) | `{{VALUE:status\|default:open}}` |
+| A large, multi-line text box | [`\|type:multiline`](./FormatSyntax.md#value-multiline) | `{{VALUE:notes\|type:multiline}}` |
+| A number, slider, or checkbox | [`\|type:number` and friends](./FormatSyntax.md#value-property-types) | `{{VALUE:rating\|type:slider\|min:0\|max:10}}` |
+| A pick list | [comma-separated options](./FormatSyntax.md#named-value) | `{{VALUE:low,medium,high}}` |
+| A pick list that accepts custom text | [`\|custom`](./FormatSyntax.md#value-custom) | `{{VALUE:home,work\|custom}}` |
+| Multiple selections | [`\|multi`](./FormatSyntax.md#value-multi) | `{{VALUE:a,b,c\|multi}}` |
+
+Good to know:
+
+- Among the input tokens, `|label:` works on `{{VALUE}}` tokens and [`{{FILE:...}}`](./FormatSyntax.md#file) pickers (not on `{{VDATE}}` or `{{FIELD}}`). On a plain text prompt the label renders as helper text below the title; on a pick list it becomes the placeholder.
+- `|type:multiline` upgrades a single token to the large prompt and overrides the global **Use Multi-line Input Prompt** setting. The reverse does not exist: with the global setting on, every plain text prompt is multi-line.
+- `|type:` flags only work on single-value tokens - a pick list ignores them.
+
+## Optional prompts
+
+Add [`|optional`](./FormatSyntax.md#optional-fields) to let a prompt be skipped, resolving to nothing:
+
+```markdown
+- [ ] {{VALUE:task}} {{VDATE:due,[📅 ]YYYY-MM-DD|optional}}
+```
+
+Optional prompts gain a **Skip** button and accept an empty submission as the answer; you are not re-asked later in the run. Skipping is an answer - pressing Esc still cancels the whole choice. `|optional` works on `{{VALUE}}` tokens, option lists, `{{VDATE}}`, and `{{FILE}}`.
+
+If a variable appears in several places, put `|optional` on every occurrence. The sequential prompts and the one-page form combine repeated flags differently, and flagging every occurrence is the only spelling that behaves the same everywhere.
+
+## Submit keys
+
+| Prompt | Submit | Also useful |
+| --- | --- | --- |
+| Single-line input (also number, slider, and date prompts) | `Enter` | |
+| Multi-line input | `Ctrl/Cmd+Enter` (`Enter` inserts a newline) | `Tab` indents; `Shift+Tab` moves focus out |
+| Pick list / suggester | `Enter` picks the highlighted option | |
+| Math prompt ([`{{MVALUE}}`](./FormatSyntax.md#mvalue)) | `Ctrl+Enter` | |
+| One-page input form | `Ctrl/Cmd+Enter` | `Tab` moves between fields |
+| Any optional prompt | | `Ctrl/Cmd+Shift+Enter` skips |
+
+`Esc` cancels the prompt and with it the whole run - nothing is created or captured. If you want a notice when that happens, enable **Show Input Cancellation Notifications** in [settings](./Settings.md#notifications).
+
+## Autocomplete inside prompts
+
+While typing in a prompt, `#` searches your vault's tags and `[[` searches your files (headings, blocks, and relative paths work too). See [Suggester System](./SuggesterSystem.md) for all triggers and keys. These triggers work in the single-line and multi-line prompts; the one-page form's text fields do not offer them, though its field and pick-list inputs have their own inline suggestions.
+
+## One form instead of many prompts
+
+Instead of answering prompts one at a time, QuickAdd can collect everything in a single form before the choice runs: every unanswered variable, rendered as the right widget (text, textarea, date with a calendar, dropdown, slider), with optional fields badged and a live file name preview.
+
+- Enable it globally with **One-page input for choices** under [Settings → Input](./Settings.md#input).
+- Template and Capture choices each have a **One-page input override** dropdown in their builder (**Follow global setting**, **Always**, **Never**), so you can turn the form on or off per choice.
+- A few inputs still run as follow-up steps after the form, such as [`{{FIELD:...|multi}}`](./FormatSyntax.md#field-multi) pickers and Capture's insert-after heading picker.
+- Cancelling the form cancels the whole run, exactly like cancelling a sequential prompt.
+
+The full behavior - what is collected, date parsing, defaults, and script-declared inputs - is documented in [One-page Inputs](./Advanced/onePageInputs.md).
+
+## For script authors
+
+User scripts can declare their inputs so they appear in the one-page form (`quickadd.inputs`), and can open a one-page form of their own at runtime with [`quickAddApi.requestInputs`](./QuickAddAPI.md). Both are covered in [One-page Inputs](./Advanced/onePageInputs.md#user-scripts-declare-inputs-optional).

--- a/docs/versioned_docs/version-2.17.2/ControllingPrompts.md
+++ b/docs/versioned_docs/version-2.17.2/ControllingPrompts.md
@@ -27,7 +27,7 @@ Prompts follow the structure of the choice, not the position of tokens in your t
 
 1. **Template choices** resolve the template path first, then the folder, then the file name, and finally the template's content. A token in the file name always prompts before anything in the template body.
 2. **Capture choices** resolve the capture target first, then the capture format.
-3. **Within one piece of text** (a file name, a template, a capture format), prompts are grouped by token kind, and only within a kind do they follow the order they appear in. Dates (`{{VDATE}}`) are asked before named values (`{{VALUE:name}}`), which are asked before fields (`{{FIELD}}`) and file pickers (`{{FILE}}`).
+3. **Within one piece of text** (a file name, a template, a capture format), prompts are grouped by token kind, and only within a kind do they follow the order they appear in. A plain `{{VALUE}}`/`{{NAME}}` is asked first of all, then dates (`{{VDATE}}`), then named values (`{{VALUE:name}}`), then fields (`{{FIELD}}`) and file pickers (`{{FILE}}`), with the math prompt (`{{MVALUE}}`) last.
 
 For example, in this template:
 
@@ -38,10 +38,10 @@ Due: {{VDATE:due,YYYY-MM-DD}}
 
 the `due` prompt appears first, even though `attendees` comes first in the text.
 
-There is no flag that reorders individual prompts. If the sequence bothers you, use the [one-page input form](#one-form-instead-of-many-prompts): it shows all inputs in a single form, and you fill them in any order you like.
+There is no flag that reorders individual prompts. If the sequence bothers you, use the [one-page input form](#one-form-instead-of-many-prompts): it lists all inputs in a single form (in the same resolution order), and you fill them in any order you like.
 
 :::note
-A suggester shared across fields with [`|name:`](./FormatSyntax.md#value-name) is resolved before the surrounding field's other prompts.
+A suggester defined with [`|name:`](./FormatSyntax.md#value-name) and its reuses can appear in any order within one piece of text - when a reuse comes before the definition, QuickAdd resolves the definition early so you are asked once.
 :::
 
 ## Shape an individual prompt
@@ -83,11 +83,11 @@ If a variable appears in several places, put `|optional` on every occurrence. Th
 | Single-line input (also number, slider, and date prompts) | `Enter` | |
 | Multi-line input | `Ctrl/Cmd+Enter` (`Enter` inserts a newline) | `Tab` indents; `Shift+Tab` moves focus out |
 | Pick list / suggester | `Enter` picks the highlighted option | |
-| Math prompt ([`{{MVALUE}}`](./FormatSyntax.md#mvalue)) | `Ctrl+Enter` | |
+| Math prompt ([`{{MVALUE}}`](./FormatSyntax.md#mvalue)) | `Ctrl/Cmd+Enter` | `Tab` jumps to the cursor marker |
 | One-page input form | `Ctrl/Cmd+Enter` | `Tab` moves between fields |
 | Any optional prompt | | `Ctrl/Cmd+Shift+Enter` skips |
 
-`Esc` cancels the prompt and with it the whole run - nothing is created or captured. If you want a notice when that happens, enable **Show Input Cancellation Notifications** in [settings](./Settings.md#notifications).
+`Esc` cancels the prompt and with it the whole run - nothing is created or captured by the cancelled choice (in a macro, steps that already ran are not undone). If you want a notice when that happens, enable **Show Input Cancellation Notifications** in [settings](./Settings.md#notifications).
 
 ## Autocomplete inside prompts
 
@@ -95,7 +95,7 @@ While typing in a prompt, `#` searches your vault's tags and `[[` searches your 
 
 ## One form instead of many prompts
 
-Instead of answering prompts one at a time, QuickAdd can collect everything in a single form before the choice runs: every unanswered variable, rendered as the right widget (text, textarea, date with a calendar, dropdown, slider), with optional fields badged and a live file name preview.
+Instead of answering prompts one at a time, QuickAdd can collect everything in a single form before the choice runs: every unanswered variable, rendered as the right widget (text, textarea, date with a calendar, dropdown, slider), with optional fields badged and, for Template choices with a file name format, a live file name preview.
 
 - Enable it globally with **One-page input for choices** under [Settings → Input](./Settings.md#input).
 - Template and Capture choices each have a **One-page input override** dropdown in their builder (**Follow global setting**, **Always**, **Never**), so you can turn the form on or off per choice.

--- a/docs/versioned_docs/version-2.17.2/FormatSyntax.md
+++ b/docs/versioned_docs/version-2.17.2/FormatSyntax.md
@@ -268,7 +268,7 @@ Notes:
 
 ## Optional fields: `|optional` {#optional-fields}
 
-Marks a prompt as optional, so it can be skipped and resolve to nothing. Works on `{{VALUE}}`/`{{NAME}}`, `{{VALUE:<variable>}}`, option lists, and `{{VDATE:...}}`.
+Marks a prompt as optional, so it can be skipped and resolve to nothing. Works on `{{VALUE}}`/`{{NAME}}`, `{{VALUE:<variable>}}`, option lists, `{{VDATE:...}}`, and `{{FILE:...}}`.
 
 ```markdown
 {{VALUE:reminder|optional}}
@@ -365,7 +365,7 @@ Example: `{{GLOBAL_VAR:Meeting Header}}`.
 
 ## `{{MVALUE}}` {#mvalue}
 
-Math modal for writing LaTeX. Use CTRL + Enter to submit.
+Math modal for writing LaTeX. Use Ctrl/Cmd + Enter to submit.
 
 Example: `Equation: ${{MVALUE}}$`.
 

--- a/docs/versioned_docs/version-2.17.2/FormatSyntax.md
+++ b/docs/versioned_docs/version-2.17.2/FormatSyntax.md
@@ -164,7 +164,7 @@ Example:
 {{VALUE:summary|type:multiline|label:Summary}}
 ```
 
-**Keyboard:** In the multi-line prompt, pressing **Tab** inserts a tab character at the cursor (handy for nested Markdown lists) instead of moving focus; with text selected, Tab indents every line the selection touches. **Shift+Tab** is left unbound, so it still moves focus out of the field.
+**Keyboard:** Submit the multi-line prompt with **Ctrl/Cmd+Enter** - plain **Enter** inserts a newline. Pressing **Tab** inserts a tab character at the cursor (handy for nested Markdown lists) instead of moving focus; with text selected, Tab indents every line the selection touches. **Shift+Tab** is left unbound, so it still moves focus out of the field. See [Controlling Prompts](./ControllingPrompts.md#submit-keys) for all prompt shortcuts.
 
 ## `{{VALUE:<variable>|type:number}}` / `|type:slider` / `|type:checkbox` / `|type:text` {#value-property-types}
 

--- a/docs/versioned_docs/version-2.17.2/Settings.md
+++ b/docs/versioned_docs/version-2.17.2/Settings.md
@@ -19,7 +19,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 - **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt.
 - **Persist Input Prompt Drafts** — Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.
 - **Use editor selection as default Capture value** — When enabled, Capture uses the current editor selection as `{{VALUE}}` and may skip the prompt. When disabled, Capture always prompts for `{{VALUE}}`.
-- **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs).
+- **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs) and [Controlling Prompts](./ControllingPrompts).
 - **Date aliases** — Shortcodes for natural language date parsing. One per line: `alias = phrase`. Example: `tm = tomorrow`. Use **Reset to defaults** to restore the built-in aliases.
 
 ## Templates & Properties

--- a/docs/versioned_docs/version-2.17.2/Settings.md
+++ b/docs/versioned_docs/version-2.17.2/Settings.md
@@ -19,7 +19,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 - **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt.
 - **Persist Input Prompt Drafts** — Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.
 - **Use editor selection as default Capture value** — When enabled, Capture uses the current editor selection as `{{VALUE}}` and may skip the prompt. When disabled, Capture always prompts for `{{VALUE}}`.
-- **One-page input for choices (Beta)** — Experimental. Resolve variables up front and show a single dynamic form before executing Template/Capture choices. See [One-page Inputs](./Advanced/onePageInputs).
+- **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs).
 - **Date aliases** — Shortcodes for natural language date parsing. One per line: `alias = phrase`. Example: `tm = tomorrow`. Use **Reset to defaults** to restore the built-in aliases.
 
 ## Templates & Properties

--- a/docs/versioned_docs/version-2.17.2/Settings.md
+++ b/docs/versioned_docs/version-2.17.2/Settings.md
@@ -16,7 +16,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 ## Input
 
-- **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt.
+- **Use Multi-line Input Prompt** — Use multi-line input prompt instead of single-line input prompt. Multi-line prompts submit with Ctrl/Cmd+Enter (Enter inserts a newline). See [Controlling Prompts](./ControllingPrompts#submit-keys).
 - **Persist Input Prompt Drafts** — Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.
 - **Use editor selection as default Capture value** — When enabled, Capture uses the current editor selection as `{{VALUE}}` and may skip the prompt. When disabled, Capture always prompts for `{{VALUE}}`.
 - **One-page input for choices** — Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs; Template and Capture choices can [override this individually](./Advanced/onePageInputs#per-choice-override). See [One-page Inputs](./Advanced/onePageInputs) and [Controlling Prompts](./ControllingPrompts).

--- a/docs/versioned_docs/version-2.17.2/SuggesterSystem.md
+++ b/docs/versioned_docs/version-2.17.2/SuggesterSystem.md
@@ -6,6 +6,8 @@ title: Suggester System
 
 QuickAdd's suggester system provides intelligent, context-aware suggestions when selecting files, tags, headings, and other content in your vault.
 
+The `#` and `[[` triggers below work in QuickAdd's single-line and multi-line input prompts. The [one-page input form](./ControllingPrompts.md#one-form-instead-of-many-prompts)'s text fields do not offer them; its field and pick-list inputs have their own inline suggestions.
+
 ![Obsidian_kKQxHJal6p](https://github.com/user-attachments/assets/cc89f672-3451-42c0-89b8-89e0a1ebc780)
 
 ## Special Search Modes

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -54,6 +54,11 @@
         { "type": "doc", "id": "VariablesDataFlow", "label": "Variables and data flow" },
         {
           "type": "doc",
+          "id": "ControllingPrompts",
+          "label": "Controlling Prompts"
+        },
+        {
+          "type": "doc",
           "id": "ApplyTemplateToNote",
           "label": "Apply Template to Note"
         },

--- a/src/choiceExecutor.onePageGate.test.ts
+++ b/src/choiceExecutor.onePageGate.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the heavy leaves of the executor's import graph (mirrors
+// choiceExecutor.preload.test.ts).
+vi.mock("./gui/choiceList/ChoiceView.svelte", () => ({}));
+vi.mock("./gui/GlobalVariables/GlobalVariablesView.svelte", () => ({}));
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+vi.mock("./main", () => ({ __esModule: true, default: class QuickAddMock {} }));
+vi.mock("./quickAddSettingsTab", () => ({
+	DEFAULT_SETTINGS: {},
+	QuickAddSettingsTab: class {},
+}));
+
+let onePageInputEnabled = false;
+vi.mock("./settingsStore", () => ({
+	settingsStore: {
+		getState: () => ({ onePageInputEnabled, ai: {}, disableOnlineFeatures: true }),
+	},
+}));
+vi.mock("./engine/runTemplateFromFolder", () => ({
+	runTemplateFromFolder: vi.fn(),
+}));
+vi.mock("./utils/frontmatterPropertyLinks", () => ({
+	getFocusedPropertyTarget: vi.fn(() => null),
+}));
+vi.mock("./utilityObsidian", async (importOriginal) => {
+	const actual = await importOriginal<Record<string, unknown>>();
+	return {
+		...actual,
+		getOpenFileOriginLeaf: vi.fn(() => null),
+	};
+});
+
+const runOnePagePreflight = vi.fn<(...args: unknown[]) => Promise<unknown>>(
+	async () => true,
+);
+vi.mock("./preflight/runOnePagePreflight", () => ({
+	runOnePagePreflight,
+}));
+
+const { ChoiceExecutor } = await import("./choiceExecutor");
+const { UserCancelError } = await import("./errors/UserCancelError");
+
+type GateHarness = {
+	runOnePagePreflightIfEnabled(choice: unknown): Promise<void>;
+	promptProvider: unknown;
+};
+
+function makeExecutor(): GateHarness {
+	return new ChoiceExecutor(
+		{ workspace: { getActiveFile: () => null } } as never,
+		{} as never,
+	) as unknown as GateHarness;
+}
+
+function choice(
+	type: string,
+	onePageInput?: "always" | "never",
+): Record<string, unknown> {
+	return { id: "gate-test", name: "Gate test", type, onePageInput };
+}
+
+describe("ChoiceExecutor one-page preflight gate", () => {
+	beforeEach(() => {
+		onePageInputEnabled = false;
+		runOnePagePreflight.mockClear();
+		runOnePagePreflight.mockResolvedValue(true);
+	});
+
+	it("runs preflight when the global toggle is on and the choice follows it", async () => {
+		onePageInputEnabled = true;
+		await makeExecutor().runOnePagePreflightIfEnabled(choice("Template"));
+		expect(runOnePagePreflight).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips preflight when the global toggle is off and the choice follows it", async () => {
+		await makeExecutor().runOnePagePreflightIfEnabled(choice("Template"));
+		expect(runOnePagePreflight).not.toHaveBeenCalled();
+	});
+
+	it("per-choice 'always' beats a disabled global toggle", async () => {
+		await makeExecutor().runOnePagePreflightIfEnabled(
+			choice("Capture", "always"),
+		);
+		expect(runOnePagePreflight).toHaveBeenCalledTimes(1);
+	});
+
+	it("per-choice 'never' beats an enabled global toggle", async () => {
+		onePageInputEnabled = true;
+		await makeExecutor().runOnePagePreflightIfEnabled(
+			choice("Template", "never"),
+		);
+		expect(runOnePagePreflight).not.toHaveBeenCalled();
+	});
+
+	it("a remote prompt provider forces preflight even with the global toggle off", async () => {
+		const executor = makeExecutor();
+		executor.promptProvider = {};
+		await executor.runOnePagePreflightIfEnabled(choice("Template"));
+		expect(runOnePagePreflight).toHaveBeenCalledTimes(1);
+	});
+
+	it("per-choice 'never' beats a remote prompt provider", async () => {
+		const executor = makeExecutor();
+		executor.promptProvider = {};
+		await executor.runOnePagePreflightIfEnabled(choice("Template", "never"));
+		expect(runOnePagePreflight).not.toHaveBeenCalled();
+	});
+
+	it("applies to Macro choices", async () => {
+		onePageInputEnabled = true;
+		await makeExecutor().runOnePagePreflightIfEnabled(choice("Macro"));
+		expect(runOnePagePreflight).toHaveBeenCalledTimes(1);
+	});
+
+	it("never runs for Multi choices, even with 'always'", async () => {
+		onePageInputEnabled = true;
+		await makeExecutor().runOnePagePreflightIfEnabled(
+			choice("Multi", "always"),
+		);
+		expect(runOnePagePreflight).not.toHaveBeenCalled();
+	});
+
+	it("converts a modal cancellation into UserCancelError so the run aborts", async () => {
+		onePageInputEnabled = true;
+		// Byte-faithful to OnePageInputModal's rejection value.
+		runOnePagePreflight.mockRejectedValue("cancelled");
+		await expect(
+			makeExecutor().runOnePagePreflightIfEnabled(choice("Template")),
+		).rejects.toThrow(UserCancelError);
+	});
+
+	it("rethrows non-cancellation preflight errors unchanged", async () => {
+		onePageInputEnabled = true;
+		const boom = new Error("collection exploded");
+		runOnePagePreflight.mockRejectedValue(boom);
+		await expect(
+			makeExecutor().runOnePagePreflightIfEnabled(choice("Template")),
+		).rejects.toBe(boom);
+	});
+});

--- a/src/choiceExecutor.onePageGate.test.ts
+++ b/src/choiceExecutor.onePageGate.test.ts
@@ -130,6 +130,28 @@ describe("ChoiceExecutor one-page preflight gate", () => {
 		).rejects.toThrow(UserCancelError);
 	});
 
+	it("execute() runs the gate before any engine, with the executor and choice", async () => {
+		// Pin the wiring, not just the gate logic: a refactor that drops the
+		// runOnePagePreflightIfEnabled call from execute() must fail here. The
+		// preflight rejects with the modal's cancellation value, so execution
+		// stops at the gate and no engine is ever constructed.
+		onePageInputEnabled = true;
+		runOnePagePreflight.mockRejectedValue("cancelled");
+		const executor = makeExecutor() as unknown as InstanceType<
+			typeof ChoiceExecutor
+		>;
+		const templateChoice = choice("Template");
+		await expect(
+			executor.execute(templateChoice as never),
+		).rejects.toThrow(UserCancelError);
+		expect(runOnePagePreflight).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			executor,
+			templateChoice,
+		);
+	});
+
 	it("rethrows non-cancellation preflight errors unchanged", async () => {
 		onePageInputEnabled = true;
 		const boom = new Error("collection exploded");

--- a/src/preflight/runOnePagePreflight.fallback.test.ts
+++ b/src/preflight/runOnePagePreflight.fallback.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import { runOnePagePreflight } from "./runOnePagePreflight";
+import { MacroAbortError } from "../errors/MacroAbortError";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import type { IChoiceExecutor } from "../IChoiceExecutor";
+
+const { logWarningMock } = vi.hoisted(() => ({
+	logWarningMock: vi.fn(),
+}));
+
+vi.mock("src/logger/logManager", () => ({
+	log: {
+		logWarning: logWarningMock,
+		logError: vi.fn(),
+		logMessage: vi.fn(),
+	},
+}));
+
+// The modal's close promise is the error source under test: a plain Error
+// stands in for any unexpected failure, "cancelled" and MacroAbortError are
+// the two cancellation shapes that must rethrow without a warning.
+let modalOutcome: () => Promise<Record<string, string>>;
+
+vi.mock("./OnePageInputModal", () => ({
+	OnePageInputModal: class {
+		get waitForClose() {
+			return modalOutcome();
+		}
+	},
+}));
+
+vi.mock("src/quickAddSettingsTab", () => ({
+	QuickAddSettingsTab: class {},
+}));
+
+vi.mock("src/main", () => ({
+	__esModule: true,
+	default: class QuickAddMock {},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("src/utilityObsidian", async () => {
+	const { TFile: TFileCls } = await import("obsidian");
+	return {
+		getMarkdownFilesInFolder: vi.fn(() => []),
+		getMarkdownFilesWithTag: vi.fn(() => []),
+		getUserScript: vi.fn(),
+		isFolder: vi.fn(() => false),
+		getTemplateFile: vi.fn((app: App, path: string) => {
+			const f = app.vault.getAbstractFileByPath(path);
+			return f instanceof TFileCls ? f : null;
+		}),
+	};
+});
+
+const createApp = () =>
+	({
+		workspace: {
+			getActiveViewOfType: vi.fn().mockReturnValue(null),
+		},
+		vault: {
+			getAbstractFileByPath: vi.fn().mockReturnValue(null),
+		},
+	}) as unknown as App;
+
+// A capture choice with one unresolved {{VALUE}} so the modal always opens.
+const createChoice = (): ICaptureChoice => ({
+	id: "fallback-choice-id",
+	name: "Fallback Choice",
+	type: "Capture",
+	command: false,
+	captureTo: "Inbox.md",
+	captureToActiveFile: true,
+	createFileIfItDoesntExist: {
+		enabled: false,
+		createWithTemplate: false,
+		template: "",
+	},
+	format: { enabled: true, format: "{{VALUE}}" },
+	prepend: false,
+	appendLink: false,
+	task: false,
+	insertAfter: {
+		enabled: false,
+		after: "",
+		insertAtEnd: false,
+		considerSubsections: false,
+		createIfNotFound: false,
+		createIfNotFoundLocation: "",
+	},
+	newLineCapture: {
+		enabled: false,
+		direction: "below",
+	},
+	openFile: false,
+	fileOpening: {
+		location: "tab",
+		direction: "vertical",
+		mode: "default",
+		focus: true,
+	},
+});
+
+const createExecutor = (): IChoiceExecutor => ({
+	execute: vi.fn(),
+	variables: new Map<string, unknown>(),
+});
+
+const createPlugin = () =>
+	({
+		settings: {
+			inputPrompt: "single-line",
+			globalVariables: {},
+			useSelectionAsCaptureValue: false,
+		},
+	}) as never;
+
+const run = (executor: IChoiceExecutor = createExecutor()) =>
+	runOnePagePreflight(createApp(), createPlugin(), executor, createChoice());
+
+describe("runOnePagePreflight fallback warning", () => {
+	beforeEach(() => {
+		logWarningMock.mockReset();
+	});
+
+	it("warns and returns false when the preflight fails unexpectedly", async () => {
+		modalOutcome = () => Promise.reject(new Error("collection exploded"));
+		await expect(run()).resolves.toBe(false);
+		expect(logWarningMock).toHaveBeenCalledTimes(1);
+		expect(logWarningMock.mock.calls[0][0]).toContain("Fallback Choice");
+		expect(logWarningMock.mock.calls[0][0]).toContain("collection exploded");
+	});
+
+	it("does not warn on a remote run, where session teardown rejects with a plain Error", async () => {
+		// The remote path never opens the modal; a lazy thunk avoids an
+		// unhandled rejection from a promise nothing awaits.
+		modalOutcome = () => Promise.reject(new Error("Interactive session ended"));
+		const executor = createExecutor();
+		executor.promptProvider = {} as never;
+		await expect(run(executor)).resolves.toBe(false);
+		expect(logWarningMock).not.toHaveBeenCalled();
+	});
+
+	it("rethrows the modal's 'cancelled' rejection without warning", async () => {
+		modalOutcome = () => Promise.reject("cancelled");
+		await expect(run()).rejects.toBe("cancelled");
+		expect(logWarningMock).not.toHaveBeenCalled();
+	});
+
+	it("rethrows a MacroAbortError without warning", async () => {
+		const abort = new MacroAbortError("Input cancelled by user");
+		modalOutcome = () => Promise.reject(abort);
+		await expect(run()).rejects.toBe(abort);
+		expect(logWarningMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -6,6 +6,7 @@ import type IChoice from "src/types/choices/IChoice";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { VALUE_SYNTAX } from "src/constants";
 import { MacroAbortError } from "src/errors/MacroAbortError";
+import { log } from "src/logger/logManager";
 import { OnePageInputModal } from "./OnePageInputModal";
 import {
 	canonicalizeOnePageFileValue,
@@ -235,7 +236,15 @@ export async function runOnePagePreflight(
 		if (error === "cancelled" || error instanceof MacroAbortError) {
 			throw error;
 		}
-		// For other errors, silently fail and continue
+		// Any other error degrades to the sequential runtime prompts. That
+		// fallback is safe, but it must not be silent: a regression here would
+		// otherwise disable the one-page form for a choice shape with no trace
+		// (and if the form was already submitted, the user gets re-asked).
+		log.logWarning(
+			`One-page input failed for choice "${choice.name}"; falling back to step-by-step prompts: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
 		return false;
 	}
 }

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -240,11 +240,16 @@ export async function runOnePagePreflight(
 		// fallback is safe, but it must not be silent: a regression here would
 		// otherwise disable the one-page form for a choice shape with no trace
 		// (and if the form was already submitted, the user gets re-asked).
-		log.logWarning(
-			`One-page input failed for choice "${choice.name}"; falling back to step-by-step prompts: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		// Remote runs are exempt: session teardown rejects the pending form with
+		// a plain Error, and "falling back to step-by-step prompts" would mislead
+		// there - the session error already surfaces to the remote client.
+		if (!choiceExecutor.promptProvider) {
+			log.logWarning(
+				`One-page input failed for choice "${choice.name}"; falling back to step-by-step prompts: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
 		return false;
 	}
 }

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -201,8 +201,8 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					control: { type: "toggle", key: "useSelectionAsCaptureValue" },
 				},
 				{
-					name: "One-page input for choices (Beta)",
-					desc: "Experimental. Resolve variables up front and show a single dynamic form before executing Template/Capture choices. See Advanced → One-page Inputs in docs.",
+					name: "One-page input for choices",
+					desc: "Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs. Template and Capture choices can override this individually. See One-page Inputs in the docs.",
 					control: { type: "toggle", key: "onePageInputEnabled" },
 				},
 				{

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -187,7 +187,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			items: [
 				{
 					name: "Use Multi-line Input Prompt",
-					desc: "Use multi-line input prompt instead of single-line input prompt",
+					desc: "Use multi-line input prompt instead of single-line input prompt. Submit multi-line prompts with Ctrl/Cmd+Enter; Enter inserts a newline.",
 					control: { type: "toggle", key: "inputPrompt" },
 				},
 				{


### PR DESCRIPTION
One-page inputs leaves Beta, and prompt control gets one canonical docs page.

## Why

Years of discussions ask the same family of questions: how do I control prompt order (#268, #331), collect everything in one form (#268, #474), label identical prompts (#492), make a prompt optional (#587), size one prompt differently (#606), pick dates or tags comfortably (#690, #718), and - the sharpest symptom - what key even submits the multiline prompt (#767, documented nowhere). The features answering all of these shipped long ago, but they were scattered across five docs pages and the flagship one still carried a Beta label.

## Graduation call (evidence)

One-page inputs shipped 2025-08-08 (#888) and has been Beta for ~11 months. The audit behind this PR found:

- Zero open issues referencing one-page inputs; all five user-reported bugs in its history (#916, #1026, #1178, #1180, #1184) closed with shipped fixes. Recent preflight churn (June-July 2026) was internal-audit hardening, not user pain.
- 142 green tests in `src/preflight` (plus preload/requestInputs suites), zero skipped, zero TODO/FIXME in the module.
- The fallback is safe by construction: anything the form does not answer degrades to the standard sequential prompts.
- The gate itself (`choiceExecutor.runOnePagePreflightIfEnabled`) had **no** tests, and non-cancel preflight errors were swallowed silently - both fixed here rather than graduated around.

Remaining gaps (no tag/file autocomplete in one-page text fields, `FIELD |multi` and heading pickers running after the form) are documented limitations, not instability, and are now stated honestly in the docs.

## What changed

- `test(executor)`: 11 tests locking the override precedence (`always` beats a disabled global, `never` beats an enabled global and a remote provider, remote runs force preflight, Multi excluded, cancellation maps to `UserCancelError`, and execute() wires the gate before any engine).
- `fix(preflight)`: non-cancellation preflight errors now log a warning instead of silently degrading users to sequential prompts. Scoped to in-app runs (remote session teardown rejects pending forms with a plain Error, where the warning would mislead); both paths tested.
- `fix(settings)`: Beta label removed; toggle copy rewritten to say what it does and scope it accurately (Macros collect script-declared inputs only; the per-choice override lives on Template and Capture). Also corrects a wrong docs claim: cancelling the one-page modal aborts the run - it does not fall back to step-by-step prompts (the old text contradicted both the code and the page's own Notes section).
- `docs`: new **Controlling Prompts** page (both `docs/docs` and `versioned_docs/version-2.17.2`, additive one-entry sidebar registrations) covering prompt order incl. token-kind grouping, `|label`, `|optional`, `|type:multiline` and friends, a full submit-key table, autocomplete triggers, and the one-page form. The multiline submit key is also documented at its highest-traffic landing spots (Format Syntax's multiline section, the Settings bullet, and the in-app setting description), and Suggester System now states where its triggers do and do not work.

## Verification

- Every behavior claim on the new page was verified live in this worktree's isolated Obsidian vault (e2e CLI): prompt order (file name before content; VDATE before named VALUE within a string), Ctrl/Cmd+Enter submit on the multiline prompt and the one-page form, Ctrl/Cmd+Shift+Enter skip, `#`/`[[` suggesters in sequential prompts and their absence in one-page fields, override `always`/`never` precedence in both directions, and cancel-aborts-the-run. `dev:errors` clean throughout.
- A 5-reviewer adversarial pass (claims vs src/, docs quality, code, and two attack lenses) with per-finding verification produced 12 confirmed findings; all are fixed in the two follow-up commits (notably: the `|name:` ordering note was wrong in the common case, the one-page file name preview is Template-only, and the fallback warning needed remote scoping).
- `pnpm build` (tsc + esbuild), full vitest suite (3648 passed / 37 skipped, +9 new tests after review fixes), `pnpm lint`, and `cd docs && pnpm build` (broken links = build failure) all green.

Refs #268, #331, #474, #492, #587, #606, #690, #718, #767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated One-page Inputs and Settings wording to remove “Beta,” clarify supported choice types, per-choice override behavior, and revised cancel semantics.
  * Added a new “Controlling Prompts” help page explaining prompt generation, ordering, optional inputs, shortcuts, autocomplete triggers, and one-page input flow.
  * Refreshed format-syntax shortcut help and optional/file support documentation; updated sidebar navigation.

* **Bug Fixes**
  * Improved one-page input fallback behavior when the modal can’t open, including clearer warnings and step-by-step fallback rules.

* **Tests**
  * Added/updated one-page preflight and fallback behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->