### PR TITLE
docs: post-merge review follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Follow Conventional Commits (`feat:`, `fix:`, `test:`, `release(version): ...`) 
 ## Documentation
 Docs live in `docs/` (Astro Starlight) and are single-version: pages in `docs/src/content/docs/docs/` serve at `/docs/` on quickadd.obsidian.guide, and edits go live when they land on `master` (deployed by Cloudflare Pages). There are no versioned snapshots - do NOT recreate `versioned_docs/` or any per-release docs copies. Historical docs states are recoverable from git tags. Every page pins its URL with a `slug:` frontmatter field; keep slugs stable, and add a 301 in `docs/public/_redirects` if one must change.
 
-Because docs track `master` while plugin releases are cut manually, docs can briefly describe features users don't have yet. The contract for that window: when documenting a feature that has not shipped in a release, add an "Introduced in vX.Y.Z" line (or an `:::note[Available in the next release]` callout) at the section you're adding, in the same PR as the docs change. Fill in the real version number if it's known from the pending release.
+Because docs track `master` while plugin releases are cut manually, docs can briefly describe features users don't have yet. The contract for that window: when documenting a feature that has not shipped in a release, add an `_Introduced in QuickAdd X.Y.Z._` line (or an `:::note[Available in the next release]` callout) at the section you're adding, in the same PR as the docs change. Fill in the real version number if it's known from the pending release.
 
 Old `/docs/<version>/...` and `/docs/next/...` URLs 301 to their current equivalents via `docs/public/_redirects` (Cloudflare Pages reads it from the build output). If a docs page is ever renamed or deleted, add a redirect for its old path there.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,4 +50,4 @@ publishes `build/`. Pull requests get preview deployments automatically.
 
 Docs are single-version: pages go live when they land on `master`. When
 documenting a feature that has not shipped in a plugin release yet, add an
-"Introduced in vX.Y.Z" note at the section (see AGENTS.md).
+`_Introduced in QuickAdd X.Y.Z._` line at the section (see AGENTS.md).

--- a/docs/functions/mcp.ts
+++ b/docs/functions/mcp.ts
@@ -34,7 +34,7 @@ interface JsonRpcRequest {
 }
 
 const PROTOCOL_VERSION = "2025-06-18";
-const SUPPORTED_VERSIONS = new Set(["2025-03-26", "2025-06-18"]);
+const SUPPORTED_VERSIONS = new Set(["2025-06-18"]);
 
 const TOOLS = [
 	{

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -68,6 +68,7 @@ const chatgptUrl = `https://chatgpt.com/?hints=search&q=${encodeURIComponent(pro
 			const label = button.querySelector("[data-label]");
 			try {
 				const res = await fetch(button.dataset.copyMarkdown ?? "");
+				if (!res.ok) throw new Error(String(res.status));
 				await navigator.clipboard.writeText(await res.text());
 				if (label) label.textContent = "Copied!";
 			} catch {


### PR DESCRIPTION
Addresses the three inline review comments on #1504 and #1505: the Copy Markdown button copied the error body when the fetch failed (now checks res.ok and reports failure); the MCP server advertised protocol 2025-03-26 while rejecting that version's batch framing (now advertises only 2025-06-18, which it fully implements); AGENTS.md/README annotation phrasing now matches the shipped `_Introduced in QuickAdd X.Y.Z._` format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the wording used for unreleased feature notes in the docs.
  * Aligned the deployment guide with the new “Introduced in QuickAdd X.Y.Z.” format.

* **Bug Fixes**
  * Improved the “Copy Markdown” action so failed requests now show a clear failure message instead of trying to copy invalid content.
  * Updated protocol compatibility so unsupported older clients are rejected more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->