### PR TITLE
feat: add command to open QuickAdd settings page

### DIFF
--- a/src/commandLabels.ts
+++ b/src/commandLabels.ts
@@ -4,4 +4,5 @@ export const QUICK_ADD_COMMAND_LABELS = {
 	applyTemplate: "Apply template to active note",
 	reloadDev: "Reload (dev)",
 	testDev: "Test (dev)",
+	openSettings: "Open settings",
 } as const;

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -51,19 +51,26 @@ export function hasConfiguredTemplateFolders(plugin: QuickAdd): boolean {
 	);
 }
 
-/** Best-effort: open QuickAdd's settings tab so the user can configure a template folder. */
-function openQuickAddSettings(app: App, pluginId: string): void {
-	const setting = (
-		app as unknown as {
-			setting?: { open?: () => void; openTabById?: (id: string) => void };
-		}
-	).setting;
-	try {
-		setting?.open?.();
-		setting?.openTabById?.(pluginId);
-	} catch {
-		// best-effort only; the Notice already tells the user where to go.
-	}
+/** Opens a plugin's settings tab. Returns false if the internal API is unavailable or throws. */
+export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
+    try {
+        const setting = (
+            app as unknown as {
+                setting?: { open?: () => void; openTabById?: (id: string) => void };
+            }
+        ).setting;
+        
+        if (!setting?.open || !setting?.openTabById) {
+            console.error("QuickAdd: Obsidian internal settings API is unavailable.");
+            return false;
+        }
+        setting.open();
+        setting.openTabById(pluginId);
+        return true;
+    } catch (error) {
+        console.error("QuickAdd: Failed to open plugin settings automatically", error);
+        return false;
+    }
 }
 
 function renderTemplateRow(path: string, el: HTMLElement): void {
@@ -122,7 +129,7 @@ export async function runTemplateFromFolder(
 					"QuickAdd: Set a template folder in Settings → QuickAdd → Templates & Properties to use “New note from template”.",
 					8000,
 				);
-				openQuickAddSettings(app, plugin.manifest.id);
+				tryOpenPluginSettings(app, plugin.manifest.id);
 				return;
 			}
 

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -8,6 +8,7 @@ import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { TemplateChoice } from "../types/choices/TemplateChoice";
 import { normalizeTemplateFolderPaths } from "../utilityObsidian";
 import { isCancellationError, reportError } from "../utils/errorUtils";
