### PR TITLE
docs: add "Coming from Templater" migration page

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -546,7 +546,7 @@ If the capture format is long, put the full format in a template file and use a 
 {{TEMPLATE:Templates/Capture Format.md}}
 ```
 
-QuickAdd replaces the token with the template file contents, then processes the result through the normal capture formatter. The referenced file can contain the same format syntax you would otherwise type inline, such as `{{VALUE}}`, `{{DATE}}`, `{{MACRO:...}}`, inline scripts, and additional `{{TEMPLATE:...}}` includes. Include the file extension in the token; template includes support `.md`, `.canvas`, and `.base` files.
+QuickAdd replaces the token with the template file contents, then processes the result through the normal capture formatter. The referenced file can contain the same format syntax you would otherwise type inline, such as `{{VALUE}}`, `{{DATE}}`, `{{MACRO:...}}`, inline scripts, and additional `{{TEMPLATE:...}}` includes. Include the file extension in the token; template includes support `.md`, `.canvas`, and `.base` files. Note that a capture inserts the included content as-is: if the referenced template starts with its own `---` frontmatter block and the target note already has one, the capture adds a literal second block rather than merging properties - use [Apply Template to Note](../ApplyTemplateToNote.md) when frontmatter should merge.
 
 One-page input preflight and `quickadd:check` scan the referenced template files too, so prompts inside a file-backed capture format appear up front like inline capture format prompts.
 

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -2,7 +2,7 @@
 title: Template
 ---
 
-The template choice type is not meant to be a replacement for [Templater](https://github.com/SilentVoid13/Templater/) plugin or core `Templates`. It's meant to augment them, to add more possibilities. You can use both QuickAdd format syntax in a Templater template - and both will work.
+The Template choice type creates notes from template files using QuickAdd's own [format syntax](../FormatSyntax.md) - prompts, dates, and variables included, with no other plugin required. If your templates come from the Templater plugin, see [Coming from Templater](../ComingFromTemplater.md) for the QuickAdd-native way to do each familiar job.
 
 :::tip Run a template without making a choice
 If you just want to spin up a note from a template in your [template folder](../Settings.md#templates--properties) without maintaining a Template choice per file, use the **New note from template** command. It lists the templates in your configured folder, prompts for the new note's name, and creates it in Obsidian's default location. When a template folder is configured, the same entry also appears in **Run QuickAdd** — at the bottom by default, or move it to the top / hide it under [Settings → Choice Picker](../Settings.md#choice-picker) — and it's scriptable via [`quickadd:run-template`](../Advanced/CLI.md#quickaddrun-template). Make a Template choice (below) when you need a fixed location, file-name format, linking, or a hotkey.

--- a/docs/docs/ComingFromTemplater.md
+++ b/docs/docs/ComingFromTemplater.md
@@ -33,11 +33,11 @@ The left column names the job; the middle names the Templater expression you may
 | Prompt for text | `tp.system.prompt` | [`{{VALUE:name}}`](./FormatSyntax.md#named-value) |
 | Pick from a list | `tp.system.suggester` | [`{{VALUE:Option A,Option B}}`](./FormatSyntax.md#named-value), [`{{FIELD:...}}`](./FormatSyntax.md#field), [`{{FILE:...}}`](./FormatSyntax.md#file) |
 | Include one template in another | `tp.file.include` | [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template) |
-| Apply a template to an existing note | manual workarounds | [Apply template to active note](./ApplyTemplateToNote.md) |
+| Apply a template to an existing note | the insert template command | [Apply template to active note](./ApplyTemplateToNote.md) |
 | Insert the clipboard | `tp.system.clipboard` | [`{{CLIPBOARD}}`](./FormatSyntax.md#clipboard) |
 | Insert the selected text | `tp.selection` | [`{{selected}}`](./FormatSyntax.md#selected) |
 | Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active); to re-render a value you prompted for, just [repeat `{{VALUE:name}}`](#prompt-once-reuse-everywhere) |
-| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent) (wiki-link), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent) (raw name, for embeds like `![[{{FILENAMECURRENT}}#Heading]]`), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) (link to the heading you're in) |
+| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent) (a link), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent) (raw name, for embeds like `![[{{FILENAMECURRENT}}#Heading]]`), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) (link to the heading you're in) |
 | Run JavaScript | `tp.user` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
 | Folder templates | folder templates | No automatic equivalent - see [Templates chosen by folder](#templates-chosen-by-folder) |
 | Cursor marker in a template | `tp.file.cursor` | No direct equivalent - see [Where the cursor lands](#where-the-cursor-lands) |
@@ -82,7 +82,7 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Insert after**: `## Log`, with **Create line if not found**
 - **Capture format**: `- {{VALUE}}`
 
-Running it and typing `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
 
 ## Templates chosen by folder
 
@@ -104,7 +104,7 @@ Due: {{VDATE:due,YYYY-MM-DD}}
 Week: {{VDATE:due,gggg-[W]WW}}
 ```
 
-Typing `tomorrow` fills both lines from one prompt: `Due: 2026-07-07` and `Week: 2026-W28`.
+Typing `tomorrow` fills both lines from one prompt - on 2026-07-06 that gives `Due: 2026-07-07` and `Week: 2026-W28`.
 
 There is no token for a file's creation or modification date - reach for a [script](#run-scripts) if you need those.
 
@@ -125,9 +125,9 @@ To gather every prompt on a single form up front instead of one dialog at a time
 
 QuickAdd has no in-template cursor marker of its own - you can't mark an arbitrary spot in a template and land there. What you can control:
 
-- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor immediately after the inserted text.
+- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets (opened focused, in an editing mode), QuickAdd places the cursor immediately after the inserted text.
 - **Apply template to active note** offers an **Insert at cursor** mode, so content lands where you already are.
-- **After creating a note**, a Template choice with **Open** leaves the cursor at the top of the note body. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
+- **After creating a note**, a Template choice with **Open** doesn't move the cursor - you typically land at the top of the note. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
 
 ## Run scripts
 

--- a/docs/docs/ComingFromTemplater.md
+++ b/docs/docs/ComingFromTemplater.md
@@ -82,7 +82,7 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Insert after**: `## Log`, with **Create line if not found**
 - **Capture format**: `- {{VALUE}}`
 
-Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. For a step-by-step walkthrough with variations, see [Capture: Add entries to your daily note](./Examples/Capture_ToDailyNote.md); [Capture choices](./Choices/CaptureChoice.md) covers every target and position option.
+Say today is 2026-07-06: running it and typing `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, with or without an existing note. For a step-by-step walkthrough with variations, see [Capture: Add entries to your daily note](./Examples/Capture_ToDailyNote.md); [Capture choices](./Choices/CaptureChoice.md) covers every target and position option.
 
 ## Templates chosen by folder
 
@@ -104,7 +104,7 @@ Due: {{VDATE:due,YYYY-MM-DD}}
 Week: {{VDATE:due,gggg-[W]WW}}
 ```
 
-Typing `tomorrow` fills both lines from one prompt - on 2026-07-06 that gives `Due: 2026-07-07` and `Week: 2026-W28`.
+Typing `tomorrow` fills both lines from one prompt - with 2026-07-06 as today, that's `Due: 2026-07-07` and `Week: 2026-W28`.
 
 There is no token for a file's creation or modification date - reach for a [script](#run-scripts) if you need those.
 

--- a/docs/docs/ComingFromTemplater.md
+++ b/docs/docs/ComingFromTemplater.md
@@ -119,7 +119,7 @@ That sharing spans [Macro choice](./Choices/MacroChoice.md) steps too. A classic
 
 You type the task name once. Scripts join the same pool: anything a script assigns to `params.variables.task` is what `{{VALUE:task}}` resolves to in later steps - see the [scripting guide](./Advanced/ScriptingGuide.md).
 
-To gather every prompt on a single form up front instead of one dialog at a time, enable [one-page input](./Advanced/onePageInputs.md).
+To gather every prompt on a single form up front instead of one dialog at a time, enable [one-page input](./Advanced/onePageInputs.md) - and see [Controlling Prompts](./ControllingPrompts.md) for everything about prompt order, labels, defaults, and skipping.
 
 ## Where the cursor lands
 

--- a/docs/docs/ComingFromTemplater.md
+++ b/docs/docs/ComingFromTemplater.md
@@ -1,0 +1,146 @@
+---
+title: Coming from Templater
+description: Migrate Templater workflows to QuickAdd - templates, prompts, dates, daily notes, folder workflows, cursor placement, and scripts, done the QuickAdd-native way.
+keywords:
+  - templater
+  - migration
+  - template
+---
+
+If you built your note workflows around the Templater plugin, this page maps each familiar job to the QuickAdd-native way to do it. Every pattern below runs on QuickAdd alone: one engine owns your prompts, dates, and file creation, which is what keeps you clear of double prompts and half-rendered template syntax (see [common migration snags](#common-migration-snags)).
+
+New to QuickAdd entirely? Start with [Getting Started](./index.md) for the choice types, then come back here for the mappings.
+
+## Point QuickAdd at your template folder
+
+You don't need to move or rewrite your template files to start. Add your existing template folder(s) under **Template folder paths** in [Settings → Templates & Properties](./Settings.md#templates--properties). That single step powers:
+
+- the **QuickAdd: New note from template** command, which lists every template in those folders and prompts for the new note's name - no per-template setup;
+- the **QuickAdd: Apply template to active note** command, whose picker offers those template files too;
+- template-path autocomplete when you configure choices.
+
+Make a [Template choice](./Choices/TemplateChoice.md) for the templates that deserve their own hotkey, a fixed destination folder, or a file name format.
+
+## The quick map
+
+The left column names the job; the middle names the Templater expression you may know it by (as a landmark only - the QuickAdd patterns don't use or require it).
+
+| The job | You may know it as | The QuickAdd way |
+| --- | --- | --- |
+| Insert the note's title | `tp.file.title` | [`{{TITLE}}`](./FormatSyntax.md#title) |
+| Today's date, any format | `tp.date.now` | [`{{DATE:YYYY-MM-DD}}`](./FormatSyntax.md#date-format), offsets like `{{DATE+7}}` |
+| Ask for a date in plain language | `tp.system.prompt` + a date parser | [`{{VDATE:due,YYYY-MM-DD}}`](./FormatSyntax.md#vdate) - natural language built in |
+| Prompt for text | `tp.system.prompt` | [`{{VALUE:name}}`](./FormatSyntax.md#named-value) |
+| Pick from a list | `tp.system.suggester` | [`{{VALUE:Option A,Option B}}`](./FormatSyntax.md#named-value), [`{{FIELD:...}}`](./FormatSyntax.md#field), [`{{FILE:...}}`](./FormatSyntax.md#file) |
+| Include one template in another | `tp.file.include` | [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template) |
+| Apply a template to an existing note | manual workarounds | [Apply template to active note](./ApplyTemplateToNote.md) |
+| Insert the clipboard | `tp.system.clipboard` | [`{{CLIPBOARD}}`](./FormatSyntax.md#clipboard) |
+| Insert the selected text | `tp.selection` | [`{{selected}}`](./FormatSyntax.md#selected) |
+| Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active) |
+| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) |
+| Run JavaScript | `tp.user` scripts, `<%* ... %>` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
+| Folder templates | folder templates | No automatic equivalent - see [Templates chosen by folder](#templates-chosen-by-folder) |
+| Cursor marker in a template | `tp.file.cursor` | No direct equivalent - see [Where the cursor lands](#where-the-cursor-lands) |
+
+## Create new notes from templates
+
+A [Template choice](./Choices/TemplateChoice.md) creates a note from a template file, with a configurable destination folder, file name format, link insertion, and open behavior. QuickAdd resolves every token - prompts included - before the note is created, so the finished note is plain text from its first moment.
+
+To position user input at an exact spot in the new note, put the token exactly where the text belongs. One named value can drive both the file name and the body:
+
+File name format: `{{VALUE:topic}}`
+
+```markdown
+---
+type: meeting
+---
+# {{TITLE}}
+
+Topic: {{VALUE:topic}}
+Date: {{DATE:YYYY-MM-DD}}
+```
+
+You are asked for `topic` once; the answer becomes the file name and fills the body, and `{{TITLE}}` renders the final file name.
+
+## Add to existing notes
+
+### Shared template content in new and existing notes
+
+Keep one template file and use it both ways - no parallel template sets:
+
+- **New notes**: point a Template choice at it, or include it inside a bigger template with [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template).
+- **Existing notes**: run **QuickAdd: Apply template to active note** (also in a file's right-click menu). You pick the template and where it goes - cursor, top, bottom, or replace - and the template's frontmatter is merged into the note's existing frontmatter, with the note's own values winning. See [Apply Template to Note](./ApplyTemplateToNote.md).
+
+A [Capture choice](./Choices/CaptureChoice.md) whose format is `{{TEMPLATE:Templates/Partial.md}}` also inserts that shared content into a target note. Prefer it for body-only snippets: a capture inserts the template text as-is, so a template that starts with its own `---` frontmatter block ends up as a literal second block instead of being merged. When the shared content carries frontmatter, use **Apply template to active note**.
+
+### Today's daily note
+
+Appending to today's note is a Capture choice with a date-formatted target path - the file doesn't have to exist beforehand:
+
+- **Capture to**: `Daily/{{DATE}}.md`
+- **Create file if it doesn't exist**, with your daily template
+- **Insert after**: `## Log`, with **Create line if not found**
+
+Running it with input `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+
+## Templates chosen by folder
+
+QuickAdd does not watch folders: nothing runs automatically when a note appears in a folder, no matter how it was created. What it offers instead is explicit and per-choice:
+
+- **One Template choice per destination.** Set **New note location** to **In a specific folder** and name the choice after the destination ("New person", "New project"). Each gets its own command and can get its own hotkey.
+- **One choice, several folders.** List multiple folders on the choice (optionally **Include subfolders**) and QuickAdd asks which one at run time.
+- **Dynamic paths.** Both the template path and the folder path accept [format syntax](./FormatSyntax.md): a template path of `Templates/{{VALUE:Person,Project,Meeting}} Template.md` picks the template from one prompt, and a folder path of `Projects/{{VALUE:client}}` files the note by answer.
+- **No setup at all**: the **New note from template** command picks any template from your template folder and creates the note in Obsidian's default location.
+
+## Dates without another plugin
+
+`{{DATE}}` renders today (`YYYY-MM-DD` by default), `{{DATE:<format>}}` takes any [Moment format](https://momentjs.com/docs/#/displaying/format/), and offsets travel in days: `{{DATE+7}}`, `{{DATE:gggg-[W]WW+7}}`. Snap to period boundaries with [`|startof:` / `|endof:`](./FormatSyntax.md#date-snap), for example `{{DATE:YYYY-MM|startof:week}}` for weekly notes that file under the month the week belongs to.
+
+For dates you enter, [`{{VDATE:name,format}}`](./FormatSyntax.md#vdate) understands natural language out of the box - no companion plugin. Type `tomorrow`, `next friday`, or `in two weeks`. Enter the date once, render it many times:
+
+```markdown
+Due: {{VDATE:due,YYYY-MM-DD}}
+Week: {{VDATE:due,gggg-[W]WW}}
+```
+
+Typing `tomorrow` fills both lines from one prompt: `Due: 2026-07-07` and `Week: 2026-W28`.
+
+There is no token for a file's creation or modification date - reach for a [script](#run-scripts) if you need those.
+
+## Prompt once, reuse everywhere
+
+Named values are shared across an entire run. `{{VALUE:topic}}` in the file name, the template body, and any other step of the same run all resolve from a single prompt - the mechanism behind the [Template choice example above](#create-new-notes-from-templates).
+
+That sharing spans [Macro choice](./Choices/MacroChoice.md) steps too. A classic two-step flow - log a task in today's daily note and create its note - is a macro of two choices sharing one name:
+
+1. A Capture choice into `Daily/{{DATE}}.md` with the format `- [ ] [[{{VALUE:task}}]]`
+2. A Template choice with file name format `{{VALUE:task}}` creating the note in your `Tasks` folder
+
+You type the task name once. Scripts join the same pool: anything a script assigns to `params.variables.task` is what `{{VALUE:task}}` resolves to in later steps - see the [scripting guide](./Advanced/ScriptingGuide.md).
+
+To gather every prompt on a single form up front instead of one dialog at a time, enable [one-page input](./Advanced/onePageInputs.md).
+
+## Where the cursor lands
+
+QuickAdd has no in-template cursor marker - you can't mark an arbitrary spot in a template and land there. What you can control:
+
+- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor at the end of what it captured.
+- **Apply template to active note** offers an **Insert at cursor** mode, so content lands where you already are.
+- **After creating a note**, a Template choice with **Open** leaves the cursor at the top of the note body. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
+
+## Run scripts
+
+QuickAdd runs JavaScript in two shapes:
+
+- **[Inline scripts](./InlineScripts.md)**: a fenced code block tagged `js quickadd` inside a template body or capture format. The block runs when the choice does, and a returned string is spliced into the output in its place.
+- **[User scripts](./Choices/MacroChoice.md)**: a `.js` file in your vault, run as a step of a Macro choice. Scripts receive `app`, the [QuickAdd API](./QuickAddAPI.md) (`inputPrompt`, `suggester`, `executeChoice`, and more), the shared `variables` map, and the `obsidian` module - see the [scripting guide](./Advanced/ScriptingGuide.md).
+
+`{{MACRO:My macro}}` embeds a macro's return value anywhere format syntax is accepted, so a computed value can flow straight into a file name, template body, or capture line.
+
+## Common migration snags
+
+These are the classic symptoms of splitting one template between two engines - each has a QuickAdd-native fix:
+
+- **You get prompted twice.** QuickAdd resolves all of its prompts before the file is created. If another engine prompts in the same template, you answer twice - once per engine. Let QuickAdd own the prompt with `{{VALUE:name}}` and reuse the answer everywhere it's needed.
+- **Template syntax shows up unrendered.** QuickAdd renders QuickAdd tokens; another engine's syntax is only rendered by that engine. If it isn't installed or doesn't run on the file, its markup stays behind as literal text. Port the line to the matching token from [the map](#the-quick-map).
+- **Capturing into a note throws template errors.** A note that keeps live template syntax can re-execute or error whenever a plugin processes the file again. QuickAdd tokens like `{{DATE:YYYY-MM-DD}}` render once, at creation, into plain text - later captures find nothing to re-run. Migrate the offending line in the template that created the note.

--- a/docs/docs/ComingFromTemplater.md
+++ b/docs/docs/ComingFromTemplater.md
@@ -82,7 +82,7 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Insert after**: `## Log`, with **Create line if not found**
 - **Capture format**: `- {{VALUE}}`
 
-Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. For a step-by-step walkthrough with variations, see [Capture: Add entries to your daily note](./Examples/Capture_ToDailyNote.md); [Capture choices](./Choices/CaptureChoice.md) covers every target and position option.
 
 ## Templates chosen by folder
 

--- a/docs/docs/ComingFromTemplater.md
+++ b/docs/docs/ComingFromTemplater.md
@@ -29,16 +29,16 @@ The left column names the job; the middle names the Templater expression you may
 | --- | --- | --- |
 | Insert the note's title | `tp.file.title` | [`{{TITLE}}`](./FormatSyntax.md#title) |
 | Today's date, any format | `tp.date.now` | [`{{DATE:YYYY-MM-DD}}`](./FormatSyntax.md#date-format), offsets like `{{DATE+7}}` |
-| Ask for a date in plain language | `tp.system.prompt` + a date parser | [`{{VDATE:due,YYYY-MM-DD}}`](./FormatSyntax.md#vdate) - natural language built in |
+| Ask for a date in plain language | `tp.system.prompt` | [`{{VDATE:due,YYYY-MM-DD}}`](./FormatSyntax.md#vdate) - natural language built in |
 | Prompt for text | `tp.system.prompt` | [`{{VALUE:name}}`](./FormatSyntax.md#named-value) |
 | Pick from a list | `tp.system.suggester` | [`{{VALUE:Option A,Option B}}`](./FormatSyntax.md#named-value), [`{{FIELD:...}}`](./FormatSyntax.md#field), [`{{FILE:...}}`](./FormatSyntax.md#file) |
 | Include one template in another | `tp.file.include` | [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template) |
 | Apply a template to an existing note | manual workarounds | [Apply template to active note](./ApplyTemplateToNote.md) |
 | Insert the clipboard | `tp.system.clipboard` | [`{{CLIPBOARD}}`](./FormatSyntax.md#clipboard) |
 | Insert the selected text | `tp.selection` | [`{{selected}}`](./FormatSyntax.md#selected) |
-| Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active) |
-| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) |
-| Run JavaScript | `tp.user` scripts, `<%* ... %>` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
+| Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active); to re-render a value you prompted for, just [repeat `{{VALUE:name}}`](#prompt-once-reuse-everywhere) |
+| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent) (wiki-link), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent) (raw name, for embeds like `![[{{FILENAMECURRENT}}#Heading]]`), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) (link to the heading you're in) |
+| Run JavaScript | `tp.user` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
 | Folder templates | folder templates | No automatic equivalent - see [Templates chosen by folder](#templates-chosen-by-folder) |
 | Cursor marker in a template | `tp.file.cursor` | No direct equivalent - see [Where the cursor lands](#where-the-cursor-lands) |
 
@@ -69,7 +69,7 @@ You are asked for `topic` once; the answer becomes the file name and fills the b
 Keep one template file and use it both ways - no parallel template sets:
 
 - **New notes**: point a Template choice at it, or include it inside a bigger template with [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template).
-- **Existing notes**: run **QuickAdd: Apply template to active note** (also in a file's right-click menu). You pick the template and where it goes - cursor, top, bottom, or replace - and the template's frontmatter is merged into the note's existing frontmatter, with the note's own values winning. See [Apply Template to Note](./ApplyTemplateToNote.md).
+- **Existing notes**: run **QuickAdd: Apply template to active note** (also in a file's right-click menu). You pick the template and where it goes - cursor, top, bottom, or replace. For the insert modes, the template's frontmatter is merged into the note's existing frontmatter, with the note's own values winning (replace overwrites the whole note, frontmatter included). See [Apply Template to Note](./ApplyTemplateToNote.md).
 
 A [Capture choice](./Choices/CaptureChoice.md) whose format is `{{TEMPLATE:Templates/Partial.md}}` also inserts that shared content into a target note. Prefer it for body-only snippets: a capture inserts the template text as-is, so a template that starts with its own `---` frontmatter block ends up as a literal second block instead of being merged. When the shared content carries frontmatter, use **Apply template to active note**.
 
@@ -80,8 +80,9 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Capture to**: `Daily/{{DATE}}.md`
 - **Create file if it doesn't exist**, with your daily template
 - **Insert after**: `## Log`, with **Create line if not found**
+- **Capture format**: `- {{VALUE}}`
 
-Running it with input `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+Running it and typing `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
 
 ## Templates chosen by folder
 
@@ -89,7 +90,7 @@ QuickAdd does not watch folders: nothing runs automatically when a note appears 
 
 - **One Template choice per destination.** Set **New note location** to **In a specific folder** and name the choice after the destination ("New person", "New project"). Each gets its own command and can get its own hotkey.
 - **One choice, several folders.** List multiple folders on the choice (optionally **Include subfolders**) and QuickAdd asks which one at run time.
-- **Dynamic paths.** Both the template path and the folder path accept [format syntax](./FormatSyntax.md): a template path of `Templates/{{VALUE:Person,Project,Meeting}} Template.md` picks the template from one prompt, and a folder path of `Projects/{{VALUE:client}}` files the note by answer.
+- **Dynamic paths.** Both the template path and the folder path accept [format syntax](./FormatSyntax.md), and one named value can drive both. A choice with template path `Templates/{{VALUE:kind}}.md` and folder path `{{VALUE:kind}}s` asks for `kind` once - answering `Person` creates the note from `Templates/Person.md` in the `Persons` folder, keeping the whole folder-to-template mapping in a single choice.
 - **No setup at all**: the **New note from template** command picks any template from your template folder and creates the note in Obsidian's default location.
 
 ## Dates without another plugin
@@ -122,9 +123,9 @@ To gather every prompt on a single form up front instead of one dialog at a time
 
 ## Where the cursor lands
 
-QuickAdd has no in-template cursor marker - you can't mark an arbitrary spot in a template and land there. What you can control:
+QuickAdd has no in-template cursor marker of its own - you can't mark an arbitrary spot in a template and land there. What you can control:
 
-- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor at the end of what it captured.
+- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor immediately after the inserted text.
 - **Apply template to active note** offers an **Insert at cursor** mode, so content lands where you already are.
 - **After creating a note**, a Template choice with **Open** leaves the cursor at the top of the note body. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
 
@@ -143,4 +144,4 @@ These are the classic symptoms of splitting one template between two engines - e
 
 - **You get prompted twice.** QuickAdd resolves all of its prompts before the file is created. If another engine prompts in the same template, you answer twice - once per engine. Let QuickAdd own the prompt with `{{VALUE:name}}` and reuse the answer everywhere it's needed.
 - **Template syntax shows up unrendered.** QuickAdd renders QuickAdd tokens; another engine's syntax is only rendered by that engine. If it isn't installed or doesn't run on the file, its markup stays behind as literal text. Port the line to the matching token from [the map](#the-quick-map).
-- **Capturing into a note throws template errors.** A note that keeps live template syntax can re-execute or error whenever a plugin processes the file again. QuickAdd tokens like `{{DATE:YYYY-MM-DD}}` render once, at creation, into plain text - later captures find nothing to re-run. Migrate the offending line in the template that created the note.
+- **Capturing into a note throws template errors.** A note that keeps live template syntax can re-execute or error whenever a plugin processes the file again. QuickAdd tokens like `{{DATE:YYYY-MM-DD}}` render once, at creation, into plain text - later captures find nothing to re-run. Migrate the offending line to a QuickAdd token and let QuickAdd create the note so the token renders - a Capture with **Create file if it doesn't exist** plus that template does both (see [Today's daily note](#todays-daily-note)).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -34,6 +34,7 @@ const sidebars = {
 			id: "index",
 			label: "Getting Started",
 		},
+		{ type: "doc", id: "ComingFromTemplater", label: "Coming from Templater" },
 		{
 			type: "doc",
 			id: "Settings",

--- a/docs/versioned_docs/version-2.17.2/Choices/CaptureChoice.md
+++ b/docs/versioned_docs/version-2.17.2/Choices/CaptureChoice.md
@@ -544,7 +544,7 @@ If the capture format is long, put the full format in a template file and use a 
 {{TEMPLATE:Templates/Capture Format.md}}
 ```
 
-QuickAdd replaces the token with the template file contents, then processes the result through the normal capture formatter. The referenced file can contain the same format syntax you would otherwise type inline, such as `{{VALUE}}`, `{{DATE}}`, `{{MACRO:...}}`, inline scripts, and additional `{{TEMPLATE:...}}` includes. Include the file extension in the token; template includes support `.md`, `.canvas`, and `.base` files.
+QuickAdd replaces the token with the template file contents, then processes the result through the normal capture formatter. The referenced file can contain the same format syntax you would otherwise type inline, such as `{{VALUE}}`, `{{DATE}}`, `{{MACRO:...}}`, inline scripts, and additional `{{TEMPLATE:...}}` includes. Include the file extension in the token; template includes support `.md`, `.canvas`, and `.base` files. Note that a capture inserts the included content as-is: if the referenced template starts with its own `---` frontmatter block and the target note already has one, the capture adds a literal second block rather than merging properties - use [Apply Template to Note](../ApplyTemplateToNote.md) when frontmatter should merge.
 
 One-page input preflight and `quickadd:check` scan the referenced template files too, so prompts inside a file-backed capture format appear up front like inline capture format prompts.
 

--- a/docs/versioned_docs/version-2.17.2/Choices/TemplateChoice.md
+++ b/docs/versioned_docs/version-2.17.2/Choices/TemplateChoice.md
@@ -2,7 +2,7 @@
 title: Template
 ---
 
-The template choice type is not meant to be a replacement for [Templater](https://github.com/SilentVoid13/Templater/) plugin or core `Templates`. It's meant to augment them, to add more possibilities. You can use both QuickAdd format syntax in a Templater template - and both will work.
+The Template choice type creates notes from template files using QuickAdd's own [format syntax](../FormatSyntax.md) - prompts, dates, and variables included, with no other plugin required. If your templates come from the Templater plugin, see [Coming from Templater](../ComingFromTemplater.md) for the QuickAdd-native way to do each familiar job.
 
 :::tip Run a template without making a choice
 If you just want to spin up a note from a template in your [template folder](../Settings.md#templates--properties) without maintaining a Template choice per file, use the **New note from template** command. It lists the templates in your configured folder, prompts for the new note's name, and creates it in Obsidian's default location. When a template folder is configured, the same entry also appears in **Run QuickAdd** — at the bottom by default, or move it to the top / hide it under [Settings → Choice Picker](../Settings.md#choice-picker) — and it's scriptable via [`quickadd:run-template`](../Advanced/CLI.md#quickaddrun-template). Make a Template choice (below) when you need a fixed location, file-name format, linking, or a hotkey.

--- a/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
+++ b/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
@@ -33,11 +33,11 @@ The left column names the job; the middle names the Templater expression you may
 | Prompt for text | `tp.system.prompt` | [`{{VALUE:name}}`](./FormatSyntax.md#named-value) |
 | Pick from a list | `tp.system.suggester` | [`{{VALUE:Option A,Option B}}`](./FormatSyntax.md#named-value), [`{{FIELD:...}}`](./FormatSyntax.md#field), [`{{FILE:...}}`](./FormatSyntax.md#file) |
 | Include one template in another | `tp.file.include` | [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template) |
-| Apply a template to an existing note | manual workarounds | [Apply template to active note](./ApplyTemplateToNote.md) |
+| Apply a template to an existing note | the insert template command | [Apply template to active note](./ApplyTemplateToNote.md) |
 | Insert the clipboard | `tp.system.clipboard` | [`{{CLIPBOARD}}`](./FormatSyntax.md#clipboard) |
 | Insert the selected text | `tp.selection` | [`{{selected}}`](./FormatSyntax.md#selected) |
 | Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active); to re-render a value you prompted for, just [repeat `{{VALUE:name}}`](#prompt-once-reuse-everywhere) |
-| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent) (wiki-link), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent) (raw name, for embeds like `![[{{FILENAMECURRENT}}#Heading]]`), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) (link to the heading you're in) |
+| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent) (a link), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent) (raw name, for embeds like `![[{{FILENAMECURRENT}}#Heading]]`), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) (link to the heading you're in) |
 | Run JavaScript | `tp.user` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
 | Folder templates | folder templates | No automatic equivalent - see [Templates chosen by folder](#templates-chosen-by-folder) |
 | Cursor marker in a template | `tp.file.cursor` | No direct equivalent - see [Where the cursor lands](#where-the-cursor-lands) |
@@ -82,7 +82,7 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Insert after**: `## Log`, with **Create line if not found**
 - **Capture format**: `- {{VALUE}}`
 
-Running it and typing `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
 
 ## Templates chosen by folder
 
@@ -104,7 +104,7 @@ Due: {{VDATE:due,YYYY-MM-DD}}
 Week: {{VDATE:due,gggg-[W]WW}}
 ```
 
-Typing `tomorrow` fills both lines from one prompt: `Due: 2026-07-07` and `Week: 2026-W28`.
+Typing `tomorrow` fills both lines from one prompt - on 2026-07-06 that gives `Due: 2026-07-07` and `Week: 2026-W28`.
 
 There is no token for a file's creation or modification date - reach for a [script](#run-scripts) if you need those.
 
@@ -125,9 +125,9 @@ To gather every prompt on a single form up front instead of one dialog at a time
 
 QuickAdd has no in-template cursor marker of its own - you can't mark an arbitrary spot in a template and land there. What you can control:
 
-- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor immediately after the inserted text.
+- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets (opened focused, in an editing mode), QuickAdd places the cursor immediately after the inserted text.
 - **Apply template to active note** offers an **Insert at cursor** mode, so content lands where you already are.
-- **After creating a note**, a Template choice with **Open** leaves the cursor at the top of the note body. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
+- **After creating a note**, a Template choice with **Open** doesn't move the cursor - you typically land at the top of the note. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
 
 ## Run scripts
 

--- a/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
+++ b/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
@@ -82,7 +82,7 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Insert after**: `## Log`, with **Create line if not found**
 - **Capture format**: `- {{VALUE}}`
 
-Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. For a step-by-step walkthrough with variations, see [Capture: Add entries to your daily note](./Examples/Capture_ToDailyNote.md); [Capture choices](./Choices/CaptureChoice.md) covers every target and position option.
+Say today is 2026-07-06: running it and typing `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, with or without an existing note. For a step-by-step walkthrough with variations, see [Capture: Add entries to your daily note](./Examples/Capture_ToDailyNote.md); [Capture choices](./Choices/CaptureChoice.md) covers every target and position option.
 
 ## Templates chosen by folder
 
@@ -104,7 +104,7 @@ Due: {{VDATE:due,YYYY-MM-DD}}
 Week: {{VDATE:due,gggg-[W]WW}}
 ```
 
-Typing `tomorrow` fills both lines from one prompt - on 2026-07-06 that gives `Due: 2026-07-07` and `Week: 2026-W28`.
+Typing `tomorrow` fills both lines from one prompt - with 2026-07-06 as today, that's `Due: 2026-07-07` and `Week: 2026-W28`.
 
 There is no token for a file's creation or modification date - reach for a [script](#run-scripts) if you need those.
 

--- a/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
+++ b/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
@@ -119,7 +119,7 @@ That sharing spans [Macro choice](./Choices/MacroChoice.md) steps too. A classic
 
 You type the task name once. Scripts join the same pool: anything a script assigns to `params.variables.task` is what `{{VALUE:task}}` resolves to in later steps - see the [scripting guide](./Advanced/ScriptingGuide.md).
 
-To gather every prompt on a single form up front instead of one dialog at a time, enable [one-page input](./Advanced/onePageInputs.md).
+To gather every prompt on a single form up front instead of one dialog at a time, enable [one-page input](./Advanced/onePageInputs.md) - and see [Controlling Prompts](./ControllingPrompts.md) for everything about prompt order, labels, defaults, and skipping.
 
 ## Where the cursor lands
 

--- a/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
+++ b/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
@@ -1,0 +1,146 @@
+---
+title: Coming from Templater
+description: Migrate Templater workflows to QuickAdd - templates, prompts, dates, daily notes, folder workflows, cursor placement, and scripts, done the QuickAdd-native way.
+keywords:
+  - templater
+  - migration
+  - template
+---
+
+If you built your note workflows around the Templater plugin, this page maps each familiar job to the QuickAdd-native way to do it. Every pattern below runs on QuickAdd alone: one engine owns your prompts, dates, and file creation, which is what keeps you clear of double prompts and half-rendered template syntax (see [common migration snags](#common-migration-snags)).
+
+New to QuickAdd entirely? Start with [Getting Started](./index.md) for the choice types, then come back here for the mappings.
+
+## Point QuickAdd at your template folder
+
+You don't need to move or rewrite your template files to start. Add your existing template folder(s) under **Template folder paths** in [Settings → Templates & Properties](./Settings.md#templates--properties). That single step powers:
+
+- the **QuickAdd: New note from template** command, which lists every template in those folders and prompts for the new note's name - no per-template setup;
+- the **QuickAdd: Apply template to active note** command, whose picker offers those template files too;
+- template-path autocomplete when you configure choices.
+
+Make a [Template choice](./Choices/TemplateChoice.md) for the templates that deserve their own hotkey, a fixed destination folder, or a file name format.
+
+## The quick map
+
+The left column names the job; the middle names the Templater expression you may know it by (as a landmark only - the QuickAdd patterns don't use or require it).
+
+| The job | You may know it as | The QuickAdd way |
+| --- | --- | --- |
+| Insert the note's title | `tp.file.title` | [`{{TITLE}}`](./FormatSyntax.md#title) |
+| Today's date, any format | `tp.date.now` | [`{{DATE:YYYY-MM-DD}}`](./FormatSyntax.md#date-format), offsets like `{{DATE+7}}` |
+| Ask for a date in plain language | `tp.system.prompt` + a date parser | [`{{VDATE:due,YYYY-MM-DD}}`](./FormatSyntax.md#vdate) - natural language built in |
+| Prompt for text | `tp.system.prompt` | [`{{VALUE:name}}`](./FormatSyntax.md#named-value) |
+| Pick from a list | `tp.system.suggester` | [`{{VALUE:Option A,Option B}}`](./FormatSyntax.md#named-value), [`{{FIELD:...}}`](./FormatSyntax.md#field), [`{{FILE:...}}`](./FormatSyntax.md#file) |
+| Include one template in another | `tp.file.include` | [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template) |
+| Apply a template to an existing note | manual workarounds | [Apply template to active note](./ApplyTemplateToNote.md) |
+| Insert the clipboard | `tp.system.clipboard` | [`{{CLIPBOARD}}`](./FormatSyntax.md#clipboard) |
+| Insert the selected text | `tp.selection` | [`{{selected}}`](./FormatSyntax.md#selected) |
+| Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active) |
+| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) |
+| Run JavaScript | `tp.user` scripts, `<%* ... %>` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
+| Folder templates | folder templates | No automatic equivalent - see [Templates chosen by folder](#templates-chosen-by-folder) |
+| Cursor marker in a template | `tp.file.cursor` | No direct equivalent - see [Where the cursor lands](#where-the-cursor-lands) |
+
+## Create new notes from templates
+
+A [Template choice](./Choices/TemplateChoice.md) creates a note from a template file, with a configurable destination folder, file name format, link insertion, and open behavior. QuickAdd resolves every token - prompts included - before the note is created, so the finished note is plain text from its first moment.
+
+To position user input at an exact spot in the new note, put the token exactly where the text belongs. One named value can drive both the file name and the body:
+
+File name format: `{{VALUE:topic}}`
+
+```markdown
+---
+type: meeting
+---
+# {{TITLE}}
+
+Topic: {{VALUE:topic}}
+Date: {{DATE:YYYY-MM-DD}}
+```
+
+You are asked for `topic` once; the answer becomes the file name and fills the body, and `{{TITLE}}` renders the final file name.
+
+## Add to existing notes
+
+### Shared template content in new and existing notes
+
+Keep one template file and use it both ways - no parallel template sets:
+
+- **New notes**: point a Template choice at it, or include it inside a bigger template with [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template).
+- **Existing notes**: run **QuickAdd: Apply template to active note** (also in a file's right-click menu). You pick the template and where it goes - cursor, top, bottom, or replace - and the template's frontmatter is merged into the note's existing frontmatter, with the note's own values winning. See [Apply Template to Note](./ApplyTemplateToNote.md).
+
+A [Capture choice](./Choices/CaptureChoice.md) whose format is `{{TEMPLATE:Templates/Partial.md}}` also inserts that shared content into a target note. Prefer it for body-only snippets: a capture inserts the template text as-is, so a template that starts with its own `---` frontmatter block ends up as a literal second block instead of being merged. When the shared content carries frontmatter, use **Apply template to active note**.
+
+### Today's daily note
+
+Appending to today's note is a Capture choice with a date-formatted target path - the file doesn't have to exist beforehand:
+
+- **Capture to**: `Daily/{{DATE}}.md`
+- **Create file if it doesn't exist**, with your daily template
+- **Insert after**: `## Log`, with **Create line if not found**
+
+Running it with input `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+
+## Templates chosen by folder
+
+QuickAdd does not watch folders: nothing runs automatically when a note appears in a folder, no matter how it was created. What it offers instead is explicit and per-choice:
+
+- **One Template choice per destination.** Set **New note location** to **In a specific folder** and name the choice after the destination ("New person", "New project"). Each gets its own command and can get its own hotkey.
+- **One choice, several folders.** List multiple folders on the choice (optionally **Include subfolders**) and QuickAdd asks which one at run time.
+- **Dynamic paths.** Both the template path and the folder path accept [format syntax](./FormatSyntax.md): a template path of `Templates/{{VALUE:Person,Project,Meeting}} Template.md` picks the template from one prompt, and a folder path of `Projects/{{VALUE:client}}` files the note by answer.
+- **No setup at all**: the **New note from template** command picks any template from your template folder and creates the note in Obsidian's default location.
+
+## Dates without another plugin
+
+`{{DATE}}` renders today (`YYYY-MM-DD` by default), `{{DATE:<format>}}` takes any [Moment format](https://momentjs.com/docs/#/displaying/format/), and offsets travel in days: `{{DATE+7}}`, `{{DATE:gggg-[W]WW+7}}`. Snap to period boundaries with [`|startof:` / `|endof:`](./FormatSyntax.md#date-snap), for example `{{DATE:YYYY-MM|startof:week}}` for weekly notes that file under the month the week belongs to.
+
+For dates you enter, [`{{VDATE:name,format}}`](./FormatSyntax.md#vdate) understands natural language out of the box - no companion plugin. Type `tomorrow`, `next friday`, or `in two weeks`. Enter the date once, render it many times:
+
+```markdown
+Due: {{VDATE:due,YYYY-MM-DD}}
+Week: {{VDATE:due,gggg-[W]WW}}
+```
+
+Typing `tomorrow` fills both lines from one prompt: `Due: 2026-07-07` and `Week: 2026-W28`.
+
+There is no token for a file's creation or modification date - reach for a [script](#run-scripts) if you need those.
+
+## Prompt once, reuse everywhere
+
+Named values are shared across an entire run. `{{VALUE:topic}}` in the file name, the template body, and any other step of the same run all resolve from a single prompt - the mechanism behind the [Template choice example above](#create-new-notes-from-templates).
+
+That sharing spans [Macro choice](./Choices/MacroChoice.md) steps too. A classic two-step flow - log a task in today's daily note and create its note - is a macro of two choices sharing one name:
+
+1. A Capture choice into `Daily/{{DATE}}.md` with the format `- [ ] [[{{VALUE:task}}]]`
+2. A Template choice with file name format `{{VALUE:task}}` creating the note in your `Tasks` folder
+
+You type the task name once. Scripts join the same pool: anything a script assigns to `params.variables.task` is what `{{VALUE:task}}` resolves to in later steps - see the [scripting guide](./Advanced/ScriptingGuide.md).
+
+To gather every prompt on a single form up front instead of one dialog at a time, enable [one-page input](./Advanced/onePageInputs.md).
+
+## Where the cursor lands
+
+QuickAdd has no in-template cursor marker - you can't mark an arbitrary spot in a template and land there. What you can control:
+
+- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor at the end of what it captured.
+- **Apply template to active note** offers an **Insert at cursor** mode, so content lands where you already are.
+- **After creating a note**, a Template choice with **Open** leaves the cursor at the top of the note body. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
+
+## Run scripts
+
+QuickAdd runs JavaScript in two shapes:
+
+- **[Inline scripts](./InlineScripts.md)**: a fenced code block tagged `js quickadd` inside a template body or capture format. The block runs when the choice does, and a returned string is spliced into the output in its place.
+- **[User scripts](./Choices/MacroChoice.md)**: a `.js` file in your vault, run as a step of a Macro choice. Scripts receive `app`, the [QuickAdd API](./QuickAddAPI.md) (`inputPrompt`, `suggester`, `executeChoice`, and more), the shared `variables` map, and the `obsidian` module - see the [scripting guide](./Advanced/ScriptingGuide.md).
+
+`{{MACRO:My macro}}` embeds a macro's return value anywhere format syntax is accepted, so a computed value can flow straight into a file name, template body, or capture line.
+
+## Common migration snags
+
+These are the classic symptoms of splitting one template between two engines - each has a QuickAdd-native fix:
+
+- **You get prompted twice.** QuickAdd resolves all of its prompts before the file is created. If another engine prompts in the same template, you answer twice - once per engine. Let QuickAdd own the prompt with `{{VALUE:name}}` and reuse the answer everywhere it's needed.
+- **Template syntax shows up unrendered.** QuickAdd renders QuickAdd tokens; another engine's syntax is only rendered by that engine. If it isn't installed or doesn't run on the file, its markup stays behind as literal text. Port the line to the matching token from [the map](#the-quick-map).
+- **Capturing into a note throws template errors.** A note that keeps live template syntax can re-execute or error whenever a plugin processes the file again. QuickAdd tokens like `{{DATE:YYYY-MM-DD}}` render once, at creation, into plain text - later captures find nothing to re-run. Migrate the offending line in the template that created the note.

--- a/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
+++ b/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
@@ -82,7 +82,7 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Insert after**: `## Log`, with **Create line if not found**
 - **Capture format**: `- {{VALUE}}`
 
-Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+Running it and typing `did a thing` creates today's note (say, `Daily/2026-07-06.md`) from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. For a step-by-step walkthrough with variations, see [Capture: Add entries to your daily note](./Examples/Capture_ToDailyNote.md); [Capture choices](./Choices/CaptureChoice.md) covers every target and position option.
 
 ## Templates chosen by folder
 

--- a/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
+++ b/docs/versioned_docs/version-2.17.2/ComingFromTemplater.md
@@ -29,16 +29,16 @@ The left column names the job; the middle names the Templater expression you may
 | --- | --- | --- |
 | Insert the note's title | `tp.file.title` | [`{{TITLE}}`](./FormatSyntax.md#title) |
 | Today's date, any format | `tp.date.now` | [`{{DATE:YYYY-MM-DD}}`](./FormatSyntax.md#date-format), offsets like `{{DATE+7}}` |
-| Ask for a date in plain language | `tp.system.prompt` + a date parser | [`{{VDATE:due,YYYY-MM-DD}}`](./FormatSyntax.md#vdate) - natural language built in |
+| Ask for a date in plain language | `tp.system.prompt` | [`{{VDATE:due,YYYY-MM-DD}}`](./FormatSyntax.md#vdate) - natural language built in |
 | Prompt for text | `tp.system.prompt` | [`{{VALUE:name}}`](./FormatSyntax.md#named-value) |
 | Pick from a list | `tp.system.suggester` | [`{{VALUE:Option A,Option B}}`](./FormatSyntax.md#named-value), [`{{FIELD:...}}`](./FormatSyntax.md#field), [`{{FILE:...}}`](./FormatSyntax.md#file) |
 | Include one template in another | `tp.file.include` | [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template) |
 | Apply a template to an existing note | manual workarounds | [Apply template to active note](./ApplyTemplateToNote.md) |
 | Insert the clipboard | `tp.system.clipboard` | [`{{CLIPBOARD}}`](./FormatSyntax.md#clipboard) |
 | Insert the selected text | `tp.selection` | [`{{selected}}`](./FormatSyntax.md#selected) |
-| Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active) |
-| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) |
-| Run JavaScript | `tp.user` scripts, `<%* ... %>` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
+| Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](./FormatSyntax.md#field-default-from-active); to re-render a value you prompted for, just [repeat `{{VALUE:name}}`](#prompt-once-reuse-everywhere) |
+| Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](./FormatSyntax.md#linkcurrent) (wiki-link), [`{{FILENAMECURRENT}}`](./FormatSyntax.md#filenamecurrent) (raw name, for embeds like `![[{{FILENAMECURRENT}}#Heading]]`), [`{{LINKSECTION}}`](./FormatSyntax.md#linksection) (link to the heading you're in) |
+| Run JavaScript | `tp.user` | [Inline scripts](./InlineScripts.md), [user scripts in macros](./Choices/MacroChoice.md), [`{{MACRO:...}}`](./FormatSyntax.md#macro) |
 | Folder templates | folder templates | No automatic equivalent - see [Templates chosen by folder](#templates-chosen-by-folder) |
 | Cursor marker in a template | `tp.file.cursor` | No direct equivalent - see [Where the cursor lands](#where-the-cursor-lands) |
 
@@ -69,7 +69,7 @@ You are asked for `topic` once; the answer becomes the file name and fills the b
 Keep one template file and use it both ways - no parallel template sets:
 
 - **New notes**: point a Template choice at it, or include it inside a bigger template with [`{{TEMPLATE:Templates/Partial.md}}`](./FormatSyntax.md#template).
-- **Existing notes**: run **QuickAdd: Apply template to active note** (also in a file's right-click menu). You pick the template and where it goes - cursor, top, bottom, or replace - and the template's frontmatter is merged into the note's existing frontmatter, with the note's own values winning. See [Apply Template to Note](./ApplyTemplateToNote.md).
+- **Existing notes**: run **QuickAdd: Apply template to active note** (also in a file's right-click menu). You pick the template and where it goes - cursor, top, bottom, or replace. For the insert modes, the template's frontmatter is merged into the note's existing frontmatter, with the note's own values winning (replace overwrites the whole note, frontmatter included). See [Apply Template to Note](./ApplyTemplateToNote.md).
 
 A [Capture choice](./Choices/CaptureChoice.md) whose format is `{{TEMPLATE:Templates/Partial.md}}` also inserts that shared content into a target note. Prefer it for body-only snippets: a capture inserts the template text as-is, so a template that starts with its own `---` frontmatter block ends up as a literal second block instead of being merged. When the shared content carries frontmatter, use **Apply template to active note**.
 
@@ -80,8 +80,9 @@ Appending to today's note is a Capture choice with a date-formatted target path 
 - **Capture to**: `Daily/{{DATE}}.md`
 - **Create file if it doesn't exist**, with your daily template
 - **Insert after**: `## Log`, with **Create line if not found**
+- **Capture format**: `- {{VALUE}}`
 
-Running it with input `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
+Running it and typing `did a thing` creates `Daily/2026-07-06.md` from the template on first capture and appends `- did a thing` under `## Log` - one hotkey, whether or not the note exists. See [Capture choices](./Choices/CaptureChoice.md) for every target and position option.
 
 ## Templates chosen by folder
 
@@ -89,7 +90,7 @@ QuickAdd does not watch folders: nothing runs automatically when a note appears 
 
 - **One Template choice per destination.** Set **New note location** to **In a specific folder** and name the choice after the destination ("New person", "New project"). Each gets its own command and can get its own hotkey.
 - **One choice, several folders.** List multiple folders on the choice (optionally **Include subfolders**) and QuickAdd asks which one at run time.
-- **Dynamic paths.** Both the template path and the folder path accept [format syntax](./FormatSyntax.md): a template path of `Templates/{{VALUE:Person,Project,Meeting}} Template.md` picks the template from one prompt, and a folder path of `Projects/{{VALUE:client}}` files the note by answer.
+- **Dynamic paths.** Both the template path and the folder path accept [format syntax](./FormatSyntax.md), and one named value can drive both. A choice with template path `Templates/{{VALUE:kind}}.md` and folder path `{{VALUE:kind}}s` asks for `kind` once - answering `Person` creates the note from `Templates/Person.md` in the `Persons` folder, keeping the whole folder-to-template mapping in a single choice.
 - **No setup at all**: the **New note from template** command picks any template from your template folder and creates the note in Obsidian's default location.
 
 ## Dates without another plugin
@@ -122,9 +123,9 @@ To gather every prompt on a single form up front instead of one dialog at a time
 
 ## Where the cursor lands
 
-QuickAdd has no in-template cursor marker - you can't mark an arbitrary spot in a template and land there. What you can control:
+QuickAdd has no in-template cursor marker of its own - you can't mark an arbitrary spot in a template and land there. What you can control:
 
-- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor at the end of what it captured.
+- **Captures follow the insertion.** With **Capture to active file**, the cursor ends up right after the inserted text; with **Open** enabled on other targets, QuickAdd opens the note and places the cursor immediately after the inserted text.
 - **Apply template to active note** offers an **Insert at cursor** mode, so content lands where you already are.
 - **After creating a note**, a Template choice with **Open** leaves the cursor at the top of the note body. To end at the bottom instead, wrap the Template choice in a [Macro choice](./Choices/MacroChoice.md) and add the **Move cursor to file end** editor command as the next step (file start and line start/end variants exist too).
 
@@ -143,4 +144,4 @@ These are the classic symptoms of splitting one template between two engines - e
 
 - **You get prompted twice.** QuickAdd resolves all of its prompts before the file is created. If another engine prompts in the same template, you answer twice - once per engine. Let QuickAdd own the prompt with `{{VALUE:name}}` and reuse the answer everywhere it's needed.
 - **Template syntax shows up unrendered.** QuickAdd renders QuickAdd tokens; another engine's syntax is only rendered by that engine. If it isn't installed or doesn't run on the file, its markup stays behind as literal text. Port the line to the matching token from [the map](#the-quick-map).
-- **Capturing into a note throws template errors.** A note that keeps live template syntax can re-execute or error whenever a plugin processes the file again. QuickAdd tokens like `{{DATE:YYYY-MM-DD}}` render once, at creation, into plain text - later captures find nothing to re-run. Migrate the offending line in the template that created the note.
+- **Capturing into a note throws template errors.** A note that keeps live template syntax can re-execute or error whenever a plugin processes the file again. QuickAdd tokens like `{{DATE:YYYY-MM-DD}}` render once, at creation, into plain text - later captures find nothing to re-run. Migrate the offending line to a QuickAdd token and let QuickAdd create the note so the token renders - a Capture with **Create file if it doesn't exist** plus that template does both (see [Today's daily note](#todays-daily-note)).

--- a/docs/versioned_sidebars/version-2.17.2-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17.2-sidebars.json
@@ -7,6 +7,11 @@
     },
     {
       "type": "doc",
+      "id": "ComingFromTemplater",
+      "label": "Coming from Templater"
+    },
+    {
+      "type": "doc",
       "id": "Settings",
       "label": "Settings"
     },


### PR DESCRIPTION
Adds a "Coming from Templater" page that maps the jobs people arrive with from Templater to the QuickAdd-native pattern for each - the single biggest recurring question family in discussions over five years.

Refs: #78, #153, #201, #360, #503, #574, #579, #596, #804, #1105

## What the page covers

- Onboarding an existing template folder (Template folder paths + New note from template + Apply template to active note)
- A jobs-first quick-map table (Templater identifiers appear only as bare backticked "you may know it as" anchors - no Templater settings, semantics, or bridge recipes, per the successor policy)
- Creating notes from templates, positioning input with named values
- Shared template content in new AND existing notes (one template set; apply-template merge vs capture literal insert)
- Today's daily note (date-formatted capture target + create-with-template + insert after)
- Templates chosen by folder - honest about the lack of an automatic folder trigger, with the four native patterns including one named value driving both template path and folder path
- Dates: formats, day offsets, startof/endof snaps, natural-language {{VDATE}} (bundled, no companion plugin)
- Prompt once, reuse everywhere ({{VALUE:name}} across file name, body, and macro steps; params.variables)
- Where the cursor lands - honest about the missing in-template cursor marker, with the Move-cursor-to-file-end macro recipe
- Run scripts (inline `js quickadd`, user scripts, {{MACRO:...}})
- Common migration snags: double prompts, unrendered syntax, capture-time template errors - each with the QuickAdd-native fix

## Verification

Every token, command name, UI label, and flow on the page was verified live in this worktree's isolated e2e vault (`obsidian:e2e`): date offsets and snaps, VDATE natural language ("tomorrow" -> one prompt rendered in two formats), prompt-once reuse across file name + body, the inline-script fence, the daily-note capture recipe (create-from-template + insert-after), apply-template frontmatter merge vs capture literal second block, cursor positions (top-of-body after Template+Open; file end via the macro editor command), one value driving template path + folder path, and both command names. Docs build (`cd docs && pnpm build`) passes; the rendered page was checked in both trees.

## Notes for review

- Ships in BOTH `docs/docs` (served at /docs/next/) and `docs/versioned_docs/version-2.17.2` (the frozen snapshot served at /docs/ - edited deliberately so current users can find the page now). Registered in both sidebars, one additive entry each.
- Replaces the first paragraph of `Choices/TemplateChoice.md` (both trees), which still called Template choices "not a replacement for Templater" - the opposite of current positioning and one click from the new page.
- Adds one sentence to `Choices/CaptureChoice.md`'s template-include section (both trees) documenting the capture frontmatter-literal-block behavior, so the migration page isn't the sole authority for it.
- Deliberately NOT touched (possible follow-up positioning pass): the remaining Templater interop mentions in QuickAddAPI.md, Advanced/APIOverview.md, MacroChoice.md, CaptureChoice.md's Templater sections, and docs/src/pages/index.tsx.

Reviewed by an ultracode multi-lens pass (fact-check vs src, policy/voice, user-lens against all ten discussions) plus two adversarial reviewers; all findings addressed or explicitly declined (Templater cursor auto-jump interop callout declined as a policy violation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Coming from Templater” guide with workflow mappings, migration tips, and examples for creating notes from templates, applying shared content, handling dates, prompts, token-driven file/body placement, and cursor positioning.
  * Clarified how template includes render and how frontmatter behaves when included content contains its own `---` block.
  * Updated Template choice and capture-format documentation to better explain QuickAdd-native syntax and placement within Templater-originated templates.
  * Added the new guide to the docs navigation (including the versioned docs set).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->