### PR TITLE
fix(builder): one labelled field per setting, previews below them, and a visible autosave contract

### DIFF
--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -64,7 +64,7 @@ from that path segment. The text inserted into the note is not changed.
 
 ### How QuickAdd picks the target {#how-quickadd-picks-a-target}
 
-When **Capture to active file** is off, the resolved _File path / format_
+When **Capture to active file** is off, the resolved _Capture to_
 value decides what happens:
 
 | You write | What happens |

--- a/docs/src/content/docs/docs/Examples/Capture_AddJournalEntry.md
+++ b/docs/src/content/docs/docs/Examples/Capture_AddJournalEntry.md
@@ -13,7 +13,7 @@ For reference, the journal entry capture in compact form:
 
 | Setting | Value |
 | --- | --- |
-| File path / format | `Daily/{{DATE:YYYY-MM-DD - ddd MMM D}}.md` |
+| Capture to | `Daily/{{DATE:YYYY-MM-DD - ddd MMM D}}.md` |
 | Write position | **After line...** |
 | Insert after | `## What did I do today?` |
 | Capture format | `- {{DATE:HH:mm}} {{VALUE}}\n` |

--- a/docs/src/content/docs/docs/Examples/Capture_ToDailyNote.md
+++ b/docs/src/content/docs/docs/Examples/Capture_ToDailyNote.md
@@ -13,7 +13,7 @@ Every recipe starts from the same base Capture choice; you only change the **Cap
 1. In QuickAdd settings, add a new **Capture** choice.
 2. Name it (for example, `Daily entry`) and open its settings.
 3. Disable **Capture to active file**.
-4. Set **File path / format** to match your vault's daily-note path and date pattern, for example `Daily/{{DATE:YYYY-MM-DD}}.md`.
+4. Set **Capture to** to match your vault's daily-note path and date pattern, for example `Daily/{{DATE:YYYY-MM-DD}}.md`.
 5. Enable **Create file if it doesn't exist**.
 6. Set **Write position** to **After line...**.
 7. In the **Insert after** field, enter the heading you want entries placed under, for example `## Journal`.
@@ -122,7 +122,7 @@ This keeps the row attached to the table:
 
 ### Tomorrow's daily note
 
