### PR TITLE
feat(prompt): paste clipboard images into value prompts

### DIFF
--- a/docs/docs/FormatSyntax.md
+++ b/docs/docs/FormatSyntax.md
@@ -94,6 +94,8 @@ Combines with a default and `optional` in any order: `{{VDATE:meeting,YYYY-MM-DD
 
 Interchangeable. Represents the value given in an input prompt. If text is selected in the current editor, it will be used as the value. For Capture choices, selection-as-value can be disabled globally or per-capture. When using the QuickAdd API, this can be passed programmatically using the reserved variable name 'value'.
 
+**Image paste:** value prompts whose answer lands in note content accept a clipboard image. Paste (Ctrl/Cmd+V) a screenshot or a copied image into the prompt: QuickAdd saves it using Obsidian's attachment location settings and inserts an embedded attachment link at the cursor - you can mix typed text and pasted images in one value, and paste more than one image. Clipboard text always takes precedence over an image (copying a FILE from a file manager usually pastes its path as text). Prompts for file names, folders, capture targets, and insert-after/before targets never accept image paste, since an embed link would break the path. Pasted attachments are ordinary vault files; cancelling the prompt afterwards does not delete them.
+
 **Inline script note:** For `js quickadd` blocks, prefer the QuickAdd API (`this.quickAddApi.inputPrompt(...)`) and `this.variables` for transformation flows. Do not rely on `{{VALUE}}` inside JavaScript string literals. See [Inline scripts](./InlineScripts.md#execution-order-and-value).
 
 **Macro note:** `{{VALUE}}` / `{{NAME}}` are scoped per template step, so each template in a macro prompts independently. Use `{{VALUE:sharedName}}` when you want one prompt reused across the macro.
@@ -555,6 +557,8 @@ Example: `> {{selected}}`.
 The current clipboard content. Will be empty if clipboard access fails due to permissions or security restrictions.
 
 In Capture choice content, if the clipboard has no text but contains a supported image, QuickAdd saves the image using Obsidian's attachment location settings and inserts an embedded attachment link. Clipboard text takes precedence when both text and an image are available.
+
+You can also paste an image directly into a [value prompt](#value) while typing - no token required.
 
 Example: `Copied: {{CLIPBOARD}}`.
 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -120,7 +120,7 @@ const values = await quickAddApi.requestInputs([
 const tagArray = values.tags.split(', ').filter(Boolean);
 ```
 
-### `inputPrompt(header: string, placeholder?: string, value?: string, options?: { cursorAtEnd?: boolean }): Promise<string>`
+### `inputPrompt(header: string, placeholder?: string, value?: string, options?: { cursorAtEnd?: boolean, imagePaste?: { sourcePath?: string } }): Promise<string>`
 Opens a prompt that asks for text input.
 
 **Parameters:**
@@ -128,6 +128,7 @@ Opens a prompt that asks for text input.
 - `placeholder`: (Optional) Placeholder text in the input field
 - `value`: (Optional) Default value
 - `options.cursorAtEnd`: (Optional) When `true`, places the caret after the default value instead of selecting it
