### PR TITLE
feat(format): {{FOLDERCURRENT}} token for the active file's folder

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -323,7 +323,7 @@ The folder of the file from which the template or capture was triggered (the act
 
 This makes per-project captures work without a macro: with **Capture To** set to
 
-```
+```text
 {{FOLDERCURRENT}}/Project Tasks.md
 ```
 

--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -317,9 +317,31 @@ The basename (without extension) of the file from which the template or capture 
 
 Example: `Notes from {{FILENAMECURRENT}}`.
 
+## `{{FOLDERCURRENT}}` {#foldercurrent}
+
+The folder of the file from which the template or capture was triggered (the active file), as a vault-relative path with no trailing slash. For an active file at the vault root it resolves to an empty string. Not to be confused with `{{FOLDER}}` below, which is the folder the *new* note is being created in.
+
+This makes per-project captures work without a macro: with **Capture To** set to
+
+```
+{{FOLDERCURRENT}}/Project Tasks.md
+```
+
+running the capture from any note inside `Projects/Alpha` targets `Projects/Alpha/Project Tasks.md`, from `Projects/Beta` it targets `Projects/Beta/Project Tasks.md`, and so on. A trailing slash (`{{FOLDERCURRENT}}/`) instead opens a file picker confined to the active file's folder.
+
+Where it resolves: capture targets and file name formats, note bodies/capture formats, and Template choice folder paths (e.g. `{{FOLDERCURRENT}}/Subnotes`).
+
+**No active file:** in paths (capture targets, file names, folder paths) a missing active file always stops the run with a clear error - it never falls back to the vault root. In note bodies it honors the same **required/optional** behavior as `{{LINKCURRENT}}` (optional resolves to an empty string).
+
+### `{{FOLDERCURRENT|name}}` - just the folder name
+
+Add the `|name` modifier to get only the last path segment: for an active file in `Projects/Acme`, `{{FOLDERCURRENT}}` is `Projects/Acme` while `{{FOLDERCURRENT|name}}` is `Acme`. Use `|name` when you want the folder's name inside a file name or note body rather than a path.
+
+Examples: `{{FOLDERCURRENT}}/Project Tasks.md`, `Tasks for {{FOLDERCURRENT|name}}`.
+
 ## `{{FOLDER}}` {#folder}
 
-The folder the note is being created in, as a vault-relative path (no trailing slash). For a note created at the vault root this resolves to an empty string.
+The folder the note is being created in, as a vault-relative path (no trailing slash). For a note created at the vault root this resolves to an empty string. (For the *active* file's folder, use `{{FOLDERCURRENT}}` above.)
 
 Where it has a value:
 

--- a/docs/versioned_docs/version-2.17.2/FormatSyntax.md
+++ b/docs/versioned_docs/version-2.17.2/FormatSyntax.md
@@ -323,7 +323,7 @@ The folder of the file from which the template or capture was triggered (the act
 
 This makes per-project captures work without a macro: with **Capture To** set to
 
-```
+```text
 {{FOLDERCURRENT}}/Project Tasks.md
 ```
 

--- a/docs/versioned_docs/version-2.17.2/FormatSyntax.md
+++ b/docs/versioned_docs/version-2.17.2/FormatSyntax.md
@@ -317,9 +317,31 @@ The basename (without extension) of the file from which the template or capture 
 
 Example: `Notes from {{FILENAMECURRENT}}`.
 
+## `{{FOLDERCURRENT}}` {#foldercurrent}
+
+The folder of the file from which the template or capture was triggered (the active file), as a vault-relative path with no trailing slash. For an active file at the vault root it resolves to an empty string. Not to be confused with `{{FOLDER}}` below, which is the folder the *new* note is being created in.
+
+This makes per-project captures work without a macro: with **Capture To** set to
+
+```
+{{FOLDERCURRENT}}/Project Tasks.md
+```
+
+running the capture from any note inside `Projects/Alpha` targets `Projects/Alpha/Project Tasks.md`, from `Projects/Beta` it targets `Projects/Beta/Project Tasks.md`, and so on. A trailing slash (`{{FOLDERCURRENT}}/`) instead opens a file picker confined to the active file's folder.
+
+Where it resolves: capture targets and file name formats, note bodies/capture formats, and Template choice folder paths (e.g. `{{FOLDERCURRENT}}/Subnotes`).
+
+**No active file:** in paths (capture targets, file names, folder paths) a missing active file always stops the run with a clear error - it never falls back to the vault root. In note bodies it honors the same **required/optional** behavior as `{{LINKCURRENT}}` (optional resolves to an empty string).
+
+### `{{FOLDERCURRENT|name}}` - just the folder name
+
+Add the `|name` modifier to get only the last path segment: for an active file in `Projects/Acme`, `{{FOLDERCURRENT}}` is `Projects/Acme` while `{{FOLDERCURRENT|name}}` is `Acme`. Use `|name` when you want the folder's name inside a file name or note body rather than a path.
+
+Examples: `{{FOLDERCURRENT}}/Project Tasks.md`, `Tasks for {{FOLDERCURRENT|name}}`.
+
 ## `{{FOLDER}}` {#folder}
 
-The folder the note is being created in, as a vault-relative path (no trailing slash). For a note created at the vault root this resolves to an empty string.
+The folder the note is being created in, as a vault-relative path (no trailing slash). For a note created at the vault root this resolves to an empty string. (For the *active* file's folder, use `{{FOLDERCURRENT}}` above.)
 
 Where it has a value:
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,8 @@ export const MATH_VALUE_SYNTAX = "{{mvalue}}";
 export const LINKCURRENT_SYNTAX = "{{linkcurrent}}";
 export const LINKSECTION_SYNTAX = "{{linksection}}";
 export const FILENAMECURRENT_SYNTAX = "{{filenamecurrent}}";
+export const FOLDERCURRENT_SYNTAX = "{{foldercurrent}}";
+export const FOLDERCURRENT_NAME_SYNTAX = "{{foldercurrent|name}}";
 export const FOLDER_SYNTAX = "{{folder}}";
 export const TITLE_SYNTAX = "{{title}}";
 export const SELECTED_SYNTAX = "{{selected}}";
@@ -73,6 +75,8 @@ export const FORMAT_SYNTAX: string[] = [
 	LINKCURRENT_SYNTAX,
 	LINKSECTION_SYNTAX,
 	FILENAMECURRENT_SYNTAX,
+	FOLDERCURRENT_SYNTAX,
+	FOLDERCURRENT_NAME_SYNTAX,
 	FOLDER_SYNTAX,
 	"{{folder|name}}",
 	"{{macro:<macroname>}}",
@@ -106,6 +110,8 @@ export const FILE_NAME_FORMAT_SYNTAX: string[] = [
 	VARIABLE_NAME_SYNTAX,
 	FIELD_VAR_SYNTAX,
 	FILE_SYNTAX,
+	FOLDERCURRENT_SYNTAX,
+	FOLDERCURRENT_NAME_SYNTAX,
 	RANDOM_SYNTAX,
 ];
 // Note: |optional is deliberately absent from FILE_NAME_FORMAT_SYNTAX — an
@@ -204,6 +210,14 @@ export const LINK_TO_CURRENT_FILE_REGEX = new RegExp(/{{LINKCURRENT}}/i);
 // cursor is under, so the link scrolls there instead of the top (issue #387).
 export const LINK_TO_CURRENT_SECTION_REGEX = new RegExp(/{{LINKSECTION}}/i);
 export const FILE_NAME_OF_CURRENT_FILE_REGEX = new RegExp(/{{FILENAMECURRENT}}/i);
+// {{FOLDERCURRENT}} resolves to the ACTIVE file's parent folder (vault-relative,
+// no trailing slash; "" for a root-level file). The optional |name modifier
+// yields just the leaf folder segment, mirroring {{FOLDER|name}}. Resolved in
+// the combined single-pass resolver (formatter.replaceCurrentFileTokensInString),
+// never via a standalone replace loop (#1358).
+export const FOLDER_OF_CURRENT_FILE_REGEX = new RegExp(
+	/{{FOLDERCURRENT(\|name)?}}/i,
+);
 // {{FOLDER}} resolves to the target folder the note is being created in.
 // The optional |name modifier yields just the leaf folder segment.
 export const TARGET_FOLDER_REGEX = new RegExp(/{{FOLDER(\|name)?}}/i);
@@ -262,6 +276,13 @@ export const LINKSECTION_SYNTAX_SUGGEST_REGEX = new RegExp(
 );
 export const FILENAMECURRENT_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[F]?[I]?[L]?[E]?[N]?[A]?[M]?[E]?[C]?[U]?[R]?[R]?[E]?[N]?[T]?[}]?[}]?$/i,
+);
+// {{FOLDER}} is a strict prefix of {{FOLDERCURRENT}}, so the two flat matchers
+// stay mutually consistent: at "{{folder" both are (correctly) offered, and the
+// first extra letter disambiguates — "{{folderc" no longer matches
+// FOLDER_SYNTAX_SUGGEST_REGEX (after R it only admits closing braces).
+export const FOLDERCURRENT_SYNTAX_SUGGEST_REGEX = new RegExp(
+	/{{[F]?[O]?[L]?[D]?[E]?[R]?[C]?[U]?[R]?[R]?[E]?[N]?[T]?[}]?[}]?$/i,
 );
 export const FOLDER_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[F]?[O]?[L]?[D]?[E]?[R]?[}]?[}]?$/i,

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -188,7 +188,10 @@ const { ChoiceAbortError } = await import("../errors/ChoiceAbortError");
 
 // --- Test helpers --------------------------------------------------------
 
