### PR TITLE
feat(prompts): say what a run-time prompt is asking for and where it goes

### DIFF
--- a/src/engine/CaptureChoiceEngine.audit-capture.test.ts
+++ b/src/engine/CaptureChoiceEngine.audit-capture.test.ts
@@ -53,6 +53,7 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 	class CaptureChoiceFormatterMock {
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setDestinationFile() {}
 		setDestinationSourcePath() {}
 		setUseSelectionAsCaptureValue() {}

--- a/src/engine/CaptureChoiceEngine.heading-picker.test.ts
+++ b/src/engine/CaptureChoiceEngine.heading-picker.test.ts
@@ -14,6 +14,7 @@ const { setInsertAfterTargetOverrideMock } = vi.hoisted(() => ({
 
 vi.mock("../formatters/captureChoiceFormatter", () => ({
 	CaptureChoiceFormatter: class {
+		setPromptRunContext() {}
 		setLinkToCurrentFileBehavior() {}
 		setUseSelectionAsCaptureValue() {}
 		setInsertAfterTargetOverride(target: string | null) {

--- a/src/engine/CaptureChoiceEngine.merge.test.ts
+++ b/src/engine/CaptureChoiceEngine.merge.test.ts
@@ -52,6 +52,7 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 	CaptureChoiceFormatter: class {
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setDestinationFile() {}
 		setDestinationSourcePath() {}
 		setUseSelectionAsCaptureValue() {}

--- a/src/engine/CaptureChoiceEngine.notice.test.ts
+++ b/src/engine/CaptureChoiceEngine.notice.test.ts
@@ -58,6 +58,7 @@ vi.mock("../formatters/captureChoiceFormatter", () => {
 		constructor() {}
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setDestinationFile() {}
 		setDestinationSourcePath() {}
 		setUseSelectionAsCaptureValue() {}

--- a/src/engine/CaptureChoiceEngine.selection.test.ts
+++ b/src/engine/CaptureChoiceEngine.selection.test.ts
@@ -49,6 +49,7 @@ vi.mock("../formatters/captureChoiceFormatter", () => ({
 			setTitleMock(value);
 		}
 		setDestinationFile() {}
+		setPromptRunContext() {}
 		setDestinationSourcePath() {}
 		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
 			return await work();

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -141,6 +141,11 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		this.choice = choice;
 		this.plugin = plugin;
 		this.formatter = new CaptureChoiceFormatter(app, plugin, choiceExecutor);
+		// Every prompt this run opens can say which choice is asking (issue #1546).
+		this.formatter.setPromptRunContext({
+			draftScopeId: choice.id,
+			choiceName: choice.name,
+		});
 	}
 
 	/**
@@ -952,7 +957,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 		const captureTo = this.choice.captureTo;
 		const formattedCaptureTo = await this.formatter.formatFileName(
 			captureTo,
-			this.choice.name,
+			"captureTarget",
 		);
 		const resolution = this.resolveCaptureTarget(formattedCaptureTo);
 
@@ -1443,8 +1448,18 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			}
 
 			// The SingleTemplateEngine has its own formatter; give it the
-			// destination folder so {{FOLDER}} resolves in the template body.
+			// destination folder so {{FOLDER}} resolves in the template body, and
+			// the run context so its prompts still name the choice and target.
 			singleTemplateEngine.setTargetFolderPath(parentFolderPath(filePath));
+			singleTemplateEngine.setPromptRunContext({
+				// Scoped to the template: the engine has its own formatter and raises
+				// its own {{VALUE}} prompt, which must not share the capture body
+				// prompt's draft key.
+				draftScopeId: `${this.choice.id}#${this.choice.createFileIfItDoesntExist.template}`,
+				choiceName: this.choice.name,
+				destination: filePath,
+				destinationKind: "file",
+			});
 
 			fileContent = await singleTemplateEngine.run();
 
@@ -1511,7 +1526,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 	private async formatFilePath(captureTo: string) {
 		const formattedCaptureTo: string = await this.formatter.formatFileName(
 			captureTo,
-			this.choice.name,
+			"captureTarget",
 		);
 
 		return this.normalizeCaptureFilePath(formattedCaptureTo);

--- a/src/engine/MacroChoiceEngine.openFilePath.audit-macro.test.ts
+++ b/src/engine/MacroChoiceEngine.openFilePath.audit-macro.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach, afterAll } from "vitest";
 
-const { formatFileNameMock, openFileMock } = vi.hoisted(() => ({
+const { formatFileNameMock, openFileMock, setPromptRunContextMock } =
+	vi.hoisted(() => ({
 	formatFileNameMock: vi.fn(async (path: string) => path),
+	setPromptRunContextMock: vi.fn(),
 	openFileMock: vi.fn(
 		async (_app: unknown, _file: unknown, _options?: unknown) => {}
 	),
-}));
+	}));
 
 vi.mock("../quickAddApi", () => ({
 	QuickAddApi: {
@@ -39,6 +41,9 @@ vi.mock("../settingsStore", () => ({
 vi.mock("../formatters/completeFormatter", () => ({
 	CompleteFormatter: class CompleteFormatterMock {
 		formatFileName = formatFileNameMock;
+		// The engine hands its ad-hoc formatter the choice name and a per-command
+		// draft scope before formatting the path (issue #1546).
+		setPromptRunContext = setPromptRunContextMock;
 	},
 }));
 vi.mock("../utilityObsidian", () => ({

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -864,6 +864,14 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 				getQuickAddInstance(),
 				this.choiceExecutor
 			);
+			// This formatter is built per command, so a {{VALUE}} in the path only
+			// gets the macro's name and its own draft scope if they are handed over
+			// (issue #1546). Scoped per command id: a macro can hold several Open
+			// File commands, and they must not share one draft.
+			formatter.setPromptRunContext({
+				choiceName: this.choice?.name,
+				draftScopeId: `${this.choice?.id ?? "macro"}#openFile:${command.id}`,
+			});
 
 			const resolvedPath = await formatter.formatFileName(
 				command.filePath,

--- a/src/engine/MacroChoiceEngine.ts
+++ b/src/engine/MacroChoiceEngine.ts
@@ -865,7 +865,10 @@ export class MacroChoiceEngine extends QuickAddChoiceEngine {
 				this.choiceExecutor
 			);
 
-			const resolvedPath = await formatter.formatFileName(command.filePath, "");
+			const resolvedPath = await formatter.formatFileName(
+				command.filePath,
+				"filePath",
+			);
 			const normalizedPath = resolvedPath.replace(/\\/g, "/");
 
 			// Validate path segments to prevent traversal attacks. A substring check

--- a/src/engine/SingleTemplateEngine.ts
+++ b/src/engine/SingleTemplateEngine.ts
@@ -27,8 +27,10 @@ export class SingleTemplateEngine extends TemplateEngine {
 			log.logError(`Template ${resolvedTemplatePath} not found.`);
 		}
 
-		templateContent = await this.formatter.withTemplatePropertyCollection(
-			() => this.formatter.formatFileContent(templateContent),
+		templateContent = await this.formatter.withTemplatePropertyCollection(() =>
+			this.formatter.withPromptScope("noteBody", templateContent, () =>
+				this.formatter.formatFileContent(templateContent),
+			),
 		);
 
 		return templateContent;

--- a/src/engine/SingleTemplateEngine.ts
+++ b/src/engine/SingleTemplateEngine.ts
@@ -4,8 +4,16 @@ import type QuickAdd from "../main";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
 import type { TemplateInclusionState } from "../formatters/formatter";
+import type { PromptScopeKind } from "../formatters/promptScope";
 
 export class SingleTemplateEngine extends TemplateEngine {
+	/**
+	 * What the rendered template becomes. Defaults to the note's body, but a
+	 * `{{TEMPLATE:...}}` spliced into a FILE NAME or folder is part of that path,
+	 * so its prompts must not claim to be asking for note content (issue #1546).
+	 */
+	private promptScope: PromptScopeKind = "noteBody";
+
 	constructor(
 		app: App,
 		plugin: QuickAdd,
@@ -14,6 +22,10 @@ export class SingleTemplateEngine extends TemplateEngine {
 		inclusion?: TemplateInclusionState,
 	) {
 		super(app, plugin, choiceExecutor, inclusion);
+	}
+
+	public setPromptScope(scope: PromptScopeKind): void {
+		this.promptScope = scope;
 	}
 	public async run(): Promise<string> {
 		// Resolve format tokens in the template path (issue #620) before reading.
@@ -28,7 +40,7 @@ export class SingleTemplateEngine extends TemplateEngine {
 		}
 
 		templateContent = await this.formatter.withTemplatePropertyCollection(() =>
-			this.formatter.withPromptScope("noteBody", templateContent, () =>
+			this.formatter.withPromptScope(this.promptScope, templateContent, () =>
 				this.formatter.formatFileContent(templateContent),
 			),
 		);

--- a/src/engine/TemplateChoiceEngine.audit-template.test.ts
+++ b/src/engine/TemplateChoiceEngine.audit-template.test.ts
@@ -32,7 +32,9 @@ vi.mock("../quickAddSettingsTab", () => {
 	};
 });
 
-const { formatFileNameMock, formatFileContentMock } = vi.hoisted(() => ({
+const { formatFileNameMock, formatFileContentMock, setPromptRunContextMock } =
+	vi.hoisted(() => ({
+	setPromptRunContextMock: vi.fn<(context: unknown) => void>(),
 	formatFileNameMock: vi.fn<(format: string, prompt: string) => Promise<string>>(),
 	formatFileContentMock: vi
 		.fn<(...args: unknown[]) => Promise<string>>()
@@ -43,7 +45,9 @@ vi.mock("../formatters/completeFormatter", () => {
 	class CompleteFormatterMock {
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
-		setPromptRunContext() {}
+		setPromptRunContext(context: unknown) {
+			setPromptRunContextMock(context);
+		}
 		setTargetFolderPath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
@@ -53,6 +57,9 @@ vi.mock("../formatters/completeFormatter", () => {
 		}
 		async formatTemplateFilePath(input: string) {
 			return input;
+		}
+		async formatFolderPath(folder: string) {
+			return folder;
 		}
 		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
 			return await work();
@@ -287,5 +294,41 @@ describe("TemplateChoiceEngine create-another collision feedback (audit)", () =>
 				instance.message.includes("Created 'Plan (1)'"),
 			),
 		).toBe(true);
+	});
+
+	// issue #1546: the prompt context line must never promise a folder the answer
+	// itself can reroute.
+	it("advertises the folder to the title prompt only when a folder is configured", async () => {
+		const { engine } = createEngine();
+		engine.choice.folder = {
+			enabled: true,
+			folders: ["Books"],
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		};
+		setPromptRunContextMock.mockClear();
+
+		await engine.run();
+
+		expect(setPromptRunContextMock).toHaveBeenCalledWith({
+			destination: "Books",
+			destinationKind: "folder",
+		});
+	});
+
+	it("withholds the folder when folder settings are off", async () => {
+		// Without a configured folder the formatted name can route the note from
+		// the vault root instead of Obsidian's default location, and the answer
+		// that reroutes it is the one being typed.
+		const { engine } = createEngine();
+		engine.choice.folder.enabled = false;
+		setPromptRunContextMock.mockClear();
+
+		await engine.run();
+
+		expect(setPromptRunContextMock).not.toHaveBeenCalledWith(
+			expect.objectContaining({ destinationKind: "folder" }),
+		);
 	});
 });

--- a/src/engine/TemplateChoiceEngine.audit-template.test.ts
+++ b/src/engine/TemplateChoiceEngine.audit-template.test.ts
@@ -43,6 +43,7 @@ vi.mock("../formatters/completeFormatter", () => {
 	class CompleteFormatterMock {
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setTargetFolderPath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -79,6 +79,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		constructor() {}
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setTargetFolderPath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);

--- a/src/engine/TemplateChoiceEngine.collision.test.ts
+++ b/src/engine/TemplateChoiceEngine.collision.test.ts
@@ -51,6 +51,7 @@ const {
 	templateInsertApplyMock,
 	templateInsertConstructorMock,
 	templateInsertSetLinkToCurrentFileBehaviorMock,
+	templateInsertSetPromptRunContextMock,
 } = vi.hoisted(() => {
 		const formatName =
 			vi.fn<(format: string, prompt: string) => Promise<string>>();
@@ -71,6 +72,7 @@ const {
 			templateInsertApplyMock: vi.fn(),
 			templateInsertConstructorMock: vi.fn(),
 			templateInsertSetLinkToCurrentFileBehaviorMock: vi.fn(),
+			templateInsertSetPromptRunContextMock: vi.fn(),
 		};
 	});
 
@@ -129,6 +131,10 @@ vi.mock("./TemplateInsertEngine", () => {
 	class TemplateInsertEngineMock {
 		constructor(...args: unknown[]) {
 			templateInsertConstructorMock(...args);
+		}
+
+		setPromptRunContext(context: unknown) {
+			templateInsertSetPromptRunContextMock(context);
 		}
 
 		setLinkToCurrentFileBehavior(behavior: "required" | "optional") {
@@ -648,6 +654,15 @@ describe("TemplateChoiceEngine collision behavior", () => {
 			expect(templateInsertSetLinkToCurrentFileBehaviorMock).toHaveBeenCalledWith(
 				"required",
 			);
+			// The insert engine owns its own formatter, so prompts raised while
+			// appending only carry the choice name / destination / draft scope if
+			// the run context is handed over (issue #1546).
+			expect(templateInsertSetPromptRunContextMock).toHaveBeenCalledWith({
+				draftScopeId: engine.choice.id,
+				choiceName: engine.choice.name,
+				destination: existingFile.path,
+				destinationKind: "file",
+			});
 			expect(templateInsertApplyMock).toHaveBeenCalledTimes(1);
 		},
 	);

--- a/src/engine/TemplateChoiceEngine.discovery.test.ts
+++ b/src/engine/TemplateChoiceEngine.discovery.test.ts
@@ -22,6 +22,7 @@ vi.mock("../formatters/completeFormatter", () => {
 	class CompleteFormatterMock {
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setTargetFolderPath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
@@ -241,7 +242,7 @@ describe("TemplateChoiceEngine note discovery", () => {
 		await engine.run();
 
 		expect(choiceExecutor.variables.has("value")).toBe(false);
-		expect(formatFileNameMock).toHaveBeenCalledWith("{{value}}", "Project note");
+		expect(formatFileNameMock).toHaveBeenCalledWith("{{value}}", "noteTitle");
 		expect(createSpy).toHaveBeenCalledWith(
 			"Brand New Project.md",
 			"Templates/Project.md",

--- a/src/engine/TemplateChoiceEngine.folderSorting.test.ts
+++ b/src/engine/TemplateChoiceEngine.folderSorting.test.ts
@@ -19,6 +19,7 @@ vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
 vi.mock("../formatters/completeFormatter", () => ({
 	CompleteFormatter: class {
 		setLinkToCurrentFileBehavior() {}
+		setPromptRunContext() {}
 		async formatTemplateFilePath(input: string): Promise<string> {
 			return input;
 		}

--- a/src/engine/TemplateChoiceEngine.notice.test.ts
+++ b/src/engine/TemplateChoiceEngine.notice.test.ts
@@ -73,6 +73,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		constructor() {}
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setTargetFolderPath() {}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
@@ -84,6 +85,13 @@ vi.mock("../formatters/completeFormatter", () => {
 			return input;
 		}
 		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
+			return await work();
+		}
+		async withPromptScope<T>(
+			_scope: string,
+			_input: string,
+			work: () => Promise<T>,
+		) {
 			return await work();
 		}
 		getAndClearTemplatePropertyVars() {

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -66,6 +66,11 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		super(app, plugin, choiceExecutor);
 		this.choiceExecutor = choiceExecutor;
 		this.choice = choice;
+		// Every prompt this run opens can say which choice is asking (issue #1546).
+		this.formatter.setPromptRunContext({
+			draftScopeId: choice.id,
+			choiceName: choice.name,
+		});
 	}
 
 	public async run(): Promise<void> {
@@ -139,10 +144,21 @@ export class TemplateChoiceEngine extends TemplateEngine {
 
 			// Make the resolved folder available to {{FOLDER}} in the file name.
 			this.formatter.setTargetFolderPath(folderPath);
+			// The title prompt below can now say where the note will be created -
+			// unless the file name format itself carries a folder while folder
+			// settings are off, in which case the format can reroute the note
+			// (shouldTreatFormattedNameAsVaultRelativePath) and the folder shown
+			// would be a lie.
+			if (this.choice.folder.enabled || !format.includes("/")) {
+				this.formatter.setPromptRunContext({
+					destination: folderPath,
+					destinationKind: "folder",
+				});
+			}
 
 			const formattedName = discoveryVaultRelativePath
 				? discoveryVaultRelativePath
-				: await this.formatter.formatFileName(format, this.choice.name);
+				: await this.formatter.formatFileName(format, "noteTitle");
 			const routedName = normalizeGeneratedFilePath(formattedName, "File name");
 			const { fileName, strippedPrefix } = discoveryVaultRelativePath
 				? { fileName: routedName, strippedPrefix: false }
@@ -590,12 +606,14 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		return null;
 	}
 
+	// Sequential, not Promise.all: these passes share one formatter, and
+	// overlapping passes interleave its per-pass prompt scope (and would stack
+	// several prompt modals at once if a folder definition contained {{VALUE}}).
 	private async formatFolderPaths(folders: string[]) {
-		const folderPaths = await Promise.all(
-			folders.map(async (folder) => {
-				return await this.formatter.formatFolderPath(folder);
-			}),
-		);
+		const folderPaths: string[] = [];
+		for (const folder of folders) {
+			folderPaths.push(await this.formatter.formatFolderPath(folder));
+		}
 
 		return folderPaths;
 	}

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -544,6 +544,15 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			this.choiceExecutor,
 			resolvedTemplatePath,
 		);
+		// This engine owns its own formatter, so the run context has to be handed
+		// over or every prompt raised while appending loses the choice name, the
+		// destination and its draft scope (issue #1546).
+		insertEngine.setPromptRunContext({
+			draftScopeId: this.choice.id,
+			choiceName: this.choice.name,
+			destination: existingFile.path,
+			destinationKind: "file",
+		});
 		insertEngine.setLinkToCurrentFileBehavior(
 			linkOptions.enabled && !linkOptions.requireActiveFile
 				? "optional"

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -144,12 +144,14 @@ export class TemplateChoiceEngine extends TemplateEngine {
 
 			// Make the resolved folder available to {{FOLDER}} in the file name.
 			this.formatter.setTargetFolderPath(folderPath);
-			// The title prompt below can now say where the note will be created -
-			// unless the file name format itself carries a folder while folder
-			// settings are off, in which case the format can reroute the note
-			// (shouldTreatFormattedNameAsVaultRelativePath) and the folder shown
-			// would be a lie.
-			if (this.choice.folder.enabled || !format.includes("/")) {
+			// The title prompt below can say where the note will be created only
+			// when a folder is actually configured. With folder settings off the
+			// formatted name can reroute the note from the vault root
+			// (shouldTreatFormattedNameAsVaultRelativePath returns false as soon
+			// as folderEnabled), and the answer that reroutes it is the very one
+			// being typed - so Obsidian's default location is not something this
+			// prompt can promise.
+			if (this.choice.folder.enabled) {
 				this.formatter.setPromptRunContext({
 					destination: folderPath,
 					destinationKind: "folder",

--- a/src/engine/TemplateEngine.ts
+++ b/src/engine/TemplateEngine.ts
@@ -8,6 +8,7 @@ import type {
 	LinkToCurrentFileBehavior,
 	TemplateInclusionState,
 } from "../formatters/formatter";
+import type { PromptRunContext } from "../formatters/promptScope";
 import type { App, TFile } from "obsidian";
 import { Notice, TFolder } from "obsidian";
 import type QuickAdd from "../main";
@@ -587,10 +588,19 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			this.formatter.setTitle(fileBasename);
 			// {{FOLDER}} in the body reflects the file's actual on-disk folder.
 			this.formatter.setTargetFolderPath(parentFolderPath(filePath));
+			// Pin the prompt destination to the path actually being created, which
+			// is NOT always the choice's computed target: a "create another file"
+			// collision mode resolves an incremented name first (issue #1546).
+			this.formatter.setPromptRunContext({
+				destination: filePath,
+				destinationKind: "file",
+			});
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
-					this.formatter.formatFileContent(templateContent),
+					this.formatter.withPromptScope("noteBody", templateContent, () =>
+						this.formatter.formatFileContent(templateContent),
+					),
 				);
 
 			// Get template variables before creating the file
@@ -643,6 +653,16 @@ export abstract class TemplateEngine extends QuickAddEngine {
 	}
 
 	/**
+	 * Propagates "which choice is asking, and where its output lands" into this
+	 * engine's own formatter, so prompts raised from a nested template
+	 * ({{TEMPLATE:...}} inclusion, or a capture creating its target file from a
+	 * template) still carry the run context (issue #1546).
+	 */
+	public setPromptRunContext(context: PromptRunContext) {
+		this.formatter.setPromptRunContext(context);
+	}
+
+	/**
 	 * Resolves QuickAdd format tokens in a template *source* path (issue #620)
 	 * via this engine's formatter, e.g. "Templates/{{value:type}} Template.md".
 	 * Call once at run() entry and reuse the result for BOTH target-path
@@ -671,10 +691,16 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			// {{FOLDER}} reflects the existing file's folder, which can differ
 			// from the choice's configured folder.
 			this.formatter.setTargetFolderPath(parentFolderPath(file.path));
+			this.formatter.setPromptRunContext({
+				destination: file.path,
+				destinationKind: "file",
+			});
 
 			const formattedTemplateContent: string =
 				await this.formatter.withTemplatePropertyCollection(() =>
-					this.formatter.formatFileContent(templateContent),
+					this.formatter.withPromptScope("noteBody", templateContent, () =>
+						this.formatter.formatFileContent(templateContent),
+					),
 				);
 
 			// Get template variables before modifying the file
@@ -719,9 +745,16 @@ export abstract class TemplateEngine extends QuickAddEngine {
 			const fileBasename = file.basename;
 			this.formatter.setTitle(fileBasename);
 			this.formatter.setTargetFolderPath(parentFolderPath(file.path));
+			this.formatter.setPromptRunContext({
+				destination: file.path,
+				destinationKind: "file",
+			});
 
-			let formattedTemplateContent: string =
-				await this.formatter.formatFileContent(templateContent);
+			let formattedTemplateContent: string = await this.formatter.withPromptScope(
+				"noteBody",
+				templateContent,
+				() => this.formatter.formatFileContent(templateContent),
+			);
 			if (file.extension === "md") {
 				formattedTemplateContent = await templaterParseTemplate(
 					this.app,

--- a/src/engine/TemplateInsertEngine.audit-template.test.ts
+++ b/src/engine/TemplateInsertEngine.audit-template.test.ts
@@ -5,6 +5,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		targetFolderPath: string | null = null;
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setTargetFolderPath(path: string | null) {
 			this.targetFolderPath = path;
 		}

--- a/src/engine/TemplateInsertEngine.test.ts
+++ b/src/engine/TemplateInsertEngine.test.ts
@@ -11,6 +11,7 @@ vi.mock("../formatters/completeFormatter", () => {
 		targetFolderPath: string | null = null;
 		setLinkToCurrentFileBehavior() {}
 		setTitle() {}
+		setPromptRunContext() {}
 		setTargetFolderPath(path: string | null) {
 			this.targetFolderPath = path;
 		}
@@ -38,6 +39,13 @@ vi.mock("../formatters/completeFormatter", () => {
 			return input;
 		}
 		async withTemplatePropertyCollection<T>(work: () => Promise<T>) {
+			return await work();
+		}
+		async withPromptScope<T>(
+			_scope: string,
+			_input: string,
+			work: () => Promise<T>,
+		) {
 			return await work();
 		}
 		getAndClearTemplatePropertyVars() {

--- a/src/engine/TemplateInsertEngine.ts
+++ b/src/engine/TemplateInsertEngine.ts
@@ -208,9 +208,13 @@ export class TemplateInsertEngine extends TemplateEngine {
 			// create the note in (the path just computed), matching what
 			// TemplateChoiceEngine produces.
 			this.formatter.setTargetFolderPath(folderPath);
+			// "generic": this computes where the choice WOULD have created the note
+			// so a move can be offered - nothing is created and nothing is opened,
+			// so no derived ask would be true here. Any prompt keeps the choice
+			// name as its title, as it does today.
 			const formattedName = await this.formatter.formatFileName(
 				choice.fileNameFormat.format,
-				choice.name,
+				"generic",
 			);
 			const routedName = normalizeGeneratedFilePath(formattedName, "File name");
 			// Mirror TemplateChoiceEngine's resolution of formatted names that
@@ -303,7 +307,9 @@ export class TemplateInsertEngine extends TemplateEngine {
 		this.formatter.setTargetFolderPath(parentFolderPath(this.targetFile.path));
 
 		let formatted = await this.formatter.withTemplatePropertyCollection(() =>
-			this.formatter.formatFileContent(templateContent),
+			this.formatter.withPromptScope("noteBody", templateContent, () =>
+				this.formatter.formatFileContent(templateContent),
+			),
 		);
 		const templatePropertyVars =
 			this.formatter.getAndClearTemplatePropertyVars();

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -303,19 +303,22 @@ describe("applyTemplateToNote (non-interactive)", () => {
 		// Two runs of the same bare template must share a draft key, so a
 		// cancelled answer is restored on the retry; a different template must not.
 		const file = makeFile();
-		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
-			templatePath: "templates/tpl.md",
-			choiceExecutor: makeExecutor(),
-		});
-		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
-			templatePath: "templates/other.md",
-			choiceExecutor: makeExecutor(),
-		});
+		for (const templatePath of [
+			"templates/tpl.md",
+			"templates/tpl.md",
+			"templates/other.md",
+		]) {
+			await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+				templatePath,
+				choiceExecutor: makeExecutor(),
+			});
+		}
 
 		const scopes = setPromptRunContextMock.mock.calls.map(
 			([context]) => (context as { draftScopeId?: string }).draftScopeId,
 		);
 		expect(scopes).toEqual([
+			"template-insert#templates/tpl.md",
 			"template-insert#templates/tpl.md",
 			"template-insert#templates/other.md",
 		]);

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { engineApplyMock, engineConstructorMock, resolvedPathMock } =
+const {
+	engineApplyMock,
+	engineConstructorMock,
+	resolvedPathMock,
+	setPromptRunContextMock,
+} =
 	vi.hoisted(() => ({
 		engineApplyMock: vi.fn(),
 		engineConstructorMock: vi.fn(),
+		setPromptRunContextMock: vi.fn<(context: unknown) => void>(),
 		// Identity by default (raw == resolved); override to simulate a path token
 		// that resolves to a different extension (issue #620).
 		resolvedPathMock: vi.fn((raw: string) => raw),
@@ -27,7 +33,9 @@ vi.mock("./TemplateInsertEngine", async (importOriginal) => {
 		async computeChoiceTargetPath() {
 			return null;
 		}
-		setPromptRunContext() {}
+		setPromptRunContext(context: unknown) {
+			setPromptRunContextMock(context);
+		}
 	}
 
 	return { ...actual, TemplateInsertEngine: TemplateInsertEngineMock };
@@ -271,6 +279,46 @@ describe("applyTemplateToNote (non-interactive)", () => {
 		});
 
 		expect(engineConstructorMock.mock.calls[0][4]).toBe("top");
+	});
+
+	// issue #1546: prompts raised while applying a template say which choice is
+	// driving and which note is being written, and get a stable per-source draft
+	// scope so one source's cancelled draft cannot pre-fill another's.
+	it("hands the engine a run context naming the target note", async () => {
+		const file = makeFile();
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: makeExecutor(),
+		});
+
+		expect(setPromptRunContextMock).toHaveBeenCalledWith({
+			choiceName: undefined,
+			draftScopeId: "template-insert#templates/tpl.md",
+			destination: file.path,
+			destinationKind: "file",
+		});
+	});
+
+	it("keeps the draft scope stable across applications of the same template", async () => {
+		// Two runs of the same bare template must share a draft key, so a
+		// cancelled answer is restored on the retry; a different template must not.
+		const file = makeFile();
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/tpl.md",
+			choiceExecutor: makeExecutor(),
+		});
+		await applyTemplateToNote(makeApp("CONTENT", file), plugin, {
+			templatePath: "templates/other.md",
+			choiceExecutor: makeExecutor(),
+		});
+
+		const scopes = setPromptRunContextMock.mock.calls.map(
+			([context]) => (context as { draftScopeId?: string }).draftScopeId,
+		);
+		expect(scopes).toEqual([
+			"template-insert#templates/tpl.md",
+			"template-insert#templates/other.md",
+		]);
 	});
 
 	it("pre-fills {{VALUE}} with the note's basename", async () => {

--- a/src/engine/applyTemplateToActiveNote.test.ts
+++ b/src/engine/applyTemplateToActiveNote.test.ts
@@ -27,6 +27,7 @@ vi.mock("./TemplateInsertEngine", async (importOriginal) => {
 		async computeChoiceTargetPath() {
 			return null;
 		}
+		setPromptRunContext() {}
 	}
 
 	return { ...actual, TemplateInsertEngine: TemplateInsertEngineMock };

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -193,15 +193,18 @@ export async function applyTemplateToNote(
 			params.choiceExecutor,
 		);
 		// Prompts raised while applying the template say which choice is driving
-		// (issue #1546). The DESTINATION is deliberately withheld until the
-		// template source path has been resolved below: tokens in that path
-		// choose which template to read, and never land in this note.
+		// and which note is being written (issue #1546). Applying a bare template
+		// has no choice, so only the destination is known. Prompts inside the
+		// template SOURCE path do not show the destination - scopeShowsDestination
+		// withholds it, because those answers pick which template to read.
 		engine.setPromptRunContext({
 			choiceName: source.kind === "choice" ? source.choice.name : undefined,
 			draftScopeId:
 				source.kind === "choice"
 					? source.choice.id
 					: `template-insert#${templatePath}`,
+			destination: file.path,
+			destinationKind: "file",
 		});
 
 		// Resolve format tokens in the path (issue #620), then re-validate that
@@ -216,11 +219,6 @@ export async function applyTemplateToNote(
 			);
 			return null;
 		}
-
-		engine.setPromptRunContext({
-			destination: file.path,
-			destinationKind: "file",
-		});
 
 		const result = await engine.apply();
 		if (!result) return null;

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -192,6 +192,18 @@ export async function applyTemplateToNote(
 			mode,
 			params.choiceExecutor,
 		);
+		// Prompts raised while applying the template say which choice is driving
+		// and which note is being written (issue #1546). Applying a bare template
+		// has no choice, so only the destination is known.
+		engine.setPromptRunContext({
+			choiceName: source.kind === "choice" ? source.choice.name : undefined,
+			draftScopeId:
+				source.kind === "choice"
+					? source.choice.id
+					: `template-insert#${templatePath}`,
+			destination: file.path,
+			destinationKind: "file",
+		});
 
 		// Resolve format tokens in the path (issue #620), then re-validate that
 		// the RESOLVED file is still a markdown template: a token can expand a

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -222,6 +222,14 @@ export async function applyTemplateToNote(
 		if (!result) return null;
 
 		if (interactive && source.kind === "choice") {
+			// Reconciliation computes where the choice WOULD create the note so a
+			// move can be offered. Any prompt it raises does not land in the note
+			// being templated, so drop the destination rather than advertise a
+			// path the answer never reaches (issue #1546).
+			engine.setPromptRunContext({
+				destination: undefined,
+				destinationKind: undefined,
+			});
 			await maybeReconcileNoteLocation(app, engine, source.choice, file);
 		}
 

--- a/src/engine/applyTemplateToActiveNote.ts
+++ b/src/engine/applyTemplateToActiveNote.ts
@@ -193,16 +193,15 @@ export async function applyTemplateToNote(
 			params.choiceExecutor,
 		);
 		// Prompts raised while applying the template say which choice is driving
-		// and which note is being written (issue #1546). Applying a bare template
-		// has no choice, so only the destination is known.
+		// (issue #1546). The DESTINATION is deliberately withheld until the
+		// template source path has been resolved below: tokens in that path
+		// choose which template to read, and never land in this note.
 		engine.setPromptRunContext({
 			choiceName: source.kind === "choice" ? source.choice.name : undefined,
 			draftScopeId:
 				source.kind === "choice"
 					? source.choice.id
 					: `template-insert#${templatePath}`,
-			destination: file.path,
-			destinationKind: "file",
 		});
 
 		// Resolve format tokens in the path (issue #620), then re-validate that
@@ -217,6 +216,11 @@ export async function applyTemplateToNote(
 			);
 			return null;
 		}
+
+		engine.setPromptRunContext({
+			destination: file.path,
+			destinationKind: "file",
+		});
 
 		const result = await engine.apply();
 		if (!result) return null;

--- a/src/engine/runTemplateFromFolder.test.ts
+++ b/src/engine/runTemplateFromFolder.test.ts
@@ -210,11 +210,7 @@ describe("createFolderTemplateChoice + real preflight collector", () => {
 		expect(unresolved.some((r) => r.id === "value")).toBe(true);
 	});
 
-	it("collects the note-name requirement even with fileNameFormat disabled", async () => {
-		// The engine resolves a disabled format to VALUE_SYNTAX either way, so
-		// preflight scans the EFFECTIVE format (issue #1546). Before that it only
-		// scanned the enabled one, leaving the implicit note-name prompt invisible
-		// to the non-interactive CLI guard and to the one-page form.
+	it("negative control: disabling fileNameFormat hides the note-name requirement", async () => {
 		const executor = createExecutor();
 		const choice = createFolderTemplateChoice("Templates/Daily.md");
 		choice.fileNameFormat = { enabled: false, format: VALUE_SYNTAX };
@@ -224,6 +220,6 @@ describe("createFolderTemplateChoice + real preflight collector", () => {
 			executor,
 			choice,
 		);
-		expect(reqs.some((r) => r.id === "value")).toBe(true);
+		expect(reqs.some((r) => r.id === "value")).toBe(false);
 	});
 });

--- a/src/engine/runTemplateFromFolder.test.ts
+++ b/src/engine/runTemplateFromFolder.test.ts
@@ -210,7 +210,11 @@ describe("createFolderTemplateChoice + real preflight collector", () => {
 		expect(unresolved.some((r) => r.id === "value")).toBe(true);
 	});
 
-	it("negative control: disabling fileNameFormat hides the note-name requirement", async () => {
+	it("collects the note-name requirement even with fileNameFormat disabled", async () => {
+		// The engine resolves a disabled format to VALUE_SYNTAX either way, so
+		// preflight scans the EFFECTIVE format (issue #1546). Before that it only
+		// scanned the enabled one, leaving the implicit note-name prompt invisible
+		// to the non-interactive CLI guard and to the one-page form.
 		const executor = createExecutor();
 		const choice = createFolderTemplateChoice("Templates/Daily.md");
 		choice.fileNameFormat = { enabled: false, format: VALUE_SYNTAX };
@@ -220,6 +224,6 @@ describe("createFolderTemplateChoice + real preflight collector", () => {
 			executor,
 			choice,
 		);
-		expect(reqs.some((r) => r.id === "value")).toBe(false);
+		expect(reqs.some((r) => r.id === "value")).toBe(true);
 	});
 });

--- a/src/engine/runTemplateFromFolder.test.ts
+++ b/src/engine/runTemplateFromFolder.test.ts
@@ -85,10 +85,15 @@ describe("createFolderTemplateChoice", () => {
 		);
 	});
 
-	it("returns a fresh uuid id each call (never persisted, no deterministic collision)", () => {
+	it("derives a stable, namespaced id from the template path", () => {
+		// Stable across runs so the note-name prompt keeps one input-draft key and
+		// cancel-and-retry restores what was typed (issue #1546); namespaced so it
+		// can never collide with a persisted choice's uuid.
 		const a = createFolderTemplateChoice("Templates/X.md");
 		const b = createFolderTemplateChoice("Templates/X.md");
-		expect(a.id).not.toBe(b.id);
+		expect(a.id).toBe(b.id);
+		expect(a.id).toBe("folder-template:Templates/X.md");
+		expect(createFolderTemplateChoice("Templates/Y.md").id).not.toBe(a.id);
 	});
 });
 

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -37,6 +37,12 @@ function templateDisplayName(path: string): string {
  */
 export function createFolderTemplateChoice(templatePath: string): ITemplateChoice {
 	const choice = new TemplateChoice(templateDisplayName(templatePath));
+	// TemplateChoice's constructor mints a fresh uuid. This choice is ephemeral
+	// and rebuilt on every invocation, so a per-run id would give the note-name
+	// prompt a new input-draft key each time and break cancel-and-retry recovery
+	// (issue #1546). Derive it from the template instead: stable across runs,
+	// distinct per template.
+	choice.id = `folder-template:${templatePath}`;
 	choice.templatePath = templatePath;
 	// Creating a brand-new note from a template — land in it, like the user expects.
 	choice.openFile = true;

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -28,12 +28,12 @@ function templateDisplayName(path: string): string {
  * Not persisted and never added to settings.choices — it exists only for the
  * duration of one ChoiceExecutor.execute() call.
  *
- * `fileNameFormat.enabled` is set explicitly rather than relying on the
- * `enabled:false` fallback. Runtime is identical either way (TemplateChoiceEngine
- * resolves both to VALUE_SYNTAX), and preflight now scans the effective format
- * too (issue #1546), so this is belt-and-braces: it keeps the implicit
- * {{value}} note-name prompt visible to the non-interactive CLI guard and to the
- * one-page input form.
+ * `fileNameFormat.enabled` MUST be true. Runtime is identical to `enabled:false`
+ * (TemplateChoiceEngine resolves both to VALUE_SYNTAX), but collectChoiceRequirements
+ * only scans the file-name format when it is enabled — so with `enabled:false` the
+ * implicit {{value}} note-name prompt is invisible to the non-interactive CLI guard
+ * (it would pass with zero unresolved inputs and then hang on an interactive prompt)
+ * and to the one-page input form (which would omit the name field).
  */
 export function createFolderTemplateChoice(templatePath: string): ITemplateChoice {
 	const choice = new TemplateChoice(templateDisplayName(templatePath));

--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -28,12 +28,12 @@ function templateDisplayName(path: string): string {
  * Not persisted and never added to settings.choices — it exists only for the
  * duration of one ChoiceExecutor.execute() call.
  *
- * `fileNameFormat.enabled` MUST be true. Runtime is identical to `enabled:false`
- * (TemplateChoiceEngine resolves both to VALUE_SYNTAX), but collectChoiceRequirements
- * only scans the file-name format when it is enabled — so with `enabled:false` the
- * implicit {{value}} note-name prompt is invisible to the non-interactive CLI guard
- * (it would pass with zero unresolved inputs and then hang on an interactive prompt)
- * and to the one-page input form (which would omit the name field).
+ * `fileNameFormat.enabled` is set explicitly rather than relying on the
+ * `enabled:false` fallback. Runtime is identical either way (TemplateChoiceEngine
+ * resolves both to VALUE_SYNTAX), and preflight now scans the effective format
+ * too (issue #1546), so this is belt-and-braces: it keeps the implicit
+ * {{value}} note-name prompt visible to the non-interactive CLI guard and to the
+ * one-page input form.
  */
 export function createFolderTemplateChoice(templatePath: string): ITemplateChoice {
 	const choice = new TemplateChoice(templateDisplayName(templatePath));

--- a/src/engine/templateEngine-title.test.ts
+++ b/src/engine/templateEngine-title.test.ts
@@ -12,6 +12,14 @@ vi.mock('../formatters/completeFormatter', () => {
             return {
                 setTitle: vi.fn((t: string) => { title = t; }),
                 setTargetFolderPath: vi.fn(),
+                setPromptRunContext: vi.fn(),
+                withPromptScope: vi.fn(
+                    async (
+                        _scope: string,
+                        _input: string,
+                        work: () => Promise<unknown>,
+                    ) => await work(),
+                ),
                 getTitle: () => title,
                 withTemplatePropertyCollection: vi.fn(
                     async (work: () => Promise<unknown>) => await work(),

--- a/src/formatters/captureChoiceFormatter-clipboard.test.ts
+++ b/src/formatters/captureChoiceFormatter-clipboard.test.ts
@@ -85,6 +85,7 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 		}
 		setLinkToCurrentFileBehavior() {}
 		setTargetFolderPath() {}
+		setPromptRunContext() {}
 	},
 }));
 
@@ -256,7 +257,7 @@ describe("CaptureChoiceFormatter clipboard image support", () => {
 		const formatter = createFormatter(app);
 		formatter.setDestinationSourcePath("Notes/Clip.md");
 
-		const result = await formatter.formatFileName("{{clipboard}}", "Capture");
+		const result = await formatter.formatFileName("{{clipboard}}");
 
 		expect(result).toBe("");
 		expect(read).not.toHaveBeenCalled();

--- a/src/formatters/captureChoiceFormatter.ts
+++ b/src/formatters/captureChoiceFormatter.ts
@@ -92,6 +92,13 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		this.clipboardAttachmentLink = undefined;
 		// {{FOLDER}} in a capture body resolves to the destination file's folder.
 		this.setTargetFolderPath(parentFolderPath(file.path));
+		// Both destination setters run on EVERY write path (existing file, created
+		// file, canvas card) immediately before the content pass, so hooking them
+		// is what lets a capture's body prompt name its target note (issue #1546).
+		this.setPromptRunContext({
+			destination: file.path,
+			destinationKind: "file",
+		});
 	}
 
 	public setDestinationSourcePath(path: string): void {
@@ -99,6 +106,7 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		this.file = null;
 		this.clipboardAttachmentLink = undefined;
 		this.setTargetFolderPath(parentFolderPath(path));
+		this.setPromptRunContext({ destination: path, destinationKind: "file" });
 	}
 
 	public setUseSelectionAsCaptureValue(value: boolean): void {
@@ -275,8 +283,14 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 	}
 
 	async formatFileContent(input: string, runTemplater = true): Promise<string> {
+		// Declared here rather than read from `this.choice`, which is still
+		// undefined on the formatContentOnly path (assigned only by
+		// formatContentWithFile/formatContent) - the very pass that opens the
+		// capture's body {{VALUE}} prompt (issue #1546).
 		let formatted = await this.withClipboardImageFallback(async () =>
-			super.formatFileContent(await this.expandTemplateLinebreaksOnce(input)),
+			this.withPromptScope("captureText", input, async () =>
+				super.formatFileContent(await this.expandTemplateLinebreaksOnce(input)),
+			),
 		);
 
 		// Run templater only once per capture payload to prevent #533 double execution
@@ -335,7 +349,9 @@ export class CaptureChoiceFormatter extends CompleteFormatter {
 		// Process the input with templater (if needed) at this stage
 		// This is the first pass where we want to run any templater code
 		const formatted = await this.withClipboardImageFallback(async () =>
-			super.formatFileContent(await this.expandTemplateLinebreaksOnce(input)),
+			this.withPromptScope("captureText", input, async () =>
+				super.formatFileContent(await this.expandTemplateLinebreaksOnce(input)),
+			),
 		);
 
 		// DON'T run templater parsing here - it will be handled either by:

--- a/src/formatters/completeFormatter.audit-formatter-core.test.ts
+++ b/src/formatters/completeFormatter.audit-formatter-core.test.ts
@@ -55,6 +55,7 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 			return mocks.templateRun.call(this);
 		}
 		setTargetFolderPath() {}
+		setPromptRunContext() {}
 		getAndClearTemplatePropertyVars() {
 			return new Map();
 		}
@@ -195,7 +196,7 @@ describe("circular {{title}} re-check after format() (format-file-title-token)",
 	it("formatFileName throws when a global snippet expands to {{title}}", async () => {
 		const f = formatter({ snip: "{{title}}" });
 		await expect(
-			f.formatFileName("{{GLOBAL_VAR:snip}}-note", "Value"),
+			f.formatFileName("{{GLOBAL_VAR:snip}}-note"),
 		).rejects.toThrow("circular dependency");
 	});
 
@@ -208,7 +209,7 @@ describe("circular {{title}} re-check after format() (format-file-title-token)",
 
 	it("formatFileName still throws on a raw {{title}} (unchanged)", async () => {
 		const f = formatter();
-		await expect(f.formatFileName("{{title}}-x", "V")).rejects.toThrow(
+		await expect(f.formatFileName("{{title}}-x")).rejects.toThrow(
 			"circular dependency",
 		);
 	});
@@ -216,7 +217,7 @@ describe("circular {{title}} re-check after format() (format-file-title-token)",
 	it("formatFileName does not false-positive on a global with no {{title}}", async () => {
 		const f = formatter({ greeting: "hello" });
 		await expect(
-			f.formatFileName("{{GLOBAL_VAR:greeting}}-note", "V"),
+			f.formatFileName("{{GLOBAL_VAR:greeting}}-note"),
 		).resolves.toBe("hello-note");
 	});
 });

--- a/src/formatters/completeFormatter.imagePaste.test.ts
+++ b/src/formatters/completeFormatter.imagePaste.test.ts
@@ -101,6 +101,7 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 		}
 		setLinkToCurrentFileBehavior() {}
 		setTargetFolderPath() {}
+		setPromptRunContext() {}
 	},
 }));
 
@@ -185,7 +186,7 @@ describe("image paste sink-context gating", () => {
 	it("never offers image paste in file name prompts", async () => {
 		const f = new CompleteFormatter(createMockApp(), plugin);
 
-		await f.formatFileName("{{VALUE}}", "value");
+		await f.formatFileName("{{VALUE}}");
 
 		expect(lastPromptOptions(mocks.inputPromptPrompt)).toBeUndefined();
 	});

--- a/src/formatters/completeFormatter.promptContext.test.ts
+++ b/src/formatters/completeFormatter.promptContext.test.ts
@@ -212,6 +212,24 @@ describe("scope isolation", () => {
 	});
 });
 
+describe("template source paths", () => {
+	it("does not claim the destination for a prompt that only picks a template", async () => {
+		const f = makeFormatter();
+		f.setPromptRunContext({
+			choiceName: "Book note",
+			destination: "Inbox/Draft.md",
+			destinationKind: "file",
+		});
+
+		// The answer chooses WHICH template file to read; it never lands in the
+		// note being written, so the line names the choice and stops there.
+		await f.formatTemplateFilePath("Templates/{{VALUE:kind}}.md");
+
+		expect(lastPromptCall()).toMatchObject({ header: "kind" });
+		expect(lastPromptCall().options?.contextLine).toBe("Book note");
+	});
+});
+
 describe("included templates", () => {
 	it("inherits the including pass's scope instead of claiming note content", async () => {
 		// `{{TEMPLATE:x}}` inside a FILE NAME is part of that file name; the child

--- a/src/formatters/completeFormatter.promptContext.test.ts
+++ b/src/formatters/completeFormatter.promptContext.test.ts
@@ -10,6 +10,26 @@ const mocks = vi.hoisted(() => ({
 	prompt: vi.fn(async () => "answer"),
 	promptWithContext: vi.fn(async () => "answer"),
 	suggest: vi.fn(async (..._args: unknown[]) => "true"),
+	childScopes: [] as string[],
+	childRunContexts: [] as unknown[],
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		setTargetFolderPath() {}
+		setPromptScope(scope: string) {
+			mocks.childScopes.push(scope);
+		}
+		setPromptRunContext(context: unknown) {
+			mocks.childRunContexts.push(context);
+		}
+		async run() {
+			return "included";
+		}
+		getAndClearTemplatePropertyVars() {
+			return new Map();
+		}
+	},
 }));
 
 vi.mock("obsidian", () => {
@@ -189,6 +209,27 @@ describe("scope isolation", () => {
 		await f.formatFileContent("{{VALUE}}");
 
 		expect(lastPromptCall().header).toBe("New template");
+	});
+});
+
+describe("included templates", () => {
+	it("inherits the including pass's scope instead of claiming note content", async () => {
+		// `{{TEMPLATE:x}}` inside a FILE NAME is part of that file name; the child
+		// engine renders it through its own formatter, so the scope has to travel.
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "My template", draftScopeId: "tpl" });
+		mocks.childScopes.length = 0;
+		mocks.childRunContexts.length = 0;
+
+		await f.formatFileName("{{TEMPLATE:Templates/Name.md}}", "noteTitle");
+
+		expect(mocks.childScopes).toEqual(["noteTitle"]);
+		// A separate draft scope, so the include's own prompt cannot open
+		// pre-filled with the parent's answer.
+		expect(mocks.childRunContexts.at(-1)).toMatchObject({
+			choiceName: "My template",
+			draftScopeId: "tpl#Templates/Name.md",
+		});
 	});
 });
 

--- a/src/formatters/completeFormatter.promptContext.test.ts
+++ b/src/formatters/completeFormatter.promptContext.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Runtime prompt context (issue #1546): what the anonymous {{VALUE}} prompt
+ * says about itself, and the invariants that keep it from saying something
+ * false.
+ */
+
+const mocks = vi.hoisted(() => ({
+	prompt: vi.fn(async () => "answer"),
+	promptWithContext: vi.fn(async () => "answer"),
+	suggest: vi.fn(async (..._args: unknown[]) => "true"),
+}));
+
+vi.mock("obsidian", () => {
+	class MarkdownView {}
+	return { MarkdownView };
+});
+
+vi.mock("../gui/InputPrompt", () => ({
+	default: class {
+		factory() {
+			return { Prompt: mocks.prompt, PromptWithContext: mocks.promptWithContext };
+		}
+	},
+}));
+
+vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
+	default: { Suggest: mocks.suggest },
+}));
+
+vi.mock("../gui/GenericInputPrompt/GenericInputPrompt", () => ({
+	default: { Prompt: mocks.prompt, PromptWithContext: mocks.promptWithContext },
+}));
+
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn(() => null) }));
+vi.mock("../gui/InputSuggester/inputSuggester", () => ({ default: {} }));
+vi.mock("../gui/MultiSuggester/multiSuggester", () => ({ default: {} }));
+vi.mock("../gui/VDateInputPrompt/VDateInputPrompt", () => ({ default: {} }));
+vi.mock("../gui/MathModal", () => ({ MathModal: {} }));
+vi.mock("../parsers/NLDParser", () => ({ NLDParser: { getNattyParser: () => ({}) } }));
+vi.mock("../logger/logManager", () => ({
+	log: { logMessage: vi.fn(), logWarning: vi.fn(), logError: vi.fn() },
+}));
+
+import { CompleteFormatter } from "./completeFormatter";
+
+const app = {
+	workspace: { getActiveFile: () => null, getActiveViewOfType: () => null },
+	fileManager: { generateMarkdownLink: () => "" },
+} as never;
+const plugin = { settings: { globalVariables: {}, inputPrompt: "single-line" } } as never;
+
+function makeFormatter() {
+	return new CompleteFormatter(app, plugin);
+}
+
+/** The (app, header, placeholder, ...) tuple the modal factory was called with. */
+function lastPromptCall() {
+	const call =
+		mocks.prompt.mock.calls.at(-1) ?? mocks.promptWithContext.mock.calls.at(-1);
+	if (!call) throw new Error("no prompt was opened");
+	const args = call as unknown as unknown[];
+	return {
+		header: args[1] as string,
+		placeholder: args[2] as string | undefined,
+		options: args.at(-1) as { contextLine?: string; draftScopeId?: string } | undefined,
+	};
+}
+
+beforeEach(() => {
+	// {{DATE}} only needs to resolve to *something* here; the tests assert on the
+	// prompt copy, not on the date.
+	(globalThis as unknown as { window: Record<string, unknown> }).window ??= {};
+	(globalThis as unknown as { window: { moment: unknown } }).window.moment = () => ({
+		add: () => ({ format: () => "2026-07-26" }),
+		format: () => "2026-07-26",
+		isValid: () => true,
+	});
+	mocks.prompt.mockClear();
+	mocks.promptWithContext.mockClear();
+	mocks.suggest.mockClear();
+});
+
+describe("anonymous {{VALUE}} prompt copy", () => {
+	it("names the note title for a Template file-name pass", async () => {
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "New template", draftScopeId: "tpl-1" });
+
+		await f.formatFileName("{{VALUE}}", "noteTitle");
+
+		expect(lastPromptCall()).toMatchObject({
+			header: "Note title",
+			placeholder: "Title for the new note",
+		});
+	});
+
+	it("keeps the choice name when the answer is only part of the file name", async () => {
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "Daily note" });
+
+		// "Note title" here would invite the user to retype the date.
+		await f.formatFileName("{{DATE:YYYY-MM-DD}} {{VALUE}}", "noteTitle");
+
+		expect(lastPromptCall()).toMatchObject({
+			header: "Daily note",
+			placeholder: "Part of the new note's title",
+		});
+	});
+
+	it("still names the capture text when the format only adds decoration", async () => {
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "Quick note" });
+
+		await f.withPromptScope("captureText", "- [ ] {{VALUE}}\n", () =>
+			f.formatFileContent("- [ ] {{VALUE}}\n"),
+		);
+
+		expect(lastPromptCall()).toMatchObject({
+			header: "Text to capture",
+			placeholder: "Text to add to the note",
+		});
+	});
+
+	it("falls back to 'Enter value' with no run context (script API, AI agent)", async () => {
+		const f = makeFormatter();
+
+		await f.formatFileContent("{{VALUE}}");
+
+		expect(lastPromptCall()).toMatchObject({ header: "Enter value" });
+	});
+});
+
+describe("prompt context line", () => {
+	it("carries the choice name and the resolved destination", async () => {
+		const f = makeFormatter();
+		f.setPromptRunContext({
+			choiceName: "New capture",
+			destination: "Daily/2026-07-26.md",
+			destinationKind: "file",
+		});
+
+		await f.withPromptScope("captureText", "{{VALUE}}", () =>
+			f.formatFileContent("{{VALUE}}"),
+		);
+
+		expect(lastPromptCall().options?.contextLine).toBe(
+			"New capture → Daily/2026-07-26.md",
+		);
+	});
+
+	it("reaches a plain prompt that has no other options set", async () => {
+		// buildInputPromptOptions used to early-return undefined for exactly this
+		// prompt, which would have swallowed both the context line and scope id.
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "New capture", draftScopeId: "cap-1" });
+
+		await f.formatFileContent("{{VALUE}}");
+
+		expect(lastPromptCall().options).toMatchObject({ draftScopeId: "cap-1" });
+	});
+});
+
+describe("scope isolation", () => {
+	it("does not let a path pass retitle a later content prompt", async () => {
+		// The old sticky `valueHeader` was set by formatFileName and never reset,
+		// so a Capture's body prompt inherited the target pass's title.
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "New capture" });
+
+		await f.formatFileName("Daily/{{DATE:YYYY-MM-DD}}.md", "captureTarget");
+		await f.withPromptScope("captureText", "{{VALUE}}", () =>
+			f.formatFileContent("{{VALUE}}"),
+		);
+
+		expect(lastPromptCall().header).toBe("Text to capture");
+	});
+
+	it("restores the previous scope when a pass throws", async () => {
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "New template" });
+
+		await expect(
+			f.withPromptScope("noteTitle", "{{VALUE}}", async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+
+		await f.formatFileContent("{{VALUE}}");
+
+		expect(lastPromptCall().header).toBe("New template");
+	});
+});
+
+describe("forced true/false picker", () => {
+	it("keeps the choice name rather than degrading to 'Choose value'", async () => {
+		const f = makeFormatter();
+		f.setPromptRunContext({ choiceName: "Task" });
+
+		await f.formatFileContent("done: {{VALUE|type:checkbox}}");
+
+		expect(mocks.suggest.mock.calls.at(-1)?.[3]).toBe("Task");
+	});
+});

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -75,6 +75,10 @@ vi.mock("../engine/SingleTemplateEngine", () => ({
 			this.targetFolderPath = path;
 		}
 
+		setPromptScope() {}
+
+		setPromptRunContext() {}
+
 		run() {
 			return mocks.templateRun.call(this);
 		}

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -625,7 +625,7 @@ describe("CompleteFormatter - #1358 token-named active file (production wiring)"
 		f.setTargetFolderPath("Projects");
 		// {{FILENAMECURRENT}} -> '{{folder}}' (the basename); the folder pass must
 		// NOT then rewrite that to 'Projects'.
-		await expect(f.formatFileName("{{FILENAMECURRENT}}", "header")).resolves.toBe(
+		await expect(f.formatFileName("{{FILENAMECURRENT}}")).resolves.toBe(
 			"{{folder}}",
 		);
 	});
@@ -640,14 +640,14 @@ describe("CompleteFormatter - {{FOLDERCURRENT}} (issue #1480)", () => {
 	it("formatFileName resolves a sibling capture target from the active file's folder", async () => {
 		const f = defaultFormatter({}, { activeFile: activeInAlpha });
 		await expect(
-			f.formatFileName("{{FOLDERCURRENT}}/Project Tasks.md", "Value"),
+			f.formatFileName("{{FOLDERCURRENT}}/Project Tasks.md"),
 		).resolves.toBe("Projects/Alpha/Project Tasks.md");
 	});
 
 	it("formatFileName resolves {{FOLDERCURRENT|name}} to the leaf folder", async () => {
 		const f = defaultFormatter({}, { activeFile: activeInAlpha });
 		await expect(
-			f.formatFileName("{{FOLDERCURRENT|name}} - notes", "Value"),
+			f.formatFileName("{{FOLDERCURRENT|name}} - notes"),
 		).resolves.toBe("Alpha - notes");
 	});
 
@@ -659,7 +659,7 @@ describe("CompleteFormatter - {{FOLDERCURRENT}} (issue #1480)", () => {
 		// Downstream path normalization strips the leading slash, so a root-level
 		// note captures to a root-level sibling.
 		await expect(
-			f.formatFileName("{{FOLDERCURRENT}}/Tasks.md", "Value"),
+			f.formatFileName("{{FOLDERCURRENT}}/Tasks.md"),
 		).resolves.toBe("/Tasks.md");
 	});
 
@@ -681,7 +681,7 @@ describe("CompleteFormatter - {{FOLDERCURRENT}} (issue #1480)", () => {
 		const f = defaultFormatter({}, { activeFile: null });
 		f.setLinkToCurrentFileBehavior("optional");
 		await expect(
-			f.formatFileName("{{FOLDERCURRENT}}/Tasks.md", "Value"),
+			f.formatFileName("{{FOLDERCURRENT}}/Tasks.md"),
 		).rejects.toThrow("Unable to get the active file's folder");
 	});
 
@@ -723,7 +723,7 @@ describe("CompleteFormatter - {{FOLDERCURRENT}} (issue #1480)", () => {
 			},
 		);
 		await expect(
-			f.formatFileName("{{FOLDERCURRENT}}/{{FILENAMECURRENT}}", "Value"),
+			f.formatFileName("{{FOLDERCURRENT}}/{{FILENAMECURRENT}}"),
 		).resolves.toBe("{{filenamecurrent}}/Meeting");
 	});
 });
@@ -740,7 +740,7 @@ describe("CompleteFormatter - title handling", () => {
 	it("formatFileName rejects {{title}} to avoid circular dependency", async () => {
 		const f = defaultFormatter();
 		await expect(
-			f.formatFileName("{{title}}-suffix", "Value"),
+			f.formatFileName("{{title}}-suffix"),
 		).rejects.toThrow("circular dependency");
 	});
 
@@ -757,7 +757,7 @@ describe("CompleteFormatter - title handling", () => {
 			{ activeFile: { basename: "Source" } },
 		);
 		await expect(
-			f.formatFileName("{{FILENAMECURRENT}}-note", "Value"),
+			f.formatFileName("{{FILENAMECURRENT}}-note"),
 		).resolves.toBe("Source-note");
 	});
 });
@@ -857,10 +857,12 @@ describe("CompleteFormatter - {{VALUE}} prompting", () => {
 			),
 		).resolves.toBe("7");
 		expect(mocks.inputPromptFactory).toHaveBeenCalledWith("slider");
+		// A folder pass whose whole format is the token: the prompt names the
+		// folder it is filling in rather than showing a bare box (issue #1546).
 		expect(mocks.inputPromptPrompt).toHaveBeenCalledWith(
 			expect.anything(),
-			"Enter value",
-			undefined,
+			"Folder",
+			"Folder for the new note",
 			"5",
 			undefined,
 			{

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -466,6 +466,7 @@ export class CompleteFormatter extends Formatter {
 		title: string;
 		placeholder?: string;
 		contextLine?: string;
+		contextLineFull?: string;
 	} {
 		const derived = describeValuePrompt(
 			this.promptScope,
@@ -478,6 +479,9 @@ export class CompleteFormatter extends Formatter {
 			title,
 			placeholder: derived.placeholder,
 			contextLine: buildPromptContextLine(this.promptRunContext, title),
+			contextLineFull: buildPromptContextLine(this.promptRunContext, title, {
+				elide: false,
+			}),
 		};
 	}
 
@@ -560,6 +564,7 @@ export class CompleteFormatter extends Formatter {
 				const promptOptions = this.buildInputPromptOptions(
 					this.valuePromptContext,
 					prompt.contextLine,
+					prompt.contextLineFull,
 				);
 				const placeholder =
 					this.valuePromptContext?.placeholder ?? prompt.placeholder;
@@ -626,6 +631,7 @@ export class CompleteFormatter extends Formatter {
 	private buildInputPromptOptions(
 		context: PromptContext | undefined,
 		contextLine?: string,
+		contextLineFull?: string,
 	): InputPromptOptions | undefined {
 		// Image paste only for free-text prompts opened while formatting note
 		// CONTENT — never for number/slider (numeric sinks) and never during
@@ -654,6 +660,7 @@ export class CompleteFormatter extends Formatter {
 			slider: context?.sliderConfig,
 			imagePaste,
 			contextLine,
+			contextLineFull,
 			draftScopeId,
 		};
 	}
@@ -705,6 +712,11 @@ export class CompleteFormatter extends Formatter {
 				this.promptRunContext,
 				variableTitle,
 			);
+			const namedContextLineFull = buildPromptContextLine(
+				this.promptRunContext,
+				variableTitle,
+				{ elide: false },
+			);
 
 			// Use VDateInputPrompt for VDATE variables
 			if (context?.type === "VDATE") {
@@ -719,6 +731,7 @@ export class CompleteFormatter extends Formatter {
 					{
 						optional: context.optional,
 						contextLine: namedContextLine,
+						contextLineFull: namedContextLineFull,
 						draftScopeId: this.promptRunContext?.draftScopeId,
 					},
 					context.withTime,
@@ -748,7 +761,11 @@ export class CompleteFormatter extends Formatter {
 					(context?.defaultValue ? context.defaultValue : undefined),
 				context?.defaultValue,
 				context?.description,
-				this.buildInputPromptOptions(context, namedContextLine),
+				this.buildInputPromptOptions(
+					context,
+					namedContextLine,
+					namedContextLineFull,
+				),
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -38,6 +38,7 @@ import { Formatter, type PromptContext } from "./formatter";
 import {
 	buildPromptContextLine,
 	describeValuePrompt,
+	isPathScope,
 	type PromptScopeKind,
 } from "./promptScope";
 import {
@@ -164,7 +165,10 @@ export class CompleteFormatter extends Formatter {
 		// (issue #1484). Restored in finally so a nested/failed pass can't
 		// leak the flag into a later path pass on the same formatter.
 		const previousImagePaste = this.contentValuePromptsAcceptImagePaste;
-		this.contentValuePromptsAcceptImagePaste = true;
+		// ...unless the declared scope says this content is destined for a PATH,
+		// which happens when a {{TEMPLATE:}} include is spliced into a file name
+		// or folder and rendered through its own formatter.
+		this.contentValuePromptsAcceptImagePaste = !isPathScope(this.promptScope);
 		try {
 			output = await this.format(output);
 		} finally {
@@ -1235,6 +1239,11 @@ export class CompleteFormatter extends Formatter {
 		// templates ({{TEMPLATE:...}}), which render via this child engine's own
 		// formatter.
 		childEngine.setTargetFolderPath(this.targetFolderPath);
+		// An include spliced into a path is part of that path: keep the caller's
+		// scope so its prompts do not claim to be asking for note content.
+		if (this.promptScope !== "generic") {
+			childEngine.setPromptScope(this.promptScope);
+		}
 		// Included templates prompt through the child's own formatter, so the run
 		// context has to travel with them or their prompts lose the choice name.
 		// The draft scope is narrowed to this template: the child raises its OWN

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -36,6 +36,11 @@ import { getActiveMarkdownEditorView } from "../utils/activeMarkdownEditor";
 import { log } from "../logger/logManager";
 import { Formatter, type PromptContext } from "./formatter";
 import {
+	buildPromptContextLine,
+	describeValuePrompt,
+	type PromptScopeKind,
+} from "./promptScope";
+import {
 	buildSectionSubpath,
 	extractHeadingsFromLines,
 } from "./helpers/sectionLink";
@@ -44,7 +49,6 @@ import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { isCancellationError } from "../utils/errorUtils";
 
 export class CompleteFormatter extends Formatter {
-	private valueHeader: string;
 	/**
 	 * True only while formatFileContent's format() pass runs. Value prompts
 	 * opened during that window accept clipboard-image paste; prompts opened
@@ -106,7 +110,15 @@ export class CompleteFormatter extends Formatter {
 		return output;
 	}
 
-	async formatFileName(input: string, valueHeader: string): Promise<string> {
+	/**
+	 * Formats a file path. `scope` says WHAT the path is, so a `{{VALUE}}` inside
+	 * it can name itself at prompt time (issue #1546): the same entry point
+	 * produces Template note titles, Capture targets and a macro's file-to-open.
+	 */
+	async formatFileName(
+		input: string,
+		scope: PromptScopeKind = "generic",
+	): Promise<string> {
 		// Check for {{title}} usage in filename which would cause infinite recursion
 		if (/\{\{title\}\}/i.test(input)) {
 			throw new Error(
@@ -114,8 +126,9 @@ export class CompleteFormatter extends Formatter {
 			);
 		}
 
-		this.valueHeader = valueHeader;
-		let output = await this.format(input);
+		let output = await this.withPromptScope(scope, input, () =>
+			this.format(input),
+		);
 		// A {{title}} produced AFTER the raw-input check — by an expanded global
 		// snippet ({{GLOBAL_VAR:x}} -> {{title}}) or a {{VALUE}} that resolved to
 		// the literal text "{{title}}" — would otherwise survive into the file name
@@ -183,7 +196,9 @@ export class CompleteFormatter extends Formatter {
 			);
 		}
 
-		const formatted = await this.format(folderName);
+		const formatted = await this.withPromptScope("folder", folderName, () =>
+			this.format(folderName),
+		);
 		// As in formatFileName: a {{title}} injected by a global snippet or a
 		// {{VALUE}} resolving to "{{title}}" slips past the raw-input check above,
 		// then the folder-only token pass would leave it literal in the path.
@@ -259,21 +274,25 @@ export class CompleteFormatter extends Formatter {
 		// Path-safe replacers, mirroring the tail of format() (completeFormatter
 		// .format) MINUS macros, inline JS, and {{TEMPLATE:}} inclusion. Keep this
 		// list in sync with format() when adding a path-safe token.
-		output = this.replaceDateInString(output);
-		output = this.replaceTimeInString(output);
-		output = await this.replaceValueInString(output);
-		output = await this.replaceSelectedInString(output);
-		output = await this.replaceClipboardInString(output);
-		output = await this.replaceDateVariableInString(output);
-		output = await this.replaceVariableInString(output);
-		output = await this.replaceFieldVarInString(output);
-		// {{FILE:...}} is path-safe (lists files + a picker, runs no code) and is
-		// collected from the template path by preflight (scanTemplateSource), so it
-		// MUST resolve here too or a `Templates/{{FILE:...|path}}` source path would
-		// prompt up front and then fail to resolve at runtime.
-		output = await this.replaceFileInString(output);
-		output = await this.replaceMathValueInString(output);
-		output = this.replaceRandomInString(output);
+		// Scoped on the ORIGINAL input: prompts opened here are filling in the
+		// template's source path, not the note being created.
+		output = await this.withPromptScope("templatePath", input, async () => {
+			let scoped = this.replaceDateInString(output);
+			scoped = this.replaceTimeInString(scoped);
+			scoped = await this.replaceValueInString(scoped);
+			scoped = await this.replaceSelectedInString(scoped);
+			scoped = await this.replaceClipboardInString(scoped);
+			scoped = await this.replaceDateVariableInString(scoped);
+			scoped = await this.replaceVariableInString(scoped);
+			scoped = await this.replaceFieldVarInString(scoped);
+			// {{FILE:...}} is path-safe (lists files + a picker, runs no code) and
+			// is collected from the template path by preflight (scanTemplateSource),
+			// so it MUST resolve here too or a `Templates/{{FILE:...|path}}` source
+			// path would prompt up front and then fail to resolve at runtime.
+			scoped = await this.replaceFileInString(scoped);
+			scoped = await this.replaceMathValueInString(scoped);
+			return this.replaceRandomInString(scoped);
+		});
 
 		// Trim so the suffix the engine reads for the extension matches the path
 		// getTemplateFile ultimately resolves (which trims) — otherwise a token
@@ -288,7 +307,9 @@ export class CompleteFormatter extends Formatter {
 	 * so selectors can reference {{linkcurrent}} and {{title}} consistently.
 	 */
 	protected async formatLocationString(input: string): Promise<string> {
-		let output = await this.format(input);
+		let output = await this.withPromptScope("lineTarget", input, () =>
+			this.format(input),
+		);
 		// Links + {{filenamecurrent}} + {{title}} in one pass so no token re-scans
 		// another's output (#1358). {{FOLDER}} and {{FOLDERCURRENT}} are
 		// deliberately left literal in location selectors (insert-after/before
@@ -432,6 +453,34 @@ export class CompleteFormatter extends Formatter {
 		}
 	}
 
+	/**
+	 * The anonymous `{{VALUE}}` prompt. Its title, placeholder and context line
+	 * come from the scope the caller declared for the string being formatted, so
+	 * a Template's title prompt and a Capture's text prompt stop looking
+	 * identical (issue #1546). The derived title is used ONLY when the answer is
+	 * the whole string; otherwise the choice name stays the title and only the
+	 * placeholder names the field, because "Note title" over a format of
+	 * `{{DATE:YYYY-MM-DD}} {{VALUE}}` would invite the user to retype the date.
+	 */
+	private describeAnonymousValuePrompt(): {
+		title: string;
+		placeholder?: string;
+		contextLine?: string;
+	} {
+		const derived = describeValuePrompt(
+			this.promptScope,
+			this.promptScopeSoleValue,
+		);
+		const title =
+			derived.title ??
+			(this.promptRunContext?.choiceName?.trim() || "Enter value");
+		return {
+			title,
+			placeholder: derived.placeholder,
+			contextLine: buildPromptContextLine(this.promptRunContext, title),
+		};
+	}
+
 	protected async promptForValue(header?: string): Promise<string> {
 		if (this.value === undefined) {
 			if (this.shouldUseSelectionForValue()) {
@@ -459,8 +508,7 @@ export class CompleteFormatter extends Formatter {
 							["true", "false"],
 							["true", "false"],
 							this.valuePromptContext.description ??
-								this.valueHeader ??
-								"Choose value",
+								this.describeAnonymousValuePrompt().title,
 							false,
 						),
 					);
@@ -472,8 +520,7 @@ export class CompleteFormatter extends Formatter {
 						["true", "false"],
 						["true", "false"],
 						this.valuePromptContext.description ??
-							this.valueHeader ??
-							"Choose value",
+							this.describeAnonymousValuePrompt().title,
 						undefined,
 						this.valuePromptContext.optional
 							? { skippable: true }
@@ -487,12 +534,18 @@ export class CompleteFormatter extends Formatter {
 					throw error;
 				}
 			}
+			const prompt = this.describeAnonymousValuePrompt();
 			// Route to a remote interactive session (Raycast) when one is driving.
+			// PromptProvider has no context-line channel, so it is folded into the
+			// header - otherwise a remote run would come out of this change with
+			// LESS context than before (the header used to be the choice name).
 			const valueProvider = this.choiceExecutor?.promptProvider;
 			if (valueProvider) {
 				this.value = await valueProvider.inputPrompt(
-					this.valueHeader ?? "Enter value",
-					this.valuePromptContext?.placeholder,
+					prompt.contextLine
+						? `${prompt.title} (${prompt.contextLine})`
+						: prompt.title,
+					this.valuePromptContext?.placeholder ?? prompt.placeholder,
 					this.valuePromptContext?.defaultValue,
 				);
 				return this.value;
@@ -506,12 +559,15 @@ export class CompleteFormatter extends Formatter {
 				const description = this.valuePromptContext?.description;
 				const promptOptions = this.buildInputPromptOptions(
 					this.valuePromptContext,
+					prompt.contextLine,
 				);
+				const placeholder =
+					this.valuePromptContext?.placeholder ?? prompt.placeholder;
 				if (linkSourcePath) {
 					this.value = await promptFactory.PromptWithContext(
 						this.app,
-						this.valueHeader ?? `Enter value`,
-						undefined,
+						prompt.title,
+						placeholder,
 						defaultValue,
 						linkSourcePath,
 						description,
@@ -520,8 +576,8 @@ export class CompleteFormatter extends Formatter {
 				} else {
 					this.value = await promptFactory.Prompt(
 						this.app,
-						this.valueHeader ?? `Enter value`,
-						undefined,
+						prompt.title,
+						placeholder,
 						defaultValue,
 						description,
 						promptOptions,
@@ -569,6 +625,7 @@ export class CompleteFormatter extends Formatter {
 
 	private buildInputPromptOptions(
 		context: PromptContext | undefined,
+		contextLine?: string,
 	): InputPromptOptions | undefined {
 		// Image paste only for free-text prompts opened while formatting note
 		// CONTENT — never for number/slider (numeric sinks) and never during
@@ -580,11 +637,14 @@ export class CompleteFormatter extends Formatter {
 			context?.inputTypeOverride !== "slider"
 				? { sourcePath: this.getLinkSourcePath() ?? "" }
 				: undefined;
+		const draftScopeId = this.promptRunContext?.draftScopeId;
 		if (
 			!context?.optional &&
 			!context?.numericConfig &&
 			!context?.sliderConfig &&
-			!imagePaste
+			!imagePaste &&
+			!contextLine &&
+			!draftScopeId
 		) {
 			return undefined;
 		}
@@ -593,6 +653,8 @@ export class CompleteFormatter extends Formatter {
 			numeric: context?.numericConfig,
 			slider: context?.sliderConfig,
 			imagePaste,
+			contextLine,
+			draftScopeId,
 		};
 	}
 
@@ -635,6 +697,15 @@ export class CompleteFormatter extends Formatter {
 			header ? `{{VALUE:${header}}}` : "a template variable",
 		);
 		try {
+			// Named prompts already title themselves with the variable name, so they
+			// only gain the run context: which choice is asking, and where the
+			// answer lands (issue #1546).
+			const variableTitle = header ?? context?.label ?? "Enter value";
+			const namedContextLine = buildPromptContextLine(
+				this.promptRunContext,
+				variableTitle,
+			);
+
 			// Use VDateInputPrompt for VDATE variables
 			if (context?.type === "VDATE") {
 				return await VDateInputPrompt.Prompt(
@@ -645,7 +716,11 @@ export class CompleteFormatter extends Formatter {
 						: "Enter a date (e.g., 'tomorrow', 'next friday', '2025-12-25')",
 					context.defaultValue,
 					context.dateFormat ?? "YYYY-MM-DD",
-					context.optional ? { optional: true } : undefined,
+					{
+						optional: context.optional,
+						contextLine: namedContextLine,
+						draftScopeId: this.promptRunContext?.draftScopeId,
+					},
 					context.withTime,
 				);
 			}
@@ -668,12 +743,12 @@ export class CompleteFormatter extends Formatter {
 			// Use default prompt for other variables
 			return await new InputPrompt().factory(context?.inputTypeOverride).Prompt(
 				this.app,
-				header ?? context?.label ?? "Enter value",
+				variableTitle,
 				context?.placeholder ??
 					(context?.defaultValue ? context.defaultValue : undefined),
 				context?.defaultValue,
 				context?.description,
-				this.buildInputPromptOptions(context),
+				this.buildInputPromptOptions(context, namedContextLine),
 			);
 		} catch (error) {
 			if (isCancellationError(error)) {
@@ -1143,6 +1218,17 @@ export class CompleteFormatter extends Formatter {
 		// templates ({{TEMPLATE:...}}), which render via this child engine's own
 		// formatter.
 		childEngine.setTargetFolderPath(this.targetFolderPath);
+		// Included templates prompt through the child's own formatter, so the run
+		// context has to travel with them or their prompts lose the choice name.
+		// The draft scope is narrowed to this template: the child raises its OWN
+		// {{VALUE}} prompt in the same run, and sharing the parent's draft key
+		// would open it pre-filled with the parent's answer.
+		if (this.promptRunContext) {
+			childEngine.setPromptRunContext({
+				...this.promptRunContext,
+				draftScopeId: `${this.promptRunContext.draftScopeId ?? ""}#${templatePath}`,
+			});
+		}
 		const content = await childEngine.run();
 		this.mergeTemplatePropertyVars(
 			childEngine.getAndClearTemplatePropertyVars(),

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -39,6 +39,7 @@ import {
 	buildPromptContextLine,
 	describeValuePrompt,
 	isPathScope,
+	scopeShowsDestination,
 	type PromptScopeKind,
 } from "./promptScope";
 import {
@@ -479,12 +480,16 @@ export class CompleteFormatter extends Formatter {
 		const title =
 			derived.title ??
 			(this.promptRunContext?.choiceName?.trim() || "Enter value");
+		const showDestination = scopeShowsDestination(this.promptScope);
 		return {
 			title,
 			placeholder: derived.placeholder,
-			contextLine: buildPromptContextLine(this.promptRunContext, title),
+			contextLine: buildPromptContextLine(this.promptRunContext, title, {
+				showDestination,
+			}),
 			contextLineFull: buildPromptContextLine(this.promptRunContext, title, {
 				elide: false,
+				showDestination,
 			}),
 		};
 	}
@@ -712,14 +717,16 @@ export class CompleteFormatter extends Formatter {
 			// only gain the run context: which choice is asking, and where the
 			// answer lands (issue #1546).
 			const variableTitle = header ?? context?.label ?? "Enter value";
+			const showDestination = scopeShowsDestination(this.promptScope);
 			const namedContextLine = buildPromptContextLine(
 				this.promptRunContext,
 				variableTitle,
+				{ showDestination },
 			);
 			const namedContextLineFull = buildPromptContextLine(
 				this.promptRunContext,
 				variableTitle,
-				{ elide: false },
+				{ elide: false, showDestination },
 			);
 
 			// Use VDateInputPrompt for VDATE variables

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -29,6 +29,11 @@ import {
 	parseFileToken,
 } from "../utils/fileSyntax";
 import { renderStoredFileValue } from "./helpers/fileTokenRendering";
+import {
+	valueAnswersWholeScope,
+	type PromptRunContext,
+	type PromptScopeKind,
+} from "./promptScope";
 import { getDate } from "../utilityObsidian";
 import type { IDateParser } from "../parsers/IDateParser";
 import { log } from "../logger/logManager";
@@ -149,6 +154,18 @@ export abstract class Formatter {
 	protected targetFolderPath: string | null = null;
 	protected valuePromptContext?: PromptContext;
 	protected templateInclusion?: TemplateInclusionState;
+	/**
+	 * What the string currently being formatted becomes, so a prompt can say what
+	 * it is asking for (issue #1546). DECLARED by the caller via
+	 * {@link withPromptScope} rather than inferred from which `format*` method
+	 * ran: `formatFileContent` is shared by template bodies, capture bodies, the
+	 * script API and the AI agent.
+	 */
+	protected promptScope: PromptScopeKind = "generic";
+	/** Whether an anonymous {{VALUE}} answers the whole of what the scope names. */
+	protected promptScopeSoleValue = false;
+	/** Which choice is asking and, once known, where the answer lands. */
+	protected promptRunContext?: PromptRunContext;
 
 	// Tracks variables collected for YAML property post-processing
 	private readonly propertyCollector: TemplatePropertyCollector;
@@ -169,6 +186,42 @@ export abstract class Formatter {
 
 	public setTemplateInclusionState(state: TemplateInclusionState): void {
 		this.templateInclusion = state;
+	}
+
+	/**
+	 * Merges into the run context describing which choice is asking and where its
+	 * output lands. Engines call this at run start with the choice, then again
+	 * with `destination` as soon as the target resolves.
+	 */
+	public setPromptRunContext(context: PromptRunContext): void {
+		this.promptRunContext = { ...this.promptRunContext, ...context };
+	}
+
+	public getPromptRunContext(): PromptRunContext | undefined {
+		return this.promptRunContext;
+	}
+
+	/**
+	 * Runs `fn` with the prompt scope set to what `input` will become. Restored in
+	 * a `finally` so a throwing pass cannot leak its scope into the next one -
+	 * exactly the bug the sticky `valueHeader` this replaces used to have, where
+	 * a Capture's file-name pass silently retitled its body prompt.
+	 */
+	public async withPromptScope<T>(
+		scope: PromptScopeKind,
+		input: string,
+		fn: () => Promise<T>,
+	): Promise<T> {
+		const previousScope = this.promptScope;
+		const previousSoleValue = this.promptScopeSoleValue;
+		this.promptScope = scope;
+		this.promptScopeSoleValue = valueAnswersWholeScope(scope, input);
+		try {
+			return await fn();
+		} finally {
+			this.promptScope = previousScope;
+			this.promptScopeSoleValue = previousSoleValue;
+		}
 	}
 
 	/** Returns true when a variable is present AND its value is not undefined.

--- a/src/formatters/promptScope.test.ts
+++ b/src/formatters/promptScope.test.ts
@@ -117,6 +117,11 @@ describe("elideMiddlePath", () => {
 		expect(elideMiddlePath(long)).toBe("Work/…/Weekly standup notes.md");
 	});
 
+	it("keeps the file name when there is only one folder to drop", () => {
+		const long = `Some Very Long Folder Name Indeed/${"n".repeat(20)}.md`;
+		expect(elideMiddlePath(long)).toBe(`…/${"n".repeat(20)}.md`);
+	});
+
 	it("does not mangle a long single segment", () => {
 		const long = `${"a".repeat(60)}.md`;
 		expect(elideMiddlePath(long)).toBe(long);

--- a/src/formatters/promptScope.test.ts
+++ b/src/formatters/promptScope.test.ts
@@ -159,3 +159,22 @@ describe("buildPromptContextLine", () => {
 		).toBeUndefined();
 	});
 });
+
+describe("buildPromptContextLine tooltip form", () => {
+	it("can render the destination un-elided for the hover tooltip", () => {
+		const context = {
+			choiceName: "Note to self",
+			destination: "Work/Clients/Acme/Meetings/2026/Weekly standup notes.md",
+			destinationKind: "file" as const,
+		};
+
+		expect(buildPromptContextLine(context, "Text to capture")).toBe(
+			"Note to self → Work/…/Weekly standup notes.md",
+		);
+		expect(
+			buildPromptContextLine(context, "Text to capture", { elide: false }),
+		).toBe(
+			"Note to self → Work/Clients/Acme/Meetings/2026/Weekly standup notes.md",
+		);
+	});
+});

--- a/src/formatters/promptScope.test.ts
+++ b/src/formatters/promptScope.test.ts
@@ -5,6 +5,7 @@ import {
 	elideMiddlePath,
 	isOnlyValueToken,
 	isSoleValueToken,
+	scopeShowsDestination,
 	valueAnswersWholeScope,
 } from "./promptScope";
 
@@ -164,6 +165,25 @@ describe("buildPromptContextLine", () => {
 		expect(
 			buildPromptContextLine({ choiceName: "Add book" }, "Add book"),
 		).toBeUndefined();
+	});
+});
+
+describe("scopeShowsDestination", () => {
+	it("withholds the destination where the answer does not land there", () => {
+		expect(scopeShowsDestination("templatePath")).toBe(false);
+		expect(scopeShowsDestination("generic")).toBe(false);
+		expect(scopeShowsDestination("noteTitle")).toBe(true);
+		expect(scopeShowsDestination("captureText")).toBe(true);
+	});
+
+	it("drops the destination from the line when withheld", () => {
+		expect(
+			buildPromptContextLine(
+				{ choiceName: "Book note", destination: "Inbox/Draft.md" },
+				"Template",
+				{ showDestination: false },
+			),
+		).toBe("Book note");
 	});
 });
 

--- a/src/formatters/promptScope.test.ts
+++ b/src/formatters/promptScope.test.ts
@@ -70,7 +70,14 @@ describe("valueAnswersWholeScope", () => {
 		expect(valueAnswersWholeScope("noteTitle", "{{VALUE}}")).toBe(true);
 	});
 
-	it("is relaxed for content: a task prefix is decoration, not input", () => {
+	it("is strict for a template body: its literals ARE the note", () => {
+		// One token, but the ask is a client name, not the note's content.
+		const body = "---\nclient: {{VALUE}}\n---\n# Onboarding checklist\n";
+		expect(valueAnswersWholeScope("noteBody", body)).toBe(false);
+		expect(valueAnswersWholeScope("noteBody", "{{VALUE}}")).toBe(true);
+	});
+
+	it("is relaxed for a capture format: a task prefix is decoration, not input", () => {
 		// The "Add to task list" toggle rewrites the format to `- [ ] {{VALUE}}`;
 		// the ask is still exactly "the text to capture".
 		expect(valueAnswersWholeScope("captureText", "- [ ] {{value}}\n")).toBe(

--- a/src/formatters/promptScope.test.ts
+++ b/src/formatters/promptScope.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildPromptContextLine,
+	describeValuePrompt,
+	elideMiddlePath,
+	isOnlyValueToken,
+	isSoleValueToken,
+	valueAnswersWholeScope,
+} from "./promptScope";
+
+/**
+ * Copy rules for runtime prompts (issue #1546). The contract these tests pin is
+ * "never assert something the configuration does not support": a derived TITLE
+ * is only allowed when the user's answer really is the whole of what the scope
+ * names.
+ */
+describe("isSoleValueToken", () => {
+	it.each([
+		"{{VALUE}}",
+		"{{value}}",
+		"{{NAME}}",
+		"  {{VALUE}}  ",
+		"{{VALUE|optional}}",
+		"{{VALUE|type:number|min:1}}",
+		"{{value}}\n",
+	])("accepts %j", (input) => {
+		expect(isSoleValueToken(input)).toBe(true);
+	});
+
+	it.each([
+		"{{VALUE:name}}",
+		"{{DATE:YYYY-MM-DD}} {{VALUE}}",
+		"- [ ] {{VALUE}}",
+		"Daily/{{VALUE}}.md",
+		"{{VALUE}} {{VALUE}}",
+		"",
+		"literal",
+	])("rejects %j", (input) => {
+		expect(isSoleValueToken(input)).toBe(false);
+	});
+});
+
+describe("isOnlyValueToken", () => {
+	it("allows literal decoration around the token", () => {
+		expect(isOnlyValueToken("- [ ] {{VALUE}}\n")).toBe(true);
+		expect(isOnlyValueToken("- {{VALUE}} #inbox")).toBe(true);
+		expect(isOnlyValueToken("{{VALUE}} {{VALUE}}")).toBe(true);
+	});
+
+	it("rejects strings carrying another token", () => {
+		expect(isOnlyValueToken("{{DATE:YYYY-MM-DD}} {{VALUE}}")).toBe(false);
+		expect(isOnlyValueToken("{{VALUE}} {{VALUE:author}}")).toBe(false);
+	});
+
+	it("rejects strings with no anonymous VALUE at all", () => {
+		expect(isOnlyValueToken("plain text")).toBe(false);
+		expect(isOnlyValueToken("{{VALUE:author}}")).toBe(false);
+	});
+});
+
+describe("valueAnswersWholeScope", () => {
+	it("is strict for paths: their literals are part of the answer", () => {
+		// "Capture target" over `Daily/{{VALUE}}.md` would invite a full path.
+		expect(valueAnswersWholeScope("captureTarget", "Daily/{{VALUE}}.md")).toBe(
+			false,
+		);
+		expect(valueAnswersWholeScope("noteTitle", "{{DATE}} {{VALUE}}")).toBe(
+			false,
+		);
+		expect(valueAnswersWholeScope("noteTitle", "{{VALUE}}")).toBe(true);
+	});
+
+	it("is relaxed for content: a task prefix is decoration, not input", () => {
+		// The "Add to task list" toggle rewrites the format to `- [ ] {{VALUE}}`;
+		// the ask is still exactly "the text to capture".
+		expect(valueAnswersWholeScope("captureText", "- [ ] {{value}}\n")).toBe(
+			true,
+		);
+		expect(valueAnswersWholeScope("captureText", "{{DATE}} {{VALUE}}")).toBe(
+			false,
+		);
+	});
+});
+
+describe("describeValuePrompt", () => {
+	it("only supplies a title when the answer is the whole thing", () => {
+		expect(describeValuePrompt("noteTitle", true)).toEqual({
+			title: "Note title",
+			placeholder: "Title for the new note",
+		});
+		expect(describeValuePrompt("noteTitle", false)).toEqual({
+			placeholder: "Part of the new note's title",
+		});
+	});
+
+	it("asserts nothing for the generic scope", () => {
+		expect(describeValuePrompt("generic", true)).toEqual({});
+		expect(describeValuePrompt("generic", false)).toEqual({});
+	});
+});
+
+describe("elideMiddlePath", () => {
+	it("leaves short paths alone", () => {
+		expect(elideMiddlePath("Daily/2026-07-26.md")).toBe("Daily/2026-07-26.md");
+	});
+
+	it("keeps the file name when eliding the middle", () => {
+		const long = "Work/Clients/Acme/Meetings/2026/Weekly standup notes.md";
+		expect(elideMiddlePath(long)).toBe("Work/…/Weekly standup notes.md");
+	});
+
+	it("does not mangle a long single segment", () => {
+		const long = `${"a".repeat(60)}.md`;
+		expect(elideMiddlePath(long)).toBe(long);
+	});
+});
+
+describe("buildPromptContextLine", () => {
+	it("pairs the choice name with the destination", () => {
+		expect(
+			buildPromptContextLine(
+				{
+					choiceName: "New capture",
+					destination: "Daily/2026-07-26.md",
+					destinationKind: "file",
+				},
+				"Text to capture",
+			),
+		).toBe("New capture → Daily/2026-07-26.md");
+	});
+
+	it("marks a folder destination with a trailing slash", () => {
+		expect(
+			buildPromptContextLine(
+				{
+					choiceName: "New template",
+					destination: "Books",
+					destinationKind: "folder",
+				},
+				"Note title",
+			),
+		).toBe("New template → Books/");
+	});
+
+	it("never repeats the choice name when it is already the title", () => {
+		expect(
+			buildPromptContextLine(
+				{ choiceName: "Add book", destination: "Books/Dune.md" },
+				"Add book",
+			),
+		).toBe("→ Books/Dune.md");
+	});
+
+	it("says nothing when there is nothing true to say", () => {
+		expect(buildPromptContextLine(undefined, "Note title")).toBeUndefined();
+		expect(buildPromptContextLine({}, "Note title")).toBeUndefined();
+		expect(
+			buildPromptContextLine({ choiceName: "Add book" }, "Add book"),
+		).toBeUndefined();
+	});
+});

--- a/src/formatters/promptScope.ts
+++ b/src/formatters/promptScope.ts
@@ -186,6 +186,15 @@ export function isPathScope(scope: PromptScopeKind): boolean {
 	);
 }
 
+/**
+ * Whether the context line may name a destination for this scope. A prompt
+ * inside a template SOURCE path chooses which template file to READ, so the
+ * note being written is not where that answer lands; `generic` knows nothing.
+ */
+export function scopeShowsDestination(scope: PromptScopeKind): boolean {
+	return scope !== "templatePath" && scope !== "generic";
+}
+
 export interface ValuePromptCopy {
 	/** Modal title, or undefined to keep the caller's fallback. */
 	title?: string;
@@ -239,7 +248,7 @@ export function elideMiddlePath(path: string, maxLength = 44): string {
 export function buildPromptContextLine(
 	context: PromptRunContext | undefined,
 	title: string | undefined,
-	options?: { elide?: boolean },
+	options?: { elide?: boolean; showDestination?: boolean },
 ): string | undefined {
 	if (!context) return undefined;
 
@@ -248,7 +257,8 @@ export function buildPromptContextLine(
 	// Omitted when it is already the title, so the name is never printed twice.
 	if (name && name !== title?.trim()) parts.push(name);
 
-	const destination = context.destination?.trim();
+	const destination =
+		options?.showDestination === false ? undefined : context.destination?.trim();
 	if (destination) {
 		const shown =
 			options?.elide === false ? destination : elideMiddlePath(destination);

--- a/src/formatters/promptScope.ts
+++ b/src/formatters/promptScope.ts
@@ -229,10 +229,19 @@ export function elideMiddlePath(path: string, maxLength = 44): string {
 	if (path.length <= maxLength) return path;
 
 	const segments = path.split("/");
-	if (segments.length <= 2) return path;
+	// Nothing to elide: a single over-long segment IS the file name, and mangling
+	// it would make it read as a different file.
+	if (segments.length === 1) return path;
+
+	const last = segments[segments.length - 1];
+	// One folder: dropping it is the only elision available, and the file name is
+	// the half worth keeping.
+	if (segments.length === 2) {
+		const elided = `${ELIDE_MARKER}/${last}`;
+		return elided.length < path.length ? elided : path;
+	}
 
 	const first = segments[0];
-	const last = segments[segments.length - 1];
 	const elided = `${first}/${ELIDE_MARKER}/${last}`;
 	// Dropping every middle folder is the shortest form this can take; if even
 	// that overflows, the CSS ellipsis handles the rest rather than mangling the

--- a/src/formatters/promptScope.ts
+++ b/src/formatters/promptScope.ts
@@ -1,0 +1,240 @@
+import { NAME_VALUE_REGEX } from "../constants";
+
+/**
+ * What the string currently being formatted will BECOME once the user answers.
+ *
+ * A runtime prompt is a question with no question text: the modal shows the
+ * choice's name and an empty box, so a Template's title prompt and a Capture's
+ * text prompt are indistinguishable (issue #1546). The scope is what lets a
+ * prompt say what it is asking for.
+ *
+ * The scope is DECLARED by the caller, never inferred from which `format*`
+ * method ran: `formatFileContent` is shared by template bodies, capture bodies,
+ * `quickAddApi.format` and the AI agent, so a capture-specific label derived
+ * from the method would be a lie in three of those four cases.
+ */
+export type PromptScopeKind =
+	| "noteTitle"
+	| "captureTarget"
+	| "captureText"
+	| "noteBody"
+	| "folder"
+	| "templatePath"
+	| "lineTarget"
+	| "filePath"
+	| "generic";
+
+/**
+ * Where the answer to a prompt ends up, when the engine already knows it.
+ * `destination` is a vault-relative path; `destinationKind` says whether it
+ * names a file or the folder a file is about to be created in.
+ */
+export interface PromptRunContext {
+	choiceName?: string;
+	/**
+	 * Identity of the PROMPT SITE for input-draft keys. Usually the choice id,
+	 * but an included `{{TEMPLATE:...}}` renders through its own formatter and
+	 * raises its own `{{VALUE}}` prompt, so it must not share the parent's key -
+	 * otherwise the second prompt of one run opens pre-filled with the first's
+	 * answer. Must be stable ACROSS runs (draft recovery after a cancel depends
+	 * on it), so it can never be a per-run value such as a fresh uuid.
+	 */
+	draftScopeId?: string;
+	destination?: string;
+	destinationKind?: "file" | "folder";
+}
+
+interface ScopeCopy {
+	/**
+	 * Modal title, used ONLY when the answer is provably the whole of what the
+	 * scope names (see {@link valueAnswersWholeScope}).
+	 */
+	ask: string;
+	/** Input placeholder for that same whole-answer case. */
+	hint: string;
+	/**
+	 * Input placeholder when the answer is only part of the result. Phrased so it
+	 * stays true for e.g. a file name format of `{{DATE:YYYY-MM-DD}} {{VALUE}}`,
+	 * where a title of "Note title" would invite the user to retype the date.
+	 */
+	partOf: string;
+}
+
+/**
+ * Scopes whose surrounding literal text is CONTENT FORMATTING rather than part
+ * of the answer. A capture format of `- [ ] {{VALUE}}` still asks for exactly
+ * "the text to capture" - the checkbox prefix is decoration nobody types. A
+ * PATH is the opposite: in `Daily/{{VALUE}}.md` the literals are part of the
+ * path, so claiming to ask for "the capture target" would over-promise.
+ */
+const FORMATTING_LITERAL_SCOPES: ReadonlySet<PromptScopeKind> = new Set([
+	"captureText",
+	"noteBody",
+]);
+
+const SCOPE_COPY: Record<Exclude<PromptScopeKind, "generic">, ScopeCopy> = {
+	noteTitle: {
+		ask: "Note title",
+		hint: "Title for the new note",
+		partOf: "Part of the new note's title",
+	},
+	captureTarget: {
+		// "Capture to" also accepts `property:`, `#tag` and `folder:` filters that
+		// drive a note picker, so the copy deliberately says "destination" rather
+		// than "path" or "note".
+		ask: "Capture target",
+		hint: "Where to capture to",
+		partOf: "Part of the capture destination",
+	},
+	captureText: {
+		ask: "Text to capture",
+		hint: "Text to add to the note",
+		partOf: "Part of the text added to the note",
+	},
+	noteBody: {
+		ask: "Note content",
+		hint: "Text inserted into the note",
+		partOf: "Part of the text inserted into the note",
+	},
+	folder: {
+		ask: "Folder",
+		hint: "Folder for the new note",
+		partOf: "Part of the folder path",
+	},
+	templatePath: {
+		ask: "Template",
+		hint: "Path to the template file",
+		partOf: "Part of the template path",
+	},
+	lineTarget: {
+		// The answer is an ANCHOR that is searched for, not the text that gets
+		// written, so both strings say "find" (and neither promises where exactly
+		// the capture lands, which depends on insert-before / insert-at-end).
+		ask: "Line to find",
+		hint: "Existing line to anchor the capture to",
+		partOf: "Part of the line to find",
+	},
+	filePath: {
+		ask: "File to open",
+		hint: "Path to the file to open",
+		partOf: "Part of the file path",
+	},
+};
+
+// Anchored copy of NAME_VALUE_REGEX: `{{VALUE}}` / `{{NAME}}` with optional
+// `|options`, and nothing else. Built from the shared source so the two can
+// never drift.
+const SOLE_VALUE_TOKEN_REGEX = new RegExp(
+	`^(?:${NAME_VALUE_REGEX.source})$`,
+	"i",
+);
+
+// Any remaining `{{...}}` token once the anonymous VALUE tokens are removed.
+const ANONYMOUS_VALUE_TOKEN_REGEX = new RegExp(NAME_VALUE_REGEX.source, "gi");
+const ANY_TOKEN_REGEX = /\{\{[^}\n\r]*\}\}/;
+
+/**
+ * True when the string being formatted is nothing but one anonymous
+ * `{{VALUE}}`/`{{NAME}}` token, i.e. the user's answer becomes the entire
+ * result verbatim.
+ */
+export function isSoleValueToken(input: string): boolean {
+	return SOLE_VALUE_TOKEN_REGEX.test(input.trim());
+}
+
+/**
+ * True when the anonymous `{{VALUE}}` is the only TOKEN in the string, i.e. the
+ * user's answer is the only thing the result varies by. Literal text may
+ * surround it.
+ */
+export function isOnlyValueToken(input: string): boolean {
+	const withoutValue = input.replace(ANONYMOUS_VALUE_TOKEN_REGEX, "");
+	if (withoutValue === input) return false;
+	return !ANY_TOKEN_REGEX.test(withoutValue);
+}
+
+/**
+ * Whether a prompt for the anonymous `{{VALUE}}` may claim to be asking for the
+ * whole of what its scope names. Paths demand the strict rule (their literals
+ * are part of the answer's meaning); content scopes tolerate literal decoration.
+ */
+export function valueAnswersWholeScope(
+	scope: PromptScopeKind,
+	input: string,
+): boolean {
+	return FORMATTING_LITERAL_SCOPES.has(scope)
+		? isOnlyValueToken(input)
+		: isSoleValueToken(input);
+}
+
+export interface ValuePromptCopy {
+	/** Modal title, or undefined to keep the caller's fallback. */
+	title?: string;
+	/** Input placeholder, or undefined for none. */
+	placeholder?: string;
+}
+
+/**
+ * Copy for the anonymous `{{VALUE}}` prompt. Named tokens ({{VALUE:x}},
+ * {{FIELD:}}, {{VDATE:}}) already title themselves with their own name and are
+ * deliberately untouched.
+ */
+export function describeValuePrompt(
+	scope: PromptScopeKind,
+	soleValue: boolean,
+): ValuePromptCopy {
+	if (scope === "generic") return {};
+	const copy = SCOPE_COPY[scope];
+	return soleValue
+		? { title: copy.ask, placeholder: copy.hint }
+		: { placeholder: copy.partOf };
+}
+
+const ELIDE_MARKER = "…";
+
+/**
+ * Shortens a vault path for the one-line context bar by eliding the MIDDLE
+ * folders, so the file name (the part that identifies the destination) always
+ * survives. CSS end-ellipsis would truncate exactly the useful half.
+ */
+export function elideMiddlePath(path: string, maxLength = 44): string {
+	if (path.length <= maxLength) return path;
+
+	const segments = path.split("/");
+	if (segments.length <= 2) return path;
+
+	const first = segments[0];
+	const last = segments[segments.length - 1];
+	const elided = `${first}/${ELIDE_MARKER}/${last}`;
+	// Dropping every middle folder is the shortest form this can take; if even
+	// that overflows, the CSS ellipsis handles the rest rather than mangling the
+	// name into something that looks like a different file.
+	return elided.length < path.length ? elided : path;
+}
+
+/**
+ * The muted line under the modal title: which choice is asking, and where the
+ * answer lands. Returns undefined when there is nothing true to say, and omits
+ * the choice name when it is already the title (so it is never printed twice).
+ */
+export function buildPromptContextLine(
+	context: PromptRunContext | undefined,
+	title: string | undefined,
+): string | undefined {
+	if (!context) return undefined;
+
+	const parts: string[] = [];
+	const name = context.choiceName?.trim();
+	// Omitted when it is already the title, so the name is never printed twice.
+	if (name && name !== title?.trim()) parts.push(name);
+
+	const destination = context.destination?.trim();
+	if (destination) {
+		const shown = elideMiddlePath(destination);
+		parts.push(
+			`→ ${context.destinationKind === "folder" ? `${shown}/` : shown}`,
+		);
+	}
+
+	return parts.length ? parts.join(" ") : undefined;
+}

--- a/src/formatters/promptScope.ts
+++ b/src/formatters/promptScope.ts
@@ -62,14 +62,17 @@ interface ScopeCopy {
 
 /**
  * Scopes whose surrounding literal text is CONTENT FORMATTING rather than part
- * of the answer. A capture format of `- [ ] {{VALUE}}` still asks for exactly
- * "the text to capture" - the checkbox prefix is decoration nobody types. A
- * PATH is the opposite: in `Daily/{{VALUE}}.md` the literals are part of the
- * path, so claiming to ask for "the capture target" would over-promise.
+ * of the answer. A capture format is a one-line template: `- [ ] {{VALUE}}`
+ * still asks for exactly "the text to capture", because the checkbox prefix is
+ * decoration nobody types.
+ *
+ * Everything else uses the strict rule. A PATH's literals are part of the
+ * answer (`Daily/{{VALUE}}.md`), and so, in practice, are a template BODY's:
+ * a body of "---\nclient: {{VALUE}}\n---\n# Onboarding" has exactly one token
+ * but is asking for a client name, not for the note's content.
  */
 const FORMATTING_LITERAL_SCOPES: ReadonlySet<PromptScopeKind> = new Set([
 	"captureText",
-	"noteBody",
 ]);
 
 const SCOPE_COPY: Record<Exclude<PromptScopeKind, "generic">, ScopeCopy> = {
@@ -165,6 +168,22 @@ export function valueAnswersWholeScope(
 	return FORMATTING_LITERAL_SCOPES.has(scope)
 		? isOnlyValueToken(input)
 		: isSoleValueToken(input);
+}
+
+/**
+ * Whether a scope names a PATH. The preflight collector still needs the plain
+ * path/content boolean (it gates image paste and the template-scan memo key),
+ * so the two stay derived from one place.
+ */
+export function isPathScope(scope: PromptScopeKind): boolean {
+	return (
+		scope === "noteTitle" ||
+		scope === "captureTarget" ||
+		scope === "folder" ||
+		scope === "templatePath" ||
+		scope === "lineTarget" ||
+		scope === "filePath"
+	);
 }
 
 export interface ValuePromptCopy {

--- a/src/formatters/promptScope.ts
+++ b/src/formatters/promptScope.ts
@@ -220,6 +220,7 @@ export function elideMiddlePath(path: string, maxLength = 44): string {
 export function buildPromptContextLine(
 	context: PromptRunContext | undefined,
 	title: string | undefined,
+	options?: { elide?: boolean },
 ): string | undefined {
 	if (!context) return undefined;
 
@@ -230,7 +231,8 @@ export function buildPromptContextLine(
 
 	const destination = context.destination?.trim();
 	if (destination) {
-		const shown = elideMiddlePath(destination);
+		const shown =
+			options?.elide === false ? destination : elideMiddlePath(destination);
 		parts.push(
 			`→ ${context.destinationKind === "folder" ? `${shown}/` : shown}`,
 		);

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -126,7 +126,11 @@ export default class GenericInputPrompt extends Modal {
 		this.contentEl.empty();
 		this.titleEl.textContent = this.header;
 
-		renderPromptContextLine(this.contentEl, this.options?.contextLine);
+		renderPromptContextLine(
+			this.contentEl,
+			this.options?.contextLine,
+			this.options?.contextLineFull,
+		);
 
 		if (this.description) {
 			const descriptionEl = this.contentEl.createDiv({

--- a/src/gui/GenericInputPrompt/GenericInputPrompt.ts
+++ b/src/gui/GenericInputPrompt/GenericInputPrompt.ts
@@ -5,6 +5,7 @@ import { TagSuggester } from "../suggesters/tagSuggester";
 import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
 import type { InputPromptOptions } from "../../types/inputPrompt";
 import { positionInputPromptCursor } from "../inputPromptCursor";
+import { renderPromptContextLine } from "../promptContextLine";
 import type { ImagePasteHandle } from "../imagePasteHandler";
 import { attachImagePasteHandler } from "../imagePasteHandler";
 
@@ -97,6 +98,7 @@ export default class GenericInputPrompt extends Modal {
 			header: this.header,
 			placeholder: this.placeholder,
 			linkSourcePath: this.linkSourcePath,
+			scopeId: options?.draftScopeId,
 		});
 		this.input = this.draftHandler.hydrate(value ?? "");
 
@@ -123,6 +125,8 @@ export default class GenericInputPrompt extends Modal {
 		this.containerEl.addClass("quickAddModal", "qaInputPrompt");
 		this.contentEl.empty();
 		this.titleEl.textContent = this.header;
+
+		renderPromptContextLine(this.contentEl, this.options?.contextLine);
 
 		if (this.description) {
 			const descriptionEl = this.contentEl.createDiv({

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -111,7 +111,11 @@ export default class GenericWideInputPrompt extends Modal {
 		this.contentEl.empty();
 		this.titleEl.textContent = this.header;
 
-		renderPromptContextLine(this.contentEl, this.options?.contextLine);
+		renderPromptContextLine(
+			this.contentEl,
+			this.options?.contextLine,
+			this.options?.contextLineFull,
+		);
 
 		if (this.description) {
 			const descriptionEl = this.contentEl.createDiv({

--- a/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
+++ b/src/gui/GenericWideInputPrompt/GenericWideInputPrompt.ts
@@ -5,6 +5,7 @@ import { TagSuggester } from "../suggesters/tagSuggester";
 import { InputPromptDraftHandler } from "../../utils/InputPromptDraftHandler";
 import type { InputPromptOptions } from "../../types/inputPrompt";
 import { positionInputPromptCursor } from "../inputPromptCursor";
+import { renderPromptContextLine } from "../promptContextLine";
 import { attachTextareaIndent } from "../components/textareaIndent";
 import { isSkipPromptShortcut } from "../GenericInputPrompt/GenericInputPrompt";
 import type { ImagePasteHandle } from "../imagePasteHandler";
@@ -85,6 +86,7 @@ export default class GenericWideInputPrompt extends Modal {
 			header: this.header,
 			placeholder: this.placeholder,
 			linkSourcePath: this.linkSourcePath,
+			scopeId: options?.draftScopeId,
 		});
 		this.input = this.draftHandler.hydrate(value ?? "");
 
@@ -108,6 +110,8 @@ export default class GenericWideInputPrompt extends Modal {
 		this.containerEl.addClass("quickAddModal", "qaWideInputPrompt");
 		this.contentEl.empty();
 		this.titleEl.textContent = this.header;
+
+		renderPromptContextLine(this.contentEl, this.options?.contextLine);
 
 		if (this.description) {
 			const descriptionEl = this.contentEl.createDiv({

--- a/src/gui/promptContextLine.ts
+++ b/src/gui/promptContextLine.ts
@@ -1,0 +1,25 @@
+/**
+ * Renders the muted line under a prompt's title that says which choice is
+ * asking and where the answer lands (issue #1546). Shared by the input-prompt
+ * modals, which do not share a base class: `GenericWideInputPrompt` extends
+ * `Modal` directly and duplicates `display()`.
+ *
+ * The full text is mirrored into `title`/`aria-label` because the line is
+ * clipped to one row: a narrow (mobile) modal would otherwise hide the tail of
+ * a long destination path with no way to read it.
+ */
+export function renderPromptContextLine(
+	container: HTMLElement,
+	contextLine: string | undefined,
+): HTMLElement | undefined {
+	const text = contextLine?.trim();
+	if (!text) return undefined;
+
+	const el = container.createDiv({
+		text,
+		cls: "qa-prompt-context",
+	});
+	el.setAttr("title", text);
+	el.setAttr("aria-label", text);
+	return el;
+}

--- a/src/gui/promptContextLine.ts
+++ b/src/gui/promptContextLine.ts
@@ -4,13 +4,14 @@
  * modals, which do not share a base class: `GenericWideInputPrompt` extends
  * `Modal` directly and duplicates `display()`.
  *
- * The full text is mirrored into `title`/`aria-label` because the line is
- * clipped to one row: a narrow (mobile) modal would otherwise hide the tail of
- * a long destination path with no way to read it.
+ * `fullText` (the same line with the destination path un-elided) becomes the
+ * hover tooltip: the line is clipped to one row and long paths are shortened,
+ * so a narrow modal would otherwise leave no way to read the whole path.
  */
 export function renderPromptContextLine(
 	container: HTMLElement,
 	contextLine: string | undefined,
+	fullText?: string,
 ): HTMLElement | undefined {
 	const text = contextLine?.trim();
 	if (!text) return undefined;
@@ -19,7 +20,7 @@ export function renderPromptContextLine(
 		text,
 		cls: "qa-prompt-context",
 	});
-	el.setAttr("title", text);
-	el.setAttr("aria-label", text);
+	const tooltip = fullText?.trim() || text;
+	if (tooltip !== text) el.setAttr("title", tooltip);
 	return el;
 }

--- a/src/gui/promptContextLine.ts
+++ b/src/gui/promptContextLine.ts
@@ -20,7 +20,8 @@ export function renderPromptContextLine(
 		text,
 		cls: "qa-prompt-context",
 	});
-	const tooltip = fullText?.trim() || text;
-	if (tooltip !== text) el.setAttr("title", tooltip);
+	// Always set, not only when elision shortened it: a long choice name alone
+	// can overflow the line, and then the tooltip is the only way to read it.
+	el.setAttr("title", fullText?.trim() || text);
 	return el;
 }

--- a/src/preflight/RequirementCollector.ts
+++ b/src/preflight/RequirementCollector.ts
@@ -10,6 +10,11 @@ import {
 	VARIABLE_REGEX,
 } from "src/constants";
 import { Formatter, type PromptContext } from "src/formatters/formatter";
+import {
+	describeValuePrompt,
+	valueAnswersWholeScope,
+	type PromptScopeKind,
+} from "src/formatters/promptScope";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import type QuickAdd from "src/main";
 import { NLDParser } from "src/parsers/NLDParser";
@@ -119,11 +124,27 @@ export class RequirementCollector extends Formatter {
 	 * into FieldRequirement.pathContext (sticky across occurrences).
 	 */
 	private scanningPathContext = false;
+	/**
+	 * What the string being scanned becomes, so the batched one-page form labels
+	 * the anonymous {{VALUE}} field the same way the sequential prompt titles it
+	 * (issue #1546). Falls back to the path/content split when a caller only
+	 * knows that much.
+	 */
+	private scanningScope: PromptScopeKind = "generic";
+	private scanningSoleValue = false;
 
 	// Entry points -------------------------------------------------------------
-	public async scanString(input: string, pathContext = false): Promise<void> {
+	public async scanString(
+		input: string,
+		pathContext = false,
+		scope: PromptScopeKind = "generic",
+	): Promise<void> {
 		const previousContext = this.scanningPathContext;
+		const previousScope = this.scanningScope;
+		const previousSoleValue = this.scanningSoleValue;
 		this.scanningPathContext = pathContext;
+		this.scanningScope = scope;
+		this.scanningSoleValue = valueAnswersWholeScope(scope, input);
 		try {
 			// Expand global variables first so we can detect inner requirements
 			const expanded = await this.replaceGlobalVarInString(input);
@@ -150,6 +171,8 @@ export class RequirementCollector extends Formatter {
 			await this.format(expanded);
 		} finally {
 			this.scanningPathContext = previousContext;
+			this.scanningScope = previousScope;
+			this.scanningSoleValue = previousSoleValue;
 		}
 	}
 
@@ -429,9 +452,13 @@ export class RequirementCollector extends Formatter {
 				this.valuePromptContext?.inputTypeOverride === "number";
 			const isSlider =
 				this.valuePromptContext?.inputTypeOverride === "slider";
+			const derived = describeValuePrompt(
+				this.scanningScope,
+				this.scanningSoleValue,
+			);
 			this.requirements.set(key, {
 				id: key,
-				label: header || "Enter value",
+				label: derived.title || header || "Enter value",
 				type:
 					isCheckbox
 						? "dropdown"
@@ -444,6 +471,7 @@ export class RequirementCollector extends Formatter {
 						? "textarea"
 						: "text",
 				description: this.valuePromptContext?.description,
+				placeholder: derived.placeholder,
 				defaultValue: this.valuePromptContext?.defaultValue,
 				numericConfig: this.valuePromptContext?.numericConfig,
 				sliderConfig: this.valuePromptContext?.sliderConfig,

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -43,6 +43,7 @@ import {
 	type FieldRequirement,
 	type FieldType,
 } from "./RequirementCollector";
+import { isPathScope, type PromptScopeKind } from "src/formatters/promptScope";
 import type { NumericInputConfig, SliderConfig } from "src/utils/valueSyntax";
 
 interface CollectChoiceRequirementsOptions {
@@ -200,13 +201,14 @@ async function scanContentWithTemplateIncludes(
 	content: string,
 	templateStack = new Set<string>(),
 	depth = 0,
-	pathContext = false,
+	scope: PromptScopeKind = "generic",
 ): Promise<void> {
+	const pathContext = isPathScope(scope);
 	// templatesToScan is a queue for this content scan. Clear it before and
 	// after scanning so refs from unrelated strings are not drained together.
 	const rawTemplateRefs = getRawTemplateRefs(content);
 	collector.templatesToScan.clear();
-	await collector.scanString(content, pathContext);
+	await collector.scanString(content, pathContext, scope);
 	const nested = [...collector.templatesToScan].filter((ref) =>
 		rawTemplateRefs.has(ref),
 	);
@@ -239,8 +241,8 @@ async function scanContentWithTemplateIncludes(
 				templateStack,
 				depth + 1,
 				// A template included FROM a path string is spliced into that
-				// path at runtime, so its tokens are path context too.
-				pathContext,
+				// path at runtime, so its tokens keep that scope too.
+				scope,
 			);
 		} finally {
 			templateStack.delete(ref);
@@ -265,7 +267,7 @@ async function scanTemplateSource(
 	templatePath: string,
 ): Promise<void> {
 	// The template PATH is path context; the template BODY below is content.
-	await collector.scanString(templatePath, true);
+	await collector.scanString(templatePath, true, "templatePath");
 
 	if (hasTemplatePathSyntax(templatePath)) {
 		log.logMessage(
@@ -279,6 +281,8 @@ async function scanTemplateSource(
 		collector,
 		await readTemplate(app, templatePath),
 		new Set([templatePath]),
+		0,
+		"noteBody",
 	);
 }
 
@@ -297,7 +301,7 @@ async function collectForTemplateChoice(
 			choice.fileNameFormat.format,
 			undefined,
 			0,
-			true, // file name = path context
+			"noteTitle",
 		);
 	}
 
@@ -309,7 +313,7 @@ async function collectForTemplateChoice(
 				folder,
 				undefined,
 				0,
-				true, // folder = path context
+				"folder",
 			);
 		}
 	}
@@ -342,7 +346,8 @@ async function collectForCaptureChoice(
 		choice.captureTo,
 		undefined,
 		0,
-		true, // capture target = path context (scanned BEFORE content so a dual-use {{VALUE}} is marked)
+		// Scanned BEFORE content so a dual-use {{VALUE}} is marked as path context.
+		"captureTarget",
 	);
 
 	if (choice.format?.enabled) {
@@ -350,6 +355,9 @@ async function collectForCaptureChoice(
 			app,
 			collector,
 			choice.format.format,
+			undefined,
+			0,
+			"captureText",
 		);
 	}
 
@@ -360,7 +368,8 @@ async function collectForCaptureChoice(
 			choice.insertAfter.after,
 			undefined,
 			0,
-			true, // location target = path context (an embed link can never match a line)
+			// An embed link can never match a line, so this is path context.
+			"lineTarget",
 		);
 	}
 
@@ -371,7 +380,7 @@ async function collectForCaptureChoice(
 			choice.insertBefore.before,
 			undefined,
 			0,
-			true, // location target = path context
+			"lineTarget",
 		);
 	}
 

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -6,7 +6,6 @@ import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import {
 	QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
 	TEMPLATE_REGEX,
-	VALUE_SYNTAX,
 } from "src/constants";
 import type QuickAdd from "src/main";
 import type ICaptureChoice from "src/types/choices/ICaptureChoice";
@@ -295,22 +294,23 @@ async function collectForTemplateChoice(
 ): Promise<RequirementCollector> {
 	const collector = new RequirementCollector(app, plugin, choiceExecutor);
 
-	// Scan the EFFECTIVE file name format, not the configured one: with the
-	// toggle off the engine still resolves VALUE_SYNTAX (TemplateChoiceEngine),
-	// so skipping it left the implicit note-name prompt invisible to the
-	// non-interactive CLI guard and to the one-page form - and, once prompts
-	// derive their copy from a scope, made the one-page form describe the note
-	// TITLE using whatever the template body said (issue #1546).
-	await scanContentWithTemplateIncludes(
-		app,
-		collector,
-		choice.fileNameFormat?.enabled
-			? choice.fileNameFormat.format
-			: VALUE_SYNTAX,
-		undefined,
-		0,
-		"noteTitle",
-	);
+	// Only the ENABLED format is scanned. The engine resolves a disabled one to
+	// VALUE_SYNTAX, so this under-collects the implicit note-name prompt - but
+	// collecting it would also make the non-interactive CLI guard reject runs the
+	// engine satisfies from the editor selection, and would show the one-page
+	// form an empty title field where the selection used to fill it in silently.
+	// Closing that needs the selection modelled here first (there is no Template
+	// counterpart to seedCaptureSelectionAsValue); tracked separately.
+	if (choice.fileNameFormat?.enabled) {
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			choice.fileNameFormat.format,
+			undefined,
+			0,
+			"noteTitle",
+		);
+	}
 
 	if (choice.folder?.enabled) {
 		for (const folder of choice.folder.folders ?? []) {
@@ -357,16 +357,16 @@ async function collectForCaptureChoice(
 		"captureTarget",
 	);
 
-	// As for the Template file name: a disabled capture format still resolves to
-	// VALUE_SYNTAX at runtime (CaptureChoiceEngine.getCaptureContent).
-	await scanContentWithTemplateIncludes(
-		app,
-		collector,
-		choice.format?.enabled ? choice.format.format : VALUE_SYNTAX,
-		undefined,
-		0,
-		"captureText",
-	);
+	if (choice.format?.enabled) {
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			choice.format.format,
+			undefined,
+			0,
+			"captureText",
+		);
+	}
 
 	if (choice.insertAfter?.enabled && !choice.insertAfter.promptHeading) {
 		await scanContentWithTemplateIncludes(

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -6,6 +6,7 @@ import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import {
 	QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
 	TEMPLATE_REGEX,
+	VALUE_SYNTAX,
 } from "src/constants";
 import type QuickAdd from "src/main";
 import type ICaptureChoice from "src/types/choices/ICaptureChoice";
@@ -294,16 +295,22 @@ async function collectForTemplateChoice(
 ): Promise<RequirementCollector> {
 	const collector = new RequirementCollector(app, plugin, choiceExecutor);
 
-	if (choice.fileNameFormat?.enabled) {
-		await scanContentWithTemplateIncludes(
-			app,
-			collector,
-			choice.fileNameFormat.format,
-			undefined,
-			0,
-			"noteTitle",
-		);
-	}
+	// Scan the EFFECTIVE file name format, not the configured one: with the
+	// toggle off the engine still resolves VALUE_SYNTAX (TemplateChoiceEngine),
+	// so skipping it left the implicit note-name prompt invisible to the
+	// non-interactive CLI guard and to the one-page form - and, once prompts
+	// derive their copy from a scope, made the one-page form describe the note
+	// TITLE using whatever the template body said (issue #1546).
+	await scanContentWithTemplateIncludes(
+		app,
+		collector,
+		choice.fileNameFormat?.enabled
+			? choice.fileNameFormat.format
+			: VALUE_SYNTAX,
+		undefined,
+		0,
+		"noteTitle",
+	);
 
 	if (choice.folder?.enabled) {
 		for (const folder of choice.folder.folders ?? []) {
@@ -350,16 +357,16 @@ async function collectForCaptureChoice(
 		"captureTarget",
 	);
 
-	if (choice.format?.enabled) {
-		await scanContentWithTemplateIncludes(
-			app,
-			collector,
-			choice.format.format,
-			undefined,
-			0,
-			"captureText",
-		);
-	}
+	// As for the Template file name: a disabled capture format still resolves to
+	// VALUE_SYNTAX at runtime (CaptureChoiceEngine.getCaptureContent).
+	await scanContentWithTemplateIncludes(
+		app,
+		collector,
+		choice.format?.enabled ? choice.format.format : VALUE_SYNTAX,
+		undefined,
+		0,
+		"captureText",
+	);
 
 	if (choice.insertAfter?.enabled && !choice.insertAfter.promptHeading) {
 		await scanContentWithTemplateIncludes(

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -316,7 +316,7 @@ describe("runOnePagePreflight template extension handling", () => {
 		);
 	});
 
-	it("leaves FIELD multi-select prompts for runtime even when the form opens", async () => {
+	it("leaves FIELD multi-select prompts for runtime instead of the one-page modal", async () => {
 		const templateFile = new TFile();
 		templateFile.path = "Templates/FieldMulti.md";
 		templateFile.name = "FieldMulti.md";
@@ -345,8 +345,6 @@ describe("runOnePagePreflight template extension handling", () => {
 
 		const executor = createExecutor();
 
-		modalResult = { value: "Some title" };
-
 		const result = await runOnePagePreflight(
 			app,
 			plugin,
@@ -354,11 +352,8 @@ describe("runOnePagePreflight template extension handling", () => {
 			createTemplateChoice("Templates/FieldMulti.md"),
 		);
 
-		// The form opens for the implicit note title (the file name format falls
-		// back to {{VALUE}} at runtime), but the FIELD multi-select is still left
-		// to a runtime prompt rather than pre-collected.
-		expect(result).toBe(true);
-		expect(modalOpenMock).toHaveBeenCalledTimes(1);
+		expect(result).toBe(false);
+		expect(modalOpenMock).not.toHaveBeenCalled();
 		expect(executor.variables.has("FIELD:topic|multi")).toBe(false);
 	});
 

--- a/src/preflight/runOnePagePreflight.selection.test.ts
+++ b/src/preflight/runOnePagePreflight.selection.test.ts
@@ -316,7 +316,7 @@ describe("runOnePagePreflight template extension handling", () => {
 		);
 	});
 
-	it("leaves FIELD multi-select prompts for runtime instead of the one-page modal", async () => {
+	it("leaves FIELD multi-select prompts for runtime even when the form opens", async () => {
 		const templateFile = new TFile();
 		templateFile.path = "Templates/FieldMulti.md";
 		templateFile.name = "FieldMulti.md";
@@ -345,6 +345,8 @@ describe("runOnePagePreflight template extension handling", () => {
 
 		const executor = createExecutor();
 
+		modalResult = { value: "Some title" };
+
 		const result = await runOnePagePreflight(
 			app,
 			plugin,
@@ -352,8 +354,11 @@ describe("runOnePagePreflight template extension handling", () => {
 			createTemplateChoice("Templates/FieldMulti.md"),
 		);
 
-		expect(result).toBe(false);
-		expect(modalOpenMock).not.toHaveBeenCalled();
+		// The form opens for the implicit note title (the file name format falls
+		// back to {{VALUE}} at runtime), but the FIELD multi-select is still left
+		// to a runtime prompt rather than pre-collected.
+		expect(result).toBe(true);
+		expect(modalOpenMock).toHaveBeenCalledTimes(1);
 		expect(executor.variables.has("FIELD:topic|multi")).toBe(false);
 	});
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -182,8 +182,9 @@
 }
 
 /* Run-time prompt context: which choice is asking, and where the answer lands.
-   One line: the middle of a long path is elided in JS (elideMiddlePath) so the
-   file name survives, and the tail is clipped here as a last resort. */
+   One line on a roomy modal: the middle of a long path is elided in JS
+   (elideMiddlePath) so the file name survives, and the tail is clipped here as
+   a last resort. */
 .quickAddModal .qa-prompt-context {
 	margin-bottom: 0.75rem;
 	color: var(--text-muted);
@@ -191,6 +192,19 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+/* On a phone-width modal a clipped line would cut off the destination, which is
+   the whole point of the line. Wrap instead, bounded to two lines. */
+@media screen and (max-width: 540px) {
+	.quickAddModal .qa-prompt-context {
+		white-space: normal;
+		overflow-wrap: anywhere;
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+	}
 }
 
 /* Preview row styling for Choice Builders. The row sits BELOW the field it

--- a/src/styles.css
+++ b/src/styles.css
@@ -181,6 +181,18 @@
 	display: block;
 }
 
+/* Run-time prompt context: which choice is asking, and where the answer lands.
+   One line: the middle of a long path is elided in JS (elideMiddlePath) so the
+   file name survives, and the tail is clipped here as a last resort. */
+.quickAddModal .qa-prompt-context {
+	margin-bottom: 0.75rem;
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 /* Preview row styling for Choice Builders. The row sits BELOW the field it
    previews (#1543), so it is styled as a quiet secondary line — a bold,
    body-sized line here reads as a heading for whatever follows it. */

--- a/src/types/inputPrompt.ts
+++ b/src/types/inputPrompt.ts
@@ -30,6 +30,11 @@ export interface InputPromptOptions {
 	 */
 	contextLine?: string;
 	/**
+	 * {@link contextLine} with the destination path un-elided, shown as the
+	 * hover tooltip so the whole path stays reachable on a narrow modal.
+	 */
+	contextLineFull?: string;
+	/**
 	 * Stable per-choice discriminator for the input-draft key. The header used to
 	 * be the only thing distinguishing one choice's prompt from another's, so two
 	 * prompts that now share a derived title (e.g. "Note title") would otherwise

--- a/src/types/inputPrompt.ts
+++ b/src/types/inputPrompt.ts
@@ -24,4 +24,17 @@ export interface InputPromptOptions {
 		max: number;
 		step: number;
 	};
+	/**
+	 * Muted one-liner under the modal title saying which choice is asking and,
+	 * when the engine already knows it, where the answer lands (issue #1546).
+	 */
+	contextLine?: string;
+	/**
+	 * Stable per-choice discriminator for the input-draft key. The header used to
+	 * be the only thing distinguishing one choice's prompt from another's, so two
+	 * prompts that now share a derived title (e.g. "Note title") would otherwise
+	 * share a draft and pre-fill each other. Also separates two choices that
+	 * happen to have the same name.
+	 */
+	draftScopeId?: string;
 }

--- a/src/utils/InputPromptDraftStore.test.ts
+++ b/src/utils/InputPromptDraftStore.test.ts
@@ -78,3 +78,77 @@ describe("InputPromptDraftStore execution scopes", () => {
 		expect(store.get(draftKey)).toBe("changed");
 	});
 });
+
+/**
+ * Once prompts derive their title from what they are asking for (issue #1546),
+ * the header stops discriminating one choice from another - "Note title" is the
+ * same string for every Template choice. `scopeId` is what keeps their drafts
+ * apart.
+ */
+describe("InputPromptDraftStore scope ids", () => {
+	const store = InputPromptDraftStore.getInstance();
+	const shouldPersist = () => true;
+	const promptKey = (scopeId?: string) => ({
+		kind: "single" as const,
+		header: "Note title",
+		placeholder: "Title for the new note",
+		scopeId,
+	});
+
+	beforeEach(() => {
+		store.clearAll();
+	});
+
+	it("does not let one choice's cancelled draft pre-fill another's prompt", () => {
+		const bookChoice = new InputPromptDraftHandler(
+			promptKey("choice-book"),
+			shouldPersist,
+		);
+		bookChoice.hydrate("");
+		bookChoice.markChanged();
+		bookChoice.persist("Sapiens", false);
+
+		const meetingChoice = new InputPromptDraftHandler(
+			promptKey("choice-meeting"),
+			shouldPersist,
+		);
+
+		expect(meetingChoice.hydrate("")).toBe("");
+	});
+
+	it("still restores the SAME choice's cancelled draft on a re-run", () => {
+		const first = new InputPromptDraftHandler(
+			promptKey("choice-book"),
+			shouldPersist,
+		);
+		first.hydrate("");
+		first.markChanged();
+		first.persist("Sapiens", false);
+
+		const rerun = new InputPromptDraftHandler(
+			promptKey("choice-book"),
+			shouldPersist,
+		);
+
+		expect(rerun.hydrate("")).toBe("Sapiens");
+	});
+
+	it("separates an included template's prompt from its parent's", () => {
+		// {{TEMPLATE:...}} renders through its own formatter and raises its own
+		// {{VALUE}} prompt in the same run.
+		const parent = new InputPromptDraftHandler(
+			promptKey("choice-meeting"),
+			shouldPersist,
+		);
+		parent.hydrate("");
+		parent.markChanged();
+		parent.persist("Alice, Bob", false);
+
+		const included = new InputPromptDraftHandler(
+			promptKey("choice-meeting#Snippets/attendees.md"),
+			shouldPersist,
+		);
+
+		expect(included.hydrate("")).toBe("");
+	});
+});

--- a/src/utils/InputPromptDraftStore.ts
+++ b/src/utils/InputPromptDraftStore.ts
@@ -5,6 +5,15 @@ export interface InputPromptDraftKey {
 	header: string;
 	placeholder?: string;
 	linkSourcePath?: string;
+	/**
+	 * Stable per-choice discriminator. The header used to be the only thing
+	 * separating one choice's prompt from another's (it was the choice name), so
+	 * once prompts derive a shared title such as "Note title" (issue #1546) a
+	 * cancelled draft from one choice would pre-fill the next. Also separates two
+	 * choices that happen to have the same name. Absent for prompts raised
+	 * outside a choice (script API), which keep the header-only key.
+	 */
+	scopeId?: string;
 }
 
 interface DraftEntry {
@@ -38,6 +47,7 @@ export class InputPromptDraftStore {
 			header: key.header,
 			placeholder: key.placeholder ?? "",
 			linkSourcePath: key.linkSourcePath ?? "",
+			scopeId: key.scopeId ?? "",
 		});
 	}
 


### PR DESCRIPTION
Closes #1546.

## The problem

A choice's run-time prompt was a modal titled with the choice name over one empty box. A Template's title prompt and a Capture's text prompt were pixel-identical, and nothing said where the answer would land.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/chhoumann/quickadd/19a4d6bbe4b953fcce26a917285e30a1df0b848d/pr-1546/before-capture.png" width="440"> | <img src="https://raw.githubusercontent.com/chhoumann/quickadd/19a4d6bbe4b953fcce26a917285e30a1df0b848d/pr-1546/after-capture.png" width="440"> |

<img src="https://raw.githubusercontent.com/chhoumann/quickadd/19a4d6bbe4b953fcce26a917285e30a1df0b848d/pr-1546/after-template.png" width="440">

Even the choice name only reached the modal by accident. `CompleteFormatter.valueHeader` was set exclusively by `formatFileName(input, choiceName)` and never reset, so it leaked from the path pass into the later content pass. Two consequences fell out of that:

- Capture to active file runs no path pass, so its body prompt was titled a bare `Enter value`.
- `MacroChoiceEngine` passed `""`, which survives `?? "Enter value"`, so a macro's Open file prompt had an **empty** modal title.

## The design

Every prompt should answer three things: what am I typing, for which choice, and where does it land. The change gives the formatter a declared per-pass **scope** plus a **run context**, and fills three slots from them:

1. **Title** = what is being asked.
2. **Context line** (new, muted, under the title) = the choice name and the resolved destination.
3. **Placeholder** = always names the field.

```
Text to capture
New capture → Daily/2026-07-26.md
[ Text to add to the note                    ]
```

Three decisions carry it.

**The scope is declared by the caller, never inferred from which `format*` method ran.** `formatFileContent` is shared by template bodies, capture bodies, `quickAddApi.format` and the AI agent, so method-derived copy would be a lie in three of those four cases.

**The derived title is used only when the answer is provably the whole of what the scope names.** Otherwise the choice name stays the title (today's behaviour) and only the placeholder names the field. For a file name format of `{{DATE:YYYY-MM-DD}} {{VALUE}}`, a title reading "Note title" would invite the user to retype the date. A vague title is not a lie; an authoritative wrong one is.

Paths use the strict rule, because their literals are part of the answer (`Daily/{{VALUE}}.md`). A capture format is a one-line template whose literals are decoration, so `- [ ] {{VALUE}}` still asks for exactly "Text to capture" - which matters, because the "Add to task list" toggle rewrites every default capture into that shape.

**No new configuration.** Author-side overrides (`{{VALUE:name}}`, `|label:`) are untouched, and named tokens keep titling themselves with their variable name; they only gain the context line.

### Copy

| Scope | Title (whole answer) | Placeholder (whole) | Placeholder (partial) |
| --- | --- | --- | --- |
| Template file name | Note title | Title for the new note | Part of the new note's title |
| Capture target | Capture target | Where to capture to | Part of the capture destination |
| Capture content | Text to capture | Text to add to the note | Part of the text added to the note |
| Template body | Note content | Text inserted into the note | Part of the text inserted into the note |
| Folder | Folder | Folder for the new note | Part of the folder path |
| Template source path | Template | Path to the template file | Part of the template path |
| Insert after/before | Line to find | Existing line to anchor the capture to | Part of the line to find |
| Macro "Open file" | File to open | Path to the file to open | Part of the file path |

## Tradeoffs

- **Title becomes the ask, not the choice name.** The choice name is the only string a multi-prompt run repeated on every modal, which is the disorientation the issue reports. It moves to the context line, so hotkey/URI/macro-nested runs (where no picker was ever shown) still see which choice is asking.
- **Draft keys gained a `scopeId`.** Converging titles would otherwise have collapsed the input-draft key across choices: a cancelled "Add book" would pre-fill "Meeting note". It also separates a `{{TEMPLATE:}}` include's own prompt from its parent's within one run, and fixes the pre-existing collision between two choices sharing a name.
- **The folder-template flow's ephemeral choice** got a path-derived id instead of a fresh uuid per run, so its draft key is stable across runs. Namespaced (`folder-template:<path>`), so it still cannot collide with a persisted choice's uuid.
- **The context line never states something it cannot back.** It withholds the destination for template-source-path prompts (the answer picks which template to read), withholds the folder when a disabled folder setting lets the file name format reroute the note, and is pinned to the file actually being created rather than the pre-collision target.
- **Remote/Raycast** has no context-line channel, so the line is folded into the header there rather than lost.
- **Suggester modals are untouched.** `FuzzySuggestModal` has no title element, and `|label:` already drives their placeholder.

## Not doing

- No per-choice prompt-label setting: the complaint is about defaults, and author overrides already exist.
- No "step N of M" counter: the sequential formatter cannot know M without running preflight.
- No changes to the choice picker (#1540 owns it) or the builder (#1543-#1545).

## Known residuals

- One-page inputs still under-collect a Template's implicit note name when the file-name format toggle is off. Collecting it made the non-interactive CLI guard reject a stock Capture the engine satisfies from the editor selection, and made the one-page form show an empty title field where the selection used to fill it in. Closing it needs the editor selection modelled in preflight for Template choices; that is a separate change, and the sequential prompt (the surface this issue is about) is correct today.
- A Template whose folder AND file name are both a bare `{{VALUE}}` prompts once; the title reflects the folder pass, which runs first.

## Validation

Reproduced first, in this worktree's own Obsidian 1.13.0 instance: both prompts came up titled with the choice name, empty placeholder, no description.

Verified after, live, across the shapes that stress the rules:

| Choice | Title | Context line | Placeholder |
| --- | --- | --- | --- |
| Template, file name `{{VALUE}}` | Note title | Add book → Books/ | Title for the new note |
| Template, `{{DATE}} {{VALUE}}` | Daily note | → Books/ | Part of the new note's title |
| Template, `{{VALUE:title}}` | title | Book w/ author → Books/ | |
| Capture + "Add to task list" | Text to capture | Quick task → Daily/2026-07-26.md | Text to add to the note |
| Capture to active file | Text to capture | Note to self → Work/…/Weekly standup notes.md | Text to add to the note |
| Capture, target `Books/{{VALUE}}.md` | Book log | | Part of the capture destination |

A three-prompt Template run reads: `Note title / Add book → Books/`, then `author / Add book → Books/Dune.md`, then `rating / Add book → Books/Dune.md`.

Long paths are elided in the middle so the file name survives (`Work/…/Weekly standup notes.md`), with the full path as the hover tooltip. Measured on the running app: 526px on a desktop modal (no clipping), and wrapping to exactly two lines with no clipping at a 300px modal width under the phone-width rules. The wide (multi-line) prompt renders the same line.

`pnpm test` (3895 passing), `pnpm lint`, `tsc`, and `pnpm run build` are green.

## Review

The design and the implementation each went through adversarial review rounds; the reviewers' confirmed findings are folded in, including several that were regressions in my own first attempt:

- A template body's literals are the note, so one `{{VALUE}}` in a structured body was enough to title the prompt "Note content".
- "Append to top/bottom" collisions build their own `TemplateInsertEngine`, which never received the run context.
- A `{{TEMPLATE:}}` include hard-coded the note-body scope, so an include spliced into a file name claimed to ask for note content and offered clipboard-image paste into a path.
- A phone-width modal clipped the context line, cutting off exactly the destination it exists to show.
- Apply-template reconciliation reused the applied note's path while asking where the note should move to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt UI can now show an optional “context line” (with tooltip) under prompt titles, including improved mobile wrapping/clamping.
  * Prompt drafts are now more reliably scoped to avoid cross-choice and included-template bleed.
  * Folder-based template “new note from template” choices now keep stable identities across runs.
* **Bug Fixes**
  * Capture, template insertion, and reconciliation flows now consistently preserve the correct destination/context and apply improved prompt scoping for note-body and target formatting.
  * Folder-path formatting no longer interleaves prompt-scoped behavior.
* **Tests**
  * Updated mocks and added/expanded coverage for prompt-context, prompt-scope, and draft scoping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
