### PR TITLE
docs: backfill Introduced-in-QuickAdd version annotations

### DIFF
--- a/docs/src/content/docs/docs/AIAssistant.md
+++ b/docs/src/content/docs/docs/AIAssistant.md
@@ -107,6 +107,8 @@ When adding a model manually, the model name must match the id your server expec
 
 ### Provider IDs and duplicate model names
 
+_Introduced in QuickAdd 2.19.0._
+
 Every provider has a stable **ID** - a short slug like `openai` or `my-proxy`, shown in the provider's edit form. The ID never changes, even if you rename the provider, and scripts use it to address a model on a specific provider.
 
 Two providers can serve models with the same name - for example, the official OpenAI provider and an OpenAI-compatible proxy can both list `gpt-4o`. Model dropdowns group models by provider so you always pick a specific provider's model, and QuickAdd remembers that choice. Reordering providers, renaming them, or auto-syncing new models never changes which endpoint an existing command talks to.

--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -43,6 +43,8 @@ obsidian vault=dev quickadd:check choice="Daily log"
 
 ### `quickadd:run-template`
 
+_Introduced in QuickAdd 2.14.0._
+
 Create a new note from a template file — no dedicated Template choice required.
 This is the scriptable form of the **New note from template** command.
 
@@ -117,6 +119,8 @@ obsidian vault=dev quickadd choice="Daily log" ui
 ```
 
 ## Interactive runs (`quickadd:interactive`)
+
+_Introduced in QuickAdd 2.16.0._
 
 Some choices prompt at *run time* for inputs that can't be collected up front -
 a macro's `quickAddApi.suggester` over data it just fetched, an `inputPrompt`,

--- a/docs/src/content/docs/docs/Advanced/ObsidianUri.md
+++ b/docs/src/content/docs/docs/Advanced/ObsidianUri.md
@@ -37,6 +37,8 @@ obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-contents=Lorem%20i
 
 ## Getting a result back (x-callback-url)
 
+_Introduced in QuickAdd 2.14.0._
+
 QuickAdd can open a callback URL after a choice finishes, so an external caller (for
 example an Apple Shortcut) can react to the result and receive the path of the affected
 note. This follows the [x-callback-url](http://x-callback-url.com/) convention.

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -81,6 +81,8 @@ If you have a tag called `#people`, and you type `#people` in the _Capture To_ f
 
 ### Capturing to filtered files
 
+_Introduced in QuickAdd 2.14.0._
+
 You can combine folder and tag filters in the _Capture To_ field with `|`.
 This is useful when the destination could live in several folders, or when it
 must match several tags.
@@ -151,6 +153,8 @@ Pass the variables object on every `executeChoice` call. Each call clears its
 temporary variables after the target choice runs.
 
 ### Capturing to a property
+
+_Introduced in QuickAdd 2.14.0._
 
 You can pre-filter the picker by an arbitrary **frontmatter property** by typing
 `property:<field>=<value>` in the _Capture To_ field. QuickAdd then asks you which
@@ -387,6 +391,8 @@ The target may span several lines: type `\n` in the **Insert after** field to ma
 
 ### Ordered section placement
 
