### PR TITLE
fix: blank choice edit modal for legacy choices missing newer boolean fields

### DIFF
--- a/src/gui/ChoiceBuilder/choiceForms-1497-legacy-missing-fields.test.ts
+++ b/src/gui/ChoiceBuilder/choiceForms-1497-legacy-missing-fields.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+// FormatPreviewField -> formatter graph pulls obsidian-dataview's CJS require.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App } from "obsidian";
+import { fireEvent, render } from "@testing-library/svelte";
+import type QuickAdd from "../../main";
+import type ICaptureChoice from "../../types/choices/ICaptureChoice";
+import type ITemplateChoice from "../../types/choices/ITemplateChoice";
+import CaptureChoiceForm from "./CaptureChoiceForm.svelte";
+import TemplateChoiceForm from "./TemplateChoiceForm.svelte";
+import Toggle from "../components/Toggle.svelte";
+import { createCaptureChoiceFormProps } from "./captureChoiceFormProps.svelte";
+import { createTemplateChoiceFormProps } from "./templateChoiceFormProps.svelte";
+import { TemplateChoiceBuilder } from "./templateChoiceBuilder";
+
+// Regression tests for #1497: choices saved before an optional boolean field
+// existed persist WITHOUT that field. Svelte 5 hard-throws (props_invalid_value)
+// when such an `undefined` is bound to a $bindable prop that has a fallback,
+// which aborted the whole choice-edit modal mount and left it blank.
+
+const plugin = {
+	getTemplateFiles: () => [],
+	settings: { choices: [] },
+} as unknown as QuickAdd;
+
+/**
+ * A Capture choice as persisted by QuickAdd before `considerSubsections`
+ * (2023) existed: insertAfter enabled, field absent. Mirrors the reporter's
+ * data.json excerpt.
+ */
+function legacyCaptureChoice(): ICaptureChoice {
+	return {
+		id: "c1",
+		name: "Legacy Capture",
+		type: "Capture",
+		command: false,
+		captureTo: "Inbox.md",
+		captureToActiveFile: false,
+		captureToCanvasNodeId: "",
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: false,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: false, format: "" },
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: {
+			enabled: true,
+			after: "## Work",
+			insertAtEnd: true,
+			createIfNotFound: true,
+			createIfNotFoundLocation: "bottom",
+		} as ICaptureChoice["insertAfter"],
+		insertBefore: {
+			enabled: false,
+			before: "",
+			createIfNotFound: false,
+			createIfNotFoundLocation: "top",
+		},
+		newLineCapture: { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: true,
+		},
+	};
+}
+
+/**
+ * A Template choice as persisted before `chooseFromSubfolders` (2023) existed,
+ * in the exact shape that crashed: fixed destination folder ("specified" mode),
+ * so the subfolders toggle actually renders.
+ */
+function legacyTemplateChoice(): ITemplateChoice {
+	return {
+		id: "t1",
+		name: "Legacy Template",
+		type: "Template",
+		command: false,
+		templatePath: "Templates/Note.md",
+		folder: {
+			enabled: true,
+			folders: ["Areas/Work"],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+		} as ITemplateChoice["folder"],
+		fileNameFormat: { enabled: false, format: "" },
+		appendLink: false,
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: true,
+		},
+		fileExistsBehavior: { kind: "prompt" },
+	};
+}
+
+describe("choice edit forms tolerate legacy choices missing newer fields (#1497)", () => {
+	it("CaptureChoiceForm mounts when insertAfter.considerSubsections is missing", () => {
+		const props = createCaptureChoiceFormProps({
+			choice: legacyCaptureChoice(),
+			app: new App(),
+			plugin,
+		});
+		const { container } = render(CaptureChoiceForm, {
+			props: { choice: props.choice, app: props.app, plugin: props.plugin },
+		});
+		// The modal body actually rendered (it was completely blank before).
+		expect(container.querySelectorAll(".setting-item").length).toBeGreaterThan(0);
+		// The section-local defaults backfilled the missing fields on the proxy,
+		// so the next save persists a fully-shaped insertAfter.
+		expect(props.choice.insertAfter.considerSubsections).toBe(false);
+	});
+
+	it("CaptureChoiceForm mounts when insertAfter.insertAtEnd (2021) is also missing", () => {
+		const choice = legacyCaptureChoice();
+		delete (choice.insertAfter as Partial<ICaptureChoice["insertAfter"]>)
+			.insertAtEnd;
+		const props = createCaptureChoiceFormProps({
+			choice,
+			app: new App(),
+			plugin,
+		});
+		const { container } = render(CaptureChoiceForm, {
+			props: { choice: props.choice, app: props.app, plugin: props.plugin },
+		});
+		expect(container.querySelectorAll(".setting-item").length).toBeGreaterThan(0);
+		expect(props.choice.insertAfter.insertAtEnd).toBe(false);
+	});
+
+	it("TemplateChoiceForm mounts when folder.chooseFromSubfolders is missing", async () => {
+		const props = createTemplateChoiceFormProps({
+			choice: legacyTemplateChoice(),
+			app: new App(),
+			plugin,
+		});
+		const { container } = render(TemplateChoiceForm, {
+			props: { choice: props.choice, app: props.app, plugin: props.plugin },
+		});
+		expect(container.querySelectorAll(".setting-item").length).toBeGreaterThan(0);
+
+		// The subfolders toggle itself rendered (it is the row that crashed).
+		const subfoldersItem = Array.from(
+			container.querySelectorAll(".setting-item"),
+		).find(
+			(el) =>
+				el.querySelector(".setting-item-name")?.textContent?.trim() ===
+				"Include subfolders",
+		);
+		expect(subfoldersItem).toBeDefined();
+		const toggle =
+			subfoldersItem?.querySelector<HTMLElement>(".checkbox-container");
+		if (!toggle) throw new Error("Subfolders toggle not rendered");
+		expect(toggle.classList.contains("is-enabled")).toBe(false);
+
+		// Flipping it writes a real boolean back onto the choice.
+		await fireEvent.click(toggle);
+		expect(props.choice.folder.chooseFromSubfolders).toBe(true);
+	});
+
+	it("TemplateChoiceBuilder backfills chooseFromSubfolders so close persists a full shape", async () => {
+		// The real edit path: builder normalizeChoice runs before the form mounts,
+		// and the choice resolved at close carries the backfilled field even when
+		// the user never touches the subfolders toggle.
+		const builder = new TemplateChoiceBuilder(
+			new App(),
+			legacyTemplateChoice(),
+			plugin,
+		);
+		builder.close();
+		const resolved = (await builder.waitForClose) as ITemplateChoice;
+		expect(resolved.folder.chooseFromSubfolders).toBe(false);
+	});
+
+	it("Toggle accepts an undefined binding and writes a boolean on flip", async () => {
+		const model = { flag: undefined as boolean | undefined };
+		const { container } = render(Toggle, {
+			props: {
+				get checked() {
+					return model.flag;
+				},
+				set checked(v: boolean | undefined) {
+					model.flag = v;
+				},
+			},
+		});
+		const el = container.querySelector<HTMLElement>(".checkbox-container");
+		if (!el) throw new Error("Toggle did not render");
+		expect(el.classList.contains("is-enabled")).toBe(false);
+		expect(el.getAttribute("aria-checked")).toBe("false");
+		await fireEvent.click(el);
+		expect(model.flag).toBe(true);
+	});
+});

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -42,6 +42,11 @@ if (insertAfter.inline === undefined) insertAfter.inline = false;
 if (insertAfter.replaceExisting === undefined)
 	insertAfter.replaceExisting = false;
 if (insertAfter.promptHeading === undefined) insertAfter.promptHeading = false;
