### PR TITLE
feat(append-link): keep the selected text as the link display text

### DIFF
--- a/docs/docs/Choices/CaptureChoice.md
+++ b/docs/docs/Choices/CaptureChoice.md
@@ -237,6 +237,8 @@ The Capture builder is grouped into sections: **Location**, **Position**, **Link
 
     For any **Current note** body placement — **Replace selection**, **After selection**, **End of line**, and **New line** — an extra _Link type_ dropdown appears, letting you choose **Link** (`[[Note]]`) or **Embed** (`![[Note]]`). An embed transcludes the linked note's contents at the placement position (for example **New line** + **Embed** drops `![[Note]]` on its own line; the inline placements insert it on the same line). The **In frontmatter property** placement and the **Specified note** destination stay link-only.
 
+    For the selection placements (**Replace selection**, **After selection**) with the **Link** type, a _Link display text_ dropdown chooses what the inserted link displays. **Selected text** keeps the highlighted text as the link's display text — selecting `Meeting with Mark` and capturing to `20240101 Meeting with Mark` inserts `[[20240101 Meeting with Mark|Meeting with Mark]]`. With nothing selected (or when the selection can't be represented safely inside a link), QuickAdd inserts the plain link instead. Multi-line selections are collapsed to a single line for the display text, and vaults using Markdown-style links get `[Meeting with Mark](20240101%20Meeting%20with%20Mark.md)`.
+
     For the **Specified note** destination, choose an existing Markdown file. QuickAdd appends a normal link at the bottom of that file after each successful capture. It does not create the index file, insert under a heading, update properties, or remove duplicate links.
 
 -   _Copy link to clipboard_ copies a link to the captured file after the Capture

--- a/docs/docs/Choices/TemplateChoice.md
+++ b/docs/docs/Choices/TemplateChoice.md
@@ -86,6 +86,8 @@ of the value, and list properties receive a new list item.
 
 **Link type**. Shown for any **Current note** body placement — **Replace selection**, **After selection**, **End of line**, and **New line**. Choose whether QuickAdd inserts a **Link** (`[[Note]]`) or an **Embed** (`![[Note]]`). An embed transcludes the linked note's contents at the placement position, so for example **New line** + **Embed** drops `![[Note]]` on its own line. The inline placements (**After selection**, **End of line**) insert the embed inline on the same line. The **In frontmatter property** placement and the **Specified note** destination stay link-only.
 