+import { tryOpenPluginSettings } from "../utils/openPluginSettings";
 
 export interface RunTemplateFromFolderParams {
 	/** When set, skips the picker and runs this template directly (CLI / scripted). */
@@ -49,28 +50,6 @@ export function hasConfiguredTemplateFolders(plugin: QuickAdd): boolean {
 	return (
 		normalizeTemplateFolderPaths(plugin.settings.templateFolderPaths).length > 0
 	);
-}
-
-/** Opens a plugin's settings tab. Returns false if the internal API is unavailable or throws. */
-export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
-	try {
-		const setting = (
-			app as unknown as {
-				setting?: { open?: () => void; openTabById?: (id: string) => void };
-			}
-		).setting;
-		
-		if (!setting?.open || !setting?.openTabById) {
-			console.error("QuickAdd: Obsidian internal settings API is unavailable.");
-			return false;
-		}
-		setting.open();
-		setting.openTabById(pluginId);
-		return true;
-	} catch (error) {
-		console.error("QuickAdd: Failed to open plugin settings automatically", error);
-		return false;
-	}
 }
 
 function renderTemplateRow(path: string, el: HTMLElement): void {

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -53,24 +53,24 @@ export function hasConfiguredTemplateFolders(plugin: QuickAdd): boolean {
 
 /** Opens a plugin's settings tab. Returns false if the internal API is unavailable or throws. */
 export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
-    try {
-        const setting = (
-            app as unknown as {
-                setting?: { open?: () => void; openTabById?: (id: string) => void };
-            }
-        ).setting;
-        
-        if (!setting?.open || !setting?.openTabById) {
-            console.error("QuickAdd: Obsidian internal settings API is unavailable.");
-            return false;
-        }
-        setting.open();
-        setting.openTabById(pluginId);
-        return true;
-    } catch (error) {
-        console.error("QuickAdd: Failed to open plugin settings automatically", error);
-        return false;
-    }
+	try {
+		const setting = (
+			app as unknown as {
+				setting?: { open?: () => void; openTabById?: (id: string) => void };
+			}
+		).setting;
+		
+		if (!setting?.open || !setting?.openTabById) {
+			console.error("QuickAdd: Obsidian internal settings API is unavailable.");
+			return false;
+		}
+		setting.open();
+		setting.openTabById(pluginId);
+		return true;
+	} catch (error) {
+		console.error("QuickAdd: Failed to open plugin settings automatically", error);
+		return false;
+	}
 }
 
 function renderTemplateRow(path: string, el: HTMLElement): void {

--- a/src/main.commandLabels.test.ts
+++ b/src/main.commandLabels.test.ts
@@ -9,6 +9,7 @@ describe("QuickAdd command labels", () => {
 			applyTemplate: "Apply template to active note",
 			reloadDev: "Reload (dev)",
 			testDev: "Test (dev)",
+			openSettings: "Open settings"
 		});
 
 		for (const label of Object.values(QUICK_ADD_COMMAND_LABELS)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,7 +112,7 @@ export default class QuickAdd extends Plugin {
 			},
 		});
 
-		// add: 
+		// add: Allows users to quickly open QuickAdd settings from the command palette
 		this.addCommand({
 			id: "open-quickadd-settings",
 			name: "Open QuickAdd settings",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all assist/source/organizeImports: Import order is critical to prevent circular dependencies - ChoiceExecutor must load before dependent classes */
 import type { Debouncer } from "obsidian";
-import { Plugin, TFile, debounce } from "obsidian";
+import { Plugin, TFile, debounce, Notice } from "obsidian";
 import { QuickAddSettingsTab } from "./quickAddSettingsTab";
 import { DEFAULT_SETTINGS } from "./settings";
 import type { QuickAddSettings } from "./settings";
@@ -46,7 +46,7 @@ import {
 	parseCallbackTargets,
 	type CallbackTargets,
 } from "./uri/uriCallback";
-import { runTemplateFromFolder } from "./engine/runTemplateFromFolder";
+import { runTemplateFromFolder, tryOpenPluginSettings } from "./engine/runTemplateFromFolder";
 
 // Parameters prefixed with `value-` get used as named values for the executed choice
 type CaptureValueParameters = { [key in `value-${string}`]?: string };
@@ -109,17 +109,6 @@ export default class QuickAdd extends Plugin {
 				ChoiceSuggester.Open(this, this.settings.choices, {
 					includeTemplateFolderRow: true,
 				});
-			},
-		});
-
-		// add: Allows users to quickly open QuickAdd settings from the command palette
-		this.addCommand({
-			id: "open-quickadd-settings",
-			name: "Open QuickAdd settings",
-			callback: () => {
-				const setting = (this.app as any).setting;
-				setting?.open?.();
-				setting?.openTabById?.(this.manifest.id);
 			},
 		});
 
@@ -221,6 +210,18 @@ export default class QuickAdd extends Plugin {
 				void fn();
 			},
 		});