+// insertAtEnd (2021) and considerSubsections (2023) postdate insertAfter itself,
+// so choices saved before then legitimately lack them (#1497).
+if (insertAfter.insertAtEnd === undefined) insertAfter.insertAtEnd = false;
+if (insertAfter.considerSubsections === undefined)
+	insertAfter.considerSubsections = false;
 if (!insertAfter.blankLineAfterMatchMode)
 	insertAfter.blankLineAfterMatchMode = "auto";
 if (!insertAfter.createIfNotFound) insertAfter.createIfNotFound = false;

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -33,6 +33,9 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 	private normalizeChoice() {
 		this.choice.fileExistsBehavior ??= { kind: "prompt" };
 		this.choice.fileOpening = normalizeFileOpening(this.choice.fileOpening);
+		// chooseFromSubfolders (2023) postdates the folder config itself, so
+		// choices saved before it existed legitimately lack it (#1497).
+		this.choice.folder.chooseFromSubfolders ??= false;
 	}
 
 	protected display() {

--- a/src/gui/components/Toggle.svelte
+++ b/src/gui/components/Toggle.svelte
@@ -5,9 +5,15 @@
  * Obsidian's `ToggleComponent` renders). Interaction lives on the container
  * (keyboard-operable via role="switch") so it works without the imperative
  * component; the inner checkbox is presentational only. See #1130 / #1250.
+ *
+ * `checked` is $bindable WITHOUT a fallback: choices saved before an optional
+ * boolean field existed bind `undefined` here, and Svelte hard-throws
+ * (props_invalid_value) on `bind:` of undefined to a prop that has a fallback,
+ * aborting the whole choice-edit modal mount (#1497). Undefined renders as
+ * off and becomes a real boolean on first flip.
  */
 let {
-	checked = $bindable(false),
+	checked = $bindable(),
 	disabled = false,
 	ariaLabel = undefined,
 	onchange = undefined,
@@ -18,9 +24,11 @@ let {
 	onchange?: ((value: boolean) => void) | undefined;
 } = $props();
 
+const isOn = $derived(checked ?? false);
+
 function flip() {
 	if (disabled) return;
-	checked = !checked;
+	checked = !isOn;
 	onchange?.(checked);
 }
 
@@ -34,16 +42,16 @@ function onKeydown(event: KeyboardEvent) {
 
 <div
 	class="checkbox-container"
-	class:is-enabled={checked}
+	class:is-enabled={isOn}
 	class:is-disabled={disabled}
 	role="switch"
-	aria-checked={checked}
+	aria-checked={isOn}
 	aria-label={ariaLabel}
 	tabindex={disabled ? -1 : 0}
 	onclick={flip}
 	onkeydown={onKeydown}
 >
-	<input type="checkbox" tabindex="-1" {checked} aria-hidden="true" />
+	<input type="checkbox" tabindex="-1" checked={isOn} aria-hidden="true" />
 </div>
 
 <style>

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -545,6 +545,11 @@ export const Modal = class {
 		(this as any).onClose?.();
 		this.containerEl.remove();
 	}
+
+	// Real Obsidian's Modal defines no-op lifecycle hooks, so subclasses may
+	// call super.onOpen()/super.onClose() (ChoiceBuilder.onClose does).
+	onOpen() {}
+	onClose() {}
 };
 
 export const Scope = class {


### PR DESCRIPTION
## What

Opening the gear/edit modal for a Capture or Template choice rendered a completely blank dialog when the choice's persisted data predates newer optional boolean fields:

- `insertAfter.considerSubsections` (added 2023-03, 26a9092d)
- `folder.chooseFromSubfolders` (added 2023-02, a7c04c63)
- `insertAfter.insertAtEnd` (added 2021-06, f0924484 - same latent crash, found while auditing)

Choice **execution** was never affected (the engines treat `undefined` as `false`); only the edit UI broke.

## Root cause

Svelte 5 hard-throws `props_invalid_value` ("Cannot do `bind:checked={undefined}` when `checked` has a fallback value") when an `undefined` value is bound to a `$bindable` prop that has a fallback - `Toggle.svelte`'s `checked = $bindable(false)`. The throw aborts the whole form mount inside the modal, which opens empty. The imperative builders this UI replaced (#1130) tolerated the missing fields, so this is a regression of the Svelte form rewrite, surfacing only for choices not re-saved since 2023.

The reporter's three-part Template trigger condition in #1497 is exactly "the subfolders toggle actually renders": folder mode resolves to `specified` (`enabled` + `!chooseWhenCreatingNote` + `!createInSameFolderAsActiveFile`), so the `Include subfolders` row mounts and binds the missing field.

## Fix

1. **`Toggle.svelte`**: drop the `$bindable` fallback and coalesce internally (`$derived(checked ?? false)`). An undefined binding now renders as "off" and becomes a real boolean on first flip. This removes the hazard class for every optional boolean field, including ones added in the future. (`Dropdown`/`ValidatedInput` keep their fallbacks: every string field bound today is either always-present in persisted data or normalized before mount - audited.)
2. **Shape backfills** per the existing defaults idiom, so the persisted shape completes on the next save: `considerSubsections`/`insertAtEnd` in `InsertAfterFields.svelte`'s init defaults block (section-local, like its siblings), `chooseFromSubfolders` in `TemplateChoiceBuilder.normalizeChoice`.

No load-time migration: `undefined` is semantically identical to `false` for the engines, and rewriting every vault's `data.json` on upgrade would cause sync churn for a UI-only defect. The reporter's suggested "tolerant modal" option is the root fix here.

## Verification

- Regression tests (`choiceForms-1497-legacy-missing-fields.test.ts`): both forms mounted with legacy-shaped choices, a builder-level test proving the resolved choice from `waitForClose` carries the backfilled field, and a direct Toggle undefined-binding test. All fail with `props_invalid_value` without the fix.
- Live e2e in real Obsidian 1.13 (isolated vault seeded with the reporter's exact broken JSON shapes): unfixed build reproduces the blank modal for both choice types with `props_invalid_value` captured in the console; fixed build renders the full form (26 setting items for Capture, 15 for Template including the previously-crashing "Include subfolders" row), and closing the modal persists `considerSubsections: false` while preserving the user's `insertAtEnd: true`. No console errors after the fix.
- Full suite (3833 tests), svelte-check, lint, production build all green.
- The Obsidian test stub gained real Modal no-op `onOpen`/`onClose` lifecycle hooks (needed by the builder-level test; matches real Obsidian).

Fixes #1497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when reopening older saved choices that are missing newer option fields.
  * Default values are now filled in automatically for insert-after and subfolder settings.
  * Toggle controls now behave correctly when their initial state is unset.

* **Tests**
  * Added regression coverage for legacy choice data, toggle behavior, and form startup/close flows.

* **Style**
  * Improved internal handling so disabled and unchecked states display consistently in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->