+**Link display text**. Shown for the selection placements (**Replace selection**, **After selection**) with the **Link** type. Chooses what the inserted link displays. **Selected text** keeps the highlighted text as the link's display text: select `Meeting with Mark`, run a Template choice whose file name format is `20240101 {{selected}}`, and the selection becomes `[[20240101 Meeting with Mark|Meeting with Mark]]` instead of a bare `[[20240101 Meeting with Mark]]`. With nothing selected (or when the selection can't be represented safely inside a link), QuickAdd inserts the plain link instead. Multi-line selections are collapsed to a single line for the display text, and vaults using Markdown-style links get `[Meeting with Mark](20240101%20Meeting%20with%20Mark.md)`.
+
 For the **Specified note** destination, choose an existing Markdown file. QuickAdd appends a normal link at the bottom of that file. It does not create the index file, insert under a heading, update properties, or remove duplicate links.
 
 **Copy link to clipboard**. Copies a link to the created file after the Template

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
@@ -105,13 +105,14 @@ function nextOptions(overrides: Partial<AppendLinkOptions>): AppendLinkOptions {
 	// Forced back to "none" when the conditions no longer hold — intentionally
 	// as lossy as the linkType reset above (switching placement away and back
 	// discards the stored preference).
+	// Falls back to the NORMALIZED value (not the raw stored one) so a
+	// malformed/unknown stored displayText is not written back on unrelated
+	// dropdown changes — the UI persists what it displays.
 	const displayText =
 		destination.type === "activeFile" &&
 		placementSupportsSelectionAlias(placement) &&
 		linkType === "link"
-			? overrides.displayText ??
-				currentOptions.displayText ??
-				normalizedDisplayText
+			? overrides.displayText ?? normalizedDisplayText
 			: "none";
 
 	return {

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.svelte
@@ -6,6 +6,7 @@ import ValidatedInput from "./ValidatedInput.svelte";
 import type {
 	AppendLinkOptions,
 	FrontmatterHandling,
+	LinkDisplayText,
 	LinkPlacement,
 	LinkType,
 } from "../../../types/linkPlacement";
@@ -14,6 +15,7 @@ import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
 	placementSupportsFrontmatter,
+	placementSupportsSelectionAlias,
 } from "../../../types/linkPlacement";
 import { normalizeAppendLinkDestinationPath } from "../../../utils/fileLinks";
 
@@ -38,6 +40,7 @@ type AppendLinkDestinationMode = "activeFile" | "specifiedFile";
 
 const normalized = $derived(normalizeAppendLinkOptions(appendLink));
 const normalizedLinkType = $derived(normalized.linkType ?? "link");
+const normalizedDisplayText = $derived(normalized.displayText);
 const normalizedFrontmatterHandling = $derived(
 	normalized.frontmatterHandling ?? DEFAULT_FRONTMATTER_HANDLING,
 );
@@ -78,6 +81,10 @@ const linkTypeOptions = [
 	{ value: "link", label: "Link" },
 	{ value: "embed", label: "Embed" },
 ];
+const displayTextOptions = [
+	{ value: "none", label: "Default" },
+	{ value: "selection", label: "Selected text" },
+];
 const frontmatterHandlingOptions = [
 	{ value: "alwaysAppend", label: "Create or convert" },
 	{ value: "createProperty", label: "Create if missing" },
@@ -95,6 +102,17 @@ function nextOptions(overrides: Partial<AppendLinkOptions>): AppendLinkOptions {
 		destination.type === "activeFile" && placementSupportsEmbed(placement)
 			? overrides.linkType ?? currentOptions.linkType ?? normalizedLinkType
 			: "link";
+	// Forced back to "none" when the conditions no longer hold — intentionally
+	// as lossy as the linkType reset above (switching placement away and back
+	// discards the stored preference).
+	const displayText =
+		destination.type === "activeFile" &&
+		placementSupportsSelectionAlias(placement) &&
+		linkType === "link"
+			? overrides.displayText ??
+				currentOptions.displayText ??
+				normalizedDisplayText
+			: "none";
 
 	return {
 		enabled: overrides.enabled ?? true,
@@ -104,6 +122,7 @@ function nextOptions(overrides: Partial<AppendLinkOptions>): AppendLinkOptions {
 			currentOptions.requireActiveFile ??
 			normalized.requireActiveFile,
 		linkType,
+		displayText,
 		destination,
 		frontmatterProperty:
 			overrides.frontmatterProperty ?? currentOptions.frontmatterProperty,
@@ -135,6 +154,12 @@ function onPlacementChange(value: string) {
 function onLinkTypeChange(value: string) {
 	appendLink = nextOptions({
 		linkType: value as LinkType,
+	});
+}
+
+function onDisplayTextChange(value: string) {
+	appendLink = nextOptions({
+		displayText: value as LinkDisplayText,
 	});
 }
 
@@ -225,6 +250,21 @@ function validateDestinationFile(raw: string) {
 						value={normalizedLinkType}
 						options={linkTypeOptions}
 						onchange={onLinkTypeChange}
+					/>
+				{/snippet}
+			</SettingItem>
+		{/if}
+
+		{#if placementSupportsSelectionAlias(normalized.placement) && normalizedLinkType === "link"}
+			<SettingItem
+				name="Link display text"
+				desc="What the inserted link displays. 'Selected text' keeps the highlighted text as the link's display text; with nothing selected, the plain link is inserted."
+			>
+				{#snippet control()}
+					<Dropdown
+						value={normalizedDisplayText}
+						options={displayTextOptions}
+						onchange={onDisplayTextChange}
 					/>
 				{/snippet}
 			</SettingItem>

--- a/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
+++ b/src/gui/ChoiceBuilder/components/AppendLinkSetting.test.ts
@@ -33,6 +33,7 @@ describe("AppendLinkSetting", () => {
 			"Link destination",
 			"Link placement",
 			"Link type",
+			"Link display text",
 		]);
 	});
 
@@ -241,5 +242,140 @@ describe("AppendLinkSetting", () => {
 		expect(
 			Array.from(container.querySelectorAll("select")).at(-1)?.value,
 		).toBe("alwaysAppend");
+	});
+});
+
+describe("AppendLinkSetting display text", () => {
+	function displayTextSelect(container: HTMLElement): HTMLSelectElement | null {
+		return (
+			Array.from(container.querySelectorAll("select")).find((select) =>
+				Array.from(select.options).some(
+					(option) => option.value === "selection",
+				),
+			) ?? null
+		);
+	}
+
+	it("shows the display text row for both selection-anchored placements with a plain link", () => {
+		for (const placement of ["replaceSelection", "afterSelection"] as const) {
+			const appendLink: AppendLinkOptions = {
+				enabled: true,
+				placement,
+				requireActiveFile: true,
+				linkType: "link",
+			};
+			const { container } = render(AppendLinkSetting, {
+				props: { appendLink, fileLabel: "created" },
+			});
+			expect(settingNames(container)).toContain("Link display text");
+			expect(displayTextSelect(container)?.value).toBe("none");
+		}
+	});
+
+	it("hides the display text row for embeds and cursor-anchored placements", () => {
+		const cases: AppendLinkOptions[] = [
+			{
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+				linkType: "embed",
+			},
+			{
+				enabled: true,
+				placement: "endOfLine",
+				requireActiveFile: true,
+				linkType: "link",
+			},
+			{
+				enabled: true,
+				placement: "newLine",
+				requireActiveFile: true,
+				linkType: "link",
+			},
+			{
+				enabled: true,
+				placement: "inFrontmatter",
+				requireActiveFile: true,
+				frontmatterProperty: "related",
+			},
+		];
+		for (const appendLink of cases) {
+			const { container } = render(AppendLinkSetting, {
+				props: { appendLink, fileLabel: "created" },
+			});
+			expect(settingNames(container)).not.toContain("Link display text");
+		}
+	});
+
+	it("hides the display text row for specified-note destinations", () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "replaceSelection",
+			requireActiveFile: true,
+			linkType: "link",
+			destination: { type: "specifiedFile", path: "Index.md" },
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+		expect(settingNames(container)).not.toContain("Link display text");
+	});
+
+	it("preserves the selection preference through unrelated dropdown changes", async () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "replaceSelection",
+			requireActiveFile: true,
+			linkType: "link",
+			displayText: "selection",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		const modeSelect = container.querySelector("select") as HTMLSelectElement;
+		await fireEvent.change(modeSelect, { target: { value: "optional" } });
+
+		expect(displayTextSelect(container)?.value).toBe("selection");
+	});
+
+	it("resets the preference to default when the placement stops supporting it (lossy, matching link type)", async () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "replaceSelection",
+			requireActiveFile: true,
+			linkType: "link",
+			displayText: "selection",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		const placementSelect = container.querySelectorAll(
+			"select",
+		)[2] as HTMLSelectElement;
+		await fireEvent.change(placementSelect, { target: { value: "endOfLine" } });
+		expect(settingNames(container)).not.toContain("Link display text");
+
+		await fireEvent.change(placementSelect, {
+			target: { value: "replaceSelection" },
+		});
+		expect(displayTextSelect(container)?.value).toBe("none");
+	});
+
+	it("stores the chosen display text on change", async () => {
+		const appendLink: AppendLinkOptions = {
+			enabled: true,
+			placement: "replaceSelection",
+			requireActiveFile: true,
+			linkType: "link",
+		};
+		const { container } = render(AppendLinkSetting, {
+			props: { appendLink, fileLabel: "created" },
+		});
+
+		const select = displayTextSelect(container) as HTMLSelectElement;
+		await fireEvent.change(select, { target: { value: "selection" } });
+		expect(displayTextSelect(container)?.value).toBe("selection");
 	});
 });

--- a/src/types/linkPlacement.test.ts
+++ b/src/types/linkPlacement.test.ts
@@ -7,6 +7,7 @@ import {
 	normalizeAppendLinkOptions,
 	placementSupportsEmbed,
 	placementSupportsFrontmatter,
+	placementSupportsSelectionAlias,
 } from "./linkPlacement";
 
 describe("LinkPlacement", () => {
@@ -42,6 +43,7 @@ describe("LinkPlacement", () => {
 			expect(normalizeAppendLinkOptions(options)).toEqual({
 				...options,
 				linkType: "link",
+				displayText: "none",
 				destination: { type: "activeFile" },
 			});
 		});
@@ -53,6 +55,7 @@ describe("LinkPlacement", () => {
 				placement: "replaceSelection",
 				requireActiveFile: true,
 				linkType: "link",
+				displayText: "none",
 				destination: { type: "activeFile" },
 			});
 		});
@@ -64,6 +67,7 @@ describe("LinkPlacement", () => {
 				placement: "replaceSelection",
 				requireActiveFile: false,
 				linkType: "link",
+				displayText: "none",
 				destination: { type: "activeFile" },
 			});
 		});