+
+		this.addCommand({
+            id: "openQuickAddSettings",
+            name: QUICK_ADD_COMMAND_LABELS.openSettings,
+            callback: () => {
+                if (!tryOpenPluginSettings(this.app, this.manifest.id)) {
+                    new Notice(
+                        "QuickAdd: Unable to open settings automatically. Open Settings -> QuickAdd manually."
+                    );
+                }
+            },
+        });
 
 		this.registerObsidianProtocolHandler("quickadd", async (e) => {
 			const parameters = e as unknown as UriParameters;

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { ConsoleErrorLogger } from "./logger/consoleErrorLogger";
 import { GuiLogger } from "./logger/guiLogger";
 import { LogManager } from "./logger/logManager";
 import { reportError, withErrorHandling } from "./utils/errorUtils";
+import { tryOpenPluginSettings } from "./utils/openPluginSettings";
 import { StartupMacroEngine } from "./engine/StartupMacroEngine";
 import { ChoiceExecutor } from "./choiceExecutor";
 import type IChoice from "./types/choices/IChoice";
@@ -46,7 +47,7 @@ import {
 	parseCallbackTargets,
 	type CallbackTargets,
 } from "./uri/uriCallback";
-import { runTemplateFromFolder, tryOpenPluginSettings } from "./engine/runTemplateFromFolder";
+import { runTemplateFromFolder } from "./engine/runTemplateFromFolder";
 
 // Parameters prefixed with `value-` get used as named values for the executed choice
 type CaptureValueParameters = { [key in `value-${string}`]?: string };

--- a/src/main.ts
+++ b/src/main.ts
@@ -212,16 +212,16 @@ export default class QuickAdd extends Plugin {
 		});
 
 		this.addCommand({
-            id: "openQuickAddSettings",
-            name: QUICK_ADD_COMMAND_LABELS.openSettings,
-            callback: () => {
-                if (!tryOpenPluginSettings(this.app, this.manifest.id)) {
-                    new Notice(
-                        "QuickAdd: Unable to open settings automatically. Open Settings -> QuickAdd manually."
-                    );
-                }
-            },
-        });
+			id: "openQuickAddSettings",
+			name: QUICK_ADD_COMMAND_LABELS.openSettings,
+			callback: () => {
+				if (!tryOpenPluginSettings(this.app, this.manifest.id)) {
+					new Notice(
+						"QuickAdd: Unable to open settings automatically. Open Settings -> QuickAdd manually."
+					);
+				}
+			},
+		});
 
 		this.registerObsidianProtocolHandler("quickadd", async (e) => {
 			const parameters = e as unknown as UriParameters;

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,6 +112,17 @@ export default class QuickAdd extends Plugin {
 			},
 		});
 
