### PR TITLE
docs: consolidate duplicated reference material

### DIFF
--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -121,6 +121,10 @@ Add `ui` to allow interactive prompts:
 obsidian vault=dev quickadd choice="Daily log" ui
 ```
 
+In a [scheduled job](/docs/Advanced/TriggerQuickAddFromOutsideObsidian/#run-quickadd-on-a-schedule),
+only add `ui` when the job runs while you are logged in and able to answer the
+prompts.
+
 ## Answer run-time prompts from outside: `quickadd:interactive` {#interactive-runs-quickaddinteractive}
 
 Some choices prompt at *run time* for inputs that can't be gathered up front -

--- a/docs/src/content/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/src/content/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -29,36 +29,17 @@ obsidian vault="My Vault" quickadd:list
 
 ## Build the link {#native-uri-syntax}
 
-Use this shape:
-
-```text
-obsidian://quickadd?choice=<encoded choice name>[&value-<name>=<encoded value>]
-```
-
-For example:
+Every recipe below opens the same link shape - the choice to run, plus a
+`value-<name>` parameter for each named value you want to pass (everything
+URL-encoded):
 
 ```text
 obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-entry=Finished%20review
 ```
 
-The parts are:
-
-- `choice` - the exact choice name to run. Encode spaces and special characters, so `Daily log` becomes `Daily%20log`.
-- `value-<name>` - sets a named QuickAdd value. `value-entry=Done` fills `{{VALUE:entry}}`; `value-log%20notes=Done` fills `{{VALUE:log notes}}`.
-- `vault` - which vault to use. Obsidian handles this before QuickAdd sees the link.
-
-Values are used exactly as passed. If a choice should ignore an accidental
-leading or trailing space for a value, add `|trim` to the format, for example
-`{{VALUE:entry|trim}}`.
-
-Unnamed values like a bare `{{VALUE}}`, `{{NAME}}`, or `{{MVALUE}}` cannot be
-filled from the link. QuickAdd prompts for them inside Obsidian as usual.
-
-:::tip
-For the full link reference, including callback links like `x-success` and
-`x-error`, see [Open QuickAdd from a URI](/docs/Advanced/ObsidianUri/). Callback
-support is opt-in and has extra restrictions that ordinary triggers do not need.
-:::
+The full link reference - the parameter breakdown, passing values, `|trim`,
+which placeholders can't be filled from a link, and the opt-in callback links
+like `x-success` - is on [Open QuickAdd from a URI](/docs/Advanced/ObsidianUri/).
 
 ## Trigger from a desktop shortcut {#desktop-shortcuts}
 
@@ -115,30 +96,18 @@ Terminal=false
 ## Run QuickAdd on a schedule {#run-quickadd-on-a-schedule}
 
 QuickAdd has no built-in background scheduler. Use your operating system's
-scheduler to run Obsidian's native CLI command.
-
-Scheduled jobs should use `quickadd:run`:
+scheduler to run Obsidian's native CLI command:
 
 ```bash
 obsidian vault="My Vault" quickadd:run choice="Daily log" value-entry="Scheduled check"
 ```
 
-By default, `quickadd:run` is non-interactive. If the choice is missing a
-required input, QuickAdd returns JSON with `missingFlags` instead of opening
-prompts. Run `quickadd:check` while building the automation to see what still
-needs to be passed. See [QuickAdd CLI](/docs/Advanced/CLI/) for the full command
-reference.
-
-```bash
-obsidian vault="My Vault" quickadd:check choice="Daily log"
-```
-
-If you intentionally want Obsidian to prompt, add `ui` - but only for jobs that
-run while you are logged in and able to answer:
-
-```bash
-obsidian vault="My Vault" quickadd:run choice="Daily log" ui
-```
+`quickadd:run` is non-interactive by default - a choice that still needs input
+returns JSON with `missingFlags` instead of opening prompts, and
+`quickadd:check` tells you up front what to pass. Those semantics, the `ui`
+flag for runs that may prompt, and the rest of the commands are covered in the
+[QuickAdd CLI reference](/docs/Advanced/CLI/); this section is about wiring the
+command into each platform's scheduler.
 
 :::caution
 Use full paths in schedulers. They usually do not load the same `PATH` as your

--- a/docs/src/content/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
+++ b/docs/src/content/docs/docs/Advanced/TriggerQuickAddFromOutsideObsidian.md
@@ -29,9 +29,10 @@ obsidian vault="My Vault" quickadd:list
 
 ## Build the link {#native-uri-syntax}
 
-Every recipe below opens the same link shape - the choice to run, plus a
-`value-<name>` parameter for each named value you want to pass (everything
-URL-encoded):
+The shortcut and in-note recipes below all open the same link shape - the
+`vault` to run in, the `choice` to run, plus a `value-<name>` parameter for
+each named value you want to pass (everything URL-encoded). Scheduled jobs use
+the [CLI](#run-quickadd-on-a-schedule) instead of a link.
 
 ```text
 obsidian://quickadd?vault=My%20Vault&choice=Daily%20log&value-entry=Finished%20review