@@ -77,7 +81,10 @@ describe("LinkPlacement", () => {
 				destination: { type: "activeFile" },
 			};
 
-			expect(normalizeAppendLinkOptions(options)).toEqual(options);
+			expect(normalizeAppendLinkOptions(options)).toEqual({
+				...options,
+				displayText: "none",
+			});
 		});
 
 		it("preserves embed linkType for every active-note body placement", () => {
@@ -134,6 +141,7 @@ describe("LinkPlacement", () => {
 			expect(normalizeAppendLinkOptions(options)).toEqual({
 				...options,
 				linkType: "link",
+				displayText: "none",
 				destination: { type: "specifiedFile", path: "Indexes/MOC.md" },
 			});
 		});
@@ -150,6 +158,7 @@ describe("LinkPlacement", () => {
 			expect(normalizeAppendLinkOptions(options)).toEqual({
 				...options,
 				linkType: "link",
+				displayText: "none",
 				destination: { type: "specifiedFile", path: "Index.md" },
 			});
 		});
@@ -167,6 +176,7 @@ describe("LinkPlacement", () => {
 			expect(normalizeAppendLinkOptions(options)).toEqual({
 				...options,
 				linkType: "link",
+				displayText: "none",
 				destination: { type: "activeFile" },
 			});
 		});
@@ -249,6 +259,97 @@ describe("LinkPlacement", () => {
 			expect(placementSupportsFrontmatter("afterSelection")).toBe(false);
 			expect(placementSupportsFrontmatter("endOfLine")).toBe(false);
 			expect(placementSupportsFrontmatter("newLine")).toBe(false);
+		});
+	});
+
+	describe("placementSupportsSelectionAlias", () => {
+		it("returns true only for selection-anchored placements", () => {
+			expect(placementSupportsSelectionAlias("replaceSelection")).toBe(true);
+			expect(placementSupportsSelectionAlias("afterSelection")).toBe(true);
+			expect(placementSupportsSelectionAlias("endOfLine")).toBe(false);
+			expect(placementSupportsSelectionAlias("newLine")).toBe(false);
+			expect(placementSupportsSelectionAlias("inFrontmatter")).toBe(false);
+		});
+	});
+
+	describe("displayText normalization", () => {
+		const base: AppendLinkOptions = {
+			enabled: true,
+			placement: "replaceSelection",
+			requireActiveFile: true,
+		};
+
+		it("keeps 'selection' for selection placements with a plain link into the active file", () => {
+			for (const placement of ["replaceSelection", "afterSelection"] as LinkPlacement[]) {
+				const normalized = normalizeAppendLinkOptions({
+					...base,
+					placement,
+					displayText: "selection",
+				});
+				expect(normalized.displayText).toBe("selection");
+			}
+		});
+
+		it("defaults to 'none' when displayText is omitted", () => {
+			expect(normalizeAppendLinkOptions(base).displayText).toBe("none");
+		});
+
+		it("normalizes legacy boolean configs to 'none'", () => {
+			expect(normalizeAppendLinkOptions(true).displayText).toBe("none");
+			expect(normalizeAppendLinkOptions(false).displayText).toBe("none");
+		});
+
+		it("normalizes malformed and unknown values to 'none' (strict allowlist)", () => {
+			for (const value of ["", "SELECTION", "title", "custom", 1, true, null]) {
+				const normalized = normalizeAppendLinkOptions({
+					...base,
+					displayText: value as AppendLinkOptions["displayText"],
+				});
+				expect(normalized.displayText).toBe("none");
+			}
+		});
+
+		it("sanitizes 'selection' away for cursor-anchored and frontmatter placements", () => {
+			for (const placement of ["endOfLine", "newLine", "inFrontmatter"] as LinkPlacement[]) {
+				const normalized = normalizeAppendLinkOptions({
+					...base,
+					placement,
+					displayText: "selection",
+				});
+				expect(normalized.displayText).toBe("none");
+			}
+		});
+
+		it("sanitizes 'selection' away for embeds", () => {
+			const normalized = normalizeAppendLinkOptions({
+				...base,
+				linkType: "embed",
+				displayText: "selection",
+			});
+			expect(normalized.linkType).toBe("embed");
+			expect(normalized.displayText).toBe("none");
+		});
+
+		it("sanitizes 'selection' away for specified-file destinations", () => {
+			const normalized = normalizeAppendLinkOptions({
+				...base,
+				displayText: "selection",
+				destination: { type: "specifiedFile", path: "Index.md" },
+			});
+			expect(normalized.displayText).toBe("none");
+		});
+
+		it("still sanitizes 'selection' when an embed request is downgraded by a specified-file destination", () => {
+			// linkType embed + specifiedFile normalizes linkType to "link", but the
+			// specified-file destination still rules out a selection alias.
+			const normalized = normalizeAppendLinkOptions({
+				...base,
+				linkType: "embed",
+				displayText: "selection",
+				destination: { type: "specifiedFile", path: "Index.md" },
+			});
+			expect(normalized.linkType).toBe("link");
+			expect(normalized.displayText).toBe("none");
 		});
 	});
 });

--- a/src/types/linkPlacement.ts
+++ b/src/types/linkPlacement.ts
@@ -10,6 +10,14 @@ export type LinkPlacement =
 
 export type LinkType = "link" | "embed";
 
+/**
+ * What the inserted link displays. "none" adds no explicit alias (Obsidian
+ * renders its default link text); "selection" keeps the selected text as the
+ * link's display text for selection-based placements. Reserved future values
+ * ("title", "custom") extend this enum without a schema break.
+ */
+export type LinkDisplayText = "none" | "selection";
+
 export type AppendLinkDestination =
 	| { type: "activeFile" }
 	| { type: "specifiedFile"; path: string };
@@ -48,6 +56,25 @@ export function placementSupportsFrontmatter(
 	return placement === "inFrontmatter";
 }
 