+		// add: 
+		this.addCommand({
+			id: "open-quickadd-settings",
+			name: "Open QuickAdd settings",
+			callback: () => {
+				const setting = (this.app as any).setting;
+				setting?.open?.();
+				setting?.openTabById?.(this.manifest.id);
+			},
+		});
+
 		this.addCommand({
 			id: "runTemplateFromFolder",
 			name: QUICK_ADD_COMMAND_LABELS.runTemplateFromFolder,

--- a/src/utils/openPluginSettings.test.ts
+++ b/src/utils/openPluginSettings.test.ts
@@ -41,7 +41,7 @@ describe("tryOpenPluginSettings", () => {
 		);
 	});
 
-	it("should return false and log error if an exception is thrown", () => {
+	it("should return false and log error if an exception is thrown from setting.open", () => {
 		const fakeApp = {
 			setting: {
 				open: () => {
@@ -56,6 +56,22 @@ describe("tryOpenPluginSettings", () => {
 		expect(result).toBe(false);
 		expect(log.logError).toHaveBeenCalledWith(
 			"QuickAdd: Failed to open plugin settings automatically: Error: Simulated error"
+		);
+	});
+
+	it("should return false and log error if opening the tab throws", () => {
+		const fakeApp = {
+			setting: {
+				open: vi.fn(),
+				openTabById: () => {
+					throw new Error("Simulated tab error");
+				},
+			},
+		} as unknown as App;
+
+		expect(tryOpenPluginSettings(fakeApp, "my-plugin")).toBe(false);
+		expect(log.logError).toHaveBeenCalledWith(
+			"QuickAdd: Failed to open plugin settings automatically: Error: Simulated tab error"
 		);
 	});
 });

--- a/src/utils/openPluginSettings.test.ts
+++ b/src/utils/openPluginSettings.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tryOpenPluginSettings } from "./openPluginSettings";
+import { log } from "../logger/logManager";
+import type { App } from "obsidian";
+
+vi.mock("../logger/logManager", () => ({
+	log: {
+		logError: vi.fn(),
+	},
+}));
+
+describe("tryOpenPluginSettings", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should successfully open tab and return true", () => {
+		const fakeApp = {
+			setting: {
+				open: vi.fn(),
+				openTabById: vi.fn(),
+			},
+		} as unknown as App;
+
+		const result = tryOpenPluginSettings(fakeApp, "my-plugin");
+
+		expect(result).toBe(true);
+		expect((fakeApp as any).setting.open).toHaveBeenCalledOnce();
+		expect((fakeApp as any).setting.openTabById).toHaveBeenCalledWith("my-plugin");
+		expect(log.logError).not.toHaveBeenCalled();
+	});
+
+	it("should return false and log error if internal API is missing", () => {
+		const fakeApp = {} as unknown as App;
+
+		const result = tryOpenPluginSettings(fakeApp, "my-plugin");
+
+		expect(result).toBe(false);
+		expect(log.logError).toHaveBeenCalledWith(
+			"QuickAdd: Obsidian internal settings API is unavailable."
+		);
+	});
+
+	it("should return false and log error if an exception is thrown", () => {
+		const fakeApp = {
+			setting: {
+				open: () => {
+					throw new Error("Simulated error");
+				},
+				openTabById: vi.fn(),
+			},
+		} as unknown as App;
+
+		const result = tryOpenPluginSettings(fakeApp, "my-plugin");
+
+		expect(result).toBe(false);
+		expect(log.logError).toHaveBeenCalledWith(
+			"QuickAdd: Failed to open plugin settings automatically: Error: Simulated error"
+		);
+	});
+});

--- a/src/utils/openPluginSettings.ts
+++ b/src/utils/openPluginSettings.ts
@@ -1,0 +1,25 @@
+import type { App } from "obsidian";
+import { log } from "../logger/logManager";
+
+/** Opens a plugin's settings tab. Returns false if the internal API is unavailable or throws. */
+export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
+	try {
+		const setting = (
+			app as unknown as {
+				setting?: { open?: () => void; openTabById?: (id: string) => void };
+			}
+		).setting;
+
+		if (!setting?.open || !setting?.openTabById) {
+			log.logError("QuickAdd: Obsidian internal settings API is unavailable.");
+			return false;
+		}
+
+		setting.open();
+		setting.openTabById(pluginId);
+		return true;
+	} catch (error) {
+		log.logError(`QuickAdd: Failed to open plugin settings automatically: ${error}`);
+		return false;
+	}
+}


### PR DESCRIPTION
##  Summary
Added a new command `Open QuickAdd settings` that allows users to directly open the QuickAdd plugin's settings page from the command palette or CLI.
This is especially useful when creating complex Macros, where one of the steps may require guiding the user to open the plugin settings.

## Changes
- Added new command `open-quickadd-settings` in `onload()` method of `src/main.ts`
- Command uses internal `app.setting.open()` + `openTabById()` to open the plugin settings tab

## Testing / validation
- Ran `pnpm run build` successfully
- Tested in a dedicated development vault
- Command appears in command palette and correctly opens QuickAdd settings page
- Verified no other files were affected

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
      — it becomes the squash-merge commit and drives the released version.
- [ ] Linked any related issue(s).
- [ ] Noted release/migration impact, if any.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to open QuickAdd settings directly (“Open settings”); it will try automatic opening and, if unavailable, prompt you to open **Settings → QuickAdd** manually.
* **Bug Fixes**
  * Updated the “missing template folder configuration” flow to use the same settings-opening behavior with a manual fallback.
* **Documentation**
  * Updated QuickAdd command labels so the new settings command shows correctly in the command list.
* **Tests**
  * Added automated tests for the settings-opening behavior and fallback messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->