### PR TITLE
feat(settings): craft pass on the choices list

### DIFF
--- a/scripts/obsidian-e2e-cli.mjs
+++ b/scripts/obsidian-e2e-cli.mjs
@@ -13,6 +13,7 @@ import {
 	readInstanceMarker,
 	reapStaleInstances,
 	resolveInstanceOptions,
+	stampInstanceMarkerAppVersion,
 	trustVaultAndVerifyQuickAdd,
 	waitForInstanceReady,
 } from "./start-obsidian-e2e-instance.mjs";
@@ -169,6 +170,12 @@ export async function ensureObsidianInstance(options) {
 	if (!ready) {
 		await launchObsidianInstance(options);
 		await waitForInstanceReady(options);
+		// The instance is up: record the app version it launched with (the
+		// resolution above) so later reuse checks compare against launch time.
+		await stampInstanceMarkerAppVersion(
+			options.instancePath,
+			compatibility.appVersion ?? null,
+		);
 	}
 
 	await trustVaultAndVerifyQuickAdd(options);

--- a/scripts/obsidian-e2e-cli.mjs
+++ b/scripts/obsidian-e2e-cli.mjs
@@ -10,6 +10,7 @@ import {
 	launchObsidianInstance,
 	parseArgs as parseInstanceArgs,
 	prepareObsidianProfile,
+	readInstanceMarker,
 	reapStaleInstances,
 	resolveInstanceOptions,
 	trustVaultAndVerifyQuickAdd,
@@ -122,6 +123,11 @@ async function isInstanceReady(options) {
 }
 
 export async function ensureObsidianInstance(options) {
+	// Read the PREVIOUS instance marker before prepareObsidianProfile rewrites
+	// it — it records the app-code version a still-running instance was
+	// launched with, which the reuse guard below compares against.
+	const previousMarker = await readInstanceMarker(options.instancePath);
+
 	const provisionResult = await provisionVault(options);
 	const profileResult = await prepareObsidianProfile(options);
 	options.userDataPath = profileResult.userDataPath;
@@ -137,7 +143,30 @@ export async function ensureObsidianInstance(options) {
 			`, plugin minAppVersion ${compatibility.minAppVersion}`,
 	);
 
-	if (!(await isInstanceReady(options))) {
+	const ready = await isInstanceReady(options);
+	if (
+		ready &&
+		previousMarker?.appVersion &&
+		compatibility.appVersion &&
+		previousMarker.appVersion !== compatibility.appVersion
+	) {
+		// A warm instance keeps the app code it was LAUNCHED with; seeding the
+		// sandbox cannot retrofit a running process. Fail loudly instead of
+		// letting the banner report a version the instance is not running.
+		throw new Error(
+			`The running e2e Obsidian instance was launched as app ${previousMarker.appVersion}, ` +
+				`but the harness now resolves ${compatibility.appVersion}. Restart it first: ` +
+				`pnpm run stop:e2e-obsidian -- --vault ${options.vaultName}`,
+		);
+	}
+	if (ready && !previousMarker?.appVersion) {
+		console.error(
+			"Note: reusing a running e2e instance whose launch-time app version was not recorded " +
+				"(marker predates the version guard); restart it if behavior looks off.",
+		);
+	}
+
+	if (!ready) {
 		await launchObsidianInstance(options);
 		await waitForInstanceReady(options);
 	}

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -221,6 +221,11 @@ export async function prepareObsidianProfile(options) {
 	const userDataPath = path.join(options.obsidianHome, "Library", "Application Support", "obsidian");
 	await fs.mkdir(userDataPath, { recursive: true, mode: 0o700 });
 	await fs.mkdir(path.join(options.obsidianHome, "Library", "Logs"), { recursive: true, mode: 0o700 });
+	// One resolution feeds BOTH the sandbox seeding and the marker, so what a
+	// fresh instance will run and what reuse checks compare are the same value
+	// (see readInstanceMarker / the CLI's reuse guard).
+	const resolvedApp = await resolveObsidianAppVersion(options);
+	await reconcileSandboxAppAsar(userDataPath, resolvedApp.newestCachedAsar);
 	await linkHostKeychains(options);
 
 	const vaultId = stableVaultId(options.vaultPath);
@@ -238,18 +243,74 @@ export async function prepareObsidianProfile(options) {
 	});
 
 	// Record which worktree this instance belongs to so the teardown reaper can
-	// reap it once that worktree is removed (see INSTANCE_MARKER_FILE).
+	// reap it once that worktree is removed (see INSTANCE_MARKER_FILE), plus the
+	// app-code version this profile was seeded for — the CLI's reuse guard
+	// compares it against a fresh resolution so a warm instance launched on an
+	// older app can't silently keep serving after the host updates Obsidian.
 	await writeJson(path.join(options.instancePath, INSTANCE_MARKER_FILE), {
 		worktreePath: options.worktreePath,
 		vaultName: options.vaultName,
 		vaultPath: options.vaultPath,
+		appVersion: resolvedApp.appVersion,
 	});
 
 	return {
 		obsidianJsonPath,
 		userDataPath,
 		vaultId,
+		appVersion: resolvedApp.appVersion,
 	};
+}
+
+/** Read an instance's marker sidecar; null when absent/unreadable (no instance
+ * yet, or a marker written by an older harness without the field callers want). */
+export async function readInstanceMarker(instancePath) {
+	try {
+		return JSON.parse(
+			await fs.readFile(path.join(instancePath, INSTANCE_MARKER_FILE), "utf8"),
+		);
+	} catch {
+		return null;
+	}
+}
+
+// The launched instance resolves its app-code asar from ITS OWN config dir:
+// $HOME is overridden to the sandbox, so the real config dir's auto-updated
+// obsidian-<version>.asar is invisible to it and it silently boots the OLDER
+// bundled installer build (verified live: real config had 1.13.0, the sandbox
+// instance ran 1.12.7 and could not render declarative settings tabs). That is
+// exactly the divergence the minAppVersion guard below predicts against — the
+// guard resolves from the REAL config dir — so make the sandbox match the
+// prediction: remove any stale sandbox asars (a leftover from an older run
+// could otherwise outrank the predicted version), then copy the exact asar the
+// resolver selected. Copy, not symlink: Obsidian manages (rewrites/deletes)
+// asars next to obsidian.json. A failed copy THROWS — succeeding silently
+// would let the guard pass while the instance boots something else. With no
+// cached asar at all the sandbox is left clean and the instance runs the
+// bundled installer build, which the guard still validates against
+// minAppVersion.
+async function reconcileSandboxAppAsar(userDataPath, newestCachedAsar) {
+	for (const name of await fs.readdir(userDataPath)) {
+		if (!OBSIDIAN_ASAR_VERSION_RE.test(name)) continue;
+		if (newestCachedAsar && name === newestCachedAsar.name) continue;
+		await fs.rm(path.join(userDataPath, name), { force: true });
+	}
+	if (!newestCachedAsar) return null;
+
+	const destination = path.join(userDataPath, newestCachedAsar.name);
+	try {
+		// Already seeded by a previous run (same name + size): skip the copy so
+		// per-command CLI calls don't rewrite ~25MB under a running instance.
+		const [source, existing] = await Promise.all([
+			fs.stat(newestCachedAsar.path),
+			fs.stat(destination),
+		]);
+		if (source.size === existing.size) return newestCachedAsar.version;
+	} catch {
+		// Destination missing — fall through to the copy.
+	}
+	await fs.copyFile(newestCachedAsar.path, destination);
+	return newestCachedAsar.version;
 }
 
 async function linkHostKeychains(options) {
@@ -399,11 +460,13 @@ export async function trustVaultAndVerifyQuickAdd(options) {
 // Obsidian has TWO versions: the installer shell (the .app, shown in the window
 // title) and the auto-updated app code (obsidian-<version>.asar, == the
 // `apiVersion` plugins see). minAppVersion is enforced against the app-code
-// version, not the installer. On macOS the app-code asar lives in the LOGIN
-// user's Application Support dir, resolved from getpwuid (os.userInfo) rather
-// than $HOME — so even though this harness isolates $HOME/--user-data-dir, the
-// launched instance loads the newest asar from the real config dir, floored at
-// the installer's bundled asar. When NO installed asar reaches minAppVersion,
+// version, not the installer. The app-code asar is resolved from the config
+// dir of the HOME the app runs under — for this harness that is the ISOLATED
+// sandbox home (verified live: with an empty sandbox the instance booted the
+// bundled installer build even though the real config dir held a newer asar),
+// so prepareObsidianProfile seeds the newest real-config asar into the sandbox
+// (seedNewestObsidianAsar) and the instance loads that, floored at the
+// installer's bundled asar. When NO installed asar reaches minAppVersion,
 // Obsidian silently runs the bundled installer build, which can be BELOW
 // minAppVersion. e2e then runs against an app QuickAdd does not support, so a
 // "missing API" crash there is a false signal (this is exactly what makes a
@@ -415,13 +478,14 @@ export async function trustVaultAndVerifyQuickAdd(options) {
 // expose `apiVersion` to a CDP-evaluated snippet (require("obsidian") is not
 // resolvable outside plugin scope, and the window title carries the INSTALLER
 // version, not the app-code version), so the app-code version cannot be read from
-// the running renderer. We therefore resolve it the same way Obsidian does — the
-// newest valid installed asar in the real config dir, floored at the bundled
-// installer asar. The guard runs BEFORE launch, so a fresh instance loads exactly
-// what we resolved. Residual edge: a warm instance reused from an earlier run
-// (see the CLI's isInstanceReady reuse) reflects the asar resolution at ITS
-// launch; an Obsidian update mid-session is not re-detected. Instances are reaped
-// per worktree and Obsidian versions are stable within a run, so this is bounded.
+// the running renderer. We therefore resolve it from the same inputs the seeding
+// uses — the newest valid installed asar in the real config dir, floored at the
+// bundled installer asar. The guard runs BEFORE launch, and prepareObsidianProfile
+// seeds that same asar into the sandbox, so a fresh instance loads exactly
+// what we resolved. A warm instance reused from an earlier run reflects the
+// asar resolution at ITS launch — the instance marker records that version and
+// the CLI's reuse guard refuses to reuse when it no longer matches a fresh
+// resolution (an Obsidian update mid-session forces an explicit restart).
 
 const OBSIDIAN_ASAR_VERSION_RE = /^obsidian-(\d+\.\d+\.\d+)\.asar$/;
 
@@ -513,6 +577,10 @@ export async function resolveObsidianAppVersion(options = {}) {
 	const configDir = options.obsidianConfigDir ?? macObsidianConfigDir();
 
 	const cachedVersions = [];
+	// The single authority for "which cached asar is newest" — the seeding step
+	// (reconcileSandboxAppAsar) copies exactly this file, so the guard's
+	// prediction and the seeded sandbox cannot diverge by construction.
+	let newestCachedAsar = null;
 	try {
 		for (const name of await fs.readdir(configDir)) {
 			if (!OBSIDIAN_ASAR_VERSION_RE.test(name)) continue;
@@ -521,7 +589,14 @@ export async function resolveObsidianAppVersion(options = {}) {
 			// either), so a half-downloaded obsidian-<newer>.asar cannot make the
 			// guard pass while the live app actually falls back to an older build.
 			const version = await readAsarPackageVersion(path.join(configDir, name));
-			if (version) cachedVersions.push(version);
+			if (!version) continue;
+			cachedVersions.push(version);
+			if (
+				!newestCachedAsar ||
+				compareObsidianVersions(version, newestCachedAsar.version) > 0
+			) {
+				newestCachedAsar = { name, path: path.join(configDir, name), version };
+			}
 		}
 	} catch {
 		// Config dir missing/unreadable — fall back to the bundled installer below.
@@ -539,7 +614,7 @@ export async function resolveObsidianAppVersion(options = {}) {
 		? all.reduce((max, v) => (compareObsidianVersions(v, max) > 0 ? v : max))
 		: null;
 
-	return { appVersion, installerVersion, cachedVersions, configDir };
+	return { appVersion, installerVersion, cachedVersions, configDir, newestCachedAsar };
 }
 
 async function readPluginMinAppVersion(worktreePath) {

--- a/scripts/start-obsidian-e2e-instance.mjs
+++ b/scripts/start-obsidian-e2e-instance.mjs
@@ -243,15 +243,19 @@ export async function prepareObsidianProfile(options) {
 	});
 
 	// Record which worktree this instance belongs to so the teardown reaper can
-	// reap it once that worktree is removed (see INSTANCE_MARKER_FILE), plus the
-	// app-code version this profile was seeded for — the CLI's reuse guard
-	// compares it against a fresh resolution so a warm instance launched on an
-	// older app can't silently keep serving after the host updates Obsidian.
+	// reap it once that worktree is removed (see INSTANCE_MARKER_FILE). The
+	// marker's appVersion is the LAUNCH-TIME version of the running instance
+	// (stamped by stampInstanceMarkerAppVersion after a successful launch), so
+	// re-preparing the profile must PRESERVE it — overwriting it with the fresh
+	// prediction here would blind the CLI's reuse guard on its second run: the
+	// first mismatch failure would already have rewritten the marker to the new
+	// version, and the still-running old instance would then look current.
+	const existingMarker = await readInstanceMarker(options.instancePath);
 	await writeJson(path.join(options.instancePath, INSTANCE_MARKER_FILE), {
 		worktreePath: options.worktreePath,
 		vaultName: options.vaultName,
 		vaultPath: options.vaultPath,
-		appVersion: resolvedApp.appVersion,
+		appVersion: existingMarker?.appVersion ?? null,
 	});
 
 	return {
@@ -272,6 +276,19 @@ export async function readInstanceMarker(instancePath) {
 	} catch {
 		return null;
 	}
+}
+
+/** Stamp the app-code version the instance was actually LAUNCHED with into the
+ * marker. Called only after a successful launch — never from profile prep — so
+ * the CLI's reuse guard keeps seeing the running instance's launch-time version
+ * across any number of prepare cycles. */
+export async function stampInstanceMarkerAppVersion(instancePath, appVersion) {
+	const marker = await readInstanceMarker(instancePath);
+	if (!marker) return;
+	await writeJson(path.join(instancePath, INSTANCE_MARKER_FILE), {
+		...marker,
+		appVersion: appVersion ?? null,
+	});
 }
 
 // The launched instance resolves its app-code asar from ITS OWN config dir:
@@ -722,6 +739,14 @@ async function main() {
 	const resolvedVaultPath = options.launch
 		? await waitForInstanceReady(options)
 		: null;
+	if (options.launch) {
+		// The instance is up: record the app version it launched with (the
+		// pre-launch resolution) for the CLI's warm-reuse guard.
+		await stampInstanceMarkerAppVersion(
+			options.instancePath,
+			compatibility?.appVersion ?? null,
+		);
+	}
 	const verifiedQuickAdd = options.launch
 		? await trustVaultAndVerifyQuickAdd(options)
 		: false;

--- a/src/gui/ChoiceBuilder/choiceForms-1497-legacy-missing-fields.test.ts
+++ b/src/gui/ChoiceBuilder/choiceForms-1497-legacy-missing-fields.test.ts
@@ -181,6 +181,52 @@ describe("choice edit forms tolerate legacy choices missing newer fields (#1497)
 		expect(resolved.folder.chooseFromSubfolders).toBe(false);
 	});
 
+	it("TemplateChoiceBuilder backfills a bare hand-edited choice (no folder/fileNameFormat at all)", async () => {
+		// A minimal, hand-edited/imported Template choice: only identity fields.
+		// Before the per-field backfills, normalizeChoice threw on
+		// `folder.chooseFromSubfolders` and the modal mounted blank.
+		const bare = {
+			id: "t2",
+			name: "Bare Template",
+			type: "Template",
+			command: false,
+		} as unknown as ITemplateChoice;
+		const builder = new TemplateChoiceBuilder(new App(), bare, plugin);
+		builder.close();
+		const resolved = (await builder.waitForClose) as ITemplateChoice;
+		expect(resolved.templatePath).toBe("");
+		expect(resolved.fileNameFormat).toEqual({ enabled: false, format: "" });
+		expect(resolved.folder).toEqual({
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		});
+	});
+
+	it("TemplateChoiceBuilder backfills PARTIAL nested configs field by field", async () => {
+		// `folder: { enabled: true }` (no folders array) and
+		// `fileNameFormat: { enabled: true }` (no format) are the partial shapes
+		// the whole-object ??= backfill missed: the form dereferences
+		// `folder.folders.length` and binds `fileNameFormat.format`.
+		const partial = {
+			id: "t3",
+			name: "Partial Template",
+			type: "Template",
+			command: false,
+			folder: { enabled: true },
+			fileNameFormat: { enabled: true },
+		} as unknown as ITemplateChoice;
+		const builder = new TemplateChoiceBuilder(new App(), partial, plugin);
+		builder.close();
+		const resolved = (await builder.waitForClose) as ITemplateChoice;
+		expect(resolved.folder.enabled).toBe(true);
+		expect(resolved.folder.folders).toEqual([]);
+		expect(resolved.folder.chooseFromSubfolders).toBe(false);
+		expect(resolved.fileNameFormat).toEqual({ enabled: true, format: "" });
+	});
+
 	it("Toggle accepts an undefined binding and writes a boolean on flip", async () => {
 		const model = { flag: undefined as boolean | undefined };
 		const { container } = render(Toggle, {

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -33,6 +33,26 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 	private normalizeChoice() {
 		this.choice.fileExistsBehavior ??= { kind: "prompt" };
 		this.choice.fileOpening = normalizeFileOpening(this.choice.fileOpening);
+		// A hand-edited or imported choice can lack these configs entirely OR
+		// carry partial objects (e.g. `folder: { enabled: true }` with no
+		// `folders` array) — without per-field backfills the builder throws
+		// during mount and the modal opens blank (#1497 class). Field-by-field,
+		// mirroring the shapes the TemplateChoice ctor creates.
+		this.choice.templatePath ??= "";
+		this.choice.fileNameFormat ??= { enabled: false, format: "" };
+		this.choice.fileNameFormat.enabled ??= false;
+		this.choice.fileNameFormat.format ??= "";
+		this.choice.folder ??= {
+			enabled: false,
+			folders: [],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		};
+		this.choice.folder.enabled ??= false;
+		this.choice.folder.folders ??= [];
+		this.choice.folder.chooseWhenCreatingNote ??= false;
+		this.choice.folder.createInSameFolderAsActiveFile ??= false;
 		// chooseFromSubfolders (2023) postdates the folder config itself, so
 		// choices saved before it existed legitimately lack it (#1497).
 		this.choice.folder.chooseFromSubfolders ??= false;

--- a/src/gui/choiceList/ChoiceItemRightButtons.svelte
+++ b/src/gui/choiceList/ChoiceItemRightButtons.svelte
@@ -34,13 +34,6 @@
 </script>
 
 <div class="rightButtonsContainer">
-    <IconButton
-        iconId="zap"
-        ariaPressed={commandEnabled}
-        label={`Command palette${choiceName ? ": " + choiceName : ""}`}
-        extraClass="qa-row-secondary-action"
-        onclick={onToggleCommand}
-    />
     {#if showConfigureButton}
         <IconButton
             iconId="settings"
@@ -75,6 +68,19 @@
         />
     {/if}
 
+    <!-- The command-palette toggle sits at the edge of the cluster, directly
+         left of the drag handle, so its always-visible ON state reads as a
+         right-ANCHORED status column instead of floating mid-row while the
+         other actions are hover-hidden. It must not move on hover, and the
+         handle must stay the row's rightmost element (drag-pill anchoring). -->
+    <IconButton
+        iconId="zap"
+        ariaPressed={commandEnabled}
+        label={`Command palette${choiceName ? ": " + choiceName : ""}`}
+        extraClass="qa-row-secondary-action"
+        onclick={onToggleCommand}
+    />
+
     <DragHandle
         label={`Reorder${choiceName ? " " + choiceName : ""}`}
         {dragDisabled}
@@ -88,6 +94,9 @@
 .rightButtonsContainer {
     display: flex;
     align-items: center;
-    gap: 8px;
+    /* Icons carry their own 3px padding inside the choice rows (24px hit
+       boxes), so a tight gap keeps the cluster compact without touching. */
+    gap: 2px;
+    flex: 0 0 auto;
 }
 </style>

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -137,7 +137,7 @@
         class:qa-empty={choices.length === 0}>
     {#each stripShadow(choices) as choice (choice.id)}
         <!-- Flip wrapper: the dndzone's direct child = the animated/draggable item.
-             Must stay margin/padding/border-less (the 12px inter-row margin lives on
+             Must stay margin/padding/border-less (the 2px inter-row margin lives on
              the inner row). data-choice-id stays on the inner row for tests/menus. -->
         <div animate:flip={{ duration: flipDurationMs }}>
             {#if choice.type !== "Multi"}
@@ -182,10 +182,10 @@
 }
 
 .choiceList.qa-nested {
-    /* Own the 12px name->first-row gap so the empty drop band sits the same distance
+    /* Own the 2px name->first-row gap so the empty drop band sits the same distance
        below the folder name as a populated folder's first row (collapses with the
        row's own margin-top, so populated folders look identical). */
-    margin-top: 12px;
+    margin-top: 2px;
     position: relative; /* anchor the ring (::before) */
     border-radius: var(--radius-m);
     transition: background-color 120ms ease;
@@ -230,11 +230,10 @@
    without changing the band's size. */
 .choiceList.qa-nested.qa-folder-empty.qa-empty::after {
     content: "Empty — add a choice or drag one here.";
-    color: var(--text-muted);
+    color: var(--text-faint);
     font-size: var(--font-ui-smaller, 12px);
-    font-style: italic;
     line-height: 1.3;
-    padding-left: 2px;
+    padding-left: 8px; /* align with the child rows' own left padding */
     pointer-events: none;
     user-select: none;
 }

--- a/src/gui/choiceList/ChoiceListItem.svelte
+++ b/src/gui/choiceList/ChoiceListItem.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import type IChoice from "../../types/choices/IChoice";
 	import RightButtons from "./ChoiceItemRightButtons.svelte";
-	import { Component, type App } from "obsidian";
+	import { Component, Platform, type App } from "obsidian";
 	import { showChoiceContextMenu, showChoiceContextMenuAtElement } from "./contextMenu";
 	import { renderChoiceName } from "./renderChoiceName";
 	import type { ChoiceListActions } from "./choiceListActions";
+	import { resolveChoiceIcon } from "../../utils/choiceUtils";
+	import ObsidianIcon from "../components/ObsidianIcon.svelte";
 
 	let {
 		choice,
@@ -62,11 +64,30 @@
 	}
 </script>
 
-<!-- Right-click opens the context menu for mouse users; keyboard users reach the
-     same actions via the "More options" button, so this row is a non-interactive
+<!-- Right-click opens the context menu for mouse users; double-click is a mouse
+     shortcut for Configure — keyboard users reach both via the (focusable)
+     "Configure" and "More options" buttons, so this row stays a non-interactive
      container (no role/tabindex). -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="choiceListItem" data-choice-id={choice.id} oncontextmenu={onContextMenu}>
+<div
+	class="choiceListItem"
+	data-choice-id={choice.id}
+	oncontextmenu={onContextMenu}
+	ondblclick={(evt) => {
+		// Desktop-only mouse shortcut: on mobile the bare row surface belongs to
+		// long-press drag, and svelte-dnd-action's touch false-alarm replays a
+		// synthetic click (see stopDragInit) that must not reach row actions.
+		if (Platform.isMobile) return;
+		// Only bare-row double-clicks configure; a double-click on a button or a
+		// rendered markdown link inside the name keeps its own meaning.
+		const target = evt.target as HTMLElement;
+		if (target.closest("button, a")) return;
+		actions.onConfigureChoice(choice);
+	}}
+>
+	<span class="qaChoiceRowIcon" aria-hidden="true">
+		<ObsidianIcon iconId={resolveChoiceIcon(choice)} size={15} />
+	</span>
 	<span class="choiceListItemName" bind:this={nameElement}></span>
 
 	<RightButtons

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -366,14 +366,18 @@
 		</div>
 	{:else}
 		<div class="choiceFilterBar">
-			<div class="choiceFilterInputWrapper">
+			<!-- Obsidian's native search-input treatment: the container class
+			     brings the leading magnifier and themed field for free, so the
+			     filter reads exactly like search fields elsewhere in the app. -->
+			<div class="search-input-container choiceFilterInput">
 				<input
-					type="text"
-					placeholder="Filter choices (fuzzy)"
+					type="search"
+					placeholder="Filter choices..."
 					bind:value={filterQuery}
 					autocapitalize="off"
 					autocorrect="off"
 					spellcheck={false}
+					enterkeyhint="search"
 					onkeydown={(e) => {
 						if (e.key === 'Escape' && filterQuery) {
 							filterQuery = "";
@@ -382,11 +386,11 @@
 					}}
 				/>
 				{#if filterQuery}
-					<button class="choiceFilterClear" aria-label="Clear filter" title="Clear"
+					<button
+						class="search-input-clear-button qaFilterClearButton"
+						aria-label="Clear filter"
 						onclick={() => (filterQuery = "")}
-					>
-						<ObsidianIcon iconId="x" size={14} />
-					</button>
+					></button>
 				{/if}
 			</div>
 		</div>
@@ -399,13 +403,20 @@
 				{actions}
 			/>
 		{:else}
-			<ChoiceList
-				{app}
-				roots={choices}
-				choices={filterChoices(choices, filterQuery)}
-				forceDragDisabled={true}
-				{actions}
-			/>
+			{@const filtered = filterChoices(choices, filterQuery)}
+			{#if filtered.length === 0}
+				<div class="choiceFilterEmpty">
+					No choices match your filter.
+				</div>
+			{:else}
+				<ChoiceList
+					{app}
+					roots={choices}
+					choices={filtered}
+					forceDragDisabled={true}
+					{actions}
+				/>
+			{/if}
 		{/if}
 
 		<div class="choiceViewBottomBar">
@@ -479,35 +490,31 @@
 	}
 
 	.choiceFilterBar {
-		margin-bottom: 0.5rem;
+		margin-bottom: 8px;
 	}
 
-	.choiceFilterInputWrapper {
-		position: relative;
-		display: flex;
-		align-items: center;
-	}
-
-	.choiceFilterInputWrapper input {
+	/* The native container is inline-block by default in some contexts; span
+	   the full row so the filter aligns with the list edges. */
+	.choiceFilterInput {
 		width: 100%;
-		padding-right: 1.6rem; /* space for clear button */
 	}
 
-	.choiceFilterClear {
-		position: absolute;
-		right: 4px;
+	/* Obsidian styles .search-input-clear-button (position, the × glyph, hover)
+	   — we only reset the <button> chrome so that styling shows through. A real
+	   <button> (Obsidian uses a div) keeps it keyboard-operable. */
+	.qaFilterClearButton {
 		background: transparent;
 		border: none;
-		cursor: pointer;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		padding: 2px;
-		color: var(--text-muted);
+		box-shadow: none;
+		padding: 0;
+		margin: 0;
+		cursor: var(--cursor, pointer);
 	}
 
-	.choiceFilterClear:hover {
-		color: var(--text-normal);
+	.choiceFilterEmpty {
+		color: var(--text-faint);
+		font-size: var(--font-ui-small, 13px);
+		padding: 12px 8px 16px;
 	}
 
 </style>

--- a/src/gui/choiceList/ChoiceView.test.ts
+++ b/src/gui/choiceList/ChoiceView.test.ts
@@ -174,7 +174,7 @@ describe("ChoiceView", () => {
 		);
 
 		// Activate the filter so the derived, force-expanded clone renders.
-		await fireEvent.input(getByPlaceholderText("Filter choices (fuzzy)"), {
+		await fireEvent.input(getByPlaceholderText("Filter choices..."), {
 			target: { value: "Findable" },
 		});
 
@@ -217,7 +217,7 @@ describe("ChoiceView", () => {
 		});
 
 		// Filter so only "Findme" matches -> the folder renders as a clone WITHOUT "Hidden".
-		await fireEvent.input(getByPlaceholderText("Filter choices (fuzzy)"), {
+		await fireEvent.input(getByPlaceholderText("Filter choices..."), {
 			target: { value: "Findme" },
 		});
 
@@ -260,7 +260,7 @@ describe("ChoiceView", () => {
 			},
 		});
 
-		await fireEvent.input(getByPlaceholderText("Filter choices (fuzzy)"), {
+		await fireEvent.input(getByPlaceholderText("Filter choices..."), {
 			target: { value: "Findme" },
 		});
 

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -6,7 +6,7 @@
     import type IMultiChoice from "../../types/choices/IMultiChoice";
     import RightButtons from "./ChoiceItemRightButtons.svelte";
     import { untrack } from "svelte";
-	import { Component, type App } from "obsidian";
+	import { Component, Platform, type App } from "obsidian";
     import type IChoice from "src/types/choices/IChoice";
     import { showChoiceContextMenu, showChoiceContextMenuAtElement } from "./contextMenu";
 	import { renderChoiceName } from "./renderChoiceName";
@@ -109,10 +109,29 @@
 
 <div>
     <!-- Right-click opens the context menu for mouse users; keyboard users reach the
-         same actions via the "More options" button, so this row is a non-interactive
-         container (no role/tabindex). -->
+         same actions via the "More options" button. A click anywhere on the row's
+         bare surface forwards to the (focusable) name-button toggle — the row div
+         itself stays a non-interactive container (no role/tabindex). -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="multiChoiceListItem" data-choice-id={choice.id} oncontextmenu={onContextMenu}>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+        class="multiChoiceListItem"
+        data-choice-id={choice.id}
+        oncontextmenu={onContextMenu}
+        onclick={(evt) => {
+            // Desktop-only: on mobile the bare row surface belongs to long-press
+            // drag, and svelte-dnd-action's touch false-alarm replays a synthetic
+            // click (see stopDragInit) that would double-toggle. The name button
+            // (protected by stopDragInit) stays the tap affordance there.
+            if (Platform.isMobile) return;
+            // The name button handles its own clicks (and bubbles here); only
+            // clicks on the row's bare surface toggle, so the action buttons and
+            // rendered markdown links keep their own meaning.
+            const target = evt.target as HTMLElement;
+            if (target.closest("button, a")) return;
+            toggleCollapsed();
+        }}
+    >
         <button
             type="button"
             class="multiChoiceListItemName"
@@ -122,13 +141,18 @@
             onclick={toggleCollapsed}
         >
             <span
-                class="multiChoiceCollapseIcon"
+                class="qaChoiceRowIcon multiChoiceCollapseIcon"
                 class:is-collapsed={choice.collapsed}
                 aria-hidden="true"
             >
                 <ObsidianIcon iconId="chevron-down" size={16} />
             </span>
             <span class="choiceListItemName" bind:this={nameElement}></span>
+            {#if choice.collapsed && choice.choices.length > 0}
+                <!-- What a closed folder hides is real information: a quiet
+                     count keeps the list scannable without expanding. -->
+                <span class="qaFolderCount" aria-hidden="true">{choice.choices.length}</span>
+            {/if}
         </button>
 
         <RightButtons
@@ -182,43 +206,49 @@
 </div>
 
 <style>
-    .multiChoiceListItem {
-        display: flex;
-        font-size: 16px;
-        align-items: center;
-        margin: 12px 0 0 0;
-    }
+    /* Row surface (min-height, padding, radius, hover, rhythm) is shared with
+       leaf rows and lives in styles.css — see "Choice list rows". Only the
+       folder-specific pieces stay here. */
 
+    /* Base icon = chevron-down (expanded); collapsed rotates to point RIGHT,
+       matching Obsidian's own collapse grammar (file explorer, outline). */
     .multiChoiceCollapseIcon {
-        display: inline-flex;
-        transition: transform 0.2s ease-in-out;
+        transition: transform 150ms ease;
     }
 
     .multiChoiceCollapseIcon.is-collapsed {
-        transform: rotate(-180deg);
+        transform: rotate(-90deg);
     }
 
-    /* Full-width collapse toggle: reset native <button> chrome to match the old
-       clickable div while keeping native keyboard activation + aria-expanded. */
+    @media (prefers-reduced-motion: reduce) {
+        .multiChoiceCollapseIcon {
+            transition: none;
+        }
+    }
+
+    /* Full-width collapse toggle: reset native <button> chrome while keeping
+       native keyboard activation + aria-expanded. It hosts the shared icon
+       column (the chevron), so the folder NAME lands on the exact leaf-name x
+       for free — same 8px column gap as the leaf rows. */
     .multiChoiceListItemName {
-        flex: 1 0 0;
-        /* Tuck the chevron into the left card-padding gutter so the Multi NAME
-           lines up flush with leaf-row names — only nested children get indented
-           (.nestedChoiceList below), not the root Multi row itself. -20px = the
-           chevron's RENDERED box (18px) + the 2px gap, so the name lands on the
-           leaf-name x. The box is 18px, not the size={16} attribute: Obsidian's
-           .svg-icon class sizes the SVG via var(--icon-size) (~18px), overriding
-           the attribute (verified in-app: width attr 16, computed 18, name flush).
-           The lucide glyph also carries ~4.5px side-bearing, so a 2px flex gap
-           yields a ~6px optical gap to the name — the prior 5px gap was ~9.5px. */
-        margin-left: -20px;
+        flex: 1 1 auto;
+        min-width: 0;
+        align-self: stretch;
         display: flex;
         align-items: center;
-        gap: 2px;
+        /* Obsidian's base button centers flex content; the name must not rely
+           on a growing child to stay left (it stopped growing for the count). */
+        justify-content: flex-start;
+        gap: 8px;
         background: transparent;
         border: none;
         box-shadow: none;
         padding: 0;
+        /* Obsidian's base button rule sets height: var(--input-height) (30px),
+           which would make folder rows 4px taller than leaf rows — the exact
+           rhythm break this redesign removes. */
+        height: auto;
+        min-height: 0;
         font: inherit;
         color: inherit;
         text-align: left;
@@ -226,6 +256,20 @@
         /* Suppress double-tap-zoom + its click delay on touch — proper touch hygiene
            for a tap target, and reduces the ghost-click the dedupe above also guards. */
         touch-action: manipulation;
+    }
+
+    /* The count reads as part of the label ("Misc · 12"), so the name must not
+       grow — it keeps its ellipsis via flex-shrink + the shared min-width: 0. */
+    .multiChoiceListItemName :global(.choiceListItemName) {
+        flex: 0 1 auto;
+    }
+
+    .qaFolderCount {
+        flex: 0 0 auto;
+        color: var(--text-faint);
+        font-size: var(--font-ui-smaller, 12px);
+        font-variant-numeric: tabular-nums;
+        line-height: 1;
     }
 
     .multiChoiceListItemName:focus-visible {
@@ -237,17 +281,29 @@
     /* Just the indent — the drop-into-folder ring is drawn on the ACTUAL dndzone
        (.choiceList, in ChoiceList.svelte) so the highlighted area equals the
        droppable area (WYSIWYG); it is NOT drawn on this wrapper, which extends past
-       the zone to the add-row/hint. */
+       the zone to the add-row/hint. The ::before is an indent GUIDE under the
+       parent's icon column (x = row padding 8px + half the 18px column, minus
+       half the line), clarifying what belongs to the open folder. */
     .nestedChoiceList {
-        padding-left: 25px;
+        position: relative;
+        padding-left: 26px;
     }
 
-    /* The per-folder add-row is the folder's own affordance: one spacing step
-       (8px) tighter than the 12px inter-row rhythm so it reads as "belongs to this
-       folder". An empty folder's add-row sits below the drop band (ChoiceList's
-       .qa-empty, which now owns the "Empty — …" hint as pseudo-content), getting
-       the same 8px gap as a populated one. */
+    .nestedChoiceList::before {
+        content: "";
+        position: absolute;
+        left: 16px;
+        top: 3px;
+        bottom: 3px;
+        width: 1px;
+        background: var(--background-modifier-border);
+        pointer-events: none;
+    }
+
+    /* The per-folder add-row reads as a ghost row of the folder: aligned to the
+       child rows' padding, one tight step (4px) below the last child. */
     .nestedAddRow {
-        margin: 8px 0 0 0;
+        margin: 2px 0 4px 0;
+        padding: 0 8px;
     }
 </style>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1263,14 +1263,118 @@
   }
 }
 
-/*  ChoiceListItem.svelte */
-.choiceListItem {
+/* ---- Choice list rows (ChoiceListItem.svelte + MultiChoiceListItem.svelte) ----
+   One shared row surface for leaves AND folders: identical min-height, padding,
+   radius and 2px rhythm, so the list scans as a single system — hierarchy is
+   carried by the icon column + indent guides, not by irregular whitespace.
+   Kept global (not component-scoped) because leaf and folder rows live in two
+   components and MUST stay pixel-identical. */
+:is(.choiceListItem, .multiChoiceListItem) {
 	display: flex;
-	font-size: 16px;
 	align-items: center;
-	margin: 12px 0 0 0;
-	/* No `transition` here: an unnamed (all-property) 1s transition smeared every
-	   drag-induced reflow over a full second — the main source of drag jitter. */
+	gap: 8px;
+	min-height: 32px;
+	margin: 2px 0 0 0;
+	padding: 3px 6px 3px 8px;
+	border-radius: var(--radius-s, 4px);
+	font-size: var(--font-ui-medium, 15px);
+	line-height: var(--line-height-tight, 1.3);
+	/* Only background-color transitions: an unnamed (all-property) 1s transition
+	   smeared every drag-induced reflow over a full second (drag jitter). */
+	transition: background-color 100ms ease;
+}
+
+:is(.choiceListItem, .multiChoiceListItem):is(:hover, :focus-within) {
+	background-color: var(--background-modifier-hover);
+}
+
+/* Leading icon column: the choice's own icon (same resolveChoiceIcon the Run
+   picker uses) on leaf rows; the collapse chevron on folder rows. Fixed 18px
+   box = Obsidian's rendered .svg-icon size, so names align at every depth.
+   --icon-size (not the svg width attr, which Obsidian's .svg-icon rule
+   overrides) draws the type glyph a step smaller than the chevron: it is
+   secondary information, not an affordance. */
+.qaChoiceRowIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 18px;
+	width: 18px;
+	color: var(--text-muted);
+	--icon-size: 15px;
+}
+
+.multiChoiceCollapseIcon {
+	--icon-size: 17px;
+}
+
+/* Reveal the per-row actions on intent (hover / keyboard focus in the row).
+   Scoped to the choice rows — the macro builder's rightButtonsContainer keeps
+   its always-visible icons. Opacity (not display) so hidden buttons keep their
+   layout AND can receive keyboard focus, which re-reveals them via
+   :focus-within. The command-palette toggle stays visible when ON (is-pressed):
+   it is state, not just an action. */
+body:not(.is-mobile)
+	:is(.choiceListItem, .multiChoiceListItem)
+	.rightButtonsContainer
+	.qa-icon-button {
+	opacity: 0;
+	transition: opacity 100ms ease, background-color 100ms ease;
+}
+
+body:not(.is-mobile)
+	:is(.choiceListItem, .multiChoiceListItem):is(:hover, :focus-within)
+	.rightButtonsContainer
+	.qa-icon-button,
+body:not(.is-mobile)
+	:is(.choiceListItem, .multiChoiceListItem)
+	.rightButtonsContainer
+	.qa-icon-button.is-pressed {
+	opacity: 1;
+}
+
+/* No hover on the device (touch): keep every action visible — there is no
+   pointer to reveal them with. (Phones/tablets additionally collapse to the ⋮
+   menu via the .is-mobile rules above, which this reveal NEVER applies to —
+   a phone must not hide its only affordance behind a hover it cannot make.) */
+@media (hover: none) {
+	body:not(.is-mobile)
+		:is(.choiceListItem, .multiChoiceListItem)
+		.rightButtonsContainer
+		.qa-icon-button {
+		opacity: 1;
+	}
+}
+
+/* Comfortable 24px hit targets with per-icon hover feedback, matching
+   Obsidian's clickable-icon feel. Scoped to the choice rows; !important matches
+   the base .qa-icon-button reset it overrides. body:not(.is-mobile) keeps the
+   mobile 8px touch-target padding (declared earlier) in charge on phones. */
+body:not(.is-mobile)
+	:is(.choiceListItem, .multiChoiceListItem)
+	.rightButtonsContainer
+	.qa-icon-button {
+	padding: 3px !important;
+}
+
+:is(.choiceListItem, .multiChoiceListItem) .rightButtonsContainer .qa-icon-button {
+	color: var(--text-muted);
+}
+
+:is(.choiceListItem, .multiChoiceListItem) .rightButtonsContainer .qa-icon-button:hover {
+	background-color: var(--background-modifier-hover);
+	color: var(--text-normal);
+}
+
+:is(.choiceListItem, .multiChoiceListItem) .rightButtonsContainer .qa-icon-button.is-pressed {
+	color: var(--text-accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	:is(.choiceListItem, .multiChoiceListItem),
+	:is(.choiceListItem, .multiChoiceListItem) .rightButtonsContainer .qa-icon-button {
+		transition: none;
+	}
 }
 
 /* ---- Drag clone -> compact pill (replaces the full-row ghost) ----
@@ -1353,8 +1457,14 @@
 }
 
 
+/* Single-line names: long names ellipsize instead of wrapping the row taller
+   (uniform rhythm survives any name). min-width:0 lets the flex item shrink. */
 .choiceListItemName {
-	flex: 1 0 0;
+	flex: 1 1 auto;
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .choiceListItemName p {

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -10,8 +10,10 @@ import {
 	INSTANCE_MARKER_FILE,
 	parseArgs,
 	prepareObsidianProfile,
+	readInstanceMarker,
 	resolveInstanceOptions,
 	resolveObsidianAppVersion,
+	stampInstanceMarkerAppVersion,
 	toInstanceShellExports,
 } from "../scripts/start-obsidian-e2e-instance.mjs";
 
@@ -315,8 +317,22 @@ describe("resolveObsidianAppVersion", () => {
 		).resolves.toBeTruthy();
 		expect(first.appVersion).toBe("1.12.7");
 
+		// The marker's appVersion records LAUNCH time, not prediction time — a
+		// profile that was prepared but never launched stays unstamped.
+		expect(
+			(await readInstanceMarker(options.instancePath))?.appVersion,
+		).toBeNull();
+
+		// Launch happened on 1.12.7: the launch path stamps the marker.
+		await stampInstanceMarkerAppVersion(options.instancePath, "1.12.7");
+		expect(
+			(await readInstanceMarker(options.instancePath))?.appVersion,
+		).toBe("1.12.7");
+
 		// Host updated: re-preparing swaps the sandbox to the new resolution and
-		// removes the now-stale asar.
+		// removes the now-stale asar — but must PRESERVE the launch-time marker
+		// (overwriting it with the new prediction would blind the CLI's reuse
+		// guard on its second run, while the old instance is still running).
 		const second = await prepareObsidianProfile({
 			...options,
 			obsidianConfigDir: await makeConfigDir(["1.13.0"]),
@@ -329,14 +345,9 @@ describe("resolveObsidianAppVersion", () => {
 			fs.stat(path.join(second.userDataPath, "obsidian-1.12.7.asar")),
 		).rejects.toMatchObject({ code: "ENOENT" });
 		expect(second.appVersion).toBe("1.13.0");
-
-		const marker = JSON.parse(
-			await fs.readFile(
-				path.join(options.instancePath, INSTANCE_MARKER_FILE),
-				"utf8",
-			),
-		);
-		expect(marker.appVersion).toBe("1.13.0");
+		expect(
+			(await readInstanceMarker(options.instancePath))?.appVersion,
+		).toBe("1.12.7");
 	});
 
 	it("floors at the bundled installer asar when the config dir is empty", async () => {

--- a/tests/start-obsidian-e2e-instance.test.ts
+++ b/tests/start-obsidian-e2e-instance.test.ts
@@ -45,7 +45,12 @@ describe("start-obsidian-e2e-instance", () => {
 			cwd,
 		);
 
-		const profile = await prepareObsidianProfile(options);
+		const profile = await prepareObsidianProfile({
+			...options,
+			// Hermetic: never scan the real host config dir / copy a real asar.
+			obsidianConfigDir: await makeTempDir("quickadd-empty-config"),
+			bundledAsarCandidates: [] as string[],
+		});
 		const registry = JSON.parse(await fs.readFile(profile.obsidianJsonPath, "utf8"));
 		const vaults = Object.values(registry.vaults) as Array<{ path: string; open: boolean }>;
 
@@ -88,8 +93,16 @@ describe("start-obsidian-e2e-instance", () => {
 			]),
 			cwd,
 		);
+		// Hermetic app-version resolution: no real host config dir, no bundled
+		// installer — so the test never copies a real ~25MB asar and the marker's
+		// appVersion is deterministically null.
+		const hermetic = {
+			...options,
+			obsidianConfigDir: await makeTempDir("quickadd-empty-config"),
+			bundledAsarCandidates: [] as string[],
+		};
 
-		await prepareObsidianProfile(options);
+		await prepareObsidianProfile(hermetic);
 
 		// The reaper keys off this exact sidecar (see isInstanceOrphaned). Prove the
 		// producer (prepareObsidianProfile, shared by start + the CLI wrapper) writes
@@ -104,6 +117,7 @@ describe("start-obsidian-e2e-instance", () => {
 			worktreePath: options.worktreePath,
 			vaultName: options.vaultName,
 			vaultPath: options.vaultPath,
+			appVersion: null,
 		});
 		expect(path.resolve(marker.worktreePath)).toBe(path.resolve(cwd));
 	});
@@ -264,6 +278,65 @@ describe("resolveObsidianAppVersion", () => {
 		});
 		expect(resolved.appVersion).toBe("1.13.0");
 		expect(resolved.cachedVersions.sort()).toEqual(["1.12.7", "1.13.0"]);
+		// The seeding step copies exactly this file (single resolver authority).
+		expect(resolved.newestCachedAsar).toEqual({
+			name: "obsidian-1.13.0.asar",
+			path: path.join(configDir, "obsidian-1.13.0.asar"),
+			version: "1.13.0",
+		});
+	});
+
+	it("seeds the resolved asar into the sandbox profile and records it in the marker", async () => {
+		// The launched instance resolves its app-code asar from the ISOLATED
+		// sandbox home; prepareObsidianProfile must therefore materialize the
+		// version the guard predicts (and reconcile away stale sandbox asars, so
+		// a leftover newer file can't outrank the prediction).
+		const cwd = await makeTempDir("quickadd-instance");
+		const options = resolveInstanceOptions(
+			parseArgs([
+				"--vault",
+				"quickadd-worktree-seed",
+				"--root",
+				"vaults",
+				"--profile-root",
+				"profiles",
+				"--no-launch",
+			]),
+			cwd,
+		);
+
+		const first = await prepareObsidianProfile({
+			...options,
+			obsidianConfigDir: await makeConfigDir(["1.12.7"]),
+			bundledAsarCandidates: [] as string[],
+		});
+		await expect(
+			fs.stat(path.join(first.userDataPath, "obsidian-1.12.7.asar")),
+		).resolves.toBeTruthy();
+		expect(first.appVersion).toBe("1.12.7");
+
+		// Host updated: re-preparing swaps the sandbox to the new resolution and
+		// removes the now-stale asar.
+		const second = await prepareObsidianProfile({
+			...options,
+			obsidianConfigDir: await makeConfigDir(["1.13.0"]),
+			bundledAsarCandidates: [] as string[],
+		});
+		await expect(
+			fs.stat(path.join(second.userDataPath, "obsidian-1.13.0.asar")),
+		).resolves.toBeTruthy();
+		await expect(
+			fs.stat(path.join(second.userDataPath, "obsidian-1.12.7.asar")),
+		).rejects.toMatchObject({ code: "ENOENT" });
+		expect(second.appVersion).toBe("1.13.0");
+
+		const marker = JSON.parse(
+			await fs.readFile(
+				path.join(options.instancePath, INSTANCE_MARKER_FILE),
+				"utf8",
+			),
+		);
+		expect(marker.appVersion).toBe("1.13.0");
 	});
 
 	it("floors at the bundled installer asar when the config dir is empty", async () => {


### PR DESCRIPTION
A fine-grained UI/UX pass on the Choices settings list, driven by live screenshot iteration in the isolated e2e vault (dark + light themes, hover/drag/filter/empty states, and Obsidian mobile emulation).

## What changed and why

**Rhythm & alignment.** Leaf rows were 21px tall on a 33px pitch while folder rows were 30px on 42px (Obsidian's base `button { height: var(--input-height) }` leaked into folder rows) - the source of the uneven spacing. Every row is now the same 32px surface with padding, radius, and a 2px gap; hierarchy is carried by structure instead of irregular whitespace.

**Type-icon column.** Each leaf row leads with its choice's icon via the existing `resolveChoiceIcon` (the same icon, including per-choice overrides, that the Run picker shows). Folders put the collapse chevron in that column, so names align at every depth and the old `-20px` chevron hack is gone. Choice *type* is finally scannable in the list.

**Actions on intent.** The six always-on action icons per row are now hover/focus-revealed with proper 24px hit targets and per-icon hover feedback. The command-palette zap moved to sit directly left of the drag handle: its always-visible ON state reads as a right-anchored status column instead of floating mid-row. The handle stays the rightmost element (the drag-pill CSS anchors to it).

**Structure affordances.** Collapsed chevrons point right (Obsidian's collapse grammar); open folders get a 1px indent guide; collapsed folders show a quiet child count attached to the name. Clicking a folder row's bare surface toggles it; double-clicking a leaf row opens its builder (both desktop-only - on mobile the row surface belongs to long-press drag and svelte-dnd's touch false-alarm replays a synthetic click).

**Filter.** Native `search-input-container` treatment, "Filter choices..." copy, native clear button, and a zero-match empty state.

**Mobile.** The hover-reveal is scoped to `body:not(.is-mobile)` so phones keep their only affordance (⋮) always visible; `@media (hover: none)` keeps actions visible on touch desktops. Verified in Obsidian mobile emulation at phone size.

## Also in this PR

- `fix(template-builder)`: `normalizeChoice` backfills `templatePath`, `fileNameFormat`, and `folder` **field by field**, so hand-edited/imported choices (including partial shapes like `folder: {enabled: true}`) can never open a blank builder modal (#1497 class). Regression tests added.
- `chore(e2e)`: the sandboxed Obsidian instance resolves its app asar from the *isolated* home, so it silently booted the older bundled installer build (1.12.7 - which cannot render declarative settings tabs) while the minAppVersion guard resolved 1.13.0 from the real config dir. The harness now seeds the resolver's newest cached asar into the sandbox (single authority, stale asars reconciled, copy failures throw), records the version in the instance marker, and the CLI refuses to reuse a warm instance whose launch-time version no longer matches.

## Verification

- 3877 vitest tests pass; svelte-check 0 errors; eslint clean.
- Live-verified in the isolated e2e vault: drag reorder (pill + drop ring + empty-folder band), keyboard reorder (ArrowUp/Down on handle, screen-reader announcement path), dblclick-configure, row-click collapse, filter + Escape + zero-match, long-name ellipsis, both themes, AI-enabled and disabled bottom bars.
- Adversarially reviewed (3 Codex reviewers: skeptic/architect/minimalist); accepted findings fixed in this PR (deep normalize backfill, mobile double-fire gating, warm-instance version guard, stale-asar reconciliation, CSS consolidation).

## Review focus

- `src/styles.css`: the `body:not(.is-mobile)` scoping vs the `.is-mobile` touch-padding rules (specificity interplay is commented).
- `MultiChoiceListItem.svelte`: the folder button reset (`height: auto`) and the count's flex interaction with name ellipsis.
- `scripts/obsidian-e2e-cli.mjs`: the reuse guard reads the *previous* instance marker before `prepareObsidianProfile` rewrites it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refined the choice list UI with clearer row icons, tighter action button spacing, and improved nested list spacing.
  * Enhanced the choice filter to use native search styling and show a clear “no matches” state.
  * Added desktop double-click to configure a choice.
* **Bug Fixes**
  * Fixed imported/hand-edited template choices missing nested configuration fields so they always render correctly.
  * Improved end-to-end instance reuse to prevent warm reuse when the cached app version doesn’t match.
* **Tests**
  * Updated e2e/choice filter regression coverage for the new behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->