+/**
+ * Placements whose insertion is anchored to the editor selection, so the
+ * selected text can meaningfully become the link's display text (alias).
+ * "endOfLine"/"newLine" are cursor-anchored, not selection-anchored, and
+ * "inFrontmatter" has no selection concept at the destination.
+ *
+ * A new placement is NOT selection-alias-capable until deliberately added here.
+ */
+const SELECTION_ALIAS_CAPABLE_PLACEMENTS: ReadonlySet<LinkPlacement> = new Set([
+	"replaceSelection",
+	"afterSelection",
+]);
+
+export function placementSupportsSelectionAlias(
+	placement: LinkPlacement,
+): boolean {
+	return SELECTION_ALIAS_CAPABLE_PLACEMENTS.has(placement);
+}
+
 function sanitizeLinkType(
 	linkType: LinkType | undefined,
 	placement: LinkPlacement,
@@ -58,6 +85,26 @@ function sanitizeLinkType(
 		placementSupportsEmbed(placement)
 		? "embed"
 		: "link";
+}
+
+/**
+ * Strict allowlist: "selection" survives only when every condition for a
+ * selection-derived alias holds. Anything else — undefined, "", legacy boolean
+ * configs, unknown values from imported settings or third-party scripts, and
+ * future values this version doesn't know — normalizes to "none".
+ */
+function sanitizeDisplayText(
+	displayText: LinkDisplayText | undefined,
+	placement: LinkPlacement,
+	destination: AppendLinkDestination,
+	linkType: LinkType,
+): LinkDisplayText {
+	return displayText === "selection" &&
+		destination.type === "activeFile" &&
+		placementSupportsSelectionAlias(placement) &&
+		linkType === "link"
+		? "selection"
+		: "none";
 }
 
 function normalizeAppendLinkDestination(
@@ -96,6 +143,15 @@ export interface AppendLinkOptions {
 	 */
 	linkType?: LinkType;
 	/**
+	 * What the inserted link displays. "selection" keeps the selected text as
+	 * the link's alias for the selection-based placements (replaceSelection,
+	 * afterSelection) when inserting a plain link into the active note.
+	 * Normalized to "none" everywhere else (embeds, frontmatter,
+	 * endOfLine/newLine, specified-note destinations). Defaults to "none" for
+	 * legacy settings.
+	 */
+	displayText?: LinkDisplayText;
+	/**
 	 * Where the generated link should be written. Omitted legacy settings target
 	 * the active Markdown editor.
 	 */
@@ -131,16 +187,23 @@ export function isAppendLinkOptions(appendLink: boolean | AppendLinkOptions): ap
  * @param appendLink - Legacy boolean or new options format
  * @returns Normalized AppendLinkOptions
  */
-export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptions): AppendLinkOptions & { linkType: LinkType; destination: AppendLinkDestination } {
+export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptions): AppendLinkOptions & { linkType: LinkType; destination: AppendLinkDestination; displayText: LinkDisplayText } {
 	if (isAppendLinkOptions(appendLink)) {
 		const placement = appendLink.placement ?? "replaceSelection";
 		const destination = normalizeAppendLinkDestination(appendLink.destination);
+		const linkType = sanitizeLinkType(appendLink.linkType, placement, destination);
 
 		return {
 			enabled: appendLink.enabled,
 			placement,
 			requireActiveFile: appendLink.requireActiveFile ?? true,
-			linkType: sanitizeLinkType(appendLink.linkType, placement, destination),
+			linkType,
+			displayText: sanitizeDisplayText(
+				appendLink.displayText,
+				placement,
+				destination,
+				linkType,
+			),
 			destination,
 			frontmatterProperty: appendLink.frontmatterProperty,
 			frontmatterHandling:
@@ -156,6 +219,7 @@ export function normalizeAppendLinkOptions(appendLink: boolean | AppendLinkOptio
 		placement: "replaceSelection", // Default placement for backward compatibility
 		requireActiveFile: appendLink ? true : false,
 		linkType: "link",
+		displayText: "none",
 		destination: { type: "activeFile" },
 	};
 }

--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { App, TFile } from "obsidian";
 import {
 	insertFileLinkToActiveView,
+	insertLinkWithPlacement,
 	setMarkdownCursorAtOffset,
 } from "./editorInsertion";
 
@@ -242,5 +243,287 @@ describe("insertFileLinkToActiveView", () => {
 				frontmatterHandling: "error",
 			}),
 		).rejects.toThrow(/does not exist/);
+	});
+});
+
+type Pos = { line: number; ch: number };
+
+/**
+ * Minimal real text-model editor: positions are {line, ch} over a string
+ * document, transaction() applies pre-edit-coordinate changes atomically,
+ * setSelections() records the resulting cursors.
+ */
+function createSelectionEditor(
+	initial: string,
+	initialSelections: Array<{ anchor: Pos; head: Pos }>,
+) {
+	let content = initial;
+	let selections = initialSelections.map((sel) => ({
+		anchor: { ...sel.anchor },
+		head: { ...sel.head },
+	}));
+
+	const posToOffset = ({ line, ch }: Pos): number => {
+		const lines = content.split("\n");
+		let offset = 0;
+		for (let i = 0; i < line; i++) offset += lines[i].length + 1;
+		return offset + ch;
+	};
+	const offsetToPos = (offset: number): Pos => {
+		const lines = content.split("\n");
+		let line = 0;
+		while (line < lines.length && offset > lines[line].length) {
+			offset -= lines[line].length + 1;
+			line++;
+		}
+		return { line, ch: offset };
+	};
+
+	const transaction = vi.fn(
+		({ changes }: { changes: Array<{ from: Pos; to?: Pos; text: string }> }) => {
+			const resolved = changes
+				.map((change) => ({
+					from: posToOffset(change.from),
+					to: posToOffset(change.to ?? change.from),
+					text: change.text,
+				}))
+				.sort((a, b) => b.from - a.from);
+			for (const change of resolved) {
+				content =
+					content.slice(0, change.from) +
+					change.text +
+					content.slice(change.to);
+			}
+		},
+	);
+
+	const editor = {
+		listSelections: vi.fn(() => selections),
+		getRange: vi.fn((from: Pos, to: Pos) =>
+			content.slice(posToOffset(from), posToOffset(to)),
+		),
+		getLine: vi.fn((line: number) => content.split("\n")[line] ?? ""),
+		posToOffset: vi.fn(posToOffset),
+		offsetToPos: vi.fn(offsetToPos),
+		transaction,
+		setSelections: vi.fn(
+			(ranges: Array<{ anchor: Pos; head?: Pos }>) => {
+				selections = ranges.map((range) => ({
+					anchor: { ...range.anchor },
+					head: { ...(range.head ?? range.anchor) },
+				}));
+			},
+		),
+		replaceSelection: vi.fn(),
+		replaceRange: vi.fn(),
+	};
+
+	return {
+		editor,
+		getContent: () => content,
+		getSelections: () => selections,
+	};
+}
+
+function createSelectionApp(
+	harness: ReturnType<typeof createSelectionEditor>,
+	{ path = "Daily.md" } = {},
+) {
+	return {
+		workspace: {
+			getActiveViewOfType: vi.fn(() => ({
+				file: { path },
+				editor: harness.editor,
+			})),
+		},
+		fileManager: {
+			generateMarkdownLink: vi.fn(
+				(
+					_file: TFile,
+					_sourcePath: string,
+					_subpath?: string,
+					alias?: string,
+				) => (alias === undefined ? "[[Created]]" : `[[Created|${alias}]]`),
+			),
+		},
+		metadataCache: {
+			fileToLinktext: vi.fn(() => "Created"),
+		},
+		vault: {
+			getConfig: vi.fn(() => false),
+		},
+	} as unknown as App;
+}
+
+describe("insertLinkWithPlacement with textForSelection", () => {
+	const linkFor = (selectedText: string) => `[[X|${selectedText}]]`;
+
+	it("replaces a single selection with its own text and collapses the cursor after the link", async () => {
+		const harness = createSelectionEditor("see Meeting with Mark today", [
+			{ anchor: { line: 0, ch: 4 }, head: { line: 0, ch: 21 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await insertLinkWithPlacement(app, "[[X]]", "replaceSelection", {
+			textForSelection: linkFor,
+		});
+
+		expect(harness.getContent()).toBe("see [[X|Meeting with Mark]] today");
+		expect(harness.editor.replaceSelection).not.toHaveBeenCalled();
+		expect(harness.editor.transaction).toHaveBeenCalledTimes(1);
+		expect(harness.getSelections()).toEqual([
+			{
+				anchor: { line: 0, ch: "see [[X|Meeting with Mark]]".length },
+				head: { line: 0, ch: "see [[X|Meeting with Mark]]".length },
+			},
+		]);
+	});
+
+	it("gives every cursor its own alias in one atomic transaction", async () => {
+		const harness = createSelectionEditor("alpha beta\ngamma delta", [
+			{ anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 5 } },
+			{ anchor: { line: 1, ch: 6 }, head: { line: 1, ch: 11 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await insertLinkWithPlacement(app, "[[X]]", "replaceSelection", {
+			textForSelection: linkFor,
+		});
+
+		expect(harness.getContent()).toBe("[[X|alpha]] beta\ngamma [[X|delta]]");
+		expect(harness.editor.transaction).toHaveBeenCalledTimes(1);
+		expect(harness.getSelections()).toEqual([
+			{
+				anchor: { line: 0, ch: "[[X|alpha]]".length },
+				head: { line: 0, ch: "[[X|alpha]]".length },
+			},
+			{
+				anchor: { line: 1, ch: "gamma [[X|delta]]".length },
+				head: { line: 1, ch: "gamma [[X|delta]]".length },
+			},
+		]);
+	});
+
+	it("handles reversed selections (head before anchor)", async () => {
+		const harness = createSelectionEditor("pick me now", [
+			{ anchor: { line: 0, ch: 7 }, head: { line: 0, ch: 5 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await insertLinkWithPlacement(app, "[[X]]", "replaceSelection", {
+			textForSelection: linkFor,
+		});
+
+		expect(harness.getContent()).toBe("pick [[X|me]] now");
+	});
+
+	it("passes an empty string for collapsed cursors", async () => {
+		const harness = createSelectionEditor("cursor here", [
+			{ anchor: { line: 0, ch: 6 }, head: { line: 0, ch: 6 } },
+		]);
+		const app = createSelectionApp(harness);
+		const textForSelection = vi.fn(() => "[[X]]");
+
+		await insertLinkWithPlacement(app, "[[X]]", "replaceSelection", {
+			textForSelection,
+		});
+
+		expect(textForSelection).toHaveBeenCalledWith("");
+		expect(harness.getContent()).toBe("cursor[[X]] here");
+	});
+
+	it("keeps the selected text and appends the aliased link for afterSelection", async () => {
+		const harness = createSelectionEditor("keep Meeting with Mark here", [
+			{ anchor: { line: 0, ch: 5 }, head: { line: 0, ch: 22 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await insertLinkWithPlacement(app, "[[X]]", "afterSelection", {
+			textForSelection: linkFor,
+		});
+
+		expect(harness.getContent()).toBe(
+			"keep Meeting with Mark[[X|Meeting with Mark]] here",
+		);
+		// afterSelection keeps the editor's default selection mapping, matching
+		// the existing replaceRange path.
+		expect(harness.editor.setSelections).not.toHaveBeenCalled();
+	});
+
+	it("leaves the plain replaceSelection path untouched when textForSelection is absent", async () => {
+		const harness = createSelectionEditor("some text", [
+			{ anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 4 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await insertLinkWithPlacement(app, "[[X]]", "replaceSelection", {});
+
+		expect(harness.editor.replaceSelection).toHaveBeenCalledWith("[[X]]");
+		expect(harness.editor.transaction).not.toHaveBeenCalled();
+	});
+});
+
+describe("insertFileLinkToActiveView displayText", () => {
+	it("keeps the selection as the link alias when displayText is 'selection'", async () => {
+		const harness = createSelectionEditor("Meeting with Mark", [
+			{ anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 17 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await expect(
+			insertFileLinkToActiveView(app, { path: "Created.md" } as TFile, {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+				linkType: "link",
+				displayText: "selection",
+				destination: { type: "activeFile" },
+			}),
+		).resolves.toBe(true);
+
+		expect(harness.getContent()).toBe("[[Created|Meeting with Mark]]");
+	});
+
+	it("inserts a plain link when displayText is omitted (legacy behavior)", async () => {
+		const harness = createSelectionEditor("Meeting with Mark", [
+			{ anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 17 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await expect(
+			insertFileLinkToActiveView(app, { path: "Created.md" } as TFile, {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+				linkType: "link",
+				destination: { type: "activeFile" },
+			}),
+		).resolves.toBe(true);
+
+		expect(harness.editor.replaceSelection).toHaveBeenCalledWith("[[Created]]");
+		expect(harness.editor.transaction).not.toHaveBeenCalled();
+	});
+
+	it("normalizes displayText away for embeds even when requested", async () => {
+		const harness = createSelectionEditor("Meeting with Mark", [
+			{ anchor: { line: 0, ch: 0 }, head: { line: 0, ch: 17 } },
+		]);
+		const app = createSelectionApp(harness);
+
+		await expect(
+			insertFileLinkToActiveView(app, { path: "Created.md" } as TFile, {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+				linkType: "embed",
+				displayText: "selection",
+				destination: { type: "activeFile" },
+			}),
+		).resolves.toBe(true);
+
+		expect(harness.editor.replaceSelection).toHaveBeenCalledWith(
+			"![[Created]]",
+		);
+		expect(harness.editor.transaction).not.toHaveBeenCalled();
 	});
 });

--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -527,3 +527,46 @@ describe("insertFileLinkToActiveView displayText", () => {
 		expect(harness.editor.transaction).not.toHaveBeenCalled();
 	});
 });
+
+describe("insertFileLinkToActiveView raw-caller guard semantics", () => {
+	it("skips silently when a partial options object omits requireActiveFile and no view is active", async () => {
+		const app = {
+			workspace: { getActiveViewOfType: vi.fn(() => null) },
+		} as unknown as App;
+
+		// No "placement" key: normalization would treat this as a legacy value
+		// and default requireActiveFile to true. The guard must keep reading the
+		// raw value so this stays a silent skip, as before the displayText work.
+		await expect(
+			insertFileLinkToActiveView(app, { path: "Created.md" } as TFile, {
+				enabled: true,
+			} as never),
+		).resolves.toBe(false);
+	});
+
+	it("still throws for strict callers when no view is active", async () => {
+		const app = {
+			workspace: { getActiveViewOfType: vi.fn(() => null) },
+		} as unknown as App;
+
+		await expect(
+			insertFileLinkToActiveView(app, { path: "Created.md" } as TFile, {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+			}),
+		).rejects.toThrow(/no active Markdown view/);
+	});
+
+	it("falls back to the plain replaceSelection insert when there are no selections", async () => {
+		const harness = createSelectionEditor("doc", []);
+		const app = createSelectionApp(harness);
+
+		await insertLinkWithPlacement(app, "[[X]]", "replaceSelection", {
+			textForSelection: () => "[[never]]",
+		});
+
+		expect(harness.editor.replaceSelection).toHaveBeenCalledWith("[[X]]");
+		expect(harness.editor.transaction).not.toHaveBeenCalled();
+	});
+});

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -1,8 +1,9 @@
-import type { App, TFile } from "obsidian";
+import type { App, Editor, EditorPosition, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
 import { log } from "../logger/logManager";
 import {
 	DEFAULT_FRONTMATTER_HANDLING,
+	normalizeAppendLinkOptions,
 	type AppendLinkOptions,
 	type FrontmatterHandling,
 	type LinkPlacement,
@@ -90,6 +91,60 @@ export function insertOnNewLineBelow(toInsert: string, app: App): boolean {
 }
 
 /**
+ * Applies one text per selection in a single atomic transaction (one undo
+ * step). replaceSelection collapses each cursor after its inserted text —
+ * matching editor.replaceSelection — because CodeMirror's default change
+ * mapping would otherwise leave the inserted text selected and the next
+ * keystroke would destroy it. afterSelection keeps the default mapping,
+ * matching the plain replaceRange path.
+ */
+function insertPerSelection(
+	editor: Editor,
+	selections: { anchor: EditorPosition; head: EditorPosition }[],
+	mode: "replaceSelection" | "afterSelection",
+	textForSelection: (selectedText: string) => string,
+): void {
+	const asIndex = (pos: EditorPosition) => editor.posToOffset(pos);
+
+	// Pre-edit coordinates, ordered top-to-bottom so post-edit cursor offsets
+	// can be computed by accumulating each earlier change's length delta.
+	const edits = selections
+		.map((sel) => {
+			const [from, to] =
+				asIndex(sel.anchor) <= asIndex(sel.head)
+					? [sel.anchor, sel.head]
+					: [sel.head, sel.anchor];
+			return { from, to, text: textForSelection(editor.getRange(from, to)) };
+		})
+		.sort((a, b) => asIndex(a.from) - asIndex(b.from));
+
+	const changes = edits.map(({ from, to, text }) =>
+		mode === "replaceSelection" ? { from, to, text } : { from: to, text },
+	);
+
+	// Post-edit cursor offsets must be derived from pre-edit offsets BEFORE
+	// the transaction mutates the document.
+	const cursorOffsets: number[] = [];
+	if (mode === "replaceSelection") {
+		let delta = 0;
+		for (const { from, to, text } of edits) {
+			cursorOffsets.push(asIndex(from) + delta + text.length);
+			delta += text.length - (asIndex(to) - asIndex(from));
+		}
+	}
+
+	editor.transaction({ changes });
+
+	if (mode === "replaceSelection") {
+		editor.setSelections(
+			cursorOffsets.map((offset) => ({
+				anchor: editor.offsetToPos(offset),
+			})),
+		);
+	}
+}
+
+/**
  * Core routine that inserts a link (or any text) in the active markdown
  * editor according to the chosen placement mode.
  *
@@ -106,12 +161,20 @@ export async function insertLinkWithPlacement(
 		requireActiveView?: boolean;
 		frontmatterProperty?: string;
 		frontmatterHandling?: FrontmatterHandling;
+		/**
+		 * When set, the selection-anchored placements (replaceSelection,
+		 * afterSelection) derive the inserted text per selection from that
+		 * selection's own text (e.g. to keep it as the link's display alias).
+		 * Other placements ignore it and insert `text`.
+		 */
+		textForSelection?: (selectedText: string) => string;
 	} = {},
 ): Promise<void> {
 	const {
 		requireActiveView = true,
 		frontmatterProperty,
 		frontmatterHandling = DEFAULT_FRONTMATTER_HANDLING,
+		textForSelection,
 	} = options;
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
 	if (!view) {
@@ -150,6 +213,17 @@ export async function insertLinkWithPlacement(
 			anchor: { ...sel.anchor },
 			head: { ...sel.head },
 		}));
+
+	//////////////////////////////////////////////////////////////////
+	//  SELECTION-ANCHORED MODES WITH PER-SELECTION TEXT
+	//////////////////////////////////////////////////////////////////
+	if (
+		textForSelection &&
+		(mode === "replaceSelection" || mode === "afterSelection")
+	) {
+		insertPerSelection(editor, selections, mode, textForSelection);
+		return;
+	}
 
 	//////////////////////////////////////////////////////////////////
 	//  REPLACE-SELECTION
@@ -233,9 +307,14 @@ export async function insertFileLinkToActiveView(
 ): Promise<boolean> {
 	if (!linkOptions?.enabled) return false;
 
+	// Re-normalizing here is idempotent for the engine callers and guarantees
+	// the cross-field sanitization (linkType, displayText) cannot be bypassed
+	// by raw options from scripts or third-party callers.
+	const normalized = normalizeAppendLinkOptions(linkOptions);
+
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
 	if (!view || !view.file) {
-		if (linkOptions.requireActiveFile) {
+		if (normalized.requireActiveFile) {
 			throw new Error("Cannot append link because no active Markdown view is available.");
 		}
 		return false;
@@ -244,18 +323,32 @@ export async function insertFileLinkToActiveView(
 	const sourcePath = view.file.path;
 	const linkText = buildFileLinkText(app, file, {
 		sourcePath,
-		linkType: linkOptions.linkType,
-		placement: linkOptions.placement,
+		linkType: normalized.linkType,
+		placement: normalized.placement,
 	});
+
+	// Normalization guarantees "selection" only for selection-anchored
+	// placements with a plain link into the active note.
+	const textForSelection =
+		normalized.displayText === "selection"
+			? (selectedText: string) =>
+					buildFileLinkText(app, file, {
+						sourcePath,
+						linkType: normalized.linkType,
+						placement: normalized.placement,
+						alias: selectedText,
+					})
+			: undefined;
 
 	await insertLinkWithPlacement(
 		app,
 		linkText,
-		linkOptions.placement,
+		normalized.placement,
 		{
 			requireActiveView: false,
-			frontmatterProperty: linkOptions.frontmatterProperty,
-			frontmatterHandling: linkOptions.frontmatterHandling,
+			frontmatterProperty: normalized.frontmatterProperty,
+			frontmatterHandling: normalized.frontmatterHandling,
+			textForSelection,
 		},
 	);
 

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -219,6 +219,7 @@ export async function insertLinkWithPlacement(
 	//////////////////////////////////////////////////////////////////
 	if (
 		textForSelection &&
+		selections.length > 0 &&
 		(mode === "replaceSelection" || mode === "afterSelection")
 	) {
 		insertPerSelection(editor, selections, mode, textForSelection);
@@ -314,7 +315,10 @@ export async function insertFileLinkToActiveView(
 
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
 	if (!view || !view.file) {
-		if (normalized.requireActiveFile) {
+		// Read the guard from the RAW options: normalization defaults a missing
+		// requireActiveFile to true, which would turn a raw caller's previous
+		// silent skip into a throw.
+		if (linkOptions.requireActiveFile) {
 			throw new Error("Cannot append link because no active Markdown view is available.");
 		}
 		return false;

--- a/src/utils/fileLinks.test.ts
+++ b/src/utils/fileLinks.test.ts
@@ -408,3 +408,63 @@ describe("file link helpers", () => {
 		).rejects.toThrow("Append link target file not found");
 	});
 });
+
+describe("prepareLinkAlias whitespace handling (via buildFileLinkText)", () => {
+	function createWikiApp(): App {
+		return {
+			fileManager: {
+				generateMarkdownLink: vi.fn(
+					(
+						file: TFile,
+						_sourcePath: string,
+						_subpath?: string,
+						alias?: string,
+					) =>
+						alias === undefined
+							? `[[${file.basename}]]`
+							: `[[${file.basename}|${alias}]]`,
+				),
+			},
+			metadataCache: { fileToLinktext: vi.fn(() => "Created Note") },
+			vault: { getConfig: vi.fn(() => false) },
+		} as unknown as App;
+	}
+
+	function aliasFor(raw: string): string {
+		const app = createWikiApp();
+		const file = {
+			basename: "Created Note",
+			path: "Projects/Created Note.md",
+		} as TFile;
+		return buildFileLinkText(app, file, {
+			sourcePath: "Daily.md",
+			linkType: "link",
+			alias: raw,
+		});
+	}
+
+	it("collapses CRLF/CR/LF runs with surrounding spaces to one space", () => {
+		expect(aliasFor("a  \r\n\t b")).toBe("[[Created Note|a b]]");
+		expect(aliasFor("a\rb\nc")).toBe("[[Created Note|a b c]]");
+	});
+
+	it("keeps interior horizontal whitespace runs intact", () => {
+		expect(aliasFor("a  \t  b")).toBe("[[Created Note|a  \t  b]]");
+	});
+
+	it(
+		"handles a long newline-free horizontal-whitespace run in linear time",
+		() => {
+			// Opener-flood ReDoS shape (#1444/#1455/#1462): a long run of spaces
+			// with no newline must not backtrack quadratically.
+			const input = `a${" ".repeat(200_000)}b`;
+			const start = performance.now();
+			const result = aliasFor(input);
+			const elapsed = performance.now() - start;
+
+			expect(result).toBe(`[[Created Note|${input}]]`);
+			expect(elapsed).toBeLessThan(1_000);
+		},
+		20_000,
+	);
+});

--- a/src/utils/fileLinks.test.ts
+++ b/src/utils/fileLinks.test.ts
@@ -159,6 +159,123 @@ describe("file link helpers", () => {
 		).toBe("[[Created Note]]");
 	});
 
+	describe("selection-derived aliases", () => {
+		function createAliasApp({ useMarkdownLinks = false } = {}): App {
+			return {
+				fileManager: {
+					generateMarkdownLink: vi.fn(
+						(
+							file: TFile,
+							_sourcePath: string,
+							_subpath?: string,
+							alias?: string,
+						) =>
+							alias === undefined
+								? `[[${file.basename}]]`
+								: `[[${file.basename}|${alias}]]`,
+					),
+				},
+				metadataCache: {
+					fileToLinktext: vi.fn(() => "Created Note"),
+				},
+				vault: {
+					getConfig: vi.fn((key: string) =>
+						key === "useMarkdownLinks" ? useMarkdownLinks : undefined,
+					),
+				},
+			} as unknown as App;
+		}
+
+		function generatedAlias(app: App): string | undefined {
+			const call = vi.mocked(app.fileManager.generateMarkdownLink).mock
+				.calls[0];
+			return call.length > 2 ? (call[3] as string | undefined) : undefined;
+		}
+
+		function buildWithAlias(app: App, alias: string): string {
+			return buildFileLinkText(app, createFile(), {
+				sourcePath: "Daily.md",
+				linkType: "link",
+				placement: "replaceSelection",
+				alias,
+			});
+		}
+
+		it("passes safe selection text through as the alias", () => {
+			const app = createAliasApp();
+			expect(buildWithAlias(app, "Meeting with Mark")).toBe(
+				"[[Created Note|Meeting with Mark]]",
+			);
+		});
+
+		it("collapses newline runs to a single space and trims", () => {
+			const app = createAliasApp();
+			buildWithAlias(app, "  first line \r\n\n  second line\n");
+			expect(generatedAlias(app)).toBe("first line second line");
+		});
+
+		it("omits the alias entirely for empty and whitespace-only selections", () => {
+			for (const raw of ["", "   ", "\n\n", " \r\n "]) {
+				const app = createAliasApp();
+				buildWithAlias(app, raw);
+				expect(generatedAlias(app)).toBeUndefined();
+				expect(app.fileManager.generateMarkdownLink).toHaveBeenCalledWith(
+					createFile(),
+					"Daily.md",
+				);
+			}
+		});
+
+		it("keeps single brackets and pipes in wiki aliases (safe per Obsidian's parser)", () => {
+			for (const safe of ["array[0] end", "a] b", "open [ bracket", "a|b"]) {
+				const app = createAliasApp();
+				buildWithAlias(app, safe);
+				expect(generatedAlias(app)).toBe(safe);
+			}
+		});
+
+		it("drops unrepresentable wiki aliases instead of mutating the text", () => {
+			// "]]" terminates the wikilink early; "[[" starts a nested link that
+			// hijacks the outer target; a trailing "]" forms "]]" with the closer.
+			for (const hostile of [
+				"a]]b",
+				"see [[Other]] ref",
+				"array[0]",
+				"trail ]",
+			]) {
+				const app = createAliasApp();
+				buildWithAlias(app, hostile);
+				expect(generatedAlias(app)).toBeUndefined();
+			}
+		});
+
+		it("escapes backslashes and brackets for markdown-link vaults", () => {
+			const cases: Array<[string, string]> = [
+				["a [x] b", "a \\[x\\] b"],
+				["C:\\path\\", "C:\\\\path\\\\"],
+				["a\\]b", "a\\\\\\]b"],
+				["array[0]", "array\\[0\\]"],
+			];
+			for (const [raw, escaped] of cases) {
+				const app = createAliasApp({ useMarkdownLinks: true });
+				buildWithAlias(app, raw);
+				expect(generatedAlias(app)).toBe(escaped);
+			}
+		});
+
+		it("ignores the alias for embeds", () => {
+			const app = createAliasApp();
+			const text = buildFileLinkText(app, createFile(), {
+				sourcePath: "Daily.md",
+				linkType: "embed",
+				placement: "replaceSelection",
+				alias: "Meeting with Mark",
+			});
+			expect(text).toBe("![[Created Note]]");
+			expect(app.fileManager.generateMarkdownLink).not.toHaveBeenCalled();
+		});
+	});
+
 	it("returns false when clipboard writes are unavailable", async () => {
 		vi.stubGlobal("navigator", {});
 

--- a/src/utils/fileLinks.ts
+++ b/src/utils/fileLinks.ts
@@ -15,7 +15,58 @@ type FileLinkTextOptions = {
 	sourcePath?: string;
 	linkType?: LinkType;
 	placement?: LinkPlacement;
+	/**
+	 * Desired display text (alias) for the link, as raw user text (e.g. the
+	 * editor selection). buildFileLinkText owns making it link-safe; text that
+	 * cannot be represented safely degrades to a plain, alias-less link.
+	 * Ignored for embeds.
+	 */
+	alias?: string;
 };
+
+function usesMarkdownLinks(app: App): boolean {
+	// vault.getConfig is the de-facto (untyped) plugin API for editor settings.
+	// Inferring the mode from a generated link's shape instead would misdetect
+	// markdown-link vaults whose note basename starts with "[".
+	const vault = app.vault as App["vault"] & {
+		getConfig?: (key: string) => unknown;
+	};
+	return vault.getConfig?.("useMarkdownLinks") === true;
+}
+
+/**
+ * Makes raw user text (e.g. an editor selection) safe to use as a link alias,
+ * or returns undefined when no (safe) alias can be produced. Obsidian's
+ * generateMarkdownLink performs no alias sanitization, so this is QuickAdd's
+ * job. Rules verified against Obsidian 1.13's own metadataCache parses:
+ *
+ * - Newlines never survive inside a link; runs collapse to a single space.
+ * - Markdown mode: "\", "[", "]" are escaped (backslash first). Escapes render
+ *   display-faithfully, so every alias is representable.
+ * - Wiki mode: backslash is NOT an escape character, so unsafe text cannot be
+ *   escaped. Single "[", "]", "|" are safe (pipes render literally in the
+ *   display). An alias containing "]]" or "[[" (a nested "[[Other]]" hijacks
+ *   the outer link's target entirely) or ending with "]" (forms "]]" with the
+ *   closing delimiter) is unrepresentable; rather than mutate the user's text,
+ *   the alias is dropped and the link stays plain.
+ */
+function prepareLinkAlias(app: App, rawAlias: string): string | undefined {
+	const alias = rawAlias.replace(/[^\S\r\n]*(?:\r\n|\r|\n)\s*/g, " ").trim();
+	if (!alias) return undefined;
+
+	if (usesMarkdownLinks(app)) {
+		return alias
+			.replace(/\\/g, "\\\\")
+			.replace(/\[/g, "\\[")
+			.replace(/\]/g, "\\]");
+	}
+
+	if (alias.includes("]]") || alias.includes("[[") || alias.endsWith("]")) {
+		return undefined;
+	}
+
+	return alias;
+}
 
 export function buildPortableFileLinkText(file: TFile): string {
 	const path = file.path.replace(/\.md$/i, "");
@@ -42,7 +93,20 @@ export function buildFileLinkText(
 	}
 
 	// Regular links honor the vault's "New link format" + markdown/wiki setting.
-	return app.fileManager.generateMarkdownLink(file, sourcePath);
+	// When the alias equals the generated link text, Obsidian omits it.
+	const alias =
+		options.alias === undefined
+			? undefined
+			: prepareLinkAlias(app, options.alias);
+	if (alias === undefined) {
+		return app.fileManager.generateMarkdownLink(file, sourcePath);
+	}
+	return app.fileManager.generateMarkdownLink(
+		file,
+		sourcePath,
+		undefined,
+		alias,
+	);
 }
 
 export function normalizeAppendLinkDestinationPath(rawPath: string): string {

--- a/src/utils/fileLinks.ts
+++ b/src/utils/fileLinks.ts
@@ -51,7 +51,12 @@ function usesMarkdownLinks(app: App): boolean {
  *   the alias is dropped and the link stays plain.
  */
 function prepareLinkAlias(app: App, rawAlias: string): string | undefined {
-	const alias = rawAlias.replace(/[^\S\r\n]*(?:\r\n|\r|\n)\s*/g, " ").trim();
+	// Single \s+ pass: a lookaround-free single quantifier cannot backtrack
+	// quadratically on long horizontal-whitespace runs (the opener-flood ReDoS
+	// shape from #1444/#1455/#1462). Only runs containing a newline collapse.
+	const alias = rawAlias
+		.replace(/\s+/g, (run) => (/[\r\n]/.test(run) ? " " : run))
+		.trim();
 	if (!alias) return undefined;
 
 	if (usesMarkdownLinks(app)) {


### PR DESCRIPTION
Adds a **Link display text** option to the append-link settings of Template and Capture choices. With `Selected text` chosen, the selection-based placements (**Replace selection**, **After selection**) keep the highlighted text as the inserted link's alias: select `Meeting with Mark`, run a Template choice named `20240101 {{selected}}`, and the selection becomes `[[20240101 Meeting with Mark|Meeting with Mark]]` instead of a bare `[[20240101 Meeting with Mark]]`. This is the exact workflow from discussion #640, including the zettelkasten block-extraction variant.

Closes #1479. Refs discussion #640.

## Design

- **Schema.** `AppendLinkOptions.displayText?: 'none' | 'selection'` - a string enum matching the option design language from the 2.13 appendLink rework and the #1422 embed work (`linkType`, `frontmatterHandling`), leaving room for future values (`title`, `custom`) without a schema break. Selection-capable placements are an exported capability set (`placementSupportsSelectionAlias`), the same pattern as `EMBED_CAPABLE_PLACEMENTS`, consumed by the normalizer and the UI so they cannot drift.
- **Normalization is a strict allowlist.** `'selection'` survives only for a plain link into the active note with a selection-anchored placement. Legacy booleans, malformed/unknown values (imported settings, third-party scripts), embeds, frontmatter, cursor-anchored placements, and specified-note destinations all normalize to `'none'`. The normalized type exposes a non-optional `displayText`, and `insertFileLinkToActiveView` re-normalizes internally so raw callers cannot bypass the sanitization.
- **Alias safety is QuickAdd's job.** Obsidian's `generateMarkdownLink` performs no alias sanitization (verified live against 1.13's parser via `metadataCache`). Rules, all grounded in live probes:
  - Newline runs collapse to a single space (multi-line zettelkasten selections stay usable); empty selections degrade to a plain link.
  - Markdown-link vaults escape `\`, `[`, `]` (renders display-faithfully, every alias representable).
  - Wiki vaults cannot escape (backslash is literal in wikilinks), so unrepresentable aliases - containing `]]` or `[[` (a nested `[[Other]]` hijacks the outer link's target entirely) or ending in `]` - are **dropped** rather than mutating the user's text. Single `[`, `]`, `|` pass through (safe per the live parser probes).
- **Insertion mechanics.** The selection placements derive each cursor's link from that selection's own text, applied in one atomic `editor.transaction` (single undo step). `replaceSelection` collapses each cursor after its inserted link, matching `editor.replaceSelection` - CodeMirror's default mapping would otherwise leave the link selected and the next keystroke would destroy it. All no-alias code paths are byte-identical to before (the no-alias `generateMarkdownLink` call still passes 2 args).
- **UI.** The dropdown shows only when the conditions hold; switching placement away and back resets it, intentionally consistent with the `linkType` reset. `nextOptions` falls back to the *normalized* value so malformed stored values are not written back on unrelated changes.

## Tradeoffs

- `afterSelection` + `Selected text` visually duplicates the text (`Meeting with Mark [[X|Meeting with Mark]]`) - opt-in, explicitly requested in #1479.
- Capture flows that consume the selection before link insertion (capture to the active file at the cursor) degrade gracefully to a plain link: the invariant is *the alias always equals the text the link replaces*, read at insertion time.
- The focused-property runtime flow routes to `appendLinkToFrontmatterProperty` before this code and intentionally never aliases.
- `endOfLine`/`newLine` are cursor-anchored, not selection-anchored, and stay out of scope; the capability set makes extending them a deliberate one-line decision.

## Validation

Design was adversarially reviewed before coding (3 lenses + 2 adversarial reviewers); the implementation got a second adversarial pass whose findings are fixed in the last commit (a quadratic-backtracking alias regex of the #1444/#1455/#1462 opener-flood class, a raw-caller `requireActiveFile` regression, an empty-selections edge, and a UI write-back of malformed values).

Everything below was proven **live** in an isolated e2e vault (Obsidian 1.13, `pnpm run provision:e2e-vault` + `obsidian:e2e`), after first reproducing the aliasless link on master:

| Scenario | Result |
| --- | --- |
| Exact #640 flow (select `Meeting with Mark`, template `20240101 {{selected}}`) | `[[20240101 Meeting with Mark\|Meeting with Mark]]`, cursor after link |
| Default settings (regression) | `[[20240101 Sync One]]` - unchanged |
| `afterSelection` | `Sync Two[[20240101 Sync Two\|Sync Two]]` |
| Embed + displayText requested | `![[20240101 Sync Three]]` - alias normalized away |
| Multi-line selection | `[[Zettel\|Confirmation Bias is a tendency of the mind]]` |
| Hostile selections (`a]]b`, `see [[Other]] ref`) | plain link, target intact |
| Safe specials (`array[0] a\|b`) | alias kept verbatim |
| Empty selection | plain link at cursor |
| Two cursors, different selections | per-selection aliases, cursors collapsed after each link, **one** undo restores all |
| Markdown-link vault | `[Meeting with Mark](Zettel%20Note11.md)`; `array[0]` -> `[array\[0\]](...)` |
| Capture to another note | selection -> `[[CaptureTarget\|Interesting idea]]`, capture landed |
| Capture to active file at cursor | degrades to plain link (selection consumed by the capture) |
| Settings UI | row renders with `Default`/`Selected text`, hides for `endOfLine`/embed, lossy round-trip shows `Default` |

Unit coverage: normalization matrix (legacy/malformed/unknown values), alias sanitizer vectors, per-selection insertion mechanics against a real text-model harness (cursor math, reversed selections, atomicity), linear-time regression test for the alias regex, and UI visibility/threading tests. Full suite: 3670 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Link display text” support so selected text can be reused as a plain link’s alias in compatible selection-based placements.
  * Added safer selection-derived alias handling, including Markdown-style link formatting.
* **Bug Fixes**
  * Multi-line/whitespace-heavy selections are normalized for cleaner display.
  * Embeds and unsupported placements/destinations automatically fall back to plain link behavior.
* **Documentation**
  * Updated CaptureChoice and TemplateChoice documentation with examples and dropdown behavior.
* **Tests**
  * Expanded test coverage for display-text normalization, insertion behavior, and alias generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->