### PR TITLE
fix: treat Markdown views without an editor as no active editor

### DIFF
--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -1719,7 +1719,7 @@ describe("CaptureChoiceEngine capture target resolution", () => {
 			},
 		};
 		app.workspace.getActiveFile = vi.fn(() => canvasFile);
-		app.workspace.getActiveViewOfType = vi.fn(() => ({}));
+		app.workspace.getActiveViewOfType = vi.fn(() => ({ editor: {} }));
 		app.vault.getAbstractFileByPath = vi.fn((path: string) =>
 			path === "Clipboard image.png" ? attachmentFile : null,
 		);

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -1,10 +1,10 @@
 import {
-	MarkdownView,
 	Notice,
 	TFile,
 	type App,
 	type WorkspaceLeaf,
 } from "obsidian";
+import { getActiveMarkdownEditorView } from "src/utils/activeMarkdownEditor";
 import InputSuggester from "src/gui/InputSuggester/inputSuggester";
 import { renderNotePathSuggestion } from "src/gui/InputSuggester/renderNotePathSuggestion";
 import { orderFilesForPicker } from "src/utils/fileOrdering";
@@ -245,8 +245,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 
 	private hasActiveMarkdownCaptureContext(): boolean {
 		const hasActiveFile = !!this.app.workspace.getActiveFile();
-		const hasActiveMarkdownView =
-			!!this.app.workspace.getActiveViewOfType(MarkdownView);
+		const hasActiveMarkdownView = !!getActiveMarkdownEditorView(this.app);
 		return hasActiveFile && hasActiveMarkdownView;
 	}
 

