### PR TITLE
feat(suggester): describe every format token in the autocomplete

### DIFF
--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -63,7 +63,7 @@ obsidian vault=dev quickadd:run-template \
 ```
 
 - `path=` is the template file (vault-relative). A leading slash is allowed and a missing `.md` extension is added, matching how Template choices resolve paths. If no file resolves there, the command returns `{"ok":false}` up front.
-- The new note's name comes from `{{value}}` - pass it as `value-value=...`. A non-interactive run with an empty or missing name returns `missingFlags` instead of creating an unnamed note. The note is created in Obsidian's "Default location for new notes".
+- The new note's name comes from `{{VALUE}}` - pass it as `value-value=...`. A non-interactive run with an empty or missing name returns `missingFlags` instead of creating an unnamed note. The note is created in Obsidian's "Default location for new notes".
 - The picker (interactive command) only lists templates inside your configured template folder(s); `path=` here is explicit, so any vault file resolves.
 - Like `quickadd:run`, name collisions on the target note still prompt interactively (the file-exists choice is not a pre-collected input).
 

--- a/docs/src/content/docs/docs/Advanced/ObsidianUri.md
+++ b/docs/src/content/docs/docs/Advanced/ObsidianUri.md
@@ -169,9 +169,9 @@ overwrites the synced version when it finally arrives.
 ### How to avoid it {#workarounds}
 
 - **Open Obsidian first**: always open Obsidian and wait for sync before using URIs.
-- **Use device-specific names**: configure different filename formats per device (for example `{{date}}-mobile`).
+- **Use device-specific names**: configure different filename formats per device (for example `{{DATE}}-mobile`).
 - **Capture to active file**: use an already-open note to avoid creating a file at all.
-- **Include timestamps**: add `{{time}}` to filenames so each one is unique.
+- **Include timestamps**: add `{{TIME}}` to filenames so each one is unique.
 
 This is a fundamental limitation of file-based sync services and cannot be
 fully resolved without sync-status APIs.

--- a/docs/src/content/docs/docs/ApplyTemplateToNote.md
+++ b/docs/src/content/docs/docs/ApplyTemplateToNote.md
@@ -48,7 +48,7 @@ QuickAdd handles a few common situations for you so you don't have to think
 about them:
 
 - **Empty notes skip the prompt.** If the note is empty (or only whitespace), the "how to apply" step is skipped and the template becomes the note's full content. The usual case is a freshly created blank note.
-- **The title fills itself in.** The note already has a name, so `{{title}}` and the unnamed `{{VALUE}}` / `{{NAME}}` resolve to the note's file name instead of prompting. Named values like `{{VALUE:project}}` still prompt as usual.
+- **The title fills itself in.** The note already has a name, so `{{TITLE}}` and the unnamed `{{VALUE}}` / `{{NAME}}` resolve to the note's file name instead of prompting. Named values like `{{VALUE:project}}` still prompt as usual.
 - **Frontmatter merges instead of stacking.** For **Insert at top**, **Append to bottom**, and **Insert at cursor**, the template's frontmatter is not added as a second `---` block. Its properties are merged into the note's existing frontmatter, and your note's existing values always win - only properties that are missing or empty in the note are filled from the template. (**Replace note content** replaces the whole note, frontmatter included.)
 - **The note can move to match the choice.** If you picked a Template choice with a folder and/or file name format, and the note's current location or name doesn't match what that choice would have produced, QuickAdd offers to move or rename the note to match. Links to the note are updated automatically. This is skipped when the choice's folder settings need a runtime folder picker, or when a file already exists at the target path.
 

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -280,7 +280,7 @@ _Task_ formats your captured text as a task (`- [ ] ...`).
 _Use editor selection as default value_ controls whether selected text in the
 editor is used as `{{VALUE}}` instead of prompting: **Follow global setting**,
 **Use selection**, or **Ignore selection** (the global default lives in
-**Settings → Input**). This does not affect `{{selected}}`.
+**Settings → Input**). This does not affect `{{SELECTED}}`.
 
 ### Pick where in the note it lands: Write position {#write-position}
 
@@ -593,7 +593,7 @@ Content
 
 **Before line…** inserts the capture before the first line matching the text
 you specify. The target accepts [format syntax](/docs/FormatSyntax/), so
-values like `{{title}}` and `{{linkcurrent}}` work in the match text.
+values like `{{TITLE}}` and `{{LINKCURRENT}}` work in the match text.
 
 **Create line if not found** works here too: QuickAdd writes the captured
 content first, then creates the missing line below it. The created line can go

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -106,7 +106,7 @@ A path is resolved with a **path-safe** subset of the format syntax:
 
 - Macros, inline JavaScript, and `{{TEMPLATE:...}}` inclusion are **not** run
   while computing a path.
-- `{{title}}` cannot be used in a path (the title is derived from the created
+- `{{TITLE}}` cannot be used in a path (the title is derived from the created
   file, not the source template).
 - The note-relative placeholders `{{FOLDER}}`, `{{FILENAMECURRENT}}`,
   `{{LINKCURRENT}}`, and `{{LINKSECTION}}` are left as-is in a template path,
@@ -260,7 +260,7 @@ display text:
 
 ```text title="You do"
 Select "Meeting with Mark", run a Template choice whose file name format is
-20240101 {{selected}}
+20240101 {{SELECTED}}
 ```
 
 ```text title="You get"

