### PR TITLE
chore(e2e): adopt shared e2e fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jsdom": "29",
     "moment": "2.30.1",
     "obsidian": "1.13.1",
-    "obsidian-e2e": "^0.7.0",
+    "obsidian-e2e": "^0.8.1",
     "semantic-release": "^25.0.5",
     "svelte": "^5",
     "svelte-check": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: 1.13.1
         version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       obsidian-e2e:
-        specifier: ^0.7.0
-        version: 0.7.0(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@29.1.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0))
+        specifier: ^0.8.1
+        version: 0.8.1(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@29.1.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.10)
       semantic-release:
         specifier: ^25.0.5
         version: 25.0.5(typescript@6.0.3)
@@ -2513,12 +2513,16 @@ packages:
   obsidian-dataview@0.5.68:
     resolution: {integrity: sha512-eoYVxqgeAUM64fV6/YXWuXvmm9DaVoR1h/O+vBIHS0yQ+n9x5MaVndD3WjcVWuaJmrMM9iwvutkbZ0aCWpLmHw==}
 
-  obsidian-e2e@0.7.0:
-    resolution: {integrity: sha512-qbYMFRU9UgbOhH8OPwnX+gCR55IvLTmrWxyUlTFH52wfTknCtaj28/t2s3aHux10byvh61ElBH04cKqfvbReyA==}
+  obsidian-e2e@0.8.1:
+    resolution: {integrity: sha512-tcIjZtGxeI5wkOMGAlSWRyEfxIG/nN9834gWgb3l92R41h0fTre8wG05KUamFkk0Lj2I1ibfN+njOIjo2WCftQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       vite-plus: ^0.1.11
+      vitest: '>=3'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   obsidian@1.13.1:
     resolution: {integrity: sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==}
@@ -5537,10 +5541,12 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  obsidian-e2e@0.7.0(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@29.1.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0)):
+  obsidian-e2e@0.8.1(vite-plus@0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@29.1.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.10):
     dependencies:
       vite-plus: 0.1.24(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@29.1.1)(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@6.0.3)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0)
       yaml: 2.9.0
+    optionalDependencies:
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))
 
   obsidian@1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6):
     dependencies:

--- a/tests/e2e/apply-template-to-active-note.test.ts
+++ b/tests/e2e/apply-template-to-active-note.test.ts
@@ -1,42 +1,25 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import {
-	captureFailureArtifacts,
-	clearVaultRunLockMarker,
-	createSandboxApi,
-} from "obsidian-e2e";
-import type {
-	ObsidianClient,
-	PluginHandle,
-	SandboxApi,
-	VaultRunLock,
-} from "obsidian-e2e";
-import {
-	acquireQuickAddVaultRunLock,
-	createQuickAddObsidianClient,
-} from "./e2eVault";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { ObsidianClient, SandboxApi } from "obsidian-e2e";
+import { createQuickAddE2EHarness, PLUGIN_ID } from "./e2eVault";
 
 // ---------------------------------------------------------------------------
 // Constants & types
 // ---------------------------------------------------------------------------
 
-const PLUGIN_ID = "quickadd";
 const TPL_CONTENT = "APPLIED_TEMPLATE_CONTENT";
 const TPL_FM = "---\nstatus: draft\npriority: high\n---\nTPL_BODY";
 const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
 
-let obsidian: ObsidianClient;
-let sandbox: SandboxApi;
-let qa: PluginHandle;
-let lock: VaultRunLock | undefined;
-
 type ApplyResult = { ok: boolean; path?: string | null; error?: string };