--- a/src/formatters/captureChoiceFormatter-1536-cursor-no-editor.test.ts
+++ b/src/formatters/captureChoiceFormatter-1536-cursor-no-editor.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App, TFile } from "obsidian";
+import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import { ChoiceAbortError } from "../errors/ChoiceAbortError";
+
+// Mocks mirror captureChoiceFormatter-742-multiline-insert.test.ts so the
+// formatter can run under jsdom without real Obsidian/Templater.
+vi.mock("../utilityObsidian", () => ({
+	templaterParseTemplate: vi.fn().mockResolvedValue(null),
+}));
+vi.mock("../gui/InputPrompt", () => ({
+	__esModule: true,
+	default: class {
+		factory() {
+			return {
+				Prompt: vi.fn().mockResolvedValue(""),
+				PromptWithContext: vi.fn().mockResolvedValue(""),
+			} as any;
+		}
+	},
+}));
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({
+	__esModule: true,
+	default: class {
+		constructor() {}
+	},
+}));
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	__esModule: true,
+	default: { Suggest: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({
+	__esModule: true,
+	default: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../utils/errorUtils", () => ({
+	__esModule: true,
+	reportError: vi.fn(),
+	isCancellationError: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../gui/MathModal", () => ({
+	__esModule: true,
+	MathModal: { Prompt: vi.fn().mockResolvedValue("") },
+}));
+vi.mock("../engine/SingleInlineScriptEngine", () => ({
+	__esModule: true,
+	SingleInlineScriptEngine: class {
+		public params = { variables: {} as Record<string, unknown> };
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleMacroEngine", () => ({
+	__esModule: true,
+	SingleMacroEngine: class {
+		async runAndGetOutput() {
+			return "";
+		}
+	},
+}));
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	__esModule: true,
+	SingleTemplateEngine: class {
+		async run() {
+			return "";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+		setLinkToCurrentFileBehavior() {}
+	},
+}));
+vi.mock("obsidian-dataview", () => ({
+	__esModule: true,
+	getAPI: vi.fn().mockReturnValue(null),
+}));
+vi.mock("../main", () => ({
+	__esModule: true,
+	default: class QuickAdd {
+		static instance = {
+			settings: { inputPrompt: "single-line" },
+			app: {
+				workspace: { getActiveViewOfType: vi.fn().mockReturnValue(null) },
+			},
+		};
+		settings = QuickAdd.instance.settings;
+		app = QuickAdd.instance.app;
+	},
+}));
+
+import { CaptureChoiceFormatter } from "./captureChoiceFormatter";
+
+const createChoice = (
+	overrides: Partial<ICaptureChoice> = {},
+): ICaptureChoice =>
+	({
+		id: "test",
+		name: "Test Choice",
+		type: "Capture",
+		command: false,
+		captureTo: "Target.md",
+		captureToActiveFile: false,
+		captureToCanvasNodeId: "",
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: false,
+			createWithTemplate: false,
+			template: "",
+		},
+		format: { enabled: false, format: "" },
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: {
+			enabled: true,
+			after: "## Log",
+			insertAtEnd: false,
+			considerSubsections: false,
+			createIfNotFound: true,
+			createIfNotFoundLocation: "cursor",
+			inline: false,
+			replaceExisting: false,
+			blankLineAfterMatchMode: "auto" as const,
+		},
+		insertBefore: {
+			enabled: false,
+			before: "",
+			createIfNotFound: false,
+			createIfNotFoundLocation: "top",
+		},
+		newLineCapture: { enabled: false, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: true,
+		},
+		...overrides,
+	}) as ICaptureChoice;
+
+const createMockApp = (activeView: unknown): App =>
+	({
+		workspace: {
+			getActiveFile: vi.fn().mockReturnValue(null),
+			getActiveViewOfType: vi.fn().mockReturnValue(activeView),
+		},
+		metadataCache: { getFileCache: vi.fn().mockReturnValue(null) },
+		fileManager: {
+			generateMarkdownLink: vi.fn().mockReturnValue(""),
+			processFrontMatter: vi.fn(),
+		},
+		vault: { adapter: { exists: vi.fn() }, cachedRead: vi.fn() },
+	}) as unknown as App;
+
+const createFile = (path = "Target.md"): TFile =>
+	({
+		path,
+		name: path,
+		basename: path.replace(/\.md$/i, ""),
+		extension: "md",
+	}) as unknown as TFile;
+
+const createFormatter = (activeView: unknown) =>
+	new CaptureChoiceFormatter(createMockApp(activeView), {
+		settings: {
+			inputPrompt: "single-line",
+			enableTemplatePropertyTypes: false,
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as any);
+
+beforeEach(() => {
+	(global as any).navigator = {
+		clipboard: { readText: vi.fn().mockResolvedValue("") },
+	};
+});
+
+describe("#1536 — create-if-not-found at cursor without an active editor", () => {
+	const SEED = "# Daily Notes\n";
+
+	it("aborts with the missing-editor diagnostic when no markdown view is active", async () => {
+		const formatter = createFormatter(null);
+		await expect(
+			formatter.formatContentWithFile("- task\n", createChoice(), SEED, createFile()),
+		).rejects.toThrow(
+			new ChoiceAbortError(
+				"Unable to insert line '## Log' at cursor position: no active markdown editor.",
+			),
+		);
+	});
+
+	it("aborts with the missing-editor diagnostic for a Markdown-masquerading view with editor: null", async () => {
+		// Thino patches getActiveViewOfType to return such a view.
+		const formatter = createFormatter({ editor: null });
+		await expect(
+			formatter.formatContentWithFile("- task\n", createChoice(), SEED, createFile()),
+		).rejects.toThrow("no active markdown editor");
+	});
+
+	it("inserts at the cursor line when a real editor is active (control)", async () => {
+		const formatter = createFormatter({
+			editor: { getCursor: () => ({ line: 0, ch: 0 }) },
+		});
+		const result = await formatter.formatContentWithFile(
+			"- task\n",
+			createChoice(),
+			SEED,
+			createFile(),
+		);
+		expect(result).toContain("## Log");
+		expect(result).toContain("- task");
+	});
+});

--- a/src/formatters/captureChoiceFormatter-frontmatter.test.ts
+++ b/src/formatters/captureChoiceFormatter-frontmatter.test.ts
@@ -579,7 +579,7 @@ describe('CaptureChoiceFormatter insert after end-of-section spacing', () => {
         file,
       ),
     ).rejects.toThrow(
-      "Unable to insert line '# Missing' at cursor position.",
+      "Unable to insert line '# Missing' at cursor position: no active markdown editor.",
     );
   });
 });

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -1,4 +1,5 @@
-import { MarkdownView, type TFile } from "obsidian";
+import type { TFile } from "obsidian";
+import { getActiveMarkdownEditorView } from "../utils/activeMarkdownEditor";
 import { getLinesInString } from "src/utility";
 import {
 	CREATE_IF_NOT_FOUND_BOTTOM,
@@ -596,10 +597,10 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			CREATE_IF_NOT_FOUND_CURSOR
 		) {
 			try {
-				const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+				const activeView = getActiveMarkdownEditorView(this.app);
 
 				if (!activeView) {
-					throw new Error("No active view.");
+					throw new Error("No active markdown editor.");
 				}
 
 				const cursor = activeView.editor.getCursor();
@@ -839,10 +840,10 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			CREATE_IF_NOT_FOUND_CURSOR
 		) {
 			try {
-				const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+				const activeView = getActiveMarkdownEditorView(this.app);
 
 				if (!activeView) {
-					throw new Error("No active view.");
+					throw new Error("No active markdown editor.");
 				}
 
 				const cursor = activeView.editor.getCursor();
@@ -893,10 +894,10 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			CREATE_IF_NOT_FOUND_CURSOR
 		) {
 			try {
-				const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+				const activeView = getActiveMarkdownEditorView(this.app);
 
 				if (!activeView) {
-					throw new Error("No active view.");
+					throw new Error("No active markdown editor.");
 				}
 
 				const cursor = activeView.editor.getCursor();

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -596,13 +596,15 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_CURSOR
 		) {
+			const activeView = getActiveMarkdownEditorView(this.app);
+
+			if (!activeView) {
+				throw new ChoiceAbortError(
+					`Unable to insert line '${this.choice.insertAfter.after}' at cursor position: no active markdown editor.`,
+				);
+			}
+
 			try {
-				const activeView = getActiveMarkdownEditorView(this.app);
-
-				if (!activeView) {
-					throw new Error("No active markdown editor.");
-				}
-
 				const cursor = activeView.editor.getCursor();
 				let targetPosition = cursor.line;
 
@@ -839,13 +841,15 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			insertBefore.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_CURSOR
 		) {
+			const activeView = getActiveMarkdownEditorView(this.app);
+
+			if (!activeView) {
+				throw new ChoiceAbortError(
+					`Unable to insert line '${insertBefore.before}' at cursor position: no active markdown editor.`,
+				);
+			}
+
 			try {
-				const activeView = getActiveMarkdownEditorView(this.app);
-
-				if (!activeView) {
-					throw new Error("No active markdown editor.");
-				}
-
 				const cursor = activeView.editor.getCursor();
 
 				return this.insertTextBeforePositionInBody(
@@ -893,13 +897,15 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 			this.choice.insertAfter?.createIfNotFoundLocation ===
 			CREATE_IF_NOT_FOUND_CURSOR
 		) {
+			const activeView = getActiveMarkdownEditorView(this.app);
+
+			if (!activeView) {
+				throw new ChoiceAbortError(
+					`Unable to insert line '${this.choice.insertAfter.after}' at cursor position: no active markdown editor.`,
+				);
+			}
+
 			try {
-				const activeView = getActiveMarkdownEditorView(this.app);
-
-				if (!activeView) {
-					throw new Error("No active markdown editor.");
-				}
-
 				const cursor = activeView.editor.getCursor();
 				const targetPosition = cursor.line;
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -775,6 +775,19 @@ describe("CompleteFormatter - selection handling", () => {
 		await expect(f.formatFolderPath("[{{SELECTED}}]")).resolves.toBe("[]");
 	});
 
+	it("replaces {{SELECTED}} with empty string when the active view has no editor (#1536)", async () => {
+		// Thino-style Markdown-masquerading view: editor is null.
+		const app = {
+			workspace: {
+				getActiveFile: () => null,
+				getActiveViewOfType: () => ({ editor: null }),
+			},
+			fileManager: { generateMarkdownLink: () => "" },
+		};
+		const f = new CompleteFormatter(app as any, makePlugin() as any);
+		await expect(f.formatFolderPath("[{{SELECTED}}]")).resolves.toBe("[]");
+	});
+
 	it("uses selected text as the {{VALUE}} when a selection exists", async () => {
 		const f = defaultFormatter({}, { selection: "picked" });
 		await expect(f.formatFolderPath("v={{VALUE}}")).resolves.toBe(

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -32,6 +32,7 @@ import {
 } from "../utils/FieldValueCollector";
 import { FieldValueProcessor } from "../utils/FieldValueProcessor";
 import { resolveActiveNoteFieldDefault } from "../utils/activeNoteFieldDefault";
+import { getActiveMarkdownEditorView } from "../utils/activeMarkdownEditor";
 import { log } from "../logger/logManager";
 import { Formatter, type PromptContext } from "./formatter";
 import {
@@ -1150,7 +1151,7 @@ export class CompleteFormatter extends Formatter {
 	}
 
 	protected async getSelectedText(): Promise<string> {
-		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+		const activeView = getActiveMarkdownEditorView(this.app);
 		if (!activeView) return "";
 
 		return activeView.editor.getSelection();

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
-import { MarkdownView, TFile } from "obsidian";
+import { TFile } from "obsidian";
+import { getActiveMarkdownEditorView } from "src/utils/activeMarkdownEditor";
 import { MAX_TEMPLATE_INCLUSION_DEPTH } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import {
@@ -321,7 +322,7 @@ async function collectForTemplateChoice(
 }
 
 function getEditorSelection(app: App): string {
-	const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+	const activeView = getActiveMarkdownEditorView(app);
 	if (!activeView) return "";
 	return activeView.editor.getSelection();
 }

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -167,6 +167,33 @@ describe("runOnePagePreflight selection-as-value", () => {
 		expect(modalOpenMock).not.toHaveBeenCalled();
 	});
 
+	it("treats a Markdown view without an editor like no selection (#1536)", async () => {
+		const choice = createChoice();
+		const executor = createExecutor();
+		const plugin = {
+			settings: {
+				inputPrompt: "single-line",
+				globalVariables: {},
+				useSelectionAsCaptureValue: true,
+			},
+		} as any;
+		// Thino-style Markdown-masquerading view: editor is null.
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn().mockReturnValue({ editor: null }),
+			},
+		} as unknown as App;
+		modalResult = { value: "Typed instead" };
+
+		const result = await runOnePagePreflight(app, plugin, executor, choice);
+
+		// The editor-less view yields no selection, so the modal collects
+		// {{VALUE}} instead of the run crashing on editor.getSelection().
+		expect(result).toBe(true);
+		expect(modalOpenMock).toHaveBeenCalled();
+		expect(executor.variables.get("value")).toBe("Typed instead");
+	});
+
 	it("collects via the promptProvider (not the Obsidian modal) for a remote run", async () => {
 		const choice = createChoice();
 		const executor = createExecutor();

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -623,8 +623,30 @@ describe("utility selection helpers", () => {
 		expect(api.utility.getSelection()).toBe("");
 	});
 
+	it("getSelection returns empty string when the active view has no editor (#1536)", () => {
+		// Thino-style Markdown-masquerading view: editor is null.
+		const app = makeApp({
+			workspace: {
+				getActiveViewOfType: () => ({ editor: null }),
+			},
+		});
+		const { api } = getApi(app);
+		expect(api.utility.getSelection()).toBe("");
+	});
+
 	it("getSelectedText reports an error and returns '' with no view", () => {
 		const { api } = getApi();
+		expect(api.utility.getSelectedText()).toBe("");
+		expect(mocks.reportError).toHaveBeenCalled();
+	});
+
+	it("getSelectedText reports an error and returns '' when the active view has no editor (#1536)", () => {
+		const app = makeApp({
+			workspace: {
+				getActiveViewOfType: () => ({ editor: null }),
+			},
+		});
+		const { api } = getApi(app);
 		expect(api.utility.getSelectedText()).toBe("");
 		expect(mocks.reportError).toHaveBeenCalled();
 	});

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -1,5 +1,5 @@
 import type { App } from "obsidian";
-import { MarkdownView } from "obsidian";
+import { getActiveMarkdownEditorView } from "./utils/activeMarkdownEditor";
 import {
 	ChunkedPrompt,
 	clearAIRequestLogEntries,
@@ -731,7 +731,7 @@ export class QuickAddApi {
 					return await navigator.clipboard.writeText(text);
 				},
 				getSelection: () => {
-					const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+					const activeView = getActiveMarkdownEditorView(app);
 
 					if (!activeView) {
 						return "";
@@ -740,11 +740,11 @@ export class QuickAddApi {
 					return activeView.editor.getSelection() ?? "";
 				},
 				getSelectedText: () => {
-					const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+					const activeView = getActiveMarkdownEditorView(app);
 
 					if (!activeView) {
 						reportError(
-							new Error("No active view"),
+							new Error("No active Markdown editor"),
 							"Could not get selected text",
 						);
 						return "";

--- a/src/types/macros/EditorCommands/EditorCommand.ts
+++ b/src/types/macros/EditorCommands/EditorCommand.ts
@@ -3,7 +3,8 @@ import { CommandType } from "../CommandType";
 import { Command } from "../Command";
 import type { IEditorCommand } from "./IEditorCommand";
 import type { App } from "obsidian";
-import { MarkdownView } from "obsidian";
+import type { MarkdownView } from "obsidian";
+import { getActiveMarkdownEditorView } from "../../../utils/activeMarkdownEditor";
 import { log } from "../../../logger/logManager";
 
 export abstract class EditorCommand extends Command implements IEditorCommand {
@@ -20,11 +21,11 @@ export abstract class EditorCommand extends Command implements IEditorCommand {
 	}
 
 	static getActiveMarkdownView(app: App): MarkdownView {
-		const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+		const activeView = getActiveMarkdownEditorView(app);
 
 		if (!activeView) {
-			log.logError("no active markdown view.");
-			throw new Error("no active markdown view.");
+			log.logError("no active markdown editor.");
+			throw new Error("no active markdown editor.");
 		}
 
 		return activeView;

--- a/src/types/macros/EditorCommands/navigationCommands.test.ts
+++ b/src/types/macros/EditorCommands/navigationCommands.test.ts
@@ -34,6 +34,14 @@ const createAppWithoutMarkdownView = (): App =>
 		},
 	}) as unknown as App;
 
+// A Markdown-masquerading view without an editor, as Thino returns (#1536).
+const createAppWithEditorlessView = (): App =>
+	({
+		workspace: {
+			getActiveViewOfType: vi.fn().mockReturnValue({ editor: null }),
+		},
+	}) as unknown as App;
+
 describe("navigation editor commands", () => {
 	it("moves cursor to file start", () => {
 		const setCursor = vi.fn();
@@ -82,7 +90,7 @@ describe("navigation editor commands", () => {
 		expect(setCursor).toHaveBeenCalledWith({ line: 7, ch: 11 });
 	});
 
-	it.each([
+	const allNavigationCommands = [
 		{
 			name: "MoveCursorToFileStartCommand",
 			run: MoveCursorToFileStartCommand.run,
@@ -99,8 +107,21 @@ describe("navigation editor commands", () => {
 			name: "MoveCursorToLineEndCommand",
 			run: MoveCursorToLineEndCommand.run,
 		},
-	])("throws when no active markdown view exists: $name", ({ run }) => {
-		const app = createAppWithoutMarkdownView();
-		expect(() => run(app)).toThrow("no active markdown view.");
-	});
+	];
+
+	it.each(allNavigationCommands)(
+		"throws when no active markdown view exists: $name",
+		({ run }) => {
+			const app = createAppWithoutMarkdownView();
+			expect(() => run(app)).toThrow("no active markdown editor.");
+		},
+	);
+
+	it.each(allNavigationCommands)(
+		"throws when the active view has no editor: $name",
+		({ run }) => {
+			const app = createAppWithEditorlessView();
+			expect(() => run(app)).toThrow("no active markdown editor.");
+		},
+	);
 });

--- a/src/utils/activeMarkdownEditor.test.ts
+++ b/src/utils/activeMarkdownEditor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import { getActiveMarkdownEditorView } from "./activeMarkdownEditor";
+
+const appWithView = (view: unknown): App =>
+	({
+		workspace: {
+			getActiveViewOfType: vi.fn(() => view),
+		},
+	}) as unknown as App;
+
+describe("getActiveMarkdownEditorView", () => {
+	it("returns null when no markdown view is active", () => {
+		expect(getActiveMarkdownEditorView(appWithView(null))).toBeNull();
+	});
+
+	it("returns null for a Markdown-masquerading view without an editor (#1536)", () => {
+		// Thino patches getActiveViewOfType to answer markdown lookups with a
+		// view whose editor is null.
+		expect(
+			getActiveMarkdownEditorView(appWithView({ editor: null })),
+		).toBeNull();
+	});
+
+	it("returns the view when it has an editor", () => {
+		const view = { editor: { getSelection: () => "" } };
+		expect(getActiveMarkdownEditorView(appWithView(view))).toBe(view);
+	});
+});

--- a/src/utils/activeMarkdownEditor.ts
+++ b/src/utils/activeMarkdownEditor.ts
@@ -1,0 +1,15 @@
+import type { App } from "obsidian";
+import { MarkdownView } from "obsidian";
+
+/**
+ * The active MarkdownView, but only when it actually exposes an editor.
+ *
+ * Some plugins (e.g. Thino) patch `Workspace.getActiveViewOfType` to answer
+ * Markdown lookups with their own Markdown-masquerading view whose `editor`
+ * is null. Every editor-dependent code path must treat such a view exactly
+ * like "no active Markdown view" (#1536).
+ */
+export function getActiveMarkdownEditorView(app: App): MarkdownView | null {
+	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	return view?.editor ? view : null;
+}

--- a/src/utils/editorInsertion.test.ts
+++ b/src/utils/editorInsertion.test.ts
@@ -215,6 +215,75 @@ describe("insertFileLinkToActiveView", () => {
 		expect(editor.replaceSelection).not.toHaveBeenCalled();
 	});
 
+	it("appends frontmatter links even when the active view has no editor (#1536)", async () => {
+		// Thino-style Markdown-masquerading view: has a file, but editor is null.
+		// The frontmatter placement never touches the editor and must keep working.
+		const frontmatter: Record<string, unknown> = {};
+		const activeFile = { path: "Folder/Host.md" } as TFile;
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn(() => ({
+					file: activeFile,
+					editor: null,
+				})),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Created]]"),
+				processFrontMatter: vi.fn(
+					async (
+						_file: TFile,
+						update: (fm: Record<string, unknown>) => void,
+					) => update(frontmatter),
+				),
+			},
+		} as unknown as App;
+
+		await expect(
+			insertFileLinkToActiveView(app, { path: "Folder/Created.md" } as TFile, {
+				enabled: true,
+				placement: "inFrontmatter",
+				requireActiveFile: true,
+				frontmatterProperty: "related",
+				frontmatterHandling: "createProperty",
+			}),
+		).resolves.toBe(true);
+
+		expect(frontmatter.related).toEqual(["[[Created]]"]);
+	});
+
+	it("treats an editor-less view like no view for text placements (#1536)", async () => {
+		const app = {
+			workspace: {
+				getActiveViewOfType: vi.fn(() => ({
+					file: { path: "Host.md" },
+					editor: null,
+				})),
+			},
+			fileManager: {
+				generateMarkdownLink: vi.fn(() => "[[Created]]"),
+			},
+		} as unknown as App;
+		const createdFile = { path: "Created.md" } as TFile;
+
+		await expect(
+			insertFileLinkToActiveView(app, createdFile, {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: false,
+			}),
+		).resolves.toBe(false);
+
+		await expect(
+			insertFileLinkToActiveView(app, createdFile, {
+				enabled: true,
+				placement: "replaceSelection",
+				requireActiveFile: true,
+			}),
+		).rejects.toThrow(
+			"Cannot append link because no active Markdown view is available.",
+		);
+	});
+
 	it("propagates configured frontmatter insertion failures", async () => {
 		const app = {
 			workspace: {
@@ -354,6 +423,34 @@ function createSelectionApp(
 		},
 	} as unknown as App;
 }
+
+describe("insertLinkWithPlacement editor-less view (#1536)", () => {
+	const editorlessApp = () =>
+		({
+			workspace: {
+				getActiveViewOfType: vi.fn(() => ({
+					file: { path: "Host.md" },
+					editor: null,
+				})),
+			},
+		}) as unknown as App;
+
+	it("throws a precise error for text placements when a view is required", async () => {
+		await expect(
+			insertLinkWithPlacement(editorlessApp(), "[[X]]", "replaceSelection"),
+		).rejects.toThrow(
+			"Cannot append link because the active Markdown view has no editor.",
+		);
+	});
+
+	it("silently skips text placements when no view is required", async () => {
+		await expect(
+			insertLinkWithPlacement(editorlessApp(), "[[X]]", "replaceSelection", {
+				requireActiveView: false,
+			}),
+		).resolves.toBeUndefined();
+	});
+});
 
 describe("insertLinkWithPlacement with textForSelection", () => {
 	const linkFor = (selectedText: string) => `[[X|${selectedText}]]`;

--- a/src/utils/editorInsertion.ts
+++ b/src/utils/editorInsertion.ts
@@ -1,5 +1,6 @@
 import type { App, Editor, EditorPosition, TFile } from "obsidian";
 import { MarkdownView } from "obsidian";
+import { getActiveMarkdownEditorView } from "./activeMarkdownEditor";
 import { log } from "../logger/logManager";
 import {
 	DEFAULT_FRONTMATTER_HANDLING,
@@ -19,7 +20,7 @@ export function getMarkdownEditorViewForFile(
 	app: App,
 	file: TFile,
 ): MarkdownView | null {
-	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	const view = getActiveMarkdownEditorView(app);
 	if (view?.file?.path === file.path) return view;
 	return null;
 }
@@ -31,7 +32,7 @@ export function getMarkdownEditorViewForFile(
  */
 export function appendToCurrentLine(toAppend: string, app: App): boolean {
 	try {
-		const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+		const activeView = getActiveMarkdownEditorView(app);
 
 		if (!activeView) {
 			log.logError(`unable to append '${toAppend}' to current line.`);
@@ -49,7 +50,7 @@ export function appendToCurrentLine(toAppend: string, app: App): boolean {
 /** @returns true if inserted, false if no active Markdown editor (or it threw). */
 export function insertOnNewLine(toInsert: string, direction: "above" | "below", app: App): boolean {
 	try {
-		const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+		const activeView = getActiveMarkdownEditorView(app);
 
 		if (!activeView) {
 			log.logError(`unable to insert '${toInsert}' on new line ${direction}.`);
@@ -204,6 +205,16 @@ export async function insertLinkWithPlacement(
 	}
 
 	const editor = view.editor;
+	// Editor-less Markdown-masquerading views (e.g. Thino's) support the
+	// frontmatter placement above, but no text placement.
+	if (!editor) {
+		const message = "Cannot append link because the active Markdown view has no editor.";
+		if (requireActiveView) {
+			throw new Error(message);
+		}
+		log.logMessage(message);
+		return;
+	}
 
 	// Snapshot current selections *before* mutating the document.
 	// We copy them because CodeMirror mutates the objects in-place.
@@ -314,7 +325,10 @@ export async function insertFileLinkToActiveView(
 	const normalized = normalizeAppendLinkOptions(linkOptions);
 
 	const view = app.workspace.getActiveViewOfType(MarkdownView);
-	if (!view || !view.file) {
+	// Only the frontmatter placement works without an editor; for text
+	// placements an editor-less view is the same as no view.
+	const editorRequired = normalized.placement !== "inFrontmatter";
+	if (!view || !view.file || (editorRequired && !view.editor)) {
 		// Read the guard from the RAW options: normalization defaults a missing
 		// requireActiveFile to true, which would turn a raw caller's previous
 		// silent skip into a throw.


### PR DESCRIPTION
Guards every editor-dependent code path against Markdown-masquerading views whose `editor` is null, so QuickAdd choices no longer crash while such a view (e.g. Thino's) is active.

## What

Thino patches `Workspace.getActiveViewOfType` to answer `MarkdownView` lookups with its own view object that has `editor: null`. QuickAdd null-checked the *view* but dereferenced `.editor` unguarded, so with a Thino leaf focused, any choice touching the selection - `{{SELECTED}}`, selection-as-value, one-page preflight, editor macro commands, cursor-anchored capture, link insertion - failed with `Cannot read properties of null (reading 'getSelection')` and nothing was created.

The fix centralizes the safe lookup in `getActiveMarkdownEditorView(app)` (`src/utils/activeMarkdownEditor.ts`), which treats an editor-less view exactly like "no active Markdown view", and applies it at every site that needs the editor:

- `CompleteFormatter.getSelectedText` (`{{SELECTED}}`) and the preflight selection collector fall back to `""` - the same behavior as no view at all.
- `api.utility.getSelection` returns `""`; `getSelectedText` reports the existing "could not get selected text" error instead of throwing a TypeError.
- `EditorCommand.getActiveMarkdownView` (all editor macro commands) fails with a clear `no active markdown editor.` error (previously `no active markdown view.`, or an opaque TypeError in the Thino case).
- Capture: the create-if-not-found-at-cursor paths, `appendToCurrentLine`, `insertOnNewLine`, `getMarkdownEditorViewForFile`, and the canvas-trigger context predicate all require a real editor.
- Link insertion: the `inFrontmatter` placement keeps working on editor-less views (it never touches the editor); text placements treat them as no-view, replacing what was previously an uncaught crash in `insertLinkWithPlacement`.

## Verification

Reproduced and verified live in the isolated e2e vault (Obsidian 1.13.0, QuickAdd 2.19.1) by simulating Thino's patch (`getActiveViewOfType` returning `{ editor: null }`):

- Pre-fix: `api.format("{{SELECTED}}")`, `getSelection()`, `getSelectedText()` all threw the reported TypeErrors.
- Post-fix: all return `""`, and a real Template choice with a `{{SELECTED}}` template runs to completion and creates its note (`sel=[]`). `dev:errors` clean.

Unit regression coverage with `{ editor: null }` views added for the helper, formatter, API, preflight, editor commands, and link insertion (`pnpm test`: 3846 passing). Adversarial review (3 Codex reviewers) found no missed unsafe dereference; accepted its suggestion to dedupe the navigation-command test matrix.

## Notes for review

- Intentional message changes: editor macro commands now say `no active markdown editor.`; `getSelectedText` reports "No active Markdown editor". Error strings only - no API change.
- `hasActiveMarkdownCaptureContext` (canvas-trigger link skip) now also requires a real editor, so a masquerading view degrades to the graceful skip instead of a downstream throw.
- Release impact: pure bug fix, `fix:` release-worthy.

Fixes #1536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when the active Markdown view exists but has no editor, preventing crashes across capture, selection, formatting, preflight, navigation, and link insertion.
  * Standardized behavior for cursor-based insertions: actions now abort with a clear “no active Markdown editor” message when needed.
  * Kept frontmatter link insertion working when no editor is required, while other editor-dependent placements now fail safely.
* **Tests**
  * Added and expanded regression coverage for editor-less (“editor null”) scenarios (including cursor and `{{SELECTED}}` behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update: verified against real Thino 3.0.15

Installed actual Thino (`obsidian-memos`) 3.0.15 in the isolated e2e vault and focused "Thino in center":

- Masquerade confirmed exactly as diagnosed: with `thino_view` active, `getActiveViewOfType(MarkdownView)` returns an object that is **not** a `MarkdownView` instance and has `editor: null`.
- `api.utility.getSelection()` and `api.format("{{SELECTED}}")` return `""` (pre-fix: the reported TypeErrors).
- A Template choice runs to completion via both the `quickadd:run` command channel and `api.executeChoice`, creating its note (`sel=[]`), with Thino still focused.
- The only console errors during the session are Obsidian core's `_onFileOpen` -> `updateViewState` crashing on Thino's fake view (`reading 'sourceMode'`) - reproducible from a bare `file-open` event with zero QuickAdd involvement. That is the Thino-side bug already reported upstream (Quorafind/Obsidian-Thino#935) and out of QuickAdd's scope.
