### PR TITLE
test(e2e): survive Obsidian 1.13 settings popout and modal DOM changes

### DIFF
--- a/tests/e2e/conditional-branch-persistence.test.ts
+++ b/tests/e2e/conditional-branch-persistence.test.ts
@@ -40,14 +40,16 @@ const clickLast=(sel)=>{const e=q(sel);if(!e.length)return 'missing '+sel;e[e.le
 // a synchronous click + immediate return transmits reliably. Sequencing is
 // handled by waitUi(): every step waits for the observable condition it needs
 // instead of guessing durations with sleeps.
-const sev = (body: string) =>
-	obsidian.dev.eval<string>(
+// Conditions return booleans (dev.eval JSON-parses results); clicks and
+// probes return strings - callers pick the type.
+const sev = <T = string>(body: string) =>
+	obsidian.dev.eval<T>(
 		`(() => { ${HELP} try { ${body} } catch(e){ return 'ERR '+String(e&&e.message||e); } })()`,
 	);
 
 /** Poll a HELP-scoped boolean expression inside the app until it holds. */
 const waitUi = (label: string, cond: string, timeoutMs = 15_000) =>
-	obsidian.waitFor(async () => (await sev(`return ${cond};`)) === true, {
+	obsidian.waitFor(async () => (await sev<boolean | string>(`return ${cond};`)) === true, {
 		message: label,
 		timeoutMs,
 	});

--- a/tests/e2e/conditional-branch-persistence.test.ts
+++ b/tests/e2e/conditional-branch-persistence.test.ts
@@ -16,30 +16,68 @@ let obsidian: ObsidianClient;
 let qa: PluginHandle;
 let lock: VaultRunLock | undefined;
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-const HELP = `const allBy=(l)=>Array.from(document.querySelectorAll('[aria-label="'+l+'"]')); const lastBy=(l)=>{const e=allBy(l);return e[e.length-1]||null;}; const byText=(t)=>Array.from(document.querySelectorAll('.modal-container button')).filter(b=>b.textContent.trim()===t);`;
-// Fast, synchronous evals only: dev.eval does not await long async bodies, but a
-// synchronous click + immediate return transmits reliably. Timing is orchestrated
-// here in Node (sleep between steps) so the app's async work settles.
+// Obsidian 1.13 opens Settings in a popout window by default
+// (settingsPopoutWindow), so the settings GUI may live in the main document
+// (modal mode / Obsidian <=1.12) OR in the popout window's document. All
+// queries go through `docs()`/`q()` so the test is window-agnostic and drives
+// whichever surface Obsidian actually rendered - the real user path.
+//
+// Modals are closed the way a user closes them: Escape, routed through
+// Obsidian's per-window keymap scope. Obsidian 1.13 removed the
+// `.modal-close-button` DOM affordance, which silently turned class-targeted
+// close clicks into no-ops; Escape is registered by Modal itself and survives
+// DOM redesigns. The KeyboardEvent is constructed in the target document's
+// realm so dispatch works in popout windows too.
+const HELP = `
+const docs=()=>{const ds=[document];const w=app.setting.popout&&app.setting.popout.win;if(w&&!w.closed)ds.push(w.document);return ds;};
+const q=(sel)=>docs().flatMap((d)=>Array.from(d.querySelectorAll(sel)));
+const lastBy=(l)=>{const e=q('[aria-label="'+l+'"]');return e[e.length-1]||null;};
+const btnByText=(t)=>q('.modal-container button').filter((b)=>b.textContent.trim()===t);
+const pressEscapeIn=(d)=>{const W=d.defaultView||window;d.body.dispatchEvent(new W.KeyboardEvent('keydown',{key:'Escape',code:'Escape',keyCode:27,which:27,bubbles:true}));};
+const clickLast=(sel)=>{const e=q(sel);if(!e.length)return 'missing '+sel;e[e.length-1].click();return 'ok';};
+`;
+// Fast, synchronous evals only: dev.eval does not await long async bodies, but
+// a synchronous click + immediate return transmits reliably. Sequencing is
+// handled by waitUi(): every step waits for the observable condition it needs
+// instead of guessing durations with sleeps.
 const sev = (body: string) =>
 	obsidian.dev.eval<string>(
 		`(() => { ${HELP} try { ${body} } catch(e){ return 'ERR '+String(e&&e.message||e); } })()`,
 	);
 
+/** Poll a HELP-scoped boolean expression inside the app until it holds. */
+const waitUi = (label: string, cond: string, timeoutMs = 15_000) =>
+	obsidian.waitFor(async () => (await sev(`return ${cond};`)) === true, {
+		message: label,
+		timeoutMs,
+	});
+
 async function closeAllModals() {
+	// Escape closes one modal per press, in every window; six rounds covers any
+	// stack this suite can produce (each sev round-trip paces the loop).
 	for (let i = 0; i < 6; i++) {
 		await sev(
-			`document.querySelectorAll('.modal-close-button').forEach(b=>b.click()); try{app.setting.close()}catch{} return '';`,
+			`docs().forEach((d)=>pressEscapeIn(d)); try{app.setting.close()}catch{} return '';`,
 		);
-		await sleep(150);
 	}
+	await waitUi("all modals closed", `q('.modal-container').length === 0`);
 }
 
 beforeAll(async () => {
 	obsidian = createQuickAddObsidianClient();
 	lock = await acquireQuickAddVaultRunLock(obsidian);
 	await lock.publishMarker(obsidian);
+	// Obsidian 1.13 defaults settingsPopoutWindow=true (Settings opens in a
+	// popout window). The popout's DOM adoption is nondeterministic under
+	// unfocused CLI automation: across clean runs the settings tree sometimes
+	// attaches to the popout document and sometimes stays detached from every
+	// document forever (see #1518) - an Obsidian-internal race this testbed
+	// cannot fix. Pin the supported main-window modal mode for determinism;
+	// the helpers above stay window-agnostic, so if a runner-side fix ever
+	// makes popouts reliable, deleting this line is the whole migration.
+	await obsidian.dev.eval(
+		`app.vault.setConfig('settingsPopoutWindow', false)`,
+	);
 	qa = obsidian.plugin(PLUGIN_ID);
 	await qa.reload({ waitUntilReady: true });
 }, 30_000);
@@ -83,44 +121,60 @@ describe("conditional command branch persistence (regression for the runes rewri
 		await closeAllModals();
 
 		// Drive the real settings GUI: configure the macro -> edit Then branch ->
-		// add a Wait command -> Save -> close the macro builder.
+		// add a Wait command -> Save -> close the macro builder. Each click waits
+		// for its target first, so the popout's async materialization is covered.
 		await sev(`app.setting.open(); return '';`);
-		await sleep(600);
+		await waitUi(
+			"settings UI rendered (main window or popout)",
+			`q('.vertical-tab-content, .setting-item').length > 0`,
+		);
 		await sev(`app.setting.openTabById('${PLUGIN_ID}'); return '';`);
-		await sleep(1500);
+		await waitUi(
+			"QuickAdd tab shows the seeded choice",
+			`!!lastBy('Configure QA-E2E Conditional')`,
+		);
+		expect(await sev(`return clickLast('[aria-label="Configure QA-E2E Conditional"]');`)).toBe("ok");
 
-		const cfg = await sev(`const c=lastBy('Configure QA-E2E Conditional'); c&&c.click(); return 'cfg='+!!c;`);
-		expect(cfg).toBe("cfg=true");
-		await sleep(1500);
-
-		// Match by aria-label PREFIX: the label now carries the condition-summary
+		// Match by aria-label PREFIX: the label carries the condition-summary
 		// suffix ("Edit then branch for <summary>"), so an exact match would miss.
-		const then = await sev(`const els=Array.from(document.querySelectorAll('[aria-label^="Edit then branch"]')); const t=els[els.length-1]; t&&t.click(); return 'then='+!!t;`);
-		expect(then).toBe("then=true");
-		await sleep(1500);
+		await waitUi(
+			"macro builder shows the conditional row",
+			`q('[aria-label^="Edit then branch"]').length > 0`,
+		);
+		expect(await sev(`return clickLast('[aria-label^="Edit then branch"]');`)).toBe("ok");
 
-		const wait = await sev(`const w=lastBy('Add wait command'); w&&w.click(); return 'wait='+!!w;`);
-		expect(wait).toBe("wait=true");
-		await sleep(800);
+		await waitUi("branch editor open", `!!lastBy('Add wait command')`);
+		expect(await sev(`return clickLast('[aria-label="Add wait command"]');`)).toBe("ok");
 
-		const saved = await sev(`const s=byText('Save'); s.length&&s[s.length-1].click(); return 'save='+s.length;`);
-		expect(saved).toBe("save=1");
-		await sleep(1200);
+		await waitUi("wait command staged", `btnByText('Save').length > 0`);
+		expect(await sev(`const s=btnByText('Save'); s[s.length-1].click(); return 'ok';`)).toBe("ok");
+		await waitUi("branch editor closed", `btnByText('Save').length === 0`);
 
-		await sev(`const x=Array.from(document.querySelectorAll('.modal-container .modal-close-button')); x.length&&x[x.length-1].click(); return '';`);
-		await sleep(1200);
-		await sev(`try{app.setting.close()}catch{} return '';`);
-		await sleep(500);
+		// Close the macro builder (Escape in its window). Its onClose resolves
+		// waitForClose, which is the ONLY path that commits the configured choice
+		// to the settings store and schedules the debounced disk save.
+		await sev(`const b=q('.macroBuilder')[0]; if(b) pressEscapeIn(b.ownerDocument); return '';`);
+		await waitUi("macro builder closed", `q('.macroBuilder').length === 0`);
 
-		// Assert the added command persisted to data.json on disk.
-		const onDiskThen = await obsidian.dev.eval<number>(`(async () => {
-			const p=app.plugins.plugins.quickadd;
-			const raw=await p.app.vault.adapter.read(p.manifest.dir+'/data.json');
-			const ch=JSON.parse(raw).choices.find(c=>c.id==='${CHOICE_ID}');
-			const cond=ch&&ch.macro.commands.find(c=>c.id==='${COND_ID}');
-			return cond ? cond.thenCommands.length : -1;
-		})()`);
-
+		// Assert the added command persisted to data.json on disk. Poll: the
+		// settings store flushes through a 1s debounce after the builder closes.
+		// Settings stays open until this lands so the assertion observes the
+		// debounced save before any teardown runs.
+		const onDiskThen = await obsidian.waitFor(
+			async () => {
+				const len = await obsidian.dev.eval<number>(`(async () => {
+					const p=app.plugins.plugins.quickadd;
+					const raw=await p.app.vault.adapter.read(p.manifest.dir+'/data.json');
+					const ch=JSON.parse(raw).choices.find(c=>c.id==='${CHOICE_ID}');
+					const cond=ch&&ch.macro.commands.find(c=>c.id==='${COND_ID}');
+					return cond ? cond.thenCommands.length : -1;
+				})()`);
+				return len === 1 ? len : false;
+			},
+			{ message: "then-branch command persisted to data.json", timeoutMs: 10_000 },
+		);
 		expect(onDiskThen).toBe(1);
+
+		await sev(`try{app.setting.close()}catch{} return '';`);
 	}, 60_000);
 });


### PR DESCRIPTION
Repairs the conditional-branch-persistence e2e flow against Obsidian 1.13, which broke two of its GUI-automation assumptions (full diagnosis in #1518):

1. **Settings popout default.** 1.13 opens Settings in a popout window (`settingsPopoutWindow` defaults on), so the test's main-document selectors found zero rows and the flow died at the first click.
2. **`.modal-close-button` removed.** Every close click (including `closeAllModals`) became a silent no-op, so the macro builder never closed; `ChoiceView.handleConfigureChoice` - the only path that commits the configured choice and schedules the debounced disk save - never ran.

What changed:

- **Window-agnostic queries**: all lookups go through a `docs()`/`q()` helper spanning the main document and the settings popout document, so the test drives whichever surface Obsidian rendered (works on 1.12 modal mode and 1.13 popout mode alike).
- **Escape instead of private chrome**: modals close via Escape dispatched through Obsidian's per-window keymap scope, constructed in the target document's realm. `Modal` registers Escape itself, so this survives DOM redesigns.
- **Condition waits instead of sleeps**: every step waits for the observable the next step needs; the final assertion polls `data.json` for the debounced save. Net effect: the test dropped from ~13s to ~3s and no longer guesses durations.
- **Determinism pin, documented**: the suite sets `settingsPopoutWindow: false` because the popout's DOM adoption is nondeterministic under unfocused CLI automation - across clean fresh-instance runs the settings tree sometimes attaches to the popout document and sometimes stays detached from every document indefinitely (Obsidian-internal race, evidence in #1518). The helpers remain window-agnostic, so if a runner-side fix ever makes popouts reliable, deleting the pin line is the entire migration.

Verification: fixed test passed 3/3 consecutive fresh-instance runs (pristine vault each time); full e2e suite 46/46 on a fresh instance with obsidian-e2e 0.8.2. No product code touched.

Reviewer note: the popout nondeterminism and the "close settings immediately after the builder loses the pending commit" timing were both observed only under automation ordering; neither is claimed as a user-facing bug here. The test now simply waits for the disk commit before any teardown.

Fixes #1518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by replacing fixed delays with condition-based UI synchronization.
  * Added deterministic handling for settings windows and modal dialogs.
  * Strengthened verification that conditional macro changes persist correctly after editing and saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->