+
+const getContext = createQuickAddE2EHarness("apply-template");
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /** Write a file into the sandbox and wait for Obsidian to index it. */
-async function seedFile(name: string, content: string) {
+async function seedFile(sandbox: SandboxApi, name: string, content: string) {
 	await sandbox.write(name, content, {
 		waitForContent: true,
 		waitOptions: WAIT_OPTS,
@@ -45,10 +28,13 @@ async function seedFile(name: string, content: string) {
 
 /**
  * Opens the note in the active leaf, then calls the public API seam
- * `applyTemplateToActiveFile`. Results land in a window global which we poll
- * for, since dev.eval does not reliably await long async bodies.
+ * `applyTemplateToActiveFile`. Results land in a window global we poll for rather
+ * than reading `evalJsonAsync`'s return: template application emits `QuickAdd:`
+ * notices into the eval output channel that corrupt the JSON envelope, so the
+ * async work is decoupled from a clean, synchronous JSON read of the global.
  */
 async function applyTemplate(
+	obsidian: ObsidianClient,
 	notePath: string,
 	templatePath: string,
 	mode?: string,
@@ -102,50 +88,22 @@ function expectOrderedSubstrings(
 }
 
 // ---------------------------------------------------------------------------
-// Lifecycle
-// ---------------------------------------------------------------------------
-
-beforeAll(async () => {
-	obsidian = createQuickAddObsidianClient();
-	lock = await acquireQuickAddVaultRunLock(obsidian);
-	await lock.publishMarker(obsidian);
-
-	qa = obsidian.plugin(PLUGIN_ID);
-	sandbox = await createSandboxApi({
-		obsidian,
-		sandboxRoot: "__obsidian_e2e__",
-		testName: "apply-template",
-	});
-
-	await seedFile("tpl-plain.md", TPL_CONTENT);
-	await seedFile("tpl-fm.md", TPL_FM);
-}, 30_000);
-
-afterAll(async () => {
-	await sandbox.cleanup();
-	await clearVaultRunLockMarker(obsidian).catch(() => {});
-	await lock?.release();
-}, 15_000);
-
-beforeEach((ctx) => {
-	ctx.onTestFailed(async () => {
-		await captureFailureArtifacts(
-			{ id: ctx.task.id, name: ctx.task.name },
-			obsidian,
-			{ plugin: qa, captureOnFailure: true },
-		);
-	});
-});
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("apply template to active note (API seam)", () => {
+	beforeAll(async () => {
+		const { sandbox } = getContext();
+		await seedFile(sandbox, "tpl-plain.md", TPL_CONTENT);
+		await seedFile(sandbox, "tpl-fm.md", TPL_FM);
+	});
+
 	it("A01: empty note fast path - applies template as full content", async () => {
-		await seedFile("a01-empty.md", "");
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "a01-empty.md", "");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a01-empty.md"),
 			sandbox.path("tpl-plain.md"),
 		);
@@ -160,9 +118,11 @@ describe("apply template to active note (API seam)", () => {
 	});
 
 	it("A02: bottom (default for non-empty notes) - appends after existing content", async () => {
-		await seedFile("a02-bottom.md", "EXISTING_CONTENT");
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "a02-bottom.md", "EXISTING_CONTENT");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a02-bottom.md"),
 			sandbox.path("tpl-plain.md"),
 		);
@@ -177,9 +137,11 @@ describe("apply template to active note (API seam)", () => {
 	});
 
 	it("A03: top - inserts before existing content", async () => {
-		await seedFile("a03-top.md", "EXISTING_CONTENT");
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "a03-top.md", "EXISTING_CONTENT");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a03-top.md"),
 			sandbox.path("tpl-plain.md"),
 			"top",
@@ -195,9 +157,11 @@ describe("apply template to active note (API seam)", () => {
 	});
 
 	it("A04: replace - replaces existing content", async () => {
-		await seedFile("a04-replace.md", "OLD_CONTENT_TO_REPLACE");
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "a04-replace.md", "OLD_CONTENT_TO_REPLACE");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a04-replace.md"),
 			sandbox.path("tpl-plain.md"),
 			"replace",
@@ -213,9 +177,11 @@ describe("apply template to active note (API seam)", () => {
 	});
 
 	it("A05: cursor - inserts via the active editor", async () => {
-		await seedFile("a05-cursor.md", "EXISTING_CONTENT");
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "a05-cursor.md", "EXISTING_CONTENT");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a05-cursor.md"),
 			sandbox.path("tpl-plain.md"),
 			"cursor",
@@ -231,12 +197,11 @@ describe("apply template to active note (API seam)", () => {
 	});
 
 	it("A06: top with frontmatter - merges template properties, existing values win", async () => {
-		await seedFile(
-			"a06-fm.md",
-			"---\nstatus: done\n---\nEXISTING_CONTENT",
-		);
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "a06-fm.md", "---\nstatus: done\n---\nEXISTING_CONTENT");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a06-fm.md"),
 			sandbox.path("tpl-fm.md"),
 			"top",
@@ -260,10 +225,12 @@ describe("apply template to active note (API seam)", () => {
 	});
 
 	it("A07: canvas template - rejects with a helpful error", async () => {
-		await seedFile("tpl-board.canvas", '{"nodes":[],"edges":[]}');
-		await seedFile("a07-canvas-tpl.md", "EXISTING_CONTENT");
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "tpl-board.canvas", '{"nodes":[],"edges":[]}');
+		await seedFile(sandbox, "a07-canvas-tpl.md", "EXISTING_CONTENT");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a07-canvas-tpl.md"),
 			sandbox.path("tpl-board.canvas"),
 		);
@@ -274,9 +241,11 @@ describe("apply template to active note (API seam)", () => {
 	});
 
 	it("A08: invalid mode - rejects with a helpful error", async () => {
-		await seedFile("a08-invalid.md", "EXISTING_CONTENT");
+		const { obsidian, sandbox } = getContext();
+		await seedFile(sandbox, "a08-invalid.md", "EXISTING_CONTENT");
 
 		const result = await applyTemplate(
+			obsidian,
 			sandbox.path("a08-invalid.md"),
 			sandbox.path("tpl-plain.md"),
 			"sideways",

--- a/tests/e2e/e2eVault.ts
+++ b/tests/e2e/e2eVault.ts
@@ -13,9 +13,8 @@ export const PLUGIN_ID = "quickadd";
 // legacy QUICKADD_E2E_* aliases remain a fallback during the migration. The
 // resolver injects the Obsidian HOME into a per-client `defaultExecOptions.env`
 // (never mutating `process.env`) and surfaces the expected vault path.
-const { expectedVaultPath, ...clientOptions } = resolveObsidianEnvOptions({
-	legacyPrefix: "QUICKADD",
-});
+const resolvedEnv = resolveObsidianEnvOptions({ legacyPrefix: "QUICKADD" });
+const { expectedVaultPath, ...clientOptions } = resolvedEnv;
 
 export const E2E_VAULT = clientOptions.vault;
 export const E2E_VAULT_EXPECTED_PATH = expectedVaultPath;
@@ -52,7 +51,7 @@ export async function acquireQuickAddVaultRunLock(
  * back after every test.
  */
 export const createQuickAddE2EHarness = createPluginHarness({
-	...resolveObsidianEnvOptions({ legacyPrefix: "QUICKADD" }),
+	...resolvedEnv,
 	pluginId: PLUGIN_ID,
 	// QuickAdd exposes its public API on the plugin instance once loaded
 	// (`app.plugins.plugins.quickadd.api`), the most precise ready signal - the

--- a/tests/e2e/e2eVault.ts
+++ b/tests/e2e/e2eVault.ts
@@ -1,63 +1,68 @@
-import path from "node:path";
 import {
 	acquireVaultRunLock,
 	createObsidianClient,
+	resolveObsidianEnvOptions,
+	verifyVaultPath,
 } from "obsidian-e2e";
-import type {
-	ObsidianClient,
-	VaultRunLock,
-} from "obsidian-e2e";
+import type { ObsidianClient, VaultRunLock } from "obsidian-e2e";
+import { createPluginHarness } from "obsidian-e2e/vitest";
 
-// Canonical OBSIDIAN_E2E_* names are emitted by the shared obsidian-e2e runner;
-// the legacy QUICKADD_E2E_* aliases remain a fallback during the migration.
-export const E2E_VAULT =
-	process.env.OBSIDIAN_E2E_VAULT ?? process.env.QUICKADD_E2E_VAULT ?? "dev";
-export const E2E_VAULT_EXPECTED_PATH =
-	process.env.OBSIDIAN_E2E_VAULT_PATH ?? process.env.QUICKADD_E2E_VAULT_PATH;
-export const E2E_OBSIDIAN_HOME =
-	process.env.OBSIDIAN_E2E_OBSIDIAN_HOME ??
-	process.env.QUICKADD_E2E_OBSIDIAN_HOME;
+export const PLUGIN_ID = "quickadd";
+
+// Canonical OBSIDIAN_E2E_* env is emitted by the shared obsidian-e2e runner; the
+// legacy QUICKADD_E2E_* aliases remain a fallback during the migration. The
+// resolver injects the Obsidian HOME into a per-client `defaultExecOptions.env`
+// (never mutating `process.env`) and surfaces the expected vault path.
+const { expectedVaultPath, ...clientOptions } = resolveObsidianEnvOptions({
+	legacyPrefix: "QUICKADD",
+});
+
+export const E2E_VAULT = clientOptions.vault;
+export const E2E_VAULT_EXPECTED_PATH = expectedVaultPath;
 
 export function createQuickAddObsidianClient(): ObsidianClient {
-	return createObsidianClient({
-		vault: E2E_VAULT,
-		...(E2E_OBSIDIAN_HOME && {
-			defaultExecOptions: {
-				env: {
-					...process.env,
-					HOME: E2E_OBSIDIAN_HOME,
-				},
-			},
-		}),
-	});
+	return createObsidianClient(clientOptions);
 }
 
 export async function verifyE2EVault(obsidian: ObsidianClient): Promise<string> {
 	await obsidian.verify();
-
-	const vaultPath = path.resolve(await obsidian.vaultPath());
-	if (E2E_VAULT_EXPECTED_PATH) {
-		const expectedPath = path.resolve(E2E_VAULT_EXPECTED_PATH);
-		if (vaultPath !== expectedPath) {
-			throw new Error(
-				[
-					`Obsidian CLI resolved E2E vault "${E2E_VAULT}" to ${vaultPath}.`,
-					`Expected ${expectedPath}.`,
-					"Refusing to run E2E tests against the wrong vault.",
-				].join(" "),
-			);
-		}
-	}
-
-	return vaultPath;
+	return verifyVaultPath({
+		actualVaultPath: await obsidian.vaultPath(),
+		expectedVaultPath: E2E_VAULT_EXPECTED_PATH,
+		vaultName: E2E_VAULT,
+	});
 }
 
 export async function acquireQuickAddVaultRunLock(
 	obsidian: ObsidianClient,
 ): Promise<VaultRunLock> {
 	const vaultPath = await verifyE2EVault(obsidian);
-	return acquireVaultRunLock({
-		vaultName: E2E_VAULT,
-		vaultPath,
-	});
+	return acquireVaultRunLock({ vaultName: E2E_VAULT, vaultPath });
 }
+
+/**
+ * Suite-scoped QuickAdd E2E harness on obsidian-e2e's shared
+ * `createPluginHarness`: one vault lock + sandbox + reload per file, per-test
+ * diagnostics reset and data restore, and failure-artifact capture. Returns the
+ * `(testName) => () => context` getter that yields `{ obsidian, plugin, sandbox }`.
+ *
+ * Only files without cross-test seeded plugin data adopt this - QuickAdd suites
+ * that seed choices in a `describe` `beforeAll` and assert them across several
+ * tests keep their bespoke per-file lifecycle, since the harness rolls data.json
+ * back after every test.
+ */
+export const createQuickAddE2EHarness = createPluginHarness({
+	...resolveObsidianEnvOptions({ legacyPrefix: "QUICKADD" }),
+	pluginId: PLUGIN_ID,
+	// QuickAdd exposes its public API on the plugin instance once loaded
+	// (`app.plugins.plugins.quickadd.api`), the most precise ready signal - the
+	// same seam other plugins integrate against.
+	waitUntilReady: (obsidian) =>
+		obsidian.dev.evalJson<boolean>(
+			`Boolean(app.plugins.plugins.${PLUGIN_ID}?.api)`,
+		),
+	// QuickAdd ships a hand-written styles.css alongside the compiled main.js, so
+	// the provisioned dev vault symlinks all three plugin artifacts.
+	symlinkArtifacts: ["main.js", "manifest.json", "styles.css"],
+	captureOnFailure: true,
+});

--- a/tests/e2e/locked-leaf-file-opening.test.ts
+++ b/tests/e2e/locked-leaf-file-opening.test.ts
@@ -30,8 +30,6 @@ type QuickAddData = {
 };
 
 type LayoutResult = {
-	ok?: boolean;
-	error?: string;
 	leftLeafId?: string;
 	leftParentId?: string | null;
 	leftPinned?: boolean;
@@ -98,69 +96,41 @@ async function seedFile(path: string, content: string) {
 	});
 }
 
-async function waitForEvalResult<T extends { ok?: boolean; error?: string }>(
-	globalName: string,
-): Promise<T> {
-	const result = await obsidian.waitFor(async () => {
-		const value = await obsidian.dev.evalJson<T | null>(
-			`window.${globalName} ?? null`,
-		);
-		return value?.ok || value?.error ? value : false;
-	}, WAIT_OPTS);
-
-	if (result.error) throw new Error(result.error);
-	return result;
-}
-
-function setupPinnedOriginLayoutCode({
+function pinnedOriginLayoutCode({
 	leftPath,
 	rightPath,
-	globalName,
 }: {
 	leftPath: string;
 	rightPath: string;
-	globalName: string;
 }) {
-	return `
-window.${globalName} = { ok: false };
-(async () => {
-	try {
-		const getFile = (path) => {
-			const file = app.vault.getAbstractFileByPath(path);
-			if (!file) throw new Error(\`Missing file: \${path}\`);
-			return file;
-		};
+	return `(async () => {
+	const getFile = (path) => {
+		const file = app.vault.getAbstractFileByPath(path);
+		if (!file) throw new Error(\`Missing file: \${path}\`);
+		return file;
+	};
 
-		const leftFile = getFile(${JSON.stringify(leftPath)});
-		const rightFile = getFile(${JSON.stringify(rightPath)});
+	const leftFile = getFile(${JSON.stringify(leftPath)});
+	const rightFile = getFile(${JSON.stringify(rightPath)});
 
-		const leftLeaf = app.workspace.getLeaf(false);
-		await leftLeaf.openFile(leftFile);
-		leftLeaf.setPinned(true);
-		app.workspace.setActiveLeaf(leftLeaf, { focus: true });
+	const leftLeaf = app.workspace.getLeaf(false);
+	await leftLeaf.openFile(leftFile);
+	leftLeaf.setPinned(true);
+	app.workspace.setActiveLeaf(leftLeaf, { focus: true });
 
-		const rightLeaf = app.workspace.getLeaf("split", "vertical");
-		await rightLeaf.openFile(rightFile);
-		rightLeaf.setPinned(false);
+	const rightLeaf = app.workspace.getLeaf("split", "vertical");
+	await rightLeaf.openFile(rightFile);
+	rightLeaf.setPinned(false);
 
-		app.workspace.setActiveLeaf(leftLeaf, { focus: true });
-		window.${globalName} = {
-			ok: true,
-			leftLeafId: leftLeaf.id ?? null,
-			leftParentId: leftLeaf.parent?.id ?? null,
-			leftPinned: !!leftLeaf.pinned || !!leftLeaf.getViewState?.()?.pinned,
-			rightLeafId: rightLeaf.id ?? null,
-			rightParentId: rightLeaf.parent?.id ?? null,
-		};
-	} catch (error) {
-		window.${globalName} = {
-			ok: false,
-			error: error instanceof Error ? error.message : String(error),
-		};
-	}
-})();
-"started";
-`;
+	app.workspace.setActiveLeaf(leftLeaf, { focus: true });
+	return {
+		leftLeafId: leftLeaf.id ?? null,
+		leftParentId: leftLeaf.parent?.id ?? null,
+		leftPinned: !!leftLeaf.pinned || !!leftLeaf.getViewState?.()?.pinned,
+		rightLeafId: rightLeaf.id ?? null,
+		rightParentId: rightLeaf.parent?.id ?? null,
+	};
+})()`;
 }
 
 function inspectOpenResultCode({
@@ -226,7 +196,6 @@ async function runOpenFileScenario(
 	const leftPath = sandbox.path(`${location}-left-locked.md`);
 	const rightPath = sandbox.path(`${location}-right-unlocked.md`);
 	const targetPath = sandbox.path(`${location}-target.md`);
-	const layoutGlobal = `__qa1165Layout_${location}`;
 
 	await seedFile(`${location}-left-locked.md`, `${location.toUpperCase()} LEFT`);
 	await seedFile(`${location}-right-unlocked.md`, `${location.toUpperCase()} RIGHT`);
@@ -238,10 +207,9 @@ async function runOpenFileScenario(
 	});
 	await qa.reload({ waitUntilReady: true });
 
-	await obsidian.dev.evalRaw(
-		setupPinnedOriginLayoutCode({ leftPath, rightPath, globalName: layoutGlobal }),
+	const layout = await obsidian.dev.evalJsonAsync<LayoutResult>(
+		pinnedOriginLayoutCode({ leftPath, rightPath }),
 	);
-	const layout = await waitForEvalResult<LayoutResult>(layoutGlobal);
 	expect(layout.leftLeafId).toBeTruthy();
 	expect(layout.leftPinned).toBe(true);
 	expect(layout.rightParentId).toBeTruthy();


### PR DESCRIPTION
## What

Rebuilds QuickAdd's E2E test-side plumbing on `obsidian-e2e@0.8.1`'s shared fixtures, removing the hand-rolled env resolution, vault-lock, and client wiring that each test file leaned on. QuickAdd is the last and shape-wise trickiest consumer (it never had a central harness factory), so the migration is a per-file decision rather than a blanket rewrite.

Follows the MetaEdit (#1511 runner, plus the harness adoption in chhoumann/MetaEdit#180) and PodNotes migrations.

## Per-file decision

| File | Decision | Why |
| --- | --- | --- |
| `e2eVault.ts` | Rebuilt on `resolveObsidianEnvOptions` + `verifyVaultPath` | Shared env resolution (canonical `OBSIDIAN_E2E_*` with legacy `QUICKADD_E2E_*` fallback, per-client HOME injection) and vault-path verification. Keeps its exported names so the per-file suites import unchanged. |
| `apply-template-to-active-note.test.ts` | Adopt `createPluginHarness`; **keep the poll** | Seeds no cross-test plugin data, so the suite-scoped lock + sandbox + reload with per-test data restore fits. The template-application helper keeps its window-global poll instead of `evalJsonAsync`: template application emits `QuickAdd:` notices into the eval channel that corrupt the JSON envelope (verified live - `evalJsonAsync` failed A01/A04 with `Unexpected token 'Q', "QuickAdd: "... is not valid JSON`). |
| `locked-leaf-file-opening.test.ts` | Env-resolver + migrate poll -> `evalJsonAsync` | Bespoke split-pane lifecycle (re-seeds data per test) stays. Its window-global layout poll migrates cleanly to `obsidian.dev.evalJsonAsync` - an async IIFE returning the layout result with no notice noise (passes live). |
| `conditional-branch-persistence.test.ts` | Env-resolver only | Single test, no sandbox, custom `closeAllModals` teardown, synchronous-eval GUI driving. Deviates from the suite shape; logic untouched. |
| `file-exists-behavior.test.ts` | Env-resolver only | Seeds 17 choices in a `describe` `beforeAll` and asserts them across 15+ tests. The harness rolls `data.json` back after every test, which would wipe the seed. |
| `macro-member-access.test.ts` | Env-resolver only | Same describe-level seed persisting across tests. |
| `scorecard-composed-flows.test.ts` | Env-resolver only | Same describe-level seed persisting across tests. |
| `template-property-links.test.ts` | Env-resolver only | Same describe-level seed persisting across tests. |

The six env-resolver-only suites need no source edits - they inherit the dedup through the rebuilt `e2eVault.ts` imports (`createQuickAddObsidianClient`, `acquireQuickAddVaultRunLock`).

## Line delta

`134 insertions(+), 186 deletions(-)` across the three touched test-side files (net -52); `e2eVault.ts` alone: +50 / -45.

## Gates

- `pnpm run build-with-lint` - green.
- `pnpm run test` (unit) - 3827 passed, 37 skipped.

## Live E2E vs baseline

Full suite via the shared runner (`start:e2e-obsidian` -> HOME remap -> `test:e2e`): **44/45**, matching the runner-migration baseline. The only failure is `conditional-branch-persistence.test.ts` (`cfg=false` - the settings GUI does not render the Configure button in time). Diagnosed, not waved through: it reproduces **identically on `master`** against the same built runtime (this PR makes no `src/` changes), confirming it is pre-existing and environmental, not a regression. `apply-template` (8/8) and `locked-leaf` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test stability by standardizing setup with a shared harness.
  * Refined template-application and file-opening test flows to use context-aware setup and cleaner data retrieval.
  * Updated layout-state handling in locked leaf scenarios for more reliable assertions.
  * Kept vault validation coverage while improving how test vault paths are resolved and verified.
* **Chores**
  * Upgraded the end-to-end testing toolkit dependency for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->