+_Introduced in QuickAdd 2.14.0._
+
 When `Create line if not found` is enabled and its location dropdown is set to **Ordered** (the full label is `Ordered (place new section among siblings)`), a missing "Insert after" heading is created at its **sorted position among same-level sibling headings** instead of at the top or bottom of the note. This is the building block for a reverse-chronological log: a new dated section is added above older ones, while a fixed title/intro stays pinned at the top.
 
 This is the recipe for the classic "daily log, newest first" note (issue [#481](https://github.com/chhoumann/quickadd/issues/481)):
@@ -454,6 +460,8 @@ A "books read" note grouped by year — **Insert after** `## {{DATE:YYYY}}`, **F
 -   **Ordered** is for headings and can't be combined with **Inline insertion**.
 
 ### Choose heading when capturing
+
+_Introduced in QuickAdd 2.14.0._
 
 Insert After normally uses a target line you type when you build the choice. Enable
 **Choose heading when capturing** to instead pick the heading **at run time**: when you

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -18,6 +18,8 @@ Example: `{{DATE:YYYY-MM-DD_HH-mm}}` or `{{DATE:YYYY-MM-DD+3}}`.
 
 ## `{{DATE:<DATEFORMAT>|startof:<unit>}}` / `{{...|endof:<unit>}}` {#date-snap}
 
+_Introduced in QuickAdd 2.14.0._
+
 Snap the date to the **start** or **end** of a period before formatting. The
 formatted output then reflects that boundary instead of the exact instant — so,
 for example, the month of a week-snapped date is the month the *week* belongs to,
@@ -81,6 +83,8 @@ You can combine a default with the `optional` flag in any order: `{{VDATE:due,YY
 **Note:** Pipe characters (`|`) cannot be used inside VDATE date formats — everything after the first pipe is treated as the default value (and flags). Use a different literal, e.g. wrap text in square brackets: `{{VDATE:due,[Due ]YYYY-MM-DD}}`.
 
 ## `{{VDATE:<variable name>, <date format>|time}}` {#vdate-time}
+
+_Introduced in QuickAdd 2.14.0._
 
 Adds a **time picker** to the date prompt (aliases: `|datetime`, `|type:datetime`), for `Date & time` properties. The calendar gains an `HH:mm` control, and picking a day keeps the time you set (it isn't reset to midnight). If you omit the date format, it defaults to `YYYY-MM-DD HH:mm`.
 
@@ -172,6 +176,8 @@ Example:
 
 ## `{{VALUE:<variable>|type:number}}` / `|type:slider` / `|type:checkbox` / `|type:text` {#value-property-types}
 
+_Introduced in QuickAdd 2.14.0._
+
 Tailors the input to an Obsidian property type. These are single-value prompts (no comma options / `|custom`):
 
 - `|type:number` shows a numeric input. The value is written unquoted (`rating: 42`), so Obsidian reads it as a **Number**. Add `|min:`, `|max:`, and/or `|step:` to constrain the input.
@@ -200,6 +206,8 @@ Example: `{{DATE:YYYY-MM-DD}}-{{VALUE:title|case:slug}}.md`.
 
 ## `{{VALUE|trim}}` / `{{NAME|trim}}` / `{{VALUE:<variable>|trim}}` {#value-trim}
 
+_Introduced in QuickAdd 2.14.0._
+
 Trims leading and trailing whitespace from the resolved value for this token. This is useful for file names, links, and properties where accidental spaces from mobile keyboards or pasted text would create a different note or link target.
 
 Example: `[[{{VALUE:title|trim}}]]`.
@@ -218,6 +226,8 @@ It composes with other VALUE options, for example `{{VALUE:title|trim|case:slug}
 Allows you to type custom values in addition to selecting from the provided options. Example: `{{VALUE:Red,Green,Blue|custom}}` will suggest Red, Green, and Blue, but also allows you to type any other value like "Purple". This is useful when you have common options but want flexibility for edge cases. **Note:** You cannot combine `|custom` with a shorthand default value - use `|default:` if you need both.
 
 ## `{{VALUE:<options>|multi}}` {#value-multi}
+
+_Introduced in QuickAdd 2.14.0._
 
 Turns an option-list suggester into a **multi-select**: pick several values and they're written as a YAML **List**. Requires an option list (2+ comma-separated values).
 
@@ -248,6 +258,8 @@ Notes:
 - With the **one-page input form** (Settings → QuickAdd), avoid commas inside an individual option (e.g. `|text:"High, urgent"`) on a `|multi` token — the one-page picker can't round-trip a comma that lives inside a single option. The default one-prompt-at-a-time picker handles it correctly.
 
 ## `{{VALUE:<options>|name:<variable name>}}` {#value-name}
+
+_Introduced in QuickAdd 2.14.0._
 
 Gives a suggester a reusable **name**, so the value you pick can be inserted again elsewhere without prompting a second time. Pick from the options once at the definition, then reuse the choice anywhere with `{{VALUE:<variable name>}}`.
 
@@ -309,6 +321,8 @@ Example: `Source: {{LINKCURRENT}}`.
 
 ## `{{LINKSECTION}}` {#linksection}
 
+_Introduced in QuickAdd 2.14.0._
+
 Like `{{LINKCURRENT}}`, but links to the **heading the cursor is currently under** (`[[Note#Heading]]` format), so clicking the link scrolls to that section instead of the top of the file. Honors the same **required/optional** behavior as `{{LINKCURRENT}}`.
 
 It picks the nearest heading at or above the cursor. When the cursor is above the first heading (or the file has no headings), it falls back to a plain whole-file link. When a heading's text is repeated in the file, it uses the disambiguating ancestor path (`[[Note#Parent#Heading]]`) so the link resolves to the right one; if even that can't uniquely identify the heading, it falls back to a whole-file link rather than linking to the wrong section.
@@ -322,6 +336,8 @@ The basename (without extension) of the file from which the template or capture 
 Example: `Notes from {{FILENAMECURRENT}}`.
 
 ## `{{FOLDERCURRENT}}` {#foldercurrent}
+
+_Introduced in QuickAdd 2.18.0._
 
 The folder of the file from which the template or capture was triggered (the active file), as a vault-relative path with no trailing slash. For an active file at the vault root it resolves to an empty string. Not to be confused with `{{FOLDER}}` below, which is the folder the *new* note is being created in.
 
@@ -344,6 +360,8 @@ Add the `|name` modifier to get only the last path segment: for an active file i
 Examples: `{{FOLDERCURRENT}}/Project Tasks.md`, `Tasks for {{FOLDERCURRENT|name}}`.
 
 ## `{{FOLDER}}` {#folder}
+
+_Introduced in QuickAdd 2.14.0._
 
 The folder the note is being created in, as a vault-relative path (no trailing slash). For a note created at the vault root this resolves to an empty string. (For the *active* file's folder, use `{{FOLDERCURRENT}}` above.)
 
@@ -403,6 +421,8 @@ Example: `project: {{FIELD:project}}`.
 
 ### `{{FIELD:<FIELDNAME>|multi}}` {#field-multi}
 
+_Introduced in QuickAdd 2.14.0._
+
 Turns FIELD suggestions into a multi-select. Pick several existing field values,
 or add custom values in the picker.
 
@@ -433,6 +453,8 @@ collects other one-page inputs first, then opens the runtime multi-select for
 the FIELD value.
 
 ### `{{FIELD:<FIELDNAME>|default-from:active}}` {#field-default-from-active}
+
+_Introduced in QuickAdd 2.14.0._
 
 Defaults the FIELD prompt to the value the same property already has on the
 **active note** - the note that was focused when you triggered QuickAdd. This is
@@ -509,6 +531,8 @@ Examples: `status: {{FIELD:status|default:Draft|default-always:true}}` or `id: {
 This is currently in beta, and the syntax can change—leave your thoughts [on issue #1429](https://github.com/chhoumann/quickadd/issues/1429).
 
 ## `{{FILE:<folder>}}` {#file}
+
+_Introduced in QuickAdd 2.14.0._
 
 Prompts you to pick a markdown **file** from `<folder>` and inserts the choice. Unlike `{{FIELD:...}}` (which suggests the *values* of a YAML field), this suggests the files themselves — handy for "metadata folders" such as a `People/` or `Research Topics/` folder where each note is an option. Because the options are real files, the list always reflects what currently exists, which keeps your links consistent.
 

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -625,6 +625,8 @@ const result = await quickAddApi.ai.chunkedPrompt(
 
 ### Tool / function calling — `ai.agent(config)`
 
+_Introduced in QuickAdd 2.14.0._
+
 Build an **agent**: give the model a prompt and a set of *tools* (JS functions), and it
 will call them in a bounded multi-step loop until it has an answer. Works across your
 configured OpenAI-compatible, Anthropic, and Gemini providers.
@@ -778,6 +780,9 @@ const selectedModel = await quickAddApi.suggester(models, models);
 Gets the maximum token limit for a model.
 
 ### `estimateTokens(text: string): number`
+
+_Introduced in QuickAdd 2.14.0._
+
 Estimates the token count for text using QuickAdd's provider-agnostic estimator.
 This is useful for rough prompt sizing, but the configured AI provider remains
 the source of truth for exact context limits and usage.

--- a/docs/src/content/docs/docs/Settings.md
+++ b/docs/src/content/docs/docs/Settings.md
@@ -50,5 +50,7 @@ The QuickAdd settings tab is reached from Obsidian's **Settings → Community pl
 
 ## Choice icons
 
+_Introduced in QuickAdd 2.14.0._
+
 - **Automatic choice icons** — QuickAdd gives each choice type a default Obsidian/Lucide icon: `file-text` for Template, `pencil` for Capture, `terminal` for Macro, and `folder` for Multi. These icons show in the QuickAdd launcher, inside Multi choice pickers, and on registered commands in the command palette / mobile editing toolbar.
 - **Override a choice's icon** — Open a choice's configuration and set **Icon** to any [Lucide](https://lucide.dev) icon id (for example `star`). Leave the field empty to use the choice type default. Icons inherit the active Obsidian theme color; QuickAdd does not set per-choice icon colors.


### PR DESCRIPTION
Final piece of the docs modernization (#1502, #1503, #1504). With per-release snapshots gone, the replacement signal for "which version added this feature" is an inline `_Introduced in QuickAdd X.Y.Z._` line under the section that documents it - the same pattern the Obsidian Tasks plugin uses, and the convention AGENTS.md now prescribes for future features.

Backfills 24 annotations covering features shipped in 2.14.0 through 2.19.0: format tokens (`|startof/|endof` date snap, `{{VDATE|time}}`, `|type:` property prompts, `|trim`, `|multi`, `|name:`, `{{LINKSECTION}}`, `{{FOLDERCURRENT}}` (2.18.0), `{{FOLDER}}`, `{{FIELD}}` variants, `{{FILE:}}`), capture targets (filtered files, property targets, ordered section placement, choose-heading), CLI (`quickadd:run-template`, `quickadd:interactive` (2.16.0), x-callback), AI (`ai.agent` tool calling, `estimateTokens`, provider-scoped model identity (2.19.0)), and choice icons.

Every mapping was verified against git: the introducing feat commit's first containing tag, or the feature's absence from the 2.13.1 tree (e.g. `estimateTokens`, `chooseHeading`, `orderedSection` are absent in 2.13.1 and present in 2.14.0). Pre-2.14.0 features deliberately get no annotation.

Build green, link/anchor checker 0 problems across 50 pages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chhoumann/quickadd/pull/1505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version callouts across several docs to show when features were introduced.
  * Clarified availability for AI assistant, CLI, URI callback, capture options, format tokens, API features, and choice icons.
  * Improved discoverability by marking specific sections with QuickAdd version notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->