--- a/docs/src/content/docs/docs/ComingFromTemplater.md
+++ b/docs/src/content/docs/docs/ComingFromTemplater.md
@@ -36,7 +36,7 @@ The left column names the job; the middle names the Templater expression you may
 | Include one template in another | `tp.file.include` | [`{{TEMPLATE:Templates/Partial.md}}`](/docs/FormatSyntax/#template) |
 | Apply a template to an existing note | the insert template command | [Apply template to active note](/docs/ApplyTemplateToNote/) |
 | Insert the clipboard | `tp.system.clipboard` | [`{{CLIPBOARD}}`](/docs/FormatSyntax/#clipboard) |
-| Insert the selected text | `tp.selection` | [`{{selected}}`](/docs/FormatSyntax/#selected) |
+| Insert the selected text | `tp.selection` | [`{{SELECTED}}`](/docs/FormatSyntax/#selected) |
 | Reuse a property from the note you're in | `tp.frontmatter` | [`{{FIELD:project\|default-from:active}}`](/docs/FormatSyntax/#field-default-from-active); to re-render a value you prompted for, just [repeat `{{VALUE:name}}`](#prompt-once-reuse-everywhere) |
 | Link back to the note you came from | `tp.file.path` workarounds | [`{{LINKCURRENT}}`](/docs/FormatSyntax/#linkcurrent) (a link), [`{{FILENAMECURRENT}}`](/docs/FormatSyntax/#filenamecurrent) (raw name, for embeds like `![[{{FILENAMECURRENT}}#Heading]]`), [`{{LINKSECTION}}`](/docs/FormatSyntax/#linksection) (link to the heading you're in) |
 | Run JavaScript | `tp.user` | [Inline scripts](/docs/InlineScripts/), [user scripts in macros](/docs/Choices/MacroChoice/), [`{{MACRO:...}}`](/docs/FormatSyntax/#macro) |

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -47,6 +47,7 @@ You describe the shape once; QuickAdd fills in the blanks every run.
 | [`{{DATE:MMMM Do}}`](#date-format) | Today, formatted your way: `July 8th` |
 | [`{{DATE+7}}`](#date) | Seven days from today |
 | [`{{DATE:YYYY-MM\|startof:week}}`](#date-snap) | The week's starting month, for weekly notes |
+| [`{{TIME}}`](#time) | The current time, like `14:05` |
 
 **The note you ran QuickAdd from**
 
@@ -156,6 +157,29 @@ Good to know:
 - An unknown unit (like `|startof:fortnight`) shows an error listing the valid units.
 
 _Introduced in QuickAdd 2.14.0._
+
+### The current time: `{{TIME}}` {#time}
+
+`{{TIME}}` becomes the current time in `HH:mm` format. `{{TIME:<format>}}`
+takes any [Moment.js format](https://momentjs.com/docs/#/displaying/format), the
+same as `{{DATE:<format>}}`.
+
+```markdown title="You write"
+- {{TIME}} {{VALUE}}
+Meeting {{DATE}} {{TIME:HH.mm}}
+```
+
+```markdown title="You get"
+- 14:05 Standup moved to Wednesday
+Meeting 2026-07-08 14.05
+```
+
+Use `{{TIME:HH.mm}}` rather than `{{TIME}}` inside a file name: `:` is not
+allowed in file names on Windows or macOS.
+
+Unlike `{{DATE}}`, `{{TIME}}` takes no `+N` offset. For a time other than "now",
+use `{{DATE:HH:mm}}` with an offset, or ask for one with
+[`{{VDATE:<name>, <format>|time}}`](#vdate).
 
 ### Ask for a date: `{{VDATE:<name>, <format>}}` {#vdate}
 

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -56,7 +56,7 @@ You describe the shape once; QuickAdd fills in the blanks every run.
 | [`{{LINKSECTION}}`](#linksection) | A link to the section your cursor is in |
 | [`{{FILENAMECURRENT}}`](#filenamecurrent) | Its file name |
 | [`{{FOLDERCURRENT}}`](#foldercurrent) | Its folder |
-| [`{{selected}}`](#selected) | The text you had selected |
+| [`{{SELECTED}}`](#selected) | The text you had selected |
 
 **The note being created**
 
@@ -607,10 +607,10 @@ _Introduced in QuickAdd 2.18.0._
 `Acme`. Use it when you want the folder's name in a file name or sentence
 rather than a path: `Tasks for {{FOLDERCURRENT|name}}`.
 
-### The selected text: `{{selected}}` {#selected}
+### The selected text: `{{SELECTED}}` {#selected}
 
 Whatever text is selected in the editor, or empty when nothing is: `>
-{{selected}}`.
+{{SELECTED}}`.
 
 ## The note being created
 

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -443,7 +443,7 @@ for (const contact of contacts) {
 ```
 
 ### `applyTemplateToActiveFile(templatePath: string, options?: { mode?: "cursor" | "top" | "bottom" | "replace" }): Promise<TFile | null>`
-Applies a template to the active note without creating a new file. The template runs through the full QuickAdd format pipeline (`{{title}}` and the unnamed `{{VALUE}}`/`{{NAME}}` resolve to the note's basename), and Templater syntax is processed. See [Apply Template to Note](/docs/ApplyTemplateToNote/) for the full behavior, including frontmatter merging.
+Applies a template to the active note without creating a new file. The template runs through the full QuickAdd format pipeline (`{{TITLE}}` and the unnamed `{{VALUE}}`/`{{NAME}}` resolve to the note's basename), and Templater syntax is processed. See [Apply Template to Note](/docs/ApplyTemplateToNote/) for the full behavior, including frontmatter merging.
 
 **Parameters:**
 - `templatePath`: Vault path to the template file
@@ -606,7 +606,7 @@ results. Use this for inputs that are too large for a single request.
 
 **Parameters:**
 - `text`: The full input text to process.
-- `promptTemplate`: The prompt run for each chunk. Reference the current chunk with `{{value:chunk}}`.
+- `promptTemplate`: The prompt run for each chunk. Reference the current chunk with `{{VALUE:chunk}}`.
 - `model`: Model identifier (bare or provider-qualified string, or `{name, provider?}` object), as for `prompt`.
 - `settings`: (Optional) Configuration object:
   - `variableName`: Output variable name (default: "output")
@@ -617,7 +617,7 @@ results. Use this for inputs that are too large for a single request.
   - `chunkSeparator`: `RegExp` used to split `text` (default: `/\n/`)
   - `chunkJoiner`: String inserted between chunk results (default: `"\n"`)
   - `shouldMerge`: Merge small adjacent chunks up to the budget (default: `true`)
-  - `maxChunkTokens`: Maximum **estimated** tokens for each chunk's text (the `{{value:chunk}}` portion only - the system prompt and prompt template are budgeted separately). Token counts are estimated locally; values above the model's estimated input budget are capped automatically.
+  - `maxChunkTokens`: Maximum **estimated** tokens for each chunk's text (the `{{VALUE:chunk}}` portion only - the system prompt and prompt template are budgeted separately). Token counts are estimated locally; values above the model's estimated input budget are capped automatically.
 
 **Behavior:**
 - Chunk sizes are estimated locally (QuickAdd no longer bundles model-specific tokenizers); the configured provider remains the source of truth for exact limits.
@@ -630,7 +630,7 @@ results. Use this for inputs that are too large for a single request.
 ```javascript
 const result = await quickAddApi.ai.chunkedPrompt(
     longText,
-    "Summarize this section:\n{{value:chunk}}",
+    "Summarize this section:\n{{VALUE:chunk}}",
     "gpt-4o",
     { variableName: "summary", chunkJoiner: "\n\n" }
 );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,84 +40,12 @@ export const CLIPBOARD_SYNTAX = "{{clipboard}}";
 export const RANDOM_SYNTAX = "{{random:<length>}}";
 export const GLOBAL_VAR_SYNTAX = "{{global_var:<name>}}";
 
-export const FORMAT_SYNTAX: string[] = [
-	DATE_SYNTAX,
-	"{{date:<dateformat>}}",
-	"{{date:<dateformat>|startof:<unit>}}",
-	"{{date:<dateformat>|endof:<unit>}}",
-	"{{vdate:<variable name>, <date format>}}",
-	"{{vdate:<variable name>, <date format>|<default value>}}",
-	VDATE_OPTIONAL_SYNTAX,
-	GLOBAL_VAR_SYNTAX,
-	VALUE_SYNTAX,
-	NAME_SYNTAX,
-	VALUE_CASE_SYNTAX,
-	VARIABLE_CASE_SYNTAX,
-	VALUE_TRIM_SYNTAX,
-	VARIABLE_TRIM_SYNTAX,
-	VARIABLE_SYNTAX,
-	VARIABLE_DEFAULT_SYNTAX,
-	VARIABLE_DEFAULT_OPTION_SYNTAX,
-	VARIABLE_LABEL_SYNTAX,
-	VARIABLE_TEXT_SYNTAX,
-	VARIABLE_NAME_SYNTAX,
-	VARIABLE_OPTIONAL_SYNTAX,
-	FIELD_VAR_SYNTAX,
-	FIELD_VAR_MULTI_SYNTAX,
-	"{{field:<fieldname>|folder:<path>}}",
-	"{{field:<fieldname>|tag:<tagname>}}",
-	"{{field:<fieldname>|inline:true}}",
-	"{{field:<fieldname>|inline:true|inline-code-blocks:ad-note}}",
-	FILE_SYNTAX,
-	FILE_MULTI_SYNTAX,
-	FILE_LINK_SYNTAX,
-	FILE_PATH_SYNTAX,
-	LINKCURRENT_SYNTAX,
-	LINKSECTION_SYNTAX,
-	FILENAMECURRENT_SYNTAX,
-	FOLDERCURRENT_SYNTAX,
-	FOLDERCURRENT_NAME_SYNTAX,
-	FOLDER_SYNTAX,
-	"{{folder|name}}",
-	"{{macro:<macroname>}}",
-	"{{macro:<macroname>|label:<label>}}",
-	"{{template:<templatepath>}}",
-	MATH_VALUE_SYNTAX,
-	SELECTED_SYNTAX,
-	CLIPBOARD_SYNTAX,
-	RANDOM_SYNTAX,
-];
-
-export const FILE_NAME_FORMAT_SYNTAX: string[] = [
-	DATE_SYNTAX,
-	"{{date:<dateformat>}}",
-	"{{date:<dateformat>|startof:<unit>}}",
-	"{{date:<dateformat>|endof:<unit>}}",
-	"{{vdate:<variable name>, <date format>}}",
-	"{{vdate:<variable name>, <date format>|<default value>}}",
-	GLOBAL_VAR_SYNTAX,
-	VALUE_SYNTAX,
-	NAME_SYNTAX,
-	VALUE_CASE_SYNTAX,
-	VARIABLE_CASE_SYNTAX,
-	VALUE_TRIM_SYNTAX,
-	VARIABLE_TRIM_SYNTAX,
-	VARIABLE_SYNTAX,
-	VARIABLE_DEFAULT_SYNTAX,
-	VARIABLE_DEFAULT_OPTION_SYNTAX,
-	VARIABLE_LABEL_SYNTAX,
-	VARIABLE_TEXT_SYNTAX,
-	VARIABLE_NAME_SYNTAX,
-	FIELD_VAR_SYNTAX,
-	FILE_SYNTAX,
-	FOLDERCURRENT_SYNTAX,
-	FOLDERCURRENT_NAME_SYNTAX,
-	RANDOM_SYNTAX,
-];
-// Note: |optional is deliberately absent from FILE_NAME_FORMAT_SYNTAX — an
-// all-optional file name that resolves empty is rejected at creation time.
-
-export const TEMPLATE_FORMAT_SYNTAX: string[] = [TITLE_SYNTAX];
+// The autocomplete's token list — with a one-line description per row and
+// per-field context gating — lives in gui/suggesters/formatTokenRegistry.ts.
+// The FORMAT_SYNTAX / FILE_NAME_FORMAT_SYNTAX / TEMPLATE_FORMAT_SYNTAX
+// cheat-sheet arrays that used to sit here were a second, undescribed copy of
+// the same token language in a third casing convention (#1542); the registry
+// replaces them.
 
 export const NUMBER_REGEX = new RegExp(/^-?[0-9]*$/);
 
@@ -287,12 +215,17 @@ export const FOLDERCURRENT_SYNTAX_SUGGEST_REGEX = new RegExp(
 export const FOLDER_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[F]?[O]?[L]?[D]?[E]?[R]?[}]?[}]?$/i,
 );
-// Requires the full literal "FILE" before offering {{FILE:}}, so it isn't
-// offered prematurely at {{F/{{FI; {{FILENAMECURRENT}} still co-suggests at
-// {{FILE (benign — both are valid completions of that prefix).
-export const FILE_SYNTAX_SUGGEST_REGEX = new RegExp(
-	/{{FILE[:]?$|{{FILE:[^\n\r}]*}}$/i,
-);
+// Flat prefix matcher like its siblings, so {{FILE:}} shows up in the bare "{{"
+// index of every token (#1542) rather than only after the full literal "FILE".
+// {{FIELD:}}, {{FILENAMECURRENT}} and the folder tokens co-suggest at the shared
+// "{{f"/"{{fi" prefixes and disambiguate on the next letter — the same trade the
+// FOLDER/FOLDERCURRENT pair already makes.
+export const FILE_SYNTAX_SUGGEST_REGEX = new RegExp(/{{[F]?[I]?[L]?[E]?[:]?$/i);
+// {{FIELD:}} is implemented and documented but had no matcher, so the
+// autocomplete never offered it (#1542). Only the pre-colon prefix is
+// reachable: the suggester stops suggesting as soon as the segment contains
+// ":", which is why no post-colon alternative is spelled out here.
+export const FIELD_SYNTAX_SUGGEST_REGEX = new RegExp(/{{[F]?[I]?[E]?[L]?[D]?[:]?$/i);
 export const TEMPLATE_SYNTAX_SUGGEST_REGEX = new RegExp(
 	/{{[T]?[E]?[M]?[P]?[L]?[A]?[T]?[E]?[:]?$|{{TEMPLATE:[^\n\r}]*[}]?[}]?$/i,
 );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,51 +1,15 @@
 export const VALUE_SYNTAX = "{{value}}";
-export const DATE_SYNTAX = "{{date}}";
-export const TIME_SYNTAX = "{{time}}";
 export const NAME_SYNTAX = "{{name}}";
-export const VARIABLE_SYNTAX = "{{value:<variable name>}}";
-export const VARIABLE_DEFAULT_SYNTAX =
-	"{{value:<variable name>|<default value>}}";
-export const VARIABLE_DEFAULT_OPTION_SYNTAX =
-	"{{value:<variable name>|default:<value>}}";
-export const VARIABLE_LABEL_SYNTAX =
-	"{{value:<variable name>|label:<helper text>}}";
-export const VARIABLE_TEXT_SYNTAX =
-	"{{value:<items>|text:<display items>}}";
-export const VARIABLE_NAME_SYNTAX =
-	"{{value:<options>|name:<variable name>}}";
-export const VARIABLE_OPTIONAL_SYNTAX =
-	"{{value:<variable name>|optional}}";
-export const VDATE_OPTIONAL_SYNTAX =
-	"{{vdate:<variable name>, <date format>|optional}}";
-export const VALUE_CASE_SYNTAX = "{{value|case:kebab}}";
-export const VARIABLE_CASE_SYNTAX = "{{value:<variable name>|case:kebab}}";
-export const VALUE_TRIM_SYNTAX = "{{value|trim}}";
-export const VARIABLE_TRIM_SYNTAX = "{{value:<variable name>|trim}}";
-export const FIELD_VAR_SYNTAX = "{{field:<field name>}}";
-export const FIELD_VAR_MULTI_SYNTAX = "{{field:<field name>|multi}}";
-export const FILE_SYNTAX = "{{file:<folder>}}";
-export const FILE_MULTI_SYNTAX = "{{file:<folder>|multi}}";
-export const FILE_LINK_SYNTAX = "{{file:<folder>|link}}";
-export const FILE_PATH_SYNTAX = "{{file:<folder>|path}}";
-export const MATH_VALUE_SYNTAX = "{{mvalue}}";
-export const LINKCURRENT_SYNTAX = "{{linkcurrent}}";
-export const LINKSECTION_SYNTAX = "{{linksection}}";
-export const FILENAMECURRENT_SYNTAX = "{{filenamecurrent}}";
-export const FOLDERCURRENT_SYNTAX = "{{foldercurrent}}";
-export const FOLDERCURRENT_NAME_SYNTAX = "{{foldercurrent|name}}";
-export const FOLDER_SYNTAX = "{{folder}}";
-export const TITLE_SYNTAX = "{{title}}";
-export const SELECTED_SYNTAX = "{{selected}}";
-export const CLIPBOARD_SYNTAX = "{{clipboard}}";
-export const RANDOM_SYNTAX = "{{random:<length>}}";
-export const GLOBAL_VAR_SYNTAX = "{{global_var:<name>}}";
 
-// The autocomplete's token list — with a one-line description per row and
-// per-field context gating — lives in gui/suggesters/formatTokenRegistry.ts.
-// The FORMAT_SYNTAX / FILE_NAME_FORMAT_SYNTAX / TEMPLATE_FORMAT_SYNTAX
-// cheat-sheet arrays that used to sit here were a second, undescribed copy of
-// the same token language in a third casing convention (#1542); the registry
-// replaces them.
+// The token language's authoring surface - one row per token, with a one-line
+// description and the fields it resolves in - lives in
+// gui/suggesters/formatTokenRegistry.ts. The FORMAT_SYNTAX /
+// FILE_NAME_FORMAT_SYNTAX / TEMPLATE_FORMAT_SYNTAX cheat-sheet arrays that used
+// to sit here were a second, undescribed copy of the same language in a third
+// casing convention (#1542), and the per-token constants existed only to build
+// them. VALUE_SYNTAX and NAME_SYNTAX stay: they are runtime defaults (the body
+// a format-less capture writes, the title prompt a template discovery step
+// looks for), not display strings.
 
 export const NUMBER_REGEX = new RegExp(/^-?[0-9]*$/);
 
@@ -218,7 +182,7 @@ export const FOLDER_SYNTAX_SUGGEST_REGEX = new RegExp(
 // Flat prefix matcher like its siblings, so {{FILE:}} shows up in the bare "{{"
 // index of every token (#1542) rather than only after the full literal "FILE".
 // {{FIELD:}}, {{FILENAMECURRENT}} and the folder tokens co-suggest at the shared
-// "{{f"/"{{fi" prefixes and disambiguate on the next letter — the same trade the
+// "{{f"/"{{fi" prefixes and disambiguate on the next letter, the same trade the
 // FOLDER/FOLDERCURRENT pair already makes.
 export const FILE_SYNTAX_SUGGEST_REGEX = new RegExp(/{{[F]?[I]?[L]?[E]?[:]?$/i);
 // {{FIELD:}} is implemented and documented but had no matcher, so the

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -83,7 +83,7 @@ function validateTemplatePath(
 // --- File name format ----------------------------------------------------
 const fileNameSuggesters = [
 	(el: HTMLInputElement | HTMLTextAreaElement) =>
-		new FormatSyntaxSuggester(app, el, plugin, true),
+		new FormatSyntaxSuggester(app, el, plugin, "fileName"),
 ];
 const discoverySupported = $derived(
 	usesDefaultTemplateTitlePrompt(

--- a/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
@@ -2,7 +2,6 @@
 import type { App } from "obsidian";
 import type QuickAdd from "../../../main";
 import type ICaptureChoice from "../../../types/choices/ICaptureChoice";
-import { FILE_NAME_FORMAT_SYNTAX } from "../../../constants";
 import { getAllFolderPathsInVault } from "../../../utilityObsidian";
 import { sortFolderPathsByTree } from "../../../utils/folder-sorting";
 import { FormatSyntaxSuggester } from "../../suggesters/formatSyntaxSuggester";
@@ -36,19 +35,16 @@ const captureTargetSuggestions = $derived.by(() => {
 		.getFiles()
 		.filter((file) => file.extension === "canvas")
 		.map((file) => file.path);
-	return Array.from(
-		new Set([
-			...folderPaths,
-			...markdownPaths,
-			...canvasPaths,
-			...FILE_NAME_FORMAT_SYNTAX,
-		]),
-	);
+	// Paths only. Format tokens used to be mixed in here too, which put a second
+	// suggester's undescribed, differently-cased copy of the token list on the
+	// same input as FormatSyntaxSuggester — two stacked popups for one language,
+	// and the generic one replaces the whole field on accept (#1542).
+	return Array.from(new Set([...folderPaths, ...markdownPaths, ...canvasPaths]));
 });
 
 const suggesters = [
 	(el: HTMLInputElement | HTMLTextAreaElement) =>
-		new FormatSyntaxSuggester(app, el, plugin),
+		new FormatSyntaxSuggester(app, el, plugin, "captureTarget"),
 ];
 
 const captureTargetFeedback = $derived.by(() =>

--- a/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
@@ -37,7 +37,7 @@ const captureTargetSuggestions = $derived.by(() => {
 		.map((file) => file.path);
 	// Paths only. Format tokens used to be mixed in here too, which put a second
 	// suggester's undescribed, differently-cased copy of the token list on the
-	// same input as FormatSyntaxSuggester — two stacked popups for one language,
+	// same input as FormatSyntaxSuggester: two stacked popups for one language,
 	// and the generic one replaces the whole field on accept (#1542).
 	return Array.from(new Set([...folderPaths, ...markdownPaths, ...canvasPaths]));
 });

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -12,7 +12,6 @@ import {
 } from "../../../constants";
 import {
 	FormatSyntaxSuggester,
-	FormatSyntaxToken,
 } from "../../suggesters/formatSyntaxSuggester";
 import { detectDateFormatFromAfter } from "../../../utils/insertAfterDateFormat";
 import { FormatDisplayFormatter } from "../../../formatters/formatDisplayFormatter";
@@ -54,13 +53,12 @@ if (!insertAfter.createIfNotFoundLocation)
 	insertAfter.createIfNotFoundLocation = CREATE_IF_NOT_FOUND_TOP;
 
 const suggesters = [
-	// Line-target field: withhold {{foldercurrent}}, which formatLocationString
-	// deliberately leaves literal in selectors (a legitimate "" resolution would
-	// match the first line), so it is never suggested where it cannot resolve.
+	// Line-target field: the "lineTarget" context withholds the tokens
+	// formatLocationString deliberately leaves literal in selectors (notably
+	// {{FOLDERCURRENT}}, whose legitimate "" resolution would match the first
+	// line), so nothing is suggested here that cannot resolve here.
 	(el: HTMLInputElement | HTMLTextAreaElement) =>
-		new FormatSyntaxSuggester(app, el, plugin, false, [
-			FormatSyntaxToken.FolderCurrent,
-		]),
+		new FormatSyntaxSuggester(app, el, plugin, "lineTarget"),
 ];
 
 const blankLineOptions = [

--- a/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
@@ -9,7 +9,6 @@ import {
 } from "../../../constants";
 import {
 	FormatSyntaxSuggester,
-	FormatSyntaxToken,
 } from "../../suggesters/formatSyntaxSuggester";
 import SettingItem from "../../components/SettingItem.svelte";
 import Toggle from "../../components/Toggle.svelte";
@@ -38,13 +37,12 @@ if (!insertBefore.createIfNotFoundLocation)
 	insertBefore.createIfNotFoundLocation = CREATE_IF_NOT_FOUND_TOP;
 
 const suggesters = [
-	// Line-target field: withhold {{foldercurrent}}, which formatLocationString
-	// deliberately leaves literal in selectors (a legitimate "" resolution would
-	// match the first line), so it is never suggested where it cannot resolve.
+	// Line-target field: the "lineTarget" context withholds the tokens
+	// formatLocationString deliberately leaves literal in selectors (notably
+	// {{FOLDERCURRENT}}, whose legitimate "" resolution would match the first
+	// line), so nothing is suggested here that cannot resolve here.
 	(el: HTMLInputElement | HTMLTextAreaElement) =>
-		new FormatSyntaxSuggester(app, el, plugin, false, [
-			FormatSyntaxToken.FolderCurrent,
-		]),
+		new FormatSyntaxSuggester(app, el, plugin, "lineTarget"),
 ];
 
 const createLocationOptions = [

--- a/src/gui/suggesters/formatSyntaxSuggester.audit-preflight-suggesters.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.audit-preflight-suggesters.test.ts
@@ -1,90 +1,10 @@
-import { describe, expect, it, beforeEach } from "vitest";
-import { FormatSyntaxSuggester } from "./formatSyntaxSuggester";
-
-function ensureObsidianDomPolyfills(): void {
-	(globalThis as any).createDiv ??= (cls?: string) => {
-		const div = document.createElement("div");
-		if (cls) div.className = cls;
-		return div;
-	};
-
-	const proto = HTMLElement.prototype as any;
-
-	proto.createDiv ??= function (arg?: string | { cls?: string }) {
-		const div = document.createElement("div");
-		if (typeof arg === "string") div.className = arg;
-		else if (arg && typeof arg === "object" && typeof arg.cls === "string")
-			div.className = arg.cls;
-		this.appendChild(div);
-		return div;
-	};
-
-	proto.empty ??= function () {
-		this.replaceChildren();
-		return this;
-	};
-
-	proto.on ??= function () {
-		return this;
-	};
-
-	proto.detach ??= function () {
-		this.remove();
-	};
-
-	proto.addClass ??= function (...classes: string[]) {
-		this.classList.add(...classes);
-		return this;
-	};
-
-	proto.removeClass ??= function (...classes: string[]) {
-		this.classList.remove(...classes);
-		return this;
-	};
-
-	proto.setAttr ??= function (name: string, value: string) {
-		this.setAttribute(name, value);
-		return this;
-	};
-}
-
-const makeApp = () =>
-	({
-		dom: { appContainerEl: document.body },
-		keymap: { pushScope: () => {}, popScope: () => {} },
-	}) as any;
-
-const makePlugin = () =>
-	({
-		settings: { choices: [], globalVariables: {} },
-		getTemplateFiles: () => [],
-	}) as any;
-
-async function suggestForFile(value: string, suggestForFileNames: boolean) {
-	const inputEl = document.createElement("input");
-	inputEl.value = value;
-	inputEl.selectionStart = value.length;
-	inputEl.selectionEnd = value.length;
-
-	const suggester = new FormatSyntaxSuggester(
-		makeApp(),
-		inputEl,
-		makePlugin(),
-		suggestForFileNames,
-	);
-	const suggestions = await suggester.getSuggestions(value);
-	suggester.destroy();
-	return suggestions;
-}
+import { describe, expect, it } from "vitest";
+import { suggestInserts } from "../../../tests/suggesters/formatSuggesterHarness";
 
 describe("FormatSyntaxSuggester file-name token gating", () => {
-	beforeEach(() => {
-		ensureObsidianDomPolyfills();
-	});
-
 	// Finding: format-core-file-options
 	it("does NOT offer {{FILE:<folder>|optional}} in the file-name field", async () => {
-		const suggestions = await suggestForFile("{{FILE", true);
+		const suggestions = await suggestInserts("{{FILE", { context: "fileName" });
 		expect(suggestions).toContain("{{FILE:<folder>}}");
 		expect(suggestions).not.toContain("{{FILE:<folder>|optional}}");
 		// |link / |path stay gated too
@@ -92,16 +12,28 @@ describe("FormatSyntaxSuggester file-name token gating", () => {
 		expect(suggestions).not.toContain("{{FILE:<folder>|path}}");
 	});
 
-	it("still offers {{FILE:<folder>|optional}} outside the file-name field", async () => {
-		const suggestions = await suggestForFile("{{FILE", false);
+	it("gates the same variants in the capture target field, which is also a path", async () => {
+		const suggestions = await suggestInserts("{{FILE", {
+			context: "captureTarget",
+		});
+		expect(suggestions).toContain("{{FILE:<folder>}}");
+		expect(suggestions).not.toContain("{{FILE:<folder>|optional}}");
+		expect(suggestions).not.toContain("{{FILE:<folder>|link}}");
+		expect(suggestions).not.toContain("{{FILE:<folder>|path}}");
+	});
+
+	it("still offers {{FILE:<folder>|optional}} in note bodies", async () => {
+		const suggestions = await suggestInserts("{{FILE");
 		expect(suggestions).toContain("{{FILE:<folder>|optional}}");
 		expect(suggestions).toContain("{{FILE:<folder>|link}}");
 		expect(suggestions).toContain("{{FILE:<folder>|path}}");
 	});
 
 	// Finding: format-file-filenamecurrent-token
-	it("offers {{filenamecurrent}} in the file-name field", async () => {
-		const suggestions = await suggestForFile("{{FILENAME", true);
-		expect(suggestions).toContain("{{filenamecurrent}}");
+	it("offers {{FILENAMECURRENT}} in the file-name field", async () => {
+		const suggestions = await suggestInserts("{{FILENAME", {
+			context: "fileName",
+		});
+		expect(suggestions).toContain("{{FILENAMECURRENT}}");
 	});
 });

--- a/src/gui/suggesters/formatSyntaxSuggester.case.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.case.test.ts
@@ -1,126 +1,41 @@
-import { describe, expect, it, beforeEach } from "vitest";
-import { FormatSyntaxSuggester } from "./formatSyntaxSuggester";
-
-function ensureObsidianDomPolyfills(): void {
-	(globalThis as any).createDiv ??= (cls?: string) => {
-		const div = document.createElement("div");
-		if (cls) div.className = cls;
-		return div;
-	};
-
-	const proto = HTMLElement.prototype as any;
-
-	proto.createDiv ??= function (arg?: string | { cls?: string }) {
-		const div = document.createElement("div");
-		if (typeof arg === "string") div.className = arg;
-		else if (arg && typeof arg === "object" && typeof arg.cls === "string")
-			div.className = arg.cls;
-		this.appendChild(div);
-		return div;
-	};
-
-	proto.empty ??= function () {
-		this.replaceChildren();
-		return this;
-	};
-
-	// Obsidian adds delegated event helpers; tests don't need behavior here.
-	proto.on ??= function () {
-		return this;
-	};
-
-	proto.detach ??= function () {
-		this.remove();
-	};
-
-	proto.addClass ??= function (...classes: string[]) {
-		this.classList.add(...classes);
-		return this;
-	};
-
-	proto.removeClass ??= function (...classes: string[]) {
-		this.classList.remove(...classes);
-		return this;
-	};
-
-	proto.setAttr ??= function (name: string, value: string) {
-		this.setAttribute(name, value);
-		return this;
-	};
-}
+import { describe, expect, it } from "vitest";
+import {
+	suggestInserts,
+	suggestRows,
+} from "../../../tests/suggesters/formatSuggesterHarness";
 
 describe("FormatSyntaxSuggester case style suggestions", () => {
-	beforeEach(() => {
-		ensureObsidianDomPolyfills();
-	});
-
 	it("suggests kebab when typing a |case: prefix", async () => {
-		const app = {
-			dom: { appContainerEl: document.body },
-			keymap: { pushScope: () => {}, popScope: () => {} },
-		} as any;
-		const plugin = {
-			settings: { choices: [], globalVariables: {} },
-			getTemplateFiles: () => [],
-		} as any;
-
-		const inputEl = document.createElement("input");
-		inputEl.value = "{{VALUE:title|case:k";
-		inputEl.selectionStart = inputEl.value.length;
-		inputEl.selectionEnd = inputEl.value.length;
-
-		const suggester = new FormatSyntaxSuggester(app, inputEl, plugin);
-		const suggestions = await suggester.getSuggestions(inputEl.value);
-		expect(suggestions).toEqual(["kebab"]);
-		suggester.destroy();
+		const s = await suggestInserts("{{VALUE:title|case:k");
+		expect(s).toEqual(["kebab"]);
 	});
 
 	it("suggests all styles (including slug) when case fragment is empty", async () => {
-		const app = {
-			dom: { appContainerEl: document.body },
-			keymap: { pushScope: () => {}, popScope: () => {} },
-		} as any;
-		const plugin = {
-			settings: { choices: [], globalVariables: {} },
-			getTemplateFiles: () => [],
-		} as any;
+		const s = await suggestInserts("{{VALUE:title|case:");
+		expect(s).toEqual([
+			"kebab",
+			"snake",
+			"camel",
+			"pascal",
+			"title",
+			"lower",
+			"upper",
+			"slug",
+		]);
+	});
 
-		const inputEl = document.createElement("input");
-		inputEl.value = "{{VALUE:title|case:";
-		inputEl.selectionStart = inputEl.value.length;
-		inputEl.selectionEnd = inputEl.value.length;
-
-		const suggester = new FormatSyntaxSuggester(app, inputEl, plugin);
-		const suggestions = await suggester.getSuggestions(inputEl.value);
-		expect(suggestions).toContain("slug");
-		expect(suggestions).toContain("kebab");
-		expect(suggestions).toContain("snake");
-		expect(suggestions).toContain("camel");
-		expect(suggestions).toContain("pascal");
-		expect(suggestions).toContain("title");
-		expect(suggestions).toContain("lower");
-		expect(suggestions).toContain("upper");
-		suggester.destroy();
+	it("shows what each style does to a title, and renders as a bare fragment", async () => {
+		const rows = await suggestRows("{{VALUE:title|case:");
+		expect(rows.find((row) => row.insert === "kebab")?.description).toBe(
+			"my-note-title",
+		);
+		expect(rows.every((row) => row.isFragment)).toBe(true);
+		// A fragment replaces the typed letters in place, so the caret stays put.
+		expect(rows.every((row) => row.caretOffset === 0)).toBe(true);
 	});
 
 	it("includes a trim example in VALUE variable suggestions", async () => {
-		const app = {
-			dom: { appContainerEl: document.body },
-			keymap: { pushScope: () => {}, popScope: () => {} },
-		} as any;
-		const plugin = {
-			settings: { choices: [], globalVariables: {} },
-			getTemplateFiles: () => [],
-		} as any;
-
-		const inputEl = document.createElement("input");
-		inputEl.value = "{{VALUE";
-		inputEl.selectionStart = inputEl.value.length;
-		inputEl.selectionEnd = inputEl.value.length;
-
-		const suggester = new FormatSyntaxSuggester(app, inputEl, plugin);
-		const suggestions = await suggester.getSuggestions(inputEl.value);
-		expect(suggestions).toContain("{{VALUE:title|trim}}");
-		suggester.destroy();
+		const s = await suggestInserts("{{VALUE");
+		expect(s).toContain("{{VALUE:title|trim}}");
 	});
 });

--- a/src/gui/suggesters/formatSyntaxSuggester.foldercurrent.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.foldercurrent.test.ts
@@ -1,115 +1,45 @@
-import { describe, expect, it, beforeEach } from "vitest";
-import { FormatSyntaxSuggester, FormatSyntaxToken } from "./formatSyntaxSuggester";
+import { describe, expect, it } from "vitest";
+import { suggestInserts } from "../../../tests/suggesters/formatSuggesterHarness";
 
-// Minimal Obsidian DOM polyfills (same shape as formatSyntaxSuggester.case.test.ts).
-function ensureObsidianDomPolyfills(): void {
-	(globalThis as any).createDiv ??= (cls?: string) => {
-		const div = document.createElement("div");
-		if (cls) div.className = cls;
-		return div;
-	};
-	const proto = HTMLElement.prototype as any;
-	proto.createDiv ??= function (arg?: string | { cls?: string }) {
-		const div = document.createElement("div");
-		if (typeof arg === "string") div.className = arg;
-		else if (arg && typeof arg === "object" && typeof arg.cls === "string")
-			div.className = arg.cls;
-		this.appendChild(div);
-		return div;
-	};
-	proto.empty ??= function () {
-		this.replaceChildren();
-		return this;
-	};
-	proto.on ??= function () {
-		return this;
-	};
-	proto.detach ??= function () {
-		this.remove();
-	};
-	proto.addClass ??= function (...classes: string[]) {
-		this.classList.add(...classes);
-		return this;
-	};
-	proto.removeClass ??= function (...classes: string[]) {
-		this.classList.remove(...classes);
-		return this;
-	};
-	proto.setAttr ??= function (name: string, value: string) {
-		this.setAttribute(name, value);
-		return this;
-	};
-}
-
-function suggestFor(
-	value: string,
-	suggestForFileNames = false,
-	excludeTokens: FormatSyntaxToken[] = [],
-): Promise<string[]> {
-	const app = {
-		dom: { appContainerEl: document.body },
-		keymap: { pushScope: () => {}, popScope: () => {} },
-	} as any;
-	const plugin = {
-		settings: { choices: [], globalVariables: {} },
-		getTemplateFiles: () => [],
-	} as any;
-	const inputEl = document.createElement("input");
-	inputEl.value = value;
-	inputEl.selectionStart = value.length;
-	inputEl.selectionEnd = value.length;
-	const suggester = new FormatSyntaxSuggester(
-		app,
-		inputEl,
-		plugin,
-		suggestForFileNames,
-		excludeTokens,
-	);
-	return suggester.getSuggestions(value).finally(() => suggester.destroy());
-}
-
-describe("FormatSyntaxSuggester {{foldercurrent}} (shared {{folder prefix)", () => {
-	beforeEach(() => {
-		ensureObsidianDomPolyfills();
+describe("FormatSyntaxSuggester {{FOLDERCURRENT}} (shared {{FOLDER prefix)", () => {
+	it("offers {{FOLDERCURRENT}} in note bodies", async () => {
+		const s = await suggestInserts("{{foldercurrent");
+		expect(s).toContain("{{FOLDERCURRENT}}");
 	});
 
-	it("offers {{foldercurrent}} in the contextual set (format bodies + Capture To field)", async () => {
-		const s = await suggestFor("{{foldercurrent");
-		expect(s).toContain("{{foldercurrent}}");
+	it("offers {{FOLDERCURRENT}} in the capture target field (#1480)", async () => {
+		const s = await suggestInserts("{{foldercurrent", { context: "captureTarget" });
+		expect(s).toContain("{{FOLDERCURRENT}}");
 	});
 
-	it("narrows to foldercurrent only once disambiguated by 'c' (contextual set)", async () => {
-		const s = await suggestFor("{{folderc");
-		expect(s).toContain("{{foldercurrent}}");
-		// {{folder|name}} lives only in the file-name set, and no bare {{folder}}
+	it("narrows to foldercurrent only once disambiguated by 'c'", async () => {
+		const s = await suggestInserts("{{folderc");
+		expect(s).toContain("{{FOLDERCURRENT}}");
+		// {{FOLDER|name}} lives only in the file-name set, and no bare {{FOLDER}}
 		// completion should survive the 'c'.
-		expect(s.some((x) => /^\{\{folder\}?\}?$/.test(x))).toBe(false);
+		expect(s.some((x) => /^\{\{FOLDER\}?\}?$/i.test(x))).toBe(false);
 	});
 
-	it("offers both folder tokens at the ambiguous {{folder prefix in the file-name set", async () => {
-		const s = await suggestFor("{{folder", true);
-		expect(s).toContain("{{folder|name}}");
-		expect(s).toContain("{{foldercurrent|name}}");
+	it("offers both folder tokens at the ambiguous {{FOLDER prefix in a file name", async () => {
+		const s = await suggestInserts("{{folder", { context: "fileName" });
+		expect(s).toContain("{{FOLDER|name}}");
+		expect(s).toContain("{{FOLDERCURRENT|name}}");
 	});
 
-	it("offers only the |name form in the file-name set (full-path nesting footgun)", async () => {
-		const s = await suggestFor("{{folderc", true);
-		expect(s).toContain("{{foldercurrent|name}}");
-		expect(s).not.toContain("{{foldercurrent}}");
-		expect(s).not.toContain("{{folder|name}}");
+	it("offers only the |name form in a file name (full-path nesting footgun)", async () => {
+		const s = await suggestInserts("{{folderc", { context: "fileName" });
+		expect(s).toContain("{{FOLDERCURRENT|name}}");
+		expect(s).not.toContain("{{FOLDERCURRENT}}");
+		expect(s).not.toContain("{{FOLDER|name}}");
 	});
 
-	it("withholds the token when excluded (insert-after/before line-target fields)", async () => {
-		// formatLocationString leaves {{foldercurrent}} literal in line selectors,
-		// so those fields exclude it — no suggester/runtime mismatch.
-		const s = await suggestFor("{{folderc", false, [
-			FormatSyntaxToken.FolderCurrent,
-		]);
-		expect(s).not.toContain("{{foldercurrent}}");
-		// Other contextual tokens are unaffected by the exclusion.
-		const links = await suggestFor("{{linkc", false, [
-			FormatSyntaxToken.FolderCurrent,
-		]);
-		expect(links).toContain("{{linkcurrent}}");
+	it("withholds the token in line-target fields", async () => {
+		// formatLocationString leaves {{FOLDERCURRENT}} literal in line selectors,
+		// so those fields do not offer it — no suggester/runtime mismatch.
+		const s = await suggestInserts("{{folderc", { context: "lineTarget" });
+		expect(s).not.toContain("{{FOLDERCURRENT}}");
+		// Other tokens are unaffected.
+		const links = await suggestInserts("{{linkc", { context: "lineTarget" });
+		expect(links).toContain("{{LINKCURRENT}}");
 	});
 });

--- a/src/gui/suggesters/formatSyntaxSuggester.linksection.test.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.linksection.test.ts
@@ -1,88 +1,27 @@
-import { describe, expect, it, beforeEach } from "vitest";
-import { FormatSyntaxSuggester } from "./formatSyntaxSuggester";
+import { describe, expect, it } from "vitest";
+import { suggestInserts } from "../../../tests/suggesters/formatSuggesterHarness";
 
-// Minimal Obsidian DOM polyfills (same shape as formatSyntaxSuggester.case.test.ts).
-function ensureObsidianDomPolyfills(): void {
-	(globalThis as any).createDiv ??= (cls?: string) => {
-		const div = document.createElement("div");
-		if (cls) div.className = cls;
-		return div;
-	};
-	const proto = HTMLElement.prototype as any;
-	proto.createDiv ??= function (arg?: string | { cls?: string }) {
-		const div = document.createElement("div");
-		if (typeof arg === "string") div.className = arg;
-		else if (arg && typeof arg === "object" && typeof arg.cls === "string")
-			div.className = arg.cls;
-		this.appendChild(div);
-		return div;
-	};
-	proto.empty ??= function () {
-		this.replaceChildren();
-		return this;
-	};
-	proto.on ??= function () {
-		return this;
-	};
-	proto.detach ??= function () {
-		this.remove();
-	};
-	proto.addClass ??= function (...classes: string[]) {
-		this.classList.add(...classes);
-		return this;
-	};
-	proto.removeClass ??= function (...classes: string[]) {
-		this.classList.remove(...classes);
-		return this;
-	};
-	proto.setAttr ??= function (name: string, value: string) {
-		this.setAttribute(name, value);
-		return this;
-	};
-}
-
-function suggestFor(value: string): Promise<string[]> {
-	const app = {
-		dom: { appContainerEl: document.body },
-		keymap: { pushScope: () => {}, popScope: () => {} },
-	} as any;
-	const plugin = {
-		settings: { choices: [], globalVariables: {} },
-		getTemplateFiles: () => [],
-	} as any;
-	const inputEl = document.createElement("input");
-	inputEl.value = value;
-	inputEl.selectionStart = value.length;
-	inputEl.selectionEnd = value.length;
-	const suggester = new FormatSyntaxSuggester(app, inputEl, plugin);
-	return suggester.getSuggestions(value).finally(() => suggester.destroy());
-}
-
-describe("FormatSyntaxSuggester {{linksection}} (shared {{link prefix)", () => {
-	beforeEach(() => {
-		ensureObsidianDomPolyfills();
-	});
-
-	it("offers both link tokens at the ambiguous {{link prefix", async () => {
-		const s = await suggestFor("{{link");
-		expect(s).toContain("{{linkcurrent}}");
-		expect(s).toContain("{{linksection}}");
+describe("FormatSyntaxSuggester {{LINKSECTION}} (shared {{LINK prefix)", () => {
+	it("offers both link tokens at the ambiguous {{LINK prefix", async () => {
+		const s = await suggestInserts("{{link");
+		expect(s).toContain("{{LINKCURRENT}}");
+		expect(s).toContain("{{LINKSECTION}}");
 	});
 
 	it("narrows to linkcurrent only once disambiguated by 'c'", async () => {
-		const s = await suggestFor("{{linkc");
-		expect(s).toContain("{{linkcurrent}}");
-		expect(s).not.toContain("{{linksection}}");
+		const s = await suggestInserts("{{linkc");
+		expect(s).toContain("{{LINKCURRENT}}");
+		expect(s).not.toContain("{{LINKSECTION}}");
 	});
 
 	it("narrows to linksection only once disambiguated by 's'", async () => {
-		const s = await suggestFor("{{links");
-		expect(s).toContain("{{linksection}}");
-		expect(s).not.toContain("{{linkcurrent}}");
+		const s = await suggestInserts("{{links");
+		expect(s).toContain("{{LINKSECTION}}");
+		expect(s).not.toContain("{{LINKCURRENT}}");
 	});
 
-	it("still completes the full {{linksection}} token", async () => {
-		const s = await suggestFor("{{linksection");
-		expect(s).toContain("{{linksection}}");
+	it("still completes the full {{LINKSECTION}} token", async () => {
+		const s = await suggestInserts("{{linksection");
+		expect(s).toContain("{{LINKSECTION}}");
 	});
 });

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -1,255 +1,46 @@
 import { TextInputSuggest } from "./suggest";
 import type { App } from "obsidian";
-import {
-	DATE_FORMAT_SYNTAX_SUGGEST_REGEX,
-	DATE_SYNTAX,
-	DATE_SYNTAX_SUGGEST_REGEX,
-	TIME_SYNTAX,
-	LINKCURRENT_SYNTAX,
-	LINKCURRENT_SYNTAX_SUGGEST_REGEX,
-	LINKSECTION_SYNTAX,
-	LINKSECTION_SYNTAX_SUGGEST_REGEX,
-	FILENAMECURRENT_SYNTAX,
-	FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
-	FILE_SYNTAX_SUGGEST_REGEX,
-	FOLDERCURRENT_SYNTAX,
-	FOLDERCURRENT_NAME_SYNTAX,
-	FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
-	FOLDER_SYNTAX_SUGGEST_REGEX,
-	MACRO_SYNTAX_SUGGEST_REGEX,
-	MATH_VALUE_SYNTAX,
-	MATH_VALUE_SYNTAX_SUGGEST_REGEX,
-	NAME_SYNTAX,
-	NAME_SYNTAX_SUGGEST_REGEX,
-	TEMPLATE_SYNTAX_SUGGEST_REGEX,
-	VALUE_SYNTAX,
-	VALUE_SYNTAX_SUGGEST_REGEX,
-	VARIABLE_DATE_SYNTAX_SUGGEST_REGEX,
-	VARIABLE_SYNTAX_SUGGEST_REGEX,
-	SELECTED_SYNTAX_SUGGEST_REGEX,
-	SELECTED_SYNTAX,
-	CLIPBOARD_SYNTAX_SUGGEST_REGEX,
-	CLIPBOARD_SYNTAX,
-	TIME_SYNTAX_SUGGEST_REGEX,
-	TITLE_SYNTAX_SUGGEST_REGEX,
-	TITLE_SYNTAX,
-	RANDOM_SYNTAX_SUGGEST_REGEX,
-	GLOBAL_VAR_SYNTAX_SUGGEST_REGEX,
-} from "../../constants";
 import type QuickAdd from "../../main";
 import { replaceRange } from "./utils";
 import { flattenChoices } from "../../utils/choiceUtils";
+import type {
+	FormatSuggestContext,
+	FormatTokenSuggestion,
+} from "./formatTokenRegistry";
+import {
+	CASE_STYLE_SUGGESTIONS,
+	EXPANSION_MIN_PREFIX,
+	entriesForContext,
+} from "./formatTokenRegistry";
 
-export enum FormatSyntaxToken {
-	Date,
-	DateFormat,
-	VariableDate,
-	Value,
-	Name,
-	Variable,
-	File,
-	LinkCurrent,
-	LinkSection,
-	FilenameCurrent,
-	FolderCurrent,
-	FolderTarget,
-	Macro,
-	Template,
-	MathValue,
-	Time,
-	Selected,
-	Clipboard,
-	Random,
-	Title,
-	GlobalVar,
-}
+export type { FormatSuggestContext } from "./formatTokenRegistry";
 
-interface TokenDefinition {
-	regex: RegExp;
-	token: FormatSyntaxToken;
-	suggestion: string;
-	cursorOffset?: number; // How far back to position cursor from end
-}
+const CASE_FRAGMENT_REGEX = /^\{\{(?:VALUE|NAME)[^\n\r}]*\|case:([a-z-]*)$/i;
 
-export class FormatSyntaxSuggester extends TextInputSuggest<string> {
-	private lastInput = "";
-	private lastInputType: FormatSyntaxToken;
-	private lastInputStart = 0;
+export class FormatSyntaxSuggester extends TextInputSuggest<FormatTokenSuggestion> {
+	/** Start offset of the fragment the accepted suggestion replaces. */
+	private replaceFrom = 0;
+	/** The letters typed after "{{", used to highlight what matched. */
+	private matchedQuery = "";
 	private readonly macroNames: string[];
 	private readonly templatePaths: string[];
-
-	// Table-driven approach for cleaner token processing
-	private readonly tokenDefinitions: TokenDefinition[] = [
-		{
-			regex: DATE_FORMAT_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.DateFormat,
-			suggestion: "{{DATE:}}",
-			cursorOffset: 2
-		},
-		{
-			regex: DATE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Date,
-			suggestion: DATE_SYNTAX
-		},
-		{
-			regex: TIME_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Time,
-			suggestion: TIME_SYNTAX
-		},
-		{
-			regex: NAME_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Name,
-			suggestion: NAME_SYNTAX
-		},
-		{
-			regex: VALUE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Value,
-			suggestion: VALUE_SYNTAX
-		},
-		{
-			regex: MATH_VALUE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.MathValue,
-			suggestion: MATH_VALUE_SYNTAX
-		},
-		{
-			regex: SELECTED_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Selected,
-			suggestion: SELECTED_SYNTAX
-		},
-		{
-			regex: CLIPBOARD_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Clipboard,
-			suggestion: CLIPBOARD_SYNTAX
-		},
-		{
-			regex: RANDOM_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Random,
-			suggestion: "{{RANDOM:}}",
-			cursorOffset: 2
-		},
-		{
-			regex: GLOBAL_VAR_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.GlobalVar,
-			suggestion: "{{GLOBAL_VAR:}}",
-			cursorOffset: 2,
-		},
-		{
-			regex: VARIABLE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Variable,
-			suggestion: "{{VALUE:}}",
-			cursorOffset: 2
-		},
-		{
-			regex: VARIABLE_DATE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.VariableDate,
-			suggestion: "{{VDATE:}}",
-			cursorOffset: 2
-		},
-		{
-			regex: FILE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.File,
-			suggestion: "{{FILE:}}",
-			cursorOffset: 2
-		},
-	];
-
-	private readonly contextualTokens: TokenDefinition[] = [
-		{
-			regex: LINKCURRENT_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.LinkCurrent,
-			suggestion: LINKCURRENT_SYNTAX
-		},
-		{
-			regex: LINKSECTION_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.LinkSection,
-			suggestion: LINKSECTION_SYNTAX
-		},
-		{
-			regex: FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.FilenameCurrent,
-			suggestion: FILENAMECURRENT_SYNTAX
-		},
-		// Offered in the contextual set because it serves BOTH format bodies and
-		// the capture "Capture to" field (which constructs this suggester without
-		// suggestForFileNames) — the field the token was built for (#1480).
-		{
-			regex: FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.FolderCurrent,
-			suggestion: FOLDERCURRENT_SYNTAX
-		},
-		{
-			regex: TITLE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Title,
-			suggestion: TITLE_SYNTAX
-		},
-		{
-			regex: TEMPLATE_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Template,
-			suggestion: "{{TEMPLATE:"
-		},
-		{
-			regex: MACRO_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.Macro,
-			suggestion: "{{MACRO:"
-		},
-	];
-
-	// Shown only in the file-name context (suggestForFileNames). The target
-	// folder is meaningful in a Template file name, but the LEAF form is offered
-	// here: the bare {{FOLDER}} expands to the full path, so `{{FOLDER}} - Note`
-	// with a nested target like Projects/Acme would yield
-	// `Projects/Acme/Projects/Acme - Note.md`. {{FOLDER|name}} avoids that
-	// duplicated-segment footgun. {{FOLDER}} is kept out of the always-shown
-	// definitions because it would resolve to "" in the capture "Capture to"
-	// field.
-	private readonly fileNameTokens: TokenDefinition[] = [
-		{
-			regex: FOLDER_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.FolderTarget,
-			suggestion: "{{folder|name}}",
-		},
-		// formatFileName resolves {{FILENAMECURRENT}} (the source note's
-		// basename), so it is valid here; {{title}} is deliberately excluded
-		// because it throws in file names.
-		{
-			regex: FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.FilenameCurrent,
-			suggestion: FILENAMECURRENT_SYNTAX,
-		},
-		// Same |name-only rationale as {{folder|name}} above: with a configured
-		// target folder, a full-path expansion in a Template file name nests under
-		// it ("Notes/Projects/Alpha/Note.md"); the leaf form avoids that footgun.
-		// The full {{foldercurrent}} remains available in the contextual set.
-		{
-			regex: FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
-			token: FormatSyntaxToken.FolderCurrent,
-			suggestion: FOLDERCURRENT_NAME_SYNTAX,
-		},
-	];
 
 	constructor(
 		public app: App,
 		public inputEl: HTMLInputElement | HTMLTextAreaElement,
 		private plugin: QuickAdd,
-		private suggestForFileNames: boolean = false,
-		// Tokens to withhold in this field. Used by the insert-after/before
-		// line-target fields, where formatLocationString deliberately leaves
-		// {{foldercurrent}} literal (it can legitimately resolve to "", and an
-		// empty selector would match the first line) — offering it there would be
-		// a suggester/runtime mismatch.
-		private excludeTokens: FormatSyntaxToken[] = []
+		private context: FormatSuggestContext = "noteContent",
 	) {
 		super(app, inputEl);
 
-		// Get macro names from choices
 		this.macroNames = flattenChoices(this.plugin.settings.choices)
 			.filter((choice) => choice.type === "Macro")
 			.map((choice) => choice.name);
-		
+
 		this.templatePaths = this.plugin.getTemplateFiles().map((file) => file.path);
 	}
 
-	async getSuggestions(inputStr: string): Promise<string[]> {
+	getSuggestions(inputStr: string): FormatTokenSuggestion[] {
 		if (this.inputEl.selectionStart === null) return [];
 		const cursorPosition: number = this.inputEl.selectionStart;
 
@@ -266,31 +57,16 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 		}
 
 		// Special-case: suggest casing styles when typing `|case:` inside VALUE/NAME tokens.
-		{
-			const caseMatch = inputSegment.match(
-				/^\{\{(?:VALUE|NAME)[^\n\r}]*\|case:([a-z-]*)$/i,
-			);
-			if (caseMatch) {
-				const fragment = caseMatch[1] ?? "";
-				const normalizedFragment = fragment.toLowerCase();
-				const styles = [
-					"kebab",
-					"snake",
-					"camel",
-					"pascal",
-					"title",
-					"lower",
-					"upper",
-					"slug",
-				];
+		const caseMatch = inputSegment.match(CASE_FRAGMENT_REGEX);
+		if (caseMatch) {
+			const fragment = caseMatch[1] ?? "";
+			this.matchedQuery = fragment;
+			this.replaceFrom = cursorPosition - fragment.length;
 
-				this.lastInput = fragment;
-				this.lastInputStart = cursorPosition - fragment.length;
-
-				return styles.filter((style) =>
-					style.startsWith(normalizedFragment),
-				);
-			}
+			const normalizedFragment = fragment.toLowerCase();
+			return CASE_STYLE_SUGGESTIONS.filter((style) =>
+				style.insert.startsWith(normalizedFragment),
+			).map((style) => ({ ...style }));
 		}
 
 		// If the segment already contains a colon we consider the token "open" for user parameters → no more format suggestions.
@@ -298,120 +74,105 @@ export class FormatSyntaxSuggester extends TextInputSuggest<string> {
 			return [];
 		}
 
-		const suggestions: string[] = [];
+		const suggestions: FormatTokenSuggestion[] = [];
+		const seen = new Set<string>();
+		const add = (suggestion: FormatTokenSuggestion) => {
+			if (seen.has(suggestion.insert)) return;
+			seen.add(suggestion.insert);
+			suggestions.push(suggestion);
+		};
 
-		// Check all token definitions
-		const allTokens = [
-			...this.tokenDefinitions,
-			...(this.suggestForFileNames ? this.fileNameTokens : this.contextualTokens)
-		].filter((def) => !this.excludeTokens.includes(def.token));
+		// Every token matcher is anchored on the leading "{{", and a match is only
+		// accepted when it runs to the cursor, so an accepted match is always the
+		// whole segment: the replaced span and the matched letters are the same
+		// for every row and can be settled once.
+		this.replaceFrom = startBrace;
+		// Highlight only the letters typed after "{{": at a bare "{{" the braces
+		// are on every row, and marking them just adds noise.
+		this.matchedQuery = inputSegment.slice(2);
 
-		for (const tokenDef of allTokens) {
-			const match = tokenDef.regex.exec(inputSegment);
-			if (!match) continue;
-
+		const matched = entriesForContext(this.context).filter((entry) => {
+			const match = entry.regex.exec(inputSegment);
 			// Only accept matches that run right up to the cursor (i.e., the user is still typing this token)
-			if (match.index + match[0].length !== inputSegment.length) {
-				continue;
-			}
+			return (
+				match !== null &&
+				match.index + match[0].length === inputSegment.length
+			);
+		});
 
-			this.lastInput = match[0];
-			this.lastInputType = tokenDef.token;
-			this.lastInputStart = cursorPosition - match[0].length;
+		// Tokens the typed letters actually start come first. The matchers admit
+		// interior matches too ("{{dat" reaches {{VDATE:}} because its optional
+		// letter classes skip the V), and those should never outrank the token the
+		// user is most likely spelling. Stable, so within each half the curated
+		// registry order survives — including the bare "{{" case, where nothing
+		// prefix-matches and the whole list keeps its reading order.
+		const query = this.matchedQuery.toLowerCase();
+		const startsWithQuery = (entry: (typeof matched)[number]) =>
+			entry.suggestion.insert.slice(2).toLowerCase().startsWith(query);
+		const ranked = [
+			...matched.filter(startsWithQuery),
+			...matched.filter((entry) => !startsWithQuery(entry)),
+		];
 
-			// Avoid duplicates
-			if (!suggestions.includes(tokenDef.suggestion)) {
-				suggestions.push(tokenDef.suggestion);
-			}
+		for (const entry of ranked) {
+			add(entry.suggestion);
 
-			// Add dynamic suggestions for template and macro
-			if (tokenDef.token === FormatSyntaxToken.Template) {
-				suggestions.push(
-					...this.templatePaths.map(
-						(templatePath) => `{{TEMPLATE:${templatePath}}}`
-					)
-				);
-			} else if (tokenDef.token === FormatSyntaxToken.Macro) {
-				suggestions.push(
-					...this.macroNames.map(
-						(macroName) => `{{MACRO:${macroName}}}`
-					)
-				);
-				suggestions.push("{{MACRO:MyMacro|label:Label}}");
-			} else if (tokenDef.token === FormatSyntaxToken.VariableDate) {
-				// Add example suggestions for VDATE with and without default values
-				suggestions.push(
-					"{{VDATE:date,YYYY-MM-DD}}",
-					"{{VDATE:date,YYYY-MM-DD|today}}",
-					"{{VDATE:dueDate,YYYY-MM-DD|next monday}}",
-					"{{VDATE:dueDate,YYYY-MM-DD|optional}}"
-				);
-			} else if (tokenDef.token === FormatSyntaxToken.GlobalVar) {
-				// Suggest defined global variable names
-				const globals = Object.keys(this.plugin?.settings?.globalVariables ?? {});
-				suggestions.push(
-					...globals.map((name) => `{{GLOBAL_VAR:${name}}}`)
-				);
-			} else if (tokenDef.token === FormatSyntaxToken.Variable) {
-				// Add example suggestions for VALUE with and without custom modifier
-				suggestions.push(
-					"{{VALUE:option1,option2,option3}}",
-					"{{VALUE:option1,option2,option3|custom}}",
-					"{{VALUE:title|label:Helper text}}",
-					"{{VALUE:option1,option2|label:Pick one}}",
-					"{{VALUE:title|label:Snake case|default:My_Title}}",
-					"{{VALUE:title|trim}}",
-					"{{VALUE:title|optional}}"
-				);
-			} else if (tokenDef.token === FormatSyntaxToken.File) {
-				// Pick a file from a folder; default inserts the basename.
-				suggestions.push("{{FILE:<folder>}}");
-				// |link / |path insert characters invalid in a file name, and
-				// |optional permits an all-optional name that resolves empty
-				// (rejected at creation time), so only offer them outside the
-				// file-name field.
-				if (!this.suggestForFileNames) {
-					suggestions.push(
-						"{{FILE:<folder>|link}}",
-						"{{FILE:<folder>|path}}",
-						"{{FILE:<folder>|optional}}",
-					);
-				}
-				suggestions.push("{{FILE:<folder>|custom}}");
+			// Worked examples arrive once the user has named the token they want,
+			// so the bare "{{" list stays an index of what exists.
+			if (!entry.expansions) continue;
+			if (this.matchedQuery.length < EXPANSION_MIN_PREFIX) continue;
+			for (const expansion of entry.expansions({
+				templatePaths: this.templatePaths,
+				macroNames: this.macroNames,
+				globalVariableNames: Object.keys(
+					this.plugin?.settings?.globalVariables ?? {},
+				),
+				context: this.context,
+				formatDate: (momentFormat) =>
+					typeof window.moment === "function"
+						? window.moment().format(momentFormat)
+						: momentFormat,
+			})) {
+				add(expansion);
 			}
 		}
 
 		return suggestions;
 	}
 
-	selectSuggestion(item: string): void {
+	selectSuggestion(item: FormatTokenSuggestion): void {
 		if (this.inputEl.selectionStart === null) return;
-		
+
 		const cursorPosition: number = this.inputEl.selectionStart;
-		const replaceStart = this.lastInputStart;
-		const replaceEnd = cursorPosition;
+		const replaceStart = this.replaceFrom;
 
 		// Replace the partial syntax with the complete syntax
-		replaceRange(this.inputEl, replaceStart, replaceEnd, item, { fromCompletion: true });
+		replaceRange(this.inputEl, replaceStart, cursorPosition, item.insert, {
+			fromCompletion: true,
+		});
 
-		// Determine cursor offset dynamically based on the chosen item
-		const offset = item.includes(":") ? 2 : 0; // place before "}}" if there is a colon
-		if (offset) {
-			const newCursorPos = replaceStart + item.length - offset;
+		if (item.caretOffset > 0) {
+			const newCursorPos = replaceStart + item.insert.length - item.caretOffset;
 			this.inputEl.setSelectionRange(newCursorPos, newCursorPos);
 		}
 
 		this.close();
 	}
 
-	renderSuggestion(value: string, el: HTMLElement): void {
+	renderSuggestion(value: FormatTokenSuggestion, el: HTMLElement): void {
 		if (!value) return;
-		// Highlight using the current query fragment for accuracy
-		this.renderMatch(el, value, this.getCurrentQuery());
-	}
+		el.classList.add("qa-format-suggestion");
 
-	private getTokenDefinition(token: FormatSyntaxToken): TokenDefinition | undefined {
-		return [...this.tokenDefinitions, ...this.contextualTokens, ...this.fileNameTokens]
-			.find(def => def.token === token);
+		const tokenEl = el.ownerDocument.createElement("span");
+		tokenEl.className = value.isFragment
+			? "qa-format-suggestion-token qa-format-suggestion-token-fragment"
+			: "qa-format-suggestion-token";
+		this.renderMatch(tokenEl, value.insert, this.matchedQuery);
+		el.appendChild(tokenEl);
+
+		const descriptionEl = el.ownerDocument.createElement("span");
+		descriptionEl.className = "qa-format-suggestion-description";
+		descriptionEl.textContent = value.description;
+		el.appendChild(descriptionEl);
 	}
 }

--- a/src/gui/suggesters/formatSyntaxSuggester.ts
+++ b/src/gui/suggesters/formatSyntaxSuggester.ts
@@ -16,6 +16,8 @@ import {
 export type { FormatSuggestContext } from "./formatTokenRegistry";
 
 const CASE_FRAGMENT_REGEX = /^\{\{(?:VALUE|NAME)[^\n\r}]*\|case:([a-z-]*)$/i;
+/** The `<folder>`-style fill-in-the-blank inside an example row. */
+const PLACEHOLDER_REGEX = /<[^<>\n\r]+>/;
 
 export class FormatSyntaxSuggester extends TextInputSuggest<FormatTokenSuggestion> {
 	/** Start offset of the fragment the accepted suggestion replaces. */
@@ -103,9 +105,9 @@ export class FormatSyntaxSuggester extends TextInputSuggest<FormatTokenSuggestio
 		// Tokens the typed letters actually start come first. The matchers admit
 		// interior matches too ("{{dat" reaches {{VDATE:}} because its optional
 		// letter classes skip the V), and those should never outrank the token the
-		// user is most likely spelling. Stable, so within each half the curated
-		// registry order survives — including the bare "{{" case, where nothing
-		// prefix-matches and the whole list keeps its reading order.
+		// user is most likely spelling. The partition is stable, so the curated
+		// registry order survives within each half; at a bare "{{" the query is
+		// empty, every row prefix-matches, and the whole list keeps its order.
 		const query = this.matchedQuery.toLowerCase();
 		const startsWithQuery = (entry: (typeof matched)[number]) =>
 			entry.suggestion.insert.slice(2).toLowerCase().startsWith(query);
@@ -151,7 +153,14 @@ export class FormatSyntaxSuggester extends TextInputSuggest<FormatTokenSuggestio
 			fromCompletion: true,
 		});
 
-		if (item.caretOffset > 0) {
+		// A row like {{FILE:<folder>}} is a shape to fill in, not a finished token.
+		// Selecting the first <placeholder> means the next keystroke replaces it,
+		// instead of leaving the literal angle brackets in the format.
+		const placeholder = PLACEHOLDER_REGEX.exec(item.insert);
+		if (placeholder) {
+			const start = replaceStart + placeholder.index;
+			this.inputEl.setSelectionRange(start, start + placeholder[0].length);
+		} else if (item.caretOffset > 0) {
 			const newCursorPos = replaceStart + item.insert.length - item.caretOffset;
 			this.inputEl.setSelectionRange(newCursorPos, newCursorPos);
 		}

--- a/src/gui/suggesters/formatTokenRegistry.test.ts
+++ b/src/gui/suggesters/formatTokenRegistry.test.ts
@@ -115,6 +115,9 @@ describe("format token autocomplete rows", () => {
 
 		const examples = await suggestInserts("{{val", VAULT);
 		expect(examples).toContain("{{VALUE:title|trim}}");
+		// Every |modifier the docs cover should be reachable as a complete,
+		// valid token, so nobody has to hand-type one inside a closed token.
+		expect(examples).toContain("{{VALUE:title|case:kebab}}");
 		expect(await suggestInserts("{{tem", VAULT)).toContain(
 			"{{TEMPLATE:Templates/Meeting.md}}",
 		);

--- a/src/gui/suggesters/formatTokenRegistry.test.ts
+++ b/src/gui/suggesters/formatTokenRegistry.test.ts
@@ -201,6 +201,10 @@ describe("format token insertion", () => {
 			return {
 				value: inputEl.value,
 				caret: inputEl.selectionStart ?? inputEl.value.length,
+				selection: [
+					inputEl.selectionStart ?? inputEl.value.length,
+					inputEl.selectionEnd ?? inputEl.value.length,
+				] as const,
 			};
 		} finally {
 			suggester.destroy();
@@ -234,5 +238,11 @@ describe("format token insertion", () => {
 	it("replaces only the token being typed", async () => {
 		const { value } = await accept("Log {{sel", "{{SELECTED}}");
 		expect(value).toBe("Log {{SELECTED}}");
+	});
+
+	it("selects the <placeholder> in an example row so it is typed over", async () => {
+		const { value, selection } = await accept("Note {{file", "{{FILE:<folder>}}");
+		expect(value).toBe("Note {{FILE:<folder>}}");
+		expect(value.slice(selection[0], selection[1])).toBe("<folder>");
 	});
 });

--- a/src/gui/suggesters/formatTokenRegistry.test.ts
+++ b/src/gui/suggesters/formatTokenRegistry.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import {
+	ensureObsidianDomPolyfills,
+	suggestInserts,
+	suggestRows,
+} from "../../../tests/suggesters/formatSuggesterHarness";
+import { FormatSyntaxSuggester } from "./formatSyntaxSuggester";
+import type { FormatSuggestContext } from "./formatTokenRegistry";
+import { ALL_FORMAT_SUGGEST_CONTEXTS } from "./formatTokenRegistry";
+
+const VAULT = {
+	templatePaths: ["Templates/Meeting.md"],
+	macroNames: ["My Macro"],
+	globalVariables: { Header: "# Log" },
+};
+
+/** Every prefix a user can be part-way through, per token family. */
+const PREFIXES = [
+	"{{",
+	"{{v",
+	"{{va",
+	"{{val",
+	"{{value",
+	"{{d",
+	"{{da",
+	"{{dat",
+	"{{date",
+	"{{f",
+	"{{fi",
+	"{{fie",
+	"{{fil",
+	"{{file",
+	"{{fo",
+	"{{folder",
+	"{{l",
+	"{{link",
+	"{{m",
+	"{{mac",
+	"{{t",
+	"{{te",
+	"{{tem",
+	"{{ti",
+	"{{s",
+	"{{c",
+	"{{g",
+	"{{r",
+	"{{VALUE:title|case:",
+];
+
+describe("format token autocomplete rows", () => {
+	it("gives every row a description, in every context, at every prefix", async () => {
+		for (const context of ALL_FORMAT_SUGGEST_CONTEXTS) {
+			for (const prefix of PREFIXES) {
+				const rows = await suggestRows(prefix, { ...VAULT, context });
+				for (const row of rows) {
+					expect(
+						row.description.trim(),
+						`"${row.insert}" at "${prefix}" (${context}) has no description`,
+					).not.toBe("");
+					// Long enough to spill past two lines stops being a one-liner.
+					expect(
+						row.description.length,
+						`"${row.insert}" description is too long to scan`,
+					).toBeLessThanOrEqual(90);
+				}
+			}
+		}
+	});
+
+	it("never repeats an insert within one list", async () => {
+		for (const context of ALL_FORMAT_SUGGEST_CONTEXTS) {
+			for (const prefix of PREFIXES) {
+				const inserts = await suggestInserts(prefix, { ...VAULT, context });
+				expect(new Set(inserts).size, `duplicate row at "${prefix}"`).toBe(
+					inserts.length,
+				);
+			}
+		}
+	});
+
+	it("writes every token in the documented casing", async () => {
+		for (const context of ALL_FORMAT_SUGGEST_CONTEXTS) {
+			for (const insert of await suggestInserts("{{", { ...VAULT, context })) {
+				const name = insert.slice(2).replace(/[:|}].*$/s, "");
+				expect(name, `"${insert}" is not upper-case`).toBe(name.toUpperCase());
+			}
+		}
+	});
+
+	it("opens with the token that explains what format syntax is for", async () => {
+		for (const context of ALL_FORMAT_SUGGEST_CONTEXTS) {
+			const inserts = await suggestInserts("{{", { ...VAULT, context });
+			// Row 0 is preselected and accepted by Enter, so it is the token a
+			// curious "{{" teaches first.
+			expect(inserts[0]).toBe("{{VALUE}}");
+		}
+	});
+
+	it("ranks the token the typed letters start above interior matches", async () => {
+		const dates = await suggestInserts("{{dat");
+		expect(dates.indexOf("{{DATE}}")).toBeLessThan(dates.indexOf("{{VDATE:}}"));
+
+		const values = await suggestInserts("{{val");
+		expect(values.indexOf("{{VALUE}}")).toBeLessThan(
+			values.indexOf("{{MVALUE}}"),
+		);
+	});
+
+	it("keeps the bare {{ list an index, and brings worked examples once asked", async () => {
+		const index = await suggestInserts("{{", VAULT);
+		expect(index).not.toContain("{{VALUE:title|trim}}");
+		expect(index).not.toContain("{{TEMPLATE:Templates/Meeting.md}}");
+		expect(index).toContain("{{VALUE:}}");
+		expect(index).toContain("{{TEMPLATE:}}");
+
+		const examples = await suggestInserts("{{val", VAULT);
+		expect(examples).toContain("{{VALUE:title|trim}}");
+		expect(await suggestInserts("{{tem", VAULT)).toContain(
+			"{{TEMPLATE:Templates/Meeting.md}}",
+		);
+		expect(await suggestInserts("{{mac", VAULT)).toContain(
+			"{{MACRO:My Macro}}",
+		);
+		expect(await suggestInserts("{{glo", VAULT)).toContain(
+			"{{GLOBAL_VAR:Header}}",
+		);
+	});
+
+	it("offers the tokens that had no matcher at all before (#1542)", async () => {
+		const index = await suggestInserts("{{");
+		expect(index).toContain("{{FIELD:}}");
+		expect(index).toContain("{{TIME:}}");
+		expect(index).toContain("{{FILE:}}");
+	});
+});
+
+describe("format token autocomplete context gating", () => {
+	// The runtime disagreement each of these encodes is why the field context is
+	// modelled at all: offering a token a field cannot resolve is a bug.
+	const forbidden: Array<[FormatSuggestContext, string, string]> = [
+		["captureTarget", "{{TITLE}}", "formatFileName throws on {{title}}"],
+		["fileName", "{{TITLE}}", "formatFileName throws on {{title}}"],
+		[
+			"captureTarget",
+			"{{LINKCURRENT}}",
+			"formatFileName leaves links literal, naming the file after the token",
+		],
+		["captureTarget", "{{LINKSECTION}}", "same as {{LINKCURRENT}}"],
+		["fileName", "{{LINKCURRENT}}", "same as captureTarget"],
+		[
+			"lineTarget",
+			"{{FOLDERCURRENT}}",
+			"formatLocationString leaves it literal in selectors",
+		],
+	];
+
+	for (const [context, insert, why] of forbidden) {
+		it(`does not offer ${insert} in ${context} (${why})`, async () => {
+			for (const prefix of PREFIXES) {
+				expect(await suggestInserts(prefix, { ...VAULT, context })).not.toContain(
+					insert,
+				);
+			}
+		});
+	}
+
+	it("keeps {{FOLDERCURRENT}} where it does resolve", async () => {
+		expect(await suggestInserts("{{", { context: "captureTarget" })).toContain(
+			"{{FOLDERCURRENT}}",
+		);
+		expect(await suggestInserts("{{", { context: "noteContent" })).toContain(
+			"{{FOLDERCURRENT}}",
+		);
+	});
+});
+
+describe("format token insertion", () => {
+	async function accept(typed: string, chosen: string) {
+		ensureObsidianDomPolyfills();
+		const app = {
+			dom: { appContainerEl: document.body },
+			keymap: { pushScope: () => {}, popScope: () => {} },
+		} as any;
+		const plugin = {
+			settings: { choices: [], globalVariables: {} },
+			getTemplateFiles: () => [],
+		} as any;
+
+		const inputEl = document.createElement("input");
+		inputEl.value = typed;
+		inputEl.selectionStart = typed.length;
+		inputEl.selectionEnd = typed.length;
+
+		const suggester = new FormatSyntaxSuggester(app, inputEl, plugin);
+		try {
+			const rows = await suggester.getSuggestions(typed);
+			const row = rows.find((candidate) => candidate.insert === chosen);
+			expect(row, `"${chosen}" was not offered for "${typed}"`).toBeDefined();
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			suggester.selectSuggestion(row!);
+			return {
+				value: inputEl.value,
+				caret: inputEl.selectionStart ?? inputEl.value.length,
+			};
+		} finally {
+			suggester.destroy();
+		}
+	}
+
+	it("parks the caret inside the braces of an empty argument", async () => {
+		const { value, caret } = await accept("Note {{dat", "{{DATE:}}");
+		expect(value).toBe("Note {{DATE:}}");
+		expect(value.slice(0, caret)).toBe("Note {{DATE:");
+	});
+
+	it("closes the braces on {{TEMPLATE:}} and {{MACRO:}} instead of stranding the caret mid-word", async () => {
+		// These two used to be inserted as the unbalanced "{{TEMPLATE:" while the
+		// caret was still moved two characters back, landing at "{{TEMPLAT|E:".
+		const template = await accept("Note {{tem", "{{TEMPLATE:}}");
+		expect(template.value).toBe("Note {{TEMPLATE:}}");
+		expect(template.value.slice(0, template.caret)).toBe("Note {{TEMPLATE:");
+
+		const macro = await accept("Note {{mac", "{{MACRO:}}");
+		expect(macro.value).toBe("Note {{MACRO:}}");
+		expect(macro.value.slice(0, macro.caret)).toBe("Note {{MACRO:");
+	});
+
+	it("leaves the caret after a token that needs no further input", async () => {
+		const { value, caret } = await accept("Note {{dat", "{{DATE}}");
+		expect(value).toBe("Note {{DATE}}");
+		expect(caret).toBe(value.length);
+	});
+
+	it("replaces only the token being typed", async () => {
+		const { value } = await accept("Log {{sel", "{{SELECTED}}");
+		expect(value).toBe("Log {{SELECTED}}");
+	});
+});

--- a/src/gui/suggesters/formatTokenRegistry.ts
+++ b/src/gui/suggesters/formatTokenRegistry.ts
@@ -1,0 +1,368 @@
+import {
+	CLIPBOARD_SYNTAX_SUGGEST_REGEX,
+	DATE_FORMAT_SYNTAX_SUGGEST_REGEX,
+	DATE_SYNTAX_SUGGEST_REGEX,
+	FIELD_SYNTAX_SUGGEST_REGEX,
+	FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
+	FILE_SYNTAX_SUGGEST_REGEX,
+	FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
+	FOLDER_SYNTAX_SUGGEST_REGEX,
+	GLOBAL_VAR_SYNTAX_SUGGEST_REGEX,
+	LINKCURRENT_SYNTAX_SUGGEST_REGEX,
+	LINKSECTION_SYNTAX_SUGGEST_REGEX,
+	MACRO_SYNTAX_SUGGEST_REGEX,
+	MATH_VALUE_SYNTAX_SUGGEST_REGEX,
+	NAME_SYNTAX_SUGGEST_REGEX,
+	RANDOM_SYNTAX_SUGGEST_REGEX,
+	SELECTED_SYNTAX_SUGGEST_REGEX,
+	TEMPLATE_SYNTAX_SUGGEST_REGEX,
+	TIME_FORMAT_SYNTAX_SUGGEST_REGEX,
+	TIME_SYNTAX_SUGGEST_REGEX,
+	TITLE_SYNTAX_SUGGEST_REGEX,
+	VALUE_SYNTAX_SUGGEST_REGEX,
+	VARIABLE_DATE_SYNTAX_SUGGEST_REGEX,
+	VARIABLE_SYNTAX_SUGGEST_REGEX,
+} from "../../constants";
+
+/**
+ * Which format field the suggester is attached to. Every field runs a different
+ * CompleteFormatter entry point, and those entry points genuinely disagree
+ * about which tokens resolve — {{TITLE}} *throws* in a file path, {{LINKCURRENT}}
+ * is left literal there, and {{FOLDER}} collapses to "" in a capture target.
+ * Offering a token the field cannot resolve is a bug, so the field context is
+ * modelled explicitly rather than as a boolean plus an exclusion list.
+ */
+export type FormatSuggestContext =
+	/** Note bodies: capture format, template content, AI prompts, script inputs. `formatFileContent`. */
+	| "noteContent"
+	/** Capture "Capture to". `formatFileName`, but the note is not created *into* a target folder. */
+	| "captureTarget"
+	/** Template "File name format". `formatFileName` with a configured target folder. */
+	| "fileName"
+	/** Insert after / insert before line targets. `formatLocationString`. */
+	| "lineTarget";
+
+export const ALL_FORMAT_SUGGEST_CONTEXTS: readonly FormatSuggestContext[] = [
+	"noteContent",
+	"captureTarget",
+	"fileName",
+	"lineTarget",
+];
+
+/** Every context whose value is fed to a formatter that produces a path. */
+const PATH_CONTEXTS: readonly FormatSuggestContext[] = ["captureTarget", "fileName"];
+const ALL: readonly FormatSuggestContext[] = ALL_FORMAT_SUGGEST_CONTEXTS;
+
+/**
+ * One row in the autocomplete. `insert` is what lands in the field; everything
+ * else exists so the row can teach what it does before it is accepted.
+ */
+export interface FormatTokenSuggestion {
+	/** Exact text written into the field when this row is accepted. */
+	insert: string;
+	/** One-line, plain-English explanation rendered beside the token (#1542). */
+	description: string;
+	/**
+	 * Where the caret lands after insertion, counted back from the end of
+	 * `insert`. 2 parks it between the closing braces of an empty argument
+	 * ("{{DATE:|}}"); 0 leaves it after the token. Explicit per row because
+	 * inferring it from the text used to mis-place the caret inside the token
+	 * word for the argument-less "{{TEMPLATE:" / "{{MACRO:" forms.
+	 */
+	caretOffset: number;
+	/** Bare fragments (the `|case:` styles) render without token styling. */
+	isFragment?: boolean;
+}
+
+export interface FormatTokenEntry {
+	/** Prefix matcher deciding whether this row is still a candidate. */
+	regex: RegExp;
+	/** The row shown for the token itself. */
+	suggestion: FormatTokenSuggestion;
+	/** Fields this token actually resolves in. */
+	contexts: readonly FormatSuggestContext[];
+	/**
+	 * Worked examples for this token family. Withheld until the user has typed
+	 * enough of the token's name to have asked for it — see
+	 * {@link EXPANSION_MIN_PREFIX} — so a bare "{{" stays a readable index.
+	 */
+	expansions?: (data: FormatTokenExpansionData) => FormatTokenSuggestion[];
+}
+
+/** Vault/settings data the dynamic rows are built from. */
+export interface FormatTokenExpansionData {
+	templatePaths: readonly string[];
+	macroNames: readonly string[];
+	globalVariableNames: readonly string[];
+	context: FormatSuggestContext;
+	/**
+	 * Renders a Moment format against the current moment, so a date example can
+	 * show what it actually produces instead of a sample that goes stale in the
+	 * source file.
+	 */
+	formatDate: (momentFormat: string) => string;
+}
+
+/**
+ * How many characters after "{{" the user must type before a token's worked
+ * examples join the list. At "{{" the popup is an index of what exists; from
+ * "{{val" on it is help with one token, so the examples earn their room.
+ */
+export const EXPANSION_MIN_PREFIX = 3;
+
+function token(
+	insert: string,
+	description: string,
+	caretOffset = insert.endsWith(":}}") ? 2 : 0,
+): FormatTokenSuggestion {
+	return { insert, description, caretOffset };
+}
+
+/**
+ * The canonical list, in the order it is offered. Ordering follows the docs'
+ * quick reference (ask for input, dates, the note you ran from, the note being
+ * created, other content) so the first row a new user meets — {{VALUE}} — is
+ * the one that explains what format syntax is for.
+ *
+ * Casing matches the documentation (uppercase token, lowercase modifiers).
+ * Every runtime regex carries /i, so this is a display convention, not a
+ * behaviour change; previously the list mixed "{{date}}" with "{{DATE:}}" and
+ * left users guessing whether the difference meant anything (#1542).
+ */
+export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
+	// == Ask for input ==
+	{
+		regex: VALUE_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{VALUE}}", "Asks you for text when the choice runs"),
+	},
+	{
+		regex: VARIABLE_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token(
+			"{{VALUE:}}",
+			"Ask once and reuse by name, or list options to pick from",
+		),
+		expansions: () => [
+			token("{{VALUE:title}}", 'Asks once, then reuses the answer as "title"'),
+			token("{{VALUE:option1,option2,option3}}", "Pick one of these options"),
+			token("{{VALUE:option1,option2,option3|custom}}", "Pick an option or type your own"),
+			token("{{VALUE:title|label:Helper text}}", "Word the prompt yourself"),
+			token("{{VALUE:option1,option2|label:Pick one}}", "A list with your own prompt text"),
+			token(
+				"{{VALUE:title|label:Snake case|default:My_Title}}",
+				"Start the prompt with an answer already filled in",
+			),
+			token("{{VALUE:title|trim}}", "Trim whitespace off the answer"),
+			token("{{VALUE:title|optional}}", "Let the prompt be skipped, leaving it empty"),
+		],
+	},
+	{
+		regex: NAME_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{NAME}}", "Another name for {{VALUE}}; they do the same thing"),
+	},
+	{
+		regex: VARIABLE_DATE_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{VDATE:}}", 'Asks you for a date; "tomorrow" works'),
+		expansions: () => [
+			token("{{VDATE:date,YYYY-MM-DD}}", 'Asks for a date, reused by name as "date"'),
+			token("{{VDATE:date,YYYY-MM-DD|today}}", "Same, with today filled in"),
+			token("{{VDATE:dueDate,YYYY-MM-DD|next monday}}", "Same, starting at next monday"),
+			token("{{VDATE:dueDate,YYYY-MM-DD|optional}}", "Same, but skippable"),
+		],
+	},
+	{
+		regex: FIELD_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token(
+			"{{FIELD:}}",
+			"Suggests values a property already has in your vault, like {{FIELD:project}}",
+		),
+	},
+	{
+		regex: FILE_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{FILE:}}", "Pick a note from a folder"),
+		expansions: ({ context }) => {
+			const rows = [
+				token("{{FILE:<folder>}}", "Pick a note from that folder; inserts its name"),
+			];
+			// |link and |path insert characters that are invalid in a file name,
+			// and |optional permits an all-optional name resolving to nothing,
+			// which is rejected at creation time.
+			if (!PATH_CONTEXTS.includes(context)) {
+				rows.push(
+					token("{{FILE:<folder>|link}}", "Same, but inserts a link to the note"),
+					token("{{FILE:<folder>|path}}", "Same, but inserts its full path"),
+					token("{{FILE:<folder>|optional}}", "Same, but skippable"),
+				);
+			}
+			rows.push(
+				token("{{FILE:<folder>|custom}}", "Same, or type a name that isn't there yet"),
+			);
+			return rows;
+		},
+	},
+	{
+		regex: MATH_VALUE_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{MVALUE}}", "Write a maths formula (LaTeX) with a live preview"),
+	},
+
+	// == Dates ==
+	{
+		regex: DATE_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{DATE}}", "Today's date, as YYYY-MM-DD"),
+	},
+	{
+		regex: DATE_FORMAT_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token(
+			"{{DATE:}}",
+			"Today's date in a format you choose, like {{DATE:MMMM Do}}",
+		),
+		// Moment format strings are the one part of the syntax nobody guesses,
+		// so these show what they render to right now rather than a sample that
+		// would go stale in the source.
+		expansions: ({ formatDate }) =>
+			["YYYY-MM-DD", "MMMM Do, YYYY", "ddd D MMM", "gggg-[W]ww"].map((fmt) =>
+				token(`{{DATE:${fmt}}}`, formatDate(fmt)),
+			),
+	},
+	{
+		regex: TIME_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{TIME}}", "The current time, as HH:mm"),
+	},
+	{
+		regex: TIME_FORMAT_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token(
+			"{{TIME:}}",
+			"The current time in a format you choose, like {{TIME:HH.mm}}",
+		),
+	},
+
+	// == The note you ran QuickAdd from ==
+	{
+		regex: LINKCURRENT_SYNTAX_SUGGEST_REGEX,
+		// Left literal by formatFileName, so a capture target would be named
+		// "[[…]]" — offered only where a link is content.
+		contexts: ["noteContent", "lineTarget"],
+		suggestion: token("{{LINKCURRENT}}", "A link to that note: [[That note]]"),
+	},
+	{
+		regex: LINKSECTION_SYNTAX_SUGGEST_REGEX,
+		contexts: ["noteContent", "lineTarget"],
+		suggestion: token("{{LINKSECTION}}", "A link to the section your cursor is in"),
+	},
+	{
+		regex: FILENAMECURRENT_SYNTAX_SUGGEST_REGEX,
+		contexts: ["noteContent", "captureTarget", "fileName", "lineTarget"],
+		suggestion: token("{{FILENAMECURRENT}}", "That note's file name"),
+	},
+	{
+		// formatLocationString deliberately leaves this literal, and an empty
+		// selector would match the first line, so it is withheld there.
+		regex: FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
+		contexts: ["noteContent", "captureTarget"],
+		suggestion: token("{{FOLDERCURRENT}}", "That note's folder"),
+	},
+	{
+		// In a template file name the full path would nest under the configured
+		// target folder ("Notes/Projects/Alpha/Note.md"), so only the leaf form
+		// is offered there.
+		regex: FOLDERCURRENT_SYNTAX_SUGGEST_REGEX,
+		contexts: ["fileName"],
+		suggestion: token("{{FOLDERCURRENT|name}}", "That note's folder name, without the path"),
+	},
+	{
+		regex: SELECTED_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{SELECTED}}", "The text you had selected in the editor"),
+	},
+
+	// == The note being created ==
+	{
+		// Throws in every path context — the title is derived from the path.
+		regex: TITLE_SYNTAX_SUGGEST_REGEX,
+		contexts: ["noteContent", "lineTarget"],
+		suggestion: token("{{TITLE}}", "The new note's file name"),
+	},
+	{
+		// The bare {{FOLDER}} expands to the full target path, so "{{FOLDER}} -
+		// Note" under Projects/Acme would yield "Projects/Acme/Projects/Acme -
+		// Note.md". The leaf form avoids that duplicated segment.
+		regex: FOLDER_SYNTAX_SUGGEST_REGEX,
+		contexts: ["fileName"],
+		suggestion: token("{{FOLDER|name}}", "The name of the folder the new note lands in"),
+	},
+
+	// == Other content ==
+	{
+		regex: CLIPBOARD_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{CLIPBOARD}}", "Whatever you copied last"),
+	},
+	{
+		regex: TEMPLATE_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{TEMPLATE:}}", "The contents of a template file"),
+		expansions: ({ templatePaths }) =>
+			templatePaths.map((path) =>
+				token(`{{TEMPLATE:${path}}}`, "Inserts this template's contents"),
+			),
+	},
+	{
+		regex: MACRO_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{MACRO:}}", "Whatever a macro returns"),
+		expansions: ({ macroNames }) => [
+			...macroNames.map((name) => token(`{{MACRO:${name}}}`, `Runs your "${name}" macro`)),
+			token("{{MACRO:MyMacro|label:Label}}", "Word the macro's own prompt yourself"),
+		],
+	},
+	{
+		regex: GLOBAL_VAR_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token("{{GLOBAL_VAR:}}", "A snippet you defined in QuickAdd's settings"),
+		expansions: ({ globalVariableNames }) =>
+			globalVariableNames.map((name) =>
+				token(`{{GLOBAL_VAR:${name}}}`, `Inserts your "${name}" snippet`),
+			),
+	},
+	{
+		regex: RANDOM_SYNTAX_SUGGEST_REGEX,
+		contexts: ALL,
+		suggestion: token(
+			"{{RANDOM:}}",
+			"A random ID of the length you give, like {{RANDOM:6}}",
+		),
+	},
+];
+
+/**
+ * Casing styles completed after `|case:` inside a VALUE/NAME token. These are
+ * bare fragments, not tokens, so each one shows what it does to a title rather
+ * than pretending to be insertable syntax on its own.
+ */
+export const CASE_STYLE_SUGGESTIONS: readonly FormatTokenSuggestion[] = [
+	{ insert: "kebab", description: "my-note-title", caretOffset: 0, isFragment: true },
+	{ insert: "snake", description: "my_note_title", caretOffset: 0, isFragment: true },
+	{ insert: "camel", description: "myNoteTitle", caretOffset: 0, isFragment: true },
+	{ insert: "pascal", description: "MyNoteTitle", caretOffset: 0, isFragment: true },
+	{ insert: "title", description: "My Note Title", caretOffset: 0, isFragment: true },
+	{ insert: "lower", description: "my note title", caretOffset: 0, isFragment: true },
+	{ insert: "upper", description: "MY NOTE TITLE", caretOffset: 0, isFragment: true },
+	{ insert: "slug", description: "my-note-title, stripped of accents and symbols", caretOffset: 0, isFragment: true },
+];
+
+/** Entries offered in a given field, in display order. */
+export function entriesForContext(
+	context: FormatSuggestContext,
+): readonly FormatTokenEntry[] {
+	return FORMAT_TOKEN_ENTRIES.filter((entry) => entry.contexts.includes(context));
+}

--- a/src/gui/suggesters/formatTokenRegistry.ts
+++ b/src/gui/suggesters/formatTokenRegistry.ts
@@ -27,7 +27,7 @@ import {
 /**
  * Which format field the suggester is attached to. Every field runs a different
  * CompleteFormatter entry point, and those entry points genuinely disagree
- * about which tokens resolve — {{TITLE}} *throws* in a file path, {{LINKCURRENT}}
+ * about which tokens resolve: {{TITLE}} *throws* in a file path, {{LINKCURRENT}}
  * is left literal there, and {{FOLDER}} collapses to "" in a capture target.
  * Offering a token the field cannot resolve is a bug, so the field context is
  * modelled explicitly rather than as a boolean plus an exclusion list.
@@ -83,8 +83,8 @@ export interface FormatTokenEntry {
 	contexts: readonly FormatSuggestContext[];
 	/**
 	 * Worked examples for this token family. Withheld until the user has typed
-	 * enough of the token's name to have asked for it — see
-	 * {@link EXPANSION_MIN_PREFIX} — so a bare "{{" stays a readable index.
+	 * enough of the token's name to have asked for it (see
+	 * {@link EXPANSION_MIN_PREFIX}), so a bare "{{" stays a readable index.
 	 */
 	expansions?: (data: FormatTokenExpansionData) => FormatTokenSuggestion[];
 }
@@ -121,7 +121,7 @@ function token(
 /**
  * The canonical list, in the order it is offered. Ordering follows the docs'
  * quick reference (ask for input, dates, the note you ran from, the note being
- * created, other content) so the first row a new user meets — {{VALUE}} — is
+ * created, other content) so the first row a new user meets, {{VALUE}}, is
  * the one that explains what format syntax is for.
  *
  * Casing matches the documentation (uppercase token, lowercase modifiers).
@@ -141,20 +141,31 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 		contexts: ALL,
 		suggestion: token(
 			"{{VALUE:}}",
-			"Ask once and reuse by name, or list options to pick from",
+			"Asks once and reuses the answer by name, or lists options to pick from",
 		),
 		expansions: () => [
 			token("{{VALUE:title}}", 'Asks once, then reuses the answer as "title"'),
-			token("{{VALUE:option1,option2,option3}}", "Pick one of these options"),
-			token("{{VALUE:option1,option2,option3|custom}}", "Pick an option or type your own"),
-			token("{{VALUE:title|label:Helper text}}", "Word the prompt yourself"),
+			token("{{VALUE:option1,option2,option3}}", "Asks you to pick one of these options"),
+			token(
+				"{{VALUE:option1,option2,option3|custom}}",
+				"Same, but you can also type your own",
+			),
+			token("{{VALUE:title|label:Note title}}", "Words the prompt yourself"),
 			token("{{VALUE:option1,option2|label:Pick one}}", "A list with your own prompt text"),
 			token(
-				"{{VALUE:title|label:Snake case|default:My_Title}}",
-				"Start the prompt with an answer already filled in",
+				"{{VALUE:title|label:Note title|default:Untitled}}",
+				"Opens the prompt with an answer already filled in",
 			),
-			token("{{VALUE:title|trim}}", "Trim whitespace off the answer"),
-			token("{{VALUE:title|optional}}", "Let the prompt be skipped, leaving it empty"),
+			token(
+				"{{VALUE:<items>|text:<display items>}}",
+				"Shows one label in the list and inserts another",
+			),
+			token(
+				"{{VALUE:option1,option2|name:category}}",
+				'Names the pick, so {{VALUE:category}} reuses it',
+			),
+			token("{{VALUE:title|trim}}", "Trims whitespace off the answer"),
+			token("{{VALUE:title|optional}}", "Lets the prompt be skipped, leaving it empty"),
 		],
 	},
 	{
@@ -169,7 +180,7 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 		expansions: () => [
 			token("{{VDATE:date,YYYY-MM-DD}}", 'Asks for a date, reused by name as "date"'),
 			token("{{VDATE:date,YYYY-MM-DD|today}}", "Same, with today filled in"),
-			token("{{VDATE:dueDate,YYYY-MM-DD|next monday}}", "Same, starting at next monday"),
+			token("{{VDATE:dueDate,YYYY-MM-DD|next monday}}", "Same, starting at next Monday"),
 			token("{{VDATE:dueDate,YYYY-MM-DD|optional}}", "Same, but skippable"),
 		],
 	},
@@ -184,10 +195,10 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 	{
 		regex: FILE_SYNTAX_SUGGEST_REGEX,
 		contexts: ALL,
-		suggestion: token("{{FILE:}}", "Pick a note from a folder"),
+		suggestion: token("{{FILE:}}", "Picks a note from a folder"),
 		expansions: ({ context }) => {
 			const rows = [
-				token("{{FILE:<folder>}}", "Pick a note from that folder; inserts its name"),
+				token("{{FILE:<folder>}}", "Picks a note from that folder and inserts its name"),
 			];
 			// |link and |path insert characters that are invalid in a file name,
 			// and |optional permits an all-optional name resolving to nothing,
@@ -200,7 +211,7 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 				);
 			}
 			rows.push(
-				token("{{FILE:<folder>|custom}}", "Same, or type a name that isn't there yet"),
+				token("{{FILE:<folder>|custom}}", "Same, but you can also type a name that is not there yet"),
 			);
 			return rows;
 		},
@@ -208,7 +219,7 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 	{
 		regex: MATH_VALUE_SYNTAX_SUGGEST_REGEX,
 		contexts: ALL,
-		suggestion: token("{{MVALUE}}", "Write a maths formula (LaTeX) with a live preview"),
+		suggestion: token("{{MVALUE}}", "Asks you for a math formula (LaTeX), with a live preview"),
 	},
 
 	// == Dates ==
@@ -227,10 +238,16 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 		// Moment format strings are the one part of the syntax nobody guesses,
 		// so these show what they render to right now rather than a sample that
 		// would go stale in the source.
-		expansions: ({ formatDate }) =>
-			["YYYY-MM-DD", "MMMM Do, YYYY", "ddd D MMM", "gggg-[W]ww"].map((fmt) =>
+		expansions: ({ formatDate }) => [
+			...["YYYY-MM-DD", "MMMM Do, YYYY", "ddd D MMM", "gggg-[W]ww"].map((fmt) =>
 				token(`{{DATE:${fmt}}}`, formatDate(fmt)),
 			),
+			token("{{DATE+7}}", "Seven days from today"),
+			token(
+				"{{DATE:YYYY-MM-DD|startof:week}}",
+				"Snapped to the start of the week, month, quarter or year",
+			),
+		],
 	},
 	{
 		regex: TIME_SYNTAX_SUGGEST_REGEX,
@@ -250,7 +267,7 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 	{
 		regex: LINKCURRENT_SYNTAX_SUGGEST_REGEX,
 		// Left literal by formatFileName, so a capture target would be named
-		// "[[…]]" — offered only where a link is content.
+		// "[[...]]", so it is offered only where a link is content.
 		contexts: ["noteContent", "lineTarget"],
 		suggestion: token("{{LINKCURRENT}}", "A link to that note: [[That note]]"),
 	},
@@ -287,7 +304,7 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 
 	// == The note being created ==
 	{
-		// Throws in every path context — the title is derived from the path.
+		// Throws in every path context: the title is derived from the path.
 		regex: TITLE_SYNTAX_SUGGEST_REGEX,
 		contexts: ["noteContent", "lineTarget"],
 		suggestion: token("{{TITLE}}", "The new note's file name"),
@@ -357,7 +374,7 @@ export const CASE_STYLE_SUGGESTIONS: readonly FormatTokenSuggestion[] = [
 	{ insert: "title", description: "My Note Title", caretOffset: 0, isFragment: true },
 	{ insert: "lower", description: "my note title", caretOffset: 0, isFragment: true },
 	{ insert: "upper", description: "MY NOTE TITLE", caretOffset: 0, isFragment: true },
-	{ insert: "slug", description: "my-note-title, stripped of accents and symbols", caretOffset: 0, isFragment: true },
+	{ insert: "slug", description: "my-note-title, guarded against reserved file names", caretOffset: 0, isFragment: true },
 ];
 
 /** Entries offered in a given field, in display order. */

--- a/src/gui/suggesters/formatTokenRegistry.ts
+++ b/src/gui/suggesters/formatTokenRegistry.ts
@@ -164,6 +164,13 @@ export const FORMAT_TOKEN_ENTRIES: readonly FormatTokenEntry[] = [
 				"{{VALUE:option1,option2|name:category}}",
 				'Names the pick, so {{VALUE:category}} reuses it',
 			),
+			// A ready-made, valid |case: token. Without it the only way to reach
+			// |case: is to hand-type it inside an already-closed token, and the
+			// live preview warns on every keystroke of a half-typed style name.
+			token(
+				"{{VALUE:title|case:kebab}}",
+				"Reshapes the answer; type |case: for every style",
+			),
 			token("{{VALUE:title|trim}}", "Trims whitespace off the answer"),
 			token("{{VALUE:title|optional}}", "Lets the prompt be skipped, leaving it empty"),
 		],

--- a/src/styles.css
+++ b/src/styles.css
@@ -1606,6 +1606,44 @@ textarea.is-valid {
 	border-radius: 2px;
 }
 
+/* Format-token autocomplete rows: the token, then what it does (#1542).
+   One line while both fit; the description wraps underneath rather than being
+   truncated, because half a sentence teaches nothing. */
+.suggestion-item.qa-format-suggestion {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	column-gap: 10px;
+	row-gap: 1px;
+	line-height: 1.35;
+}
+
+.qa-format-suggestion-token {
+	flex: 0 0 auto;
+	font-family: var(--font-monospace);
+	font-size: var(--font-smaller);
+	white-space: pre;
+}
+
+.qa-format-suggestion-token-fragment {
+	/* |case: styles are bare fragments, not tokens; keep them monospace but
+	   without the emphasis that says "this is insertable syntax on its own". */
+	color: var(--text-muted);
+}
+
+.qa-format-suggestion-description {
+	flex: 1 1 12em;
+	min-width: 0;
+	color: var(--text-muted);
+	font-size: var(--font-smaller);
+}
+
+.suggestion-item.qa-format-suggestion.is-selected .qa-format-suggestion-description,
+.suggestion-item.qa-format-suggestion.is-selected .qa-format-suggestion-token-fragment {
+	color: inherit;
+	opacity: 0.75;
+}
+
 /* User script settings modal - prevent textarea horizontal growth */
 .userScriptSettingsModal .setting-item-control {
 	min-width: 0;

--- a/tests/suggesters/formatSuggesterHarness.ts
+++ b/tests/suggesters/formatSuggesterHarness.ts
@@ -1,0 +1,112 @@
+import { FormatSyntaxSuggester } from "../../src/gui/suggesters/formatSyntaxSuggester";
+import type { FormatSuggestContext } from "../../src/gui/suggesters/formatTokenRegistry";
+import type { FormatTokenSuggestion } from "../../src/gui/suggesters/formatTokenRegistry";
+
+/**
+ * Minimal Obsidian DOM helpers the suggester's base class reaches for. The
+ * vitest stub does not provide them, and each format-suggester spec used to
+ * carry its own copy.
+ */
+export function ensureObsidianDomPolyfills(): void {
+	(globalThis as any).createDiv ??= (cls?: string) => {
+		const div = document.createElement("div");
+		if (cls) div.className = cls;
+		return div;
+	};
+
+	const proto = HTMLElement.prototype as any;
+
+	proto.createDiv ??= function (arg?: string | { cls?: string }) {
+		const div = document.createElement("div");
+		if (typeof arg === "string") div.className = arg;
+		else if (arg && typeof arg === "object" && typeof arg.cls === "string")
+			div.className = arg.cls;
+		this.appendChild(div);
+		return div;
+	};
+
+	proto.empty ??= function () {
+		this.replaceChildren();
+		return this;
+	};
+
+	proto.on ??= function () {
+		return this;
+	};
+
+	proto.detach ??= function () {
+		this.remove();
+	};
+
+	proto.addClass ??= function (...classes: string[]) {
+		this.classList.add(...classes);
+		return this;
+	};
+
+	proto.removeClass ??= function (...classes: string[]) {
+		this.classList.remove(...classes);
+		return this;
+	};
+
+	proto.setAttr ??= function (name: string, value: string) {
+		this.setAttribute(name, value);
+		return this;
+	};
+}
+
+export interface SuggestOptions {
+	context?: FormatSuggestContext;
+	templatePaths?: string[];
+	macroNames?: string[];
+	globalVariables?: Record<string, string>;
+}
+
+/** Runs the real suggester against `value` with the caret at its end. */
+export async function suggestRows(
+	value: string,
+	options: SuggestOptions = {},
+): Promise<FormatTokenSuggestion[]> {
+	ensureObsidianDomPolyfills();
+
+	const app = {
+		dom: { appContainerEl: document.body },
+		keymap: { pushScope: () => {}, popScope: () => {} },
+	} as any;
+	const plugin = {
+		settings: {
+			choices: (options.macroNames ?? []).map((name) => ({
+				id: name,
+				name,
+				type: "Macro",
+			})),
+			globalVariables: options.globalVariables ?? {},
+		},
+		getTemplateFiles: () =>
+			(options.templatePaths ?? []).map((path) => ({ path })),
+	} as any;
+
+	const inputEl = document.createElement("input");
+	inputEl.value = value;
+	inputEl.selectionStart = value.length;
+	inputEl.selectionEnd = value.length;
+
+	const suggester = new FormatSyntaxSuggester(
+		app,
+		inputEl,
+		plugin,
+		options.context,
+	);
+	try {
+		return await suggester.getSuggestions(value);
+	} finally {
+		suggester.destroy();
+	}
+}
+
+/** The strings the rows would insert, in display order. */
+export async function suggestInserts(
+	value: string,
+	options: SuggestOptions = {},
+): Promise<string[]> {
+	return (await suggestRows(value, options)).map((row) => row.insert);
+}


### PR DESCRIPTION
Turns the `{{`-triggered format-token autocomplete from a shortcut for people who already know the syntax into the place where you learn it (#1542).

## The problem

Typing `{{` in a format field opened this:

```
{{DATE:}}  {{date}}  {{time}}  {{name}}  {{value}}  {{mvalue}}  {{selected}}
{{clipboard}}  {{RANDOM:}}  {{GLOBAL_VAR:}}  {{VALUE:}}  …31 rows
```

Nothing said what `{{mvalue}}` was, how `{{selected}}` differed from `{{value}}`, or whether the casing difference between `{{DATE:}}` and `{{date}}` meant anything. 11 of the 31 rows were `{{VALUE:…}}` / `{{VDATE:…}}` worked examples, fired before the user had typed a single token letter, and row 0 (which Enter accepts) was `{{DATE:}}`.

## Before / after

### Capture format field, typing `{{`

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/chhoumann/quickadd/08656cc86fb2fbdca39649e1d1cba7581a3a8964/01-before-format-field.png) | ![after](https://raw.githubusercontent.com/chhoumann/quickadd/08656cc86fb2fbdca39649e1d1cba7581a3a8964/02-after-format-field.png) |

31 bare rows in three casing styles, 11 of them `{{VALUE:...}}` / `{{VDATE:...}}` examples fired before a token letter was typed → 22 described rows, one convention, opening on `{{VALUE}}`.

### Capture "File path / format" field, typing `{{ti`

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/chhoumann/quickadd/08656cc86fb2fbdca39649e1d1cba7581a3a8964/03-before-capture-to.png) | ![after](https://raw.githubusercontent.com/chhoumann/quickadd/08656cc86fb2fbdca39649e1d1cba7581a3a8964/04-after-capture-to.png) |

The path field offered `{{title}}`, which makes `formatFileName` throw on every run of that choice. It now offers only what that field resolves. (There was also a second, undescribed popup stacked exactly underneath this one, seeded from `FILE_NAME_FORMAT_SYNTAX`; it is gone.)

### Once you have named a token, and in light theme

| `{{dat` (ranking + live date examples) | `{{val` (worked examples) | Light theme |
| --- | --- | --- |
| ![dat](https://raw.githubusercontent.com/chhoumann/quickadd/08656cc86fb2fbdca39649e1d1cba7581a3a8964/05-after-date-prefix.png) | ![val](https://raw.githubusercontent.com/chhoumann/quickadd/08656cc86fb2fbdca39649e1d1cba7581a3a8964/06-after-value-prefix.png) | ![light](https://raw.githubusercontent.com/chhoumann/quickadd/08656cc86fb2fbdca39649e1d1cba7581a3a8964/07-after-light-theme.png) |

`{{dat` leads with `{{DATE}}` rather than `{{VDATE:}}` (prefix matches outrank interior ones), and the date examples show what they render to right now.

<sub>Screenshots live on the `assets/pr-1549-screenshots` branch, pinned by SHA so they stay out of this PR's diff. Delete that branch once this merges.</sub>

## What changed

**Every row explains itself.** A one-line description beside the token, in the same words as the docs' quick reference, wrapping rather than truncating. Suggestions are typed objects now (`{ insert, description, caretOffset }`), so a row structurally cannot exist without one, and a test asserts it for every context at every prefix.

**One casing convention**, matching the documentation: upper-case token, lower-case modifiers. Every runtime regex carries `/i`, so this only changes what gets inserted from here on; existing choices are untouched.

**A curated list.** Ordered like the docs (ask for input → dates → the note you ran from → the note being created → other content). A bare `{{` is an index of what exists (22 rows, down from 31) and opens on `{{VALUE}}`, the token that explains what format syntax is for. Worked examples for a family join once you have typed 3 characters, and tokens the typed letters actually *start* now outrank interior matches, so `{{dat` leads with `{{DATE}}` instead of `{{VDATE:}}`.

**Two tokens that were never offered at all.** `{{FIELD:}}` and `{{TIME:}}` are implemented and documented but had no matcher; the autocomplete had never mentioned them. `{{TIME}}` had no docs section either, so it gets one.

**Date examples show what they render to now** (`{{DATE:gggg-[W]ww}}` → `2026-W31`) instead of a sample that ages in the source.

## Correctness, not just copy

Which tokens a field offers is now an explicit `FormatSuggestContext` (`noteContent` | `captureTarget` | `fileName` | `lineTarget`) instead of a boolean plus an exclusion list, because the formatter entry points genuinely disagree. That surfaced three live defects:

- The Capture **"Capture to"** field offered `{{TITLE}}`, which makes `formatFileName` **throw on every run** of that choice, plus `{{LINKCURRENT}}` / `{{LINKSECTION}}`, which it leaves literal (naming the file after the token), plus the `{{FILE:…|link}}` / `|path` / `|optional` variants that the file-name field deliberately withholds.
- That same field carried a **second, undescribed copy of the token language in a third casing convention**, seeded from `FILE_NAME_FORMAT_SYNTAX` into a `GenericTextSuggester` on the same input: two stacked popups for one language, and accepting from the generic one replaces the entire field value.
- Accepting `{{TEMPLATE:` or `{{MACRO:` inserted an *unbalanced* string while still moving the caret two characters back, landing it **inside the token word** at `{{TEMPLAT|E:` — with no recovery, because the popup goes silent once a colon is typed. Both now insert a closed `{{TEMPLATE:}}` and park the caret between the braces; caret placement is a property of each row rather than inferred from its text.

Also: the match highlight was passed the whole field value instead of the typed fragment, so it marked nothing as soon as the field held any other text; and accepting a fill-in-the-blank row like `{{FILE:<folder>}}` now selects `<folder>` so the next keystroke replaces it.

`FORMAT_SYNTAX`, `FILE_NAME_FORMAT_SYNTAX`, `TEMPLATE_FORMAT_SYNTAX` and the 30 per-token string constants that existed only to build them are gone; the registry replaces them. Three forms that lost their only autocomplete surface with those arrays (`|startof:`/`|endof:` from #511, `|name:` from #148, `|text:`) are back as examples under the token they belong to.

## What this deliberately does not do

The issue's first ask — *advertise the affordance* — is not here, on purpose. Its two natural homes are owned by sibling issues filed from the same walkthrough: a contextual hint/docs link under the format field is #1541's stated scope, and the placeholder that would become a worked example (`Daily/{{DATE}}.md`) is #1544's. Building either here means two workers editing the same `SettingItem` block.

Two in-layer alternatives were considered and rejected:

- **Trigger on a single `{`.** The popup captures Enter while open (`suggest.ts:58`), so `{` + Enter in a capture format holding JSON or code would insert a token instead of a newline. A real, data-shaped regression.
- **Open the full list on focus when the field is empty.** Fires on every builder open, 22 rows over the form, and on the "Capture to" field it would race the file suggester on the same element.

**So #1542 should stay open** until #1541 or #1544 lands the hint. A user who never types `{{` sees no change from this PR.

A second follow-up was scoped out after review: the popup still goes silent the moment you type `:`, which is exactly when you need help with a Moment format. Fixing that inside the popup would duplicate `FormatPreviewField` (which already renders the resolved format live under the field) and would have to weaken the `:` bail-out that keeps the popup out of the way for every other colon token. The `{{DATE:}}` description carries a worked example instead.

## Found while testing this, filed separately

The live format preview re-formats on every keystroke and emits the same warnings the real run does, so typing an argument value stacks one Notice per character (`|case:pascal` → 5 notices; anonymous `{{VALUE|type:number}}` → 10, via a `quiet`-forwarding bug in `valueSyntax.ts`). Measured identical on master, and the fix touches four files this PR does not, so it is **#1558** rather than more diff here.

The one part that was this PR's doing is fixed in `b56ca4c6`: deleting the cheat-sheet arrays dropped master's ready-made `{{value:<name>|case:kebab}}` example, which left hand-typing `|case:` inside a closed token as the only route to it - exactly the path that stacks the notices.

## Validation

- `pnpm run build`, `pnpm run test` (3871 passing), `pnpm run lint`, `pnpm run check`, and the docs site build are all green.
- Live-verified in an isolated Obsidian 1.13.0 vault on this build: bare `{{` in the capture format field renders 22 described rows; the same choice's capture target renders 19 with no `{{TITLE}}` and no link tokens, and a single popup where there used to be two; `{{dat` leads with `{{DATE}}` and shows live-rendered date examples; clicking `{{TEMPLATE:}}` yields `Note {{TEMPLATE:}}` with the caret at index 16; clicking `{{FILE:<folder>}}` selects `<folder>`. Checked in both themes.
- Design reviewed by 3 independent critics plus 20 adversarial refuters before implementation, and the diff reviewed again by 4 reviewers (correctness / regression / UX-copy / maintainability) plus 20 refuters. No must-fix or should-fix finding survived verification; the confirmed nits are folded into the third commit.

## Review focus

- `formatTokenRegistry.ts`: the `contexts` on each entry are the load-bearing part. Each one encodes a real formatter behaviour, and the tests name the reason.
- The upper-casing is cosmetic *only* because every runtime regex is `/i` — worth a second pair of eyes on that claim.
- `EXPANSION_MIN_PREFIX = 3` is a judgement call about when worked examples earn their room.

Refs #1542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Improvements**
  * Enhanced format-token autocomplete with context-aware suggestions, improved description text, worked examples, and more reliable insertion/caret behavior.
  * Added support for current-time formatting via `{{TIME}}` (including `{{TIME:<format>}}` variants).
  * Improved suggestion visibility and layout for format-token suggestion rows.
* **Documentation**
  * Updated placeholder guidance to consistently use uppercase tokens (e.g., `{{VALUE}}`, `{{TITLE}}`, `{{SELECTED}}`) and corrected filename/time templating examples.
  * Clarified how template application resolves `{{TITLE}}` and `{{VALUE}}`/`{{NAME}}` depending on whether a note already has a name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->