-type FakeFile = { basename: string } | null;
+type FakeFile = {
+	basename: string;
+	parent?: { path: string } | null;
+} | null;
 
 interface FakeAppState {
 	activeFile: FakeFile;
@@ -625,6 +628,91 @@ describe("CompleteFormatter - #1358 token-named active file (production wiring)"
 		await expect(f.formatFileName("{{FILENAMECURRENT}}", "header")).resolves.toBe(
 			"{{folder}}",
 		);
+	});
+});
+
+describe("CompleteFormatter - {{FOLDERCURRENT}} (issue #1480)", () => {
+	const activeInAlpha: FakeFile = {
+		basename: "Meeting",
+		parent: { path: "Projects/Alpha" },
+	};
+
+	it("formatFileName resolves a sibling capture target from the active file's folder", async () => {
+		const f = defaultFormatter({}, { activeFile: activeInAlpha });
+		await expect(
+			f.formatFileName("{{FOLDERCURRENT}}/Project Tasks.md", "Value"),
+		).resolves.toBe("Projects/Alpha/Project Tasks.md");
+	});
+
+	it("formatFileName resolves {{FOLDERCURRENT|name}} to the leaf folder", async () => {
+		const f = defaultFormatter({}, { activeFile: activeInAlpha });
+		await expect(
+			f.formatFileName("{{FOLDERCURRENT|name}} - notes", "Value"),
+		).resolves.toBe("Alpha - notes");
+	});
+
+	it("collapses the root folder path '/' to an empty string", async () => {
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "RootNote", parent: { path: "/" } } },
+		);
+		// Downstream path normalization strips the leading slash, so a root-level
+		// note captures to a root-level sibling.
+		await expect(
+			f.formatFileName("{{FOLDERCURRENT}}/Tasks.md", "Value"),
+		).resolves.toBe("/Tasks.md");
+	});
+
+	it("formatFileContent resolves the token in a note body", async () => {
+		const f = defaultFormatter({}, { activeFile: activeInAlpha });
+		await expect(
+			f.formatFileContent("Filed under {{foldercurrent}}"),
+		).resolves.toBe("Filed under Projects/Alpha");
+	});
+
+	it("formatFolderPath resolves the token (and composes with a subpath)", async () => {
+		const f = defaultFormatter({}, { activeFile: activeInAlpha });
+		await expect(
+			f.formatFolderPath("{{FOLDERCURRENT}}/Subnotes"),
+		).resolves.toBe("Projects/Alpha/Subnotes");
+	});
+
+	it("formatFileName throws without an active file, even in optional mode (no silent root capture)", async () => {
+		const f = defaultFormatter({}, { activeFile: null });
+		f.setLinkToCurrentFileBehavior("optional");
+		await expect(
+			f.formatFileName("{{FOLDERCURRENT}}/Tasks.md", "Value"),
+		).rejects.toThrow("Unable to get the active file's folder");
+	});
+
+	it("formatFolderPath throws without an active file", async () => {
+		const f = defaultFormatter({}, { activeFile: null });
+		await expect(f.formatFolderPath("{{FOLDERCURRENT}}")).rejects.toThrow(
+			"Unable to get the active file's folder",
+		);
+	});
+
+	it("formatFileContent strips the token in optional mode without an active file", async () => {
+		const f = defaultFormatter({}, { activeFile: null });
+		f.setLinkToCurrentFileBehavior("optional");
+		await expect(
+			f.formatFileContent("in [{{FOLDERCURRENT}}]"),
+		).resolves.toBe("in []");
+	});
+
+	it("does not re-scan a folder literally named like a token (#1358)", async () => {
+		const f = defaultFormatter(
+			{},
+			{
+				activeFile: {
+					basename: "Meeting",
+					parent: { path: "{{filenamecurrent}}" },
+				},
+			},
+		);
+		await expect(
+			f.formatFileName("{{FOLDERCURRENT}}/{{FILENAMECURRENT}}", "Value"),
+		).resolves.toBe("{{filenamecurrent}}/Meeting");
 	});
 });
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -685,6 +685,18 @@ describe("CompleteFormatter - {{FOLDERCURRENT}} (issue #1480)", () => {
 		).rejects.toThrow("Unable to get the active file's folder");
 	});
 
