### PR TITLE
fix: the first-run experience, from install to first working choice

### DIFF
--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -10,7 +10,9 @@ import { MacroChoiceEngine } from "./engine/MacroChoiceEngine";
 import type { IChoiceExecutor } from "./IChoiceExecutor";
 import type { PromptProvider } from "./interactive/promptProvider";
 import type IMultiChoice from "./types/choices/IMultiChoice";
-import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
+import ChoiceSuggester, {
+	emptyFolderNoticeText,
+} from "./gui/suggesters/choiceSuggester";
 import { settingsStore } from "./settingsStore";
 import { runOnePagePreflight } from "./preflight/runOnePagePreflight";
 import { MacroAbortError } from "./errors/MacroAbortError";
@@ -329,7 +331,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		// picker (no Back row is appended on this path) that reads as a broken command.
 		// Surface a Notice instead so the user knows the folder simply has nothing in it.
 		if (multiChoice.choices.length === 0) {
-			new Notice(`Folder "${multiChoice.name}" is empty.`);
+			new Notice(emptyFolderNoticeText(multiChoice.name));
 			return;
 		}
 

--- a/src/docs.test.ts
+++ b/src/docs.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./logger/logManager", () => ({ log: { logError: vi.fn() } }));
+
+import { log } from "./logger/logManager";
+import { createDocsLink, DOCS_URLS, openDocsUrl } from "./docs";
+
+describe("createDocsLink", () => {
+	it("opens externally without handing the docs site a window reference", () => {
+		const parent = document.createElement("div");
+
+		const link = createDocsLink(parent, DOCS_URLS.gettingStarted, "Learn more");
+
+		expect(link.getAttribute("target")).toBe("_blank");
+		// noopener is the security-relevant half; noreferrer keeps the vault's
+		// local page out of the referrer.
+		expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+		expect(link.getAttribute("href")).toBe(DOCS_URLS.gettingStarted);
+		expect(link.textContent).toBe("Learn more");
+		expect(parent.contains(link)).toBe(true);
+	});
+
+	it("builds the anchor from the parent's document so popouts work", () => {
+		const popout = document.implementation.createHTMLDocument("popout");
+		const parent = popout.createElement("div");
+
+		const link = createDocsLink(parent, DOCS_URLS.packages, "Learn more");
+
+		expect(link.ownerDocument).toBe(popout);
+	});
+
+	it("accepts a fragment parent (settings descriptions are built detached)", () => {
+		const fragment = document.createDocumentFragment();
+
+		createDocsLink(fragment, DOCS_URLS.onePageInputs, "Learn more");
+
+		expect(fragment.querySelector("a")?.getAttribute("href")).toBe(
+			DOCS_URLS.onePageInputs,
+		);
+	});
+});
+
+describe("openDocsUrl", () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it("opens from the owner's window so a popout does not target the main one", () => {
+		const open = vi.fn();
+		const owner = document.createElement("div");
+		Object.defineProperty(owner.ownerDocument, "defaultView", {
+			configurable: true,
+			value: { open },
+		});
+
+		openDocsUrl(DOCS_URLS.gettingStarted, owner);
+
+		expect(open).toHaveBeenCalledWith(
+			DOCS_URLS.gettingStarted,
+			"_blank",
+			"noopener,noreferrer",
+		);
+	});
+
+	// A failure to open the docs must never take down the click handler it was
+	// called from.
+	it("logs instead of throwing when the window refuses", () => {
+		vi.spyOn(window, "open").mockImplementation(() => {
+			throw new Error("blocked");
+		});
+
+		expect(() => openDocsUrl(DOCS_URLS.gettingStarted)).not.toThrow();
+		expect(log.logError).toHaveBeenCalledWith(
+			expect.stringContaining("Failed to open documentation"),
+		);
+	});
+});
+
+describe("DOCS_URLS", () => {
+	// The docs site (Astro Starlight) serves the trailing-slash form; omitting it
+	// costs a redirect hop on every click.
+	it("uses the canonical trailing-slash form", () => {
+		for (const url of Object.values(DOCS_URLS)) {
+			const path = new URL(url).pathname;
+			expect(path.endsWith("/")).toBe(true);
+		}
+	});
+});