--- a/docs/src/content/docs/docs/Choices/MacroChoice.md
+++ b/docs/src/content/docs/docs/Choices/MacroChoice.md
@@ -200,6 +200,8 @@ file or in a ` ```js ` code block inside a note. Scripts have access to:
 - The QuickAdd API
 - A `variables` object for passing data between commands
 
+<a id="basic-script-structure"></a>
+
 The basic shape is an exported async function - QuickAdd calls it with a
 `params` object that carries everything you need:
 
@@ -216,10 +218,10 @@ module.exports = async (params) => {
 };
 ```
 
-<a id="basic-script-structure"></a>
 <a id="using-the-quickadd-api"></a>
 <a id="getting-the-current-selection"></a>
 <a id="accessing-other-plugins"></a>
+<a id="exporting-multiple-functions"></a>
 
 Everything else about writing scripts lives in the
 [User Scripts reference](/docs/UserScripts/):
@@ -242,7 +244,6 @@ variables, and the `executeChoice` boundary - see
 [Variables and data flow](/docs/VariablesDataFlow/).
 
 <a id="advanced-script-patterns"></a>
-<a id="exporting-multiple-functions"></a>
 
 ## Run one export directly: `Macro::member` {#direct-function-access}
 

--- a/docs/src/content/docs/docs/Choices/MacroChoice.md
+++ b/docs/src/content/docs/docs/Choices/MacroChoice.md
@@ -113,7 +113,7 @@ whose name starts with a dot. Obsidian may exclude hidden folders from its file
 index, and QuickAdd builds the picker from Obsidian's indexed files, so a hidden
 script never shows up. Use a normal folder such as `scripts/`, or a visible
 underscore-prefixed folder such as `_quickadd/scripts/`. Full rules are in