-Change **File path / format** to:
+Change **Capture to** to:
 
 ```
 Daily/{{DATE:YYYY-MM-DD+1}}.md
@@ -145,7 +145,7 @@ Enable **Create line if not found** with placement **Top** (or **Bottom**). Quic
 Use **Before line...** instead of **After line...** and target the placeholder, such as `<!-- quickadd:notes -->`. See [Insert before](/docs/Choices/CaptureChoice/#insert-before) for the full setting.
 
 **Capture writes to the wrong file.**
-The date pattern in **File path / format** must match your vault's daily-note naming exactly. If your notes are named `2025.01.15.md` inside `Journal/`, use `Journal/{{DATE:YYYY.MM.DD}}.md`.
+The date pattern in **Capture to** must match your vault's daily-note naming exactly. If your notes are named `2025.01.15.md` inside `Journal/`, use `Journal/{{DATE:YYYY.MM.DD}}.md`.
 
 **Table rows or callout content breaks when using bottom-of-file placement.**
 Use **After line...** with **Insert at end of section** instead of **Bottom of file**. Bottom-of-file placement starts non-task captures on a new line, and when the file already ends with a newline that leaves a blank line before the captured content. That blank line splits table rows and callout blocks.

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -10,6 +10,7 @@ import Toggle from "../components/Toggle.svelte";
 import Dropdown from "../components/Dropdown.svelte";
 import ChoiceNameHeader from "./components/ChoiceNameHeader.svelte";
 import ValidatedInput from "./components/ValidatedInput.svelte";
+import LabeledField from "./components/LabeledField.svelte";
 import FormatPreviewField from "./components/FormatPreviewField.svelte";
 import AppendLinkSetting from "./components/AppendLinkSetting.svelte";
 import OpenFileSetting from "./components/OpenFileSetting.svelte";
@@ -100,25 +101,30 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 	</SettingItem>
 
 	{#if choice.createFileIfItDoesntExist.enabled}
-		<SettingItem name="Create file with given template.">
+		<LabeledField
+			name="Create file with a template"
+			desc="Path to the template QuickAdd applies to the new file."
+			bodyVisible={choice.createFileIfItDoesntExist.createWithTemplate}
+		>
 			{#snippet control()}
 				<Toggle
 					bind:checked={choice.createFileIfItDoesntExist.createWithTemplate}
 				/>
 			{/snippet}
-		</SettingItem>
-		<ValidatedInput
-			value={choice.createFileIfItDoesntExist.template}
-			placeholder="Template path"
-			disabled={!choice.createFileIfItDoesntExist.createWithTemplate}
-			{app}
-			suggestions={templateFilePaths}
-			maxSuggestions={50}
-			validator={validateTemplate}
-			ariaLabel="Template path"
-			onChange={(value) =>
-				(choice.createFileIfItDoesntExist.template = value.trim())}
-		/>
+			{#snippet children(id)}
+				<ValidatedInput
+					{id}
+					value={choice.createFileIfItDoesntExist.template}
+					placeholder="Template path"
+					{app}
+					suggestions={templateFilePaths}
+					maxSuggestions={50}
+					validator={validateTemplate}
+					onChange={(value) =>
+						(choice.createFileIfItDoesntExist.template = value.trim())}
+				/>
+			{/snippet}
+		</LabeledField>
 	{/if}
 {/if}
 
@@ -146,22 +152,27 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 	{/snippet}
 </SettingItem>
 
-<SettingItem name="Capture format" desc="Set the format of the capture.">
+<LabeledField
+	name="Capture format"
+	desc="Set the format of the capture. When off, the captured text is written as-is."
+	bodyVisible={choice.format.enabled}
+>
 	{#snippet control()}
 		<Toggle bind:checked={choice.format.enabled} />
 	{/snippet}
-</SettingItem>
-<ValidatedInput
-	inputKind="textarea"
-	bind:value={choice.format.format}
-	placeholder="Format"
-	disabled={!choice.format.enabled}
-	required={choice.format.enabled}
-	requiredMessage="Capture format is required when enabled"
-	makeSuggesters={formatSuggesters}
-	ariaLabel="Format"
-/>
-<FormatPreviewField value={choice.format.format} {app} {plugin} />
+	{#snippet children(id)}
+		<ValidatedInput
+			{id}
+			inputKind="textarea"
+			bind:value={choice.format.format}
+			placeholder="Format"
+			required
+			requiredMessage="Capture format is required when enabled"
+			makeSuggesters={formatSuggesters}
+		/>
+		<FormatPreviewField value={choice.format.format} {app} {plugin} />
+	{/snippet}
+</LabeledField>
 
 <SettingItem name="Behavior" heading />
 {#if !choice.captureToActiveFile}

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -151,7 +151,6 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 		<Toggle bind:checked={choice.format.enabled} />
 	{/snippet}
 </SettingItem>
-<FormatPreviewField value={choice.format.format} {app} {plugin} />
 <ValidatedInput
 	inputKind="textarea"
 	bind:value={choice.format.format}
@@ -162,6 +161,7 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 	makeSuggesters={formatSuggesters}
 	ariaLabel="Format"
 />
+<FormatPreviewField value={choice.format.format} {app} {plugin} />
 
 <SettingItem name="Behavior" heading />
 {#if !choice.captureToActiveFile}

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -154,7 +154,7 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 
 <LabeledField
 	name="Capture format"
-	desc="Set the format of the capture. When off, the captured text is written as-is."
+	desc={"Set the format of the capture. When off, QuickAdd captures {{VALUE}} on its own - what you type at the prompt, or the current selection."}
 	bodyVisible={choice.format.enabled}
 >
 	{#snippet control()}

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -231,11 +231,58 @@ describe("CaptureChoiceForm", () => {
 		expect(toggle.classList.contains("is-enabled")).toBe(true);
 	});
 
+	// #1544: the capture target used to be described by three rows — a control-less
+	// "Capture to", the "Capture to active file" toggle, a control-less "File path /
+	// format" — and the input that actually holds it advertised itself as a *file
+	// name* format. One decision, one label, one description, one input.
+	it("describes the capture target with a single labelled field", () => {
+		const { container, getByLabelText } = mountForm();
+		const names = settingNames(container);
+
+		expect(names).not.toContain("File path / format");
+		expect(names.filter((name) => name === "Capture to")).toHaveLength(1);
+
+		const input = getByLabelText("Capture to") as HTMLInputElement;
+		expect(input.placeholder).toBe("Daily/{{DATE}}.md");
+
+		// The label is a real <label for>, and the field lives in the same group.
+		const label = container.querySelector(
+			"label.setting-item-name",
+		) as HTMLLabelElement;
+		expect(label.htmlFor).toBe(input.id);
+		expect(input.closest(".qa-field")).toBe(label.closest(".qa-field"));
+	});
+
+	it("hides the capture format field entirely while the format toggle is off", async () => {
+		const { container, props } = mountForm();
+		const field = () =>
+			settingItem(container, "Capture format").closest(".qa-field") as HTMLElement;
+
+		expect(field().querySelector("textarea")).toBeNull();
+		// With no field to point at there is no dangling <label for>.
+		expect(field().querySelector("label.setting-item-name")).toBeNull();
+
+		const toggle = settingItem(container, "Capture format").querySelector(
+			".checkbox-container",
+		) as HTMLElement;
+		await fireEvent.click(toggle);
+		flushSync();
+
+		expect(props.choice.format.enabled).toBe(true);
+		const textarea = field().querySelector("textarea") as HTMLTextAreaElement;
+		expect(textarea).not.toBeNull();
+		expect(textarea.disabled).toBe(false);
+		expect(
+			(field().querySelector("label.setting-item-name") as HTMLLabelElement)
+				.htmlFor,
+		).toBe(textarea.id);
+	});
+
 	// #1543: the preview used to render above the field it previews, and rendered
 	// as a bare "Preview:" with nothing after it whenever the field was empty.
 	it("renders the preview after the field it previews, and only once the field has a value", async () => {
 		const { container, getByLabelText } = mountForm();
-		const input = getByLabelText("File path / format") as HTMLInputElement;
+		const input = getByLabelText("Capture to") as HTMLInputElement;
 
 		await settleValidation();
 		const preview = previewRows(container)[0];
@@ -259,7 +306,7 @@ describe("CaptureChoiceForm", () => {
 
 	it("shows recognized feedback and hides the path preview for picker filter targets", async () => {
 		const { container, getByLabelText } = mountForm();
-		const input = getByLabelText("File path / format") as HTMLInputElement;
+		const input = getByLabelText("Capture to") as HTMLInputElement;
 		// Only the capture-target preview renders: the capture format is empty, and
 		// an empty field shows no preview row at all (#1543).
 		expect(previewRows(container)).toHaveLength(1);
@@ -280,7 +327,7 @@ describe("CaptureChoiceForm", () => {
 
 	it("rejects multi-select capture target filters before runtime", async () => {
 		const { container, getByLabelText } = mountForm();
-		const input = getByLabelText("File path / format") as HTMLInputElement;
+		const input = getByLabelText("Capture to") as HTMLInputElement;
 		expect(previewRows(container)).toHaveLength(1);
 
 		input.value = "tag:work|multi";
@@ -298,7 +345,7 @@ describe("CaptureChoiceForm", () => {
 
 	it("does not show the canvas node picker for filter syntax that ends in .canvas", async () => {
 		const { container, getByLabelText, props } = mountForm();
-		const input = getByLabelText("File path / format") as HTMLInputElement;
+		const input = getByLabelText("Capture to") as HTMLInputElement;
 		props.choice.captureToCanvasNodeId = "stale-node-id";
 
 		input.value = "folder:Boards.canvas";

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -108,6 +108,10 @@ function mountForm() {
 async function settleValidation() {
 	await tick();
 	await tick();
+	// The preview row resolves through an async formatter, so a macrotask flush is
+	// required on top of the microtask ticks before asserting on preview rows.
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await tick();
 }
 
 function describedHint(
@@ -227,17 +231,45 @@ describe("CaptureChoiceForm", () => {
 		expect(toggle.classList.contains("is-enabled")).toBe(true);
 	});
 
+	// #1543: the preview used to render above the field it previews, and rendered
+	// as a bare "Preview:" with nothing after it whenever the field was empty.
+	it("renders the preview after the field it previews, and only once the field has a value", async () => {
+		const { container, getByLabelText } = mountForm();
+		const input = getByLabelText("File path / format") as HTMLInputElement;
+
+		await settleValidation();
+		const preview = previewRows(container)[0];
+		expect(preview).toBeDefined();
+		expect(
+			input.compareDocumentPosition(preview) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+
+		input.value = "";
+		await fireEvent.input(input);
+		await settleValidation();
+		expect(previewRows(container)).toHaveLength(0);
+
+		input.value = "Inbox.md";
+		await fireEvent.input(input);
+		await settleValidation();
+		expect(previewRows(container)).toHaveLength(1);
+		expect(previewRows(container)[0].textContent).toContain("Inbox.md");
+	});
+
 	it("shows recognized feedback and hides the path preview for picker filter targets", async () => {
 		const { container, getByLabelText } = mountForm();
 		const input = getByLabelText("File path / format") as HTMLInputElement;
-		expect(previewRows(container)).toHaveLength(2);
+		// Only the capture-target preview renders: the capture format is empty, and
+		// an empty field shows no preview row at all (#1543).
+		expect(previewRows(container)).toHaveLength(1);
 
 		input.value = "folder:Goals|folder:Projects|tag:active";
 		await fireEvent.input(input);
 		await settleValidation();
 
 		const hint = describedHint(container, input);
-		expect(previewRows(container)).toHaveLength(1);
+		expect(previewRows(container)).toHaveLength(0);
 		expect(hint.textContent).toContain("Recognized filtered picker");
 		expect(hint.textContent).toContain("folders Goals or Projects");
 		expect(hint.textContent).toContain("tag active");
@@ -249,14 +281,14 @@ describe("CaptureChoiceForm", () => {
 	it("rejects multi-select capture target filters before runtime", async () => {
 		const { container, getByLabelText } = mountForm();
 		const input = getByLabelText("File path / format") as HTMLInputElement;
-		expect(previewRows(container)).toHaveLength(2);
+		expect(previewRows(container)).toHaveLength(1);
 
 		input.value = "tag:work|multi";
 		await fireEvent.input(input);
 		await settleValidation();
 
 		const hint = describedHint(container, input);
-		expect(previewRows(container)).toHaveLength(1);
+		expect(previewRows(container)).toHaveLength(0);
 		expect(hint.textContent).toBe(
 			"Capture target filters select one destination file. Use {{FILE:...|multi}} in the capture format for multi-value metadata.",
 		);

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -208,18 +208,18 @@ function onModeChange(value: string) {
 		<Toggle bind:checked={choice.fileNameFormat.enabled} />
 	{/snippet}
 </SettingItem>
-<FormatPreviewField
-	value={choice.fileNameFormat.format}
-	formatterKind="fileName"
-	{app}
-	{plugin}
-/>
 <ValidatedInput
 	bind:value={choice.fileNameFormat.format}
 	placeholder="File name format"
 	disabled={!choice.fileNameFormat.enabled}
 	makeSuggesters={fileNameSuggesters}
 	ariaLabel="File name format"
+/>
+<FormatPreviewField
+	value={choice.fileNameFormat.format}
+	formatterKind="fileName"
+	{app}
+	{plugin}
 />
 
 <SettingItem name="Location" heading />

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -32,6 +32,7 @@ import Toggle from "../components/Toggle.svelte";
 import Dropdown from "../components/Dropdown.svelte";
 import ChoiceNameHeader from "./components/ChoiceNameHeader.svelte";
 import ValidatedInput from "./components/ValidatedInput.svelte";
+import LabeledField from "./components/LabeledField.svelte";
 import FormatPreviewField from "./components/FormatPreviewField.svelte";
 import AppendLinkSetting from "./components/AppendLinkSetting.svelte";
 import OpenFileSetting from "./components/OpenFileSetting.svelte";
@@ -191,36 +192,44 @@ function onModeChange(value: string) {
 
 <SettingItem name="Template" heading />
 
-<SettingItem name="Template Path" desc="Path to the Template." />
-<ValidatedInput
-	value={choice.templatePath}
-	placeholder="Template path"
-	{app}
-	suggestions={templatePaths}
-	maxSuggestions={50}
-	validator={validateTemplatePath}
-	ariaLabel="Template path"
-	onChange={(value) => (choice.templatePath = value.trim())}
-/>
+<LabeledField name="Template path" desc="Path to the template this choice creates notes from.">
+	{#snippet children(id)}
+		<ValidatedInput
+			{id}
+			value={choice.templatePath}
+			placeholder="Template path"
+			{app}
+			suggestions={templatePaths}
+			maxSuggestions={50}
+			validator={validateTemplatePath}
+			onChange={(value) => (choice.templatePath = value.trim())}
+		/>
+	{/snippet}
+</LabeledField>
 
-<SettingItem name="File name format" desc="Set the file name format.">
+<LabeledField
+	name="File name format"
+	desc="Set the file name format. When off, QuickAdd asks for the note title."
+	bodyVisible={choice.fileNameFormat.enabled}
+>
 	{#snippet control()}
 		<Toggle bind:checked={choice.fileNameFormat.enabled} />
 	{/snippet}
-</SettingItem>
-<ValidatedInput
-	bind:value={choice.fileNameFormat.format}
-	placeholder="File name format"
-	disabled={!choice.fileNameFormat.enabled}
-	makeSuggesters={fileNameSuggesters}
-	ariaLabel="File name format"
-/>
-<FormatPreviewField
-	value={choice.fileNameFormat.format}
-	formatterKind="fileName"
-	{app}
-	{plugin}
-/>
+	{#snippet children(id)}
+		<ValidatedInput
+			{id}
+			bind:value={choice.fileNameFormat.format}
+			placeholder="File name format"
+			makeSuggesters={fileNameSuggesters}
+		/>
+		<FormatPreviewField
+			value={choice.fileNameFormat.format}
+			formatterKind="fileName"
+			{app}
+			{plugin}
+		/>
+	{/snippet}
+</LabeledField>
 
 <SettingItem name="Location" heading />
 

--- a/src/gui/ChoiceBuilder/autosaveFooter.test.ts
+++ b/src/gui/ChoiceBuilder/autosaveFooter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+// FormatPreviewField -> formatter graph pulls obsidian-dataview's CJS require.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App } from "obsidian";
+import { flushSync } from "svelte";
+import type QuickAdd from "../../main";
+import type ICaptureChoice from "../../types/choices/ICaptureChoice";
+import { CaptureChoice } from "../../types/choices/CaptureChoice";
+import { CaptureChoiceBuilder } from "./captureChoiceBuilder";
+
+const plugin = {
+	getTemplateFiles: () => [],
+	settings: { choices: [] },
+} as unknown as QuickAdd;
+
+function openBuilder() {
+	return new CaptureChoiceBuilder(
+		new App(),
+		new CaptureChoice("Capture under test"),
+		plugin,
+	);
+}
+
+// #1545: the builder saves on close by any route, but nothing said so and there
+// was no completion affordance — the last row was "Icon" and then the modal
+// simply ended.
+describe("choice builder autosave footer", () => {
+	it("states the autosave contract and closes on Done", () => {
+		const modal = openBuilder();
+
+		const footer = modal.modalEl.querySelector(
+			".qa-builder-footer",
+		) as HTMLElement;
+		expect(footer).not.toBeNull();
+		expect(footer.textContent).toContain(
+			"Changes to this choice are saved automatically",
+		);
+
+		// Pinned outside the scrolling content, next to it — the doubt is not
+		// confined to the bottom of a long form.
+		expect(modal.contentEl.querySelector(".qa-builder-footer")).toBeNull();
+		expect(footer.parentElement).toBe(modal.modalEl);
+		expect(modal.containerEl.classList.contains("qa-choice-builder")).toBe(true);
+
+		const done = footer.querySelector("button") as HTMLButtonElement;
+		expect(done.textContent).toBe("Done");
+		const close = vi.spyOn(modal, "close").mockImplementation(() => {});
+		done.click();
+		expect(close).toHaveBeenCalledTimes(1);
+	});
+
+	// The footer's claim is only honest if closing really does persist the edits.
+	it("resolves the edited choice when the modal closes", async () => {
+		const modal = openBuilder();
+		const input = modal.contentEl.querySelector(
+			'input[placeholder="Daily/{{DATE}}.md"]',
+		) as HTMLInputElement;
+		input.value = "Daily/{{DATE}}.md";
+		input.dispatchEvent(new Event("input", { bubbles: true }));
+		flushSync();
+
+		modal.onClose();
+
+		const resolved = (await modal.waitForClose) as ICaptureChoice;
+		expect(resolved.captureTo).toBe("Daily/{{DATE}}.md");
+	});
+});

--- a/src/gui/ChoiceBuilder/choiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/choiceBuilder.ts
@@ -1,6 +1,7 @@
 import { type App, Modal } from "obsidian";
 import type { MountHandle } from "../svelte/mountComponent";
 import { snapshot } from "../svelte/persist.svelte";
+import { addAutosaveFooter } from "./components/autosaveFooter";
 import type IChoice from "../../types/choices/IChoice";
 
 /**
@@ -26,6 +27,9 @@ export abstract class ChoiceBuilder extends Modal {
 		});
 
 		this.containerEl.addClass("quickAddModal");
+		// Installed here, not in display(): display() runs from the subclass
+		// constructor and is re-run by builders that rebuild their content.
+		addAutosaveFooter(this, "choice");
 		this.open();
 	}
 

--- a/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
@@ -128,9 +128,6 @@ function validateCaptureTo(value: string) {
 		name="File path / format"
 		desc={"Choose a file, folder, #tag, property:field=value, or format syntax (e.g., {{DATE}})"}
 	/>
-	{#if !usesPickerTargetSyntax}
-		<FormatPreviewField value={choice.captureTo} formatterKind="fileName" {app} {plugin} />
-	{/if}
 	<ValidatedInput
 		value={choice.captureTo}
 		placeholder="File name format"
@@ -142,6 +139,9 @@ function validateCaptureTo(value: string) {
 		ariaLabel="File path / format"
 		onChange={onCaptureToChange}
 	/>
+	{#if !usesPickerTargetSyntax}
+		<FormatPreviewField value={choice.captureTo} formatterKind="fileName" {app} {plugin} />
+	{/if}
 
 	{#if isCanvasTarget}
 		<SettingItem

--- a/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
@@ -10,6 +10,7 @@ import { isCanvasTargetPath, normalizeVaultPath } from "../canvasNodes";
 import SettingItem from "../../components/SettingItem.svelte";
 import Toggle from "../../components/Toggle.svelte";
 import ValidatedInput from "./ValidatedInput.svelte";
+import LabeledField from "./LabeledField.svelte";
 import FormatPreviewField from "./FormatPreviewField.svelte";
 import CanvasNodePicker from "./CanvasNodePicker.svelte";
 import { getCaptureTargetFeedback } from "./captureTargetFeedback";
@@ -99,7 +100,18 @@ function onCaptureToChange(value: string) {
 
 function validateCaptureTo(value: string) {
 	const feedback = getCaptureTargetFeedback(value);
-	if (!feedback) return true;
+	if (!feedback) {
+		// An empty target is a supported mode, not an omission: it resolves to the
+		// vault-wide note picker at run time (resolveCaptureTarget -> "vault"). Say
+		// so, rather than leaving a blank field looking unfinished.
+		if (!value.trim()) {
+			return {
+				valid: true,
+				message: "Leave empty to pick the note each time this choice runs.",
+			};
+		}
+		return true;
+	}
 
 	return {
 		valid: feedback.valid,
@@ -110,11 +122,9 @@ function validateCaptureTo(value: string) {
 </script>
 
 <SettingItem
-	name="Capture to"
-	desc="Vault-relative path, #tag, or property:field=value. Supports format syntax (use trailing '/' for folders)."
-/>
-
-<SettingItem name="Capture to active file">
+	name="Capture to active file"
+	desc="Capture into whichever note is open when the choice runs, instead of a fixed target."
+>
 	{#snippet control()}
 		<Toggle
 			checked={choice.captureToActiveFile}
@@ -124,24 +134,27 @@ function validateCaptureTo(value: string) {
 </SettingItem>
 
 {#if !choice.captureToActiveFile}
-	<SettingItem
-		name="File path / format"
-		desc={"Choose a file, folder, #tag, property:field=value, or format syntax (e.g., {{DATE}})"}
-	/>
-	<ValidatedInput
-		value={choice.captureTo}
-		placeholder="File name format"
-		{app}
-		suggestions={captureTargetSuggestions}
-		maxSuggestions={50}
-		makeSuggesters={suggesters}
-		validator={validateCaptureTo}
-		ariaLabel="File path / format"
-		onChange={onCaptureToChange}
-	/>
-	{#if !usesPickerTargetSyntax}
-		<FormatPreviewField value={choice.captureTo} formatterKind="fileName" {app} {plugin} />
-	{/if}
+	<LabeledField
+		name="Capture to"
+		desc={"Vault-relative path to a file or folder, a #tag, or property:field=value. Supports format syntax like {{DATE}}; end with '/' to capture into a folder."}
+	>
+		{#snippet children(id)}
+			<ValidatedInput
+				{id}
+				value={choice.captureTo}
+				placeholder={"Daily/{{DATE}}.md"}
+				{app}
+				suggestions={captureTargetSuggestions}
+				maxSuggestions={50}
+				makeSuggesters={suggesters}
+				validator={validateCaptureTo}
+				onChange={onCaptureToChange}
+			/>
+			{#if !usesPickerTargetSyntax}
+				<FormatPreviewField value={choice.captureTo} formatterKind="fileName" {app} {plugin} />
+			{/if}
+		{/snippet}
+	</LabeledField>
 
 	{#if isCanvasTarget}
 		<SettingItem

--- a/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
+++ b/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
@@ -5,10 +5,14 @@ import { FormatDisplayFormatter } from "../../../formatters/formatDisplayFormatt
 import { FileNameDisplayFormatter } from "../../../formatters/fileNameDisplayFormatter";
 
 /**
- * Live "Preview: …" row for a format/filename field. Un-debounced to preserve
- * the imperative builders' per-keystroke behavior (Plan 010 debounce is
- * deliberately out of scope for #1130). A monotonic token drops stale async
- * results so the latest value always wins.
+ * Live "Preview: …" row for a format/filename field. Renders BELOW the input it
+ * previews (issue #1543 — it used to sit above, where it read as the field's
+ * label), and not at all while the field is empty, so there is never a dangling
+ * "Preview:" with nothing after it.
+ *
+ * Un-debounced to preserve the imperative builders' per-keystroke behavior (Plan
+ * 010 debounce is deliberately out of scope for #1130). A monotonic token drops
+ * stale async results so the latest value always wins.
  */
 let {
 	value,
@@ -35,8 +39,14 @@ let {
 	targetFolderPath?: string;
 } = $props();
 
-let preview = $state("Loading preview…");
+let preview = $state("");
 let previewToken = 0;
+
+// Gate the row on the RAW value, never on the resolved preview: the formatter is
+// async, so the row must mount (empty) and then be filled for `aria-live` to
+// announce the result. Gating on the resolved text would mount it already
+// populated, and the announcement would be lost.
+const hasValue = $derived(value.trim().length > 0);
 
 // app/plugin/kind are stable for the field's lifetime, so this $derived computes
 // the formatter once; the reactive effect below then only re-runs on `value`
@@ -52,6 +62,14 @@ const formatter = $derived(
 
 $effect(() => {
 	const current = value;
+	// Clearing the field also clears the cached preview (and cancels any in-flight
+	// resolve), so re-typing never flashes the previous value's result in the
+	// freshly re-mounted row.
+	if (!current.trim()) {
+		previewToken++;
+		preview = "";
+		return;
+	}
 	// Resolve {{FOLDER}} / {{FOLDER|name}} against the configured target folder,
 	// or a "Folder/Name" placeholder so the token never previews blank when no
 	// caller wires the real path in (issue: FOLDER preview always empty).
@@ -70,7 +88,9 @@ $effect(() => {
 });
 </script>
 
-<div class="qa-preview-row">
-	<span class="qa-preview-label">Preview: </span>
-	<span aria-live="polite">{preview}</span>
-</div>
+{#if hasValue}
+	<div class="qa-preview-row">
+		<span class="qa-preview-label">Preview: </span>
+		<span class="qa-preview-value" aria-live="polite">{preview}</span>
+	</div>
+{/if}

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -264,7 +264,6 @@ function onPromptHeadingToggle(value: boolean) {
 		name="Insert after"
 		desc="Insert capture after specified text. Accepts format syntax. Tip: use a heading (starts with #) to target a section. Blank line handling is configurable below."
 	/>
-	<FormatPreviewField value={insertAfter.after} formatterKind="lineTarget" {app} {plugin} />
 	<ValidatedInput
 		bind:value={insertAfter.after}
 		placeholder="Insert after"
@@ -273,6 +272,7 @@ function onPromptHeadingToggle(value: boolean) {
 		makeSuggesters={suggesters}
 		ariaLabel="Insert after"
 	/>
+	<FormatPreviewField value={insertAfter.after} formatterKind="lineTarget" {app} {plugin} />
 
 	<SettingItem
 		name="Inline insertion"

--- a/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertAfterFields.svelte
@@ -20,6 +20,7 @@ import SettingItem from "../../components/SettingItem.svelte";
 import Toggle from "../../components/Toggle.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
 import ValidatedInput from "./ValidatedInput.svelte";
+import LabeledField from "./LabeledField.svelte";
 import FormatPreviewField from "./FormatPreviewField.svelte";
 
 /** Reactive port of captureChoiceBuilder.addInsertAfterFields. */
@@ -260,19 +261,22 @@ function onPromptHeadingToggle(value: boolean) {
 		section.
 	</div>
 {:else}
-	<SettingItem
+	<LabeledField
 		name="Insert after"
 		desc="Insert capture after specified text. Accepts format syntax. Tip: use a heading (starts with #) to target a section. Blank line handling is configurable below."
-	/>
-	<ValidatedInput
-		bind:value={insertAfter.after}
-		placeholder="Insert after"
-		required
-		requiredMessage="Insert after text is required"
-		makeSuggesters={suggesters}
-		ariaLabel="Insert after"
-	/>
-	<FormatPreviewField value={insertAfter.after} formatterKind="lineTarget" {app} {plugin} />
+	>
+		{#snippet children(id)}
+			<ValidatedInput
+				{id}
+				bind:value={insertAfter.after}
+				placeholder="Insert after"
+				required
+				requiredMessage="Insert after text is required"
+				makeSuggesters={suggesters}
+			/>
+			<FormatPreviewField value={insertAfter.after} formatterKind="lineTarget" {app} {plugin} />
+		{/snippet}
+	</LabeledField>
 
 	<SettingItem
 		name="Inline insertion"

--- a/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
@@ -58,7 +58,6 @@ const createLocationOptions = [
 	name="Insert before"
 	desc="Insert capture before specified text. Accepts format syntax."
 />
-<FormatPreviewField value={insertBefore.before} formatterKind="lineTarget" {app} {plugin} />
 <ValidatedInput
 	bind:value={insertBefore.before}
 	placeholder="Insert before"
@@ -67,6 +66,7 @@ const createLocationOptions = [
 	makeSuggesters={suggesters}
 	ariaLabel="Insert before"
 />
+<FormatPreviewField value={insertBefore.before} formatterKind="lineTarget" {app} {plugin} />
 
 <SettingItem
 	name="Create line if not found"

--- a/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
+++ b/src/gui/ChoiceBuilder/components/InsertBeforeFields.svelte
@@ -15,6 +15,7 @@ import SettingItem from "../../components/SettingItem.svelte";
 import Toggle from "../../components/Toggle.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
 import ValidatedInput from "./ValidatedInput.svelte";
+import LabeledField from "./LabeledField.svelte";
 import FormatPreviewField from "./FormatPreviewField.svelte";
 
 /** Reactive port of captureChoiceBuilder.addInsertBeforeFields. */
@@ -54,19 +55,22 @@ const createLocationOptions = [
 ];
 </script>
 
-<SettingItem
+<LabeledField
 	name="Insert before"
 	desc="Insert capture before specified text. Accepts format syntax."
-/>
-<ValidatedInput
-	bind:value={insertBefore.before}
-	placeholder="Insert before"
-	required
-	requiredMessage="Insert before text is required"
-	makeSuggesters={suggesters}
-	ariaLabel="Insert before"
-/>
-<FormatPreviewField value={insertBefore.before} formatterKind="lineTarget" {app} {plugin} />
+>
+	{#snippet children(id)}
+		<ValidatedInput
+			{id}
+			bind:value={insertBefore.before}
+			placeholder="Insert before"
+			required
+			requiredMessage="Insert before text is required"
+			makeSuggesters={suggesters}
+		/>
+		<FormatPreviewField value={insertBefore.before} formatterKind="lineTarget" {app} {plugin} />
+	{/snippet}
+</LabeledField>
 
 <SettingItem
 	name="Create line if not found"

--- a/src/gui/ChoiceBuilder/components/LabeledField.svelte
+++ b/src/gui/ChoiceBuilder/components/LabeledField.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import SettingItem from "../../components/SettingItem.svelte";
+
+/**
+ * A full-width field with a real label: an Obsidian `.setting-item` row carrying
+ * the name, description and (optionally) the toggle that enables the field, with
+ * the field itself on its own line beneath — `<label for>`-bound to the name.
+ *
+ * The builders used to hand-assemble this shape from three unrelated siblings: a
+ * control-less SettingItem for the label, a preview row, and a bare full-width
+ * input. Nothing tied the parts together, so every assembly drifted on its own —
+ * which is how one field ended up described three ways (#1544), how the preview
+ * ended up above the input it previews (#1543), and how the create-with-template
+ * path input ended up with no visible label at all.
+ */
+let {
+	name,
+	desc = undefined,
+	control = undefined,
+	bodyVisible = true,
+	children,
+}: {
+	name: string;
+	desc?: string | undefined;
+	/** Control on the label row, e.g. the toggle that enables the field. */
+	control?: Snippet | undefined;
+	/**
+	 * Render the field itself. False hides the body entirely (used instead of a
+	 * greyed-out box when the row's toggle is off) — and with no body there is no
+	 * control to point at, so the `<label for>` is dropped with it.
+	 */
+	bodyVisible?: boolean;
+	/** The field. Receives the id to put on the control the label binds to. */
+	children: Snippet<[string]>;
+} = $props();
+
+const fieldId = $props.id();
+</script>
+
+<div class="qa-field">
+	<SettingItem {name} {desc} {control} labelFor={bodyVisible ? fieldId : undefined} />
+	{#if bodyVisible}
+		<div class="qa-field-body">{@render children(fieldId)}</div>
+	{/if}
+</div>

--- a/src/gui/ChoiceBuilder/components/ValidatedInput.svelte
+++ b/src/gui/ChoiceBuilder/components/ValidatedInput.svelte
@@ -37,6 +37,7 @@ let {
 	maxSuggestions = Infinity,
 	makeSuggesters = [],
 	app = undefined,
+	id = undefined,
 	ariaLabel = undefined,
 	onChange = undefined,
 }: {
@@ -52,6 +53,8 @@ let {
 	maxSuggestions?: number;
 	makeSuggesters?: SuggesterFactory[];
 	app?: App | undefined;
+	/** Set by LabeledField so the row's `<label for>` binds to this control. */
+	id?: string | undefined;
 	ariaLabel?: string | undefined;
 	onChange?: ((value: string) => void) | undefined;
 } = $props();
@@ -144,6 +147,7 @@ function attach(el: HTMLInputElement | HTMLTextAreaElement): AnySuggest[] {
 		class="qa-validated-input-full-width qa-validated-input-margin-8 qa-validated-input-textarea"
 		class:is-invalid={invalid}
 		class:is-valid={!invalid && hintVariant === "success" && hintMessage.length > 0}
+		{id}
 		{placeholder}
 		{disabled}
 		aria-label={ariaLabel}
@@ -159,6 +163,7 @@ function attach(el: HTMLInputElement | HTMLTextAreaElement): AnySuggest[] {
 		class="qa-validated-input-full-width qa-validated-input-margin-8"
 		class:is-invalid={invalid}
 		class:is-valid={!invalid && hintVariant === "success" && hintMessage.length > 0}
+		{id}
 		{placeholder}
 		{disabled}
 		aria-label={ariaLabel}

--- a/src/gui/ChoiceBuilder/components/autosaveFooter.ts
+++ b/src/gui/ChoiceBuilder/components/autosaveFooter.ts
@@ -1,0 +1,46 @@
+import type { Modal } from "obsidian";
+
+/**
+ * Pin an autosave footer to the bottom of a builder modal: a quiet statement
+ * that edits persist, plus a Done button that just closes.
+ *
+ * The builders save on close by ANY route — the X, Escape, a click outside —
+ * because the caller persists whatever the modal resolves with (see
+ * ChoiceView.handleConfigureChoice). Nothing in the UI said so, and the modal had
+ * no Save/Done/Cancel at all, so a user who had just spent minutes configuring a
+ * capture had no way to know whether closing would keep or discard the work
+ * (#1545). The footer states the contract where it is needed — before the close —
+ * and gives the completion affordance the modal never had.
+ *
+ * Appended to `modalEl` as a sibling of `modal-content` rather than into the
+ * content itself, so it stays pinned while the settings scroll (the doubt is not
+ * confined to the bottom of a long form) and so a builder that rebuilds its
+ * content cannot drop it — MacroBuilder.reload() empties contentEl. Idempotent
+ * for the same reason.
+ *
+ * @param subject What the modal edits, e.g. "choice" or "macro".
+ */
+export function addAutosaveFooter(modal: Modal, subject: string): void {
+	modal.containerEl.addClass("qa-choice-builder");
+	if (modal.modalEl.querySelector(".qa-builder-footer")) return;
+
+	// Plain DOM rather than Obsidian's createDiv/createSpan helpers, which the
+	// vitest environment does not implement.
+	const doc = modal.modalEl.ownerDocument;
+	const footer = doc.createElement("div");
+	footer.className = "qa-builder-footer";
+
+	const note = doc.createElement("span");
+	note.className = "qa-builder-footer-note";
+	note.textContent = `Changes to this ${subject} are saved automatically`;
+	footer.appendChild(note);
+
+	const done = doc.createElement("button");
+	done.type = "button";
+	done.className = "mod-cta";
+	done.textContent = "Done";
+	done.addEventListener("click", () => modal.close());
+	footer.appendChild(done);
+
+	modal.modalEl.appendChild(footer);
+}

--- a/src/gui/MacroGUIs/MacroBuilder.test.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.test.ts
@@ -39,4 +39,34 @@ describe("MacroBuilder", () => {
 			"Lucide/Obsidian icon id",
 		);
 	});
+
+	// #1545: the builder autosaves on close but never said so, and had no
+	// completion affordance at all.
+	it("pins one autosave footer that survives a content rebuild", () => {
+		const modal = new MacroBuilder(
+			new App(),
+			{ settings: { choices: [] } } as unknown as QuickAdd,
+			new MacroChoice("Macro under test"),
+			[],
+		);
+
+		const footers = () =>
+			Array.from(modal.modalEl.querySelectorAll(".qa-builder-footer"));
+		expect(footers()).toHaveLength(1);
+		expect(footers()[0].textContent).toContain(
+			"Changes to this macro are saved automatically",
+		);
+		// Outside modal-content, so it stays put while the settings scroll.
+		expect(modal.contentEl.querySelector(".qa-builder-footer")).toBeNull();
+
+		// reload() empties contentEl and re-runs display(); the footer is neither
+		// dropped nor duplicated.
+		(modal as unknown as { reload: () => void }).reload();
+		expect(footers()).toHaveLength(1);
+
+		const done = footers()[0].querySelector("button") as HTMLButtonElement;
+		const close = vi.spyOn(modal, "close").mockImplementation(() => {});
+		done.click();
+		expect(close).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -14,6 +14,7 @@ import type { IConditionalCommand } from "../../types/macros/Conditional/ICondit
 import { ConditionalCommandSettingsModal } from "./ConditionalCommandSettingsModal";
 import { ConditionalBranchEditorModal } from "./ConditionalBranchEditorModal";
 import { addChoiceIconSetting } from "../ChoiceBuilder/components/choiceIconSetting";
+import { addAutosaveFooter } from "../ChoiceBuilder/components/autosaveFooter";
 
 function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 	const arr: IChoice[] = [];
@@ -56,6 +57,9 @@ export class MacroBuilder extends Modal {
 		);
 
 		this.display();
+		// Installed here, not in display(): reload() re-runs display(), which
+		// empties contentEl. The footer lives on modalEl and survives that.
+		addAutosaveFooter(this, "macro");
 		this.open();
 	}
 

--- a/src/gui/components/SettingItem.svelte
+++ b/src/gui/components/SettingItem.svelte
@@ -13,6 +13,7 @@ let {
 	name = undefined,
 	desc = undefined,
 	heading = false,
+	labelFor = undefined,
 	control = undefined,
 	children = undefined,
 }: {
@@ -21,6 +22,13 @@ let {
 	desc?: string | undefined;
 	/** Renders the heading variant (no control slot). */
 	heading?: boolean;
+	/**
+	 * Id of the control this row labels. Renders the name as a real `<label for>`
+	 * instead of a `<div>`, which is what binds a full-width field on the line
+	 * below to the name above it (see LabeledField). Opt-in: rows whose control
+	 * lives in `control` are already reachable and keep the plain `<div>`.
+	 */
+	labelFor?: string | undefined;
 	/** Control(s) placed in `.setting-item-control`. */
 	control?: Snippet | undefined;
 	/** Alias for `control` so the row can be used with default slot content. */
@@ -30,7 +38,13 @@ let {
 
 <div class="setting-item" class:setting-item-heading={heading}>
 	<div class="setting-item-info">
-		{#if name}<div class="setting-item-name">{name}</div>{/if}
+		{#if name}
+			{#if labelFor}
+				<label class="setting-item-name" for={labelFor}>{name}</label>
+			{:else}
+				<div class="setting-item-name">{name}</div>
+			{/if}
+		{/if}
 		{#if desc}<div class="setting-item-description">{desc}</div>{/if}
 	</div>
 	<div class="setting-item-control">

--- a/src/styles.css
+++ b/src/styles.css
@@ -100,10 +100,19 @@
    the rest of the modal. */
 .quickAddModal.qa-choice-builder .modal {
 	overflow: hidden;
+	/* A scrollport clips ink overflow at its padding box, and the builder's
+	   full-width fields are exactly as wide as it — so a focus or validity ring,
+	   which paints outside the border box, would lose its left and right edges.
+	   Hand the horizontal inset to the scrollport itself. */
+	padding-inline: 0;
 }
 
 .quickAddModal.qa-choice-builder .modal-content {
 	overflow-y: auto;
+	padding-inline: var(--size-4-4);
+	/* Reserve the scrollbar gutter unconditionally, so the pinned footer below can
+	   mirror it and stay aligned with the rows whether or not they scroll. */
+	scrollbar-gutter: stable;
 }
 
 .quickAddModal.qa-choice-builder .qa-builder-footer {
@@ -113,7 +122,14 @@
 	gap: var(--size-4-2);
 	flex-shrink: 0;
 	margin-top: var(--size-4-2);
-	padding-top: var(--size-4-3);
+	/* Sibling of the scrollport, so it carries the same inset itself — including
+	   the scrollbar gutter, which `overflow: hidden` + `scrollbar-gutter: stable`
+	   reserves at the platform's own width without ever showing a scrollbar. Without
+	   it the Done button and the footer rule overhang the rows above by the width
+	   of the scrollbar. */
+	padding: var(--size-4-3) var(--size-4-4) 0;
+	overflow: hidden;
+	scrollbar-gutter: stable;
 	border-top: var(--border-width) solid var(--background-modifier-border);
 }
 
@@ -127,25 +143,25 @@
    dialog height, and keep the button clear of the home indicator. */
 .is-phone .quickAddModal.qa-choice-builder .modal {
 	max-height: var(--dialog-max-height);
+	/* Core gives the phone modal only its safe-area insets; the padding-inline: 0
+	   above would otherwise drop them. */
+	padding-left: var(--safe-area-inset-left);
+	padding-right: var(--safe-area-inset-right);
 }
 
 .is-phone .quickAddModal.qa-choice-builder .qa-builder-footer {
-	padding-bottom: var(--safe-area-inset-bottom);
+	padding-bottom: max(var(--size-4-4), var(--safe-area-inset-bottom));
 }
 
 /* Full-width labelled field (LabeledField.svelte): the `.setting-item` carries
    the name/description, the body carries the field itself. Obsidian zeroes a
    `.setting-item`'s border-top and padding-top when it is `:first-child` of its
-   parent, and its padding-bottom when it is `:last-child` — inside the wrapper
-   it is both — so the wrapper takes over the row separator and vertical rhythm. */
+   parent — which it always is here — so the wrapper takes over the row separator
+   and the group's outer rhythm. The inner row keeps Obsidian's own padding-bottom,
+   and that is what separates the label from the field beneath it. */
 .quickAddModal .qa-field {
 	border-top: var(--border-width) solid var(--background-modifier-border);
 	padding: var(--size-4-4) 0;
-}
-
-.quickAddModal .qa-field > .setting-item {
-	padding-top: 0;
-	padding-bottom: 0;
 }
 
 /* The wrapper also breaks Obsidian's `.setting-item + .setting-item-heading`

--- a/src/styles.css
+++ b/src/styles.css
@@ -93,6 +93,46 @@
 	max-height: 70%;
 }
 
+/* Autosave footer for the choice builders (#1545). Core already lays `.modal`
+   out as a flex column with `.modal-content` as the growing item, so moving the
+   scrollport onto the content is all it takes to pin the footer — which also
+   re-pins the absolutely-positioned close button, previously scrolled away with
+   the rest of the modal. */
+.quickAddModal.qa-choice-builder .modal {
+	overflow: hidden;
+}
+
+.quickAddModal.qa-choice-builder .modal-content {
+	overflow-y: auto;
+}
+
+.quickAddModal.qa-choice-builder .qa-builder-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--size-4-2);
+	flex-shrink: 0;
+	margin-top: var(--size-4-2);
+	padding-top: var(--size-4-3);
+	border-top: var(--border-width) solid var(--background-modifier-border);
+}
+
+.quickAddModal.qa-choice-builder .qa-builder-footer-note {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+}
+
+/* On a phone the 70% cap above is the binding constraint, and a pinned footer
+   would eat into an already-short sheet. Hand the builder back Obsidian's own
+   dialog height, and keep the button clear of the home indicator. */
+.is-phone .quickAddModal.qa-choice-builder .modal {
+	max-height: var(--dialog-max-height);
+}
+
+.is-phone .quickAddModal.qa-choice-builder .qa-builder-footer {
+	padding-bottom: var(--safe-area-inset-bottom);
+}
+
 /* Full-width labelled field (LabeledField.svelte): the `.setting-item` carries
    the name/description, the body carries the field itself. Obsidian zeroes a
    `.setting-item`'s border-top and padding-top when it is `:first-child` of its

--- a/src/styles.css
+++ b/src/styles.css
@@ -93,12 +93,20 @@
 	max-height: 70%;
 }
 
-/* Preview row styling for Choice Builders */
+/* Preview row styling for Choice Builders. The row sits BELOW the field it
+   previews (#1543), so it is styled as a quiet secondary line — a bold,
+   body-sized line here reads as a heading for whatever follows it. */
 .quickAddModal .qa-preview-row {
-	margin: 6px 0;
+	margin: 0 0 8px;
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+	overflow-wrap: anywhere;
 }
 .quickAddModal .qa-preview-label {
 	font-weight: 600;
+}
+.quickAddModal .qa-preview-value {
+	color: var(--text-normal);
 }
 
 .quickAddModal .qa-onepage-title {
@@ -1575,6 +1583,16 @@ body:not(.is-mobile)
 	font-size: 12px;
 	color: var(--text-error);
 	min-height: 16px;
+}
+
+/* With no message the hint reserved ~28px of dead space between a field and
+   whatever follows it — including its own preview row (#1543). Collapse it via
+   :empty rather than `display: none` so the aria-live region stays in the
+   accessibility tree and still announces the first message that lands in it. */
+.qa-field-hint:empty {
+	min-height: 0;
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
 /* A valid field can still show an informational hint (e.g. a template path with

--- a/src/styles.css
+++ b/src/styles.css
@@ -93,6 +93,38 @@
 	max-height: 70%;
 }
 
+/* Full-width labelled field (LabeledField.svelte): the `.setting-item` carries
+   the name/description, the body carries the field itself. Obsidian zeroes a
+   `.setting-item`'s border-top and padding-top when it is `:first-child` of its
+   parent, and its padding-bottom when it is `:last-child` — inside the wrapper
+   it is both — so the wrapper takes over the row separator and vertical rhythm. */
+.quickAddModal .qa-field {
+	border-top: var(--border-width) solid var(--background-modifier-border);
+	padding: var(--size-4-4) 0;
+}
+
+.quickAddModal .qa-field > .setting-item {
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
+/* The wrapper also breaks Obsidian's `.setting-item + .setting-item-heading`
+   sibling rule, so restore the group spacing above a following section heading. */
+.quickAddModal .qa-field + .setting-item-heading {
+	margin-top: 0.75em;
+}
+
+/* The last element in the body owns the wrapper's bottom padding. */
+.quickAddModal .qa-field-body > *:last-child {
+	margin-bottom: 0;
+}
+
+/* `.setting-item-name` is styled by class, not tag; `<label>` is inline by
+   default, which would shift the name's line box by the inline leading. */
+.quickAddModal label.setting-item-name {
+	display: block;
+}
+
 /* Preview row styling for Choice Builders. The row sits BELOW the field it
    previews (#1543), so it is styled as a quiet secondary line — a bold,
    body-sized line here reads as a heading for whatever follows it. */


### PR DESCRIPTION
One coherent pass over the choice-builder modals, closing #1543, #1544 and #1545. All three were filed from the same first-run walkthrough of 2.19.1 on a clean vault, and all three turned out to be symptoms of one structural gap.

## The real problem

The builders have two kinds of row. Obsidian `.setting-item` rows (label + description left, control right) read fine. Full-width fields do not: there was no primitive for them, so each one was hand-assembled from three unrelated siblings — a control-less `.setting-item` for the label, a preview `<div>`, and a bare full-width `<input>`. Nothing grouped the parts, nothing associated the label with the control, and every assembly drifted independently.

That is where all three reports come from:

- **#1543** the preview `<div>` ended up *above* the input, where it reads as that input's label, and rendered as a bare bold `Preview:` with nothing after it whenever the field was empty.
- **#1544** the capture target accumulated two label rows plus a toggle, and the input that actually holds it advertised itself as a *file name* format when it wants a path.
- The create-with-template path input had no visible label at all.

**#1545** is separate: the builder saves on close by every route — the X, Escape, a click outside — because the caller persists whatever the modal resolves with. Nothing said so, and the modal had no Save/Done/Cancel at all: the last row is "Icon" and then it ends.

## What changed

**A `LabeledField` primitive.** An Obsidian `.setting-item` carrying the name, description and (optionally) the toggle that enables the field, with the field itself beneath it in the same group, bound by a real `<label for>`. `SettingItem` gained an opt-in `labelFor`; `ValidatedInput` gained an `id`. `bodyVisible={false}` hides the body *and* drops the `labelFor` with it, so a dangling `for` is unrepresentable.

Migrated: capture target, Capture format, create-with-template, Template path, File name format, Insert after, Insert before.

**Capture target collapsed to one field.** One label, one description, one input. The placeholder becomes a worked example (`Daily/{{DATE}}.md`), and an empty value now says what it does — `Leave empty to pick the note each time this choice runs.` — because empty is a supported mode (it resolves to the vault-wide picker), not an omission.

**Preview below its field, and only when there is one.** Gated on the raw value rather than the resolved text, so the `aria-live` region still announces the async result; restyled as a quiet secondary line instead of a bold body-sized one. The always-reserved validation hint now collapses with `:empty` rather than `display: none`, which would drop the live region out of the accessibility tree.

**Toggle-gated fields hide their body** instead of showing a greyed-out box — a 10rem dead textarea in the Capture format case.

**A pinned autosave footer.** States the contract plus a Done button that just closes. Appended to `modalEl` rather than into the settings, so it is visible wherever the user is when the doubt arrives — not only after scrolling to the bottom — and so a builder that rebuilds its content (`MacroBuilder.reload`) cannot drop it. Applied to the Capture, Template and Macro builders, which all autosave; **not** to the folder settings modal, which has real Save/Cancel semantics and rejects on cancel.

## Before / after

| | before | after |
|---|---|---|
| Capture builder, empty | <img width="380" src="https://raw.githubusercontent.com/chhoumann/quickadd/96b399d5934afc29c370856a53f0187ad14910a8/pr-1543/before-1-empty.png"> | <img width="380" src="https://raw.githubusercontent.com/chhoumann/quickadd/96b399d5934afc29c370856a53f0187ad14910a8/pr-1543/after-1-empty.png"> |
| with a target typed | <img width="380" src="https://raw.githubusercontent.com/chhoumann/quickadd/96b399d5934afc29c370856a53f0187ad14910a8/pr-1543/before-2-filled.png"> | <img width="380" src="https://raw.githubusercontent.com/chhoumann/quickadd/96b399d5934afc29c370856a53f0187ad14910a8/pr-1543/after-2-filled.png"> |
| bottom of the builder | <img width="380" src="https://raw.githubusercontent.com/chhoumann/quickadd/96b399d5934afc29c370856a53f0187ad14910a8/pr-1543/before-3-bottom.png"> | <img width="380" src="https://raw.githubusercontent.com/chhoumann/quickadd/96b399d5934afc29c370856a53f0187ad14910a8/pr-1543/after-3-bottom.png"> |

## Tradeoffs and things worth reviewing

**The wrapper, not a flat row.** `LabeledField` wraps the `.setting-item` in a `.qa-field` div. That makes the inner row `:first-child`, which triggers Obsidian's `border-top: none; padding-top: 0` reset (`app.css`), and drops it out of `:last-child`, and breaks the `.setting-item + .setting-item-heading` sibling rule. The wrapper takes those over explicitly. The alternative — a stacked modifier on a single `.setting-item` — needs to override `display`, `padding`, `> *:first-child` margin, and the whole `.setting-item-control` flex block, and `InsertAfterFields` already nests `.setting-item`s inside a control snippet. Measured live in 1.13.0 rather than reasoned about.

**Hiding a toggled-off field rather than disabling it.** State is retained (`choice.format.format` is untouched), and the rest of these forms already gate whole sections behind `{#if}`. The cost is that you cannot read a stored format without switching the toggle back on.

**`Done` does not commit anything.** It calls the same `close()` as the X. That is the point: no new save path, and the footer's claim is only honest because closing already persisted. There is a test asserting that end to end.

**No Cancel / discard.** Deliberately declined here. `ChoiceView` inserts a new choice into the list *before* the builder opens and saves unconditionally, and `normalizeChoice` mutates the caller's live object — so a Discard button would still commit a blank auto-named choice on the create path. Real undo means Save/Cancel plus create-rollback, which is a different PR.

**`scrollbar-gutter: stable` on the footer.** The footer sits outside the scrollport, so without it the Done button and the footer rule overhang the rows above by the width of the scrollbar (15px here, but it is a user/platform setting). `overflow: hidden` + `scrollbar-gutter: stable` is how CSS lets a non-scrolling element reserve the same gutter. Both sides reserve it unconditionally so alignment holds whether or not the form scrolls — verified in both states.

**Escape stays overloaded** (first Escape closes the suggester, second closes the modal). That is correct behaviour; the reporter's confusion in #1545 was downstream of the missing autosave statement, which is what this fixes.

## Validation

- `pnpm build`, eslint, `svelte-check` (0 errors), and the full vitest suite: **3855 passed**. New tests cover the single-labelled capture target, `<label for>` binding, the toggle-gated body, preview placement + empty state, footer idempotence across `MacroBuilder.reload()`, and that closing really does resolve the edited choice.
- Live in Obsidian 1.13.0, in this worktree's own isolated e2e vault: all three builders; separator, padding and heading rhythm at every migrated field; the footer pinned (which also re-pins the close button, previously scrolled away); Done aligned with the controls above it in both the scrolling and non-scrolling cases; the invalid-target ring unclipped on all four sides; the format-token suggester unaffected (it renders into `.app-container`, outside the modal).
- Design and diff each went through an adversarial review round. Four findings survived verification and are folded in: the wrapper's `:first-child` CSS reset (would have silently removed every migrated field's separator), `display: none` vs `:empty` on the live region, the clipped validity rings, and the phone height/safe-area handling.

Scoped to builder layout, labels and affordances. Format-token autocomplete (#1542) and run-time prompts (#1546) are separate.

Closes #1543
Closes #1544
Closes #1545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent autosave footers with a Done button to Choice and Macro builders.
  * Improved form labeling and accessibility across builder fields.
  * Added clearer conditional visibility for optional settings and previews.
* **Improvements**
  * Capture target and formatting previews now provide clearer feedback and avoid displaying empty or stale previews.
  * Updated builder layout, spacing, scrolling, and footer styling.
* **Documentation**
  * Updated guides and examples to consistently use the “Capture to” setting terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->