+- `options.imagePaste`: (Optional) Accept clipboard-image paste: the image is saved as a vault attachment (per Obsidian's attachment settings) and an embed link is inserted at the caret. Clipboard text always wins over an image. Only enable this when the value flows into note content - an embed link in a file name or path would corrupt it. `sourcePath` is the note path the link will live in when known; omit it to get vault-root links that resolve from anywhere.
 
 **Returns:** Promise resolving to the entered string.
 

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -20,6 +20,11 @@ import {
 import * as positioning from "./helpers/insertionPositioning";
 import { insertAtNoteBodyStartWithResult } from "../utils/noteContentInsertion";
 import { parentFolderPath } from "../utils/pathUtils";
+import {
+	buildImageEmbedLink,
+	IMAGE_CLIPBOARD_MIME_EXTENSIONS,
+	saveClipboardImageToVault,
+} from "../utils/clipboardImageAttachments";
 
 /**
 	* Only ASCII whitespace counts as "nothing to capture". Unicode spaces such as
@@ -27,14 +32,6 @@ import { parentFolderPath } from "../utils/pathUtils";
 	* dropped, even though String.prototype.trim() strips them (issue #760).
 	*/
 const ASCII_WHITESPACE_ONLY_REGEX = /^[ \t\r\n\f\v]*$/;
-const imageClipboardMimeExtensions: Record<string, string> = {
-	"image/png": "png",
-	"image/jpeg": "jpg",
-	"image/jpg": "jpg",
-	"image/gif": "gif",
-	"image/webp": "webp",
-	"image/svg+xml": "svg",
-};
 
 function isCaptureContentEmpty(content: string): boolean {
 	return ASCII_WHITESPACE_ONLY_REGEX.test(content);
@@ -199,19 +196,18 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			return null;
 		}
 
-		const extension = imageClipboardMimeExtensions[item.mimeType];
-		const filename = `Clipboard image ${this.formatAttachmentTimestamp(new Date())}.${extension}`;
 		const sourcePath = this.getLinkSourcePath() ?? "";
-		const attachmentPath =
-			await this.app.fileManager.getAvailablePathForAttachment(
-				filename,
-				sourcePath || undefined,
-			);
-		const file = await this.app.vault.createBinary(attachmentPath, data);
+		const file = await saveClipboardImageToVault(
+			this.app,
+			data,
+			item.mimeType,
+			sourcePath,
+		);
+		// Record BEFORE link generation so a linking failure still leaves the
+		// created file visible to the engine's rollback.
 		this.createdClipboardAttachmentPaths.push(file.path);
-		const link = this.app.fileManager.generateMarkdownLink(file, sourcePath);
 
-		return link.startsWith("!") ? link : `!${link}`;
+		return buildImageEmbedLink(this.app, file, sourcePath);
 	}
 
 	private async getFirstClipboardImageItem(clipboard: {
@@ -220,21 +216,12 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		const items = await clipboard.read();
 		for (const clipboardItem of items) {
 			const mimeType = clipboardItem.types.find(
-				(type) => imageClipboardMimeExtensions[type] !== undefined,
+				(type) => IMAGE_CLIPBOARD_MIME_EXTENSIONS[type] !== undefined,
 			);
 			if (mimeType) return { clipboardItem, mimeType };
 		}
 
 		return null;
-	}
-
-	private formatAttachmentTimestamp(date: Date): string {
-		const pad = (value: number) => String(value).padStart(2, "0");
-		return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
-			date.getDate(),
-		)} ${pad(date.getHours())}.${pad(date.getMinutes())}.${pad(
-			date.getSeconds(),
-		)}`;
 	}
 
 	protected getCurrentFileLink(): string | null {

--- a/src/formatters/completeFormatter.imagePaste.test.ts
+++ b/src/formatters/completeFormatter.imagePaste.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+
+/**
+ * Guards the sink-context gate for prompt image paste (issue #1484): value
+ * prompts opened while formatting note CONTENT carry `imagePaste` in their
+ * options; prompts opened from PATH passes (file name, folder, capture
+ * destination, location targets) never do - an embed link in a path would
+ * corrupt it.
+ */
+
+const mocks = vi.hoisted(() => ({
+	inputPromptPrompt: vi.fn(),
+	inputPromptPromptWithContext: vi.fn(),
+	inputPromptFactory: vi.fn(),
+}));
+
+vi.mock("obsidian", () => ({
+	MarkdownView: class {},
+	normalizePath: (path: string) =>
+		path.replace(/\\/g, "/").replace(/\/+/g, "/"),
+}));
+
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory(inputTypeOverride?: string) {
+			mocks.inputPromptFactory(inputTypeOverride);
+			return {
+				Prompt: mocks.inputPromptPrompt,
+				PromptWithContext: mocks.inputPromptPromptWithContext,
+			};
+		}
+	},
+}));
+
+vi.mock("src/gui/GenericInputPrompt/GenericInputPrompt", () => ({
+	__esModule: true,
+	default: { PromptWithContext: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("src/gui/MultiSuggester/multiSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock("src/gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		async runAndGetOutput() {
+			return "";
+		}
+		getVariables() {
+			return new Map();
+		}
+	},
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+		setTargetFolderPath() {}
+	},
+}));
+
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../logger/logManager", () => ({
+	log: { logError: vi.fn(), logWarning: vi.fn(), logMessage: vi.fn() },
+}));
+
+import { CompleteFormatter } from "./completeFormatter";
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+function createMockApp(): App {
+	return {
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(null),
+		},
+		metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		fileManager: {
+			generateMarkdownLink: vi.fn((file: TFile) => `[[${file.path}]]`),
+			getAvailablePathForAttachment: vi.fn(async () => "Assets/x.png"),
+		},
+		vault: {
+			adapter: { exists: vi.fn() },
+			cachedRead: vi.fn(),
+		},
+	} as unknown as App;
+}
+
+const plugin = {
+	settings: {
+		enableTemplatePropertyTypes: false,
+		globalVariables: {},
+		inputPrompt: "single-line",
+	},
+} as never;
+
+function lastPromptOptions(mock: ReturnType<typeof vi.fn>) {
+	const call = mock.mock.calls.at(-1);
+	if (!call) throw new Error("prompt was not called");
+	return call[5];
+}
+
+beforeEach(() => {
+	mocks.inputPromptPrompt.mockReset().mockResolvedValue("typed");
+	mocks.inputPromptPromptWithContext.mockReset().mockResolvedValue("typed");
+	mocks.inputPromptFactory.mockReset();
+	Object.defineProperty(globalThis, "navigator", {
+		value: { clipboard: { readText: vi.fn().mockResolvedValue("") } },
+		configurable: true,
+	});
+});
+
+describe("image paste sink-context gating", () => {
+	it("offers image paste for {{VALUE}} prompts during content formatting", async () => {
+		const f = new CompleteFormatter(createMockApp(), plugin);
+
+		await f.formatFileContent("{{VALUE}}");
+
+		expect(lastPromptOptions(mocks.inputPromptPrompt)).toEqual({
+			optional: undefined,
+			numeric: undefined,
+			slider: undefined,
+			imagePaste: { sourcePath: "" },
+		});
+	});
+
+	it("offers image paste for named {{VALUE:x}} prompts during content formatting", async () => {
+		const f = new CompleteFormatter(createMockApp(), plugin);
+
+		await f.formatFileContent("{{VALUE:note body}}");
+
+		expect(lastPromptOptions(mocks.inputPromptPrompt)).toMatchObject({
+			imagePaste: { sourcePath: "" },
+		});
+	});
+
+	it("never offers image paste in file name prompts", async () => {
+		const f = new CompleteFormatter(createMockApp(), plugin);
+
+		await f.formatFileName("{{VALUE}}", "value");
+
+		expect(lastPromptOptions(mocks.inputPromptPrompt)).toBeUndefined();
+	});
+
+	it("never offers image paste in folder path prompts", async () => {
+		const f = new CompleteFormatter(createMockApp(), plugin);
+
+		await f.formatFolderPath("{{VALUE:folder}}");
+
+		expect(lastPromptOptions(mocks.inputPromptPrompt)).toBeUndefined();
+	});
+
+	it("never offers image paste in template path prompts", async () => {
+		const f = new CompleteFormatter(createMockApp(), plugin);
+
+		await f.formatTemplateFilePath("Templates/{{VALUE:kind}}.md");
+
+		expect(lastPromptOptions(mocks.inputPromptPrompt)).toBeUndefined();
+	});
+
+	it("restores the path-context default after content formatting", async () => {
+		const f = new CompleteFormatter(createMockApp(), plugin);
+
+		await f.formatFileContent("{{VALUE:first}}");
+		await f.formatFolderPath("{{VALUE:second}}");
+
+		expect(lastPromptOptions(mocks.inputPromptPrompt)).toBeUndefined();
+	});
+
+	it("keeps number/slider prompts free of image paste even in content", async () => {
+		const f = new CompleteFormatter(createMockApp(), plugin);
+
+		await f.formatFileContent("{{VALUE:n|type:number}}");
+
+		const options = lastPromptOptions(mocks.inputPromptPrompt);
+		expect(options?.imagePaste).toBeUndefined();
+	});
+
+	it("passes the capture destination as the paste sourcePath", async () => {
+		const f = new CaptureChoiceFormatter(createMockApp(), plugin);
+		f.setDestinationSourcePath("Journal/2026-07-06.md");
+
+		await f.formatContentOnly("{{VALUE}}");
+
+		// Capture value prompts route through PromptWithContext because a
+		// link source path exists; options stay the 6th argument.
+		const options =
+			mocks.inputPromptPromptWithContext.mock.calls.at(-1)?.[6] ??
+			lastPromptOptions(mocks.inputPromptPrompt);
+		expect(options?.imagePaste).toEqual({
+			sourcePath: "Journal/2026-07-06.md",
+		});
+	});
+});

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -44,6 +44,13 @@ import { isCancellationError } from "../utils/errorUtils";
 
 export class CompleteFormatter extends Formatter {
 	private valueHeader: string;
+	/**
+	 * True only while formatFileContent's format() pass runs. Value prompts
+	 * opened during that window accept clipboard-image paste; prompts opened
+	 * from path passes (file name, folder, template path, location targets)
+	 * never do — an embed link in a path would corrupt it (issue #1484).
+	 */
+	private contentValuePromptsAcceptImagePaste = false;
 
 	constructor(
 		protected app: App,
@@ -135,7 +142,20 @@ export class CompleteFormatter extends Formatter {
 	async formatFileContent(input: string): Promise<string> {
 		let output: string = input;
 
-		output = await this.format(output);
+		// formatFileContent is the ONLY content pass: every path pass
+		// (formatFileName/formatFolderPath/formatTemplateFilePath/
+		// formatLocationString) calls format() directly. Image paste in value
+		// prompts is therefore enabled exactly here — a pasted embed link is
+		// note-body material and must never reach a file-name/path prompt
+		// (issue #1484). Restored in finally so a nested/failed pass can't
+		// leak the flag into a later path pass on the same formatter.
+		const previousImagePaste = this.contentValuePromptsAcceptImagePaste;
+		this.contentValuePromptsAcceptImagePaste = true;
+		try {
+			output = await this.format(output);
+		} finally {
+			this.contentValuePromptsAcceptImagePaste = previousImagePaste;
+		}
 		// Resolve ALL note-derived tokens ({{linkcurrent}}, {{linksection}},
 		// {{filenamecurrent}}, {{folder}}, {{foldercurrent}}, {{title}}) in ONE
 		// pass so no token re-scans another's generated output — fixing both the
@@ -549,13 +569,29 @@ export class CompleteFormatter extends Formatter {
 	private buildInputPromptOptions(
 		context: PromptContext | undefined,
 	): InputPromptOptions | undefined {
-		if (!context?.optional && !context?.numericConfig && !context?.sliderConfig) {
+		// Image paste only for free-text prompts opened while formatting note
+		// CONTENT — never for number/slider (numeric sinks) and never during
+		// path passes (see contentValuePromptsAcceptImagePaste). The checkbox
+		// picker never reaches the input-prompt factory.
+		const imagePaste =
+			this.contentValuePromptsAcceptImagePaste &&
+			context?.inputTypeOverride !== "number" &&
+			context?.inputTypeOverride !== "slider"
+				? { sourcePath: this.getLinkSourcePath() ?? "" }
+				: undefined;
+		if (
+			!context?.optional &&
+			!context?.numericConfig &&
+			!context?.sliderConfig &&
+			!imagePaste
+		) {
 			return undefined;
 		}
 		return {
 			optional: context?.optional,
 			numeric: context?.numericConfig,
 			slider: context?.sliderConfig,
+			imagePaste,
 		};
 	}
 

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -5,6 +5,8 @@ import { TagSuggester } from "../suggesters/tagSuggester";
 import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
 import type { InputPromptOptions } from "../../types/inputPrompt";
 import { positionInputPromptCursor } from "../inputPromptCursor";
+import type { ImagePasteHandle } from "../imagePasteHandler";
+import { attachImagePasteHandler } from "../imagePasteHandler";
 
 /**
  * The keyboard gesture that skips an optional prompt: ctrl/cmd+shift+Enter.
@@ -34,6 +36,7 @@ export default class GenericInputPrompt extends Modal {
 	private readonly description?: string;
 	private fileSuggester: FileSuggester;
 	private tagSuggester: TagSuggester;
+	private imagePasteHandle?: ImagePasteHandle;
 
 	public static Prompt(
 		app: App,
@@ -163,6 +166,14 @@ export default class GenericInputPrompt extends Modal {
 			.onChange((value) => this.onInputChanged(value))
 			.inputEl.addEventListener("keydown", this.submitEnterCallback);
 
+		if (this.options?.imagePaste) {
+			this.imagePasteHandle = attachImagePasteHandler(
+				this.app,
+				textComponent.inputEl,
+				this.options.imagePaste,
+			);
+		}
+
 		return textComponent;
 	}
 
@@ -236,6 +247,13 @@ export default class GenericInputPrompt extends Modal {
 	}
 
 	private submit() {
+		if (this.didSubmit) return;
+		// A pasted image may still be saving; defer so Ctrl+V-then-Enter
+		// submits WITH the embed link instead of racing the save.
+		if (this.imagePasteHandle?.isBusy()) {
+			void this.imagePasteHandle.whenIdle().then(() => this.submit());
+			return;
+		}
 		const rawInput = this.inputComponent?.inputEl?.value ?? this.input;
 		this.input = this.transformInputOnSubmit(rawInput);
 		this.didSubmit = true;
@@ -284,6 +302,7 @@ export default class GenericInputPrompt extends Modal {
 			"keydown",
 			this.submitEnterCallback
 		);
+		this.imagePasteHandle?.detach();
 	}
 
 	onOpen() {

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -29,6 +29,7 @@ export default class GenericInputPrompt extends Modal {
 	private resolvePromise: (input: string) => void;
 	private rejectPromise: (reason?: unknown) => void;
 	private didSubmit = false;
+	private didClose = false;
 	protected inputComponent: TextComponent;
 	protected input: string;
 	private readonly placeholder: string;
@@ -247,7 +248,10 @@ export default class GenericInputPrompt extends Modal {
 	}
 
 	private submit() {
-		if (this.didSubmit) return;
+		// didClose guards the deferred path below: cancel/Esc while a paste
+		// save is in flight must not let the queued submit fire on the closed
+		// modal (re-resolving the rejected promise, double onClose).
+		if (this.didSubmit || this.didClose) return;
 		// A pasted image may still be saving; defer so Ctrl+V-then-Enter
 		// submits WITH the embed link instead of racing the save.
 		if (this.imagePasteHandle?.isBusy()) {
@@ -312,6 +316,7 @@ export default class GenericInputPrompt extends Modal {
 	}
 
 	onClose() {
+		this.didClose = true;
 		if (!this.didSubmit) {
 			this.syncInputFromEl();
 		}

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.test.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.test.ts
@@ -112,3 +112,119 @@ describe("GenericWideInputPrompt returns the user's input verbatim", () => {
 		);
 	});
 });
+
+describe("image paste submit/cancel races (issue #1484)", () => {
+	beforeEach(() => {
+		fakeApp = makeFakeApp();
+		setQuickAddInstance({
+			app: fakeApp,
+			registerEvent: () => {},
+		} as unknown as QuickAdd);
+	});
+
+	afterEach(() => {
+		for (const el of Array.from(document.body.children)) el.remove();
+	});
+
+	function makePasteApp() {
+		let resolveCreate: () => void = () => {};
+		const created = new Promise<{ path: string }>((resolve) => {
+			resolveCreate = () => resolve({ path: "img.png" });
+		});
+		let createCalled = false;
+		const app = {
+			...makeFakeApp(),
+			fileManager: {
+				getNewFileParent: () => ({ path: "" }),
+				getAvailablePathForAttachment: async () => "img.png",
+				generateMarkdownLink: (file: { path: string }) => `![[${file.path}]]`,
+			},
+			vault: {
+				...makeFakeApp().vault,
+				createBinary: () => {
+					createCalled = true;
+					return created;
+				},
+			},
+		};
+		return {
+			app,
+			resolveCreate,
+			createStarted: () => createCalled,
+		};
+	}
+
+	function openPromptWithPaste(app: unknown) {
+		const waitForClose = GenericWideInputPrompt.Prompt(
+			app as never,
+			"Header",
+			undefined,
+			undefined,
+			undefined,
+			{ imagePaste: {} },
+		);
+		const textarea = document.querySelector(
+			"textarea.wideInputPromptInputEl",
+		) as HTMLTextAreaElement;
+		return { waitForClose, textarea };
+	}
+
+	function dispatchImagePaste(textarea: HTMLTextAreaElement) {
+		const file = new File([new Uint8Array([1, 2, 3])], "img.png", {
+			type: "image/png",
+		});
+		const clipboardData = {
+			getData: () => "",
+			items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+			files: [file],
+		};
+		const event = new Event("paste", { bubbles: true, cancelable: true });
+		Object.defineProperty(event, "clipboardData", { value: clipboardData });
+		textarea.dispatchEvent(event);
+	}
+
+	async function waitFor(predicate: () => boolean) {
+		for (let i = 0; i < 200 && !predicate(); i++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+		expect(predicate()).toBe(true);
+	}
+
+	it("a ctrl+Enter during the save defers and submits WITH the embed link", async () => {
+		const { app, resolveCreate, createStarted } = makePasteApp();
+		const { waitForClose, textarea } = openPromptWithPaste(app);
+
+		dispatchImagePaste(textarea);
+		await waitFor(createStarted);
+		textarea.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true }),
+		);
+		resolveCreate();
+
+		await expect(waitForClose).resolves.toBe("![[img.png]]");
+	});
+
+	it("cancel during an in-flight save never fires the deferred submit", async () => {
+		const { app, resolveCreate, createStarted } = makePasteApp();
+		const { waitForClose, textarea } = openPromptWithPaste(app);
+
+		dispatchImagePaste(textarea);
+		await waitFor(createStarted);
+		// Enter queues a deferred submit behind the pending save...
+		textarea.dispatchEvent(
+			new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true }),
+		);
+		// ...then the user cancels before the save lands.
+		const cancelButton = Array.from(
+			document.querySelectorAll("button"),
+		).find((button) => button.textContent === "Cancel") as HTMLButtonElement;
+		cancelButton.click();
+
+		await expect(waitForClose).rejects.toBe("No input given.");
+
+		// The save landing later must NOT resurrect the submit on the closed
+		// modal (deferred submit is guarded by didClose).
+		resolveCreate();
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	});
+});

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -7,6 +7,8 @@ import type { InputPromptOptions } from "../../types/inputPrompt";
 import { positionInputPromptCursor } from "../inputPromptCursor";
 import { attachTextareaIndent } from "../components/textareaIndent";
 import { isSkipPromptShortcut } from "../GenericInputPrompt/GenericInputPrompt";
+import type { ImagePasteHandle } from "../imagePasteHandler";
+import { attachImagePasteHandler } from "../imagePasteHandler";
 
 export default class GenericWideInputPrompt extends Modal {
 	public waitForClose: Promise<string>;
@@ -22,6 +24,7 @@ export default class GenericWideInputPrompt extends Modal {
 	private fileSuggester: FileSuggester;
 	private tagSuggester: TagSuggester;
 	private disposeIndent?: () => void;
+	private imagePasteHandle?: ImagePasteHandle;
 
 	public static Prompt(
 		app: App,
@@ -148,6 +151,14 @@ export default class GenericWideInputPrompt extends Modal {
 		// Tab inserts a tab / indents instead of moving focus (issue #764).
 		this.disposeIndent = attachTextareaIndent(textComponent.inputEl);
 
+		if (this.options?.imagePaste) {
+			this.imagePasteHandle = attachImagePasteHandler(
+				this.app,
+				textComponent.inputEl,
+				this.options.imagePaste,
+			);
+		}
+
 		return textComponent;
 	}
 
@@ -223,6 +234,12 @@ export default class GenericWideInputPrompt extends Modal {
 
 	private submit() {
 		if (this.didSubmit) return;
+		// A pasted image may still be saving; defer so ctrl/cmd+Enter right
+		// after Ctrl+V submits WITH the embed link instead of racing the save.
+		if (this.imagePasteHandle?.isBusy()) {
+			void this.imagePasteHandle.whenIdle().then(() => this.submit());
+			return;
+		}
 		// Resolve the textarea value verbatim — identical to the single-line
 		// GenericInputPrompt (whose transformInputOnSubmit is the identity). The
 		// substituted {{VALUE}} is never linebreak-processed (the formatter's
@@ -277,6 +294,7 @@ export default class GenericWideInputPrompt extends Modal {
 			this.submitEnterCallback,
 		);
 		this.disposeIndent?.();
+		this.imagePasteHandle?.detach();
 	}
 
 	onOpen() {

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -16,6 +16,7 @@ export default class GenericWideInputPrompt extends Modal {
 	private resolvePromise: (input: string) => void;
 	private rejectPromise: (reason?: unknown) => void;
 	private didSubmit = false;
+	private didClose = false;
 	private inputComponent: TextAreaComponent;
 	private input: string;
 	private readonly placeholder: string;
@@ -233,7 +234,10 @@ export default class GenericWideInputPrompt extends Modal {
 	};
 
 	private submit() {
-		if (this.didSubmit) return;
+		// didClose guards the deferred path below: cancel/Esc while a paste
+		// save is in flight must not let the queued submit fire on the closed
+		// modal (re-resolving the rejected promise, double onClose).
+		if (this.didSubmit || this.didClose) return;
 		// A pasted image may still be saving; defer so ctrl/cmd+Enter right
 		// after Ctrl+V submits WITH the embed link instead of racing the save.
 		if (this.imagePasteHandle?.isBusy()) {
@@ -304,6 +308,7 @@ export default class GenericWideInputPrompt extends Modal {
 	}
 
 	onClose() {
+		this.didClose = true;
 		if (!this.didSubmit) {
 			this.syncInputFromEl();
 		}

--- a/src/gui/imagePasteHandler.test.ts
+++ b/src/gui/imagePasteHandler.test.ts
@@ -360,3 +360,92 @@ describe("attachImagePasteHandler", () => {
 		).toBe("Journal/today.md");
 	});
 });
+
+describe("attachImagePasteHandler - review hardening (issue #1484)", () => {
+	it("uses the DataTransferItem MIME when the File reports an empty type", async () => {
+		const { app, getAvailablePathForAttachment } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		// getAsFile() can return a File whose .type is empty; the item's
+		// declared MIME must drive the extension.
+		const bare = new File([new Uint8Array([1])], "img", { type: "" });
+		const data = {
+			getData: () => "",
+			items: [{ kind: "file", type: "image/png", getAsFile: () => bare }],
+			files: [],
+		} as unknown as DataTransfer;
+		dispatchPaste(input, data);
+		await flushSaves(handle);
+
+		expect(getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.stringMatching(/\.png$/),
+			undefined,
+		);
+		expect(input.value).toMatch(/!\[\[.*\.png\]\]/);
+	});
+
+	it("ignores Object.prototype member names masquerading as MIME types", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		const event = dispatchPaste(
+			input,
+			makeClipboardData([makeImageFile("evil", "constructor")]),
+		);
+		await flushSaves(handle);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("keeps whenIdle resolved (never rejected) when link insertion fails", async () => {
+		const { app } = makeApp();
+		const input = makeInput();
+		const setRangeText = input.setRangeText.bind(input);
+		input.setRangeText = () => {
+			throw new Error("insertion blew up");
+		};
+		const handle = attachImagePasteHandler(app, input, {});
+
+		dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await expect(handle.whenIdle()).resolves.toBeUndefined();
+		await flushSaves(handle);
+
+		expect(Notice).toHaveBeenCalledWith(
+			expect.stringContaining("could not insert its link"),
+		);
+		expect(handle.isBusy()).toBe(false);
+		input.setRangeText = setRangeText;
+	});
+
+	it("serializes saves across two handlers (one-page cross-field pastes)", async () => {
+		const { app, created } = makeApp();
+		let inFlight = 0;
+		let maxInFlight = 0;
+		const realCreate = app.vault.createBinary as ReturnType<typeof vi.fn>;
+		realCreate.mockImplementation(async (path: string) => {
+			inFlight++;
+			maxInFlight = Math.max(maxInFlight, inFlight);
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			inFlight--;
+			created.push(path);
+			return { path } as TFile;
+		});
+		const inputA = makeInput();
+		const inputB = makeInput();
+		const handleA = attachImagePasteHandler(app, inputA, {});
+		const handleB = attachImagePasteHandler(app, inputB, {});
+
+		dispatchPaste(inputA, makeClipboardData([makeImageFile("a.png")]));
+		dispatchPaste(inputB, makeClipboardData([makeImageFile("b.png")]));
+		await flushSaves(handleA);
+		await flushSaves(handleB);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(created).toHaveLength(2);
+		expect(new Set(created).size).toBe(2);
+		expect(maxInFlight).toBe(1);
+	});
+});

--- a/src/gui/imagePasteHandler.test.ts
+++ b/src/gui/imagePasteHandler.test.ts
@@ -1,0 +1,362 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import { attachImagePasteHandler } from "./imagePasteHandler";
+
+vi.mock("obsidian", () => ({
+	Notice: vi.fn(),
+}));
+
+vi.mock("../logger/logManager", () => ({
+	log: { logError: vi.fn(), logWarning: vi.fn(), logMessage: vi.fn() },
+}));
+
+import { Notice } from "obsidian";
+
+function makeApp() {
+	const created: string[] = [];
+	const createBinary = vi.fn(async (path: string, _data: ArrayBuffer) => {
+		created.push(path);
+		return { path } as TFile;
+	});
+	const getAvailablePathForAttachment = vi.fn(
+		async (filename: string, _sourcePath?: string) => {
+			// Mimic Obsidian's dedupe against files that already exist.
+			let candidate = `attachments/${filename}`;
+			let counter = 1;
+			while (created.includes(candidate)) {
+				candidate = `attachments/${filename.replace(/(\.\w+)$/, ` ${counter}$1`)}`;
+				counter++;
+			}
+			return candidate;
+		},
+	);
+	const generateMarkdownLink = vi.fn(
+		(file: TFile, _sourcePath: string) => `![[${file.path}]]`,
+	);
+	const app = {
+		vault: { createBinary },
+		fileManager: { getAvailablePathForAttachment, generateMarkdownLink },
+	} as unknown as App;
+	return { app, createBinary, getAvailablePathForAttachment, created };
+}
+
+function makeImageFile(name = "img.png", type = "image/png"): File {
+	return new File([new Uint8Array([1, 2, 3])], name, { type });
+}
+
+/**
+ * jsdom has no DataTransfer constructor; the handler only touches
+ * getData/items/files, so a structural fake dispatched via a plain Event with
+ * a defined clipboardData property exercises the same code path.
+ */
+function makeClipboardData(images: File[], text = ""): DataTransfer {
+	return {
+		getData: (format: string) => (format === "text/plain" ? text : ""),
+		items: images.map((file) => ({
+			kind: "file",
+			type: file.type,
+			getAsFile: () => file,
+		})),
+		files: images,
+	} as unknown as DataTransfer;
+}
+
+function dispatchPaste(
+	el: HTMLElement,
+	data: DataTransfer,
+): ClipboardEvent {
+	const event = new Event("paste", { bubbles: true, cancelable: true });
+	Object.defineProperty(event, "clipboardData", { value: data });
+	el.dispatchEvent(event);
+	return event as ClipboardEvent;
+}
+
+async function flushSaves(handle: { whenIdle(): Promise<void> }) {
+	await handle.whenIdle();
+	// whenIdle resolves via .finally; give the insertion microtask a beat.
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeInput(): HTMLInputElement {
+	const input = document.createElement("input");
+	document.body.appendChild(input);
+	return input;
+}
+
+function makeTextarea(): HTMLTextAreaElement {
+	const textarea = document.createElement("textarea");
+	document.body.appendChild(textarea);
+	return textarea;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = "";
+	vi.mocked(Notice).mockClear();
+});
+
+describe("attachImagePasteHandler", () => {
+	it("saves a pasted image and inserts an embed link at the caret", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		input.value = "before after";
+		input.setSelectionRange(7, 7);
+		const handle = attachImagePasteHandler(app, input, {});
+
+		const event = dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		expect(event.defaultPrevented).toBe(true);
+		await flushSaves(handle);
+
+		expect(createBinary).toHaveBeenCalledTimes(1);
+		expect(input.value).toBe(
+			"before ![[attachments/Clipboard image" +
+				input.value.slice("before ![[attachments/Clipboard image".length, input.value.indexOf("]]") + 2) +
+				"after",
+		);
+		expect(input.value).toMatch(
+			/^before !\[\[attachments\/Clipboard image .*\.png\]\]after$/,
+		);
+	});
+
+	it("fires an input event so component onChange observers update", async () => {
+		const { app } = makeApp();
+		const input = makeInput();
+		const onInput = vi.fn();
+		input.addEventListener("input", onInput);
+		const handle = attachImagePasteHandler(app, input, {});
+
+		dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await flushSaves(handle);
+
+		expect(onInput).toHaveBeenCalled();
+	});
+
+	it("lets text win: no save, no preventDefault when text/plain is non-empty", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		const event = dispatchPaste(
+			input,
+			makeClipboardData([makeImageFile()], "clipboard text"),
+		);
+		await flushSaves(handle);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("whitespace-only text still wins (parity with the capture fallback)", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		const event = dispatchPaste(input, makeClipboardData([makeImageFile()], "  "));
+		await flushSaves(handle);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("ignores pastes without image data", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		const event = dispatchPaste(input, makeClipboardData([]));
+		await flushSaves(handle);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("ignores non-image files", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		const event = dispatchPaste(
+			input,
+			makeClipboardData([makeImageFile("doc.pdf", "application/pdf")]),
+		);
+		await flushSaves(handle);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("saves multiple images sequentially with distinct paths, space-joined in inputs", async () => {
+		const { app, created } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		dispatchPaste(
+			input,
+			makeClipboardData([makeImageFile("a.png"), makeImageFile("b.png")]),
+		);
+		await flushSaves(handle);
+
+		expect(created).toHaveLength(2);
+		expect(new Set(created).size).toBe(2);
+		expect(input.value).toMatch(/^!\[\[.*\]\] !\[\[.*\]\]$/);
+	});
+
+	it("joins multiple images with newlines in textareas", async () => {
+		const { app } = makeApp();
+		const textarea = makeTextarea();
+		const handle = attachImagePasteHandler(app, textarea, {});
+
+		dispatchPaste(
+			textarea,
+			makeClipboardData([makeImageFile("a.png"), makeImageFile("b.png")]),
+		);
+		await flushSaves(handle);
+
+		expect(textarea.value).toMatch(/^!\[\[.*\]\]\n!\[\[.*\]\]$/);
+	});
+
+	it("freezes the input during the save and unfreezes afterwards", async () => {
+		const { app } = makeApp();
+		let resolveCreate: () => void = () => {};
+		const createBinary = app.vault.createBinary as ReturnType<typeof vi.fn>;
+		createBinary.mockImplementationOnce(
+			(path: string) =>
+				new Promise<TFile>((resolve) => {
+					resolveCreate = () => resolve({ path } as TFile);
+				}),
+		);
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await vi.waitFor(() => expect(createBinary).toHaveBeenCalled());
+		expect(input.readOnly).toBe(true);
+		expect(handle.isBusy()).toBe(true);
+
+		resolveCreate();
+		await flushSaves(handle);
+		expect(input.readOnly).toBe(false);
+		expect(handle.isBusy()).toBe(false);
+	});
+
+	it("notices instead of interleaving when a second paste arrives mid-save", async () => {
+		const { app } = makeApp();
+		let resolveCreate: () => void = () => {};
+		const createBinary = app.vault.createBinary as ReturnType<typeof vi.fn>;
+		createBinary.mockImplementationOnce(
+			(path: string) =>
+				new Promise<TFile>((resolve) => {
+					resolveCreate = () => resolve({ path } as TFile);
+				}),
+		);
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await vi.waitFor(() => expect(createBinary).toHaveBeenCalled());
+		const second = dispatchPaste(input, makeClipboardData([makeImageFile()]));
+
+		expect(second.defaultPrevented).toBe(true);
+		expect(Notice).toHaveBeenCalledWith(
+			expect.stringContaining("still being saved"),
+		);
+
+		resolveCreate();
+		await flushSaves(handle);
+		// Only the first paste's image landed.
+		expect(input.value.match(/!\[\[/g)).toHaveLength(1);
+	});
+
+	it("keeps successfully saved images when a later one fails, and notices", async () => {
+		const { app } = makeApp();
+		const input = makeInput();
+		(app.vault.createBinary as ReturnType<typeof vi.fn>)
+			.mockImplementationOnce(async (path: string) => ({ path }) as TFile)
+			.mockImplementationOnce(async () => {
+				throw new Error("disk full");
+			});
+		const handle = attachImagePasteHandler(app, input, {});
+
+		dispatchPaste(
+			input,
+			makeClipboardData([makeImageFile("a.png"), makeImageFile("b.png")]),
+		);
+		await flushSaves(handle);
+
+		expect(input.value.match(/!\[\[/g)).toHaveLength(1);
+		expect(Notice).toHaveBeenCalledWith(
+			expect.stringContaining("failed to save pasted image"),
+		);
+		expect(input.readOnly).toBe(false);
+	});
+
+	it("does nothing after detach", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+		handle.detach();
+
+		const event = dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await flushSaves(handle);
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it("skips the text insertion when detached mid-save (modal closed)", async () => {
+		const { app } = makeApp();
+		let resolveCreate: () => void = () => {};
+		const createBinary = app.vault.createBinary as ReturnType<typeof vi.fn>;
+		createBinary.mockImplementationOnce(
+			(path: string) =>
+				new Promise<TFile>((resolve) => {
+					resolveCreate = () => resolve({ path } as TFile);
+				}),
+		);
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await vi.waitFor(() => expect(createBinary).toHaveBeenCalled());
+		handle.detach();
+		resolveCreate();
+		await flushSaves(handle);
+
+		expect(input.value).toBe("");
+	});
+
+	it("ignores paste during IME composition", async () => {
+		const { app, createBinary } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {});
+
+		input.dispatchEvent(new Event("compositionstart"));
+		const during = dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		expect(during.defaultPrevented).toBe(false);
+
+		input.dispatchEvent(new Event("compositionend"));
+		dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await flushSaves(handle);
+
+		expect(createBinary).toHaveBeenCalledTimes(1);
+	});
+
+	it("passes the sourcePath through to placement and link generation", async () => {
+		const { app, getAvailablePathForAttachment } = makeApp();
+		const input = makeInput();
+		const handle = attachImagePasteHandler(app, input, {
+			sourcePath: "Journal/today.md",
+		});
+
+		dispatchPaste(input, makeClipboardData([makeImageFile()]));
+		await flushSaves(handle);
+
+		expect(getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.any(String),
+			"Journal/today.md",
+		);
+		expect(
+			(app.fileManager.generateMarkdownLink as ReturnType<typeof vi.fn>).mock
+				.calls[0][1],
+		).toBe("Journal/today.md");
+	});
+});

--- a/src/gui/imagePasteHandler.test.ts
+++ b/src/gui/imagePasteHandler.test.ts
@@ -107,11 +107,6 @@ describe("attachImagePasteHandler", () => {
 		await flushSaves(handle);
 
 		expect(createBinary).toHaveBeenCalledTimes(1);
-		expect(input.value).toBe(
-			"before ![[attachments/Clipboard image" +
-				input.value.slice("before ![[attachments/Clipboard image".length, input.value.indexOf("]]") + 2) +
-				"after",
-		);
 		expect(input.value).toMatch(
 			/^before !\[\[attachments\/Clipboard image .*\.png\]\]after$/,
 		);

--- a/src/gui/imagePasteHandler.ts
+++ b/src/gui/imagePasteHandler.ts
@@ -1,0 +1,179 @@
+import type { App } from "obsidian";
+import { Notice } from "obsidian";
+import { log } from "../logger/logManager";
+import {
+	buildImageEmbedLink,
+	IMAGE_CLIPBOARD_MIME_EXTENSIONS,
+	saveClipboardImageToVault,
+} from "../utils/clipboardImageAttachments";
+
+export interface ImagePasteOptions {
+	/**
+	 * Note path the inserted link will live in when known (capture
+	 * destination). "" (default) resolves attachment placement against the
+	 * vault root and makes the link a vault-root path that resolves from any
+	 * note - never guess (e.g. the active file): a wrong guess generates
+	 * relative links that break from the real destination.
+	 */
+	sourcePath?: string;
+}
+
+export interface ImagePasteHandle {
+	/** True while an image save is in flight. */
+	isBusy(): boolean;
+	/** Resolves once no image save is in flight (immediately when idle). */
+	whenIdle(): Promise<void>;
+	/** Removes all listeners; a still-running save keeps its file but skips the text insertion. */
+	detach(): void;
+}
+
+/**
+ * Lets an input/textarea accept clipboard IMAGE paste: the image is saved as a
+ * vault attachment (via Obsidian's attachment-folder logic) and an embed link
+ * is inserted at the caret. Clipboard TEXT always wins - when text/plain is
+ * non-empty the event is left to the default paste, byte-parity with the
+ * shipped `{{CLIPBOARD}}` image fallback's precedence.
+ *
+ * Attach only to inputs whose value flows into note content as free text;
+ * a pasted embed link in a file-name or path prompt would corrupt the path.
+ */
+export function attachImagePasteHandler(
+	app: App,
+	inputEl: HTMLInputElement | HTMLTextAreaElement,
+	options: ImagePasteOptions = {},
+): ImagePasteHandle {
+	const sourcePath = options.sourcePath ?? "";
+	let pendingSave: Promise<void> | null = null;
+	let detached = false;
+	let composing = false;
+
+	const onCompositionStart = () => {
+		composing = true;
+	};
+	const onCompositionEnd = () => {
+		composing = false;
+	};
+
+	const onPaste = (event: ClipboardEvent) => {
+		const data = event.clipboardData;
+		if (!data) return;
+		// Mid-IME-composition value mutation desyncs the composition buffer.
+		if (composing) return;
+		// Text wins: leave the event to the default paste. Untrimmed check, so
+		// whitespace-only text still wins (parity with the capture fallback).
+		if (data.getData("text/plain").length > 0) return;
+
+		// Extract the Files SYNCHRONOUSLY: Chromium neuters the DataTransfer
+		// once this handler yields (items empty, getAsFile() null after await).
+		const images = collectImageFiles(data);
+		if (images.length === 0) return;
+
+		event.preventDefault();
+		if (pendingSave) {
+			new Notice(
+				"QuickAdd: an image is still being saved — paste again in a moment.",
+			);
+			return;
+		}
+		pendingSave = saveAndInsert(images).finally(() => {
+			pendingSave = null;
+		});
+	};
+
+	async function saveAndInsert(images: File[]): Promise<void> {
+		// Freeze the input during the save so the caret cannot go stale from
+		// typing; the embed is inserted at the LIVE selection afterwards.
+		const wasReadOnly = inputEl.readOnly;
+		inputEl.readOnly = true;
+		inputEl.setAttribute("aria-busy", "true");
+		inputEl.classList.add("qa-image-paste-busy");
+
+		const links: string[] = [];
+		try {
+			// Strictly sequential: the attachment-path dedupe only sees files
+			// whose createBinary landed, so parallel same-second saves collide.
+			for (const image of images) {
+				const file = await saveClipboardImageToVault(
+					app,
+					await image.arrayBuffer(),
+					image.type,
+					sourcePath,
+				);
+				links.push(buildImageEmbedLink(app, file, sourcePath));
+			}
+		} catch (error) {
+			// Images saved before the failure keep their links (they are real
+			// vault files by now); only the failing one is reported.
+			log.logError(
+				`Failed to save pasted image: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			new Notice("QuickAdd: failed to save pasted image.");
+		} finally {
+			inputEl.readOnly = wasReadOnly;
+			inputEl.removeAttribute("aria-busy");
+			inputEl.classList.remove("qa-image-paste-busy");
+		}
+
+		if (links.length === 0 || detached) return;
+		insertAtSelection(
+			inputEl,
+			links.join(inputEl.tagName === "TEXTAREA" ? "\n" : " "),
+		);
+	}
+
+	inputEl.addEventListener("paste", onPaste);
+	inputEl.addEventListener("compositionstart", onCompositionStart);
+	inputEl.addEventListener("compositionend", onCompositionEnd);
+
+	return {
+		isBusy: () => pendingSave !== null,
+		whenIdle: () => pendingSave ?? Promise.resolve(),
+		detach: () => {
+			detached = true;
+			inputEl.removeEventListener("paste", onPaste);
+			inputEl.removeEventListener("compositionstart", onCompositionStart);
+			inputEl.removeEventListener("compositionend", onCompositionEnd);
+		},
+	};
+}
+
+function collectImageFiles(data: DataTransfer): File[] {
+	const images: File[] = [];
+	for (const item of Array.from(data.items ?? [])) {
+		if (item.kind !== "file") continue;
+		if (IMAGE_CLIPBOARD_MIME_EXTENSIONS[item.type] === undefined) continue;
+		const file = item.getAsFile();
+		if (file) images.push(file);
+	}
+	if (images.length > 0) return images;
+
+	// Some webviews only populate .files.
+	for (const file of Array.from(data.files ?? [])) {
+		if (IMAGE_CLIPBOARD_MIME_EXTENSIONS[file.type] !== undefined) {
+			images.push(file);
+		}
+	}
+	return images;
+}
+
+function insertAtSelection(
+	inputEl: HTMLInputElement | HTMLTextAreaElement,
+	text: string,
+): void {
+	inputEl.focus();
+	// execCommand is undo-integrated and fires 'input' natively; ownerDocument
+	// keeps it popout-window safe. Deprecated but the only undo-preserving
+	// path for input/textarea; fall back to setRangeText when unavailable.
+	let inserted = false;
+	try {
+		inserted = inputEl.ownerDocument.execCommand("insertText", false, text);
+	} catch {
+		inserted = false;
+	}
+	if (inserted) return;
+
+	const start = inputEl.selectionStart ?? inputEl.value.length;
+	const end = inputEl.selectionEnd ?? start;
+	inputEl.setRangeText(text, start, end, "end");
+	inputEl.dispatchEvent(new Event("input", { bubbles: true }));
+}

