### PR TITLE
fix: keep the blank line after frontmatter on top-of-file capture

### DIFF
--- a/src/ai/tools/builtins/builtins.test.ts
+++ b/src/ai/tools/builtins/builtins.test.ts
@@ -104,6 +104,27 @@ describe("vault write tools — safety", () => {
 		).rejects.toThrow(/not found/i);
 	});
 
+	it("append_to_note position=top keeps the frontmatter separator line (issue #1538)", async () => {
+		const file = fileLike("Daily/2026-07-25.md");
+		const modify = vi.fn(async () => undefined);
+		const app = makeApp({
+			vault: {
+				getAbstractFileByPath: () => file,
+				read: vi.fn(async () => "---\ndate: 2026-07-25\n---\n\nExisting\n"),
+				modify,
+			},
+		});
+		const tools = createVaultTools(app);
+		await tools.append_to_note.execute(
+			{ path: "Daily/2026-07-25.md", content: "note text", position: "top" },
+			{ toolCallId: "c", toolName: "append_to_note" },
+		);
+		expect(modify).toHaveBeenCalledWith(
+			file,
+			"---\ndate: 2026-07-25\n---\n\nnote text\nExisting\n",
+		);
+	});
+
 	it("respects allowedRoots for reads", async () => {
 		const app = makeApp();
 		const tools = createVaultTools(app, { allowedRoots: ["AI"] });

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -301,6 +301,29 @@ describe("insertBodyIntoNoteContent", () => {
 			insertBodyIntoNoteContent("---\r\nt: 1\r\n---\r\nBody", "new", "top"),
 		).toBe("---\r\nt: 1\r\n---\r\nnew\nBody");
 	});
+
+	it("keeps the blank line separating the note's frontmatter from its body (issue #1538)", () => {
+		// Symmetric with the no-separator note above: the block lands tight against
+		// the following line, and the note's separator line stays where it was.
+		expect(insertBodyIntoNoteContent("---\na: 1\n---\n\nBody\n", "TPL", "top")).toBe(
+			"---\na: 1\n---\n\nTPL\nBody\n",
+		);
+		// A body that already ends in a newline still gets exactly ONE blank line of
+		// separation below it (it used to get two, by stacking onto the separator).
+		expect(
+			insertBodyIntoNoteContent("---\na: 1\n---\n\nBody\n", "TPL\n", "top"),
+		).toBe("---\na: 1\n---\n\nTPL\n\nBody\n");
+	});
+
+	it("does not double the blank line for a template whose own body starts blank", () => {
+		// splitTemplateFrontmatter keeps the template's separator newline, so this is
+		// the shape every "---\nfm\n---\n\nContent" template produces.
+		const { body } = splitTemplateFrontmatter("---\nt: x\n---\n\nContent");
+		expect(body).toBe("\nContent");
+		expect(insertBodyIntoNoteContent("---\na: 1\n---\n\nExisting", body, "top")).toBe(
+			"---\na: 1\n---\n\nContent\n\nExisting",
+		);
+	});
 });
 
 describe("TemplateInsertEngine.apply", () => {

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -71,7 +71,8 @@ export function splitTemplateFrontmatter(content: string): {
 
 /**
  * Inserts a template body into existing note content. "top" is
- * frontmatter-aware: the body lands below the note's frontmatter block.
+ * frontmatter-aware: the body lands below the note's frontmatter block, including
+ * the blank line that separates that block from the body (issue #1538).
  *
  * The "top" branch reuses the shared, fence-safe `insertAtNoteBodyStart`
  * (src/utils/noteContentInsertion.ts). Appending a newline to the body expresses

--- a/src/formatters/captureChoiceFormatter-481-ordered.test.ts
+++ b/src/formatters/captureChoiceFormatter-481-ordered.test.ts
@@ -253,6 +253,27 @@ describe("#481 — ordered create-if-not-found placement", () => {
 		);
 	});
 
+	it("creates the first-ever section below the frontmatter separator line (issue #1538)", async () => {
+		// No headings in the body -> the "bodyStart" slot, which routes through the
+		// shared frontmatter-aware top insertion.
+		const choice = createChoice({
+			after: "## Log",
+			orderBy: { by: "insertion", direction: "desc", unparseable: "bottom" },
+		});
+		const seed = "---\ndate: 2026-07-25\n---\n\nSome text\n";
+		const out = await runOnce(choice, seed, "- entry\n");
+		expect(out).toBe("---\ndate: 2026-07-25\n---\n\n## Log\n- entry\nSome text\n");
+	});
+
+	it("never places a created section inside a frontmatter-only note's YAML", async () => {
+		const choice = createChoice({
+			after: "## Log",
+			orderBy: { by: "insertion", direction: "desc", unparseable: "bottom" },
+		});
+		const out = await runOnce(choice, "---\ntags: x\n---", "- entry\n");
+		expect(out).toBe("---\ntags: x\n---\n## Log\n- entry\n");
+	});
+
 	it("creates the first-ever section after the preamble, blurb stays above", async () => {
 		const choice = createChoice({
 			after: "## TODAY",

--- a/src/formatters/captureChoiceFormatter-frontmatter.test.ts
+++ b/src/formatters/captureChoiceFormatter-frontmatter.test.ts
@@ -849,9 +849,15 @@ describe('CaptureChoiceFormatter #647 frontmatter-aware top insertion', () => {
     );
   });
 
-  it('absorbs an existing CRLF blank line after the fence instead of doubling it', async () => {
+  it('keeps the blank line separating frontmatter from the body (issue #1538)', async () => {
+    expect(await topInsert('---\ndate: 2026-07-25\n---\n\n## Log\n\n## Tasks\n')).toBe(
+      '---\ndate: 2026-07-25\n---\n\nINSERTED\n## Log\n\n## Tasks\n',
+    );
+  });
+
+  it('keeps an existing CRLF separator line after the fence (issue #1538)', async () => {
     expect(await topInsert('---\r\ntitle: A\r\n---\r\n\r\nBody')).toBe(
-      '---\r\ntitle: A\r\n---\r\nINSERTED\r\nBody',
+      '---\r\ntitle: A\r\n---\r\n\r\nINSERTED\nBody',
     );
   });
 
@@ -862,10 +868,11 @@ describe('CaptureChoiceFormatter #647 frontmatter-aware top insertion', () => {
   });
 
   it('treats a leading-blank-line fence as no frontmatter (Obsidian-consistent) and inserts at absolute top', async () => {
-    // exists:false (fence not at offset 0) -> capture lands at the very top; the
-    // note's existing leading blank line is reused as the separator, not doubled.
+    // exists:false (fence not at offset 0) -> capture lands at the very top. The
+    // note's leading blank line is kept: consuming it would move the fence to
+    // offset 0 territory and silently reshape the note (issue #1538).
     expect(await topInsert('\n---\ntitle: A\n---\n# Body')).toBe(
-      'INSERTED\n---\ntitle: A\n---\n# Body',
+      'INSERTED\n\n---\ntitle: A\n---\n# Body',
     );
   });
 
@@ -900,5 +907,98 @@ describe('CaptureChoiceFormatter #647 frontmatter-aware top insertion', () => {
       createTFile('Note.md'),
     );
     expect(result).toBe('## Missing\n- [ ] CAP\n# Header');
+  });
+
+  // Every "create the missing target at the top" path routes through the same
+  // frontmatter-aware primitive. Without a note that HAS a separator line, each of
+  // these could silently revert to the #1538 behaviour with the suite still green.
+  describe('create-if-not-found at top, into a note with a separator line', () => {
+    const NOTE = '---\ndate: 2026-07-25\n---\n\n## Log\n';
+    const insertAfterTarget = (overrides: Record<string, unknown> = {}) => ({
+      enabled: true,
+      after: '## Missing',
+      insertAtEnd: false,
+      considerSubsections: false,
+      createIfNotFound: true,
+      createIfNotFoundLocation: 'top',
+      inline: false,
+      replaceExisting: false,
+      blankLineAfterMatchMode: 'auto',
+      ...overrides,
+    });
+
+    it('creates a missing insert-after section below the separator line', async () => {
+      const result = await makeFormatter().formatContentWithFile(
+        '- entry',
+        createChoice({
+          captureToActiveFile: false,
+          insertAfter: insertAfterTarget() as any,
+        }),
+        NOTE,
+        createTFile('Note.md'),
+      );
+      expect(result).toBe(
+        '---\ndate: 2026-07-25\n---\n\n## Missing\n- entry\n## Log\n',
+      );
+    });
+
+    it('creates a missing INLINE insert-after target below the separator line', async () => {
+      const result = await makeFormatter().formatContentWithFile(
+        'Status: done',
+        createChoice({
+          captureToActiveFile: false,
+          insertAfter: insertAfterTarget({ after: 'MISSING', inline: true }) as any,
+        }),
+        NOTE,
+        createTFile('Note.md'),
+      );
+      expect(result).toBe(
+        '---\ndate: 2026-07-25\n---\n\nMISSINGStatus: done\n## Log\n',
+      );
+    });
+
+    it('degrades an ordered create with a non-heading anchor to below the separator line', async () => {
+      const result = await makeFormatter().formatContentWithFile(
+        '- entry\n',
+        createChoice({
+          captureToActiveFile: false,
+          insertAfter: insertAfterTarget({
+            after: 'Some anchor',
+            orderBy: { by: 'insertion', direction: 'desc', unparseable: 'bottom' },
+          }) as any,
+        }),
+        NOTE,
+        createTFile('Note.md'),
+      );
+      expect(result).toBe(
+        '---\ndate: 2026-07-25\n---\n\nSome anchor\n- entry\n## Log\n',
+      );
+    });
+
+    it('creates a missing insert-before target below the separator line and tracks the cursor', async () => {
+      const formatter = makeFormatter();
+      const result = await formatter.formatContentWithFile(
+        '- entry',
+        createChoice({
+          captureToActiveFile: false,
+          insertBefore: {
+            enabled: true,
+            before: '## Missing',
+            createIfNotFound: true,
+            createIfNotFoundLocation: 'top',
+          },
+        }),
+        NOTE,
+        createTFile('Note.md'),
+      );
+      expect(result).toBe(
+        '---\ndate: 2026-07-25\n---\n\n- entry\n## Missing\n## Log\n',
+      );
+      // This is the only caller passing a non-default cursorOffsetInText: the cursor
+      // must land at the end of the capture, not at the end of the created anchor.
+      expect(formatter.getCaptureInsertionEndOffset()).toBe(
+        '---\ndate: 2026-07-25\n---\n\n- entry'.length,
+      );
+    });
   });
 });

--- a/src/formatters/captureChoiceFormatter-write-position.test.ts
+++ b/src/formatters/captureChoiceFormatter-write-position.test.ts
@@ -235,6 +235,35 @@ describe("CaptureChoiceFormatter write position behavior", () => {
 		);
 	});
 
+	it("tracks cursor past the frontmatter separator line (issue #1538)", async () => {
+		const formatter = new CaptureChoiceFormatter(
+			createMockApp(),
+			{
+				settings: {
+					enableTemplatePropertyTypes: false,
+					globalVariables: {},
+					showCaptureNotification: false,
+					showInputCancellationNotification: true,
+				},
+			} as any,
+		);
+
+		const result = await formatter.formatContentWithFile(
+			"Call the dentist",
+			createChoice({ captureToActiveFile: false, prepend: false }),
+			"---\ndate: 2026-07-25\n---\n\n## Log\n\n## Tasks\n",
+			createFile(),
+		);
+
+		expect(result).toBe(
+			"---\ndate: 2026-07-25\n---\n\nCall the dentist\n## Log\n\n## Tasks\n",
+		);
+		// The cursor lands at the end of the capture, not one line too early.
+		expect(formatter.getCaptureInsertionEndOffset()).toBe(
+			"---\ndate: 2026-07-25\n---\n\nCall the dentist".length,
+		);
+	});
+
 	it("writes to bottom for non-active targets when prepend is true", async () => {
 		const formatter = new CaptureChoiceFormatter(
 			createMockApp(),

--- a/src/utils/noteContentInsertion.test.ts
+++ b/src/utils/noteContentInsertion.test.ts
@@ -118,6 +118,19 @@ describe("insertAtNoteBodyStart", () => {
 		);
 	});
 
+	it("counts a whitespace-only leading payload line as the payload's own blank line", () => {
+		// Same blank-line definition on both sides, so a template whose separator
+		// carries trailing spaces does not stack two blanks above the insert.
+		expect(insertAtNoteBodyStart("---\na: 1\n---\n\nBody", "   \nContent")).toBe(
+			"---\na: 1\n---\n   \nContent\n\nBody",
+		);
+		// ...but the payload still gets a leading separator when its first line has
+		// visible content, so it can never glue onto the closing fence.
+		expect(insertAtNoteBodyStart("---\na: 1\n---", "   Content")).toBe(
+			"---\na: 1\n---\n   Content",
+		);
+	});
+
 	it("never eats a blank first line when there is no frontmatter", () => {
 		expect(insertAtNoteBodyStart("\n## Log\n", "CAP")).toBe("CAP\n\n## Log\n");
 		expect(insertAtNoteBodyStart("\n\n## Log\n", "CAP")).toBe("CAP\n\n\n## Log\n");

--- a/src/utils/noteContentInsertion.test.ts
+++ b/src/utils/noteContentInsertion.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getBodyStartOffset, insertAtNoteBodyStart } from "./noteContentInsertion";
+import {
+	getBodyStartOffset,
+	insertAtNoteBodyStart,
+	insertAtNoteBodyStartWithResult,
+} from "./noteContentInsertion";
 
 describe("getBodyStartOffset", () => {
 	it("returns 0 when there is no frontmatter", () => {
@@ -57,19 +61,66 @@ describe("insertAtNoteBodyStart", () => {
 		);
 	});
 
-	it("absorbs an existing blank line after the fence rather than doubling it", () => {
+	it("keeps the blank line that separates frontmatter from the body (issue #1538)", () => {
 		expect(insertAtNoteBodyStart("---\ntitle: A\n---\n\nBody", "INSERTED")).toBe(
-			"---\ntitle: A\n---\nINSERTED\nBody",
+			"---\ntitle: A\n---\n\nINSERTED\nBody",
 		);
 	});
 
-	it("preserves CRLF frontmatter and absorbs a CRLF blank line", () => {
+	it("reproduces issue #1538 verbatim", () => {
+		expect(
+			insertAtNoteBodyStart(
+				"---\ndate: 2026-07-25\n---\n\n## Log\n\n## Tasks\n",
+				"Call the dentist",
+			),
+		).toBe("---\ndate: 2026-07-25\n---\n\nCall the dentist\n## Log\n\n## Tasks\n");
+	});
+
+	it("preserves CRLF frontmatter and its CRLF separator line", () => {
 		expect(
 			insertAtNoteBodyStart("---\r\ntitle: A\r\n---\r\n# Body\r\n", "INSERTED"),
 		).toBe("---\r\ntitle: A\r\n---\r\nINSERTED\n# Body\r\n");
+		// The separator's own \r\n survives verbatim; only QuickAdd's injected
+		// terminator is a lone \n (the house convention for every insert helper).
 		expect(
 			insertAtNoteBodyStart("---\r\ntitle: A\r\n---\r\n\r\nBody", "INSERTED"),
-		).toBe("---\r\ntitle: A\r\n---\r\nINSERTED\r\nBody");
+		).toBe("---\r\ntitle: A\r\n---\r\n\r\nINSERTED\nBody");
+	});
+
+	it("treats only ONE blank line as the frontmatter separator", () => {
+		expect(insertAtNoteBodyStart("---\na: 1\n---\n\n\n## Log", "CAP")).toBe(
+			"---\na: 1\n---\n\nCAP\n\n## Log",
+		);
+	});
+
+	it("skips a whitespace-only separator line without rewriting its bytes", () => {
+		expect(insertAtNoteBodyStart("---\na: 1\n---\n   \n## Log\n", "CAP")).toBe(
+			"---\na: 1\n---\n   \nCAP\n## Log\n",
+		);
+	});
+
+	it("handles a separator line that is the last line of the note", () => {
+		expect(insertAtNoteBodyStart("---\na: 1\n---\n\n", "CAP")).toBe(
+			"---\na: 1\n---\n\nCAP",
+		);
+	});
+
+	it("does not skip the separator when the payload brings its own leading blank line", () => {
+		// Otherwise the payload's newline and the note's separator would stack two
+		// blank lines. The first case is byte-identical to pre-#1538 output; the
+		// second still gains the trailing terminator, which is what stops the
+		// payload from swallowing the separator line.
+		expect(insertAtNoteBodyStart("---\na: 1\n---\n\nExisting", "\nContent\n")).toBe(
+			"---\na: 1\n---\n\nContent\n\nExisting",
+		);
+		expect(insertAtNoteBodyStart("---\na: 1\n---\n\n## Log", "\n- x")).toBe(
+			"---\na: 1\n---\n\n- x\n\n## Log",
+		);
+	});
+
+	it("never eats a blank first line when there is no frontmatter", () => {
+		expect(insertAtNoteBodyStart("\n## Log\n", "CAP")).toBe("CAP\n\n## Log\n");
+		expect(insertAtNoteBodyStart("\n\n## Log\n", "CAP")).toBe("CAP\n\n\n## Log\n");
 	});
 
 	it("treats a CRLF-leading payload as already newline-started (no doubled blank line)", () => {
@@ -91,6 +142,24 @@ describe("insertAtNoteBodyStart", () => {
 		expect(r1).toBe("---\ntitle: A\n---\nA\nBody");
 		const r2 = insertAtNoteBodyStart(r1, "B");
 		expect(r2).toBe("---\ntitle: A\n---\nB\nA\nBody");
+	});
+
+	it("keeps the separator line put across repeated captures (no accumulating blanks)", () => {
+		const r1 = insertAtNoteBodyStart("---\na: 1\n---\n\nBody", "A");
+		expect(r1).toBe("---\na: 1\n---\n\nA\nBody");
+		const r2 = insertAtNoteBodyStart(r1, "B");
+		expect(r2).toBe("---\na: 1\n---\n\nB\nA\nBody");
+	});
+
+	it("reports the inserted-text offsets past the skipped separator line", () => {
+		const content = "---\ndate: 2026-07-25\n---\n\n## Log\n";
+		const result = insertAtNoteBodyStartWithResult(content, "Call the dentist");
+		expect(result.insertedStartOffset).toBe(
+			"---\ndate: 2026-07-25\n---\n\n".length,
+		);
+		expect(
+			result.content.slice(result.insertedStartOffset ?? 0, result.insertedEndOffset ?? 0),
+		).toBe("Call the dentist");
 	});
 
 	it("keeps the fence intact for a CRLF frontmatter-only note with no trailing newline (EOF + leading separator)", () => {

--- a/src/utils/noteContentInsertion.ts
+++ b/src/utils/noteContentInsertion.ts
@@ -15,6 +15,10 @@ export interface NoteBodyInsertionResult {
  * fence that is not at offset 0 is not, and `...`-style closes are rejected. This
  * is deliberately content-based (the metadata cache is not consulted) so a stale
  * or cold cache cannot place text in the wrong spot.
+ *
+ * This is the STRUCTURAL boundary, and it lands on the start of the blank line that
+ * usually separates frontmatter from the body. It is therefore the wrong offset to
+ * write at — see `getBodyInsertOffset` below, which is what the insertion uses.
  */
 export function getBodyStartOffset(content: string): number {
 	const info = getFrontMatterInfo(content);
@@ -22,17 +26,63 @@ export function getBodyStartOffset(content: string): number {
 }
 
 /**
- * Insert `text` at the start of the note body — after frontmatter when present —
- * guaranteeing the inserted text occupies its own line(s):
+ * Offset a top-of-body insertion actually lands on: the frontmatter boundary from
+ * {@link getBodyStartOffset}, plus the blank line that separates the frontmatter
+ * block from the body when the note has one.
+ *
+ * `getFrontMatterInfo().contentStart` points at the byte right after the closing
+ * fence's newline — i.e. at the START of that separator line, not after it. Writing
+ * there wedges the capture between the fence and the blank line, so the note reads
+ * as if its frontmatter and body were never separated (issue #1538). The separator
+ * line is document furniture belonging to the frontmatter block, so the body starts
+ * below it.
+ *
+ * Deliberately narrow:
+ *  - only when frontmatter exists. A note with no frontmatter that happens to start
+ *    with a blank line still gets "top of file" taken literally, at offset 0.
+ *  - only ONE line. A longer blank run is body spacing the user chose, and only the
+ *    first line of it is the frontmatter separator.
+ *  - only when `text` does not already open with a newline. Such a payload supplies
+ *    its own separation, and skipping as well would stack two blank lines (same
+ *    "don't double" rule the leading separator below applies).
+ *
+ * A closing fence sitting at EOF (`---\n---`) has nothing after it, so there is no
+ * separator to find and the offset stays on the fence — where the leading separator
+ * below takes over and keeps the fence intact.
+ *
+ * Not exported: {@link getBodyStartOffset} stays the pure frontmatter boundary that
+ * `insertionPositioning.getBodyStartLine` uses for heading masking and ordered
+ * section placement, and that boundary must not move.
+ */
+function getBodyInsertOffset(content: string, text: string): number {
+	const start = getBodyStartOffset(content);
+	if (start === 0) return 0;
+	if (/^\r?\n/.test(text)) return start;
+
+	// A blank line is anything up to the next line break that has no visible
+	// content — `"   \n"` and CRLF blanks included. It is skipped over, never
+	// rewritten, so its bytes survive verbatim.
+	const separator = /^[^\S\r\n]*\r?\n/.exec(content.slice(start));
+	return separator ? start + separator[0].length : start;
+}
+
+/**
+ * Insert `text` at the start of the note body — below frontmatter and its separator
+ * line when present — under one invariant: **the insertion adds whole lines. It never
+ * merges with, and never deletes, an existing line.** Two separators enforce it:
  *
  *  - a leading newline when the preceding block (frontmatter, or nothing) does not
  *    already end with one. This protects frontmatter-only notes whose closing fence
  *    sits at EOF (`---\n---`), where the body offset lands on the fence itself.
- *  - a trailing newline when body content would otherwise follow on the same line.
+ *  - a trailing newline whenever any body content follows, so the payload terminates
+ *    its own line. This is unconditional on purpose: a `rest` that begins with a
+ *    newline does NOT mean the payload is already separated — it means the first body
+ *    line is EMPTY, and an unterminated payload would take that empty line's place,
+ *    silently deleting a line from the note (issue #1538).
  *
- * The trailing check is CRLF-aware so an existing blank line is absorbed rather
- * than doubled. The injected separator is a lone `\n` (matching the existing
- * capture/template insertion helpers); Obsidian tolerates the resulting mixed EOL.
+ * The injected separator is a lone `\n` (matching the existing capture/template
+ * insertion helpers, which splice on `\n` too); Obsidian tolerates the resulting
+ * mixed EOL in a CRLF note.
  *
  * `TemplateInsertEngine.insertBodyIntoNoteContent` reuses this same primitive for its
  * "top" insert, but passes `body + "\n"` so an applied template block always ends on its
@@ -53,14 +103,14 @@ export function insertAtNoteBodyStartWithResult(
 		};
 	}
 
-	const start = getBodyStartOffset(content);
+	const start = getBodyInsertOffset(content, text);
 	const head = content.slice(0, start);
 	const rest = content.slice(start);
 
 	const leadingSeparator =
 		head.length > 0 && !head.endsWith("\n") && !/^\r?\n/.test(text) ? "\n" : "";
 	const trailingSeparator =
-		rest.length > 0 && !text.endsWith("\n") && !/^\r?\n/.test(rest) ? "\n" : "";
+		rest.length > 0 && !text.endsWith("\n") ? "\n" : "";
 
 	const insertedStartOffset = head.length + leadingSeparator.length;
 	const insertedEndOffset = insertedStartOffset + text.length;

--- a/src/utils/noteContentInsertion.ts
+++ b/src/utils/noteContentInsertion.ts
@@ -7,6 +7,16 @@ export interface NoteBodyInsertionResult {
 }
 
 /**
+ * A leading BLANK line: everything up to the first line break, with no visible
+ * content. Trailing spaces/tabs count (`"   \n"` reads as blank to Obsidian) and
+ * CRLF is handled, but the line break itself is required — `"   text"` is content.
+ */
+const LEADING_BLANK_LINE = /^[^\S\r\n]*\r?\n/;
+
+/** A leading line break, i.e. "this text already begins on a line of its own". */
+const LEADING_LINE_BREAK = /^\r?\n/;
+
+/**
  * Offset at which the note body begins — immediately after the YAML frontmatter
  * block when present, otherwise 0.
  *
@@ -42,9 +52,11 @@ export function getBodyStartOffset(content: string): number {
  *    with a blank line still gets "top of file" taken literally, at offset 0.
  *  - only ONE line. A longer blank run is body spacing the user chose, and only the
  *    first line of it is the frontmatter separator.
- *  - only when `text` does not already open with a newline. Such a payload supplies
- *    its own separation, and skipping as well would stack two blank lines (same
- *    "don't double" rule the leading separator below applies).
+ *  - only when `text` does not already open with a blank line of its own. Such a
+ *    payload supplies its own separation, and skipping as well would stack two blank
+ *    lines (the "don't double" rule the leading separator below also applies). The
+ *    payload is judged by the SAME blank-line definition as the note, so a template
+ *    whose separator carries trailing spaces is recognised too.
  *
  * A closing fence sitting at EOF (`---\n---`) has nothing after it, so there is no
  * separator to find and the offset stays on the fence — where the leading separator
@@ -57,12 +69,10 @@ export function getBodyStartOffset(content: string): number {
 function getBodyInsertOffset(content: string, text: string): number {
 	const start = getBodyStartOffset(content);
 	if (start === 0) return 0;
-	if (/^\r?\n/.test(text)) return start;
+	if (LEADING_BLANK_LINE.test(text)) return start;
 
-	// A blank line is anything up to the next line break that has no visible
-	// content — `"   \n"` and CRLF blanks included. It is skipped over, never
-	// rewritten, so its bytes survive verbatim.
-	const separator = /^[^\S\r\n]*\r?\n/.exec(content.slice(start));
+	// The separator is skipped over, never rewritten, so its bytes survive verbatim.
+	const separator = LEADING_BLANK_LINE.exec(content.slice(start));
 	return separator ? start + separator[0].length : start;
 }
 
@@ -107,8 +117,13 @@ export function insertAtNoteBodyStartWithResult(
 	const head = content.slice(0, start);
 	const rest = content.slice(start);
 
+	// Note the deliberately different predicate here: this asks "does the payload
+	// already start on its own line", so a payload opening with `"   \n"` still needs
+	// the separator (its visible `"   "` would otherwise glue onto the fence).
 	const leadingSeparator =
-		head.length > 0 && !head.endsWith("\n") && !/^\r?\n/.test(text) ? "\n" : "";
+		head.length > 0 && !head.endsWith("\n") && !LEADING_LINE_BREAK.test(text)
+			? "\n"
+			: "";
 	const trailingSeparator =
 		rest.length > 0 && !text.endsWith("\n") ? "\n" : "";
 


### PR DESCRIPTION
Closes #1538

## The problem

A Capture with **Write position = "Top of file"** into a note that has frontmatter deleted the blank line separating the frontmatter block from the body. Reproduced live in a clean Obsidian 1.13.0 vault, byte-verified with `od -c`:

```
before: ---\ndate: 2026-07-25\n---\n\n## Log\n\n## Tasks\n
after:  ---\ndate: 2026-07-25\n---\nCall the dentist\n## Log\n\n## Tasks\n
```

```
        BEFORE (2.19.1)                  AFTER (this PR)
        ---                              ---
        date: 2026-07-25                 date: 2026-07-25
        ---                              ---
        Call the dentist                 <- blank line gone
        ## Log                           Call the dentist
                                         ## Log
```

Capturing into a daily note is close to the canonical first thing a new user sets up, so this was the first output many people ever saw from QuickAdd.

### What it looks like

Same vault, same note, same Capture choice ("Top of file", no format, no task); only the plugin build differs. Source mode, so the frontmatter fence and the blank line are visible.

| 1. The note, before capturing | 2. `master` (af70dcb6) - blank line eaten | 3. This PR - blank line kept |
| --- | --- | --- |
| <img width="330" src="https://raw.githubusercontent.com/chhoumann/quickadd/aa3c55ac3feba6346df070becdde18fd00a347bb/pr-1538/1-note-before-capture.png"> | <img width="330" src="https://raw.githubusercontent.com/chhoumann/quickadd/aa3c55ac3feba6346df070becdde18fd00a347bb/pr-1538/2-master-blank-line-eaten.png"> | <img width="330" src="https://raw.githubusercontent.com/chhoumann/quickadd/aa3c55ac3feba6346df070becdde18fd00a347bb/pr-1538/3-fixed-blank-line-kept.png"> |
| the blank line separates the frontmatter from `## Log` | the capture takes that blank line's place: it is glued under `---` **and** onto `## Log`, and the note is one line shorter | the separator survives in place; the capture sits where the body starts |

Byte-level, straight off disk in the isolated vault (`Daily/2026-07-26.md`):

```diff
  seed      '---\ndate: 2026-07-26\n---\n\n## Log\n\n## Tasks\n'
- master    '---\ndate: 2026-07-26\n---\nCall the dentist\n## Log\n\n## Tasks\n'
+ this PR   '---\ndate: 2026-07-26\n---\n\nCall the dentist\n## Log\n\n## Tasks\n'
```

The `\n\n` after the closing `---` is what master turns into a single `\n`: the blank line is not moved, it is **deleted**.

## Root cause

`insertAtNoteBodyStartWithResult` (`src/utils/noteContentInsertion.ts`), two independent defects:

1. **The trailing separator was suppressed when the remaining content started with a newline.** That condition does not mean "the payload already lands on its own line" - it means *the first body line is EMPTY*, so an unterminated payload took that empty line's place and the note lost a line. This was general: it also fired with no frontmatter at all, on any note whose first line is blank.

2. **`getFrontMatterInfo().contentStart` points at the START of the separator line, not after it.** So even with the payload terminated, the capture wedged itself between the closing fence and the blank line, and the note read as if frontmatter and body had never been separated.

`getBodyStartOffset` returning the structural boundary is correct - it just is not the offset you should *write* at.

## The fix

Top-of-body insertion now holds one invariant: **it adds whole lines, and never merges with or deletes an existing one.**

- The trailing separator is unconditional when body content follows.
- A new private `getBodyInsertOffset(content, text)` treats the blank line directly after the closing fence as part of the frontmatter block, so the capture lands below it.

Result: the separator survives in place, and the capture sits tight above the following content - byte-symmetric with what the same capture already does in a note *without* frontmatter (`Call the dentist\n## Log`).

The skip is deliberately narrow:

| gate | why |
| --- | --- |
| frontmatter must exist | a note with no frontmatter that starts with a blank line still takes "Top of file" literally, at offset 0 |
| exactly ONE line | a longer blank run is body spacing the user chose; only its first line is the separator |
| payload must not already start with a newline | otherwise the payload's own blank and the note's separator stack two blanks - and that is the shape *every* frontmatter-bearing template produces (`splitTemplateFrontmatter` keeps the leading newline) |

`getBodyStartOffset` is **unchanged**, so `insertionPositioning.getBodyStartLine` - which anchors heading masking and ordered-section placement - does not move. The two notions are now documented against each other.

## Blast radius

The same primitive backs seven paths, all fixed by this change and all now pinned by tests:

- Capture "Top of file" (target file) and "Top of file (after frontmatter)" (active file)
- create-if-not-found at top: insert-after, inline insert-after, insert-before (the one caller that carries a `cursorOffsetInText`)
- ordered section creation: the `bodyStart` slot and the non-heading-anchor degrade
- `TemplateInsertEngine.insertBodyIntoNoteContent("top")`
- the AI tool `vaultTools.append_to_note(position: "top")`

Template-apply also gets strictly better here: a template body ending in a newline used to stack onto the note's separator and produce *two* blank lines; it now produces exactly the one the documented policy promises.

## Accepted trade-offs

1. **No blank line is added below the capture.** The issue's "Expected" block shows one, but that would be a global spacing-policy change: every capture path is tight (single newline), and repeated captures would accumulate airy spacing. The issue's own "at minimum" framing is what this ships.
2. **Injected separators stay a lone `\n`, even in CRLF notes.** The note's own separator survives byte-verbatim (`---\r\n\r\nINSERTED\nBody`); only QuickAdd's terminator is LF. That is the pre-existing house convention across every insert helper, and Obsidian tolerates the mixed EOL. Making it EOL-aware is a separate polish pass.
3. **`insertTextAfterPositionInBody`'s blank-line absorption is untouched** - that is the shipped, user-configurable contract of #312.
4. Two existing tests asserted the old behaviour by name ("absorbs an existing blank line…"). They are renamed and re-pointed as deliberate contract changes, not mechanically updated.

## Validation

- **Live, in a real Obsidian 1.13.0 vault** (worktree-local e2e vault, driven through the real `quickadd:run` command path, every result byte-inspected with `od -c`): the issue's repro; repeated captures (separator stays put, no accumulation); no-frontmatter; frontmatter without a separator; two separator lines; frontmatter-only at EOF; frontmatter-only with trailing newline; empty frontmatter; task capture; leading-blank-line note with no frontmatter; whitespace-only separator; and the active-file "Top of file (after frontmatter)" placement.
- **3868 unit tests green**, `tsc` and `eslint` clean.
- **Mutation-checked**: reverting either half of the fix turns 21 tests red, including all four create-if-not-found caller paths and the insert-before cursor offset. An earlier revision passed the full suite with four of those paths silently reverted; an adversarial review pass caught that gap and it is now closed.

## Review round

Both bots landed on the same seam, and Codex found a real asymmetry: `getBodyInsertOffset` judged the *note's* separator with a whitespace-aware pattern but the *payload* with a bare-newline one, so a payload opening with `"   \n"` (a template whose own separator carries trailing spaces) was not recognised as bringing its own separation and stacked two blank lines. Fixed in 63ca50fa - both sides now share one named `LEADING_BLANK_LINE`, which also addresses CodeRabbit's hoist-the-regexes nitpick. The *leading* separator deliberately keeps the stricter `/^\r?\n/`: it answers a different question, and a payload opening with visible `"   "` must still not glue onto the closing fence. Both behaviours are pinned by a new test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved template, capture, and “create-if-not-found” insertion into notes with YAML frontmatter.
  - Content inserted at the top now lands consistently below the frontmatter separator line.
  - Preserved the single blank-line boundary between frontmatter and body, preventing missing or extra spacing (including CRLF).
  - Prevented placements from occurring inside the frontmatter block and fixed edge cases for missing headings/anchors.
  - Ensured insertion end offsets match the actual inserted text (cursor positioning accuracy).
- **Documentation**
  - Clarified “top” insertion behavior relative to YAML frontmatter and the separating blank line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->