### PR TITLE
feat(ai): provider-scoped model identity

### DIFF
--- a/docs/docs/AIAssistant.md
+++ b/docs/docs/AIAssistant.md
@@ -104,6 +104,14 @@ Leaving the API key blank works for Ollama. Model import from `/v1/models` sends
 
 When adding a model manually, the model name must match the id your server expects, such as `mistral` or `llama3.1`. The **Max Tokens** value is the model's context window. See [Model settings and token budgets](#model-settings-and-token-budgets).
 
+### Provider IDs and duplicate model names
+
+Every provider has a stable **ID** - a short slug like `openai` or `my-proxy`, shown in the provider's edit form. The ID never changes, even if you rename the provider, and scripts use it to address a model on a specific provider.
+
+Two providers can serve models with the same name - for example, the official OpenAI provider and an OpenAI-compatible proxy can both list `gpt-4o`. Model dropdowns group models by provider so you always pick a specific provider's model, and QuickAdd remembers that choice. Reordering providers, renaming them, or auto-syncing new models never changes which endpoint an existing command talks to.
+
+If the provider a command is pinned to is later deleted, QuickAdd falls back to the first provider that serves a model with that name and warns you about the switch. Re-select the model in the command to pin it again.
+
 ### Model source
 
 Each provider has a **Model source** setting:

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -583,7 +583,7 @@ const result = await quickAddApi.ai.prompt(
 
 **Note:** For newer models like `gpt-4o` or custom provider models, add them in Settings → QuickAdd → AI → Providers. Some providers support auto-sync to automatically update available models.
 
-### `chunkedPrompt(text: string, promptTemplate: string, model: string | {name: string}, settings?: object): Promise<object>`
+### `chunkedPrompt(text: string, promptTemplate: string, model: string | {name: string, provider?: string}, settings?: object): Promise<object>`
 Splits `text` into chunks, runs `promptTemplate` once per chunk, and joins the
 results. Use this for inputs that are too large for a single request.
 

--- a/docs/docs/QuickAddAPI.md
+++ b/docs/docs/QuickAddAPI.md
@@ -527,12 +527,15 @@ const tomorrowTask = `Tasks for ${quickAddApi.date.tomorrow("dddd, MMMM D")}`;
 
 Access via `quickAddApi.ai`:
 
-### `prompt(prompt: string, model: string | {name: string}, settings?: object): Promise<object>`
+### `prompt(prompt: string, model: string | {name: string, provider?: string}, settings?: object): Promise<object>`
 Sends a prompt to an AI model and returns the response.
 
 **Parameters:**
 - `prompt`: The prompt text
-- `model`: Model identifier - either a string (e.g., `"gpt-4"`) or object with name property (e.g., `{name: "gpt-4"}`). The model must be configured in Settings → QuickAdd → AI → Providers.
+- `model`: Model identifier. The model must be configured in Settings → QuickAdd → AI → Providers. Accepts:
+  - A model name string, e.g. `"gpt-4o"`. Resolves to the first provider that serves it.
+  - A provider-qualified string, e.g. `"openai/gpt-4o"`, where the prefix is a provider's stable ID (shown in the provider's edit form) or display name. Use this when two providers serve the same model name. If a provider literally serves a model whose id IS the whole string (OpenRouter's `openai/gpt-4o`, for example), that literal model wins - use the object form to override.
+  - An object, e.g. `{name: "gpt-4o", provider: "openai"}`. With `provider` set, the lookup is scoped to exactly that provider and cannot be shadowed by literal slash-named models.
 - `settings`: (Optional) Configuration object:
   - `variableName`: Output variable name (default: "output")
   - `shouldAssignVariables`: Auto-assign to variables (default: false)
@@ -587,7 +590,7 @@ results. Use this for inputs that are too large for a single request.
 **Parameters:**
 - `text`: The full input text to process.
 - `promptTemplate`: The prompt run for each chunk. Reference the current chunk with `{{value:chunk}}`.
-- `model`: Model identifier (string or `{name}`), as for `prompt`.
+- `model`: Model identifier (bare or provider-qualified string, or `{name, provider?}` object), as for `prompt`.
 - `settings`: (Optional) Configuration object:
   - `variableName`: Output variable name (default: "output")
   - `shouldAssignVariables`: Auto-assign to variables (default: false)
@@ -655,7 +658,7 @@ const { text, steps, toolCalls } = await agent.generate({
 ```
 
 **`ai.agent(config)`** returns an Agent. Config:
-- `model` — a configured model name (string) or `{ name }`.
+- `model` — a configured model: bare name (`"gpt-4o"`), provider-qualified string (`"openai/gpt-4o"`), or `{ name, provider? }` object, as for `ai.prompt`.
 - `system` — system prompt (defaults to your AI Assistant default system prompt).
 - `tools` — an object map of tool name → tool (from `ai.tool()` and/or `ai.tools.*`).
 - `toolChoice` — `"auto"` (default) | `"none"` | `"required"` | `{ type: "tool", toolName }`.

--- a/src/ai/AIAssistant.chunkedPrompt.test.ts
+++ b/src/ai/AIAssistant.chunkedPrompt.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AIProvider } from "./Provider";
 import type { App } from "obsidian";
 import type { CommonResponse } from "./OpenAIRequest";
 
@@ -63,6 +64,13 @@ function makeSettings(overrides: Partial<Parameters<typeof ChunkedPrompt>[1]> = 
 	return {
 		apiKey: "key",
 		model: { name: "test-model", maxTokens: 1000 },
+		provider: {
+			name: "TestProvider",
+			endpoint: "https://example.test/v1",
+			apiKey: "",
+			models: [],
+			modelSource: "providerApi",
+		} as AIProvider,
 		outputVariableName: "output",
 		showAssistantMessages: false,
 		systemPrompt: "system",
@@ -115,15 +123,19 @@ describe("ChunkedPrompt", () => {
 	});
 
 	it("throws before dispatch when prompt overhead exceeds the whole context window", async () => {
-		mocks.getModelMaxTokens.mockReturnValue(10);
 		// Overhead-heavy template: the rendered template alone exceeds the model's
-		// entire context window, so no completion could ever fit.
+		// entire context window (read straight off the model), so no completion
+		// could ever fit.
 		const overheadFormatter = vi.fn(
 			async () => "static prompt overhead that consumes the whole model budget"
 		);
 
 		await expect(
-			ChunkedPrompt(makeApp(), makeSettings(), overheadFormatter)
+			ChunkedPrompt(
+				makeApp(),
+				makeSettings({ model: { name: "test-model", maxTokens: 10 } }),
+				overheadFormatter
+			)
 		).rejects.toThrow(/exceeds the model's entire context window/);
 		expect(mocks.makeRequest).not.toHaveBeenCalled();
 	});

--- a/src/ai/AIAssistant.ts
+++ b/src/ai/AIAssistant.ts
@@ -11,8 +11,7 @@ import { isCancellationError } from "src/utils/errorUtils";
 import type { OpenAIModelParameters } from "./OpenAIModelParameters";
 import { OpenAIRequest } from "./OpenAIRequest";
 import { isLikelyContextLimitError } from "./providerErrors";
-import type { Model } from "./Provider";
-import { getModelMaxTokens } from "./aiHelpers";
+import type { AIProvider, Model } from "./Provider";
 import { makeNoticeHandler } from "./makeNoticeHandler";
 import { estimateModelInputBudget, estimateTokenCount } from "./tokenEstimator";
 import { log } from "src/logger/logManager";
@@ -230,6 +229,8 @@ async function getTargetPromptTemplate(
 interface Params {
 	apiKey: string;
 	model: Model;
+	/** The provider the model was resolved to; the apiKey belongs to it. */
+	provider: AIProvider;
 	systemPrompt: string;
 	outputVariableName: string;
 	promptTemplate: {
@@ -270,6 +271,7 @@ export async function runAIAssistant(
 		const {
 			apiKey,
 			model,
+			provider,
 			outputVariableName: outputVariable,
 			promptTemplate,
 			systemPrompt,
@@ -302,6 +304,7 @@ export async function runAIAssistant(
 			app,
 			apiKey,
 			model,
+			provider,
 			systemPrompt,
 			settings.modelOptions
 		);
@@ -391,6 +394,7 @@ export async function Prompt(
 		const {
 			apiKey,
 			model,
+			provider,
 			outputVariableName: outputVariable,
 			systemPrompt,
 			prompt,
@@ -410,6 +414,7 @@ export async function Prompt(
 			app,
 			apiKey,
 			model,
+			provider,
 			systemPrompt,
 			modelOptions
 		);
@@ -849,6 +854,7 @@ export async function ChunkedPrompt(
 		const {
 			apiKey,
 			model,
+			provider,
 			outputVariableName: outputVariable,
 			systemPrompt,
 			promptTemplate,
@@ -884,7 +890,7 @@ export async function ChunkedPrompt(
 			);
 		}
 
-		const fullContextTokens = getModelMaxTokens(model.name);
+		const fullContextTokens = model.maxTokens;
 		const estimatedInputBudget = estimateModelInputBudget(fullContextTokens);
 		const overheadPrompt = removeChunkProbeFromRenderedPrompt(overheadProbe);
 		const promptOverhead =
@@ -926,6 +932,7 @@ export async function ChunkedPrompt(
 			app,
 			apiKey,
 			model,
+			provider,
 			systemPrompt,
 			modelOptions
 		);

--- a/src/ai/OpenAIRequest.audit-cleanup.test.ts
+++ b/src/ai/OpenAIRequest.audit-cleanup.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { App } from "obsidian";
-import type { Model } from "./Provider";
+import type { AIProvider, Model } from "./Provider";
 
 // Finding: ai-assistant-disable-online-features — the "online features disabled"
 // guard in OpenAIRequest hardcoded the provider name ("Blocking request to
@@ -61,6 +61,10 @@ function makeApp(): App {
 }
 
 const anthropicModel: Model = { name: "claude-3-5-sonnet", maxTokens: 200000 };
+const anthropicProvider = {
+	name: "Anthropic",
+	endpoint: "https://api.anthropic.com",
+} as AIProvider;
 
 describe("OpenAIRequest disable-online-features guard wording", () => {
 	beforeEach(() => {
@@ -76,6 +80,7 @@ describe("OpenAIRequest disable-online-features guard wording", () => {
 			makeApp(),
 			"key",
 			anthropicModel,
+			anthropicProvider,
 			"system"
 		);
 

--- a/src/ai/OpenAIRequest.sampling.test.ts
+++ b/src/ai/OpenAIRequest.sampling.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { App } from "obsidian";
-import type { Model } from "./Provider";
+import type { AIProvider, Model } from "./Provider";
 
 const storeState = vi.hoisted(() => ({
 	disableOnlineFeatures: false,
@@ -46,6 +46,10 @@ vi.mock("src/logger/logManager", () => ({
 const { requestUrlMock, getModelProviderMock, noticeMock } = mocks;
 
 const { OpenAIRequest, chatRequest } = await import("./OpenAIRequest");
+
+// OpenAIRequest/chatRequest now take the caller-resolved provider explicitly
+// (#1495); these tests keep selecting it via getModelProviderMock.
+const currentProvider = () => getModelProviderMock() as AIProvider;
 
 function makeApp(): App {
 	return {
@@ -123,7 +127,7 @@ describe("sampling parameter recovery (single-prompt path)", () => {
 			.mockReturnValueOnce(Promise.resolve(openaiSuccess("recovered")));
 
 		const model: Model = { name: "o3-mini", maxTokens: 200000 };
-		const makeRequest = OpenAIRequest(makeApp(), "sk", model, "sys", {
+		const makeRequest = OpenAIRequest(makeApp(), "sk", model, currentProvider(), "sys", {
 			temperature: 0.7,
 		});
 
@@ -146,7 +150,7 @@ describe("sampling parameter recovery (single-prompt path)", () => {
 			maxTokens: 1050000,
 			supportsTemperature: false,
 		};
-		const makeRequest = OpenAIRequest(makeApp(), "sk", model, "sys", {
+		const makeRequest = OpenAIRequest(makeApp(), "sk", model, currentProvider(), "sys", {
 			temperature: 0.3,
 			top_p: 0.9,
 		});
@@ -177,7 +181,7 @@ describe("sampling parameter recovery (single-prompt path)", () => {
 		);
 
 		const model: Model = { name: "gpt-4-32k", maxTokens: 32768 };
-		const makeRequest = OpenAIRequest(makeApp(), "sk", model, "sys", {
+		const makeRequest = OpenAIRequest(makeApp(), "sk", model, currentProvider(), "sys", {
 			temperature: 0.7,
 		});
 
@@ -193,7 +197,7 @@ describe("sampling parameter recovery (single-prompt path)", () => {
 		);
 
 		const model: Model = { name: "o3-mini", maxTokens: 200000 };
-		const makeRequest = OpenAIRequest(makeApp(), "sk", model, "sys", {});
+		const makeRequest = OpenAIRequest(makeApp(), "sk", model, currentProvider(), "sys", {});
 
 		await expect(makeRequest("hello")).rejects.toThrow("Unsupported parameter");
 		expect(requestUrlMock).toHaveBeenCalledTimes(1);
@@ -234,7 +238,7 @@ describe("Anthropic single-prompt sampling + output cap", () => {
 			maxOutputTokens: 64000,
 			supportsTemperature: true,
 		};
-		const makeRequest = OpenAIRequest(makeApp(), "sk-ant", model, "sys", {
+		const makeRequest = OpenAIRequest(makeApp(), "sk-ant", model, currentProvider(), "sys", {
 			temperature: 0.4,
 		});
 
@@ -266,7 +270,7 @@ describe("Anthropic single-prompt sampling + output cap", () => {
 
 		// No metadata (e.g. user-added model): the reactive retry is the net.
 		const model: Model = { name: "claude-sonnet-5", maxTokens: 1000000 };
-		const makeRequest = OpenAIRequest(makeApp(), "sk-ant", model, "sys", {
+		const makeRequest = OpenAIRequest(makeApp(), "sk-ant", model, currentProvider(), "sys", {
 			temperature: 0.7,
 		});
 
@@ -295,7 +299,7 @@ describe("sampling parameter recovery (chat/tool path)", () => {
 			.mockReturnValueOnce(Promise.resolve(openaiSuccess("chat ok")));
 
 		const model: Model = { name: "o4-mini", maxTokens: 200000 };
-		const res = await chatRequest(makeApp(), "sk", model, {
+		const res = await chatRequest(makeApp(), "sk", model, currentProvider(), {
 			messages: [{ role: "user", content: "hello" }],
 			modelParams: { top_p: 0.5 },
 		});

--- a/src/ai/OpenAIRequest.test.ts
+++ b/src/ai/OpenAIRequest.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { App } from "obsidian";
-import type { Model } from "./Provider";
+import type { AIProvider, Model } from "./Provider";
 import {
 	classifyProviderError,
 	isLikelyContextLimitError,
@@ -54,6 +54,10 @@ const {
 } = mocks;
 
 const { OpenAIRequest } = await import("./OpenAIRequest");
+
+// OpenAIRequest now takes the caller-resolved provider explicitly (#1495);
+// these tests keep selecting it via getModelProviderMock and read it back here.
+const currentProvider = () => getModelProviderMock() as AIProvider;
 
 // A minimal app whose activeEditor is undefined so preventCursorChange becomes a no-op.
 function makeApp(): App {
@@ -142,6 +146,7 @@ describe("OpenAIRequest", () => {
 				makeApp(),
 				"key",
 				openAIModel,
+				currentProvider(),
 				"system"
 			);
 
@@ -156,7 +161,7 @@ describe("OpenAIRequest", () => {
 			const model: Model = { name: "gpt-4o", maxTokens: 1 };
 			getModelProviderMock.mockReturnValue(openAIProvider);
 			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
-			const makeRequest = OpenAIRequest(makeApp(), "key", model, "system");
+			const makeRequest = OpenAIRequest(makeApp(), "key", model, currentProvider(), "system");
 
 			await expect(makeRequest("prompt")).resolves.toBeDefined();
 			expect(requestUrlMock).toHaveBeenCalledTimes(1);
@@ -170,27 +175,12 @@ describe("OpenAIRequest", () => {
 			getModelProviderMock.mockReturnValue(openAIProvider);
 			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
 
-			const makeRequest = OpenAIRequest(makeApp(), "key", model, "system");
+			const makeRequest = OpenAIRequest(makeApp(), "key", model, currentProvider(), "system");
 			await expect(makeRequest("prompt")).resolves.toBeDefined();
 			expect(requestUrlMock).toHaveBeenCalledTimes(1);
 			expect(mocks.logMessageMock).not.toHaveBeenCalledWith(
 				expect.stringContaining("Estimated prompt size")
 			);
-		});
-
-		it("throws when no provider is found for the model", async () => {
-			getModelProviderMock.mockReturnValue(undefined);
-			const makeRequest = OpenAIRequest(
-				makeApp(),
-				"key",
-				openAIModel,
-				"system"
-			);
-
-			await expect(makeRequest("prompt")).rejects.toThrow(
-				"Model gpt-4o not found with any provider."
-			);
-			expect(requestUrlMock).not.toHaveBeenCalled();
 		});
 	});
 
@@ -210,7 +200,7 @@ describe("OpenAIRequest", () => {
 				},
 				text: '{"error":{"code":"context_length_exceeded"}}',
 			});
-			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, currentProvider(), "sys");
 
 			let thrown: unknown;
 			try {
@@ -238,7 +228,7 @@ describe("OpenAIRequest", () => {
 					},
 				},
 			});
-			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, currentProvider(), "sys");
 
 			let thrown: unknown;
 			await expect(makeRequest("prompt")).rejects.toThrow(
@@ -263,7 +253,7 @@ describe("OpenAIRequest", () => {
 					},
 				},
 			});
-			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, currentProvider(), "sys");
 
 			let thrown: unknown;
 			try {
@@ -287,6 +277,7 @@ describe("OpenAIRequest", () => {
 				makeApp(),
 				"secret-key",
 				openAIModel,
+				currentProvider(),
 				"system"
 			);
 			await makeRequest("prompt");
@@ -306,7 +297,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				openAIModel,
+				openAIModel, currentProvider(),
 				"you are helpful",
 				params
 			);
@@ -328,7 +319,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				openAIModel,
+				openAIModel, currentProvider(),
 				"sys"
 			);
 			await makeRequest("hi");
@@ -341,7 +332,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				openAIModel,
+				openAIModel, currentProvider(),
 				"sys"
 			);
 			const result = await makeRequest("hi");
@@ -384,7 +375,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"anthropic-key",
-				anthropicModel,
+				anthropicModel, currentProvider(),
 				"system prompt"
 			);
 			await makeRequest("hello claude");
@@ -422,7 +413,7 @@ describe("OpenAIRequest", () => {
 				},
 			});
 
-			const makeRequest = OpenAIRequest(makeApp(), "anthropic-key", anthropicModel, "");
+			const makeRequest = OpenAIRequest(makeApp(), "anthropic-key", anthropicModel, currentProvider(), "");
 			await makeRequest("hi");
 
 			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
@@ -444,7 +435,7 @@ describe("OpenAIRequest", () => {
 				},
 			});
 
-			const makeRequest = OpenAIRequest(makeApp(), "anthropic-key", anthropicModel, "   ");
+			const makeRequest = OpenAIRequest(makeApp(), "anthropic-key", anthropicModel, currentProvider(), "   ");
 			await makeRequest("hi");
 
 			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
@@ -468,7 +459,7 @@ describe("OpenAIRequest", () => {
 				},
 			});
 
-			const makeRequest = OpenAIRequest(makeApp(), "anthropic-key", anthropicModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "anthropic-key", anthropicModel, currentProvider(), "sys");
 			const result = await makeRequest("q");
 
 			expect(result.content).toBe("after the tool block");
@@ -491,7 +482,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				anthropicModel,
+				anthropicModel, currentProvider(),
 				"sys"
 			);
 			const result = await makeRequest("q");
@@ -538,7 +529,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"gem ini/key",
-				geminiModel,
+				geminiModel, currentProvider(),
 				"system instruction text"
 			);
 			await makeRequest("hi gemini");
@@ -564,7 +555,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				geminiModel,
+				geminiModel, currentProvider(),
 				"  you are helpful  "
 			);
 			await makeRequest("hi");
@@ -584,7 +575,7 @@ describe("OpenAIRequest", () => {
 				json: { candidates: [{ content: { role: "model", parts: [] } }] },
 			});
 
-			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "   ");
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, currentProvider(), "   ");
 			await makeRequest("hi");
 
 			const body = JSON.parse(requestUrlMock.mock.calls[0][0].body);
@@ -599,7 +590,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				geminiModel,
+				geminiModel, currentProvider(),
 				"sys",
 				{
 					temperature: 0.3,
@@ -622,7 +613,7 @@ describe("OpenAIRequest", () => {
 				json: { candidates: [{ content: { role: "model", parts: [] } }] },
 			});
 
-			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "sys", {
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, currentProvider(), "sys", {
 				frequency_penalty: 0.5,
 			});
 			await makeRequest("hi");
@@ -656,7 +647,7 @@ describe("OpenAIRequest", () => {
 				},
 			});
 
-			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, currentProvider(), "sys");
 			const result = await makeRequest("hi");
 
 			expect(result.content).toBe("Hello world");
@@ -674,7 +665,7 @@ describe("OpenAIRequest", () => {
 				json: { candidates: [{ content: { role: "model", parts: [] } }] },
 			});
 
-			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "key", geminiModel, currentProvider(), "sys");
 			const result = await makeRequest("hi");
 
 			expect(result.content).toBe("");
@@ -696,7 +687,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				openAIModel,
+				openAIModel, currentProvider(),
 				"sys",
 				{ temperature: 0.2 }
 			);
@@ -732,7 +723,7 @@ describe("OpenAIRequest", () => {
 			const makeRequest = OpenAIRequest(
 				makeApp(),
 				"key",
-				openAIModel,
+				openAIModel, currentProvider(),
 				"sys"
 			);
 
@@ -752,7 +743,7 @@ describe("OpenAIRequest", () => {
 			const networkError = new Error("boom");
 			requestUrlMock.mockRejectedValue(networkError);
 
-			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, currentProvider(), "sys");
 
 			await expect(makeRequest("prompt")).rejects.toMatchObject({
 				cause: networkError,
@@ -763,7 +754,7 @@ describe("OpenAIRequest", () => {
 			getModelProviderMock.mockReturnValue(openAIProvider);
 			requestUrlMock.mockRejectedValue("plain string failure");
 
-			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, "sys");
+			const makeRequest = OpenAIRequest(makeApp(), "key", openAIModel, currentProvider(), "sys");
 
 			await expect(makeRequest("prompt")).rejects.toThrow(
 				"Error while making request to OpenAI: plain string failure"
@@ -777,7 +768,7 @@ describe("OpenAIRequest", () => {
 			requestUrlMock.mockResolvedValue({ json: openAIResponse() });
 
 			const { app, calls, cursor, selections } = makeAppWithEditor();
-			const makeRequest = OpenAIRequest(app, "key", openAIModel, "sys");
+			const makeRequest = OpenAIRequest(app, "key", openAIModel, currentProvider(), "sys");
 			await makeRequest("prompt");
 
 			expect(calls.setCursor).toHaveBeenCalledWith(cursor);

--- a/src/ai/OpenAIRequest.ts
+++ b/src/ai/OpenAIRequest.ts
@@ -16,7 +16,6 @@ import {
 import { preventCursorChange } from "./preventCursorChange";
 import type { AIProvider, Model } from "./Provider";
 import { getProviderKind } from "./Provider";
-import { getModelProvider } from "./aiHelpers";
 import type { NormalizedChatRequest } from "./tools/NormalizedTools";
 import {
 	buildChatBody,
@@ -359,6 +358,11 @@ export function OpenAIRequest(
 	app: App,
 	apiKey: string,
 	model: Model,
+	// The provider the CALLER resolved (it already chose the API key from it).
+	// Passed through rather than re-derived from model.name — a first-match
+	// re-lookup here could route a provider-pinned model (#1495) to a different
+	// endpoint than the key belongs to.
+	modelProvider: AIProvider,
 	systemPrompt: string,
 	modelParams: Partial<OpenAIModelParameters> = {}
 ): (prompt: string) => Promise<CommonResponse> {
@@ -371,12 +375,6 @@ export function OpenAIRequest(
 
 		const estimatedTokenCount =
 			estimateTokenCount(prompt) + estimateTokenCount(systemPrompt);
-
-		const modelProvider = getModelProvider(model.name);
-
-		if (!modelProvider) {
-			throw new Error(`Model ${model.name} not found with any provider.`);
-		}
 
 		const requestStart = Date.now();
 		const requestLogId = beginAIRequestLogEntry({
@@ -605,6 +603,8 @@ export async function chatRequest(
 	app: App,
 	apiKey: string,
 	model: Model,
+	// Caller-resolved provider; see OpenAIRequest for why it is never re-derived.
+	modelProvider: AIProvider,
 	request: NormalizedChatRequest,
 	afterRequestCallback?: () => void,
 ): Promise<CommonResponse> {
@@ -615,10 +615,6 @@ export async function chatRequest(
 		);
 	}
 
-	const modelProvider = getModelProvider(model.name);
-	if (!modelProvider) {
-		throw new Error(`Model ${model.name} not found with any provider.`);
-	}
 	const kind = getProviderKind(modelProvider);
 	// Same sampling safety as the single-prompt path: drop params the model's
 	// metadata marks unsupported, and keep the sent set for the reactive retry.

--- a/src/ai/Provider.test.ts
+++ b/src/ai/Provider.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { getProviderKind } from "./Provider";
+import type { AIProvider } from "./Provider";
+import {
+	activeModelRef,
+	ensureProviderIds,
+	getProviderKind,
+	slugifyProviderId,
+	uniqueProviderId,
+} from "./Provider";
 
 describe("getProviderKind", () => {
 	it("prefers an explicit kind", () => {
@@ -34,5 +41,81 @@ describe("getProviderKind", () => {
 		expect(getProviderKind({ name: "OpenRouter" })).toBe("openai");
 		expect(getProviderKind({ endpoint: "not a url" })).toBe("openai");
 		expect(getProviderKind({})).toBe("openai");
+	});
+});
+
+function bareProvider(name: string, id?: string): AIProvider {
+	return {
+		id,
+		name,
+		endpoint: "https://example.test",
+		apiKey: "",
+		models: [],
+		modelSource: "providerApi",
+	};
+}
+
+describe("slugifyProviderId", () => {
+	it("lowercases and collapses non-alphanumerics to single dashes", () => {
+		expect(slugifyProviderId("OpenAI")).toBe("openai");
+		expect(slugifyProviderId("Hugging Face")).toBe("hugging-face");
+		expect(slugifyProviderId("My  LLM! Proxy")).toBe("my-llm-proxy");
+	});
+
+	it("never emits a slash (the qualified-form delimiter) and never an empty id", () => {
+		expect(slugifyProviderId("a/b/c")).toBe("a-b-c");
+		expect(slugifyProviderId("///")).toBe("provider");
+		expect(slugifyProviderId("")).toBe("provider");
+	});
+});
+
+describe("uniqueProviderId / ensureProviderIds", () => {
+	it("suffixes when the base id is taken", () => {
+		const providers = [bareProvider("OpenAI", "openai")];
+		expect(uniqueProviderId("openai", providers)).toBe("openai-2");
+	});
+
+	it("enforces the slug charset on any base, not just caller discipline", () => {
+		expect(uniqueProviderId("My/Weird Provider", [])).toBe(
+			"my-weird-provider",
+		);
+	});
+
+	it("reassigns duplicate EXISTING ids so refs stay unambiguous (first keeps it)", () => {
+		const providers = [
+			bareProvider("OpenAI", "openai"),
+			bareProvider("OpenAI Clone", "openai"),
+		];
+
+		expect(ensureProviderIds(providers)).toBe(true);
+		expect(providers.map((p) => p.id)).toEqual(["openai", "openai-2"]);
+	});
+
+	it("assigns ids only to providers lacking one, uniquely, and reports changes", () => {
+		const providers = [
+			bareProvider("OpenAI", "openai"),
+			bareProvider("Custom"),
+			bareProvider("Custom"),
+		];
+
+		expect(ensureProviderIds(providers)).toBe(true);
+		expect(providers.map((p) => p.id)).toEqual([
+			"openai",
+			"custom",
+			"custom-2",
+		]);
+		// Second pass: nothing to do.
+		expect(ensureProviderIds(providers)).toBe(false);
+	});
+});
+
+describe("activeModelRef", () => {
+	it("returns the ref only while it matches the legacy string", () => {
+		const ref = { providerId: "openai", name: "gpt-4o" };
+		expect(activeModelRef("gpt-4o", ref)).toBe(ref);
+		// Drift: an older QuickAdd rewrote the string; the stale ref is inert.
+		expect(activeModelRef("o3", ref)).toBeUndefined();
+		expect(activeModelRef(undefined, ref)).toBeUndefined();
+		expect(activeModelRef("gpt-4o", undefined)).toBeUndefined();
 	});
 });

--- a/src/ai/Provider.ts
+++ b/src/ai/Provider.ts
@@ -9,6 +9,15 @@ export type ModelDiscoveryMode = "modelsDev" | "providerApi" | "auto";
 export type ProviderKind = "openai" | "anthropic" | "gemini";
 
 export interface AIProvider {
+	/**
+	 * Stable identity used by persisted model references and the script API's
+	 * qualified `providerId/model` form. A lowercase slug, unique across the
+	 * configured providers, never containing "/" (the qualified-form delimiter).
+	 * Immutable once assigned — `name` is the editable display label.
+	 * Optional only because pre-2.19 data.json files lack it; every creation
+	 * path and the pinAiModelRefs migration assign one.
+	 */
+	id?: string;
 	name: string;
 	endpoint: string;
 	/** SecretStorage key name for this provider's API key. */
@@ -63,6 +72,97 @@ function endpointHost(endpoint?: string): string {
 		}
 	}
 	return "";
+}
+
+/**
+ * Provider-scoped model reference. The persisted identity of a pinned model:
+ * a bare name string cannot express WHICH provider serves it once two
+ * providers list the same id (#1495). Persisted alongside the legacy bare-name
+ * string, which writers keep in sync (`model === modelRef.name`) so downgrades
+ * and cross-vault imports degrade to today's first-match behavior.
+ */
+export interface ModelRef {
+	providerId: string;
+	name: string;
+}
+
+/**
+ * Derive a provider id slug from a display name: lowercase, `a-z0-9-` only.
+ * The charset intentionally excludes "/" so splitting a qualified
+ * `providerId/model` string at its FIRST slash is unambiguous even for models
+ * whose own names contain slashes (OpenRouter's `openai/gpt-4o` etc.).
+ */
+export function slugifyProviderId(name: string): string {
+	const slug = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return slug || "provider";
+}
+
+/**
+ * A provider id equal to the slug of `base`, or `-2`, `-3`, … suffixed when
+ * other providers already claim it. Every creation path goes through here so
+ * two providers can never share an id and no id can ever contain "/" —
+ * enforced HERE rather than by caller discipline.
+ */
+export function uniqueProviderId(
+	base: string,
+	providers: AIProvider[],
+): string {
+	const slug = slugifyProviderId(base);
+	const taken = new Set(
+		providers.map((p) => p.id).filter((id): id is string => !!id),
+	);
+
+	let candidate = slug;
+	for (let i = 2; taken.has(candidate); i++) {
+		candidate = `${slug}-${i}`;
+	}
+
+	return candidate;
+}
+
+/**
+ * Give every provider a unique stable id. Providers without one (pre-2.19
+ * data, hand-edited data.json) get a fresh slug; when two providers CLAIM the
+ * same id (only possible via hand-editing), the first keeps it — so refs
+ * pointing at the duplicated id keep resolving to the provider they resolve
+ * to today — and later claimants are reassigned. Returns true when anything
+ * changed, so callers know the settings need persisting.
+ */
+export function ensureProviderIds(providers: AIProvider[]): boolean {
+	let changed = false;
+	const seen = new Set<string>();
+	for (const provider of providers) {
+		if (provider.id && !seen.has(provider.id)) {
+			seen.add(provider.id);
+			continue;
+		}
+
+		provider.id = uniqueProviderId(
+			provider.id ?? provider.name,
+			providers,
+		);
+		seen.add(provider.id);
+		changed = true;
+	}
+
+	return changed;
+}
+
+/**
+ * The ref, but only while it still matches the legacy string field. The two
+ * can drift apart when an older QuickAdd (which writes only `model`) edited a
+ * command after an upgrade pinned it — a stale ref must never override what
+ * the user visibly selected. Drift makes the ref inert; re-selecting the
+ * model in the dropdown re-pins it.
+ */
+export function activeModelRef(
+	model: string | undefined,
+	modelRef: ModelRef | undefined,
+): ModelRef | undefined {
+	return modelRef && modelRef.name === model ? modelRef : undefined;
 }
 
 export interface Model {
@@ -142,6 +242,7 @@ export function cloneModelSeeds(
 }
 
 const OpenAIProvider: AIProvider = {
+	id: "openai",
 	name: "OpenAI",
 	endpoint: "https://api.openai.com/v1",
 	kind: "openai",
@@ -152,6 +253,7 @@ const OpenAIProvider: AIProvider = {
 };
 
 const GeminiProvider: AIProvider = {
+	id: "gemini",
 	name: "Gemini",
 	endpoint: "https://generativelanguage.googleapis.com",
 	kind: "gemini",

--- a/src/ai/aiHelpers.resolveModel.test.ts
+++ b/src/ai/aiHelpers.resolveModel.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "src/settings";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+import { log } from "src/logger/logManager";
+import type { AIProvider } from "./Provider";
+import {
+	resetModelResolutionWarnings,
+	resolveModel,
+	resolveModelInputOrThrow,
+	resolveModelScoped,
+} from "./aiHelpers";
+
+function provider(overrides: Partial<AIProvider>): AIProvider {
+	return {
+		name: "Provider",
+		endpoint: "https://example.test/v1",
+		apiKey: "",
+		models: [],
+		modelSource: "providerApi",
+		...overrides,
+	};
+}
+
+// The #1495 collision scenario: native OpenAI plus an OpenRouter-style proxy
+// whose LITERAL model ids carry vendor prefixes, including "openai/gpt-4o".
+function openAI(): AIProvider {
+	return provider({
+		id: "openai",
+		name: "OpenAI",
+		endpoint: "https://api.openai.com/v1",
+		models: [
+			{ name: "gpt-4o", maxTokens: 128_000 },
+			{ name: "o3", maxTokens: 200_000 },
+		],
+	});
+}
+
+function openRouter(): AIProvider {
+	return provider({
+		id: "openrouter",
+		name: "OpenRouter",
+		endpoint: "https://openrouter.ai/api/v1",
+		models: [
+			{ name: "openai/gpt-4o", maxTokens: 128_000 },
+			{ name: "gpt-4o", maxTokens: 64_000 },
+		],
+	});
+}
+
+function setProviders(providers: AIProvider[]): void {
+	const current = settingsStore.getState();
+	settingsStore.setState({ ai: { ...current.ai, providers } });
+}
+
+beforeEach(() => {
+	settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	resetModelResolutionWarnings();
+	vi.restoreAllMocks();
+});
+
+describe("resolveModel — object refs (pinned commands)", () => {
+	it("resolves by stable provider id, not first match", () => {
+		setProviders([openRouter(), openAI()]);
+
+		const resolved = resolveModel({ providerId: "openai", name: "gpt-4o" });
+
+		expect(resolved?.provider.name).toBe("OpenAI");
+		expect(resolved?.model.maxTokens).toBe(128_000);
+	});
+
+	it("falls back to first-match with a warning when the pinned provider is gone", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		setProviders([openRouter()]);
+
+		const resolved = resolveModel({ providerId: "openai", name: "gpt-4o" });
+
+		expect(resolved?.provider.name).toBe("OpenRouter");
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toContain('pinned to provider "openai"');
+	});
+
+	it("warns only once per dangling ref (settings modals re-render per keystroke)", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		setProviders([openRouter()]);
+
+		resolveModel({ providerId: "openai", name: "gpt-4o" });
+		resolveModel({ providerId: "openai", name: "gpt-4o" });
+
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-warns when the SAME dangling ref later falls back to a different provider", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		setProviders([openRouter()]);
+		resolveModel({ providerId: "openai", name: "gpt-4o" });
+
+		const other = provider({
+			id: "groq",
+			name: "Groq",
+			models: [{ name: "gpt-4o", maxTokens: 1 }],
+		});
+		setProviders([other, openRouter()]);
+		resolveModel({ providerId: "openai", name: "gpt-4o" });
+
+		expect(warn).toHaveBeenCalledTimes(2);
+	});
+
+	it("silent resolution never consumes the warn-once budget of a later run", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		setProviders([openRouter()]);
+
+		// A settings modal rendering with the dangling ref…
+		resolveModel({ providerId: "openai", name: "gpt-4o" }, { silent: true });
+		expect(warn).not.toHaveBeenCalled();
+
+		// …must not silence the warning when the command actually RUNS.
+		resolveModel({ providerId: "openai", name: "gpt-4o" });
+		expect(warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns undefined when neither the pin nor any provider serves the model", () => {
+		setProviders([openAI()]);
+
+		expect(
+			resolveModel({ providerId: "gone", name: "no-such-model" }),
+		).toBeUndefined();
+	});
+});
+
+describe("resolveModel — strings", () => {
+	it("keeps legacy first-match for bare names, in provider order", () => {
+		setProviders([openRouter(), openAI()]);
+
+		const resolved = resolveModel("gpt-4o");
+
+		expect(resolved?.provider.name).toBe("OpenRouter");
+		expect(resolved?.model.maxTokens).toBe(64_000);
+	});
+
+	it("warns once when a bare name is served by several providers", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		setProviders([openRouter(), openAI()]);
+
+		resolveModel("gpt-4o");
+		resolveModel("gpt-4o");
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toContain("openai/gpt-4o");
+		expect(warn.mock.calls[0][0]).toContain("openrouter/gpt-4o");
+	});
+
+	it("lets a LITERAL slash-named model shadow the qualified form (legacy scripts win)", () => {
+		setProviders([openAI(), openRouter()]);
+
+		// OpenRouter literally serves a model named "openai/gpt-4o"; a script
+		// passing that string resolved to it before #1495 and still must.
+		const resolved = resolveModel("openai/gpt-4o");
+
+		expect(resolved?.provider.name).toBe("OpenRouter");
+		expect(resolved?.model.name).toBe("openai/gpt-4o");
+	});
+
+	it("reads provider/model as qualified when no literal name matches", () => {
+		setProviders([openRouter(), openAI()]);
+
+		const resolved = resolveModel("openai/o3");
+
+		expect(resolved?.provider.name).toBe("OpenAI");
+		expect(resolved?.model.name).toBe("o3");
+	});
+
+	it("matches the qualified prefix against display names too, case-insensitively", () => {
+		setProviders([openAI()]);
+
+		expect(resolveModel("OpenAI/o3")?.model.name).toBe("o3");
+		expect(resolveModel("openai/o3")?.model.name).toBe("o3");
+	});
+
+	it("splits at the FIRST slash so slash-named models stay addressable per provider", () => {
+		setProviders([openAI(), openRouter()]);
+
+		const resolved = resolveModel("openrouter/openai/gpt-4o");
+
+		expect(resolved?.provider.name).toBe("OpenRouter");
+		expect(resolved?.model.name).toBe("openai/gpt-4o");
+	});
+
+	it("returns undefined for unknown names and degenerate qualified forms", () => {
+		setProviders([openAI()]);
+
+		expect(resolveModel("nope")).toBeUndefined();
+		expect(resolveModel("/gpt-4o")).toBeUndefined();
+		expect(resolveModel("openai/")).toBeUndefined();
+		expect(resolveModel("nope/gpt-4o")).toBeUndefined();
+	});
+});
+
+describe("resolveModelScoped", () => {
+	it("is never shadowed by another provider's literal slash-named model", () => {
+		setProviders([openRouter(), openAI()]);
+
+		const resolved = resolveModelScoped("openai", "gpt-4o");
+
+		expect(resolved?.provider.name).toBe("OpenAI");
+		expect(resolved?.model.maxTokens).toBe(128_000);
+	});
+
+	it("returns undefined when the provider doesn't serve the model", () => {
+		setProviders([openAI()]);
+
+		expect(resolveModelScoped("openai", "gemini-2.5-pro")).toBeUndefined();
+	});
+});
+
+describe("resolveModelInputOrThrow", () => {
+	it("throws for empty or nameless input", () => {
+		setProviders([openAI()]);
+
+		expect(() => resolveModelInputOrThrow("")).toThrow(
+			"Invalid model parameter",
+		);
+		expect(() =>
+			resolveModelInputOrThrow({} as { name: string }),
+		).toThrow("Invalid model parameter");
+	});
+
+	it("scopes exactly via the object form's provider — the shadow escape hatch", () => {
+		setProviders([openAI(), openRouter()]);
+
+		// The string form resolves to OpenRouter's literal model (legacy rule);
+		// the object form must reach native OpenAI regardless.
+		const viaString = resolveModelInputOrThrow("openai/gpt-4o");
+		const viaObject = resolveModelInputOrThrow({
+			provider: "openai",
+			name: "gpt-4o",
+		});
+
+		expect(viaString.provider.name).toBe("OpenRouter");
+		expect(viaObject.provider.name).toBe("OpenAI");
+	});
+
+	it("suggests qualified forms when a qualified string misses", () => {
+		setProviders([openAI(), openRouter()]);
+
+		expect(() =>
+			resolveModelInputOrThrow("gemini/gpt-4o"),
+		).toThrow(/Did you mean/);
+	});
+
+	it("suggests the object form when a qualified string is shadowed by a literal model id", () => {
+		const warn = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		setProviders([openAI(), openRouter()]);
+
+		// "openai/gpt-4o" is a literal model id on OpenRouter, so suggesting the
+		// string form for native OpenAI would route users to OpenRouter.
+		resolveModel("gpt-4o");
+
+		expect(warn).toHaveBeenCalledTimes(1);
+		expect(warn.mock.calls[0][0]).toContain(
+			'{ name: "gpt-4o", provider: "openai" }',
+		);
+	});
+
+	it("points at settings when nothing matches at all", () => {
+		setProviders([openAI()]);
+
+		expect(() => resolveModelInputOrThrow("claude-x")).toThrow(
+			"not found in configured providers",
+		);
+	});
+});

--- a/src/ai/aiHelpers.resolveModel.test.ts
+++ b/src/ai/aiHelpers.resolveModel.test.ts
@@ -186,6 +186,15 @@ describe("resolveModel — strings", () => {
 		expect(resolved?.model.name).toBe("openai/gpt-4o");
 	});
 
+	it("tolerates null/undefined input (malformed persisted data) instead of throwing", () => {
+		setProviders([openAI()]);
+
+		expect(
+			resolveModel(undefined as unknown as string),
+		).toBeUndefined();
+		expect(resolveModel(null as unknown as string)).toBeUndefined();
+	});
+
 	it("returns undefined for unknown names and degenerate qualified forms", () => {
 		setProviders([openAI()]);
 

--- a/src/ai/aiHelpers.ts
+++ b/src/ai/aiHelpers.ts
@@ -113,6 +113,10 @@ export function resolveModel(
 	const all = providers();
 	const silent = options?.silent === true;
 
+	// Tolerate malformed persisted data (a command whose model was never set):
+	// the object branch below would throw on `input.providerId`, and settings-UI
+	// callers rely on an undefined result to fall back instead of blanking.
+	if (input == null) return undefined;
 	if (typeof input !== "string") {
 		const provider = all.find((p) => p.id === input.providerId);
 		const model = provider?.models.find((m) => m.name === input.name);

--- a/src/ai/aiHelpers.ts
+++ b/src/ai/aiHelpers.ts
@@ -1,8 +1,23 @@
+import { log } from "src/logger/logManager";
 import { settingsStore } from "src/settingsStore";
+import type { AIProvider, Model, ModelRef } from "./Provider";
 import { estimateModelInputBudget } from "./tokenEstimator";
 
 /** Conservative context-window fallback when no model is known or configured. */
 const FALLBACK_MODEL_MAX_TOKENS = 4096;
+
+/** A model together with the provider that will serve it. */
+export interface ResolvedModel {
+	provider: AIProvider;
+	model: Model;
+}
+
+/**
+ * Anything the plugin accepts as a model reference: a provider-scoped ref
+ * (pinned commands, script object form) or a string — either a bare model
+ * name (legacy) or the qualified `providerId/modelName` form.
+ */
+export type ModelInput = ModelRef | string;
 
 export function getModelNames() {
 	const aiSettings = settingsStore.getState().ai;
@@ -12,33 +27,210 @@ export function getModelNames() {
 		.map((model) => model.name);
 }
 
-export function getModelByName(model: string) {
-	const aiSettings = settingsStore.getState().ai;
-
-	return aiSettings.providers
-		.flatMap((provider) => provider.models)
-		.find((m) => m.name === model);
+function providers(): AIProvider[] {
+	return settingsStore.getState().ai.providers;
 }
 
-export function getModelMaxTokens(model: string) {
-	const aiSettings = settingsStore.getState().ai;
+/** Legacy resolution: the FIRST provider (in settings order) listing the name. */
+function findByBareName(
+	providers: AIProvider[],
+	name: string,
+): ResolvedModel | undefined {
+	for (const provider of providers) {
+		const model = provider.models.find((m) => m.name === name);
+		if (model) return { provider, model };
+	}
+	return undefined;
+}
 
-	const modelData = aiSettings.providers
-		.flatMap((provider) => provider.models)
-		.find((m) => m.name === model);
+/**
+ * Qualified `providerId/name` forms of every provider serving `name`, for
+ * warnings and error hints. A qualified form can itself be SHADOWED — some
+ * other provider serving a literal model whose id is that whole string
+ * (OpenRouter's `openai/gpt-4o`) — in which case the string form wouldn't
+ * reach the intended provider, so the hint appends the object-form escape.
+ */
+function qualifiedNamesFor(modelName: string): string[] {
+	const all = providers();
+	return all
+		.filter((p) => p.models.some((m) => m.name === modelName))
+		.map((p) => {
+			const qualified = `${p.id ?? p.name}/${modelName}`;
+			const shadowed = all.some((other) =>
+				other.models.some((m) => m.name === qualified),
+			);
+			return shadowed
+				? `{ name: "${modelName}", provider: "${p.id ?? p.name}" } (the string "${qualified}" is itself a model id on another provider)`
+				: qualified;
+		});
+}
 
-	if (modelData) {
-		return modelData.maxTokens;
+// One warning per subject per session — a script calling ai.prompt in a loop,
+// or a settings modal re-rendering with a dangling ref, must not stack a
+// Notice per iteration.
+const warnedResolutions = new Set<string>();
+
+function warnOnce(key: string, message: string): void {
+	if (warnedResolutions.has(key)) return;
+	warnedResolutions.add(key);
+	log.logWarning(message);
+}
+
+/** Test seam: clears the warn-once memory between test cases. */
+export function resetModelResolutionWarnings(): void {
+	warnedResolutions.clear();
+}
+
+/**
+ * Resolve a model reference to the model AND the provider that serves it.
+ *
+ * Object refs (pinned commands, script object form) resolve by stable provider
+ * id. A dangling ref — its provider deleted, or the model removed from it —
+ * falls back to legacy bare-name first-match, LOUDLY when that lands on a
+ * different provider: rerouting to another endpoint and API key must never be
+ * silent.
+ *
+ * Strings resolve bare-name-first: existing configs and scripts, including
+ * models whose literal names contain slashes (OpenRouter's "openai/gpt-4o"),
+ * keep resolving byte-identically to the pre-#1495 rule. Only when no model
+ * matches the whole string is it read as qualified `provider/model`, split at
+ * the FIRST slash; the prefix matches a provider id or display name
+ * (case-insensitively). Provider ids never contain "/", so the split is
+ * unambiguous. Scripts that need to override a literal slash-named model use
+ * the object form `{ provider, name }`.
+ */
+export function resolveModel(
+	input: ModelInput,
+	options?: {
+		/**
+		 * Suppress resolution warnings. For settings-UI/metadata callers
+		 * (dropdown preselection, slider bounds): a modal render must never
+		 * consume the warn-once budget that belongs to an actual run.
+		 */
+		silent?: boolean;
+	},
+): ResolvedModel | undefined {
+	const all = providers();
+	const silent = options?.silent === true;
+
+	if (typeof input !== "string") {
+		const provider = all.find((p) => p.id === input.providerId);
+		const model = provider?.models.find((m) => m.name === input.name);
+		if (provider && model) return { provider, model };
+
+		const fallback = findByBareName(all, input.name);
+		if (fallback) {
+			if (!silent) {
+				// The fallback target is part of the key: if the fallback later
+				// lands on a DIFFERENT provider, that is a new reroute and warns
+				// again.
+				warnOnce(
+					`pin:${input.providerId}/${input.name}→${fallback.provider.id ?? fallback.provider.name}`,
+					`Model "${input.name}" is pinned to provider "${input.providerId}", which no longer serves it. ` +
+						`Using "${fallback.provider.name}" instead — re-select the model in the command's settings to pin it again.`,
+				);
+			}
+			return fallback;
+		}
+		return undefined;
 	}
 