+	it("formatFolderPath strips the leading slash a root-level active file produces", async () => {
+		const f = defaultFormatter(
+			{},
+			{ activeFile: { basename: "RootNote", parent: { path: "/" } } },
+		);
+		// "" + "/Subnotes" would otherwise reach validateFolderPath as an empty
+		// first segment and silently fall back to the vault root.
+		await expect(
+			f.formatFolderPath("{{FOLDERCURRENT}}/Subnotes"),
+		).resolves.toBe("Subnotes");
+	});
+
 	it("formatFolderPath throws without an active file", async () => {
 		const f = defaultFormatter({}, { activeFile: null });
 		await expect(f.formatFolderPath("{{FOLDERCURRENT}}")).rejects.toThrow(

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -119,12 +119,15 @@ export class CompleteFormatter extends Formatter {
 				"{{title}} cannot be used in file names as it would create a circular dependency. The title is derived from the filename itself.",
 			);
 		}
-		// {{filenamecurrent}} + {{folder}} in one pass (links stay literal in a
-		// file name; {{title}} threw above). One pass so no token re-scans
-		// another's output (#1358).
+		// {{filenamecurrent}} + {{folder}} + {{foldercurrent}} in one pass (links
+		// stay literal in a file name; {{title}} threw above). One pass so no token
+		// re-scans another's output (#1358). activeFolder is "path": this entry
+		// point produces file paths (file names AND capture targets), where a
+		// missing active file must abort rather than strip to a root-level path.
 		output = this.replaceCurrentFileTokensInString(output, {
 			fileName: true,
 			folder: true,
+			activeFolder: "path",
 		});
 		return output;
 	}
@@ -134,13 +137,17 @@ export class CompleteFormatter extends Formatter {
 
 		output = await this.format(output);
 		// Resolve ALL note-derived tokens ({{linkcurrent}}, {{linksection}},
-		// {{filenamecurrent}}, {{folder}}, {{title}}) in ONE pass so no token
-		// re-scans another's generated output — fixing both the cross-pass
-		// corruption and the infinite loop a token-named file/title caused (#1358).
+		// {{filenamecurrent}}, {{folder}}, {{foldercurrent}}, {{title}}) in ONE
+		// pass so no token re-scans another's generated output — fixing both the
+		// cross-pass corruption and the infinite loop a token-named file/title
+		// caused (#1358). activeFolder is "content": in a note body an unresolved
+		// token cannot misplace data, so it follows the same required/optional
+		// contract as the link/file-name tokens.
 		output = this.replaceCurrentFileTokensInString(output, {
 			links: true,
 			fileName: true,
 			folder: true,
+			activeFolder: "content",
 			title: true,
 		});
 
@@ -169,8 +176,14 @@ export class CompleteFormatter extends Formatter {
 		// {{FOLDER}} in a folder definition is self-referential: the target
 		// folder isn't known while folders are being resolved, so it collapses
 		// to an empty string rather than leaking the literal token into a path.
+		// {{FOLDERCURRENT}} is NOT self-referential (the active file's folder is
+		// known here) and must resolve: left verbatim it would be threaded into
+		// getOrCreateFolder and CREATE a vault folder literally named
+		// "{{foldercurrent}}". "path" mode: no active file aborts with a clear
+		// error instead of silently collapsing the folder to the vault root.
 		return this.replaceCurrentFileTokensInString(formatted, {
 			folder: true,
+			activeFolder: "path",
 		});
 	}
 
@@ -249,10 +262,11 @@ export class CompleteFormatter extends Formatter {
 	protected async formatLocationString(input: string): Promise<string> {
 		let output = await this.format(input);
 		// Links + {{filenamecurrent}} + {{title}} in one pass so no token re-scans
-		// another's output (#1358). {{FOLDER}} is deliberately left literal in
-		// location selectors (insert-after/before targets) — an empty resolution
-		// would match the first line, and folder reflection isn't meaningful for a
-		// line target.
+		// another's output (#1358). {{FOLDER}} and {{FOLDERCURRENT}} are
+		// deliberately left literal in location selectors (insert-after/before
+		// targets) — both can legitimately resolve to an empty string ("" target
+		// folder / root-level active file), and an empty selector would match the
+		// first line. Tokens that are nonempty-or-throw (links, file name) stay.
 		output = this.replaceCurrentFileTokensInString(output, {
 			links: true,
 			fileName: true,
@@ -276,6 +290,21 @@ export class CompleteFormatter extends Formatter {
 		if (!currentFile) return null;
 
 		return currentFile.basename;
+	}
+
+	/**
+	 * {{foldercurrent}}: the active file's parent folder, vault-relative with no
+	 * trailing slash. Obsidian's root TFolder has path "/", which collapses to ""
+	 * (matching setTargetFolderPath) so a root-level note yields a root-relative
+	 * sibling path instead of a literal leading "/". Uses the LIVE active file,
+	 * byte-consistent with getCurrentFileName/getCurrentFileLink.
+	 */
+	protected getCurrentFolderPath(): string | null {
+		const currentFile = this.app.workspace.getActiveFile();
+		if (!currentFile) return null;
+
+		const parentPath = currentFile.parent?.path ?? "";
+		return parentPath === "/" ? "" : parentPath;
 	}
 
 	/**

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -181,10 +181,17 @@ export class CompleteFormatter extends Formatter {
 		// getOrCreateFolder and CREATE a vault folder literally named
 		// "{{foldercurrent}}". "path" mode: no active file aborts with a clear
 		// error instead of silently collapsing the folder to the vault root.
-		return this.replaceCurrentFileTokensInString(formatted, {
+		const resolved = this.replaceCurrentFileTokensInString(formatted, {
 			folder: true,
 			activeFolder: "path",
 		});
+		// A token that legitimately resolves to "" at the START of the path (a
+		// root-level active file in "{{FOLDERCURRENT}}/Subnotes", or the {{FOLDER}}
+		// collapse above) leaves a leading "/", which validateFolderPath would
+		// reject as an empty first segment — falling back to the vault root
+		// instead of using "Subnotes". Strip leading slashes so the folder path is
+		// root-relative, matching what the capture/file-name paths do downstream.
+		return resolved.replace(/^\/+/, "");
 	}
 
 	/**

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -195,8 +195,8 @@ export class CompleteFormatter extends Formatter {
 	 * tokens, but never runs macros, inline JavaScript, or {{TEMPLATE:}}
 	 * inclusion — a file-path lookup should not execute code or splice another
 	 * template's body into a path. Note-relative tokens ({{title}}, {{FOLDER}},
-	 * {{FILENAMECURRENT}}, {{LINKCURRENT}}, {{LINKSECTION}}) are intentionally
-	 * left literal: a
+	 * {{FOLDERCURRENT}}, {{FILENAMECURRENT}}, {{LINKCURRENT}}, {{LINKSECTION}})
+	 * are intentionally left literal: a
 	 * source template has no "current note" or target folder, so an unresolved
 	 * token fails visibly instead of silently collapsing the path.
 	 *

--- a/src/formatters/displayFormatter-foldercurrent.test.ts
+++ b/src/formatters/displayFormatter-foldercurrent.test.ts
@@ -69,6 +69,20 @@ describe("Display formatters - {{foldercurrent}} preview", () => {
 		);
 	});
 
+	it("line-target preview mode leaves the token literal (matches formatLocationString)", async () => {
+		const f = new FormatDisplayFormatter(
+			makeApp(activeInAlpha),
+			plugin,
+			undefined,
+			{ resolveActiveFolder: false },
+		);
+		await expect(f.format("## {{foldercurrent}}")).resolves.toBe(
+			"## {{foldercurrent}}",
+		);
+		// Other note-derived tokens still preview normally in that mode.
+		await expect(f.format("{{filenamecurrent}}")).resolves.toBe("Meeting");
+	});
+
 	it("previews show a root-level active file's folder as empty (truthful)", async () => {
 		const f = new FileNameDisplayFormatter(
 			makeApp({ basename: "Root", path: "Root.md", parent: { path: "/" } }),

--- a/src/formatters/displayFormatter-foldercurrent.test.ts
+++ b/src/formatters/displayFormatter-foldercurrent.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import { FileNameDisplayFormatter } from "./fileNameDisplayFormatter";
+import { FormatDisplayFormatter } from "./formatDisplayFormatter";
+import type QuickAdd from "../main";
+
+// FormatDisplayFormatter statically imports SingleTemplateEngine, whose module
+// graph reaches obsidian-dataview (which requires a real 'obsidian' module).
+// The {{foldercurrent}} preview never touches templates, so stub it out.
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		run(): Promise<string> {
+			return Promise.resolve("");
+		}
+	},
+}));
+
+/**
+ * {{foldercurrent}} previews (issue #1480): both display formatters resolve the
+ * token through a never-null preview resolver, so a live preview shows the
+ * active file's folder (placeholder when none) and can never hit the runtime's
+ * missing-active-file throw.
+ */
+
+function makeApp(activeFile: unknown): App {
+	return {
+		workspace: { getActiveFile: () => activeFile },
+		vault: { getMarkdownFiles: () => [] },
+		metadataCache: { getFileCache: () => null },
+	} as unknown as App;
+}
+
+const plugin = {
+	settings: { globalVariables: {}, choices: [] },
+} as unknown as QuickAdd;
+
+const activeInAlpha = {
+	basename: "Meeting",
+	path: "Projects/Alpha/Meeting.md",
+	parent: { path: "Projects/Alpha" },
+};
+
+describe("Display formatters - {{foldercurrent}} preview", () => {
+	it("file-name preview shows the active file's folder path", async () => {
+		const f = new FileNameDisplayFormatter(makeApp(activeInAlpha), plugin);
+		await expect(f.format("{{foldercurrent}}/Tasks.md")).resolves.toBe(
+			"Projects/Alpha/Tasks.md",
+		);
+	});
+
+	it("file-name preview shows the leaf for |name", async () => {
+		const f = new FileNameDisplayFormatter(makeApp(activeInAlpha), plugin);
+		await expect(f.format("{{foldercurrent|name}} note")).resolves.toBe(
+			"Alpha note",
+		);
+	});
+
+	it("file-name preview falls back to a placeholder without an active file (no throw)", async () => {
+		const f = new FileNameDisplayFormatter(makeApp(null), plugin);
+		await expect(f.format("{{foldercurrent}}/Tasks.md")).resolves.toBe(
+			"current_folder/Tasks.md",
+		);
+	});
+
+	it("body preview resolves the token", async () => {
+		const f = new FormatDisplayFormatter(makeApp(activeInAlpha), plugin);
+		await expect(f.format("Filed under {{foldercurrent}}")).resolves.toBe(
+			"Filed under Projects/Alpha",
+		);
+	});
+
+	it("previews show a root-level active file's folder as empty (truthful)", async () => {
+		const f = new FileNameDisplayFormatter(
+			makeApp({ basename: "Root", path: "Root.md", parent: { path: "/" } }),
+			plugin,
+		);
+		await expect(f.format("{{foldercurrent}}/Tasks.md")).resolves.toBe(
+			"/Tasks.md",
+		);
+	});
+});

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -10,6 +10,7 @@ import {
 	getSuggestionPreview,
 	getCurrentFileLinkPreview,
 	getCurrentFileNamePreview,
+	getCurrentFolderPathPreview,
 	DateFormatPreviewGenerator
 } from "./helpers/previewHelpers";
 import { getValueVariableBaseName } from "../utils/valueSyntax";
@@ -45,11 +46,13 @@ export class FileNameDisplayFormatter extends Formatter {
 			output = await this.replaceVariableInString(output);
 			output = await this.replaceFieldVarInString(output);
 			output = await this.replaceFileInString(output);
-			// {{filenamecurrent}} + {{folder}} in one pass so neither re-scans the
-			// other's output (#1358).
+			// {{filenamecurrent}} + {{folder}} + {{foldercurrent}} in one pass so no
+			// token re-scans another's output (#1358). The preview resolver below
+			// never returns null, so "path" mode cannot throw here.
 			output = this.replaceCurrentFileTokensInString(output, {
 				fileName: true,
 				folder: true,
+				activeFolder: "path",
 			});
 			output = this.replaceRandomInString(output);
 		} catch {
@@ -95,6 +98,11 @@ export class FileNameDisplayFormatter extends Formatter {
 	protected getCurrentFileName(): string | null {
 		if (!this.app) return "current_filename";
 		return getCurrentFileNamePreview(this.app.workspace.getActiveFile());
+	}
+
+	protected getCurrentFolderPath(): string | null {
+		if (!this.app) return "current_folder";
+		return getCurrentFolderPathPreview(this.app.workspace.getActiveFile());
 	}
 
 	protected suggestForValue(

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -26,6 +26,13 @@ export class FormatDisplayFormatter extends Formatter {
 		app: App,
 		private readonly plugin: QuickAdd,
 		dateParser?: IDateParser,
+		// Line-target fields (insert-after/before) preview with
+		// { resolveActiveFolder: false }: their runtime path
+		// (formatLocationString) deliberately leaves {{foldercurrent}} literal,
+		// so the preview must too — otherwise a manually typed or imported
+		// selector previews as a resolved folder while the capture searches for
+		// the literal token.
+		private readonly opts: { resolveActiveFolder?: boolean } = {},
 	) {
 		super(app);
 		this.dateParser = dateParser || NLDParser;
@@ -56,7 +63,9 @@ export class FormatDisplayFormatter extends Formatter {
 				links: true,
 				fileName: true,
 				folder: true,
-				activeFolder: "content",
+				...(this.opts.resolveActiveFolder === false
+					? {}
+					: { activeFolder: "content" as const }),
 			});
 			output = await this.replaceMacrosInString(output);
 			output = await this.replaceTemplateInString(output);

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -13,6 +13,7 @@ import {
 	getCurrentFileLinkPreview,
 	getCurrentFileLinkToSectionPreview,
 	getCurrentFileNamePreview,
+	getCurrentFolderPathPreview,
 	DateFormatPreviewGenerator
 } from "./helpers/previewHelpers";
 import { getValueVariableBaseName } from "../utils/valueSyntax";
@@ -47,13 +48,15 @@ export class FormatDisplayFormatter extends Formatter {
 			output = await this.replaceClipboardInString(output);
 			output = await this.replaceDateVariableInString(output);
 			output = await this.replaceVariableInString(output);
-			// Links + {{filenamecurrent}} + {{folder}} in one pass so no token
-			// re-scans another's output (#1358). ({{title}} has never been resolved
-			// in this preview formatter — preserved by omitting it.)
+			// Links + {{filenamecurrent}} + {{folder}} + {{foldercurrent}} in one
+			// pass so no token re-scans another's output (#1358). ({{title}} has
+			// never been resolved in this preview formatter — preserved by omitting
+			// it.) The preview resolver never returns null, so no throw here.
 			output = this.replaceCurrentFileTokensInString(output, {
 				links: true,
 				fileName: true,
 				folder: true,
+				activeFolder: "content",
 			});
 			output = await this.replaceMacrosInString(output);
 			output = await this.replaceTemplateInString(output);
@@ -110,6 +113,11 @@ export class FormatDisplayFormatter extends Formatter {
 	protected getCurrentFileName(): string | null {
 		if (!this.app) return "current_filename";
 		return getCurrentFileNamePreview(this.app.workspace.getActiveFile());
+	}
+
+	protected getCurrentFolderPath(): string | null {
+		if (!this.app) return "current_folder";
+		return getCurrentFolderPathPreview(this.app.workspace.getActiveFile());
 	}
 
 	protected suggestForValue(

--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -32,6 +32,8 @@ const CURRENT_AND_2120_EXAMPLES = [
 	"Notes from {{FILENAMECURRENT}}",
 	"Filed under {{FOLDER}}",
 	"{{FOLDER|name}} - {{VALUE:title}}",
+	"{{FOLDERCURRENT}}/Project Tasks.md",
+	"Tasks for {{FOLDERCURRENT|name}}",
 	"{{MACRO:Generate summary}}",
 	"{{MACRO:Choose project|label:Project}}",
 	"{{TEMPLATE:Templates/Meeting.md}}",
@@ -152,6 +154,9 @@ class DocsExampleFormatter extends Formatter {
 		output = this.replaceLinkToCurrentSectionInString(output);
 		output = await this.replaceCurrentFileNameInString(output);
 		output = this.replaceTargetFolderInString(output);
+		output = this.replaceCurrentFileTokensInString(output, {
+			activeFolder: "content",
+		});
 		output = this.replaceRandomInString(output);
 		output = this.replaceTitleInString(output);
 		return output;
@@ -180,6 +185,10 @@ class DocsExampleFormatter extends Formatter {
 
 	protected getCurrentFileName(): string {
 		return "Current Note";
+	}
+
+	protected getCurrentFolderPath(): string {
+		return "Projects/Alpha";
 	}
 
 	protected getVariableValue(variableName: string): string {

--- a/src/formatters/formatter-foldercurrent.test.ts
+++ b/src/formatters/formatter-foldercurrent.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import { Formatter } from "./formatter";
+
+/**
+ * Combined-pass semantics for {{FOLDERCURRENT}} (issue #1480): the active
+ * file's folder, resolved in the same single function-replacer pass as the
+ * other note-derived tokens (#1358). The distinguishing contracts under test:
+ *  - "path" mode: a missing active file ALWAYS throws, even when the
+ *    (append-link-controlled) behavior is "optional" — a strip would silently
+ *    retarget the produced path to the vault root.
+ *  - "content" mode: follows the sibling tokens' required/optional contract.
+ *  - "" (root-level active file) is a legitimate resolution, never "missing".
+ * CompleteFormatter's production wiring is covered in completeFormatter.test.ts.
+ */
+
+class StubFormatter extends Formatter {
+	public activeFolderPath: string | null = null;
+
+	constructor() {
+		super();
+	}
+
+	protected async format(input: string): Promise<string> {
+		return input;
+	}
+
+	protected getCurrentFileLink(): string | null {
+		return null;
+	}
+
+	protected getCurrentFileName(): string | null {
+		return "ActiveNote";
+	}
+
+	protected getCurrentFolderPath(): string | null {
+		return this.activeFolderPath;
+	}
+
+	protected async promptForValue(): Promise<string> {
+		return "";
+	}
+
+	protected async promptForMathValue(): Promise<string> {
+		return "";
+	}
+
+	protected getVariableValue(_variableName: string): string {
+		return "";
+	}
+
+	protected async suggestForValue(): Promise<string> {
+		return "";
+	}
+
+	protected suggestForFile(): string {
+		return "";
+	}
+
+	protected async suggestForField(): Promise<string> {
+		return "";
+	}
+
+	protected async getMacroValue(): Promise<string> {
+		return "";
+	}
+
+	protected async promptForVariable(): Promise<string> {
+		return "";
+	}
+
+	protected async getTemplateContent(): Promise<string> {
+		return "";
+	}
+
+	protected async getSelectedText(): Promise<string> {
+		return "";
+	}
+
+	protected async getClipboardContent(): Promise<string> {
+		return "";
+	}
+
+	protected isTemplatePropertyTypesEnabled(): boolean {
+		return false;
+	}
+
+	public processPath(input: string): string {
+		return this.replaceCurrentFileTokensInString(input, {
+			fileName: true,
+			folder: true,
+			activeFolder: "path",
+		});
+	}
+
+	public processContent(input: string): string {
+		return this.replaceCurrentFileTokensInString(input, {
+			links: true,
+			fileName: true,
+			folder: true,
+			activeFolder: "content",
+			title: true,
+		});
+	}
+
+	public processWithoutActiveFolder(input: string): string {
+		return this.replaceCurrentFileTokensInString(input, {
+			fileName: true,
+			folder: true,
+		});
+	}
+}
+
+function makeFormatter(activeFolderPath: string | null): StubFormatter {
+	const formatter = new StubFormatter();
+	formatter.activeFolderPath = activeFolderPath;
+	return formatter;
+}
+
+describe("Formatter {{FOLDERCURRENT}} token", () => {
+	it("resolves {{FOLDERCURRENT}} to the active file's folder path in a capture target", () => {
+		const formatter = makeFormatter("Projects/Alpha");
+		expect(formatter.processPath("{{FOLDERCURRENT}}/Project Tasks.md")).toBe(
+			"Projects/Alpha/Project Tasks.md",
+		);
+	});
+
+	it("resolves {{FOLDERCURRENT|name}} to the leaf folder segment", () => {
+		const formatter = makeFormatter("Projects/Alpha");
+		expect(formatter.processPath("{{FOLDERCURRENT|name}} tasks")).toBe(
+			"Alpha tasks",
+		);
+	});
+
+	it("treats a single-segment folder as both full path and leaf", () => {
+		const formatter = makeFormatter("Inbox");
+		expect(
+			formatter.processPath("{{FOLDERCURRENT}}|{{FOLDERCURRENT|name}}"),
+		).toBe("Inbox|Inbox");
+	});
+
+	it("is case-insensitive for the token and the modifier", () => {
+		const formatter = makeFormatter("Projects/Alpha");
+		expect(
+			formatter.processPath("{{foldercurrent}} / {{FolderCurrent|NAME}}"),
+		).toBe("Projects/Alpha / Alpha");
+	});
+
+	it("replaces multiple occurrences in one pass", () => {
+		const formatter = makeFormatter("A/B");
+		expect(formatter.processPath("{{FOLDERCURRENT}}-{{FOLDERCURRENT}}")).toBe(
+			"A/B-A/B",
+		);
+	});
+
+	it("treats '$' in a folder name literally (no regex re-expansion)", () => {
+		const formatter = makeFormatter("Cash$Money");
+		expect(formatter.processPath("{{FOLDERCURRENT}}")).toBe("Cash$Money");
+	});
+
+	it("treats a root-level active file ('') as a legitimate resolution, not missing", () => {
+		const formatter = makeFormatter("");
+		// Downstream (resolveCaptureTarget / normalizeMarkdownFilePath) strips the
+		// leading slash, landing the capture at the vault root — the correct
+		// sibling of a root-level note.
+		expect(formatter.processPath("{{FOLDERCURRENT}}/Tasks.md")).toBe(
+			"/Tasks.md",
+		);
+		expect(formatter.processPath("{{FOLDERCURRENT|name}}")).toBe("");
+	});
+
+	it("keeps {{FOLDER}} and {{FOLDERCURRENT}} independent in one pass", () => {
+		const formatter = makeFormatter("Projects/Alpha");
+		formatter.setTargetFolderPath("Journal/Daily");
+		expect(
+			formatter.processPath(
+				"{{FOLDER}} + {{FOLDERCURRENT}} + {{FOLDER|name}} + {{FOLDERCURRENT|name}}",
+			),
+		).toBe("Journal/Daily + Projects/Alpha + Daily + Alpha");
+	});
+
+	it("leaves the token verbatim when the activeFolder category is inactive", () => {
+		const formatter = makeFormatter("Projects/Alpha");
+		expect(formatter.processWithoutActiveFolder("{{FOLDERCURRENT}}/x")).toBe(
+			"{{FOLDERCURRENT}}/x",
+		);
+	});
+
+	it("does not re-scan a folder value that is itself named like a token (#1358)", () => {
+		const formatter = makeFormatter("{{filenamecurrent}}");
+		// The folder value must be inserted literally while the real
+		// {{FILENAMECURRENT}} elsewhere still resolves independently.
+		expect(
+			formatter.processPath("{{FOLDERCURRENT}}/{{FILENAMECURRENT}}"),
+		).toBe("{{filenamecurrent}}/ActiveNote");
+	});
+
+	describe("missing active file", () => {
+		const error =
+			"Unable to get the active file's folder. Make sure you have a file open in the editor.";
+
+		it("throws in path mode with required behavior", () => {
+			const formatter = makeFormatter(null);
+			expect(() => formatter.processPath("{{FOLDERCURRENT}}/x.md")).toThrow(
+				error,
+			);
+		});
+
+		it("throws in path mode even when behavior is optional (no silent root capture)", () => {
+			const formatter = makeFormatter(null);
+			formatter.setLinkToCurrentFileBehavior("optional");
+			expect(() => formatter.processPath("{{FOLDERCURRENT}}/x.md")).toThrow(
+				error,
+			);
+		});
+
+		it("throws in content mode with required behavior", () => {
+			const formatter = makeFormatter(null);
+			expect(() => formatter.processContent("in {{FOLDERCURRENT}}")).toThrow(
+				error,
+			);
+		});
+
+		it("strips in content mode when behavior is optional", () => {
+			const formatter = makeFormatter(null);
+			formatter.setLinkToCurrentFileBehavior("optional");
+			expect(formatter.processContent("in [{{FOLDERCURRENT}}]")).toBe(
+				"in []",
+			);
+		});
+	});
+});

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -642,9 +642,12 @@ export abstract class Formatter {
 		// In a "path" context a missing active folder ALWAYS aborts, regardless of
 		// the (append-link-controlled) required/optional behaviour: stripping the
 		// token would leave a fully valid path that silently retargets the write
-		// (e.g. "{{foldercurrent}}/Tasks.md" -> the vault root). No other missing
-		// token can co-occur here in practice — path contexts never enable links —
-		// so this early throw does not reorder the legacy message precedence below.
+		// (e.g. "{{foldercurrent}}/Tasks.md" -> the vault root). Path contexts
+		// never enable links, but they DO enable fileName, so a missing
+		// {{filenamecurrent}} can co-occur — this early throw then reports the
+		// folder message instead of the file-name one. Acceptable: both point at
+		// the same remedy (open a file), and only the folder token carries the
+		// must-not-strip property that justifies preempting the behaviour check.
 		const activeFolderError =
 			"Unable to get the active file's folder. Make sure you have a file open in the editor.";
 		if (missingActiveFolder && opts.activeFolder === "path") {

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -488,7 +488,8 @@ export abstract class Formatter {
 
 	/**
 	 * Resolves the note-derived contextual tokens — {{linkcurrent}},
-	 * {{linksection}}, {{filenamecurrent}}, {{folder}}/{{folder|name}} and
+	 * {{linksection}}, {{filenamecurrent}}, {{folder}}/{{folder|name}},
+	 * {{foldercurrent}}/{{foldercurrent|name}} and
 	 * {{title}} — in a SINGLE function-replacer pass. Each token's replacement
 	 * embeds user-controlled text (the active file's basename, the target folder's
 	 * name, the note title), so resolving them as separate sequential passes lets
@@ -511,6 +512,17 @@ export abstract class Formatter {
 	 * {{folder}}/{{title}} never throw. The link message takes precedence over the
 	 * file-name message, matching the legacy "links resolved before file name"
 	 * order.
+	 *
+	 * {{foldercurrent}} (the ACTIVE file's folder, issue #1480) is mode-scoped via
+	 * `activeFolder`: in "path" contexts (file names, capture targets, folder
+	 * paths) a missing active file ALWAYS throws — an optional-strip there would
+	 * silently retarget the produced path to the vault root (e.g.
+	 * "{{foldercurrent}}/Tasks.md" -> "/Tasks.md"), misplacing data whenever the
+	 * append-link setting has relaxed the behaviour to "optional" (that knob
+	 * governs link insertion, never where data files). In "content" contexts it
+	 * follows the same required/optional contract as the link/file-name tokens.
+	 * A root-level active file resolves to "" — a LEGITIMATE value, so "missing"
+	 * is detected with `=== null`, never falsiness.
 	 */
 	protected replaceCurrentFileTokensInString(
 		input: string,
@@ -518,15 +530,19 @@ export abstract class Formatter {
 			links?: boolean;
 			fileName?: boolean;
 			folder?: boolean;
+			activeFolder?: "path" | "content";
 			title?: boolean;
 		},
 	): string {
 		// One alternation over every note-derived token. The |name modifier is
-		// scoped to FOLDER (capture group 3) so the other tokens match EXACTLY as
-		// their individual regexes do (e.g. {{TITLE|name}} stays literal). Built
-		// fresh per call so the global lastIndex is never shared across invocations.
+		// scoped to the two FOLDER tokens (capture group 3) so the other tokens
+		// match EXACTLY as their individual regexes do (e.g. {{TITLE|name}} stays
+		// literal). FOLDERCURRENT is listed before its prefix FOLDER purely to
+		// avoid a pointless backtrack — the trailing `}}` makes the arms
+		// unambiguous either way. Built fresh per call so the global lastIndex is
+		// never shared across invocations.
 		const regex =
-			/{{(?:(LINKCURRENT|LINKSECTION|FILENAMECURRENT|TITLE)|(FOLDER)(\|name)?)}}/gi;
+			/{{(?:(LINKCURRENT|LINKSECTION|FILENAMECURRENT|TITLE)|(FOLDERCURRENT|FOLDER)(\|name)?)}}/gi;
 
 		// Each category is resolved lazily, at most once. `undefined` means "not
 		// yet resolved"; the resolvers may legitimately return null/"" (a missing
@@ -537,9 +553,13 @@ export abstract class Formatter {
 		let fileName: string | null | undefined;
 		let folderFull: string | undefined;
 		let folderLeaf: string | undefined;
+		// null = no active file; "" = root-level active file (legitimate).
+		let activeFolderFull: string | null | undefined;
+		let activeFolderLeaf: string | null | undefined;
 		let title: string | undefined;
 		let missingLink = false;
 		let missingFileName = false;
+		let missingActiveFolder = false;
 
 		const output = input.replace(
 			regex,
@@ -549,6 +569,32 @@ export abstract class Formatter {
 				folderToken: string | undefined,
 				folderModifier: string | undefined,
 			) => {
+				// FOLDERCURRENT (optional |name): the ACTIVE file's folder. "" (a
+				// root-level file) is a legitimate resolution; only null marks the
+				// active file as missing.
+				if (
+					folderToken !== undefined &&
+					folderToken.toUpperCase() === "FOLDERCURRENT"
+				) {
+					if (!opts.activeFolder) return match;
+					if (activeFolderFull === undefined) {
+						activeFolderFull = this.getCurrentFolderPath();
+						if (activeFolderFull === null) {
+							activeFolderLeaf = null;
+						} else {
+							const slash = activeFolderFull.lastIndexOf("/");
+							activeFolderLeaf =
+								slash === -1
+									? activeFolderFull
+									: activeFolderFull.slice(slash + 1);
+						}
+					}
+					if (activeFolderFull === null) missingActiveFolder = true;
+					return (
+						(folderModifier ? activeFolderLeaf : activeFolderFull) ?? ""
+					);
+				}
+
 				// FOLDER (optional |name). Never throws; "" when no target folder.
 				if (folderToken !== undefined) {
 					if (!opts.folder) return match;
@@ -593,15 +639,30 @@ export abstract class Formatter {
 			},
 		);
 
+		// In a "path" context a missing active folder ALWAYS aborts, regardless of
+		// the (append-link-controlled) required/optional behaviour: stripping the
+		// token would leave a fully valid path that silently retargets the write
+		// (e.g. "{{foldercurrent}}/Tasks.md" -> the vault root). No other missing
+		// token can co-occur here in practice — path contexts never enable links —
+		// so this early throw does not reorder the legacy message precedence below.
+		const activeFolderError =
+			"Unable to get the active file's folder. Make sure you have a file open in the editor.";
+		if (missingActiveFolder && opts.activeFolder === "path") {
+			throw new Error(activeFolderError);
+		}
+
 		// Required/optional handling mirrors the individual replacers. A missing
 		// link takes precedence over a missing file name (legacy "links first"
-		// order); the messages are kept byte-identical to those replacers.
-		if (missingLink || missingFileName) {
+		// order), and both over a missing active folder; the link/file-name
+		// messages are kept byte-identical to those replacers.
+		if (missingLink || missingFileName || missingActiveFolder) {
 			if (this.linkToCurrentFileBehavior === "required") {
 				throw new Error(
 					missingLink
 						? "Unable to get current file path. Make sure you have a file open in the editor."
-						: "Unable to get current file name. Make sure you have a file open in the editor.",
+						: missingFileName
+							? "Unable to get current file name. Make sure you have a file open in the editor."
+							: activeFolderError,
 				);
 			}
 			log.logMessage(
@@ -702,7 +763,20 @@ export abstract class Formatter {
 		return null;
 	}
 
-
+	/**
+	 * Resolves the ACTIVE file's parent folder for {{foldercurrent}} as a clean
+	 * vault-relative path (no leading/trailing slash; "" for a root-level file,
+	 * mirroring setTargetFolderPath's "/" -> "" collapse). Returns null ONLY when
+	 * there is no active file — "" is a legitimate resolution, and the combined
+	 * resolver distinguishes the two with `=== null`. Defaults to "not supported"
+	 * (null) so subclasses that never enable the `activeFolder` category — and
+	 * the many test stubs — need no change; the runtime resolver lives in
+	 * CompleteFormatter, and the preview formatters override it with a
+	 * never-null preview value.
+	 */
+	protected getCurrentFolderPath(): string | null {
+		return null;
+	}
 
 	/**
 	 * Warn once when the same `|name` is given two different option lists in one

--- a/src/formatters/helpers/previewHelpers.ts
+++ b/src/formatters/helpers/previewHelpers.ts
@@ -107,6 +107,20 @@ export function getCurrentFileNamePreview(activeFile?: {basename: string} | null
 }
 
 /**
+ * Gets a {{foldercurrent}} preview: the active file's folder path. Obsidian's
+ * root TFolder has path "/", which the runtime resolver collapses to "" - the
+ * preview shows the same truthful empty string. Never null, so the preview
+ * pass can never hit the runtime's missing-active-file throw.
+ */
+export function getCurrentFolderPathPreview(
+	activeFile?: { parent?: { path: string } | null } | null,
+): string {
+	if (!activeFile) return "current_folder";
+	const parentPath = activeFile.parent?.path ?? "";
+	return parentPath === "/" ? "" : parentPath;
+}
+
+/**
  * Enhanced date format preview generator with comprehensive pattern support
  */
 export class DateFormatPreviewGenerator {

--- a/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
+++ b/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
@@ -18,7 +18,12 @@ let {
 	targetFolderPath,
 }: {
 	value: string;
-	formatterKind?: "format" | "fileName";
+	/**
+	 * "lineTarget" is the insert-after/before selector preview: identical to
+	 * "format" except {{foldercurrent}} stays literal, matching the runtime
+	 * formatLocationString (which deliberately never resolves it in selectors).
+	 */
+	formatterKind?: "format" | "fileName" | "lineTarget";
 	app: App;
 	plugin: QuickAdd;
 	/**
@@ -40,7 +45,9 @@ let previewToken = 0;
 const formatter = $derived(
 	formatterKind === "fileName"
 		? new FileNameDisplayFormatter(app, plugin)
-		: new FormatDisplayFormatter(app, plugin),
+		: new FormatDisplayFormatter(app, plugin, undefined, {
+				resolveActiveFolder: formatterKind !== "lineTarget",
+			}),
 );
 
 $effect(() => {

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -10,7 +10,10 @@ import {
 	CREATE_IF_NOT_FOUND_ORDERED,
 	CREATE_IF_NOT_FOUND_TOP,
 } from "../../../constants";
-import { FormatSyntaxSuggester } from "../../suggesters/formatSyntaxSuggester";
+import {
+	FormatSyntaxSuggester,
+	FormatSyntaxToken,
+} from "../../suggesters/formatSyntaxSuggester";
 import { detectDateFormatFromAfter } from "../../../utils/insertAfterDateFormat";
 import { FormatDisplayFormatter } from "../../../formatters/formatDisplayFormatter";
 import SettingItem from "../../components/SettingItem.svelte";
@@ -46,8 +49,13 @@ if (!insertAfter.createIfNotFoundLocation)
 	insertAfter.createIfNotFoundLocation = CREATE_IF_NOT_FOUND_TOP;
 
 const suggesters = [
+	// Line-target field: withhold {{foldercurrent}}, which formatLocationString
+	// deliberately leaves literal in selectors (a legitimate "" resolution would
+	// match the first line), so it is never suggested where it cannot resolve.
 	(el: HTMLInputElement | HTMLTextAreaElement) =>
-		new FormatSyntaxSuggester(app, el, plugin),
+		new FormatSyntaxSuggester(app, el, plugin, false, [
+			FormatSyntaxToken.FolderCurrent,
+		]),
 ];
 
 const blankLineOptions = [

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -259,7 +259,7 @@ function onPromptHeadingToggle(value: boolean) {
 		name="Insert after"
 		desc="Insert capture after specified text. Accepts format syntax. Tip: use a heading (starts with #) to target a section. Blank line handling is configurable below."
 	/>
-	<FormatPreviewField value={insertAfter.after} {app} {plugin} />
+	<FormatPreviewField value={insertAfter.after} formatterKind="lineTarget" {app} {plugin} />
 	<ValidatedInput
 		bind:value={insertAfter.after}
 		placeholder="Insert after"

--- a/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
@@ -58,7 +58,7 @@ const createLocationOptions = [
 	name="Insert before"
 	desc="Insert capture before specified text. Accepts format syntax."
 />
-<FormatPreviewField value={insertBefore.before} {app} {plugin} />
+<FormatPreviewField value={insertBefore.before} formatterKind="lineTarget" {app} {plugin} />
 <ValidatedInput
 	bind:value={insertBefore.before}
 	placeholder="Insert before"

--- a/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
@@ -7,7 +7,10 @@ import {
 	CREATE_IF_NOT_FOUND_CURSOR,
 	CREATE_IF_NOT_FOUND_TOP,
 } from "../../../constants";
-import { FormatSyntaxSuggester } from "../../suggesters/formatSyntaxSuggester";
+import {
+	FormatSyntaxSuggester,
+	FormatSyntaxToken,
+} from "../../suggesters/formatSyntaxSuggester";
 import SettingItem from "../../components/SettingItem.svelte";
 import Toggle from "../../components/Toggle.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
@@ -35,8 +38,13 @@ if (!insertBefore.createIfNotFoundLocation)
 	insertBefore.createIfNotFoundLocation = CREATE_IF_NOT_FOUND_TOP;
 
 const suggesters = [
+	// Line-target field: withhold {{foldercurrent}}, which formatLocationString
+	// deliberately leaves literal in selectors (a legitimate "" resolution would
+	// match the first line), so it is never suggested where it cannot resolve.
 	(el: HTMLInputElement | HTMLTextAreaElement) =>
-		new FormatSyntaxSuggester(app, el, plugin),
+		new FormatSyntaxSuggester(app, el, plugin, false, [
+			FormatSyntaxToken.FolderCurrent,
+		]),
 ];
 
 const createLocationOptions = [

--- a/src/gui/suggesters/formatSyntaxSuggester.foldercurrent.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.foldercurrent.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { FormatSyntaxSuggester } from "./formatSyntaxSuggester";
+
+// Minimal Obsidian DOM polyfills (same shape as formatSyntaxSuggester.case.test.ts).
+function ensureObsidianDomPolyfills(): void {
+	(globalThis as any).createDiv ??= (cls?: string) => {
+		const div = document.createElement("div");
+		if (cls) div.className = cls;
+		return div;
+	};
+	const proto = HTMLElement.prototype as any;
+	proto.createDiv ??= function (arg?: string | { cls?: string }) {
+		const div = document.createElement("div");
+		if (typeof arg === "string") div.className = arg;
+		else if (arg && typeof arg === "object" && typeof arg.cls === "string")
+			div.className = arg.cls;
+		this.appendChild(div);
+		return div;
+	};
+	proto.empty ??= function () {
+		this.replaceChildren();
+		return this;
+	};
+	proto.on ??= function () {
+		return this;
+	};
+	proto.detach ??= function () {
+		this.remove();
+	};
+	proto.addClass ??= function (...classes: string[]) {
+		this.classList.add(...classes);
+		return this;
+	};
+	proto.removeClass ??= function (...classes: string[]) {
+		this.classList.remove(...classes);
+		return this;
+	};
+	proto.setAttr ??= function (name: string, value: string) {
+		this.setAttribute(name, value);
+		return this;
+	};
+}
+
+function suggestFor(
+	value: string,
+	suggestForFileNames = false,
+): Promise<string[]> {
+	const app = {
+		dom: { appContainerEl: document.body },
+		keymap: { pushScope: () => {}, popScope: () => {} },
+	} as any;
+	const plugin = {
+		settings: { choices: [], globalVariables: {} },
+		getTemplateFiles: () => [],
+	} as any;
+	const inputEl = document.createElement("input");
+	inputEl.value = value;
+	inputEl.selectionStart = value.length;
+	inputEl.selectionEnd = value.length;
+	const suggester = new FormatSyntaxSuggester(
+		app,
+		inputEl,
+		plugin,
+		suggestForFileNames,
+	);
+	return suggester.getSuggestions(value).finally(() => suggester.destroy());
+}
+
+describe("FormatSyntaxSuggester {{foldercurrent}} (shared {{folder prefix)", () => {
+	beforeEach(() => {
+		ensureObsidianDomPolyfills();
+	});
+
+	it("offers {{foldercurrent}} in the contextual set (format bodies + Capture To field)", async () => {
+		const s = await suggestFor("{{foldercurrent");
+		expect(s).toContain("{{foldercurrent}}");
+	});
+
+	it("narrows to foldercurrent only once disambiguated by 'c' (contextual set)", async () => {
+		const s = await suggestFor("{{folderc");
+		expect(s).toContain("{{foldercurrent}}");
+		// {{folder|name}} lives only in the file-name set, and no bare {{folder}}
+		// completion should survive the 'c'.
+		expect(s.some((x) => /^\{\{folder\}?\}?$/.test(x))).toBe(false);
+	});
+
+	it("offers both folder tokens at the ambiguous {{folder prefix in the file-name set", async () => {
+		const s = await suggestFor("{{folder", true);
+		expect(s).toContain("{{folder|name}}");
+		expect(s).toContain("{{foldercurrent|name}}");
+	});
+
+	it("offers only the |name form in the file-name set (full-path nesting footgun)", async () => {
+		const s = await suggestFor("{{folderc", true);
+		expect(s).toContain("{{foldercurrent|name}}");
+		expect(s).not.toContain("{{foldercurrent}}");
+		expect(s).not.toContain("{{folder|name}}");
+	});
+});

--- a/src/gui/suggesters/formatSyntaxSuggester.foldercurrent.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.foldercurrent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { FormatSyntaxSuggester } from "./formatSyntaxSuggester";
+import { FormatSyntaxSuggester, FormatSyntaxToken } from "./formatSyntaxSuggester";
 
 // Minimal Obsidian DOM polyfills (same shape as formatSyntaxSuggester.case.test.ts).
 function ensureObsidianDomPolyfills(): void {
@@ -44,6 +44,7 @@ function ensureObsidianDomPolyfills(): void {
 function suggestFor(
 	value: string,
 	suggestForFileNames = false,
+	excludeTokens: FormatSyntaxToken[] = [],
 ): Promise<string[]> {
 	const app = {
 		dom: { appContainerEl: document.body },
@@ -62,6 +63,7 @@ function suggestFor(
 		inputEl,
 		plugin,
 		suggestForFileNames,
+		excludeTokens,
 	);
 	return suggester.getSuggestions(value).finally(() => suggester.destroy());
 }
@@ -95,5 +97,19 @@ describe("FormatSyntaxSuggester {{foldercurrent}} (shared {{folder prefix)", () 
 		expect(s).toContain("{{foldercurrent|name}}");
 		expect(s).not.toContain("{{foldercurrent}}");
 		expect(s).not.toContain("{{folder|name}}");
+	});
+
+	it("withholds the token when excluded (insert-after/before line-target fields)", async () => {
+		// formatLocationString leaves {{foldercurrent}} literal in line selectors,
+		// so those fields exclude it — no suggester/runtime mismatch.
+		const s = await suggestFor("{{folderc", false, [
+			FormatSyntaxToken.FolderCurrent,
+		]);
+		expect(s).not.toContain("{{foldercurrent}}");
+		// Other contextual tokens are unaffected by the exclusion.
+		const links = await suggestFor("{{linkc", false, [
+			FormatSyntaxToken.FolderCurrent,
+		]);
+		expect(links).toContain("{{linkcurrent}}");
 	});
 });

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -12,6 +12,9 @@ import {
 	FILENAMECURRENT_SYNTAX,
 	FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
 	FILE_SYNTAX_SUGGEST_REGEX,
+	FOLDERCURRENT_SYNTAX,
+	FOLDERCURRENT_NAME_SYNTAX,
+	FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
 	FOLDER_SYNTAX_SUGGEST_REGEX,
 	MACRO_SYNTAX_SUGGEST_REGEX,
 	MATH_VALUE_SYNTAX,
@@ -48,6 +51,7 @@ enum FormatSyntaxToken {
 	LinkCurrent,
 	LinkSection,
 	FilenameCurrent,
+	FolderCurrent,
 	FolderTarget,
 	Macro,
 	Template,
@@ -165,6 +169,14 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 			token: FormatSyntaxToken.FilenameCurrent,
 			suggestion: FILENAMECURRENT_SYNTAX
 		},
+		// Offered in the contextual set because it serves BOTH format bodies and
+		// the capture "Capture to" field (which constructs this suggester without
+		// suggestForFileNames) — the field the token was built for (#1480).
+		{
+			regex: FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
+			token: FormatSyntaxToken.FolderCurrent,
+			suggestion: FOLDERCURRENT_SYNTAX
+		},
 		{
 			regex: TITLE_SYNTAX_SUGGEST_REGEX,
 			token: FormatSyntaxToken.Title,
@@ -203,6 +215,15 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 			regex: FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
 			token: FormatSyntaxToken.FilenameCurrent,
 			suggestion: FILENAMECURRENT_SYNTAX,
+		},
+		// Same |name-only rationale as {{folder|name}} above: with a configured
+		// target folder, a full-path expansion in a Template file name nests under
+		// it ("Notes/Projects/Alpha/Note.md"); the leaf form avoids that footgun.
+		// The full {{foldercurrent}} remains available in the contextual set.
+		{
+			regex: FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
+			token: FormatSyntaxToken.FolderCurrent,
+			suggestion: FOLDERCURRENT_NAME_SYNTAX,
 		},
 	];
 

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -40,7 +40,7 @@ import type QuickAdd from "../../main";
 import { replaceRange } from "./utils";
 import { flattenChoices } from "../../utils/choiceUtils";
 
-enum FormatSyntaxToken {
+export enum FormatSyntaxToken {
 	Date,
 	DateFormat,
 	VariableDate,
@@ -231,7 +231,13 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 		public app: App,
 		public inputEl: HTMLInputElement | HTMLTextAreaElement,
 		private plugin: QuickAdd,
-		private suggestForFileNames: boolean = false
+		private suggestForFileNames: boolean = false,
+		// Tokens to withhold in this field. Used by the insert-after/before
+		// line-target fields, where formatLocationString deliberately leaves
+		// {{foldercurrent}} literal (it can legitimately resolve to "", and an
+		// empty selector would match the first line) — offering it there would be
+		// a suggester/runtime mismatch.
+		private excludeTokens: FormatSyntaxToken[] = []
 	) {
 		super(app, inputEl);
 
@@ -298,7 +304,7 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 		const allTokens = [
 			...this.tokenDefinitions,
 			...(this.suggestForFileNames ? this.fileNameTokens : this.contextualTokens)
-		];
+		].filter((def) => !this.excludeTokens.includes(def.token));
 
 		for (const tokenDef of allTokens) {
 			const match = tokenDef.regex.exec(inputSegment);


### PR DESCRIPTION
Adds a first-class format-syntax token for the active file's folder, so captures can target a sibling of the active note (`{{FOLDERCURRENT}}/Project Tasks.md`) without the two-step macro workaround.

Closes #1480. Refs discussion #214 (the original ask) - per-project capture into a same-named sibling file.

## Design

**Name.** `{{FOLDERCURRENT}}` follows the existing family shape (`{{LINKCURRENT}}`, `{{FILENAMECURRENT}}` - noun + `CURRENT`), pairing with `{{FOLDER}}` (target folder of the note being created) and inheriting the `|name` leaf modifier from `{{FOLDER|name}}`. The issue's `{{CURRENTFOLDERPATH}}` matches no existing token shape.

**Semantics.** Resolves to the active file's parent folder, vault-relative, no trailing slash. Obsidian's root `TFolder.path` is `"/"`, collapsed to `""` (mirroring `setTargetFolderPath`), so a root-level note captures to a root-level sibling. `{{FOLDERCURRENT|name}}` yields the leaf segment.

**Rescan safety (#1358).** Resolved inside the existing single-pass note-derived-token resolver (`replaceCurrentFileTokensInString`) - alternation extended to `(FOLDERCURRENT|FOLDER)(\|name)?` - so a folder literally named like a token can never loop or corrupt another token's output.

**No active file - the key contract.** Context-dependent, hardened by adversarial design review:
- **Path contexts** (`formatFileName` = file names + capture targets, `formatFolderPath` = Template folder strings): a missing active file **always throws** a clear error, even when the append-link setting has relaxed `linkToCurrentFileBehavior` to `optional`. An optional-strip would turn `{{FOLDERCURRENT}}/Tasks.md` into `/Tasks.md` and silently capture to the vault root; the append-link knob governs link insertion, never where data files. (`{{FILENAMECURRENT}}` is accidentally saved from the analogous hazard by the empty-basename guard; an empty folder leaves a fully valid path, so the guard lives in the token.)
- **Content** (`formatFileContent`): follows the sibling tokens' required/optional contract - an empty string in a note body cannot misplace data.
- `""` (root) is a legitimate resolution; missing is detected with `=== null`, never falsiness.

**Where it deliberately does NOT resolve.**
- Insert-after/before line selectors (`formatLocationString`): like `{{FOLDER}}`, it can legitimately resolve to `""`, and an empty selector would match the first line. The line-target fields' suggesters withhold it so it is never offered where it stays literal.
- Template SOURCE paths (`formatTemplateFilePath`): all note-relative tokens stay literal there (family-uniform).
- `formatFolderPath` IS enabled (reviewer-driven reversal): left literal, the token would be threaded into `getOrCreateFolder(..., {allowCreate: true})` and silently create a vault folder named `{{foldercurrent}}`; and `{{FOLDERCURRENT}}/Subnotes` composes in a way the existing `createInSameFolderAsActiveFile` setting cannot express.

**Security.** The value comes from `TFile.parent.path` - vault-internal, NFC-normalized, never contains `..`/`\`/absolute segments - inserted via function replacer (no `$` expansion, never re-scanned). The formatted target still flows through `normalizeGeneratedFilePath` and the authoritative `escapesVaultBoundary` sink. A tokenized capture target already classifies as no-picker-scope (`hasTemplatePathSyntax`), so the #1448 reserved-variable confinement is unaffected.

**Discoverability.** Suggester: bare token in the contextual set (format bodies + Capture To field); `{{foldercurrent|name}}`-only in the Template file-name set (same footgun rationale as `{{folder|name}}`: a full-path expansion nests under a configured folder). Live previews in both display formatters via a never-null preview resolver.

## Validation

- Full suite green (3600+ tests incl. 30 new: single-pass semantics, path-vs-content missing-file contract, root collapse, #1358 adversarial folder names, suggester prefix interplay, previews), eslint, tsc, svelte-check.
- **Live e2e** (isolated Obsidian 1.13.0 instance, `obsidian:e2e`), reproducing discussion #214: one capture choice `Capture To: {{FOLDERCURRENT}}/Project Tasks.md`
  - from `Projects/Alpha/Meeting.md` -> task landed in `Projects/Alpha/Project Tasks.md`; Beta untouched
  - from `Projects/Beta/Kickoff.md` -> landed in Beta's sibling
  - create-if-missing sibling created in the active folder
  - root-level note (`parent.path === "/"`) -> sibling created at vault root
  - no active file -> error notice "Unable to get the active file's folder. Make sure you have a file open in the editor.", zero files written
  - **append-link optional mode + no active file -> same clear error, no silent root write** (the design-review scenario)
- Design + implementation each passed a two-reviewer adversarial pass (independent lenses); all findings addressed in the last commit or noted below.

## Tradeoffs / notes for review

- **Versioned docs**: the token is documented in `docs/docs` AND the frozen `version-2.17.2` snapshot. One reviewer objected (snapshot documents an unreleased token); kept because the docs site serves the versioned snapshot at its root (`docs/docs` is `/next/`), so docs-only-in-next are invisible to users - established repo practice. Drop the versioned hunk if you prefer snapshot purity.
- Known pre-existing residuals (shared by ALL tokens, documented, not fixed here): a vault folder literally named like a capture selector (`#x`, `property:x`) makes the formatted target reparse as that selector (visible picker, never a silent write); the capture folder-picker branch re-runs `formatFileName` on the picked path.
- Inherited surfaces via `formatFileName` (intentional): macro Open File paths, `TemplateInsertEngine` move-offer names, Template file names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `{{FOLDERCURRENT}}` and `{{FOLDERCURRENT|name}}` format syntax for active-file folder paths, including file-name, note content, folder path generation, and template folder selection.
  * Enhanced autocomplete to surface the new token in the correct fields.

* **Bug Fixes**
  * Corrected root/no-active-file behavior for folder-current resolution.
  * Prevented unintended re-processing when folder paths resemble placeholders.

* **Documentation**
  * Updated both current and versioned format syntax docs to clarify `{{FOLDER}}` vs `{{FOLDERCURRENT}}` usage and behaviors.

* **Tests**
  * Added coverage for token resolution, previews, and line-target selector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->