--- a/src/docs.test.ts
+++ b/src/docs.test.ts
@@ -46,18 +46,35 @@ describe("openDocsUrl", () => {
 	it("opens from the owner's window so a popout does not target the main one", () => {
 		const open = vi.fn();
 		const owner = document.createElement("div");
+		// jsdom has no second window to borrow, so stand one in. Restored by hand:
+		// vi.restoreAllMocks() does not undo defineProperty, and leaving the real
+		// document.defaultView shadowed would poison every later test in the run.
+		const original = Object.getOwnPropertyDescriptor(
+			owner.ownerDocument,
+			"defaultView",
+		);
 		Object.defineProperty(owner.ownerDocument, "defaultView", {
 			configurable: true,
 			value: { open },
 		});
 
-		openDocsUrl(DOCS_URLS.gettingStarted, owner);
+		try {
+			openDocsUrl(DOCS_URLS.gettingStarted, owner);
+		} finally {
+			if (original) {
+				Object.defineProperty(owner.ownerDocument, "defaultView", original);
+			} else {
+				Reflect.deleteProperty(owner.ownerDocument, "defaultView");
+			}
+		}
 
 		expect(open).toHaveBeenCalledWith(
 			DOCS_URLS.gettingStarted,
 			"_blank",
 			"noopener,noreferrer",
 		);
+		// The real window is back, so a later openDocsUrl() targets it again.
+		expect(document.defaultView).toBe(window);
 	});
 
 	// A failure to open the docs must never take down the click handler it was

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -45,7 +45,7 @@ export function openDocsUrl(url: string, owner?: Node): void {
  * at the main window.
  */
 export function createDocsLink(
-	parent: HTMLElement,
+	parent: HTMLElement | DocumentFragment,
 	url: string,
 	text: string,
 ): HTMLAnchorElement {
@@ -54,6 +54,10 @@ export function createDocsLink(
 	link.href = url;
 	link.target = "_blank";
 	link.rel = "noopener noreferrer";
+	// Obsidian's `a { color: var(--link-color) }` is invalid at computed-value
+	// time inside a setting description, so a bare anchor there inherits
+	// --text-muted and stops reading as a link. Pin the accent colour.
+	link.classList.add("quickadd-docs-link");
 	parent.append(link);
 	return link;
 }

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -54,9 +54,9 @@ export function createDocsLink(
 	link.href = url;
 	link.target = "_blank";
 	link.rel = "noopener noreferrer";
-	// Obsidian's `a { color: var(--link-color) }` is invalid at computed-value
-	// time inside a setting description, so a bare anchor there inherits
-	// --text-muted and stops reading as a link. Pin the accent colour.
+	// Obsidian deliberately mutes links inside `.setting-item-description`
+	// (--link-color: var(--text-muted)), where a docs link would read as prose.
+	// See .quickadd-docs-link in styles.css for the deliberate deviation.
 	link.classList.add("quickadd-docs-link");
 	parent.append(link);
 	return link;

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -1,0 +1,59 @@
+import { createOwnedElement, getOwnerWindow } from "./utils/activeWindow";
+import { log } from "./logger/logManager";
+
+/**
+ * Canonical documentation URLs.
+ *
+ * QuickAdd's power surface is syntax you have to learn ({{VALUE}}, {{DATE}},
+ * capture targets, one-page inputs), so the manual has to be reachable from the
+ * places where a user is actually stuck (issue #1541). `manifest.json`'s
+ * `helpUrl` is NOT that entry point: Obsidian 1.13 does not surface it anywhere
+ * in the UI. Keep `gettingStarted` byte-identical to it all the same.
+ *
+ * Trailing slashes are the canonical form the docs site serves (Astro
+ * Starlight); omitting one costs a redirect hop.
+ */
+export const DOCS_BASE_URL = "https://quickadd.obsidian.guide";
+
+export const DOCS_URLS = {
+	gettingStarted: `${DOCS_BASE_URL}/docs/`,
+	onePageInputs: `${DOCS_BASE_URL}/docs/Advanced/onePageInputs/`,
+	userScripts: `${DOCS_BASE_URL}/docs/Choices/MacroChoice/#user-scripts`,
+	packages: `${DOCS_BASE_URL}/docs/Choices/Packages/`,
+} as const;
+
+/**
+ * Open a documentation URL in the user's browser.
+ *
+ * `owner` is any node in the surface the click came from, so a click inside a
+ * popout window opens from THAT window rather than the main one. Prefer
+ * {@link createDocsLink} wherever an anchor can be rendered; this exists for
+ * the handful of programmatic entry points (icon buttons) that have no anchor.
+ */
+export function openDocsUrl(url: string, owner?: Node): void {
+	try {
+		const win = owner ? getOwnerWindow(owner) : window;
+		win.open(url, "_blank", "noopener,noreferrer");
+	} catch (error) {
+		log.logError(`QuickAdd: Failed to open documentation (${url}): ${error}`);
+	}
+}
+
+/**
+ * Append a documentation link to `parent`. Built from the parent's own document
+ * so it works inside popout windows, where the `document` global still points
+ * at the main window.
+ */
+export function createDocsLink(
+	parent: HTMLElement,
+	url: string,
+	text: string,
+): HTMLAnchorElement {
+	const link = createOwnedElement(parent, "a");
+	link.textContent = text;
+	link.href = url;
+	link.target = "_blank";
+	link.rel = "noopener noreferrer";
+	parent.append(link);
+	return link;
+}

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -8,7 +8,7 @@ import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import { TemplateChoice } from "../types/choices/TemplateChoice";
 import { normalizeTemplateFolderPaths } from "../utilityObsidian";
 import { isCancellationError, reportError } from "../utils/errorUtils";
-import { tryOpenPluginSettings } from "../utils/openPluginSettings";
+import { openQuickAddSettings } from "../utils/openPluginSettings";
 
 export interface RunTemplateFromFolderParams {
 	/** When set, skips the picker and runs this template directly (CLI / scripted). */
@@ -108,7 +108,7 @@ export async function runTemplateFromFolder(
 					"QuickAdd: Set a template folder in Settings → QuickAdd → Templates & Properties to use “New note from template”.",
 					8000,
 				);
-				tryOpenPluginSettings(app, plugin.manifest.id);
+				openQuickAddSettings(app, plugin.manifest.id, { notice: false });
 				return;
 			}
 

--- a/src/gui/MacroGUIs/noScriptsFoundNotice.ts
+++ b/src/gui/MacroGUIs/noScriptsFoundNotice.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
 import { Notice } from "obsidian";
+import { createDocsLink, DOCS_URLS } from "../../docs";
 
 /**
  * Shows a notice to the user when no user scripts are found in their vault.
@@ -30,13 +31,8 @@ export function showNoScriptsFoundNotice(app: App): void {
 	);
 	content.append(doc.createElement("br"));
 
-	const link = doc.createElement("a");
-	link.textContent = "View documentation";
-	link.href = "https://quickadd.obsidian.guide/docs/Choices/MacroChoice#user-scripts";
-	link.target = "_blank";
-	link.rel = "noopener noreferrer";
+	const link = createDocsLink(content, DOCS_URLS.userScripts, "View documentation");
 	link.classList.add("quickadd-notice-link");
-	content.append(link);
 }
 
 function appendDiv(parent: HTMLElement, text: string, cls?: string): HTMLDivElement {

--- a/src/gui/MacroGUIs/noScriptsFoundNotice.ts
+++ b/src/gui/MacroGUIs/noScriptsFoundNotice.ts
@@ -31,8 +31,7 @@ export function showNoScriptsFoundNotice(app: App): void {
 	);
 	content.append(doc.createElement("br"));
 
-	const link = createDocsLink(content, DOCS_URLS.userScripts, "View documentation");
-	link.classList.add("quickadd-notice-link");
+	createDocsLink(content, DOCS_URLS.userScripts, "View documentation");
 }
 
 function appendDiv(parent: HTMLElement, text: string, cls?: string): HTMLDivElement {

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -239,7 +239,7 @@
 	async function handleRenameChoice(choice: IChoice) {
 		if (!choice) return;
 
-		const newName = await promptRenameChoice(app, choice.name);
+		const newName = await promptRenameChoice(app, choice.name, choice.type);
 		if (!newName) return;
 
 		const live = liveChoice(choice);

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -28,6 +28,7 @@
 	import { AIAssistantSettingsModal } from "../AIAssistantSettingsModal";
 	import ObsidianIcon from "../components/ObsidianIcon.svelte";
 	import { promptRenameChoice } from "../choiceRename";
+	import { DOCS_URLS } from "../../docs";
 	import AddChoiceControls from "./AddChoiceControls.svelte";
 	import { uniqueDefaultChoiceName } from "./choiceTypeMeta";
 	import ChoiceList from "./ChoiceList.svelte";
@@ -357,8 +358,16 @@
 			<ObsidianIcon iconId="folder-plus" size={28} />
 			<div class="choiceEmptyTitle">No choices yet</div>
 			<p class="choiceEmptyBody">
-				A choice is an action QuickAdd can run — create a note, capture
+				A choice is an action QuickAdd can run: create a note, capture
 				text, or run a macro. Group them with folders.
+				<!-- The one place a brand-new user is guaranteed to look, so it
+				     carries the plugin's only prominent docs link (#1541). -->
+				<a
+					class="quickadd-docs-link"
+					href={DOCS_URLS.gettingStarted}
+					target="_blank"
+					rel="noopener noreferrer">Learn more</a
+				>
 			</p>
 			<div class="choiceEmptyActions">
 				<AddChoiceControls onAddChoice={addChoiceToList} />

--- a/src/gui/choiceList/ChoiceView.test.ts
+++ b/src/gui/choiceList/ChoiceView.test.ts
@@ -15,6 +15,7 @@ vi.mock("../choiceRename", () => ({
 import { App } from "obsidian";
 import { fireEvent, render } from "@testing-library/svelte";
 import ChoiceView from "./ChoiceView.svelte";
+import { promptRenameChoice } from "../choiceRename";
 import type QuickAdd from "../../main";
 import type IChoice from "../../types/choices/IChoice";
 import type { Plain } from "../svelte/persist.svelte";
@@ -311,5 +312,20 @@ describe("ChoiceView", () => {
 			"Child",
 			"New folder",
 		]);
+	});
+
+	// Issue #1539: the rename prompt that follows "New folder" must be told it is
+	// naming a folder, so its header reads "Folder name" and not "Choice name".
+	it("passes the choice type to the rename prompt so folders say 'folder'", async () => {
+		const { getByLabelText } = renderChoiceView([], vi.fn());
+
+		await fireEvent.click(getByLabelText("New folder"));
+
+		await vi.waitFor(() => expect(promptRenameChoice).toHaveBeenCalled());
+		expect(promptRenameChoice).toHaveBeenCalledWith(
+			expect.anything(),
+			"New folder",
+			"Multi",
+		);
 	});
 });

--- a/src/gui/choiceList/ChoiceView.test.ts
+++ b/src/gui/choiceList/ChoiceView.test.ts
@@ -314,6 +314,19 @@ describe("ChoiceView", () => {
 		]);
 	});
 
+	// Issue #1541: the first-run empty state is the one place a brand-new user is
+	// guaranteed to look, so it carries the plugin's most prominent docs link.
+	it("links the documentation from the empty state", () => {
+		const { container } = renderChoiceView([], vi.fn());
+
+		const link = container.querySelector("a");
+		expect(link?.getAttribute("href")).toBe(
+			"https://quickadd.obsidian.guide/docs/",
+		);
+		expect(link?.getAttribute("target")).toBe("_blank");
+		expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+	});
+
 	// Issue #1539: the rename prompt that follows "New folder" must be told it is
 	// naming a folder, so its header reads "Folder name" and not "Choice name".
 	it("passes the choice type to the rename prompt so folders say 'folder'", async () => {

--- a/src/gui/choiceRename.test.ts
+++ b/src/gui/choiceRename.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted so the vi.mock factory (which vitest lifts to the top of the file) can
+// close over the spy without touching an uninitialised module-level binding.
+const { promptSpy } = vi.hoisted(() => ({
+	promptSpy: vi.fn<
+		(
+			app: unknown,
+			header: string,
+			placeholder?: string,
+			value?: string,
+		) => Promise<string>
+	>(),
+}));
+
+vi.mock("./GenericInputPrompt/GenericInputPrompt", () => ({
+	default: { Prompt: promptSpy },
+}));
+
+import type { App } from "obsidian";
+import { promptRenameChoice } from "./choiceRename";
+
+const app = {} as App;
+
+describe("promptRenameChoice", () => {
+	beforeEach(() => {
+		promptSpy.mockReset();
+		promptSpy.mockResolvedValue("Renamed");
+	});
+
+	// Issue #1539: folders are Multi choices internally, but the UI calls them
+	// folders everywhere else — so the rename prompt must too.
+	it("asks for a folder name when renaming a Multi", async () => {
+		await promptRenameChoice(app, "New folder", "Multi");
+
+		expect(promptSpy.mock.calls[0][1]).toBe("Folder name");
+	});
+
+	it.each(["Template", "Capture", "Macro"] as const)(
+		"asks for a choice name when renaming a %s",
+		async (type) => {
+			await promptRenameChoice(app, "New choice", type);
+
+			expect(promptSpy.mock.calls[0][1]).toBe("Choice name");
+		},
+	);
+
+	it("falls back to the choice wording when no type is given", async () => {
+		await promptRenameChoice(app, "New choice");
+
+		expect(promptSpy.mock.calls[0][1]).toBe("Choice name");
+	});
+
+	it("returns the trimmed new name", async () => {
+		promptSpy.mockResolvedValue("  Reading list  ");
+
+		await expect(promptRenameChoice(app, "New folder", "Multi")).resolves.toBe(
+			"Reading list",
+		);
+	});
+
+	it("returns null when the name is unchanged", async () => {
+		promptSpy.mockResolvedValue("New folder");
+
+		await expect(promptRenameChoice(app, "New folder", "Multi")).resolves.toBe(
+			null,
+		);
+	});
+});

--- a/src/gui/choiceRename.ts
+++ b/src/gui/choiceRename.ts
@@ -1,15 +1,27 @@
 import type { App } from "obsidian";
 import GenericInputPrompt from "./GenericInputPrompt/GenericInputPrompt";
 import { log } from "src/logger/logManager";
+import type { ChoiceType } from "../types/choices/choiceType";
+
+/**
+ * Header for the rename prompt. Folders are `Multi` choices internally, but the
+ * UI calls them folders everywhere else ("New folder", "Add folder to {name}"),
+ * so asking for a *choice* name right after the user asked for a *folder* is a
+ * jolt on the very first interaction with the plugin (issue #1539).
+ */
+function renamePromptHeader(type?: ChoiceType): string {
+	return type === "Multi" ? "Folder name" : "Choice name";
+}
 
 export async function promptRenameChoice(
 	app: App,
 	currentName: string,
+	type?: ChoiceType,
 ): Promise<string | null> {
 	try {
 		const newName = await GenericInputPrompt.Prompt(
 			app,
-			"Choice name",
+			renamePromptHeader(type),
 			undefined,
 			currentName,
 		);

--- a/src/gui/choiceRename.ts
+++ b/src/gui/choiceRename.ts
@@ -5,9 +5,9 @@ import type { ChoiceType } from "../types/choices/choiceType";
 
 /**
  * Header for the rename prompt. Folders are `Multi` choices internally, but the
- * UI calls them folders everywhere else ("New folder", "Add folder to {name}"),
- * so asking for a *choice* name right after the user asked for a *folder* is a
- * jolt on the very first interaction with the plugin (issue #1539).
+ * UI calls them folders everywhere else ("New folder", "Add folder to {name}",
+ * "Edit folder"), so asking for a *choice* name right after the user asked for a
+ * *folder* is a jolt on the very first interaction with the plugin (#1539).
  */
 function renamePromptHeader(type?: ChoiceType): string {
 	return type === "Multi" ? "Folder name" : "Choice name";

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -270,6 +270,55 @@ describe("ChoiceSuggester", () => {
 		});
 	});
 
+	// Issue #1540: the launcher's input rendered completely blank; every Obsidian
+	// picker labels its own.
+	describe("placeholder", () => {
+		it("labels the top level with a default hint", () => {
+			expect(makeSuggester(rootChoices).inputEl.placeholder).toBe(
+				"Select a choice",
+			);
+		});
+
+		it("lets an explicit placeholder win", () => {
+			const s = new ChoiceSuggester(plugin, rootChoices, {
+				choiceExecutor: executor,
+				placeholder: "  Pick a meeting  ",
+			});
+
+			expect(s.inputEl.placeholder).toBe("Pick a meeting");
+		});
+
+		it("falls back to the default for a blank explicit placeholder", () => {
+			const s = new ChoiceSuggester(plugin, rootChoices, {
+				choiceExecutor: executor,
+				placeholder: "   ",
+			});
+
+			expect(s.inputEl.placeholder).toBe("Select a choice");
+		});
+
+		it("restores the level's own hint when Back re-opens it", () => {
+			const s = new ChoiceSuggester(plugin, [makeBack(rootChoices)], {
+				choiceExecutor: executor,
+				placeholder: "Work",
+				placeholderStack: ["Select a choice"],
+			});
+			const openSpy = vi
+				.spyOn(ChoiceSuggester, "Open")
+				.mockImplementation(() => {});
+
+			s.onChooseItem(s.getItems()[0], new MouseEvent("click"));
+
+			const [, , options] = openSpy.mock.calls[0] as unknown as [
+				QuickAdd,
+				IChoice[],
+				{ placeholder?: string; placeholderStack?: Array<string | undefined> },
+			];
+			expect(options.placeholder).toBe("Select a choice");
+			expect(options.placeholderStack).toEqual([]);
+		});
+	});
+
 	describe("getSuggestions", () => {
 		it("shows only the current level for an empty query", () => {
 			const suggester = makeSuggester(rootChoices);
@@ -555,21 +604,34 @@ describe("ChoiceSuggester", () => {
 
 		// The command/URI path (choiceExecutor.onChooseMultiType) already refuses to
 		// open an empty folder; the picker used to open a level whose only row was
-		// "← Back". Both entry points to the same folder now say the same thing.
-		it("refuses to drill into an empty folder and says why", () => {
+		// "← Back". Both entry points to the same folder now say the same thing —
+		// and because SuggestModal closes before onChooseItem runs, the picker has
+		// to be re-opened on the SAME level or the mis-click ejects the user.
+		it("stays on the current level and says why for an empty folder", () => {
 			const openSpy = vi
 				.spyOn(ChoiceSuggester, "Open")
 				.mockImplementation(() => {});
 			const empty = multi("Reading", []);
+			const level = [topNote, empty];
 			(Notice as unknown as { instances: unknown[] }).instances = [];
 
-			makeSuggester([empty]).onChooseItem(empty, new MouseEvent("click"));
+			makeSuggester(level).onChooseItem(empty, new MouseEvent("click"));
 
-			expect(openSpy).not.toHaveBeenCalled();
 			expect(
 				(Notice as unknown as { instances: Array<{ message: string }> })
 					.instances.map((n) => n.message),
 			).toEqual(['Folder "Reading" is empty.']);
+
+			const [, passedChoices, options] = openSpy.mock.calls[0] as unknown as [
+				QuickAdd,
+				IChoice[],
+				{ placeholder?: string; placeholderStack?: Array<string | undefined> },
+			];
+			// Same level, same navigation state — no extra Back item is pushed.
+			expect(passedChoices).toEqual(level);
+			expect(passedChoices.some((c) => c.id === BACK_CHOICE_ID)).toBe(false);
+			expect(options.placeholder).toBe("Select a choice");
+			expect(options.placeholderStack).toEqual([]);
 		});
 
 		// ...but Back must still work even when the level it returns to is empty,

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { App } from "obsidian";
+import { App, Notice } from "obsidian";
 
 vi.mock("obsidian-dataview", () => ({
 	getAPI: vi.fn(),
@@ -492,7 +492,9 @@ describe("ChoiceSuggester", () => {
 			// still defaults from the original trigger note, not a re-read.
 			expect(options.triggerContext).toEqual({ activeFile: null });
 			expect(options.placeholder).toBe("Work");
-			expect(options.placeholderStack).toEqual([undefined]);
+			// The stack records the level we came FROM, so Back restores the
+			// launcher's default hint rather than a blank input (issue #1540).
+			expect(options.placeholderStack).toEqual(["Select a choice"]);
 		});
 
 		it("threads a captured trigger context to the leaf execution (issue #1429)", () => {
@@ -549,6 +551,42 @@ describe("ChoiceSuggester", () => {
 			];
 			// A real back item is appended, so the user is not stranded.
 			expect(passedChoices.some((c) => c.id === BACK_CHOICE_ID)).toBe(true);
+		});
+
+		// The command/URI path (choiceExecutor.onChooseMultiType) already refuses to
+		// open an empty folder; the picker used to open a level whose only row was
+		// "← Back". Both entry points to the same folder now say the same thing.
+		it("refuses to drill into an empty folder and says why", () => {
+			const openSpy = vi
+				.spyOn(ChoiceSuggester, "Open")
+				.mockImplementation(() => {});
+			const empty = multi("Reading", []);
+			(Notice as unknown as { instances: unknown[] }).instances = [];
+
+			makeSuggester([empty]).onChooseItem(empty, new MouseEvent("click"));
+
+			expect(openSpy).not.toHaveBeenCalled();
+			expect(
+				(Notice as unknown as { instances: Array<{ message: string }> })
+					.instances.map((n) => n.message),
+			).toEqual(['Folder "Reading" is empty.']);
+		});
+
+		// ...but Back must still work even when the level it returns to is empty,
+		// since the back item carries the previous level as its payload.
+		it("still navigates back when the back item wraps an empty level", () => {
+			const openSpy = vi
+				.spyOn(ChoiceSuggester, "Open")
+				.mockImplementation(() => {});
+			const back = makeBack([]);
+
+			makeSuggester([back]).onChooseItem(back, new MouseEvent("click"));
+
+			const [, passedChoices] = openSpy.mock.calls[0] as unknown as [
+				QuickAdd,
+				IChoice[],
+			];
+			expect(passedChoices).toEqual([]);
 		});
 	});
 

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -29,10 +29,10 @@ import { createOwnedElement } from "../../utils/activeWindow";
 const backLabel = "← Back";
 
 /**
- * Search hint for the launcher's input. Obsidian's own pickers all label theirs
- * ("Find or create a note…", "Select a command…"); QuickAdd's rendered
- * completely blank, which reads as an unfinished surface (issue #1540). Nested
- * levels override this with the folder's name or custom placeholder.
+ * Search hint for the launcher's input. Every Obsidian picker labels its own;
+ * QuickAdd's rendered completely blank, which reads as an unfinished surface
+ * (issue #1540). Nested levels override this with the folder's name or its
+ * custom placeholder.
  */
 const DEFAULT_PLACEHOLDER = "Select a choice";
 
@@ -183,8 +183,8 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 				: { activeFile: this.app.workspace.getActiveFile() };
 		this.placeholderStack = options?.placeholderStack ?? [];
 		// `currentPlaceholder` is what a nested level pushes onto the stack so Back
-		// can restore it, so it must hold the effective placeholder — including the
-		// default — not just an explicitly-passed one.
+		// can restore it, so it must hold the effective placeholder (including the
+		// default), not just an explicitly-passed one.
 		this.currentPlaceholder = options?.placeholder?.trim() || DEFAULT_PLACEHOLDER;
 		this.setPlaceholder(this.currentPlaceholder);
 		this.markdownComponent.load();
@@ -372,8 +372,21 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		// The command/URI path already refuses this with a Notice (choiceExecutor
 		// .onChooseMultiType); say the same thing here so both entry points to the
 		// same folder behave the same.
+		//
+		// SuggestModal.selectSuggestion closes the modal BEFORE onChooseItem runs,
+		// so returning here would eject the user from the picker entirely. Re-open
+		// the level they were on (this.choices already carries its Back row, and the
+		// synthetic template row at the top level) so a mis-click on an empty folder
+		// costs a notice, not the whole navigation stack.
 		if (!isBack && choices.length === 0) {
 			new Notice(emptyFolderNoticeText(multi.name));
+			ChoiceSuggester.Open(this.plugin, this.choices, {
+				choiceExecutor: this.choiceExecutor,
+				focusedProperty: this.focusedProperty,
+				triggerContext: this.triggerContext,
+				placeholder: this.currentPlaceholder,
+				placeholderStack: this.placeholderStack,
+			});
 			return;
 		}
 

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -3,6 +3,7 @@ import {
 	Component,
 	FuzzySuggestModal,
 	MarkdownRenderer,
+	Notice,
 	prepareFuzzySearch,
 	setIcon,
 } from "obsidian";
@@ -26,6 +27,23 @@ import { resolveChoiceIcon } from "../../utils/choiceUtils";
 import { createOwnedElement } from "../../utils/activeWindow";
 
 const backLabel = "← Back";
+
+/**
+ * Search hint for the launcher's input. Obsidian's own pickers all label theirs
+ * ("Find or create a note…", "Select a command…"); QuickAdd's rendered
+ * completely blank, which reads as an unfinished surface (issue #1540). Nested
+ * levels override this with the folder's name or custom placeholder.
+ */
+const DEFAULT_PLACEHOLDER = "Select a choice";
+
+/**
+ * Shared wording for "you opened a folder that has nothing in it", so the
+ * picker's drill-down and the command/URI execute path (choiceExecutor) say the
+ * same thing.
+ */
+export function emptyFolderNoticeText(folderName: string): string {
+	return `Folder "${folderName}" is empty.`;
+}
 
 /**
  * Sentinel id for the synthetic "New note from template" launcher row (#1023).
@@ -100,6 +118,16 @@ type ChoiceSuggesterOptions = {
 	includeTemplateFolderRow?: boolean;
 };
 
+/**
+ * Whether the synthetic "New note from template" row would actually appear in
+ * the top-level launcher. Exported so the launcher entry point can tell whether
+ * the picker has anything at all to show before opening it (issue #1540).
+ */
+export function shouldShowTemplateFolderRow(plugin: QuickAdd): boolean {
+	const rowPosition = plugin.settings.templateFolderLauncherRow ?? "bottom";
+	return rowPosition !== "off" && hasConfiguredTemplateFolders(plugin);
+}
+
 function createTemplateFolderRow(): IChoice {
 	return {
 		id: RUN_TEMPLATE_FROM_FOLDER_ID,
@@ -154,8 +182,11 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 				? options.triggerContext ?? null
 				: { activeFile: this.app.workspace.getActiveFile() };
 		this.placeholderStack = options?.placeholderStack ?? [];
-		this.currentPlaceholder = options?.placeholder?.trim() || undefined;
-		if (this.currentPlaceholder) this.setPlaceholder(this.currentPlaceholder);
+		// `currentPlaceholder` is what a nested level pushes onto the stack so Back
+		// can restore it, so it must hold the effective placeholder — including the
+		// default — not just an explicitly-passed one.
+		this.currentPlaceholder = options?.placeholder?.trim() || DEFAULT_PLACEHOLDER;
+		this.setPlaceholder(this.currentPlaceholder);
 		this.markdownComponent.load();
 
 		// Insert the synthetic "New note from template" row only at the top level
@@ -168,7 +199,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		if (options?.includeTemplateFolderRow) {
 			const rowPosition =
 				this.plugin.settings.templateFolderLauncherRow ?? "bottom";
-			if (rowPosition !== "off" && hasConfiguredTemplateFolders(this.plugin)) {
+			if (shouldShowTemplateFolderRow(this.plugin)) {
 				const row = createTemplateFolderRow();
 				this.choices =
 					rowPosition === "top"
@@ -336,6 +367,15 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 	private onChooseMultiType(multi: IMultiChoice) {
 		const choices = [...multi.choices];
 		const isBack = multi.id === BACK_CHOICE_ID;
+
+		// Drilling into an empty folder would open a level whose only row is "← Back".
+		// The command/URI path already refuses this with a Notice (choiceExecutor
+		// .onChooseMultiType); say the same thing here so both entry points to the
+		// same folder behave the same.
+		if (!isBack && choices.length === 0) {
+			new Notice(emptyFolderNoticeText(multi.name));
+			return;
+		}
 
 		if (!isBack) {
 			const back = new MultiChoice(backLabel).addChoices(this.choices);

--- a/src/gui/suggesters/openChoiceLauncher.test.ts
+++ b/src/gui/suggesters/openChoiceLauncher.test.ts
@@ -9,8 +9,9 @@ import ChoiceSuggester from "./choiceSuggester";
 import { NO_CHOICES_NOTICE, openChoiceLauncher } from "./openChoiceLauncher";
 
 type LauncherPluginSettings = {
-	choices: IChoice[];
+	choices: unknown;
 	templateFolderPaths?: string[];
+	/** `undefined` is the legacy data.json shape, which means "bottom". */
 	templateFolderLauncherRow?: "off" | "top" | "bottom";
 };
 
@@ -31,9 +32,9 @@ describe("openChoiceLauncher", () => {
 			manifest: { id: "quickadd" },
 			settings: {
 				templateFolderPaths: settings.templateFolderPaths ?? [],
-				// Mirror DEFAULT_SETTINGS: undefined means "bottom".
-				templateFolderLauncherRow:
-					settings.templateFolderLauncherRow ?? "bottom",
+				// Passed through verbatim (including undefined) so the production
+				// `?? "bottom"` fallback is the thing under test.
+				templateFolderLauncherRow: settings.templateFolderLauncherRow,
 				choices: settings.choices,
 			},
 		} as unknown as QuickAdd;
@@ -119,11 +120,27 @@ describe("openChoiceLauncher", () => {
 		expect(noticeMessages()).toEqual([NO_CHOICES_NOTICE]);
 	});
 
-	it("guards when a template folder is configured but the row would be empty", () => {
+	// Legacy data.json has no templateFolderLauncherRow at all; DEFAULT_SETTINGS
+	// treats that as "bottom", so the row (and the picker) must still appear.
+	it("treats a missing row position as 'bottom'", () => {
 		openChoiceLauncher(
-			pluginWith({ choices: [], templateFolderPaths: [] }),
+			pluginWith({
+				choices: [],
+				templateFolderPaths: ["Templates"],
+				templateFolderLauncherRow: undefined,
+			}),
 		);
 
+		expect(openSpy).toHaveBeenCalled();
+		expect(noticeMessages()).toEqual([]);
+	});
+
+	// A corrupt data.json keeps a non-array `choices` (main.ts deliberately does
+	// not overwrite it), which used to make "QuickAdd: Run" throw a TypeError.
+	it("falls back to the first-run guidance on a corrupt choices list", () => {
+		openChoiceLauncher(pluginWith({ choices: null }));
+
 		expect(openSpy).not.toHaveBeenCalled();
+		expect(noticeMessages()).toEqual([NO_CHOICES_NOTICE]);
 	});
 });

--- a/src/gui/suggesters/openChoiceLauncher.test.ts
+++ b/src/gui/suggesters/openChoiceLauncher.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App, Notice } from "obsidian";
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import ChoiceSuggester from "./choiceSuggester";
+import { NO_CHOICES_NOTICE, openChoiceLauncher } from "./openChoiceLauncher";
+
+type LauncherPluginSettings = {
+	choices: IChoice[];
+	templateFolderPaths?: string[];
+	templateFolderLauncherRow?: "off" | "top" | "bottom";
+};
+
+function noticeMessages(): string[] {
+	return (
+		Notice as unknown as { instances: Array<{ message: string }> }
+	).instances.map((n) => n.message);
+}
+
+describe("openChoiceLauncher", () => {
+	let openSpy: ReturnType<typeof vi.spyOn>;
+	let openTabById: ReturnType<typeof vi.fn>;
+	let app: App;
+
+	function pluginWith(settings: LauncherPluginSettings): QuickAdd {
+		return {
+			app,
+			manifest: { id: "quickadd" },
+			settings: {
+				templateFolderPaths: settings.templateFolderPaths ?? [],
+				// Mirror DEFAULT_SETTINGS: undefined means "bottom".
+				templateFolderLauncherRow:
+					settings.templateFolderLauncherRow ?? "bottom",
+				choices: settings.choices,
+			},
+		} as unknown as QuickAdd;
+	}
+
+	const aChoice = (): IChoice =>
+		({ id: "c1", name: "Add task", type: "Capture", command: false }) as IChoice;
+
+	beforeEach(() => {
+		app = new App();
+		openTabById = vi.fn();
+		(app as unknown as { setting: unknown }).setting = {
+			open: vi.fn(),
+			openTabById,
+		};
+		openSpy = vi.spyOn(ChoiceSuggester, "Open").mockImplementation(() => {});
+		(Notice as unknown as { instances: unknown[] }).instances = [];
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Issue #1540: the fresh-install path. An empty picker over "No results
+	// found." is a dead end; send the user to where choices are made instead.
+	it("opens settings instead of an empty picker when there is nothing to run", () => {
+		openChoiceLauncher(pluginWith({ choices: [] }));
+
+		expect(openSpy).not.toHaveBeenCalled();
+		expect(noticeMessages()).toEqual([NO_CHOICES_NOTICE]);
+		expect(openTabById).toHaveBeenCalledWith("quickadd");
+	});
+
+	// The notice already names "Settings → QuickAdd", so a second generic notice
+	// about not being able to open settings would just be noise.
+	it("does not stack a second notice when settings cannot be opened", () => {
+		const plugin = pluginWith({ choices: [] });
+		(plugin.app as unknown as { setting: unknown }).setting = undefined;
+
+		openChoiceLauncher(plugin);
+
+		expect(noticeMessages()).toEqual([NO_CHOICES_NOTICE]);
+	});
+
+	it("opens the picker as soon as there is a choice", () => {
+		openChoiceLauncher(pluginWith({ choices: [aChoice()] }));
+
+		expect(noticeMessages()).toEqual([]);
+		expect(openTabById).not.toHaveBeenCalled();
+		expect(openSpy).toHaveBeenCalledWith(expect.anything(), [aChoice()], {
+			includeTemplateFolderRow: true,
+		});
+	});
+
+	// With zero choices but a configured template folder the launcher still has a
+	// working action ("New note from template…"), so the guard must not fire.
+	it.each(["bottom", "top"] as const)(
+		"opens the picker for a template-folder row at %s with zero choices",
+		(templateFolderLauncherRow) => {
+			openChoiceLauncher(
+				pluginWith({
+					choices: [],
+					templateFolderPaths: ["Templates"],
+					templateFolderLauncherRow,
+				}),
+			);
+
+			expect(openSpy).toHaveBeenCalled();
+			expect(noticeMessages()).toEqual([]);
+		},
+	);
+
+	it("guards again once the template-folder row is turned off", () => {
+		openChoiceLauncher(
+			pluginWith({
+				choices: [],
+				templateFolderPaths: ["Templates"],
+				templateFolderLauncherRow: "off",
+			}),
+		);
+
+		expect(openSpy).not.toHaveBeenCalled();
+		expect(noticeMessages()).toEqual([NO_CHOICES_NOTICE]);
+	});
+
+	it("guards when a template folder is configured but the row would be empty", () => {
+		openChoiceLauncher(
+			pluginWith({ choices: [], templateFolderPaths: [] }),
+		);
+
+		expect(openSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/gui/suggesters/openChoiceLauncher.ts
+++ b/src/gui/suggesters/openChoiceLauncher.ts
@@ -17,8 +17,8 @@ export const NO_CHOICES_NOTICE =
  * ribbon icon).
  *
  * On a fresh install this used to open a fuzzy picker with a blank input over
- * Obsidian's bare "No results found." — the first thing a new user does landing
- * on a dead end with no hint that choices live in settings (issue #1540). When
+ * Obsidian's bare "No results found.": the first thing a new user does landing
+ * on a dead end, with no hint that choices live in settings (issue #1540). When
  * there is genuinely nothing to pick, say so and take them where they need to
  * go instead of opening an empty picker.
  *
@@ -26,8 +26,14 @@ export const NO_CHOICES_NOTICE =
  * that synthetic row is a working action in its own right.
  */
 export function openChoiceLauncher(plugin: QuickAdd): void {
+	// main.ts deliberately leaves a corrupt (non-array) `choices` intact rather
+	// than overwriting the user's data, so normalize here: a broken data.json
+	// should land on the first-run guidance, not a bare TypeError.
+	const choices = Array.isArray(plugin.settings.choices)
+		? plugin.settings.choices
+		: [];
 	const hasSomethingToPick =
-		plugin.settings.choices.length > 0 || shouldShowTemplateFolderRow(plugin);
+		choices.length > 0 || shouldShowTemplateFolderRow(plugin);
 
 	if (!hasSomethingToPick) {
 		new Notice(NO_CHOICES_NOTICE, 8000);
@@ -35,7 +41,7 @@ export function openChoiceLauncher(plugin: QuickAdd): void {
 		return;
 	}
 
-	ChoiceSuggester.Open(plugin, plugin.settings.choices, {
+	ChoiceSuggester.Open(plugin, choices, {
 		includeTemplateFolderRow: true,
 	});
 }

--- a/src/gui/suggesters/openChoiceLauncher.ts
+++ b/src/gui/suggesters/openChoiceLauncher.ts
@@ -1,0 +1,41 @@
+import { Notice } from "obsidian";
+import type QuickAdd from "../../main";
+import { openQuickAddSettings } from "../../utils/openPluginSettings";
+import ChoiceSuggester, { shouldShowTemplateFolderRow } from "./choiceSuggester";
+
+/**
+ * What the user is told when "QuickAdd: Run" has nothing to run. Mirrors the
+ * shape of the plugin's other "this surface has nothing to offer" notices
+ * (runTemplateFromFolder's missing-template-folder notice), which name the exact
+ * settings path rather than leaving the user to find it.
+ */
+export const NO_CHOICES_NOTICE =
+	"QuickAdd: No choices yet. Create your first one in Settings → QuickAdd.";
+
+/**
+ * Opens the top-level choice launcher (the "QuickAdd: Run" command and the
+ * ribbon icon).
+ *
+ * On a fresh install this used to open a fuzzy picker with a blank input over
+ * Obsidian's bare "No results found." — the first thing a new user does landing
+ * on a dead end with no hint that choices live in settings (issue #1540). When
+ * there is genuinely nothing to pick, say so and take them where they need to
+ * go instead of opening an empty picker.
+ *
+ * "Nothing to pick" means no choices AND no "New note from template" row, since
+ * that synthetic row is a working action in its own right.
+ */
+export function openChoiceLauncher(plugin: QuickAdd): void {
+	const hasSomethingToPick =
+		plugin.settings.choices.length > 0 || shouldShowTemplateFolderRow(plugin);
+
+	if (!hasSomethingToPick) {
+		new Notice(NO_CHOICES_NOTICE, 8000);
+		openQuickAddSettings(plugin.app, plugin.manifest.id, { notice: false });
+		return;
+	}
+
+	ChoiceSuggester.Open(plugin, plugin.settings.choices, {
+		includeTemplateFolderRow: true,
+	});
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all assist/source/organizeImports: Import order is critical to prevent circular dependencies - ChoiceExecutor must load before dependent classes */
 import type { Debouncer } from "obsidian";
-import { Plugin, TFile, debounce, Notice } from "obsidian";
+import { Plugin, TFile, debounce } from "obsidian";
 import { QuickAddSettingsTab } from "./quickAddSettingsTab";
 import { DEFAULT_SETTINGS } from "./settings";
 import type { QuickAddSettings } from "./settings";
@@ -9,7 +9,7 @@ import { ConsoleErrorLogger } from "./logger/consoleErrorLogger";
 import { GuiLogger } from "./logger/guiLogger";
 import { LogManager } from "./logger/logManager";
 import { reportError, withErrorHandling } from "./utils/errorUtils";
-import { tryOpenPluginSettings } from "./utils/openPluginSettings";
+import { openQuickAddSettings } from "./utils/openPluginSettings";
 import { StartupMacroEngine } from "./engine/StartupMacroEngine";
 import { ChoiceExecutor } from "./choiceExecutor";
 import type IChoice from "./types/choices/IChoice";
@@ -216,11 +216,7 @@ export default class QuickAdd extends Plugin {
 			id: "openQuickAddSettings",
 			name: QUICK_ADD_COMMAND_LABELS.openSettings,
 			callback: () => {
-				if (!tryOpenPluginSettings(this.app, this.manifest.id)) {
-					new Notice(
-						"QuickAdd: Unable to open settings automatically. Open Settings -> QuickAdd manually."
-					);
-				}
+				openQuickAddSettings(this.app, this.manifest.id);
 			},
 		});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ import {
 	isPathWithinTemplateFolders,
 	normalizeTemplateFolderPaths,
 } from "./utilityObsidian";
-import ChoiceSuggester from "./gui/suggesters/choiceSuggester";
+import { openChoiceLauncher } from "./gui/suggesters/openChoiceLauncher";
 import { QuickAddApi } from "./quickAddApi";
 import migrate from "./migrations/migrate";
 import { settingsStore } from "./settingsStore";
@@ -107,9 +107,7 @@ export default class QuickAdd extends Plugin {
 			id: "runQuickAdd",
 			name: QUICK_ADD_COMMAND_LABELS.run,
 			callback: () => {
-				ChoiceSuggester.Open(this, this.settings.choices, {
-					includeTemplateFolderRow: true,
-				});
+				openChoiceLauncher(this);
 			},
 		});
 
@@ -310,9 +308,7 @@ export default class QuickAdd extends Plugin {
 
 		if (this.settings.enableRibbonIcon) {
 			this.addRibbonIcon("file-plus", "QuickAdd", () => {
-				ChoiceSuggester.Open(this, this.settings.choices, {
-					includeTemplateFolderRow: true,
-				});
+				openChoiceLauncher(this);
 			});
 		}
 

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -10,6 +10,7 @@ import { settingsStore } from "./settingsStore";
 import { DEFAULT_SETTINGS, type QuickAddSettings } from "./settings";
 import { deepClone } from "./utils/deepClone";
 import { InputPromptDraftStore } from "./utils/InputPromptDraftStore";
+import { DOCS_URLS } from "./docs";
 import type QuickAdd from "./main";
 
 // Importing the settings tab transitively pulls in ChoiceView -> the Dataview
@@ -295,15 +296,18 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 	// in a macro-builder notice.
 	it("puts a documentation control on the first group's heading", () => {
 		const tab = makeTab();
-		const [choicesGroup] = tab.getSettingDefinitions() as unknown as Array<{
-			extraButtons?: Array<(component: ExtraButtonComponent) => unknown>;
-		}>;
+		const choicesGroup = (
+			tab.getSettingDefinitions() as unknown as Array<{
+				heading?: string;
+				extraButtons?: Array<(component: ExtraButtonComponent) => unknown>;
+			}>
+		).find((group) => group.heading === "Choices & Packages");
 
-		expect(choicesGroup.extraButtons).toHaveLength(1);
+		expect(choicesGroup?.extraButtons).toHaveLength(1);
 
 		const button = new ExtraButtonComponent(document.createElement("div"));
 		const open = vi.spyOn(window, "open").mockImplementation(() => null);
-		choicesGroup.extraButtons?.[0](button);
+		choicesGroup?.extraButtons?.[0](button);
 		button.extraSettingsEl.dispatchEvent(new MouseEvent("click"));
 
 		expect(open).toHaveBeenCalledWith(
@@ -312,6 +316,17 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 			"noopener,noreferrer",
 		);
 		open.mockRestore();
+	});
+
+	// docs.ts promises gettingStarted stays byte-identical to manifest.json's
+	// helpUrl. Obsidian 1.13 does not surface helpUrl anywhere, so nothing else
+	// would catch the two drifting apart.
+	it("keeps the getting-started URL in sync with manifest.json helpUrl", () => {
+		const manifest = JSON.parse(
+			readFileSync(join(__dirname, "../manifest.json"), "utf8"),
+		) as { helpUrl?: string };
+
+		expect(manifest.helpUrl).toBe(DOCS_URLS.gettingStarted);
 	});
 
 	it("links the one-page inputs docs instead of naming them in prose", () => {
@@ -330,7 +345,7 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 		expect(link?.getAttribute("href")).toBe(
 			"https://quickadd.obsidian.guide/docs/Advanced/onePageInputs/",
 		);
-		expect(link?.textContent).toBe("Learn more");
+		expect(link?.textContent).toBe("Learn more about one-page inputs");
 		// The old prose pointed at docs the user could not reach.
 		expect(host.textContent).not.toContain("See One-page Inputs in the docs");
 	});

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { App, Component } from "obsidian";
+import { App, Component, ExtraButtonComponent, Setting } from "obsidian";
 import { renderChoiceName } from "./gui/choiceList/renderChoiceName";
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 import { formatDateAliasLines } from "./utils/dateAliases";
@@ -289,5 +289,133 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 			"Search nested choices",
 			"“New note from template” in the launcher",
 		]);
+	});
+
+	// Issue #1541: the whole plugin used to contain exactly one docs URL, buried
+	// in a macro-builder notice.
+	it("puts a documentation control on the first group's heading", () => {
+		const tab = makeTab();
+		const [choicesGroup] = tab.getSettingDefinitions() as unknown as Array<{
+			extraButtons?: Array<(component: ExtraButtonComponent) => unknown>;
+		}>;
+
+		expect(choicesGroup.extraButtons).toHaveLength(1);
+
+		const button = new ExtraButtonComponent(document.createElement("div"));
+		const open = vi.spyOn(window, "open").mockImplementation(() => null);
+		choicesGroup.extraButtons?.[0](button);
+		button.extraSettingsEl.dispatchEvent(new MouseEvent("click"));
+
+		expect(open).toHaveBeenCalledWith(
+			"https://quickadd.obsidian.guide/docs/",
+			"_blank",
+			"noopener,noreferrer",
+		);
+		open.mockRestore();
+	});
+
+	it("links the one-page inputs docs instead of naming them in prose", () => {
+		const tab = makeTab();
+		const groups = tab.getSettingDefinitions() as unknown as Array<{
+			items?: Array<{ name?: string; desc?: string | DocumentFragment }>;
+		}>;
+		const item = groups
+			.flatMap((g) => g.items ?? [])
+			.find((i) => i.name === "One-page input for choices");
+		const desc = item?.desc as DocumentFragment;
+
+		const host = document.createElement("div");
+		host.append(desc.cloneNode(true));
+		const link = host.querySelector("a");
+		expect(link?.getAttribute("href")).toBe(
+			"https://quickadd.obsidian.guide/docs/Advanced/onePageInputs/",
+		);
+		expect(link?.textContent).toBe("Learn more");
+		// The old prose pointed at docs the user could not reach.
+		expect(host.textContent).not.toContain("See One-page Inputs in the docs");
+	});
+});
+
+// Issue #1547: "Export package…" was the first concrete action a brand-new user
+// saw below the "No choices yet" empty state, with nothing to export.
+describe("Packages row export availability", () => {
+	function renderPackagesRow(): {
+		setting: Setting;
+		exportButton: HTMLButtonElement;
+		cleanup: () => void;
+	} {
+		const app = new App();
+		const plugin = { app } as unknown as QuickAdd;
+		const tab = new QuickAddSettingsTab(app, plugin);
+		const setting = new Setting(document.createElement("div"));
+		const cleanup = (
+			tab as unknown as { renderPackages: (s: Setting) => () => void }
+		).renderPackages(setting);
+		const buttons = setting.controlEl.querySelectorAll("button");
+		return {
+			setting,
+			exportButton: buttons[0] as HTMLButtonElement,
+			cleanup,
+		};
+	}
+
+	beforeEach(() => {
+		settingsStore.replaceState(deepClone(DEFAULT_SETTINGS));
+		settingsStore.setState({ choices: [] });
+	});
+
+	it("disables export and explains why when there is nothing to export", () => {
+		const { setting, exportButton, cleanup } = renderPackagesRow();
+
+		expect(exportButton.disabled).toBe(true);
+		expect(exportButton.getAttribute("aria-label")).toBe("Nothing to export yet");
+		// Touch has no hover, so the reason is also always visible.
+		expect(setting.descEl.textContent).toContain(
+			"Export becomes available once you have a choice.",
+		);
+		cleanup();
+	});
+
+	it("leaves import available so a starter package can be brought in", () => {
+		const { setting, cleanup } = renderPackagesRow();
+		const importButton = setting.controlEl.querySelectorAll("button")[1] as
+			HTMLButtonElement;
+
+		expect(importButton.disabled).toBe(false);
+		cleanup();
+	});
+
+	// The declarative tab renders once and never re-renders on store changes, so
+	// creating a first choice with the tab open must still flip the button.
+	it("enables export live when the first choice appears", () => {
+		const { setting, exportButton, cleanup } = renderPackagesRow();
+
+		settingsStore.setState({
+			choices: [
+				{ id: "c1", name: "Add task", type: "Capture", command: false },
+			] as unknown as QuickAddSettings["choices"],
+		});
+
+		expect(exportButton.disabled).toBe(false);
+		expect(exportButton.hasAttribute("aria-label")).toBe(false);
+		expect(setting.descEl.textContent).not.toContain(
+			"Export becomes available",
+		);
+		// No accumulated copies of the description from repeated applies.
+		expect(setting.descEl.querySelectorAll("a")).toHaveLength(1);
+		cleanup();
+	});
+
+	it("stops listening once the row is torn down", () => {
+		const { exportButton, cleanup } = renderPackagesRow();
+		cleanup();
+
+		settingsStore.setState({
+			choices: [
+				{ id: "c1", name: "Add task", type: "Capture", command: false },
+			] as unknown as QuickAddSettings["choices"],
+		});
+
+		expect(exportButton.disabled).toBe(true);
 	});
 });

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -34,6 +34,7 @@ import {
 	parseDateAliasLines,
 } from "./utils/dateAliases";
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
+import { createDocsLink, DOCS_URLS, openDocsUrl } from "./docs";
 
 /** String-named keys of {@link QuickAddSettings} — used to type the declarative
  * `control` keys so a mistyped key is caught at compile time. */
@@ -43,6 +44,8 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	public plugin: QuickAdd;
 	private choiceViewHandle: MountHandle | null = null;
 	private globalVariablesViewHandle: MountHandle | null = null;
+	/** Live store subscription behind the Packages row's Export state. */
+	private packagesUnsubscribe: (() => void) | null = null;
 
 	constructor(app: App, plugin: QuickAdd) {
 		super(app, plugin);
@@ -130,6 +133,11 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.choiceViewHandle = null;
 		this.globalVariablesViewHandle?.destroy();
 		this.globalVariablesViewHandle = null;
+		// Safety net for the Packages subscription: the render cleanup already
+		// unsubscribes, but this row outlives no view of its own, so a missed
+		// cleanup would leak a listener for the plugin's lifetime.
+		this.packagesUnsubscribe?.();
+		this.packagesUnsubscribe = null;
 	}
 
 	// ----- group builders -----
@@ -138,6 +146,20 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		return {
 			type: "group",
 			heading: "Choices & Packages",
+			// QuickAdd's power surface is syntax you have to learn ({{VALUE}},
+			// {{DATE}}, capture targets, ...) and until now the manual was reachable
+			// from exactly one place in the whole plugin (issue #1541). A help icon
+			// on the first heading is Obsidian's own idiom for this, and it costs the
+			// page no vertical space — the choices list stays the focus.
+			extraButtons: [
+				(button) =>
+					button
+						.setIcon("help-circle")
+						.setTooltip("QuickAdd documentation")
+						.onClick(() =>
+							openDocsUrl(DOCS_URLS.gettingStarted, button.extraSettingsEl),
+						),
+			],
 			items: [
 				{
 					name: "Choices",
@@ -202,7 +224,12 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 				},
 				{
 					name: "One-page input for choices",
-					desc: "Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs. Template and Capture choices can override this individually. See One-page Inputs in the docs.",
+					// The trailing sentence used to read "See One-page Inputs in the
+					// docs." as plain, unlinked prose (issue #1541).
+					desc: this.descWithDocsLink(
+						"Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs. Template and Capture choices can override this individually. ",
+						DOCS_URLS.onePageInputs,
+					),
 					control: { type: "toggle", key: "onePageInputEnabled" },
 				},
 				{
@@ -337,6 +364,19 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 
 	// ----- render helpers -----
 
+	/**
+	 * A description ending in a "Learn more" link. Built fresh on every call: the
+	 * declarative renderer clones fragments before inserting them, but
+	 * getSettingDefinitions() runs per render anyway, so a fresh fragment is free
+	 * and cannot be accidentally re-parented.
+	 */
+	private descWithDocsLink(text: string, url: string): DocumentFragment {
+		const fragment = document.createDocumentFragment();
+		fragment.append(document.createTextNode(text));
+		createDocsLink(fragment, url, "Learn more");
+		return fragment;
+	}
+
 	/** Strip the label/description column and let a row span the full width —
 	 * used to host the mounted Svelte views. The declarative API requires a
 	 * `name` on every definition (for search indexing); we set it on the def and
@@ -394,29 +434,80 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		};
 	}
 
-	private renderPackages(setting: Setting): void {
+	/** Packages description, with the reason Export is unavailable when it is. */
+	private packagesDesc(hasNothingToExport: boolean): DocumentFragment {
+		return this.descWithDocsLink(
+			hasNothingToExport
+				? "Bundle or import QuickAdd automations as reusable packages. Export becomes available once you have a choice. "
+				: "Bundle or import QuickAdd automations as reusable packages. ",
+			DOCS_URLS.packages,
+		);
+	}
+
+	private renderPackages(setting: Setting): () => void {
 		// Both package actions are secondary utilities — not the page's primary
 		// action ("New choice" is) — so neither is a CTA. Keeping only one filled
 		// primary button in the view avoids competing purple CTAs (per the
 		// one-primary-button-per-page rule).
-		setting.addButton((button) =>
-			button
-				.setButtonText("Export package…")
-				.onClick(() => {
-					const choicesSnapshot = settingsStore.getState().choices;
-					new ExportPackageModal(
-						this.app,
-						this.plugin,
-						choicesSnapshot,
-					).open();
-				}),
-		);
+		let exportButton: ButtonComponent | undefined;
+		setting.addButton((button) => {
+			exportButton = button;
+			button.setButtonText("Export package…").onClick(() => {
+				const choicesSnapshot = settingsStore.getState().choices;
+				new ExportPackageModal(
+					this.app,
+					this.plugin,
+					choicesSnapshot,
+				).open();
+			});
+		});
 
+		// Import stays available with zero choices on purpose: importing a package
+		// is one of the most useful things a brand-new user can do, so the block as
+		// a whole is not de-emphasised — only the action that cannot work is.
 		setting.addButton((button) =>
 			button.setButtonText("Import package…").onClick(() => {
 				new ImportPackageModal(this.app).open();
 			}),
 		);
+
+		// "Export package…" used to be the first concrete action a new user saw
+		// below the "No choices yet" empty state, with nothing to export (issue
+		// #1547). The tooltip covers desktop hover; the description carries the
+		// same reason for touch, where there is no hover.
+		const apply = (hasNothingToExport: boolean): void => {
+			setting.setDesc(this.packagesDesc(hasNothingToExport));
+			if (!exportButton) return;
+			exportButton.setDisabled(hasNothingToExport);
+			if (hasNothingToExport) {
+				exportButton.setTooltip("Nothing to export yet");
+			} else {
+				// setTooltip("") is unspecified; Obsidian's tooltip is driven by
+				// aria-label, so drop the attribute outright.
+				exportButton.buttonEl.removeAttribute("aria-label");
+			}
+		};
+
+		// The declarative tab renders once and does NOT re-render on store changes,
+		// so subscribe to keep the state honest while the tab stays open.
+		let hasNothingToExport = settingsStore.getState().choices.length === 0;
+		apply(hasNothingToExport);
+
+		this.packagesUnsubscribe?.();
+		const unsubscribe = settingsStore.subscribe((settings) => {
+			const next = settings.choices.length === 0;
+			if (next === hasNothingToExport) return;
+			hasNothingToExport = next;
+			apply(next);
+		});
+		this.packagesUnsubscribe = unsubscribe;
+
+		return () => {
+			unsubscribe();
+			if (this.packagesUnsubscribe === unsubscribe) {
+				this.packagesUnsubscribe = null;
+			}
+		};
 	}
 
 	private renderDateAliases(setting: Setting): void {

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -40,6 +40,14 @@ import { createDocsLink, DOCS_URLS, openDocsUrl } from "./docs";
  * `control` keys so a mistyped key is caught at compile time. */
 type SettingsKey = Extract<keyof QuickAddSettings, string>;
 
+/**
+ * Shared by the Packages definition (which is what the settings search indexes)
+ * and by the rendered description (which the row rewrites as the export state
+ * changes), so the two can never drift.
+ */
+const PACKAGES_DESC =
+	"Bundle or import QuickAdd automations as reusable packages.";
+
 export class QuickAddSettingsTab extends PluginSettingTab {
 	public plugin: QuickAdd;
 	private choiceViewHandle: MountHandle | null = null;
@@ -150,7 +158,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			// {{DATE}}, capture targets, ...) and until now the manual was reachable
 			// from exactly one place in the whole plugin (issue #1541). A help icon
 			// on the first heading is Obsidian's own idiom for this, and it costs the
-			// page no vertical space — the choices list stays the focus.
+			// page no vertical space, so the choices list stays the focus.
 			extraButtons: [
 				(button) =>
 					button
@@ -167,7 +175,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 				},
 				{
 					name: "Packages",
-					desc: "Bundle or import QuickAdd automations as reusable packages.",
+					desc: PACKAGES_DESC,
 					render: (setting) => this.renderPackages(setting),
 				},
 			],
@@ -229,6 +237,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					desc: this.descWithDocsLink(
 						"Collect a choice's inputs in one form before it runs, instead of one prompt at a time. Works with Template and Capture choices, and with Macros whose scripts declare inputs. Template and Capture choices can override this individually. ",
 						DOCS_URLS.onePageInputs,
+						"Learn more about one-page inputs",
 					),
 					control: { type: "toggle", key: "onePageInputEnabled" },
 				},
@@ -365,15 +374,22 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	// ----- render helpers -----
 
 	/**
-	 * A description ending in a "Learn more" link. Built fresh on every call: the
+	 * A description ending in a documentation link. Built fresh on every call: the
 	 * declarative renderer clones fragments before inserting them, but
 	 * getSettingDefinitions() runs per render anyway, so a fresh fragment is free
 	 * and cannot be accidentally re-parented.
+	 *
+	 * `linkText` names its destination wherever two links could be on screen at
+	 * once, matching Obsidian's own "Learn more about ..." phrasing.
 	 */
-	private descWithDocsLink(text: string, url: string): DocumentFragment {
+	private descWithDocsLink(
+		text: string,
+		url: string,
+		linkText = "Learn more",
+	): DocumentFragment {
 		const fragment = document.createDocumentFragment();
 		fragment.append(document.createTextNode(text));
-		createDocsLink(fragment, url, "Learn more");
+		createDocsLink(fragment, url, linkText);
 		return fragment;
 	}
 
@@ -438,9 +454,10 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	private packagesDesc(hasNothingToExport: boolean): DocumentFragment {
 		return this.descWithDocsLink(
 			hasNothingToExport
-				? "Bundle or import QuickAdd automations as reusable packages. Export becomes available once you have a choice. "
-				: "Bundle or import QuickAdd automations as reusable packages. ",
+				? `${PACKAGES_DESC} Export becomes available once you have a choice. `
+				: `${PACKAGES_DESC} `,
 			DOCS_URLS.packages,
+			"Learn more about packages",
 		);
 	}
 
@@ -464,7 +481,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 
 		// Import stays available with zero choices on purpose: importing a package
 		// is one of the most useful things a brand-new user can do, so the block as
-		// a whole is not de-emphasised — only the action that cannot work is.
+		// a whole is not de-emphasised, only the action that cannot work.
 		setting.addButton((button) =>
 			button.setButtonText("Import package…").onClick(() => {
 				new ImportPackageModal(this.app).open();
@@ -474,7 +491,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		// "Export package…" used to be the first concrete action a new user saw
 		// below the "No choices yet" empty state, with nothing to export (issue
 		// #1547). The tooltip covers desktop hover; the description carries the
-		// same reason for touch, where there is no hover.
+		// same reason for touch, where there is no hover, and for screen readers.
 		const apply = (hasNothingToExport: boolean): void => {
 			setting.setDesc(this.packagesDesc(hasNothingToExport));
 			if (!exportButton) return;

--- a/src/styles.css
+++ b/src/styles.css
@@ -553,6 +553,20 @@
 	text-decoration: underline;
 }
 
+/* docs.ts — documentation links (#1541). Obsidian's own `a { color:
+   var(--link-color) }` is invalid at computed-value time inside a
+   `.setting-item-description`, so a bare anchor there inherits --text-muted and
+   reads as prose. Pin the accent colour so every docs link looks the same
+   wherever it lands. */
+.quickadd-docs-link {
+	color: var(--text-accent);
+	text-decoration: underline;
+}
+
+.quickadd-docs-link:hover {
+	color: var(--text-accent-hover, var(--text-accent));
+}
+
 /* Shared accessible icon button (IconButton.svelte / DragHandle.svelte, #1250).
    Resets Obsidian's default <button> chrome so an icon-only <button> looks like the
    borderless inline icons it replaced, while keeping native keyboard/focus behaviour.

--- a/src/styles.css
+++ b/src/styles.css
@@ -548,16 +548,11 @@
 	max-width: 100%;
 }
 
-.quickadd-notice-link {
-	color: var(--interactive-accent);
-	text-decoration: underline;
-}
-
-/* docs.ts — documentation links (#1541). Obsidian's own `a { color:
-   var(--link-color) }` is invalid at computed-value time inside a
-   `.setting-item-description`, so a bare anchor there inherits --text-muted and
-   reads as prose. Pin the accent colour so every docs link looks the same
-   wherever it lands. */
+/* docs.ts - documentation links (#1541). Obsidian deliberately mutes links inside
+   `.setting-item-description` (`--link-color: var(--text-muted)`), so a bare anchor
+   there reads as prose, which is a large part of why QuickAdd's docs stayed
+   invisible. This is an intentional deviation: pin the accent colour so every docs
+   link looks the same wherever it lands. */
 .quickadd-docs-link {
 	color: var(--text-accent);
 	text-decoration: underline;

--- a/src/utils/openPluginSettings.test.ts
+++ b/src/utils/openPluginSettings.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { tryOpenPluginSettings } from "./openPluginSettings";
+import { openQuickAddSettings, tryOpenPluginSettings } from "./openPluginSettings";
 import { log } from "../logger/logManager";
 import type { App } from "obsidian";
+import { Notice } from "obsidian";
 
 vi.mock("../logger/logManager", () => ({
 	log: {
@@ -73,5 +74,46 @@ describe("tryOpenPluginSettings", () => {
 		expect(log.logError).toHaveBeenCalledWith(
 			"QuickAdd: Failed to open plugin settings automatically: Error: Simulated tab error"
 		);
+	});
+});
+
+describe("openQuickAddSettings", () => {
+	const workingApp = () =>
+		({ setting: { open: vi.fn(), openTabById: vi.fn() } }) as unknown as App;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(Notice as unknown as { instances: unknown[] }).instances = [];
+	});
+
+	it("opens the tab and stays silent on success", () => {
+		const app = workingApp();
+
+		expect(openQuickAddSettings(app, "quickadd")).toBe(true);
+		expect(
+			(app as unknown as { setting: { openTabById: ReturnType<typeof vi.fn> } })
+				.setting.openTabById,
+		).toHaveBeenCalledWith("quickadd");
+		expect((Notice as unknown as { instances: unknown[] }).instances).toHaveLength(0);
+	});
+
+	it("tells the user where to go when the internal API is unavailable", () => {
+		expect(openQuickAddSettings({} as App, "quickadd")).toBe(false);
+
+		const notices = (Notice as unknown as { instances: Array<{ message: string }> })
+			.instances;
+		expect(notices).toHaveLength(1);
+		expect(notices[0].message).toBe(
+			"QuickAdd: Unable to open settings automatically. Open Settings → QuickAdd manually.",
+		);
+	});
+
+	// Callers that already explained themselves (runTemplateFromFolder) must not
+	// stack a second, generic notice on top of their specific one.
+	it("suppresses the fallback notice when asked to", () => {
+		expect(openQuickAddSettings({} as App, "quickadd", { notice: false })).toBe(
+			false,
+		);
+		expect((Notice as unknown as { instances: unknown[] }).instances).toHaveLength(0);
 	});
 });

--- a/src/utils/openPluginSettings.test.ts
+++ b/src/utils/openPluginSettings.test.ts
@@ -6,7 +6,7 @@ import { Notice } from "obsidian";
 
 vi.mock("../logger/logManager", () => ({
 	log: {
-		logError: vi.fn(),
+		logMessage: vi.fn(),
 	},
 }));
 
@@ -28,21 +28,21 @@ describe("tryOpenPluginSettings", () => {
 		expect(result).toBe(true);
 		expect((fakeApp as any).setting.open).toHaveBeenCalledOnce();
 		expect((fakeApp as any).setting.openTabById).toHaveBeenCalledWith("my-plugin");
-		expect(log.logError).not.toHaveBeenCalled();
+		expect(log.logMessage).not.toHaveBeenCalled();
 	});
 
-	it("should return false and log error if internal API is missing", () => {
+	it("should return false and log (without a notice) if the internal API is missing", () => {
 		const fakeApp = {} as unknown as App;
 
 		const result = tryOpenPluginSettings(fakeApp, "my-plugin");
 
 		expect(result).toBe(false);
-		expect(log.logError).toHaveBeenCalledWith(
+		expect(log.logMessage).toHaveBeenCalledWith(
 			"QuickAdd: Obsidian internal settings API is unavailable."
 		);
 	});
 
-	it("should return false and log error if an exception is thrown from setting.open", () => {
+	it("should return false and log if an exception is thrown from setting.open", () => {
 		const fakeApp = {
 			setting: {
 				open: () => {
@@ -55,12 +55,12 @@ describe("tryOpenPluginSettings", () => {
 		const result = tryOpenPluginSettings(fakeApp, "my-plugin");
 
 		expect(result).toBe(false);
-		expect(log.logError).toHaveBeenCalledWith(
+		expect(log.logMessage).toHaveBeenCalledWith(
 			"QuickAdd: Failed to open plugin settings automatically: Error: Simulated error"
 		);
 	});
 
-	it("should return false and log error if opening the tab throws", () => {
+	it("should return false and log if opening the tab throws", () => {
 		const fakeApp = {
 			setting: {
 				open: vi.fn(),
@@ -71,7 +71,7 @@ describe("tryOpenPluginSettings", () => {
 		} as unknown as App;
 
 		expect(tryOpenPluginSettings(fakeApp, "my-plugin")).toBe(false);
-		expect(log.logError).toHaveBeenCalledWith(
+		expect(log.logMessage).toHaveBeenCalledWith(
 			"QuickAdd: Failed to open plugin settings automatically: Error: Simulated tab error"
 		);
 	});
@@ -108,12 +108,18 @@ describe("openQuickAddSettings", () => {
 		);
 	});
 
-	// Callers that already explained themselves (runTemplateFromFolder) must not
-	// stack a second, generic notice on top of their specific one.
-	it("suppresses the fallback notice when asked to", () => {
+	// Callers that already explained themselves (openChoiceLauncher,
+	// runTemplateFromFolder) must not stack a second, generic notice on top of
+	// their specific one. This is why the failure path logs through logMessage:
+	// GuiLogger turns every logError into a 15-second Notice, which would defeat
+	// the suppression entirely.
+	it("suppresses every notice when asked to, but still logs", () => {
 		expect(openQuickAddSettings({} as App, "quickadd", { notice: false })).toBe(
 			false,
 		);
 		expect((Notice as unknown as { instances: unknown[] }).instances).toHaveLength(0);
+		expect(log.logMessage).toHaveBeenCalledWith(
+			"QuickAdd: Obsidian internal settings API is unavailable.",
+		);
 	});
 });

--- a/src/utils/openPluginSettings.ts
+++ b/src/utils/openPluginSettings.ts
@@ -12,7 +12,10 @@ export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
 		).setting;
 
 		if (!setting?.open || !setting?.openTabById) {
-			log.logError("QuickAdd: Obsidian internal settings API is unavailable.");
+			// logMessage, not logError: GuiLogger turns every logError into a
+			// 15-second Notice, and every caller of this helper already shows its own
+			// (more useful) message on failure. Console diagnostics are kept.
+			log.logMessage("QuickAdd: Obsidian internal settings API is unavailable.");
 			return false;
 		}
 
@@ -20,7 +23,9 @@ export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
 		setting.openTabById(pluginId);
 		return true;
 	} catch (error) {
-		log.logError(`QuickAdd: Failed to open plugin settings automatically: ${error}`);
+		log.logMessage(
+			`QuickAdd: Failed to open plugin settings automatically: ${error}`,
+		);
 		return false;
 	}
 }
@@ -31,7 +36,7 @@ export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
  * modules can reach it without value-importing the plugin entry point (the
  * import-cycle invariant from #1249).
  *
- * Pass `notice: false` when the caller has already explained itself — a second,
+ * Pass `notice: false` when the caller has already explained itself: a second,
  * generic notice on top of a specific one is noise.
  */
 export function openQuickAddSettings(

--- a/src/utils/openPluginSettings.ts
+++ b/src/utils/openPluginSettings.ts
@@ -1,4 +1,5 @@
 import type { App } from "obsidian";
+import { Notice } from "obsidian";
 import { log } from "../logger/logManager";
 
 /** Opens a plugin's settings tab. Returns false if the internal API is unavailable or throws. */
@@ -22,4 +23,27 @@ export function tryOpenPluginSettings(app: App, pluginId: string): boolean {
 		log.logError(`QuickAdd: Failed to open plugin settings automatically: ${error}`);
 		return false;
 	}
+}
+
+/**
+ * Opens QuickAdd's settings tab, telling the user how to get there by hand when
+ * the internal API is unavailable. Lives here rather than in `main.ts` so leaf
+ * modules can reach it without value-importing the plugin entry point (the
+ * import-cycle invariant from #1249).
+ *
+ * Pass `notice: false` when the caller has already explained itself — a second,
+ * generic notice on top of a specific one is noise.
+ */
+export function openQuickAddSettings(
+	app: App,
+	pluginId: string,
+	options?: { notice?: boolean },
+): boolean {
+	const opened = tryOpenPluginSettings(app, pluginId);
+	if (!opened && options?.notice !== false) {
+		new Notice(
+			"QuickAdd: Unable to open settings automatically. Open Settings → QuickAdd manually.",
+		);
+	}
+	return opened;
 }

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -55,9 +55,10 @@ export class ButtonComponent extends BaseComponent {
     return this;
   }
 
-  // Mirrors Obsidian: the disabled state lands on the native button, and the
-  // tooltip is driven by aria-label (its delegated pointerover handler).
+  // Mirrors Obsidian: BaseComponent tracks the flag, the native button carries
+  // it, and the tooltip is driven by aria-label (a delegated pointerover handler).
   setDisabled(disabled: boolean): this {
+    super.setDisabled(disabled);
     this.buttonEl.disabled = disabled;
     return this;
   }
@@ -100,13 +101,12 @@ export class ExtraButtonComponent extends BaseComponent {
     return this;
   }
 
-  setDisabled(disabled: boolean): this {
-    this.extraSettingsEl.toggleAttribute("disabled", disabled);
-    return this;
-  }
-
+  // Obsidian keeps a single callback rather than accumulating listeners, and
+  // skips it while disabled.
   onClick(cb: () => void): this {
-    this.extraSettingsEl.addEventListener("click", cb);
+    this.extraSettingsEl.onclick = () => {
+      if (!this.disabled) cb();
+    };
     return this;
   }
 }

--- a/tests/obsidian-stub.ts
+++ b/tests/obsidian-stub.ts
@@ -55,7 +55,15 @@ export class ButtonComponent extends BaseComponent {
     return this;
   }
 
-  setTooltip(): this {
+  // Mirrors Obsidian: the disabled state lands on the native button, and the
+  // tooltip is driven by aria-label (its delegated pointerover handler).
+  setDisabled(disabled: boolean): this {
+    this.buttonEl.disabled = disabled;
+    return this;
+  }
+
+  setTooltip(tooltip: string): this {
+    this.buttonEl.setAttribute("aria-label", tooltip);
     return this;
   }
 
@@ -69,6 +77,36 @@ export class ButtonComponent extends BaseComponent {
 
   onClick(cb: () => void): this {
     this.buttonEl.addEventListener("click", cb);
+    return this;
+  }
+}
+
+export class ExtraButtonComponent extends BaseComponent {
+  extraSettingsEl: HTMLElement;
+
+  constructor(containerEl: HTMLElement) {
+    super();
+    this.extraSettingsEl = document.createElement("div");
+    containerEl.appendChild(this.extraSettingsEl);
+  }
+
+  setIcon(): this {
+    return this;
+  }
+
+  // Obsidian drives its tooltip off aria-label.
+  setTooltip(tooltip: string): this {
+    this.extraSettingsEl.setAttribute("aria-label", tooltip);
+    return this;
+  }
+
+  setDisabled(disabled: boolean): this {
+    this.extraSettingsEl.toggleAttribute("disabled", disabled);
+    return this;
+  }
+
+  onClick(cb: () => void): this {
+    this.extraSettingsEl.addEventListener("click", cb);
     return this;
   }
 }
@@ -230,6 +268,9 @@ export class Setting {
   }
 
   setDesc(desc: string | DocumentFragment): this {
+    // Obsidian replaces the description; appending would let repeated calls
+    // accumulate copies that the real app never shows.
+    this.descEl.replaceChildren();
     if (typeof desc === "string") {
       this.descEl.textContent = desc;
     } else {
@@ -882,6 +923,7 @@ export default {
   Component,
   BaseComponent,
   ButtonComponent,
+  ExtraButtonComponent,
   ToggleComponent,
   DropdownComponent,
   TextComponent,


### PR DESCRIPTION
Closes the four issues that together make up the broken first-run experience between installing QuickAdd and the first working choice.

Closes #1539
Closes #1540
Closes #1541
Closes #1547

They share two surfaces - the settings choice tab and the run picker - so they ship as one coherent change rather than four PRs racing each other through the same files.

## The problem

All four were reproduced live on a clean vault (Obsidian 1.13.0, QuickAdd 2.19.1, zero choices, no other community plugins) before anything was designed:

| | Before |
|---|---|
| **`QuickAdd: Run` on a fresh install** (#1540) | A picker with a blank input over Obsidian's bare "No results found." The most obvious first thing a new user does lands on a wall, with nothing saying choices exist or that they live in settings. |
| **"New folder"** (#1539) | Creates the folder, then opens a rename prompt titled **"Choice name"**. The UI calls them folders everywhere else. |
| **Documentation** (#1541) | The entire source contained exactly one docs URL, buried in the macro builder's "no scripts found" notice. The settings page even carried the sentence *"See One-page Inputs in the docs."* as plain, unlinked prose. |
| **"Export package…"** (#1547) | Enabled, prominent, and useless on a fresh install - the first concrete action below the "No choices yet" empty state, with nothing to export. |

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/chhoumann/quickadd/128dba8c25bf998d818f77b6a378d997b490d4d8/before-launcher.png" width="420"> | <img src="https://raw.githubusercontent.com/chhoumann/quickadd/128dba8c25bf998d818f77b6a378d997b490d4d8/after-launcher.png" width="420"> |
| <img src="https://raw.githubusercontent.com/chhoumann/quickadd/128dba8c25bf998d818f77b6a378d997b490d4d8/before-settings.png" width="420"> | <img src="https://raw.githubusercontent.com/chhoumann/quickadd/128dba8c25bf998d818f77b6a378d997b490d4d8/after-settings.png" width="420"> |
| <img src="https://raw.githubusercontent.com/chhoumann/quickadd/128dba8c25bf998d818f77b6a378d997b490d4d8/before-folder-rename.png" width="420"> | <img src="https://raw.githubusercontent.com/chhoumann/quickadd/128dba8c25bf998d818f77b6a378d997b490d4d8/after-folder-rename.png" width="420"> |

## What changed

### #1540 - the launcher no longer opens with nothing in it

`openChoiceLauncher()` (new, `src/gui/suggesters/openChoiceLauncher.ts`) is now what the `QuickAdd: Run` command and the ribbon icon call. When the picker has nothing to offer it says so and opens QuickAdd's settings instead of opening an empty modal:

> QuickAdd: No choices yet. Create your first one in Settings → QuickAdd.

**"Nothing to offer" means no choices AND no "New note from template" row**, since that synthetic row is a working action in its own right - a user with zero choices but a configured template folder still gets a useful picker.

This is deliberately the same shape as QuickAdd's existing answer to "this surface has nothing to offer": `runTemplateFromFolder` already shows a notice naming the exact settings path and opens the tab when no template folder is configured. **An earlier design injected synthetic "Create your first choice…" / "Read the documentation" rows into the picker instead. It was rejected in review**: those rows vanish on the first keystroke (fuzzy search filters them), the lead row promised to create something while only opening settings, and they put permanent complexity in the hottest code path to serve a once-per-lifetime state.

Two smaller fixes on the same surface:

- **The picker input finally carries a placeholder** ("Select a choice"). Every Obsidian picker labels its own; QuickAdd's rendered completely blank. Nested levels keep the folder's name or custom placeholder, and Back now restores the launcher's hint instead of a blank input.
- **Drilling into an empty folder** used to open a level whose only row was "← Back". The command/URI path already refused this with a notice; both paths now share one string. Because `SuggestModal` closes *before* `onChooseItem` runs, the picker is re-opened on the same level, so a mis-click costs a notice rather than the whole navigation stack.

<img src="https://raw.githubusercontent.com/chhoumann/quickadd/128dba8c25bf998d818f77b6a378d997b490d4d8/after-placeholder.png" width="480">

### #1539 - "Folder name", not "Choice name"

`promptRenameChoice` takes the choice type and titles the prompt accordingly. Folders are `Multi` choices internally, but the UI calls them folders everywhere else ("New folder", "Add folder to {name}", "Edit folder"). The builder header (Template and Capture only - folders have no builder) keeps the default.

### #1541 - the documentation is reachable

- A **help control on the "Choices & Packages" heading** (`SettingDefinitionGroup.extraButtons`, Obsidian's own idiom) opens the getting-started guide. It costs the page no vertical space, so the choices list stays the focus for the ~99% of sessions where the user is not new. *An earlier design added a "Documentation" row as the first row of the tab; review found `extraButtons` and it is strictly better.*
- The **"No choices yet" empty state** - the one place a brand-new user is guaranteed to look - gets a "Learn more" link.
- The **one-page-input and Packages descriptions** end in real links. The unlinked "See One-page Inputs in the docs." sentence is gone.
- `src/docs.ts` holds the canonical URLs (all four verified live: HTTP 200, no redirect hop) plus a popout-safe link builder. The macro-builder notice now uses it, so there is one place to change a docs URL. **Sibling PRs for #1542-#1545 can pick this up for contextual builder links** - that part of #1541 is deliberately left to them to avoid four PRs colliding in the same builder files.

Docs links carry a class pinning the accent colour. Obsidian deliberately sets `--link-color: var(--text-muted)` inside `.setting-item-description`, so a bare anchor there reads as prose - which is a large part of how QuickAdd's docs stayed invisible. The deviation is labelled as deliberate in the CSS.

### #1547 - Export is gated on having something to export

Disabled until there is a choice, with the reason both in a tooltip and in the always-visible description (touch has no hover, and screen readers do not get tooltips). The state flips live via a store subscription, since the declarative settings tab renders once and never re-renders.

**Import stays enabled on purpose.** The issue floats de-emphasising the whole Packages block; that would be wrong - importing a package is one of the most useful things a brand-new user can do. Only the action that cannot work is gated.

### Shared

`openQuickAddSettings()` moved out of `main.ts` into `src/utils/openPluginSettings.ts` so leaf modules can reach it without value-importing the plugin entry point (#1249's import-cycle invariant).

## Validation

Everything below was exercised in this worktree's isolated Obsidian 1.13.0 vault, not just in tests.

- **#1539** - "New folder" → prompt titled "Folder name", prefilled "New folder".
- **#1540** - zero choices: `QuickAdd: Run` (command *and* ribbon) shows the notice and opens the QuickAdd settings tab (page-side probe: `activeTab: "quickadd"`); no modal. With a choice present, the picker opens with `placeholder: "Select a choice"`. Clicking an empty folder: `Folder "Journal" is empty.` and the picker **stays open on the same level** with the same rows and placeholder.
- **#1541** - the help control calls `window.open("https://quickadd.obsidian.guide/docs/", "_blank", "noopener,noreferrer")`; all three docs links compute to the accent colour and point at their verified URLs.
- **#1547** - fresh vault: Export greyed out, tooltip "Nothing to export yet" renders on a real pointer hover (dispatched via CDP), description carries the reason. Creating the first choice **with the tab still open** flips Export to enabled, drops the stale `aria-label`, and removes the extra sentence with no duplicated description.
- `dev:errors` clean throughout.
- `pnpm run build`, `pnpm lint`, `pnpm test` (3888 passing) green.

## Review

Two multi-agent adversarial passes: one on the design before any code, one on the finished branch (3 lenses × find, then independent refutation of every finding). Both changed the outcome materially:

- The design review **killed the synthetic launcher rows** and **killed the "Documentation" settings row** (`extraButtons` exists), and **refuted my assumption** that a disabled button cannot show a tooltip - Obsidian's tooltip is delegated off `aria-label` and Blink does dispatch hover on disabled controls. Confirmed live here.
- The branch review caught the **empty-folder picker ejection** (`SuggestModal` closes before `onChooseItem`) and that **`{ notice: false }` did not actually suppress anything** - `tryOpenPluginSettings` logged through `log.logError`, and `GuiLogger` turns every `logError` into a 15-second Notice, so both failure paths stacked two notices. The test that "proved" the suppression only passed because it mocked the logger. Both fixed in `d5f8dd16`; the helper now logs through `logMessage` (console only).

## Notes for review

- **Release impact**: `fix:` + `feat:` commits, release-worthy. No migration, no settings-schema change, no API change.
- **Behaviour change worth a second look**: `QuickAdd: Run` with zero choices no longer opens a modal. It matches the plugin's existing precedent and cannot fire once the user has a single choice.
- The Packages row's `desc` is intentionally duplicated between the definition (what settings *search* indexes) and the rendered description (what the row rewrites) - both derive from one constant so they cannot drift.
- Deliberately out of scope, worth their own issues: sentence-case pass over the settings headings; folder deletion still says "choice" (`choiceService.ts` - exactly #1539's bug class, one function over); rendering empty folders as non-drillable in the picker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized “Docs” link utilities and integrated documentation links across onboarding, settings, notices, and choice UIs.
  * Added folder-specific rename prompts (including passing choice type) and improved “empty state” guidance with “Learn more”.
  * Packages export availability now updates live based on whether choices exist.
* **Bug Fixes**
  * Improved empty-folder handling: shows a consistent notice and keeps the user in the correct picker level.
  * Safer behavior when choice data is missing/corrupt and improved “Open QuickAdd settings” messaging.
* **Tests**
  * Added/expanded coverage for docs link creation/opening, rename prompts, empty states, and launcher behavior.
* **Style**
  * Updated documentation link styling via a dedicated CSS class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->