--- a/src/gui/imagePasteHandler.ts
+++ b/src/gui/imagePasteHandler.ts
@@ -75,12 +75,14 @@ export function attachImagePasteHandler(
 			);
 			return;
 		}
+		// saveAndInsert never rejects (both phases catch), so pendingSave and
+		// the whenIdle()-deferred submits can never be dropped by a rejection.
 		pendingSave = saveAndInsert(images).finally(() => {
 			pendingSave = null;
 		});
 	};
 
-	async function saveAndInsert(images: File[]): Promise<void> {
+	async function saveAndInsert(images: PastedImage[]): Promise<void> {
 		// Freeze the input during the save so the caret cannot go stale from
 		// typing; the embed is inserted at the LIVE selection afterwards.
 		const wasReadOnly = inputEl.readOnly;
@@ -90,14 +92,14 @@ export function attachImagePasteHandler(
 
 		const links: string[] = [];
 		try {
-			// Strictly sequential: the attachment-path dedupe only sees files
-			// whose createBinary landed, so parallel same-second saves collide.
+			// Strictly sequential AND globally queued: the attachment-path
+			// dedupe only sees files whose createBinary landed, so concurrent
+			// same-second saves (multi-image paste, or pastes into two fields
+			// of the one-page form) would resolve the same path and collide.
 			for (const image of images) {
-				const file = await saveClipboardImageToVault(
-					app,
-					await image.arrayBuffer(),
-					image.type,
-					sourcePath,
+				const data = await image.file.arrayBuffer();
+				const file = await enqueueVaultSave(() =>
+					saveClipboardImageToVault(app, data, image.mimeType, sourcePath),
 				);
 				links.push(buildImageEmbedLink(app, file, sourcePath));
 			}
@@ -115,10 +117,20 @@ export function attachImagePasteHandler(
 		}
 
 		if (links.length === 0 || detached) return;
-		insertAtSelection(
-			inputEl,
-			links.join(inputEl.tagName === "TEXTAREA" ? "\n" : " "),
-		);
+		try {
+			insertAtSelection(
+				inputEl,
+				links.join(inputEl.tagName === "TEXTAREA" ? "\n" : " "),
+			);
+		} catch (error) {
+			// The files exist and are usable; only the text insertion failed.
+			log.logError(
+				`Failed to insert pasted image link: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			new Notice(
+				"QuickAdd: saved the pasted image but could not insert its link.",
+			);
+		}
 	}
 
 	inputEl.addEventListener("paste", onPaste);
@@ -137,20 +149,46 @@ export function attachImagePasteHandler(
 	};
 }
 
-function collectImageFiles(data: DataTransfer): File[] {
-	const images: File[] = [];
+interface PastedImage {
+	file: File;
+	/**
+	 * MIME from the DataTransferItem (or File) that matched the supported
+	 * map - carried separately because getAsFile() can return a File whose
+	 * .type is empty or differs from the item's.
+	 */
+	mimeType: string;
+}
+
+/**
+ * Serializes all clipboard-image vault writes in this window: the attachment
+ * path dedupe only sees landed files, so two same-second saves racing (e.g.
+ * pastes into two one-page fields) would resolve the same path.
+ */
+let vaultSaveQueue: Promise<unknown> = Promise.resolve();
+function enqueueVaultSave<T>(work: () => Promise<T>): Promise<T> {
+	const result = vaultSaveQueue.then(work, work);
+	vaultSaveQueue = result.catch(() => undefined);
+	return result;
+}
+
+function isSupportedImageMime(type: string): boolean {
+	return Object.hasOwn(IMAGE_CLIPBOARD_MIME_EXTENSIONS, type);
+}
+
+function collectImageFiles(data: DataTransfer): PastedImage[] {
+	const images: PastedImage[] = [];
 	for (const item of Array.from(data.items ?? [])) {
 		if (item.kind !== "file") continue;
-		if (IMAGE_CLIPBOARD_MIME_EXTENSIONS[item.type] === undefined) continue;
+		if (!isSupportedImageMime(item.type)) continue;
 		const file = item.getAsFile();
-		if (file) images.push(file);
+		if (file) images.push({ file, mimeType: item.type });
 	}
 	if (images.length > 0) return images;
 
 	// Some webviews only populate .files.
 	for (const file of Array.from(data.files ?? [])) {
-		if (IMAGE_CLIPBOARD_MIME_EXTENSIONS[file.type] !== undefined) {
-			images.push(file);
+		if (isSupportedImageMime(file.type)) {
+			images.push({ file, mimeType: file.type });
 		}
 	}
 	return images;

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -4,6 +4,18 @@ import type { FieldRequirement } from "./RequirementCollector";
 import { OnePageInputModal } from "./OnePageInputModal";
 import { buildValueVariableKey } from "src/utils/valueSyntax";
 
+const { attachImagePasteHandlerMock } = vi.hoisted(() => ({
+	attachImagePasteHandlerMock: vi.fn(() => ({
+		isBusy: (): boolean => false,
+		whenIdle: () => Promise.resolve(),
+		detach: vi.fn(),
+	})),
+}));
+
+vi.mock("src/gui/imagePasteHandler", () => ({
+	attachImagePasteHandler: attachImagePasteHandlerMock,
+}));
+
 vi.mock("obsidian", () => {
 	class Modal {
 		containerEl: HTMLElement;
@@ -758,5 +770,103 @@ describe("OnePageInputModal", () => {
 			modal.onClose();
 			await expect(modal.waitForClose).resolves.toEqual({ note: "" });
 		});
+	});
+});
+
+describe("OnePageInputModal - image paste wiring (issue #1484)", () => {
+	beforeEach(() => {
+		ensureObsidianDomPolyfills();
+		attachImagePasteHandlerMock.mockClear();
+	});
+
+	it("wires image paste for content text and textarea fields", () => {
+		const requirements: FieldRequirement[] = [
+			{ id: "body", label: "Body", type: "textarea" },
+			{ id: "note", label: "Note", type: "text" },
+		];
+
+		new OnePageInputModal({} as App, requirements, new Map());
+
+		expect(attachImagePasteHandlerMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("never wires image paste for path-context fields", () => {
+		const requirements: FieldRequirement[] = [
+			{ id: "topic", label: "Topic", type: "text", pathContext: true },
+			{ id: "body", label: "Body", type: "textarea" },
+		];
+
+		new OnePageInputModal({} as App, requirements, new Map());
+
+		expect(attachImagePasteHandlerMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips non-free-text field types", () => {
+		const requirements: FieldRequirement[] = [
+			{ id: "n", label: "N", type: "number" },
+			{
+				id: "pick",
+				label: "Pick",
+				type: "dropdown",
+				options: ["a", "b"],
+			},
+		];
+
+		new OnePageInputModal({} as App, requirements, new Map());
+
+		expect(attachImagePasteHandlerMock).not.toHaveBeenCalled();
+	});
+
+	it("detaches all paste handlers on close", () => {
+		const detach = vi.fn();
+		attachImagePasteHandlerMock.mockReturnValueOnce({
+			isBusy: () => false,
+			whenIdle: () => Promise.resolve(),
+			detach,
+		});
+		const requirements: FieldRequirement[] = [
+			{ id: "body", label: "Body", type: "text" },
+		];
+
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		modal.waitForClose.catch(() => {}); // close-without-submit rejects
+		modal.onClose();
+
+		expect(detach).toHaveBeenCalled();
+	});
+
+	it("defers submit while a pasted image is still saving", async () => {
+		let resolveIdle: () => void = () => {};
+		const idle = new Promise<void>((resolve) => {
+			resolveIdle = resolve;
+		});
+		let busy = true;
+		attachImagePasteHandlerMock.mockReturnValueOnce({
+			isBusy: () => busy,
+			whenIdle: () => idle,
+			detach: vi.fn(),
+		});
+		const requirements: FieldRequirement[] = [
+			{ id: "body", label: "Body", type: "text" },
+		];
+		const modal = new OnePageInputModal({} as App, requirements, new Map());
+		const submitButton = Array.from(
+			(modal as any).contentEl.querySelectorAll(
+				"button",
+			) as NodeListOf<HTMLButtonElement>,
+		).find((button) => button.textContent === "Submit") as HTMLButtonElement;
+
+		submitButton.click();
+		// Not settled yet: the submit deferred on the busy handle.
+		let settled = false;
+		void modal.waitForClose.then(() => {
+			settled = true;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(settled).toBe(false);
+
+		busy = false;
+		resolveIdle();
+		await expect(modal.waitForClose).resolves.toEqual({ body: "" });
 	});
 });

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -23,6 +23,8 @@ type CompletionInputEvent = Event & {
 };
 
 import type { FieldRequirement } from "./RequirementCollector";
+import type { ImagePasteHandle } from "src/gui/imagePasteHandler";
+import { attachImagePasteHandler } from "src/gui/imagePasteHandler";
 import {
 	mapMappedSuggesterValue,
 	resolveDropdownInitialValue,
@@ -52,6 +54,7 @@ export class OnePageInputModal extends Modal {
 	private previewContainerEl: HTMLElement | null = null;
 	private updatePreviewDebounced: () => void;
 	private settled = false;
+	private readonly imagePasteHandles: ImagePasteHandle[] = [];
 
 	public waitForClose: Promise<Record<string, string>>;
 	private resolvePromise!: (values: Record<string, string>) => void;
@@ -171,6 +174,7 @@ export class OnePageInputModal extends Modal {
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
 				input.inputEl.addClass("qa-onepage-textarea");
+				this.enableImagePaste(req, input.inputEl);
 				break;
 			}
 			case "text": {
@@ -183,6 +187,7 @@ export class OnePageInputModal extends Modal {
 					.setPlaceholder(req.placeholder ?? "")
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
+				this.enableImagePaste(req, input.inputEl);
 				break;
 			}
 			case "number": {
@@ -572,11 +577,28 @@ export class OnePageInputModal extends Modal {
 					.setPlaceholder(req.placeholder ?? "")
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
+				this.enableImagePaste(req, input.inputEl);
 			}
 		}
 
 		// Initialize stored value for empty inputs to ensure presence
 		if (!this.result.has(req.id)) this.result.set(req.id, starting);
+	}
+
+	/**
+	 * Free-text fields accept clipboard-image paste UNLESS any scanned
+	 * occurrence of the variable was path context (file name, folder, capture
+	 * target, location target, template path) - an embed link would corrupt a
+	 * path (issue #1484). The destination is unresolved at preflight time, so
+	 * the saver runs with "" (vault-root placement and links that resolve
+	 * from anywhere).
+	 */
+	private enableImagePaste(
+		req: FieldRequirement,
+		inputEl: HTMLInputElement | HTMLTextAreaElement,
+	): void {
+		if (req.pathContext) return;
+		this.imagePasteHandles.push(attachImagePasteHandler(this.app, inputEl, {}));
 	}
 
 	private decorateLabel(req: FieldRequirement): string | DocumentFragment {
@@ -594,6 +616,16 @@ export class OnePageInputModal extends Modal {
 	}
 
 	private submit() {
+		if (this.settled) return;
+		// A pasted image may still be saving in one of the fields; defer so
+		// paste-then-Mod+Enter submits WITH the embed link.
+		const busyHandle = this.imagePasteHandles.find((handle) =>
+			handle.isBusy(),
+		);
+		if (busyHandle) {
+			void busyHandle.whenIdle().then(() => this.submit());
+			return;
+		}
 		const out: Record<string, string> = {};
 		const requirementsById = new Map(
 			this.requirements.map((req) => [req.id, req]),
@@ -657,6 +689,8 @@ export class OnePageInputModal extends Modal {
 	}
 
 	onClose() {
+		for (const handle of this.imagePasteHandles) handle.detach();
+		this.imagePasteHandles.length = 0;
 		// Esc (or any close that isn't submit/cancel) must settle the promise,
 		// otherwise the choice execution hangs forever on waitForClose.
 		if (!this.settled) {

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -4,6 +4,7 @@ import {
 	FIELD_VARIABLE_PREFIX,
 	FILE_REGEX,
 	GLOBAL_VAR_REGEX,
+	MATH_VALUE_REGEX,
 	NAME_VALUE_REGEX,
 	TEMPLATE_REGEX,
 	VARIABLE_REGEX,
@@ -87,11 +88,14 @@ export class RequirementCollector extends Formatter {
 	public readonly requirements = new Map<string, FieldRequirement>();
 	public readonly templatesToScan = new Set<string>();
 	/**
-	 * Cross-branch memo for the template-inclusion walk: template ref → the
-	 * shallowest depth it was fully scanned at during this collection.
-	 * Requirements dedupe by id, so re-scanning a template reachable through
-	 * many distinct paths adds nothing - without this memo a dense template
-	 * DAG fans out as branching^depth (~1M scans at 4×10), freezing the UI.
+	 * Cross-branch memo for the template-inclusion walk: `<context>:<ref>`
+	 * (context = "path" | "content") → the shallowest depth the template was
+	 * fully scanned at during this collection. Requirements dedupe by id, so
+	 * re-scanning a template reachable through many distinct paths adds
+	 * nothing - without this memo a dense template DAG fans out as
+	 * branching^depth (~1M scans at 4×10), freezing the UI. Keyed per context
+	 * because a content-scanned template reached again from a path string
+	 * must be re-walked to taint its variables as path context (#1484).
 	 */
 	public readonly scannedTemplateRefDepths = new Map<string, number>();
 
@@ -127,15 +131,21 @@ export class RequirementCollector extends Formatter {
 			this.scanVariableTokens(expanded);
 			this.scanDateTokens(expanded);
 			this.scanFileTokens(expanded);
-			// Anonymous {{VALUE}}/{{NAME}} resolution is cached, so the
-			// promptForValue hook fires once per collector; a path string
-			// scanned AFTER a content string that already registered "value"
-			// must still taint it (named variables get per-occurrence marking
-			// in scanVariableTokens; the anonymous token needs this textual
-			// re-check).
-			if (pathContext && new RegExp(NAME_VALUE_REGEX.source, "i").test(expanded)) {
-				const anonymousValue = this.requirements.get("value");
-				if (anonymousValue) anonymousValue.pathContext = true;
+			// Anonymous {{VALUE}}/{{NAME}} and {{MVALUE}} resolutions are
+			// cached, so their prompt hooks fire once per collector; a path
+			// string scanned AFTER a content string that already registered
+			// them must still taint them (named variables get per-occurrence
+			// marking in scanVariableTokens; these singleton tokens need this
+			// textual re-check).
+			if (pathContext) {
+				if (new RegExp(NAME_VALUE_REGEX.source, "i").test(expanded)) {
+					const anonymousValue = this.requirements.get("value");
+					if (anonymousValue) anonymousValue.pathContext = true;
+				}
+				if (new RegExp(MATH_VALUE_REGEX.source, "i").test(expanded)) {
+					const mathValue = this.requirements.get("mvalue");
+					if (mathValue) mathValue.pathContext = true;
+				}
 			}
 			await this.format(expanded);
 		} finally {
@@ -525,6 +535,10 @@ export class RequirementCollector extends Formatter {
 				placeholder: "e.g., 2+2*3",
 			});
 		}
+		// {{MVALUE}} is legal in path strings too; taint like the VALUE hooks
+		// so its free-text field never offers image paste there (#1484). This
+		// hook fires once per collector, but path strings are scanned first.
+		this.markScanContext(this.requirements.get(key)!);
 		return "";
 	}
 

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -4,6 +4,7 @@ import {
 	FIELD_VARIABLE_PREFIX,
 	FILE_REGEX,
 	GLOBAL_VAR_REGEX,
+	NAME_VALUE_REGEX,
 	TEMPLATE_REGEX,
 	VARIABLE_REGEX,
 } from "src/constants";
@@ -57,6 +58,14 @@ export interface FieldRequirement {
 	multiEmit?: "text" | "linklist"; // |multi:linklist wraps picks as [[name]]
 	filters?: string; // serialized filters for FIELD variables
 	source?: "collected" | "script"; // provenance for UX badges
+	/**
+	 * True when ANY scanned occurrence of the variable sits in a path-context
+	 * string (file name format, folder path, capture target, insert-after/
+	 * before targets, template path). Sticky: one path usage disables
+	 * image paste for the field - an embed link in a path would corrupt it
+	 * (issue #1484). Content-only fields stay unset.
+	 */
+	pathContext?: boolean;
 	/** Prompt at runtime instead of the one-page form when the form has no safe widget. */
 	runtimeOnly?: boolean;
 	/** True only when EVERY scanned occurrence of the variable is |optional. */
@@ -101,15 +110,42 @@ export class RequirementCollector extends Formatter {
 		}
 	}
 
+	/**
+	 * True while the current scanString walks a path-context string. Flows
+	 * into FieldRequirement.pathContext (sticky across occurrences).
+	 */
+	private scanningPathContext = false;
+
 	// Entry points -------------------------------------------------------------
-	public async scanString(input: string): Promise<void> {
-		// Expand global variables first so we can detect inner requirements
-		const expanded = await this.replaceGlobalVarInString(input);
-		// Run a safe formatting pass that collects variables but avoids side-effects
-		this.scanVariableTokens(expanded);
-		this.scanDateTokens(expanded);
-		this.scanFileTokens(expanded);
-		await this.format(expanded);
+	public async scanString(input: string, pathContext = false): Promise<void> {
+		const previousContext = this.scanningPathContext;
+		this.scanningPathContext = pathContext;
+		try {
+			// Expand global variables first so we can detect inner requirements
+			const expanded = await this.replaceGlobalVarInString(input);
+			// Run a safe formatting pass that collects variables but avoids side-effects
+			this.scanVariableTokens(expanded);
+			this.scanDateTokens(expanded);
+			this.scanFileTokens(expanded);
+			// Anonymous {{VALUE}}/{{NAME}} resolution is cached, so the
+			// promptForValue hook fires once per collector; a path string
+			// scanned AFTER a content string that already registered "value"
+			// must still taint it (named variables get per-occurrence marking
+			// in scanVariableTokens; the anonymous token needs this textual
+			// re-check).
+			if (pathContext && new RegExp(NAME_VALUE_REGEX.source, "i").test(expanded)) {
+				const anonymousValue = this.requirements.get("value");
+				if (anonymousValue) anonymousValue.pathContext = true;
+			}
+			await this.format(expanded);
+		} finally {
+			this.scanningPathContext = previousContext;
+		}
+	}
+
+	/** Sticky path-context marking: one path occurrence taints the field. */
+	private markScanContext(req: FieldRequirement): void {
+		if (this.scanningPathContext) req.pathContext = true;
 	}
 
 	protected async format(input: string): Promise<string> {
@@ -237,9 +273,11 @@ export class RequirementCollector extends Formatter {
 					req.sliderConfig = parsed.sliderConfig;
 				}
 				if (defaultValue) req.defaultValue = defaultValue;
+				this.markScanContext(req);
 				this.requirements.set(requirementId, req);
 			} else {
 				const existing = this.requirements.get(requirementId)!;
+				this.markScanContext(existing);
 				// Order-independent named reuse: when a later occurrence carries
 				// the option list ({{VALUE:a,b|name:x}}) but the requirement was
 				// first recorded option-less (a bare {{VALUE:x}} reuse seen
@@ -404,6 +442,12 @@ export class RequirementCollector extends Formatter {
 				optional: this.valuePromptContext?.optional,
 			});
 		}
+		// This hook fires once per collector ({{VALUE}} resolution is cached),
+		// but path strings are always scanned before content strings by the
+		// per-choice collectors, so a dual-use anonymous VALUE is first seen -
+		// and marked - in path context. The sticky mark below also covers the
+		// already-registered case for safety.
+		this.markScanContext(this.requirements.get(key)!);
 		return ""; // return inert value to keep scanning
 	}
 
@@ -466,6 +510,7 @@ export class RequirementCollector extends Formatter {
 			if (context?.defaultValue) req.defaultValue = context.defaultValue;
 			this.requirements.set(key, req);
 		}
+		this.markScanContext(this.requirements.get(key)!);
 
 		return context?.defaultValue ?? "";
 	}

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -1432,3 +1432,166 @@ describe("collectChoiceRequirements - template path format syntax (issue #620)",
 		expect(getTemplateFileMock).not.toHaveBeenCalled();
 	});
 });
+
+describe("collectChoiceRequirements - image-paste path-context provenance (issue #1484)", () => {
+	const templateBodies = new Map<string, string>();
+	const app = {
+		vault: {
+			cachedRead: vi.fn(
+				async (file: { path: string }) => templateBodies.get(file.path) ?? "",
+			),
+		},
+		metadataCache: { getFileCache: vi.fn(() => null) },
+	} as unknown as App;
+	const plugin = {
+		settings: {
+			inputPrompt: "single-line",
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any;
+
+	beforeEach(() => {
+		templateBodies.clear();
+		getTemplateFileMock.mockReset();
+		getTemplateFileMock.mockImplementation((_app: App, path: string) =>
+			templateBodies.has(path) ? ({ path } as never) : null,
+		);
+	});
+
+	function executor(): IChoiceExecutor {
+		return { execute: vi.fn(), variables: new Map<string, unknown>() };
+	}
+
+	async function collect(choice: ICaptureChoice | ITemplateChoice) {
+		return collectChoiceRequirements(app, plugin, executor(), choice);
+	}
+
+	function byId(
+		requirements: Awaited<ReturnType<typeof collectChoiceRequirements>>,
+		id: string,
+	) {
+		const requirement = requirements.find((req) => req.id === id);
+		if (!requirement) throw new Error(`requirement '${id}' not collected`);
+		return requirement;
+	}
+
+	it("marks variables used in the capture target as path context", async () => {
+		const choice = {
+			...createCaptureChoice("Journal/{{VALUE:topic}}.md"),
+			format: { enabled: true, format: "{{VALUE:body}}" },
+		} as ICaptureChoice;
+
+		const requirements = await collect(choice);
+
+		expect(byId(requirements, "topic").pathContext).toBe(true);
+		expect(byId(requirements, "body").pathContext).toBeUndefined();
+	});
+
+	it("keeps a dual-use variable path-tainted regardless of scan order", async () => {
+		// insertAfter is scanned AFTER the content format; the sticky mark must
+		// still taint a variable first seen in content.
+		const choice = {
+			...createCaptureChoice("Inbox.md"),
+			format: { enabled: true, format: "{{VALUE:section}}" },
+			insertAfter: {
+				enabled: true,
+				after: "## {{VALUE:section}}",
+				insertAtEnd: false,
+				considerSubsections: false,
+				createIfNotFound: false,
+				createIfNotFoundLocation: "",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collect(choice);
+
+		expect(byId(requirements, "section").pathContext).toBe(true);
+	});
+
+	it("taints the anonymous VALUE when it also appears in a later path string", async () => {
+		const choice = {
+			...createCaptureChoice("Inbox.md"),
+			format: { enabled: true, format: "note: {{VALUE}}" },
+			insertBefore: {
+				enabled: true,
+				before: "{{VALUE}} marker",
+				createIfNotFound: false,
+				createIfNotFoundLocation: "",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collect(choice);
+
+		expect(byId(requirements, "value").pathContext).toBe(true);
+	});
+
+	it("marks template file-name and folder variables as path context, body as content", async () => {
+		templateBodies.set("Templates/Note.md", "Body: {{VALUE:body}}");
+		const choice = {
+			id: "template-choice",
+			name: "Template Choice",
+			type: "Template",
+			command: false,
+			templatePath: "Templates/Note.md",
+			fileNameFormat: { enabled: true, format: "{{VALUE:name}}" },
+			folder: {
+				enabled: true,
+				folders: ["Projects/{{VALUE:area}}"],
+				chooseWhenCreatingNote: false,
+				createInSameFolderAsActiveFile: false,
+				chooseFromSubfolders: false,
+			},
+			appendLink: false,
+			openFile: false,
+			fileOpening: {
+				location: "tab",
+				direction: "vertical",
+				mode: "default",
+				focus: true,
+			},
+			fileExistsBehavior: { kind: "prompt" },
+		} as unknown as ITemplateChoice;
+
+		const requirements = await collect(choice);
+
+		expect(byId(requirements, "name").pathContext).toBe(true);
+		expect(byId(requirements, "area").pathContext).toBe(true);
+		expect(byId(requirements, "body").pathContext).toBeUndefined();
+	});
+
+	it("propagates path context into templates included from a path string", async () => {
+		templateBodies.set("Templates/NamePart.md", "{{VALUE:part}}");
+		const choice = {
+			...createCaptureChoice("Inbox.md"),
+			format: { enabled: true, format: "ok" },
+			insertAfter: {
+				enabled: true,
+				after: "{{TEMPLATE:Templates/NamePart.md}}",
+				insertAtEnd: false,
+				considerSubsections: false,
+				createIfNotFound: false,
+				createIfNotFoundLocation: "",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collect(choice);
+
+		expect(byId(requirements, "part").pathContext).toBe(true);
+	});
+
+	it("keeps template-include variables in CONTENT strings unmarked", async () => {
+		templateBodies.set("Templates/Snippet.md", "{{VALUE:snippetValue}}");
+		const choice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:Templates/Snippet.md}}",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collect(choice);
+
+		expect(byId(requirements, "snippetValue").pathContext).toBeUndefined();
+	});
+});

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -1595,3 +1595,96 @@ describe("collectChoiceRequirements - image-paste path-context provenance (issue
 		expect(byId(requirements, "snippetValue").pathContext).toBeUndefined();
 	});
 });
+
+describe("collectChoiceRequirements - path-context memo (issue #1484 review fix)", () => {
+	const templateBodies = new Map<string, string>();
+	const app = {
+		vault: {
+			cachedRead: vi.fn(
+				async (file: { path: string }) => templateBodies.get(file.path) ?? "",
+			),
+		},
+		metadataCache: { getFileCache: vi.fn(() => null) },
+	} as unknown as App;
+	const plugin = {
+		settings: {
+			inputPrompt: "single-line",
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any;
+
+	beforeEach(() => {
+		templateBodies.clear();
+		getTemplateFileMock.mockReset();
+		getTemplateFileMock.mockImplementation((_app: App, path: string) =>
+			templateBodies.has(path) ? ({ path } as never) : null,
+		);
+	});
+
+	it("re-taints a template first scanned from content when a path string includes it too", async () => {
+		// The template-inclusion memo must be keyed per context: the capture
+		// FORMAT (content) is scanned before insert-after (path), so a
+		// ref-only memo would skip the second walk and leave `part` pastable.
+		templateBodies.set("Templates/Shared.md", "{{VALUE:part}}");
+		const choice = {
+			...createCaptureChoice("Inbox.md"),
+			format: {
+				enabled: true,
+				format: "{{TEMPLATE:Templates/Shared.md}}",
+			},
+			insertAfter: {
+				enabled: true,
+				after: "{{TEMPLATE:Templates/Shared.md}}",
+				insertAtEnd: false,
+				considerSubsections: false,
+				createIfNotFound: false,
+				createIfNotFoundLocation: "",
+			},
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			{ execute: vi.fn(), variables: new Map<string, unknown>() },
+			choice,
+		);
+
+		const part = requirements.find((req) => req.id === "part");
+		expect(part?.pathContext).toBe(true);
+	});
+
+	it("taints {{MVALUE}} used in a capture target", async () => {
+		const choice = {
+			...createCaptureChoice("Math/{{MVALUE}}.md"),
+			format: { enabled: true, format: "{{MVALUE}}" },
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			{ execute: vi.fn(), variables: new Map<string, unknown>() },
+			choice,
+		);
+
+		const mvalue = requirements.find((req) => req.id === "mvalue");
+		expect(mvalue?.pathContext).toBe(true);
+	});
+
+	it("keeps {{MVALUE}} used only in content pastable", async () => {
+		const choice = {
+			...createCaptureChoice("Inbox.md"),
+			format: { enabled: true, format: "{{MVALUE}}" },
+		} as ICaptureChoice;
+
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			{ execute: vi.fn(), variables: new Map<string, unknown>() },
+			choice,
+		);
+
+		const mvalue = requirements.find((req) => req.id === "mvalue");
+		expect(mvalue?.pathContext).toBeUndefined();
+	});
+});

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -222,9 +222,13 @@ async function scanContentWithTemplateIncludes(
 		// branching^depth invocations). A ref first seen NEAR the depth cap is
 		// re-scanned if met again shallower, so the memo never truncates a
 		// subtree the old walk would have explored.
-		const scannedDepth = collector.scannedTemplateRefDepths.get(ref);
+		// The memo is keyed per CONTEXT: a template first scanned from content
+		// must be re-scanned when later reached from a path string, or its
+		// variables would keep image paste despite feeding a path (#1484).
+		const memoKey = `${pathContext ? "path" : "content"}:${ref}`;
+		const scannedDepth = collector.scannedTemplateRefDepths.get(memoKey);
 		if (scannedDepth !== undefined && scannedDepth <= depth) continue;
-		collector.scannedTemplateRefDepths.set(ref, depth);
+		collector.scannedTemplateRefDepths.set(memoKey, depth);
 		templateStack.add(ref);
 		try {
 			await scanContentWithTemplateIncludes(

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -199,12 +199,13 @@ async function scanContentWithTemplateIncludes(
 	content: string,
 	templateStack = new Set<string>(),
 	depth = 0,
+	pathContext = false,
 ): Promise<void> {
 	// templatesToScan is a queue for this content scan. Clear it before and
 	// after scanning so refs from unrelated strings are not drained together.
 	const rawTemplateRefs = getRawTemplateRefs(content);
 	collector.templatesToScan.clear();
-	await collector.scanString(content);
+	await collector.scanString(content, pathContext);
 	const nested = [...collector.templatesToScan].filter((ref) =>
 		rawTemplateRefs.has(ref),
 	);
@@ -232,6 +233,9 @@ async function scanContentWithTemplateIncludes(
 				await readTemplate(app, ref),
 				templateStack,
 				depth + 1,
+				// A template included FROM a path string is spliced into that
+				// path at runtime, so its tokens are path context too.
+				pathContext,
 			);
 		} finally {
 			templateStack.delete(ref);
@@ -255,7 +259,8 @@ async function scanTemplateSource(
 	collector: RequirementCollector,
 	templatePath: string,
 ): Promise<void> {
-	await collector.scanString(templatePath);
+	// The template PATH is path context; the template BODY below is content.
+	await collector.scanString(templatePath, true);
 
 	if (hasTemplatePathSyntax(templatePath)) {
 		log.logMessage(
@@ -285,12 +290,22 @@ async function collectForTemplateChoice(
 			app,
 			collector,
 			choice.fileNameFormat.format,
+			undefined,
+			0,
+			true, // file name = path context
 		);
 	}
 
 	if (choice.folder?.enabled) {
 		for (const folder of choice.folder.folders ?? []) {
-			await scanContentWithTemplateIncludes(app, collector, folder);
+			await scanContentWithTemplateIncludes(
+				app,
+				collector,
+				folder,
+				undefined,
+				0,
+				true, // folder = path context
+			);
 		}
 	}
 
@@ -316,7 +331,14 @@ async function collectForCaptureChoice(
 ): Promise<RequirementCollector> {
 	const collector = new RequirementCollector(app, plugin, choiceExecutor);
 
-	await scanContentWithTemplateIncludes(app, collector, choice.captureTo);
+	await scanContentWithTemplateIncludes(
+		app,
+		collector,
+		choice.captureTo,
+		undefined,
+		0,
+		true, // capture target = path context (scanned BEFORE content so a dual-use {{VALUE}} is marked)
+	);
 
 	if (choice.format?.enabled) {
 		await scanContentWithTemplateIncludes(
@@ -331,6 +353,9 @@ async function collectForCaptureChoice(
 			app,
 			collector,
 			choice.insertAfter.after,
+			undefined,
+			0,
+			true, // location target = path context (an embed link can never match a line)
 		);
 	}
 
@@ -339,6 +364,9 @@ async function collectForCaptureChoice(
 			app,
 			collector,
 			choice.insertBefore.before,
+			undefined,
+			0,
+			true, // location target = path context
 		);
 	}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1539,3 +1539,9 @@ textarea.is-valid {
 	/* Darkened red so white pill text clears WCAG AA at small sizes. */
 	--qa-sev-critical-pill: color-mix(in srgb, var(--color-red, #c0392b) 82%, #000);
 }
+
+/* Input frozen while a pasted clipboard image is being saved (issue #1484). */
+.qa-image-paste-busy {
+	opacity: 0.7;
+	cursor: progress;
+}

--- a/src/types/inputPrompt.ts
+++ b/src/types/inputPrompt.ts
@@ -2,6 +2,18 @@ export interface InputPromptOptions {
 	cursorAtEnd?: boolean;
 	/** Token carries |optional: show a Skip button and accept empty submissions as the answer. */
 	optional?: boolean;
+	/**
+	 * Accept clipboard IMAGE paste: the image is saved as a vault attachment
+	 * (via Obsidian's attachment-folder settings) and an embed link is
+	 * inserted at the caret. Clipboard text always wins over an image. Set
+	 * ONLY for prompts whose value flows into note content as free text -
+	 * never for file-name/folder/path prompts, where an embed link would
+	 * corrupt the path.
+	 */
+	imagePaste?: {
+		/** Note path the link will live in when known; "" (default) emits vault-root links that resolve from anywhere. */
+		sourcePath?: string;
+	};
 	numeric?: {
 		min?: number;
 		max?: number;

--- a/src/utils/clipboardImageAttachments.test.ts
+++ b/src/utils/clipboardImageAttachments.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import {
+	IMAGE_CLIPBOARD_MIME_EXTENSIONS,
+	buildImageEmbedLink,
+	formatClipboardAttachmentTimestamp,
+	saveClipboardImageToVault,
+} from "./clipboardImageAttachments";
+
+function makeApp(overrides?: {
+	getAvailablePathForAttachment?: (
+		filename: string,
+		sourcePath?: string,
+	) => Promise<string>;
+	generateMarkdownLink?: (file: TFile, sourcePath: string) => string;
+}) {
+	const createBinary = vi.fn(
+		async (path: string, _data: ArrayBuffer) => ({ path }) as TFile,
+	);
+	const getAvailablePathForAttachment = vi.fn(
+		overrides?.getAvailablePathForAttachment ??
+			(async (filename: string) => `attachments/${filename}`),
+	);
+	const generateMarkdownLink = vi.fn(
+		overrides?.generateMarkdownLink ??
+			((file: TFile) => `![[${file.path}]]`),
+	);
+	const app = {
+		vault: { createBinary },
+		fileManager: { getAvailablePathForAttachment, generateMarkdownLink },
+	} as unknown as App;
+	return { app, createBinary, getAvailablePathForAttachment, generateMarkdownLink };
+}
+
+const data = new ArrayBuffer(8);
+
+describe("saveClipboardImageToVault", () => {
+	it("saves via the attachment-folder API with the destination as context", async () => {
+		const { app, createBinary, getAvailablePathForAttachment } = makeApp();
+
+		const file = await saveClipboardImageToVault(
+			app,
+			data,
+			"image/png",
+			"Journal/inbox.md",
+		);
+
+		expect(getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.stringMatching(/^Clipboard image .*\.png$/),
+			"Journal/inbox.md",
+		);
+		expect(createBinary).toHaveBeenCalledWith(
+			expect.stringMatching(/^attachments\/Clipboard image .*\.png$/),
+			data,
+		);
+		expect(file.path).toMatch(/^attachments\/Clipboard image .*\.png$/);
+	});
+
+	it("passes undefined source context when the destination is unknown", async () => {
+		const { app, getAvailablePathForAttachment } = makeApp();
+
+		await saveClipboardImageToVault(app, data, "image/png", "");
+
+		expect(getAvailablePathForAttachment).toHaveBeenCalledWith(
+			expect.any(String),
+			undefined,
+		);
+	});
+
+	it("rejects unsupported MIME types without touching the vault", async () => {
+		const { app, createBinary } = makeApp();
+
+		await expect(
+			saveClipboardImageToVault(app, data, "application/pdf", ""),
+		).rejects.toThrow(/Unsupported clipboard image type/);
+		expect(createBinary).not.toHaveBeenCalled();
+	});
+
+	it.each(["../escape.png", "/tmp/x.png", "C:\\evil.png"])(
+		"refuses to write outside the vault (%s)",
+		async (badPath) => {
+			const { app, createBinary } = makeApp({
+				getAvailablePathForAttachment: async () => badPath,
+			});
+
+			await expect(
+				saveClipboardImageToVault(app, data, "image/png", ""),
+			).rejects.toThrow(/outside the vault/);
+			expect(createBinary).not.toHaveBeenCalled();
+		},
+	);
+
+	it("uses the extension from the MIME map", () => {
+		expect(IMAGE_CLIPBOARD_MIME_EXTENSIONS["image/webp"]).toBe("webp");
+		expect(IMAGE_CLIPBOARD_MIME_EXTENSIONS["image/svg+xml"]).toBe("svg");
+	});
+});
+
+describe("buildImageEmbedLink", () => {
+	it("uses '' source so the link resolves from any destination", () => {
+		const { app, generateMarkdownLink } = makeApp();
+
+		const link = buildImageEmbedLink(app, { path: "a.png" } as TFile, "");
+
+		expect(generateMarkdownLink).toHaveBeenCalledWith(expect.anything(), "");
+		expect(link).toBe("![[a.png]]");
+	});
+
+	it("forces the embed prefix when the user's link format lacks it", () => {
+		const { app } = makeApp({
+			generateMarkdownLink: (file) => `[[${file.path}]]`,
+		});
+
+		const link = buildImageEmbedLink(app, { path: "a.jpg" } as TFile, "");
+
+		expect(link.startsWith("![[")).toBe(true);
+	});
+});
+
+describe("formatClipboardAttachmentTimestamp", () => {
+	it("matches the shipped 'YYYY-MM-DD HH.mm.ss' convention", () => {
+		const stamp = formatClipboardAttachmentTimestamp(
+			new Date(2026, 6, 6, 9, 5, 3),
+		);
+		expect(stamp).toBe("2026-07-06 09.05.03");
+	});
+});

--- a/src/utils/clipboardImageAttachments.ts
+++ b/src/utils/clipboardImageAttachments.ts
@@ -1,0 +1,88 @@
+import type { App, TFile } from "obsidian";
+import { escapesVaultBoundary } from "./vaultPathBoundary";
+
+/**
+ * Clipboard image MIME types QuickAdd accepts, mapped to the file extension the
+ * saved attachment gets. Shared by the Capture `{{CLIPBOARD}}` image fallback
+ * (PR #1393) and direct image paste into prompt inputs (issue #1484) so both
+ * surfaces accept exactly the same formats.
+ */
+export const IMAGE_CLIPBOARD_MIME_EXTENSIONS: Record<string, string> = {
+	"image/png": "png",
+	"image/jpeg": "jpg",
+	"image/jpg": "jpg",
+	"image/gif": "gif",
+	"image/webp": "webp",
+	"image/svg+xml": "svg",
+};
+
+export function formatClipboardAttachmentTimestamp(date: Date): string {
+	const pad = (value: number) => String(value).padStart(2, "0");
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+		date.getDate(),
+	)} ${pad(date.getHours())}.${pad(date.getMinutes())}.${pad(
+		date.getSeconds(),
+	)}`;
+}
+
+/**
+ * Saves clipboard image bytes as a vault attachment and returns the created
+ * file. Link generation is a separate step ({@link buildImageEmbedLink}) so a
+ * caller can record the created file for rollback/tracking BEFORE anything
+ * that might still fail - a file created but untracked is an orphan no
+ * cleanup can find.
+ *
+ * Placement is delegated to `fileManager.getAvailablePathForAttachment`, which
+ * honors the user's attachment-folder setting and dedupes name collisions
+ * against files already in the vault. Callers saving MULTIPLE images must
+ * therefore save strictly sequentially: the dedupe only sees files whose
+ * `createBinary` has landed, so two same-second saves with in-flight writes
+ * would resolve the same path and the second would throw.
+ */
+export async function saveClipboardImageToVault(
+	app: App,
+	data: ArrayBuffer,
+	mimeType: string,
+	sourcePath: string,
+): Promise<TFile> {
+	const extension = IMAGE_CLIPBOARD_MIME_EXTENSIONS[mimeType];
+	if (!extension) {
+		throw new Error(`Unsupported clipboard image type: ${mimeType}`);
+	}
+
+	const filename = `Clipboard image ${formatClipboardAttachmentTimestamp(
+		new Date(),
+	)}.${extension}`;
+	const attachmentPath = await app.fileManager.getAvailablePathForAttachment(
+		filename,
+		sourcePath || undefined,
+	);
+	// The attachment path comes from user-configurable settings; refuse any
+	// resolution that would write outside the vault (defense in depth at the
+	// write sink, mirroring the repo's other vault-boundary guards).
+	if (escapesVaultBoundary(attachmentPath)) {
+		throw new Error(
+			`Refusing to save clipboard image outside the vault: '${attachmentPath}'`,
+		);
+	}
+	return app.vault.createBinary(attachmentPath, data);
+}
+
+/**
+ * Builds the embed link for a saved attachment, forcing the `!` prefix and
+ * honoring the user's wikilink/markdown preference.
+ *
+ * `sourcePath` is the note the link will live in when known (capture
+ * destination), or "" when the destination is not yet resolved - "" makes
+ * `generateMarkdownLink` emit a vault-root path that resolves from anywhere,
+ * which is safer than guessing (e.g. the active file) and generating a
+ * relative link that breaks from the real destination.
+ */
+export function buildImageEmbedLink(
+	app: App,
+	file: TFile,
+	sourcePath: string,
+): string {
+	const link = app.fileManager.generateMarkdownLink(file, sourcePath);
+	return link.startsWith("!") ? link : `!${link}`;
+}

--- a/src/utils/clipboardImageAttachments.ts
+++ b/src/utils/clipboardImageAttachments.ts
@@ -7,14 +7,17 @@ import { escapesVaultBoundary } from "./vaultPathBoundary";
  * (PR #1393) and direct image paste into prompt inputs (issue #1484) so both
  * surfaces accept exactly the same formats.
  */
-export const IMAGE_CLIPBOARD_MIME_EXTENSIONS: Record<string, string> = {
-	"image/png": "png",
-	"image/jpeg": "jpg",
-	"image/jpg": "jpg",
-	"image/gif": "gif",
-	"image/webp": "webp",
-	"image/svg+xml": "svg",
-};
+// Null prototype so a hostile MIME like "constructor" can never hit an
+// inherited Object.prototype member in the index lookups below.
+export const IMAGE_CLIPBOARD_MIME_EXTENSIONS: Record<string, string> =
+	Object.assign(Object.create(null) as Record<string, string>, {
+		"image/png": "png",
+		"image/jpeg": "jpg",
+		"image/jpg": "jpg",
+		"image/gif": "gif",
+		"image/webp": "webp",
+		"image/svg+xml": "svg",
+	});
 
 export function formatClipboardAttachmentTimestamp(date: Date): string {
 	const pad = (value: number) => String(value).padStart(2, "0");


### PR DESCRIPTION
Closes #1484. Motivated by discussions #609 and #1100.

## What

Pasting an image (Ctrl/Cmd+V) into a QuickAdd value prompt now saves it as a vault attachment and inserts an embed link at the caret. Works in the single-line prompt, the wide (multiline) prompt, and one-page form text/textarea fields. You can mix typed text with pasted images in one value, and paste several images at once.

The `{{CLIPBOARD}}` image fallback (the token half of this ask) already shipped in 2.14.0 (#1393); this PR delivers the interactive half - #609's literal ask ("paste a screenshot into the capture prompt").

## Design

Full design doc was ultracode-reviewed (3 lenses + 2 adversarial reviewers) before coding; all blocking findings are incorporated.

- **Sink-context gating (the review's unanimous concern):** value prompts are shared between content and path formatting. `formatFileContent` is the only content pass in `CompleteFormatter` (every path pass - file name, folder, template path, location targets - calls `format()` directly), so image paste is enabled exactly while that pass runs. A `{{VALUE:x}}` prompt raised while resolving `Journal/{{VALUE:x}}.md` never offers paste; the same variable prompted for note content does. The one-page form gets the same rule via sticky path-context provenance recorded during requirement collection (any occurrence in a file name format, folder path, capture target, insert-after/before target, or template path taints the field; templates included *from* a path string inherit path context).
- **Text wins:** non-empty `text/plain` (untrimmed - byte parity with the shipped `{{CLIPBOARD}}` precedence) leaves the paste to the default handler. Browser image copies carry `text/html` + `image/png` with no `text/plain`, so they paste as images; copying a *file* in Finder/Explorer pastes its path as text (documented).
- **Concurrency:** files are extracted from the `DataTransfer` synchronously (Chromium neuters it once the handler yields), saved strictly sequentially (the attachment-path dedupe only sees landed files - two same-second screenshots would otherwise collide), and the input is frozen (`readOnly` + busy cue) during the save so the caret cannot go stale. Submit during a save defers until the embed is inserted, so Ctrl+V-then-Enter keeps the image. A second paste mid-save gets a Notice instead of a silent drop. IME composition is respected.
- **Insertion:** `execCommand('insertText')` (undo-integrated, fires `input` natively, popout-safe via `ownerDocument`) with a `setRangeText` + synthetic `input` fallback.
- **Placement/naming:** `app.fileManager.getAvailablePathForAttachment` (honors the user's attachment settings, never a hardcoded folder) + the shipped `Clipboard image YYYY-MM-DD HH.mm.ss.<ext>` convention. Links via `generateMarkdownLink` with a forced `!` prefix. `sourcePath` is the capture destination when known, else `""` (vault-root links that resolve from anywhere - never a guess like the active file, which would break relative-link vaults).
- **Lifecycle:** once pasted, the attachment is an ordinary vault file - QuickAdd never deletes it (matches Obsidian editor paste; also keeps recovered prompt drafts containing the embed valid). Contrast: the `{{CLIPBOARD}}` fallback's rollback-on-abort is unchanged - those files are created invisibly mid-format, so rollback is safe there.
- **Mobile:** standard web APIs only (`ClipboardEvent.clipboardData`), no Electron, no `Platform` gating - works where the webview supports image paste and degrades to a silent no-op elsewhere.
- **Refactor bonus:** the save/link logic is extracted to `src/utils/clipboardImageAttachments.ts` (shared with the capture fallback) and now refuses attachment paths that escape the vault boundary (`escapesVaultBoundary`), hardening the shipped path too.

### Accepted residuals (deliberate)

- Paste-then-cancel (or a format that never inserts `{{VALUE}}`) leaves the attachment - same as Obsidian editor paste.
- Inserted link text shares the typed-text channel: later formatter passes rescan it, identical exposure to typing the same string and to the shipped `{{CLIPBOARD}}` fallback (only observable with an attachment folder literally named with `{{TOKEN}}` text).
- `quickAddApi.inputPrompt`/`wideInputPrompt` accept the new `imagePaste` option (documented) since `InputPromptOptions` passes through verbatim; scripts must opt in.
- FIELD/FILE free-text fallback prompts and suggester/number/slider/date inputs stay text-only by design.
- No settings off-switch in v1: text-wins preserves every existing paste behavior; a toggle can be added later without redesign.

Out of scope (possible follow-ups): `{{CLIPBOARD}}` image fallback for Template choices; drag-and-drop of image files onto prompts.

## Validation

Unit: 30+ new tests (paste handler semantics incl. races/partial failure/IME, saver boundary guard, sink-context gating incl. flag restoration, provenance collection incl. dual-use and template-include inheritance, one-page wiring/defer/teardown). Full suite green (3,600+ tests), lint, typecheck, build.

Live e2e (isolated vault, this branch's build, synthetic `ClipboardEvent` with real PNG `File`s; zero runtime errors captured across the session):

| # | Scenario | Result |
|---|----------|--------|
| Before | Paste image into capture prompt (v2.17.2 behavior) | No-op: input unchanged, no file created |
| A | Paste after typed text in single-line capture prompt, Enter | `inbox.md` got `- screenshot: ![[Clipboard image 2026-07-06 22.34.03.png]]`; input frozen during save; `verified:true` |
| B | Clipboard has text + image | Handler stands down (no preventDefault, no file) - text wins |
| C | `{{VALUE:topic}}` prompt for `Journal/{{VALUE:topic}}.md` (path context) | Paste ignored, no file |
| C2 | Next prompt in the SAME run (`{{VALUE:body}}`, content) | Paste accepted; note created with embed - flag restores between passes |
| D/E | Two images in one paste into wide prompt, attachment folder `attachments/` (did not exist) | Both saved with distinct same-second names (`... .png`, `... 1.png`), newline-joined, folder auto-created, ctrl+Enter submitted |
| F | One-page form for the same choice | `topic` field inert, `body` field accepts; cancel clean |
| G | `{{CLIPBOARD}}` image fallback after the refactor | Still saves + embeds (`clip: ![[...]]`) - regression-free |
| H | Cancel after paste | Prompt closes cleanly, capture aborts, attachment persists per design |

Adversarial implementation review (2 opposite-model + 1 same-model reviewers) ran before this PR; all findings (one must-fix: the template-inclusion memo dropped later path-context taint; plus deferred-submit-after-cancel guards, never-rejecting save promise, item-MIME carry, null-prototype MIME map, cross-field save serialization, `{{MVALUE}}` taint) are fixed in the final commit, each re-verified live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Value prompts now accept clipboard-image pastes (Ctrl/Cmd+V), saving images as vault attachments and inserting embeds at the cursor; paste is disabled for filename/folder/capture-target related prompts.
  * The QuickAdd `inputPrompt` `options` now supports `imagePaste` to enable the same behavior.
* **Bug Fixes**
  * Improved handling of submit/cancel timing during image saving, preventing incorrect deferred submissions.
  * Added busy-state styling while clipboard images are processed.
* **Documentation**
  * Updated format syntax and QuickAdd API docs to describe image paste rules and attachment behavior.
* **Tests**
  * Added new suites covering gating, ordering, multi-image pastes, and race/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->