-[User scripts](#user-scripts).
+[User Scripts](/docs/UserScripts/#adding-scripts-to-macros).
 :::
 
 Good to know:
@@ -200,36 +200,8 @@ file or in a ` ```js ` code block inside a note. Scripts have access to:
 - The QuickAdd API
 - A `variables` object for passing data between commands
 
-:::caution[Where scripts can live]
-A user script (a `.js` file, or a note with a ` ```js ` block) must sit inside
-your Obsidian vault, but **not** in the `.obsidian` directory or in any hidden
-folder (one whose name starts with a dot).
-
-✅ **Valid locations:**
-
-- `/scripts/myScript.js`
-- `/_quickadd/scripts/myScript.js`
-- `/macros/utilities/helper.js`
-- `/my-custom-folder/script.js`
-- Any folder in your vault except `.obsidian` or a hidden folder
-
-❌ **Invalid locations:**
-
-- `/.obsidian/plugins/quickadd/scripts/myScript.js`
-- `/.obsidian/scripts/myScript.js`
-- `/.quickadd/scripts/myScript.js` (hidden folder - use `_quickadd` instead)
-- `/.scripts/myScript.js` (hidden folder - use `_scripts` instead)
-- Any path within the `.obsidian` directory
-- Any path within a folder starting with a dot (.)
-
-Scripts in the `.obsidian` directory or in hidden folders are intentionally
-ignored and won't appear in the script picker.
-:::
-
-### The basic script shape {#basic-script-structure}
-
-Export an async function. QuickAdd calls it with a `params` object that carries
-everything you need.
+The basic shape is an exported async function - QuickAdd calls it with a
+`params` object that carries everything you need:
 
 ```javascript
 module.exports = async (params) => {
@@ -244,75 +216,20 @@ module.exports = async (params) => {
 };
 ```
 
-### Prompt the user: the QuickAdd API {#using-the-quickadd-api}
+<a id="basic-script-structure"></a>
+<a id="using-the-quickadd-api"></a>
+<a id="getting-the-current-selection"></a>
+<a id="accessing-other-plugins"></a>
 
-`quickAddApi` gives you ready-made prompts so you don't have to build UI:
+Everything else about writing scripts lives in the
+[User Scripts reference](/docs/UserScripts/):
 
-```javascript
-module.exports = async (params) => {
-    const { quickAddApi } = params;
-
-    // Input prompt - get text from user
-    const name = await quickAddApi.inputPrompt("Enter your name:");
-
-    // Yes/No prompt
-    const confirmed = await quickAddApi.yesNoPrompt("Are you sure?");
-
-    // Suggester - let user choose from options
-    const choice = await quickAddApi.suggester(
-        ["Option 1", "Option 2", "Option 3"],  // Display values
-        ["value1", "value2", "value3"]         // Actual values
-    );
-
-    // Wide input prompt - for longer text
-    const longText = await quickAddApi.wideInputPrompt("Enter description:");
-
-    // Checkbox prompt - multiple selections
-    const selections = await quickAddApi.checkboxPrompt(
-        ["Task 1", "Task 2", "Task 3"]
-    );
-};
-```
-
-For the full list of methods, see the [QuickAdd API](/docs/QuickAddAPI/).
-
-### Read the editor selection {#getting-the-current-selection}
-
-Use the utility helper to read whatever text is selected in the active editor.
-It returns an empty string when nothing is selected or no editor is active.
-
-```javascript
-module.exports = async (params) => {
-    const selection = params.quickAddApi.utility.getSelection();
-    if (selection) {
-        params.variables.selectedText = selection;
-    }
-};
-```
-
-### Reach into other plugins {#accessing-other-plugins}
-
-A script can talk to other Obsidian plugins through `app.plugins.plugins`. Check
-that the plugin is there before using it:
-
-```javascript
-module.exports = async (params) => {
-    const { app } = params;
-
-    // Access Templater
-    const templater = app.plugins.plugins["templater-obsidian"];
-    if (templater) {
-        // Use Templater API
-    }
-
-    // Access MetaEdit
-    const metaedit = app.plugins.plugins["metaedit"];
-    if (metaedit) {
-        const { update } = metaedit.api;
-        await update("property", "value", "path/to/file.md");
-    }
-};
-```
+- [Where a script can live](/docs/UserScripts/#adding-scripts-to-macros) - `.js` file or note code block, and which folders QuickAdd's picker can see.
+- [Prompt the user](/docs/UserScripts/#user-input) - input prompts, suggesters, yes/no, and checkbox prompts via `quickAddApi`; the full method list is in the [QuickAdd API](/docs/QuickAddAPI/).
+- [Read the editor selection](/docs/QuickAddAPI/#getselection-string) - `quickAddApi.utility.getSelection()`.
+- [Reach into other plugins](/docs/UserScripts/#accessing-other-plugins) - talk to Templater, MetaEdit, or any plugin through `app.plugins.plugins`.
+- [Offer several actions from one script](/docs/UserScripts/#multiple-entry-points) - export more than one function and pick at run time.
+- [Configurable settings](/docs/UserScripts/#configurable-options), [error handling and `abort()`](/docs/UserScripts/#error-handling-and-macro-control), and a shelf of [copy-paste recipes](/docs/UserScripts/#common-patterns--recipes).
 
 ## Pass data between commands: variables {#variables-and-data-flow}
 
@@ -324,46 +241,14 @@ For the full rules - named `VALUE` prompts, empty values, AI Assistant output
 variables, and the `executeChoice` boundary - see
 [Variables and data flow](/docs/VariablesDataFlow/).
 
-## Advanced script patterns {#advanced-script-patterns}
+<a id="advanced-script-patterns"></a>
+<a id="exporting-multiple-functions"></a>
 
-### Offer several actions from one script {#exporting-multiple-functions}
+## Run one export directly: `Macro::member` {#direct-function-access}
 
-A script can export more than one function, so one file offers a menu of
-actions:
-
-```javascript
-module.exports = {
-    option1: async (params) => {
-        console.log("Running option 1");
-    },
-
-    option2: async (params) => {
-        console.log("Running option 2");
-    },
-
-    // Can also include variables
-    defaultValue: "some default",
-
-    // Main entry point
-    start: async (params) => {
-        const { quickAddApi } = params;
-        const choice = await quickAddApi.suggester(
-            ["Run Option 1", "Run Option 2"],
-            ["option1", "option2"]
-        );
-
-        if (choice === "option1") {
-            await module.exports.option1(params);
-        } else if (choice === "option2") {
-            await module.exports.option2(params);
-        }
-    }
-};
-```
-
-### Run one export directly: `Macro::member` {#direct-function-access}
-
-You can skip the "which export?" prompt by naming the function:
+When a script [exports several functions](/docs/UserScripts/#multiple-entry-points),
+QuickAdd normally asks which one to run. You can skip that prompt by naming the
+function:
 
 - `{{MACRO:MyMacro::option1}}` runs `option1` directly.
 - `{{MACRO:MyMacro::start}}` runs the `start` function.

--- a/docs/src/content/docs/docs/TemplatePropertyTypes.md
+++ b/docs/src/content/docs/docs/TemplatePropertyTypes.md
@@ -168,14 +168,15 @@ This means you can safely type natural prose like `Hello, world` into a
 formatted array.
 
 <a id="complex-nested-structures"></a>
+<a id="project-management"></a>
 
 Nesting goes as deep as you need: objects inside objects, arrays inside
-objects, arrays **of** objects (`tasks: [{ name: "Research", complete: true }]`
-becomes a list of mappings), and `null` leaves all serialize the same way. The
-worked example below shows a nested structure end to end.
+objects, arrays **of** objects (a project's
+`tasks: [{ name: "Research", complete: true }]` becomes a list of mappings),
+and `null` leaves all serialize the same way. The worked example below shows a
+nested structure end to end.
 
 <a id="real-world-examples"></a>
-<a id="project-management"></a>
 
 ## A worked example: academic papers {#academic-papers}
 

--- a/docs/src/content/docs/docs/TemplatePropertyTypes.md
+++ b/docs/src/content/docs/docs/TemplatePropertyTypes.md
@@ -167,50 +167,19 @@ This means you can safely type natural prose like `Hello, world` into a
 `sources` marked as a multi-value property will still receive a properly
 formatted array.
 
-### Deeply nested data works too {#complex-nested-structures}
+<a id="complex-nested-structures"></a>
 
-The feature supports deeply nested structures:
+Nesting goes as deep as you need: objects inside objects, arrays inside
+objects, arrays **of** objects (`tasks: [{ name: "Research", complete: true }]`
+becomes a list of mappings), and `null` leaves all serialize the same way. The
+worked example below shows a nested structure end to end.
 
-```javascript
-QuickAdd.variables.paper = {
-    title: "Advanced Research",
-    authors: ["Alice", "Bob"],
-    metadata: {
-        year: 2023,
-        conference: "ICML",
-        tags: ["ML", "AI"],
-        metrics: {
-            pages: 12,
-            citations: null
-        }
-    },
-    reviewed: true
-};
-```
+<a id="real-world-examples"></a>
+<a id="project-management"></a>
 
-Results in:
+## A worked example: academic papers {#academic-papers}
 
-```yaml
-paper:
-  title: Advanced Research
-  authors:
-    - Alice
-    - Bob
-  metadata:
-    year: 2023
-    conference: ICML
-    tags:
-      - ML
-      - AI
-    metrics:
-      pages: 12
-      citations: null
-  reviewed: true
-```
-
-## Real-world examples {#real-world-examples}
-
-### Academic papers {#academic-papers}
+One structure from a script, through a template, into typed front matter.
 
 **Script:**
 ```javascript
@@ -272,44 +241,6 @@ metrics:
 
 ## Summary
 Paper by Ashish Vaswani,Noam Shazeer,Niki Parmar published in NIPS (2017).
-```
-
-### Project management {#project-management}
-
-**Script:**
-```javascript
-QuickAdd.variables.project = {
-    name: "Website Redesign",
-    status: "in-progress",
-    team: ["Alice", "Bob", "Carol"],
-    priority: 3,
-    tasks: [
-        { name: "Research", complete: true },
-        { name: "Design", complete: false },
-        { name: "Development", complete: false }
-    ],
-    deadline: "2023-12-01"
-};
-```
-
-**Result:**
-```yaml
-project:
-  name: Website Redesign
-  status: in-progress
-  team:
-    - Alice
-    - Bob
-    - Carol
-  priority: 3
-  tasks:
-    - name: Research
-      complete: true
-    - name: Design
-      complete: false
-    - name: Development
-      complete: false
-  deadline: "2023-12-01"
 ```
 
 ## Captures and fresh templates {#captures--fresh-templates}

--- a/docs/src/content/docs/docs/UserScripts.md
+++ b/docs/src/content/docs/docs/UserScripts.md
@@ -40,8 +40,30 @@ A user script can live in either of two places inside your vault:
 
 The note form is handy on mobile, where Obsidian can't open `.js` files at all.
 
-Avoid `.obsidian` and hidden dot-folders such as `.scripts`, because Obsidian
-may exclude them from the vault file index QuickAdd uses for script discovery.
+:::caution[Where scripts can live]
+A user script must sit inside your Obsidian vault, but **not** in the
+`.obsidian` directory or in any hidden folder (one whose name starts with a
+dot). Obsidian may exclude those from the vault file index QuickAdd uses for
+script discovery, so a script there is intentionally ignored and won't appear
+in the script picker.
+
+✅ **Valid locations:**
+
+- `/scripts/myScript.js`
+- `/_quickadd/scripts/myScript.js`
+- `/macros/utilities/helper.js`
+- `/my-custom-folder/script.js`
+- Any folder in your vault except `.obsidian` or a hidden folder
+
+❌ **Invalid locations:**
+
+- `/.obsidian/plugins/quickadd/scripts/myScript.js`
+- `/.obsidian/scripts/myScript.js`
+- `/.quickadd/scripts/myScript.js` (hidden folder - use `_quickadd` instead)
+- `/.scripts/myScript.js` (hidden folder - use `_scripts` instead)
+- Any path within the `.obsidian` directory
+- Any path within a folder starting with a dot (.)
+:::
 
 In the Macro Builder, **Browse** opens QuickAdd's picker of discovered scripts
 (both `.js` files and notes that contain a code block); it is not a native file
@@ -375,6 +397,33 @@ await quickAddApi.executeChoice("My Other Choice", {
     customVariable: "value"
 });
 ```
+
+### Reach into other plugins {#accessing-other-plugins}
+
+A script can talk to other Obsidian plugins through `app.plugins.plugins`. Check
+that the plugin is there before using it:
+
+```javascript
+module.exports = async (params) => {
+    const { app } = params;
+
+    // Access Templater
+    const templater = app.plugins.plugins["templater-obsidian"];
+    if (templater) {
+        // Use Templater API
+    }
+
+    // Access MetaEdit
+    const metaedit = app.plugins.plugins["metaedit"];
+    if (metaedit) {
+        const { update } = metaedit.api;
+        await update("property", "value", "path/to/file.md");
+    }
+};
+```
+
+The plugin must be installed and enabled in the vault, so check for it and fail
+with a clear message when it's missing.
 
 ## Handle errors and stop a macro {#error-handling-and-macro-control}
 

--- a/docs/src/content/docs/docs/UserScripts.md
+++ b/docs/src/content/docs/docs/UserScripts.md
@@ -643,7 +643,9 @@ another way:
 
 ### Offer several actions from one script {#multiple-entry-points}
 
-Export an object with multiple functions that users can choose from:
+Export an object with multiple functions that users can choose from. The object
+can also carry plain values (a default or shared constant) alongside the
+functions:
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
Follow-up to #1509, addressing the pre-existing structural overlap that PR's review flagged and deliberately deferred: three places where one page restated another page's reference material, so readers found competing, drift-prone copies.

## What changed

- **MacroChoice no longer doubles as a second User Scripts page.** Its scripting reference collapses to the basic script shape plus a linked hub into the User Scripts reference; `Macro::member` resolution (macro-specific) stays in full. Facts that existed only on MacroChoice moved rather than vanished: the detailed valid/invalid script-location list and the reach-into-other-plugins recipe now live in UserScripts, and the multi-export section there now states that an exported object may carry plain values alongside functions.
- **The outside-Obsidian trigger page is a recipes page again.** Its restated URI grammar and CLI flag semantics shrink to pointers at the URI and CLI references; the platform recipes that exist nowhere else (macOS launchd, Windows Task Scheduler and Obsidian.com, Linux cron/.desktop escaping) are untouched. The ui-only-when-logged-in caveat moves to the CLI page, where `ui` is documented.
- **TemplatePropertyTypes demonstrates the conversion twice, not four times.** The walkthrough stays; the standalone nested-data section becomes a short note (keeping the arrays-of-objects fact); one end-to-end worked example remains and the second (project management) is folded into the note.

Net: -160 lines of duplication, zero facts lost.

## Anchor safety

Every removed heading id survives as an invisible alias anchor, placed at the closest surviving content (an adversarial review pass caught three aliases that initially landed below or away from what they name - fixed). Sitewide link+anchor validation over the built output passes; the plugin-source-linked `MacroChoice#user-scripts` remains a real heading.

## Review notes

An independent Codex skeptic pass verified fact-by-fact that each removed block's content still exists somewhere; its only findings were the three alias placements, fixed in the second commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified scheduling behavior for `quickadd`/`quickadd:run`, including when the `ui` option is appropriate.
  * Simplified and standardized `obsidian://quickadd` link construction, with guidance to use the CLI for scheduled jobs.
  * Improved User Scripts documentation with clearer valid script locations, examples for accessing other plugin APIs, and support for multiple exported actions.
  * Updated Macro Choice and Template Property Types docs with improved structure and a worked example for nested template properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->