-	throw new Error(`Model ${model} not found with any provider.`);
+	const bare = findByBareName(all, input);
+	if (bare) {
+		const candidates = qualifiedNamesFor(input);
+		if (candidates.length > 1 && !silent) {
+			warnOnce(
+				`ambiguous:${input}→${bare.provider.id ?? bare.provider.name}`,
+				`Model "${input}" is served by ${candidates.length} providers; using "${bare.provider.name}". ` +
+					`Qualify it to choose explicitly: ${candidates.join(", ")}.`,
+			);
+		}
+		return bare;
+	}
+
+	const slash = input.indexOf("/");
+	if (slash <= 0 || slash === input.length - 1) return undefined;
+
+	return resolveModelScoped(input.slice(0, slash), input.slice(slash + 1));
 }
 
-export function getModelProvider(modelName: string) {
-	const aiSettings = settingsStore.getState().ai;
+/**
+ * Resolve a model within one provider, addressed by stable id or display name
+ * (case-insensitively). The precise form: unlike bare strings it can never be
+ * shadowed by a literal slash-named model on another provider.
+ */
+export function resolveModelScoped(
+	providerKey: string,
+	modelName: string,
+): ResolvedModel | undefined {
+	const all = providers();
+	const key = providerKey.trim().toLowerCase();
 
-	return aiSettings.providers.find((provider) =>
-		provider.models.some((m) => m.name === modelName)
+	const provider =
+		all.find((p) => p.id?.toLowerCase() === key) ??
+		all.find((p) => p.name.trim().toLowerCase() === key);
+	const model = provider?.models.find((m) => m.name === modelName);
+	if (provider && model) return { provider, model };
+
+	return undefined;
+}
+
+
+/**
+ * Model parameter accepted by the script API (ai.prompt / ai.agent /
+ * ai.getMaxTokens): a bare name, a qualified "providerId/modelName" string, or
+ * an object form whose optional `provider` (stable id or display name) scopes
+ * the lookup exactly — the escape hatch when a literal slash-named model on
+ * one provider shadows the qualified string form.
+ */
+export type ScriptModelInput = string | { name: string; provider?: string };
+
+/** resolveModel for script inputs, throwing actionable errors instead of returning undefined. */
+export function resolveModelInputOrThrow(
+	input: ScriptModelInput,
+): ResolvedModel {
+	const name = typeof input === "string" ? input : input?.name;
+	if (!name) {
+		throw new Error(
+			`Invalid model parameter. Expected a string (e.g., "gpt-4o" or "openai/gpt-4o") or an object with a name property (e.g., {name: "gpt-4o", provider: "openai"})`,
+		);
+	}
+
+	const resolved =
+		typeof input !== "string" && input.provider
+			? resolveModelScoped(input.provider, name)
+			: resolveModel(name);
+
+	if (!resolved) {
+		// When the model exists but the addressed provider doesn't serve it,
+		// point at the forms that WOULD resolve.
+		const bareName = name.includes("/")
+			? name.slice(name.indexOf("/") + 1)
+			: name;
+		const candidates = [
+			...qualifiedNamesFor(name),
+			...(bareName !== name ? qualifiedNamesFor(bareName) : []),
+		];
+		const hint = candidates.length
+			? ` Did you mean ${candidates.join(" or ")}?`
+			: " Add it in Settings → QuickAdd → AI → Providers, or enable auto-sync for your provider.";
+		throw new Error(
+			`Model '${typeof input === "string" ? input : `${input.provider ?? ""}/${name}`}' not found in configured providers.${hint}`,
+		);
+	}
+
+	return resolved;
+}
+
+export function getModelMaxTokens(model: ModelInput) {
+	const resolved = resolveModel(model);
+
+	if (resolved) {
+		return resolved.model.maxTokens;
+	}
+
+	throw new Error(
+		`Model ${typeof model === "string" ? model : model.name} not found with any provider.`,
 	);
 }
 
@@ -70,11 +262,13 @@ export function getLargestModelMaxTokens(): number {
  * real limit.
  */
 export function getMaxChunkTokensUpperBound(
-	modelName: string,
+	model: ModelInput,
 	systemPromptTokens: number,
 ): number {
-	const model = getModelByName(modelName);
-	const maxTokens = model?.maxTokens ?? getLargestModelMaxTokens();
+	// Silent: this feeds a settings-modal slider bound; rendering a modal must
+	// not consume the warn-once budget that belongs to an actual run.
+	const resolved = resolveModel(model, { silent: true });
+	const maxTokens = resolved?.model.maxTokens ?? getLargestModelMaxTokens();
 
 	return Math.max(1, estimateModelInputBudget(maxTokens) - systemPromptTokens);
 }

--- a/src/ai/modelRefPinning.ts
+++ b/src/ai/modelRefPinning.ts
@@ -1,0 +1,55 @@
+import type IChoice from "src/types/choices/IChoice";
+import { CommandType } from "src/types/macros/CommandType";
+import type { ICommand } from "src/types/macros/ICommand";
+import { walkAllCommandsInSettings } from "src/migrations/helpers/choice-traversal";
+import type { AIProvider, ModelRef } from "./Provider";
+
+type AICommandish = ICommand & {
+	model?: string;
+	modelRef?: ModelRef;
+};
+
+function isAICommand(command: ICommand): command is AICommandish {
+	return (
+		command.type === CommandType.AIAssistant ||
+		command.type === CommandType.InfiniteAIAssistant
+	);
+}
+
+/**
+ * Pin every AI command in `choices` whose bare model name is not yet (validly)
+ * pinned to the provider the pre-#1495 first-match rule resolves it to TODAY —
+ * behavior-preserving by construction. Used by the one-time pinAiModelRefs
+ * migration AND by package import, which can introduce bare-name commands
+ * long after the migration ran. A ref that no longer matches the legacy
+ * string is stale and gets re-pinned from the string. "Ask me" and names no
+ * configured provider serves are left unpinned. Returns how many commands
+ * were pinned; mutates in place.
+ */
+export function pinAiCommandModelRefs(
+	choices: IChoice[],
+	providers: AIProvider[],
+	onPin?: (command: AICommandish, ref: ModelRef) => void,
+): number {
+	let pinned = 0;
+
+	walkAllCommandsInSettings({ choices }, (command) => {
+		if (!isAICommand(command)) return;
+		if (command.modelRef && command.modelRef.name === command.model) return;
+		if (!command.model || command.model === "Ask me") return;
+
+		// The pre-#1495 rule, verbatim: FIRST provider (in settings order)
+		// listing the name.
+		const provider = providers.find((p) =>
+			p.models.some((m) => m.name === command.model),
+		);
+		if (!provider?.id) return;
+
+		const ref: ModelRef = { providerId: provider.id, name: command.model };
+		command.modelRef = ref;
+		pinned++;
+		onPin?.(command, ref);
+	});
+
+	return pinned;
+}

--- a/src/ai/modelRefPinning.ts
+++ b/src/ai/modelRefPinning.ts
@@ -35,7 +35,20 @@ export function pinAiCommandModelRefs(
 
 	walkAllCommandsInSettings({ choices }, (command) => {
 		if (!isAICommand(command)) return;
-		if (command.modelRef && command.modelRef.name === command.model) return;
+		// Preserve an existing ref only when it is VALID here: it matches the
+		// legacy string AND its provider exists in THIS provider set and serves
+		// the model. An imported ref from another vault (or one whose provider
+		// was deleted) is dangling — left alone it would warn on every run and
+		// still reroute by first-match, so it adopts this vault's current
+		// first-match pin like any bare name.
+		if (command.modelRef && command.modelRef.name === command.model) {
+			const pinnedProvider = providers.find(
+				(p) => p.id === command.modelRef?.providerId,
+			);
+			if (pinnedProvider?.models.some((m) => m.name === command.model)) {
+				return;
+			}
+		}
 		if (!command.model || command.model === "Ask me") return;
 
 		// The pre-#1495 rule, verbatim: FIRST provider (in settings order)

--- a/src/ai/providerPresets.ts
+++ b/src/ai/providerPresets.ts
@@ -2,6 +2,12 @@ import type { ModelDiscoveryMode, ProviderKind } from "./Provider";
 import type { CURRENT_MODEL_SEEDS } from "./Provider";
 
 export interface ProviderPreset {
+  /**
+   * Canonical stable provider id assigned when this preset is added (see
+   * AIProvider["id"]). Must equal slugifyProviderId(name) so a pre-2.19
+   * provider id-backfilled by migration matches a freshly added preset.
+   */
+  id: string;
   name: string;
   endpoint: string;
   doc?: string;
@@ -21,6 +27,7 @@ export interface ProviderPreset {
 
 export const PROVIDER_PRESETS: ProviderPreset[] = [
   {
+    id: "openai",
     name: "OpenAI",
     endpoint: "https://api.openai.com/v1",
     doc: "https://platform.openai.com/docs/models",
@@ -29,6 +36,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     seedKey: "openai",
   },
   {
+    id: "gemini",
     name: "Gemini",
     endpoint: "https://generativelanguage.googleapis.com",
     doc: "https://ai.google.dev/gemini-api/docs",
@@ -37,6 +45,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     seedKey: "google",
   },
   {
+    id: "anthropic",
     name: "Anthropic",
     endpoint: "https://api.anthropic.com",
     doc: "https://docs.anthropic.com/",
@@ -45,6 +54,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     seedKey: "anthropic",
   },
   {
+    id: "groq",
     name: "Groq",
     endpoint: "https://api.groq.com/openai/v1",
     doc: "https://console.groq.com/docs/models",
@@ -52,6 +62,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     modelSource: "auto",
   },
   {
+    id: "togetherai",
     name: "TogetherAI",
     endpoint: "https://api.together.xyz/v1",
     doc: "https://docs.together.ai/docs/serverless-models",
@@ -59,6 +70,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     modelSource: "auto",
   },
   {
+    id: "openrouter",
     name: "OpenRouter",
     endpoint: "https://openrouter.ai/api/v1",
     doc: "https://openrouter.ai/models",
@@ -66,6 +78,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     modelSource: "auto",
   },
   {
+    id: "hugging-face",
     name: "Hugging Face",
     endpoint: "https://router.huggingface.co/v1",
     doc: "https://huggingface.co/docs/inference-providers",
@@ -73,6 +86,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     modelSource: "auto",
   },
   {
+    id: "mistral",
     name: "Mistral",
     endpoint: "https://api.mistral.ai/v1",
     doc: "https://docs.mistral.ai/getting-started/models/",
@@ -80,6 +94,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     modelSource: "auto",
   },
   {
+    id: "deepseek",
     name: "DeepSeek",
     endpoint: "https://api.deepseek.com",
     doc: "https://platform.deepseek.com/api-docs/",

--- a/src/ai/tools/Agent.audit-ai-tools.test.ts
+++ b/src/ai/tools/Agent.audit-ai-tools.test.ts
@@ -22,8 +22,13 @@ vi.mock("../../formatters/completeFormatter", () => ({
 }));
 
 vi.mock("../aiHelpers", () => ({
-	getModelByName: (name: string) => ({ name, maxTokens: 128000 }),
-	getModelProvider: () => ({ name: "OpenAI", kind: "openai", endpoint: "https://x" }),
+	resolveModelInputOrThrow: (input: string | { name: string }) => ({
+		model: {
+			name: typeof input === "string" ? input : input.name,
+			maxTokens: 128000,
+		},
+		provider: { name: "OpenAI", kind: "openai", endpoint: "https://x" },
+	}),
 }));
 
 vi.mock("../providerSecrets", () => ({ resolveProviderApiKey: async () => "key" }));

--- a/src/ai/tools/Agent.audit-cleanup.test.ts
+++ b/src/ai/tools/Agent.audit-cleanup.test.ts
@@ -26,8 +26,13 @@ vi.mock("../../formatters/completeFormatter", () => ({
 }));
 
 vi.mock("../aiHelpers", () => ({
-	getModelByName: (name: string) => ({ name, maxTokens: 128000 }),
-	getModelProvider: () => ({ name: "OpenAI", kind: "openai", endpoint: "https://x" }),
+	resolveModelInputOrThrow: (input: string | { name: string }) => ({
+		model: {
+			name: typeof input === "string" ? input : input.name,
+			maxTokens: 128000,
+		},
+		provider: { name: "OpenAI", kind: "openai", endpoint: "https://x" },
+	}),
 }));
 
 vi.mock("../providerSecrets", () => ({ resolveProviderApiKey: async () => "key" }));

--- a/src/ai/tools/Agent.test.ts
+++ b/src/ai/tools/Agent.test.ts
@@ -22,8 +22,13 @@ vi.mock("../../formatters/completeFormatter", () => ({
 }));
 
 vi.mock("../aiHelpers", () => ({
-	getModelByName: (name: string) => ({ name, maxTokens: 128000 }),
-	getModelProvider: () => ({ name: "OpenAI", kind: "openai", endpoint: "https://x" }),
+	resolveModelInputOrThrow: (input: string | { name: string }) => ({
+		model: {
+			name: typeof input === "string" ? input : input.name,
+			maxTokens: 128000,
+		},
+		provider: { name: "OpenAI", kind: "openai", endpoint: "https://x" },
+	}),
 }));
 
 vi.mock("../providerSecrets", () => ({ resolveProviderApiKey: async () => "key" }));

--- a/src/ai/tools/Agent.ts
+++ b/src/ai/tools/Agent.ts
@@ -14,8 +14,8 @@ import { settingsStore } from "../../settingsStore";
 import { CompleteFormatter } from "../../formatters/completeFormatter";
 import { makeNoticeHandler } from "../makeNoticeHandler";
 import { MacroAbortError } from "../../errors/MacroAbortError";
-import { getModelByName, getModelProvider } from "../aiHelpers";
-import type { Model } from "../Provider";
+import { resolveModelInputOrThrow } from "../aiHelpers";
+import type { AIProvider, Model } from "../Provider";
 import { resolveProviderApiKey } from "../providerSecrets";
 import { classifyProviderError } from "../providerErrors";
 import { preventCursorChange } from "../preventCursorChange";
@@ -151,21 +151,9 @@ export class Agent {
 			);
 		}
 
-		const modelName =
-			typeof this.config.model === "string"
-				? this.config.model
-				: this.config.model?.name;
-		if (!modelName) throw new Error("ai.agent requires a model name.");
-		const model = getModelByName(modelName);
-		if (!model) {
-			throw new Error(
-				`Model '${modelName}' not found in configured providers. Add it in Settings → QuickAdd → AI → Providers.`,
-			);
-		}
-		const modelProvider = getModelProvider(model.name);
-		if (!modelProvider) {
-			throw new Error(`No provider configured for model '${model.name}'.`);
-		}
+		const { model, provider: modelProvider } = resolveModelInputOrThrow(
+			this.config.model,
+		);
 		const apiKey = await resolveProviderApiKey(this.app, modelProvider);
 
 		// Build the seed request: [system?, user(formatted prompt)].
@@ -209,6 +197,7 @@ export class Agent {
 						this.app,
 						apiKey,
 						model,
+						modelProvider,
 						turnReq,
 						restoreCursor,
 					);
@@ -232,6 +221,7 @@ export class Agent {
 					loop,
 					request,
 					model,
+					modelProvider,
 					apiKey,
 					options.schema,
 					restoreCursor,
@@ -430,6 +420,7 @@ export class Agent {
 		loop: RunToolLoopResult,
 		request: NormalizedChatRequest,
 		model: Model,
+		modelProvider: AIProvider,
 		apiKey: string,
 		schema: JSONSchema,
 		restoreCursor: () => void,
@@ -473,6 +464,7 @@ export class Agent {
 				this.app,
 				apiKey,
 				model,
+				modelProvider,
 				repairReq,
 				restoreCursor,
 			);

--- a/src/ai/tools/aiToolTypes.ts
+++ b/src/ai/tools/aiToolTypes.ts
@@ -101,7 +101,12 @@ export interface GenerateResult {
 
 /** Config for `ai.agent(config)`. */
 export interface AgentConfig {
-	model: string | { name: string };
+	/**
+	 * Bare model name, qualified "providerId/modelName" string, or an object
+	 * whose optional `provider` (stable id or display name) scopes the lookup
+	 * to one provider exactly.
+	 */
+	model: string | { name: string; provider?: string };
 	system?: string;
 	tools?: ToolSet;
 	toolChoice?: ToolChoice;

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -37,12 +37,9 @@ import { runAIAssistant } from "src/ai/AIAssistant";
 import { resolveProviderApiKey } from "src/ai/providerSecrets";
 import { settingsStore } from "src/settingsStore";
 import { CompleteFormatter } from "src/formatters/completeFormatter";
-import {
-	getModelByName,
-	getModelNames,
-	getModelProvider,
-} from "src/ai/aiHelpers";
-import type { Model } from "src/ai/Provider";
+import type { ResolvedModel } from "src/ai/aiHelpers";
+import { resolveModel } from "src/ai/aiHelpers";
+import { activeModelRef } from "src/ai/Provider";
 import type { IOpenFileCommand } from "../types/macros/QuickCommands/IOpenFileCommand";
 import { openFile } from "../utilityObsidian";
 import { TFile } from "obsidian";
@@ -631,55 +628,31 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 
 		const aiSettings = settingsStore.getState().ai;
 
-		const options = getModelNames();
-		let modelName: string;
+		let resolved: ResolvedModel | undefined;
 		if (command.model === "Ask me") {
-			// Route to a remote interactive session (Raycast) when one is driving.
-			const provider = this.choiceExecutor.promptProvider;
-			if (provider) {
-				modelName = String(
-					await provider.suggester(options, options, "Select a model"),
-				);
-			} else if (this.choiceExecutor.interactive === false) {
-				// Non-interactive run (CLI without `ui`): the "Ask me" model picker has
-				// no one to answer it. Abort with an actionable error instead of hanging.
-				throw new ChoiceAbortError(
-					"This AI command is set to \"Ask me\" for the model, but this run is non-interactive. " +
-						"Pick a specific model in the command, or re-run with the ui flag.",
-				);
-			} else {
-				try {
-					modelName = await GenericSuggester.Suggest(this.app, options, options);
-				} catch (error) {
-					if (isCancellationError(error)) {
-						throw new UserCancelError("Input cancelled by user");
-					}
-					throw error;
-				}
-			}
+			resolved = await this.pickModelInteractively();
 		} else {
-			modelName = command.model;
+			// Prefer the pinned provider-scoped ref — but only while it matches
+			// the legacy string (a stale ref from a downgrade edit must not
+			// override the visible selection). Bare names resolve first-match,
+			// as they always have.
+			resolved = resolveModel(
+				activeModelRef(command.model, command.modelRef) ?? command.model,
+			);
+			if (!resolved) {
+				throw new Error(
+					`Model ${command.model} not found with any provider.`,
+				);
+			}
 		}
 
-		const model: Model | undefined = getModelByName(modelName);
-
-		if (!model) {
-			throw new Error(`Model ${modelName} not found with any provider.`);
-		}
+		const { model, provider: modelProvider } = resolved;
 
 		const formatter = new CompleteFormatter(
 			this.app,
 			getQuickAddInstance(),
 			this.choiceExecutor
 		);
-
-		const modelProvider = getModelProvider(model.name);
-
-		if (!modelProvider) {
-			throw new Error(
-				`Model ${model.name} not found in the AI providers settings.`
-			);
-		}
 
 		const apiKey = await resolveProviderApiKey(this.app, modelProvider);
 
@@ -688,6 +661,7 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 			{
 				apiKey,
 				model,
+				provider: modelProvider,
 				outputVariableName: command.outputVariableName,
 				promptTemplate: command.promptTemplate,
 				promptTemplateFolder: aiSettings.promptTemplatesFolderPath,
@@ -704,6 +678,69 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 
 		for (const key in aiOutputVariables) {
 				this.choiceExecutor.variables.set(key, aiOutputVariables[key]);
+		}
+	}
+
+	/**
+	 * The "Ask me" model picker. Entries are provider-scoped so two providers
+	 * serving the same model name are distinguishable — picking from a flat
+	 * name list would silently first-match, defeating the point of asking.
+	 */
+	private async pickModelInteractively(): Promise<ResolvedModel> {
+		const providers = settingsStore.getState().ai.providers;
+		const entries: { label: string; qualified: string; resolved: ResolvedModel }[] =
+			providers.flatMap((provider) =>
+				provider.models.map((model) => ({
+					label: `${model.name} (${provider.name})`,
+					qualified: `${provider.id ?? provider.name}/${model.name}`,
+					resolved: { provider, model },
+				})),
+			);
+
+		if (entries.length === 0) {
+			throw new Error(
+				"No AI models are configured. Add a provider with models in the AI Assistant settings.",
+			);
+		}
+
+		// Route to a remote interactive session (Raycast) when one is driving.
+		const promptProvider = this.choiceExecutor.promptProvider;
+		if (promptProvider) {
+			const picked = String(
+				await promptProvider.suggester(
+					entries.map((entry) => entry.label),
+					entries.map((entry) => entry.qualified),
+					"Select a model",
+				),
+			);
+			const entry = entries.find((e) => e.qualified === picked);
+			if (!entry) {
+				throw new Error(`Model ${picked} not found with any provider.`);
+			}
+			return entry.resolved;
+		}
+
+		if (this.choiceExecutor.interactive === false) {
+			// Non-interactive run (CLI without `ui`): the "Ask me" model picker has
+			// no one to answer it. Abort with an actionable error instead of hanging.
+			throw new ChoiceAbortError(
+				"This AI command is set to \"Ask me\" for the model, but this run is non-interactive. " +
+					"Pick a specific model in the command, or re-run with the ui flag.",
+			);
+		}
+
+		try {
+			return await GenericSuggester.Suggest(
+				this.app,
+				entries.map((entry) => entry.label),
+				entries.map((entry) => entry.resolved),
+				"Select a model",
+			);
+		} catch (error) {
+			if (isCancellationError(error)) {
+				throw new UserCancelError("Input cancelled by user");
+			}
+			throw error;
 		}
 	}
 

--- a/src/gui/AIAssistantProvidersModal.ts
+++ b/src/gui/AIAssistantProvidersModal.ts
@@ -2,6 +2,7 @@
 import type { App } from "obsidian";
 import { ButtonComponent, Modal, Notice, SecretComponent, Setting } from "obsidian";
 import type { AIProvider } from "src/ai/Provider";
+import { ensureProviderIds } from "src/ai/Provider";
 import { mergeModels } from "src/ai/modelsDirectory";
 import { syncProviderModels } from "src/ai/modelSyncService";
 import { settingsStore } from "src/settingsStore";
@@ -27,6 +28,9 @@ export class AIAssistantProvidersModal extends Modal {
 		super(app);
 
 		this.providers = providers;
+		// Providers from hand-edited data.json may lack the stable id that
+		// pinned model refs and the qualified script syntax rely on.
+		ensureProviderIds(this.providers);
 
 		this.waitForClose = new Promise<AIProvider[]>((resolve, reject) => {
 			this.rejectPromise = reject;
@@ -149,9 +153,14 @@ export class AIAssistantProvidersModal extends Modal {
 	}
 
 	addNameSetting(container: HTMLElement) {
+		const providerId = this.selectedProvider!.id;
 		new Setting(container)
 			.setName("Name")
-			.setDesc("The name of the provider")
+			.setDesc(
+				providerId
+					? `The display name of the provider. Its stable ID is "${providerId}" — use that to qualify models in scripts, e.g. ai.prompt with "${providerId}/model-name".`
+					: "The display name of the provider",
+			)
 			.addText((text) => {
 				text.setValue(this.selectedProvider!.name).onChange((value) => {
 					this.selectedProvider!.name = value;

--- a/src/gui/AIAssistantSettingsModal.ts
+++ b/src/gui/AIAssistantSettingsModal.ts
@@ -5,7 +5,7 @@ import { FormatSyntaxSuggester } from "./suggesters/formatSyntaxSuggester";
 import { getQuickAddInstance } from "src/quickAddInstance";
 import { FormatDisplayFormatter } from "src/formatters/formatDisplayFormatter";
 import { AIAssistantProvidersModal } from "./AIAssistantProvidersModal";
-import { getModelNames } from "src/ai/aiHelpers";
+import { populateModelDropdown } from "./modelSelect";
 import { GenericTextSuggester } from "./suggesters/genericTextSuggester";
 import { getAllFolderPathsInVault } from "src/utilityObsidian";
 
@@ -80,27 +80,17 @@ export class AIAssistantSettingsModal extends Modal {
 			.setName("Default Model")
 			.setDesc("The default model for the AI Assistant")
 			.addDropdown((dropdown) => {
-				const models = getModelNames();
-				for (const model of models) {
-					dropdown.addOption(model, model);
-				}
-
-				dropdown.addOption("Ask me", "Ask me");
-
-				// If the pinned model was deleted, the option no longer exists and
-				// setValue would silently fall back to the first option while the
-				// stored (now invalid) name persists. Surface the mismatch with a
-				// disabled "(missing)" entry so the dropdown reflects the saved value.
-				const stored = this.settings.defaultModel;
-				const isKnown = stored === "Ask me" || models.includes(stored);
-				if (stored && !isKnown) {
-					dropdown.addOption(stored, `(missing) ${stored}`);
-				}
-
-				dropdown.setValue(stored);
-				dropdown.onChange((value) => {
-					this.settings.defaultModel = value;
-				});
+				populateModelDropdown(
+					dropdown,
+					{
+						model: this.settings.defaultModel,
+						modelRef: this.settings.defaultModelRef,
+					},
+					(selection) => {
+						this.settings.defaultModel = selection.model;
+						this.settings.defaultModelRef = selection.modelRef;
+					},
+				);
 			});
 	}
 

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-cleanup.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-cleanup.test.ts
@@ -6,16 +6,26 @@ vi.mock("obsidian-dataview", () => ({
 vi.mock("src/settingsStore", () => ({
 	settingsStore: {
 		getState: () => ({
-			ai: { promptTemplatesFolderPath: "", showAssistant: false },
+			ai: {
+				promptTemplatesFolderPath: "",
+				showAssistant: false,
+				providers: [
+					{
+						id: "test",
+						name: "TestProvider",
+						endpoint: "https://example.test/v1",
+						apiKey: "",
+						models: [{ name: "gpt-test", maxTokens: 1000 }],
+						modelSource: "providerApi",
+					},
+				],
+			},
 			disableOnlineFeatures: false,
 		}),
 	},
 }));
 vi.mock("src/quickAddInstance", () => ({
 	getQuickAddInstance: vi.fn(() => ({})),
-}));
-vi.mock("src/ai/aiHelpers", () => ({
-	getModelNames: vi.fn(() => ["gpt-test"]),
 }));
 vi.mock("src/utilityObsidian", () => ({
 	getMarkdownFilesInFolder: vi.fn(() => []),
@@ -95,14 +105,15 @@ describe("AIAssistantCommandSettingsModal Model dropdown missing-model handling"
 		const modal = new AIAssistantCommandSettingsModal(testApp(), command);
 
 		const select = getModelSelect(modal);
-		const missing = Array.from(select.options).find(
-			(opt) => opt.value === "deleted-model"
+		const missing = Array.from(select.options).find((opt) =>
+			opt.textContent?.startsWith("(missing)")
 		);
 
 		expect(missing).toBeDefined();
 		expect(missing?.textContent).toBe("(missing) deleted-model");
+		expect(missing?.disabled).toBe(true);
 		// The dropdown reflects the stored value instead of silently defaulting.
-		expect(select.value).toBe("deleted-model");
+		expect(select.value).toBe(missing?.value);
 
 		modal.close();
 	});
@@ -115,7 +126,7 @@ describe("AIAssistantCommandSettingsModal Model dropdown missing-model handling"
 		const labels = Array.from(select.options).map((opt) => opt.textContent);
 
 		expect(labels).not.toContain("(missing) gpt-test");
-		expect(select.value).toBe("gpt-test");
+		expect(select.selectedOptions[0]?.textContent).toBe("gpt-test");
 
 		modal.close();
 	});

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-macro.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.audit-macro.test.ts
@@ -6,16 +6,26 @@ vi.mock("obsidian-dataview", () => ({
 vi.mock("src/settingsStore", () => ({
 	settingsStore: {
 		getState: () => ({
-			ai: { promptTemplatesFolderPath: "", showAssistant: false },
+			ai: {
+				promptTemplatesFolderPath: "",
+				showAssistant: false,
+				providers: [
+					{
+						id: "test",
+						name: "TestProvider",
+						endpoint: "https://example.test/v1",
+						apiKey: "",
+						models: [{ name: "gpt-test", maxTokens: 1000 }],
+						modelSource: "providerApi",
+					},
+				],
+			},
 			disableOnlineFeatures: false,
 		}),
 	},
 }));
 vi.mock("src/quickAddInstance", () => ({
 	getQuickAddInstance: vi.fn(() => ({})),
-}));
-vi.mock("src/ai/aiHelpers", () => ({
-	getModelNames: vi.fn(() => ["gpt-test"]),
 }));
 vi.mock("src/utilityObsidian", () => ({
 	getMarkdownFilesInFolder: vi.fn(() => []),

--- a/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantCommandSettingsModal.ts
@@ -9,8 +9,9 @@ import { getMarkdownFilesInFolder } from "src/utilityObsidian";
 import { settingsStore } from "src/settingsStore";
 import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
 import { estimateTokenCount } from "src/ai/tokenEstimator";
-import { getModelNames } from "src/ai/aiHelpers";
 import { addSamplingParamSettings } from "./samplingParamSettings";
+import { populateModelDropdown } from "../modelSelect";
+import { activeModelRef } from "src/ai/Provider";
 
 export class AIAssistantCommandSettingsModal extends Modal {
 	public waitForClose: Promise<IAIAssistantCommand | null>;
@@ -118,7 +119,8 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			addSamplingParamSettings(
 				this.contentEl,
 				this.settings.modelParameters,
-				this.settings.model,
+				activeModelRef(this.settings.model, this.settings.modelRef) ??
+					this.settings.model,
 				() => this.reload()
 			);
 		}
@@ -196,32 +198,9 @@ export class AIAssistantCommandSettingsModal extends Modal {
 			.setName("Model")
 			.setDesc("The model the AI Assistant will use")
 			.addDropdown((dropdown) => {
-				const models = getModelNames();
-				for (const model of models) {
-					dropdown.addOption(model, model);
-				}
-
-				dropdown.addOption("Ask me", "Ask me");
-
-				// If the pinned model was deleted, the option no longer exists and
-				// setValue would silently fall back to the first option while the
-				// stored (now invalid) name persists. Surface the mismatch with a
-				// disabled "(missing)" entry so the dropdown reflects the saved value.
-				const stored = this.settings.model;
-				const isKnown = stored === "Ask me" || models.includes(stored);
-				if (stored && !isKnown) {
-					dropdown.addOption(stored, `(missing) ${stored}`);
-					// Disable it so the stale value is shown but can't be re-selected
-					// and re-saved as a valid choice.
-					const missingOption = Array.from(
-						dropdown.selectEl.options,
-					).find((option) => option.value === stored);
-					if (missingOption) missingOption.disabled = true;
-				}
-
-				dropdown.setValue(stored);
-				dropdown.onChange((value) => {
-					this.settings.model = value;
+				populateModelDropdown(dropdown, this.settings, (selection) => {
+					this.settings.model = selection.model;
+					this.settings.modelRef = selection.modelRef;
 
 					this.reload();
 				});

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.test.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.test.ts
@@ -113,8 +113,8 @@ describe("InfiniteAIAssistantCommandSettingsModal max-chunk-tokens", () => {
 		const select = modal.contentEl.querySelector<HTMLSelectElement>("select");
 		expect(select).not.toBeNull();
 
-		const missing = Array.from(select!.options).find(
-			(option) => option.value === "removed-model-9000",
+		const missing = Array.from(select!.options).find((option) =>
+			option.textContent?.startsWith("(missing)"),
 		);
 		expect(missing).toBeDefined();
 		expect(missing!.textContent).toBe("(missing) removed-model-9000");

--- a/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
+++ b/src/gui/MacroGUIs/AIAssistantInfiniteCommandSettingsModal.ts
@@ -6,7 +6,9 @@ import { FormatDisplayFormatter } from "src/formatters/formatDisplayFormatter";
 import type { IInfiniteAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
 import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
 import { estimateTokenCount } from "src/ai/tokenEstimator";
-import { getMaxChunkTokensUpperBound, getModelNames } from "src/ai/aiHelpers";
+import { getMaxChunkTokensUpperBound } from "src/ai/aiHelpers";
+import { populateModelDropdown } from "../modelSelect";
+import { activeModelRef } from "src/ai/Provider";
 import { addSamplingParamSettings } from "./samplingParamSettings";
 
 export class InfiniteAIAssistantCommandSettingsModal extends Modal {
@@ -88,7 +90,8 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			addSamplingParamSettings(
 				this.contentEl,
 				this.settings.modelParameters,
-				this.settings.model,
+				activeModelRef(this.settings.model, this.settings.modelRef) ??
+					this.settings.model,
 				() => this.reload()
 			);
 		}
@@ -107,31 +110,9 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 			.setName("Model")
 			.setDesc("The model the AI Assistant will use")
 			.addDropdown((dropdown) => {
-				const models = getModelNames();
-				for (const model of models) {
-					dropdown.addOption(model, model);
-				}
-
-				dropdown.addOption("Ask me", "Ask me");
-
-				// If the pinned model was deleted, the option no longer exists and
-				// setValue would silently fall back to the first option while the
-				// stored (now invalid) name persists. Surface the mismatch with a
-				// disabled "(missing)" entry so the dropdown reflects the saved
-				// value (mirrors AIAssistantCommandSettingsModal).
-				const stored = this.settings.model;
-				const isKnown = stored === "Ask me" || models.includes(stored);
-				if (stored && !isKnown) {
-					dropdown.addOption(stored, `(missing) ${stored}`);
-					const missingOption = Array.from(
-						dropdown.selectEl.options,
-					).find((option) => option.value === stored);
-					if (missingOption) missingOption.disabled = true;
-				}
-
-				dropdown.setValue(stored);
-				dropdown.onChange((value) => {
-					this.settings.model = value;
+				populateModelDropdown(dropdown, this.settings, (selection) => {
+					this.settings.model = selection.model;
+					this.settings.modelRef = selection.modelRef;
 
 					this.reload();
 				});
@@ -259,7 +240,8 @@ export class InfiniteAIAssistantCommandSettingsModal extends Modal {
 				// sentinel (resolved at runtime) or a model that was removed. Use
 				// a fallback bound instead of throwing, which would blank the modal.
 				const sliderMax = getMaxChunkTokensUpperBound(
-					this.settings.model,
+					activeModelRef(this.settings.model, this.settings.modelRef) ??
+						this.settings.model,
 					this.systemPromptTokenLength,
 				);
 				slider.setLimits(1, sliderMax, 1);

--- a/src/gui/MacroGUIs/samplingParamSettings.ts
+++ b/src/gui/MacroGUIs/samplingParamSettings.ts
@@ -6,7 +6,7 @@ import {
 	DEFAULT_TOP_P,
 	type OpenAIModelParameters,
 } from "src/ai/OpenAIModelParameters";
-import { getModelByName } from "src/ai/aiHelpers";
+import { resolveModel, type ModelInput } from "src/ai/aiHelpers";
 import type { SamplingParamKey } from "src/ai/samplingParams";
 
 interface SamplingSliderSpec {
@@ -74,10 +74,10 @@ const SLIDER_SPECS: SamplingSliderSpec[] = [
 export function addSamplingParamSettings(
 	container: HTMLElement,
 	modelParameters: Partial<OpenAIModelParameters>,
-	selectedModelName: string,
+	selectedModel: ModelInput,
 	reload: () => void,
 ): void {
-	const model = getModelByName(selectedModelName);
+	const model = resolveModel(selectedModel, { silent: true })?.model;
 	if (model?.supportsTemperature === false) {
 		container.createEl("div", {
 			text: `${model.name} uses fixed sampling, so these settings are not sent to it.`,

--- a/src/gui/PackageManager/ImportPackageModal.svelte
+++ b/src/gui/PackageManager/ImportPackageModal.svelte
@@ -349,6 +349,7 @@
 			const result = await applyPackageImport({
 				app,
 				existingChoices: settingsStore.getState().choices,
+				aiProviders: settingsStore.getState().ai.providers,
 				pkg: loadedPackage.pkg,
 				choiceDecisions: snapshotChoiceDecisions(
 					analysis.choiceConflicts,

--- a/src/gui/ProviderPickerModal.ts
+++ b/src/gui/ProviderPickerModal.ts
@@ -1,7 +1,7 @@
 import type { App} from "obsidian";
 import { Modal, Notice, SecretComponent, Setting } from "obsidian";
 import type { AIProvider } from "src/ai/Provider";
-import { cloneModelSeeds } from "src/ai/Provider";
+import { cloneModelSeeds, uniqueProviderId } from "src/ai/Provider";
 import { syncProviderModels } from "src/ai/modelSyncService";
 import type { ProviderPreset } from "src/ai/providerPresets";
 import { PROVIDER_PRESETS } from "src/ai/providerPresets";
@@ -122,6 +122,7 @@ export class ProviderPickerModal extends Modal {
               const provider: AIProvider = {
                 name: preset.name,
                 endpoint: preset.endpoint,
+                id: uniqueProviderId(preset.id, this.providers),
                 kind: preset.kind,
                 apiKey: "",
                 apiKeyRef: selectedSecret,
@@ -154,7 +155,7 @@ export class ProviderPickerModal extends Modal {
       .setDesc("Create any custom endpoint (OpenAI-compatible or otherwise)")
       .addButton((b) => {
         b.setButtonText("Add custom...").onClick(() => {
-          const provider: AIProvider = { name: "Custom", endpoint: "", apiKey: "", apiKeyRef: "", models: [], modelSource: "providerApi" };
+          const provider: AIProvider = { id: uniqueProviderId("custom", this.providers), name: "Custom", endpoint: "", apiKey: "", apiKeyRef: "", models: [], modelSource: "providerApi" };
           this.providers.push(provider);
           new Notice("Custom provider added. Click Edit to configure.");
           this.close();

--- a/src/gui/modelSelect.test.ts
+++ b/src/gui/modelSelect.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DropdownComponent } from "obsidian";
+import type { AIProvider } from "src/ai/Provider";
+import { resetModelResolutionWarnings } from "src/ai/aiHelpers";
+import { DEFAULT_SETTINGS } from "src/settings";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+import { populateModelDropdown, type ModelSelection } from "./modelSelect";
+
+// A minimal stand-in for Obsidian's DropdownComponent over a real <select>,
+// enough for the builder: addOption/setValue/onChange plus direct selectEl use.
+function makeDropdown() {
+	const selectEl = document.createElement("select");
+	let changeHandler: ((value: string) => void) | undefined;
+
+	const dropdown = {
+		selectEl,
+		addOption(value: string, display: string) {
+			const option = document.createElement("option");
+			option.value = value;
+			option.text = display;
+			selectEl.appendChild(option);
+			return dropdown;
+		},
+		setValue(value: string) {
+			selectEl.value = value;
+			return dropdown;
+		},
+		onChange(handler: (value: string) => void) {
+			changeHandler = handler;
+			return dropdown;
+		},
+	};
+
+	return {
+		dropdown: dropdown as unknown as DropdownComponent,
+		selectEl,
+		select(value: string) {
+			selectEl.value = value;
+			changeHandler?.(value);
+		},
+	};
+}
+
+function provider(overrides: Partial<AIProvider>): AIProvider {
+	return {
+		name: "Provider",
+		endpoint: "https://example.test/v1",
+		apiKey: "",
+		models: [],
+		modelSource: "providerApi",
+		...overrides,
+	};
+}
+
+function setProviders(providers: AIProvider[]): void {
+	const current = settingsStore.getState();
+	settingsStore.setState({ ai: { ...current.ai, providers } });
+}
+
+const twoProvidersSameModel = () => [
+	provider({
+		id: "openai",
+		name: "OpenAI",
+		models: [{ name: "gpt-4o", maxTokens: 128_000 }],
+	}),
+	provider({
+		id: "proxy",
+		name: "Proxy",
+		models: [{ name: "gpt-4o", maxTokens: 64_000 }],
+	}),
+];
+
+beforeEach(() => {
+	settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+	resetModelResolutionWarnings();
+});
+
+describe("populateModelDropdown", () => {
+	it("groups options per provider so duplicate names are distinguishable", () => {
+		setProviders(twoProvidersSameModel());
+		const { dropdown, selectEl } = makeDropdown();
+
+		populateModelDropdown(dropdown, { model: "Ask me" }, vi.fn());
+
+		const groups = Array.from(selectEl.querySelectorAll("optgroup"));
+		expect(groups.map((g) => g.label)).toEqual(["OpenAI", "Proxy"]);
+		expect(
+			groups.map((g) => Array.from(g.children).map((o) => o.textContent)),
+		).toEqual([["gpt-4o"], ["gpt-4o"]]);
+		// "Ask me" stays a top-level option, first.
+		expect(selectEl.options[0].value).toBe("Ask me");
+	});
+
+	it("writes BOTH fields (name + provider-scoped ref) on selection", () => {
+		setProviders(twoProvidersSameModel());
+		const { dropdown, selectEl, select } = makeDropdown();
+		const onSelect = vi.fn<(selection: ModelSelection) => void>();
+
+		populateModelDropdown(dropdown, { model: "Ask me" }, onSelect);
+
+		const proxyOption = Array.from(selectEl.options).find((o) =>
+			o.value.startsWith("proxy/"),
+		);
+		select(proxyOption!.value);
+
+		expect(onSelect).toHaveBeenCalledWith({
+			model: "gpt-4o",
+			modelRef: { providerId: "proxy", name: "gpt-4o" },
+		});
+	});
+
+	it("clears the ref when 'Ask me' is selected", () => {
+		setProviders(twoProvidersSameModel());
+		const { dropdown, select } = makeDropdown();
+		const onSelect = vi.fn<(selection: ModelSelection) => void>();
+
+		populateModelDropdown(
+			dropdown,
+			{ model: "gpt-4o", modelRef: { providerId: "proxy", name: "gpt-4o" } },
+			onSelect,
+		);
+		select("Ask me");
+
+		expect(onSelect).toHaveBeenCalledWith({
+			model: "Ask me",
+			modelRef: undefined,
+		});
+	});
+
+	it("preselects the pinned provider's entry, not the first duplicate", () => {
+		setProviders(twoProvidersSameModel());
+		const { dropdown, selectEl } = makeDropdown();
+
+		populateModelDropdown(
+			dropdown,
+			{ model: "gpt-4o", modelRef: { providerId: "proxy", name: "gpt-4o" } },
+			vi.fn(),
+		);
+
+		expect(selectEl.value.startsWith("proxy/")).toBe(true);
+	});
+
+	it("preselects the first-match entry for a legacy bare name (mirrors runtime)", () => {
+		setProviders(twoProvidersSameModel());
+		const { dropdown, selectEl } = makeDropdown();
+
+		populateModelDropdown(dropdown, { model: "gpt-4o" }, vi.fn());
+
+		expect(selectEl.value.startsWith("openai/")).toBe(true);
+	});
+
+	it("ignores a STALE ref and preselects by the legacy string instead", () => {
+		setProviders(twoProvidersSameModel());
+		const { dropdown, selectEl } = makeDropdown();
+
+		populateModelDropdown(
+			dropdown,
+			// Ref name drifted from the string (downgrade edit): the string wins.
+			{ model: "gpt-4o", modelRef: { providerId: "proxy", name: "o3" } },
+			vi.fn(),
+		);
+
+		expect(selectEl.value.startsWith("openai/")).toBe(true);
+	});
+
+	it("shows a disabled (missing) entry for a stored model that no longer exists", () => {
+		setProviders(twoProvidersSameModel());
+		const { dropdown, selectEl, select } = makeDropdown();
+		const onSelect = vi.fn();
+
+		populateModelDropdown(
+			dropdown,
+			{
+				model: "claude-x",
+				modelRef: { providerId: "anthropic", name: "claude-x" },
+			},
+			onSelect,
+		);
+
+		const missing = Array.from(selectEl.options).find((o) =>
+			o.text.startsWith("(missing)"),
+		);
+		expect(missing?.text).toBe("(missing) anthropic/claude-x");
+		expect(missing?.disabled).toBe(true);
+		expect(selectEl.value).toBe(missing?.value);
+
+		// Selecting the placeholder must never fire a save.
+		select(missing!.value);
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+});

--- a/src/gui/modelSelect.ts
+++ b/src/gui/modelSelect.ts
@@ -1,0 +1,152 @@
+import type { DropdownComponent } from "obsidian";
+import { resolveModel } from "src/ai/aiHelpers";
+import type { ModelRef } from "src/ai/Provider";
+import { activeModelRef } from "src/ai/Provider";
+import { settingsStore } from "src/settingsStore";
+
+/**
+ * What a model dropdown reads and writes: the legacy name string (or the
+ * "Ask me" sentinel) plus the provider-scoped ref. Writers keep both in sync —
+ * `model === modelRef.name` whenever `modelRef` is set (see IAIAssistantCommand).
+ */
+export interface ModelSelection {
+	model: string;
+	modelRef?: ModelRef;
+}
+
+const ASK_ME = "Ask me";
+// Option value for the disabled placeholder that surfaces a stored-but-missing
+// model. Providers/models can't collide with it: option values for real models
+// are always "<qualified>:<index>" built below.
+const MISSING_VALUE = "__qa-missing-model__";
+
+/**
+ * Populate a model dropdown, grouped per provider so two providers serving the
+ * same model name (#1495) are distinguishable, and keep BOTH persisted fields
+ * (legacy name + provider-scoped ref) in sync on selection.
+ *
+ * - "Ask me" stays the first, top-level option.
+ * - A stored model that no longer exists is shown as a disabled "(missing)"
+ *   entry instead of silently snapping to the first option.
+ * - A legacy bare-name selection (no ref) preselects the entry the runtime's
+ *   first-match rule would use, so the dropdown shows what would actually run.
+ */
+export function populateModelDropdown(
+	dropdown: DropdownComponent,
+	current: ModelSelection,
+	onSelect: (selection: ModelSelection) => void,
+): void {
+	const providers = settingsStore.getState().ai.providers;
+	const selectEl = dropdown.selectEl;
+	const doc = selectEl.ownerDocument;
+
+	// A ref that no longer matches the legacy string is stale (older QuickAdd
+	// edited the command); the string is what the user last visibly chose.
+	current = {
+		model: current.model,
+		modelRef: activeModelRef(current.model, current.modelRef),
+	};
+
+	dropdown.addOption(ASK_ME, ASK_ME);
+
+	// Option values must be unique even when names repeat across providers and
+	// providers lack ids (hand-edited data.json), so key by entry index.
+	const entriesByValue = new Map<
+		string,
+		{ providerId?: string; modelName: string }
+	>();
+
+	let index = 0;
+	for (const provider of providers) {
+		if (provider.models.length === 0) continue;
+
+		const group = doc.createElement("optgroup");
+		group.label = provider.name;
+		selectEl.appendChild(group);
+
+		for (const model of provider.models) {
+			const value = `${provider.id ?? provider.name}/${model.name}:${index++}`;
+			entriesByValue.set(value, {
+				providerId: provider.id,
+				modelName: model.name,
+			});
+
+			const option = doc.createElement("option");
+			option.value = value;
+			option.text = model.name;
+			group.appendChild(option);
+		}
+	}
+
+	const selectedValue = findSelectedValue(current, entriesByValue);
+	if (selectedValue) {
+		dropdown.setValue(selectedValue);
+	} else {
+		// The stored model was deleted (or its provider was). Reflect the saved
+		// value with a disabled entry instead of silently showing the first
+		// option while a different value persists.
+		const label = current.modelRef
+			? `${current.modelRef.providerId}/${current.modelRef.name}`
+			: current.model;
+		dropdown.addOption(MISSING_VALUE, `(missing) ${label}`);
+		const missingOption = Array.from(selectEl.options).find(
+			(option) => option.value === MISSING_VALUE,
+		);
+		if (missingOption) missingOption.disabled = true;
+		dropdown.setValue(MISSING_VALUE);
+	}
+
+	dropdown.onChange((value) => {
+		if (value === MISSING_VALUE) return;
+		if (value === ASK_ME) {
+			onSelect({ model: ASK_ME, modelRef: undefined });
+			return;
+		}
+
+		const entry = entriesByValue.get(value);
+		if (!entry) return;
+
+		onSelect({
+			model: entry.modelName,
+			// A provider without an id (hand-edited data.json that hasn't passed
+			// through the id backfill yet) can't be pinned; the bare name keeps
+			// legacy first-match behavior.
+			modelRef: entry.providerId
+				? { providerId: entry.providerId, name: entry.modelName }
+				: undefined,
+		});
+	});
+}
+
+function findSelectedValue(
+	current: ModelSelection,
+	entriesByValue: Map<string, { providerId?: string; modelName: string }>,
+): string | undefined {
+	if (!current.model || current.model === ASK_ME) return ASK_ME;
+
+	if (current.modelRef) {
+		for (const [value, entry] of entriesByValue) {
+			if (
+				entry.providerId === current.modelRef.providerId &&
+				entry.modelName === current.modelRef.name
+			) {
+				return value;
+			}
+		}
+		return undefined;
+	}
+
+	// Legacy bare name: preselect the provider the runtime would first-match.
+	// Silent — rendering a dropdown must not consume the runtime warn-once budget.
+	const resolved = resolveModel(current.model, { silent: true });
+	if (!resolved) return undefined;
+	for (const [value, entry] of entriesByValue) {
+		if (
+			entry.providerId === resolved.provider.id &&
+			entry.modelName === resolved.model.name
+		) {
+			return value;
+		}
+	}
+	return undefined;
+}

--- a/src/migrations/migrate.ts
+++ b/src/migrations/migrate.ts
@@ -16,6 +16,7 @@ import { deepClone } from "src/utils/deepClone";
 import migrateProviderApiKeysToSecretStorage from "./migrateProviderApiKeysToSecretStorage";
 import migrateToMultipleTemplateFolders from "./migrateToMultipleTemplateFolders";
 import refreshStaleDefaultModelSeeds from "./refreshStaleDefaultModelSeeds";
+import pinAiModelRefs from "./pinAiModelRefs";
 import { settingsStore } from "src/settingsStore";
 
 const migrations: Migrations = {
@@ -33,6 +34,7 @@ const migrations: Migrations = {
 	migrateProviderApiKeysToSecretStorage,
 	migrateToMultipleTemplateFolders,
 	refreshStaleDefaultModelSeeds,
+	pinAiModelRefs,
 };
 
 async function migrate(plugin: QuickAdd): Promise<void> {

--- a/src/migrations/pinAiModelRefs.test.ts
+++ b/src/migrations/pinAiModelRefs.test.ts
@@ -194,6 +194,59 @@ describe("pinAiModelRefs migration", () => {
 		});
 	});
 
+	it("re-pins a ref whose provider does not exist in this vault (cross-vault import shape)", async () => {
+		const command = aiCommand("gpt-4o");
+		// Name matches, but "their-proxy" is the EXPORTING vault's provider id.
+		command.modelRef = { providerId: "their-proxy", name: "gpt-4o" };
+
+		settingsStore.setState({
+			choices: [macroChoiceWith([command])],
+			ai: {
+				...settingsStore.getState().ai,
+				providers: [
+					provider({
+						name: "OpenAI",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+
+		expect(storedCommands()[0].modelRef).toEqual({
+			providerId: "openai",
+			name: "gpt-4o",
+		});
+	});
+
+	it("re-pins a ref whose provider exists but no longer serves the model", async () => {
+		const command = aiCommand("gpt-4o");
+		command.modelRef = { providerId: "openai", name: "gpt-4o" };
+
+		settingsStore.setState({
+			choices: [macroChoiceWith([command])],
+			ai: {
+				...settingsStore.getState().ai,
+				providers: [
+					provider({ id: "openai", name: "OpenAI", models: [] }),
+					provider({
+						id: "proxy",
+						name: "Proxy",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+
+		expect(storedCommands()[0].modelRef).toEqual({
+			providerId: "proxy",
+			name: "gpt-4o",
+		});
+	});
+
 	it("reaches AI commands nested in Multi folders", async () => {
 		const nested = {
 			id: "multi-1",

--- a/src/migrations/pinAiModelRefs.test.ts
+++ b/src/migrations/pinAiModelRefs.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type QuickAdd from "src/main";
+import type { AIProvider } from "src/ai/Provider";
+import { DEFAULT_SETTINGS } from "src/settings";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+import { CommandType } from "src/types/macros/CommandType";
+import type IChoice from "src/types/choices/IChoice";
+import type { IAIAssistantCommand } from "src/types/macros/QuickCommands/IAIAssistantCommand";
+import pinAiModelRefs from "./pinAiModelRefs";
+
+const mockPlugin = {} as unknown as QuickAdd;
+
+function provider(overrides: Partial<AIProvider>): AIProvider {
+	return {
+		name: "Provider",
+		endpoint: "https://example.test/v1",
+		apiKey: "",
+		models: [],
+		modelSource: "providerApi",
+		...overrides,
+	};
+}
+
+function aiCommand(model: string): IAIAssistantCommand {
+	return {
+		id: `cmd-${model}`,
+		name: `AI: ${model}`,
+		type: CommandType.AIAssistant,
+		model,
+		systemPrompt: "",
+		outputVariableName: "output",
+		promptTemplate: { enable: false, name: "" },
+		modelParameters: {},
+	};
+}
+
+function macroChoiceWith(commands: IAIAssistantCommand[]): IChoice {
+	return {
+		id: "macro-1",
+		name: "Macro",
+		type: "Macro",
+		command: false,
+		macro: { name: "Macro", id: "m1", commands },
+	} as unknown as IChoice;
+}
+
+function storedCommands(): IAIAssistantCommand[] {
+	const choice = settingsStore.getState().choices[0] as unknown as {
+		macro: { commands: IAIAssistantCommand[] };
+	};
+	return choice.macro.commands;
+}
+
+beforeEach(() => {
+	settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+});
+
+describe("pinAiModelRefs migration", () => {
+	it("assigns stable ids to providers that lack one", async () => {
+		settingsStore.setState({
+			ai: {
+				...settingsStore.getState().ai,
+				providers: [
+					provider({ name: "OpenAI" }),
+					provider({ name: "My Proxy" }),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+
+		expect(
+			settingsStore.getState().ai.providers.map((p) => p.id),
+		).toEqual(["openai", "my-proxy"]);
+	});
+
+	it("pins each command to the provider first-match resolves to today", async () => {
+		settingsStore.setState({
+			choices: [macroChoiceWith([aiCommand("gpt-4o")])],
+			ai: {
+				...settingsStore.getState().ai,
+				providers: [
+					// The proxy comes FIRST: pre-#1495 resolution routed gpt-4o to
+					// it, so the pin must record the proxy — not the official one.
+					provider({
+						name: "Proxy",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+					provider({
+						name: "OpenAI",
+						models: [{ name: "gpt-4o", maxTokens: 2 }],
+					}),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+
+		expect(storedCommands()[0].modelRef).toEqual({
+			providerId: "proxy",
+			name: "gpt-4o",
+		});
+		// The legacy string stays untouched for downgrades/imports.
+		expect(storedCommands()[0].model).toBe("gpt-4o");
+	});
+
+	it("leaves 'Ask me' and unresolvable models unpinned", async () => {
+		settingsStore.setState({
+			choices: [
+				macroChoiceWith([aiCommand("Ask me"), aiCommand("deleted-model")]),
+			],
+			ai: {
+				...settingsStore.getState().ai,
+				providers: [
+					provider({
+						name: "OpenAI",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+
+		expect(storedCommands()[0].modelRef).toBeUndefined();
+		expect(storedCommands()[1].modelRef).toBeUndefined();
+		expect(storedCommands()[1].model).toBe("deleted-model");
+	});
+
+	it("pins the default model and preserves an existing ref on re-run", async () => {
+		settingsStore.setState({
+			ai: {
+				...settingsStore.getState().ai,
+				defaultModel: "gpt-4o",
+				providers: [
+					provider({
+						name: "OpenAI",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+					provider({
+						id: "proxy",
+						name: "Proxy",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+		expect(settingsStore.getState().ai.defaultModelRef).toEqual({
+			providerId: "openai",
+			name: "gpt-4o",
+		});
+
+		// A second run (e.g. after a partial-failure retry) must not re-pin.
+		settingsStore.setState({
+			ai: {
+				...settingsStore.getState().ai,
+				defaultModelRef: { providerId: "proxy", name: "gpt-4o" },
+			},
+		});
+		await pinAiModelRefs.migrate(mockPlugin);
+		expect(settingsStore.getState().ai.defaultModelRef).toEqual({
+			providerId: "proxy",
+			name: "gpt-4o",
+		});
+	});
+
+	it("re-pins a STALE ref (name drifted from the legacy string) from the string", async () => {
+		const command = aiCommand("gpt-4o");
+		// An older QuickAdd rewrote the visible model string while this pinned
+		// ref survived in data.json.
+		command.modelRef = { providerId: "proxy", name: "o3" };
+
+		settingsStore.setState({
+			choices: [macroChoiceWith([command])],
+			ai: {
+				...settingsStore.getState().ai,
+				providers: [
+					provider({
+						name: "OpenAI",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+
+		expect(storedCommands()[0].modelRef).toEqual({
+			providerId: "openai",
+			name: "gpt-4o",
+		});
+	});
+
+	it("reaches AI commands nested in Multi folders", async () => {
+		const nested = {
+			id: "multi-1",
+			name: "Folder",
+			type: "Multi",
+			command: false,
+			choices: [macroChoiceWith([aiCommand("gpt-4o")])],
+		} as unknown as IChoice;
+
+		settingsStore.setState({
+			choices: [nested],
+			ai: {
+				...settingsStore.getState().ai,
+				providers: [
+					provider({
+						name: "OpenAI",
+						models: [{ name: "gpt-4o", maxTokens: 1 }],
+					}),
+				],
+			},
+		});
+
+		await pinAiModelRefs.migrate(mockPlugin);
+
+		const multi = settingsStore.getState().choices[0] as unknown as {
+			choices: Array<{ macro: { commands: IAIAssistantCommand[] } }>;
+		};
+		expect(multi.choices[0].macro.commands[0].modelRef).toEqual({
+			providerId: "openai",
+			name: "gpt-4o",
+		});
+	});
+});

--- a/src/migrations/pinAiModelRefs.ts
+++ b/src/migrations/pinAiModelRefs.ts
@@ -1,0 +1,85 @@
+import {
+	ensureProviderIds,
+	type AIProvider,
+	type ModelRef,
+} from "src/ai/Provider";
+import { pinAiCommandModelRefs } from "src/ai/modelRefPinning";
+import type IChoice from "src/types/choices/IChoice";
+import { settingsStore } from "src/settingsStore";
+import { deepClone } from "src/utils/deepClone";
+import { log } from "src/logger/logManager";
+import type { Migration } from "./Migrations";
+
+/**
+ * The pre-#1495 resolution rule, applied verbatim: the FIRST provider (in
+ * settings order) listing the model name. Local rather than resolveModel so
+ * the migration operates on ITS drafts, not the live store.
+ */
+function firstMatchProvider(
+	providers: AIProvider[],
+	modelName: string,
+): AIProvider | undefined {
+	return providers.find((provider) =>
+		provider.models.some((model) => model.name === modelName),
+	);
+}
+
+/**
+ * Pin every stored bare model name to the provider it resolves to TODAY
+ * (#1495). Behavior-preserving by construction: each ref records exactly what
+ * the first-match rule currently picks, so no command changes endpoint or key
+ * during the upgrade — the ref only protects it from being rerouted later
+ * when another provider gains the same model name.
+ *
+ * "Ask me" and names no provider serves are left unpinned; the latter keep
+ * failing at run time with the same error as before, visible in the model
+ * dropdown as "(missing)".
+ */
+const pinAiModelRefs: Migration = {
+	description:
+		"Pin AI commands' models to the provider they currently resolve to, and give every provider a stable id.",
+
+	migrate: async (_) => {
+		const state = settingsStore.getState();
+		const providers = deepClone(state.ai.providers ?? []) as AIProvider[];
+		const choices = deepClone(state.choices ?? []) as IChoice[];
+
+		ensureProviderIds(providers);
+
+		pinAiCommandModelRefs(choices, providers, (command, ref) => {
+			log.logMessage(
+				`Pinned AI command "${command.name}"'s model to ${ref.providerId}/${ref.name}.`,
+			);
+		});
+
+		// Same rules for the default model: preserve a still-valid ref, re-pin
+		// a stale one from the string, leave "Ask me"/unresolvable unpinned.
+		let defaultModelRef: ModelRef | undefined;
+		const defaultModel = state.ai.defaultModel;
+		if (
+			state.ai.defaultModelRef &&
+			state.ai.defaultModelRef.name === defaultModel
+		) {
+			defaultModelRef = state.ai.defaultModelRef;
+		} else if (defaultModel && defaultModel !== "Ask me") {
+			const provider = firstMatchProvider(providers, defaultModel);
+			if (provider?.id) {
+				defaultModelRef = { providerId: provider.id, name: defaultModel };
+				log.logMessage(
+					`Pinned the default model to ${provider.id}/${defaultModel}.`,
+				);
+			}
+		}
+
+		settingsStore.setState({
+			choices,
+			ai: {
+				...settingsStore.getState().ai,
+				providers,
+				...(defaultModelRef ? { defaultModelRef } : {}),
+			},
+		});
+	},
+};
+
+export default pinAiModelRefs;

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -92,9 +92,26 @@ vi.mock("./ai/tokenEstimator", () => ({
 	estimateTokenCount: mocks.estimateTokenCount,
 }));
 vi.mock("./ai/aiHelpers", () => ({
-	getModelByName: mocks.getModelByName,
 	getModelNames: mocks.getModelNames,
-	getModelProvider: mocks.getModelProvider,
+	// Mirrors the real resolver's contract through the two legacy mocks the
+	// tests configure per-case: resolve the model, pair it with its provider,
+	// throw an actionable error when the model is unknown.
+	resolveModelInputOrThrow: (input: string | { name?: string }) => {
+		const name = typeof input === "string" ? input : input?.name;
+		if (!name) {
+			throw new Error(
+				"Invalid model parameter. Expected a string or an object with a name property",
+			);
+		}
+		const model = mocks.getModelByName(name);
+		if (!model) {
+			throw new Error(`Model '${name}' not found in configured providers.`);
+		}
+		return {
+			model,
+			provider: mocks.getModelProvider(name) ?? { name: "MockProvider" },
+		};
+	},
 }));
 vi.mock("./ai/providerSecrets", () => ({
 	resolveProviderApiKey: mocks.resolveProviderApiKey,
@@ -664,7 +681,9 @@ describe("ai sync helpers", () => {
 	it("getMaxTokens throws when the model is unknown", () => {
 		mocks.getModelByName.mockReturnValue(undefined);
 		const { api } = getApi();
-		expect(() => api.ai.getMaxTokens("nope")).toThrow("Model nope not found.");
+		expect(() => api.ai.getMaxTokens("nope")).toThrow(
+			"not found in configured providers",
+		);
 	});
 
 	it("estimateTokens delegates to the provider-agnostic estimator", () => {
@@ -747,15 +766,6 @@ describe("ai.prompt validation", () => {
 		const { api } = getApi();
 		await expect(api.ai.prompt("hi", "gpt-4")).rejects.toThrow(
 			"not found in configured providers",
-		);
-	});
-
-	it("throws when no provider is configured for the model", async () => {
-		mocks.getModelByName.mockReturnValue({ name: "gpt-4", maxTokens: 1 });
-		mocks.getModelProvider.mockReturnValue(undefined);
-		const { api } = getApi();
-		await expect(api.ai.prompt("hi", "gpt-4")).rejects.toThrow(
-			"No provider configured",
 		);
 	});
 

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -10,9 +10,9 @@ import {
 } from "./ai/AIAssistant";
 import { estimateTokenCount } from "./ai/tokenEstimator";
 import {
-	getModelByName,
 	getModelNames,
-	getModelProvider,
+	resolveModelInputOrThrow,
+	type ScriptModelInput,
 } from "./ai/aiHelpers";
 import type { OpenAIModelParameters } from "./ai/OpenAIModelParameters";
 import type { Model } from "./ai/Provider";
@@ -490,7 +490,7 @@ export class QuickAddApi {
 			ai: {
 				prompt: async (
 					prompt: string,
-					model: Model | string,
+					model: ScriptModelInput,
 					settings?: Partial<{
 						variableName: string;
 						shouldAssignVariables: boolean;
@@ -516,32 +516,8 @@ export class QuickAddApi {
 						choiceExecutor,
 					).format;
 
-					// Normalize model input to Model object
-					let _model: Model;
-					const modelName = typeof model === "string" ? model : model?.name;
-
-					if (!modelName) {
-						throw new Error(`Invalid model parameter. Expected a string (e.g., "gpt-4") or object with name property (e.g., {name: "gpt-4"})`);
-					}
-
-					// Look up the model in configured providers
-					const foundModel = getModelByName(modelName);
-					if (!foundModel) {
-						throw new Error(
-							`Model '${modelName}' not found in configured providers. ` +
-							`Add it in Settings → QuickAdd → AI → Providers, or enable auto-sync for your provider.`
-						);
-					}
-					_model = foundModel;
-
-					const modelProvider = getModelProvider(_model.name);
-
-					if (!modelProvider) {
-						throw new Error(
-							`No provider configured for model '${_model.name}'. ` +
-							`Please configure a provider in Settings → QuickAdd → AI.`
-						);
-					}
+					const { model: _model, provider: modelProvider } =
+						resolveModelInputOrThrow(model);
 
 					const apiKey = await resolveProviderApiKey(app, modelProvider);
 
@@ -553,6 +529,7 @@ export class QuickAddApi {
 						app,
 						{
 							model: _model,
+							provider: modelProvider,
 							prompt,
 							apiKey,
 							modelOptions: settings?.modelOptions ?? {},
@@ -589,7 +566,7 @@ export class QuickAddApi {
 				chunkedPrompt: async (
 					text: string,
 					promptTemplate: string,
-					model: Model | string,
+					model: ScriptModelInput,
 					settings?: Partial<{
 						variableName: string;
 						shouldAssignVariables: boolean;
@@ -620,32 +597,8 @@ export class QuickAddApi {
 						choiceExecutor,
 					).format;
 
-					// Normalize model input to Model object
-					let _model: Model;
-					const modelName = typeof model === "string" ? model : model?.name;
-
-					if (!modelName) {
-						throw new Error(`Invalid model parameter. Expected a string (e.g., "gpt-4") or object with name property (e.g., {name: "gpt-4"})`);
-					}
-
-					// Look up the model in configured providers
-					const foundModel = getModelByName(modelName);
-					if (!foundModel) {
-						throw new Error(
-							`Model '${modelName}' not found in configured providers. ` +
-							`Add it in Settings → QuickAdd → AI → Providers, or enable auto-sync for your provider.`
-						);
-					}
-					_model = foundModel;
-
-					const modelProvider = getModelProvider(_model.name);
-
-					if (!modelProvider) {
-						throw new Error(
-							`No provider configured for model '${_model.name}'. ` +
-							`Please configure a provider in Settings → QuickAdd → AI.`
-						);
-					}
+					const { model: _model, provider: modelProvider } =
+						resolveModelInputOrThrow(model);
 
 					const apiKey = await resolveProviderApiKey(app, modelProvider);
 
@@ -657,6 +610,7 @@ export class QuickAddApi {
 						app,
 						{
 							model: _model,
+							provider: modelProvider,
 							text,
 							promptTemplate,
 							chunkSeparator: settings?.chunkSeparator ?? /\n/,
@@ -703,14 +657,8 @@ export class QuickAddApi {
 				getModels: () => {
 					return getModelNames();
 				},
-				getMaxTokens: (modelName: string) => {
-					const model = getModelByName(modelName);
-
-					if (!model) {
-						throw new Error(`Model ${modelName} not found.`);
-					}
-
-					return model.maxTokens;
+				getMaxTokens: (modelName: ScriptModelInput) => {
+					return resolveModelInputOrThrow(modelName).model.maxTokens;
 				},
 				estimateTokens(text: string) {
 					return estimateTokenCount(text);

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -18,6 +18,8 @@ import type { IConditionalCommand } from "../types/macros/Conditional/ICondition
 import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
 import type { IUserScript } from "../types/macros/IUserScript";
 import { CommandType } from "../types/macros/CommandType";
+import type { AIProvider } from "../ai/Provider";
+import { pinAiCommandModelRefs } from "../ai/modelRefPinning";
 import { log } from "../logger/logManager";
 import { decodeFromBase64 } from "../utils/base64";
 import { deepClone } from "../utils/deepClone";
@@ -79,6 +81,14 @@ export interface ApplyImportOptions {
 	pkg: QuickAddPackage;
 	choiceDecisions: ChoiceImportDecision[];
 	assetDecisions: AssetImportDecision[];
+	/**
+	 * The vault's configured AI providers. When given, imported AI commands
+	 * carrying only a bare model name are pinned to the provider that name
+	 * first-match resolves to at import time (#1495) — the one-time migration
+	 * has already run by then and would never see them. Optional so callers
+	 * without provider context (tests) import unchanged.
+	 */
+	aiProviders?: AIProvider[];
 }
 
 export interface ApplyImportResult {
@@ -637,6 +647,17 @@ export async function applyPackageImport(
 			);
 			preparedChoices.set(entry.choice.id, remapped);
 		}
+
+	// Pin imported bare-name AI commands before insertion: cross-vault refs
+	// that survived export are kept when still valid; everything else adopts
+	// this vault's current first-match provider, so a later provider add or
+	// reorder can't silently reroute the imported command.
+	if (options.aiProviders?.length) {
+		pinAiCommandModelRefs(
+			Array.from(preparedChoices.values()),
+			options.aiProviders,
+		);
+	}
 
 	const handledChoices = new Set<string>();
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import type { Model } from "./ai/Provider";
+import type { Model, ModelRef } from "./ai/Provider";
 import { DefaultProviders, type AIProvider } from "./ai/Provider";
 import type IChoice from "./types/choices/IChoice";
 import { DEFAULT_DATE_ALIASES } from "./utils/dateAliases";
@@ -66,6 +66,12 @@ export interface QuickAddSettings {
 		// is `string`, which already covers the sentinel — adding `| "Ask me"` would
 		// be a redundant union member that `string` subsumes.
 		defaultModel: Model["name"];
+		/**
+		 * Provider-scoped identity of the default model. Preferred over
+		 * `defaultModel` at runtime; absent for "Ask me". Writers keep
+		 * `defaultModel === defaultModelRef.name`.
+		 */
+		defaultModelRef?: ModelRef;
 		defaultSystemPrompt: string;
 		promptTemplatesFolderPath: string;
 		showAssistant: boolean;
@@ -96,6 +102,7 @@ export interface QuickAddSettings {
 		migrateProviderApiKeysToSecretStorage: boolean;
 		migrateToMultipleTemplateFolders: boolean;
 		refreshStaleDefaultModelSeeds: boolean;
+		pinAiModelRefs: boolean;
 	};
 }
 
@@ -150,5 +157,6 @@ export const DEFAULT_SETTINGS: QuickAddSettings = {
 		migrateProviderApiKeysToSecretStorage: false,
 		migrateToMultipleTemplateFolders: false,
 		refreshStaleDefaultModelSeeds: false,
+		pinAiModelRefs: false,
 	},
 };

--- a/src/types/macros/QuickCommands/AIAssistantCommand.ts
+++ b/src/types/macros/QuickCommands/AIAssistantCommand.ts
@@ -2,6 +2,7 @@ import { Command } from "../Command";
 import { CommandType } from "../CommandType";
 import type { IAIAssistantCommand } from "./IAIAssistantCommand";
 import { settingsStore } from "src/settingsStore";
+import { activeModelRef, type ModelRef } from "src/ai/Provider";
 import type { OpenAIModelParameters } from "src/ai/OpenAIModelParameters";
 
 export class AIAssistantCommand extends Command implements IAIAssistantCommand {
@@ -10,6 +11,7 @@ export class AIAssistantCommand extends Command implements IAIAssistantCommand {
 	declare type: CommandType;
 
 	model: string;
+	modelRef?: ModelRef;
 	systemPrompt: string;
 	outputVariableName: string;
 	promptTemplate: {
@@ -24,6 +26,11 @@ export class AIAssistantCommand extends Command implements IAIAssistantCommand {
 		const defaults = settingsStore.getState().ai;
 
 		this.model = defaults.defaultModel;
+		const defaultRef = activeModelRef(
+			defaults.defaultModel,
+			defaults.defaultModelRef,
+		);
+		this.modelRef = defaultRef ? { ...defaultRef } : undefined;
 		this.systemPrompt = defaults.defaultSystemPrompt;
 		this.outputVariableName = "output";
 		this.promptTemplate = { enable: false, name: "" };

--- a/src/types/macros/QuickCommands/IAIAssistantCommand.ts
+++ b/src/types/macros/QuickCommands/IAIAssistantCommand.ts
@@ -1,8 +1,16 @@
 import type { ICommand } from "../ICommand";
+import type { ModelRef } from "src/ai/Provider";
 import type { OpenAIModelParameters } from "src/ai/OpenAIModelParameters";
 
 interface IBaseAIAssistantCommand extends ICommand {
+	/** Model name, or the "Ask me" sentinel. Kept in sync with modelRef (legacy readers, downgrades). */
 	model: string;
+	/**
+	 * Provider-scoped identity of the pinned model. Preferred over `model` at
+	 * runtime; absent for "Ask me" and for commands from pre-2.19 data that the
+	 * migration could not resolve. Writers keep `model === modelRef.name`.
+	 */
+	modelRef?: ModelRef;
 	systemPrompt: string;
 	outputVariableName: string;
 	modelParameters: Partial<OpenAIModelParameters>;


### PR DESCRIPTION
Model references were bare names resolved to the FIRST provider that lists them, which decides the endpoint and API key. With live model import and auto-sync (#1494), two providers exposing the same id is now likely (OpenAI + an OpenAI-compatible proxy both listing `gpt-4o`), so reordering or adding providers could silently reroute existing AI commands. Follow-up from #1493 / PR #1494.

Closes #1495

## What changed

- **Stable provider ids.** Each provider gets an immutable slug id (`openai`, `my-proxy`); the display name stays freely editable and is shown alongside the id in the provider edit form. Presets carry canonical ids; hand-edited data.json is backfilled defensively, including deduplication of hand-duplicated ids.
- **Provider-scoped refs, write-both persistence.** AI commands and the default model persist `modelRef: {providerId, name}` alongside the legacy `model` string. Writers keep both in sync; readers treat a ref whose `name` drifted from the string as stale (`activeModelRef`), so a downgrade edit can never be silently overridden and cross-vault imports degrade to the old first-match rule.
- **One resolver** (`resolveModel`): object refs resolve by id, with a loud fallback-keyed warning when a pinned provider is gone; strings resolve bare-exact FIRST, then as qualified `provider/model` split at the first slash. Bare-first is deliberate: OpenRouter-style providers serve literal slash-named models (`openai/gpt-4o`), and existing scripts must keep resolving byte-identically. UI/metadata callers resolve silently so a modal render never consumes the warn-once budget of an actual run.
- **Provider threaded through the request layer.** `OpenAIRequest`/`chatRequest` take the caller-resolved provider instead of re-deriving it by name - previously the API key's provider and the endpoint's provider were two independent first-match lookups.
- **Grouped model dropdowns** (one shared builder replaces three copies): models grouped per provider, duplicate names distinguishable, `(missing)` placeholder for deleted pins, selection writes both fields. The "Ask me" runtime picker shows provider-qualified entries.
- **Behavior-preserving migration** pins every stored bare name to the provider first-match resolves to at migration time; package import pins incoming bare-name commands the same way (the migration has already run by then).
- **Script API**: `ai.prompt` / `ai.agent` / `ai.getMaxTokens` accept `"openai/gpt-4o"` qualified strings and a `{name, provider}` object form that cannot be shadowed by literal slash-named models. Error messages suggest the forms that would resolve.

## Why not persist "openai/gpt-4o" strings?

Slashes are part of real model ids on the very providers this issue is about (OpenRouter/TogetherAI/HF presets). `openai/gpt-4o` is irrecoverably ambiguous between "provider openai, model gpt-4o" and OpenRouter's literal model of that name - same string, different endpoint and key. So the string form is the *surface* syntax (UI, script API, docs) while persistence is structured.

## Verification

- 3903 unit tests pass (new: resolver semantics incl. the shadow case, slug/id dedup, migration idempotence + stale-ref re-pin, dropdown builder); lint and build clean.
- Live e2e in an isolated vault against two request-logging mock providers serving the same model name: the upgrade migration assigned ids and pinned command + default to the first-match provider; after reversing provider order the pinned command still hit the pinned endpoint (pre-PR behavior would reroute); `ai.prompt` bare/qualified/object forms routed correctly with the ambiguity warning; deleting the pinned provider fell back loudly with no console errors.
- Adversarial review (3 Codex reviewers) - all accepted findings fixed: stale-ref drift guard, duplicate-id dedup, pin-on-import, warn-once isolation between UI and runtime, shadowed-suggestion hints, slug enforcement in `uniqueProviderId`, removal of the legacy split-lookup exports.

## Review focus

- Resolution order semantics in `src/ai/aiHelpers.ts` (bare-exact-first is the back-compat keystone).
- The stale-ref rule (`activeModelRef`) and its call sites - it is what makes the parallel-field persistence safe.
- Migration + import pinning (`src/ai/modelRefPinning.ts`, `src/migrations/pinAiModelRefs.ts`, `applyPackageImport`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-scoped model selection with stable provider IDs, including provider-qualified identifiers and grouped dropdown entries for duplicate model names.
  * Added pinned model reference support (including default model refs) and an automatic migration to backfill existing commands/settings.
  * Quick Add AI APIs now accept the expanded model identifier forms consistently across prompt/chunkedPrompt/getMaxTokens.
* **Bug Fixes**
  * Missing/removed models now show a disabled “(missing)” fallback and won’t silently remap to another provider/model.
  * AI requests and tool/repair flows now consistently use the resolved provider for correct routing.
* **Documentation**
  * Updated AI docs with guidance on provider IDs, duplicate model names, and the supported model identifier formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->