### PR TITLE
fix(settings): call a folder a folder in the delete confirmation

### DIFF
--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -443,7 +443,9 @@ describe("choiceService", () => {
 			const title = mocks.yesNoPrompt.mock.calls[0][1] as string;
 			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
 			expect(title).toBe("Confirm deletion of folder");
-			expect(message).toContain("Deleting this folder");
+			expect(message).toContain(
+				"Deleting this folder will also delete all (1) choice inside it",
+			);
 			expect(message).not.toContain("Deleting this choice");
 		});
 

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -433,6 +433,29 @@ describe("choiceService", () => {
 			expect(message).toContain("choices inside it");
 		});
 
+		// Issue #1552: folders are Multi choices internally, but the confirmation must
+		// call them folders like the rest of the UI does.
+		it("calls a Multi choice a folder in the title and the warning", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const multi = createChoice("Multi", "Group") as IMultiChoice;
+			multi.choices = [createChoice("Template", "a")];
+			await deleteChoiceWithConfirmation(multi, fakeApp);
+			const title = mocks.yesNoPrompt.mock.calls[0][1] as string;
+			const message = mocks.yesNoPrompt.mock.calls[0][2] as string;
+			expect(title).toBe("Confirm deletion of folder");
+			expect(message).toContain("Deleting this folder");
+			expect(message).not.toContain("Deleting this choice");
+		});
+
+		it("still calls a non-Multi choice a choice in the title", async () => {
+			mocks.yesNoPrompt.mockResolvedValue(true);
+			const choice = createChoice("Template", "Del");
+			await deleteChoiceWithConfirmation(choice, fakeApp);
+			expect(mocks.yesNoPrompt.mock.calls[0][1]).toBe(
+				"Confirm deletion of choice",
+			);
+		});
+
 		it("warns about macro commands for a Macro choice", async () => {
 			mocks.yesNoPrompt.mockResolvedValue(true);
 			const macro = createChoice("Macro", "MyMacro");

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -223,6 +223,12 @@ export async function deleteChoiceWithConfirmation(
 	const isMulti = choice.type === "Multi";
 	const isMacro = choice.type === "Macro";
 
+	// Folders are Multi choices internally, but the UI calls them folders everywhere
+	// else ("New folder", "Add folder to {name}", "Edit folder", and the rename prompt
+	// since #1539). The delete confirmation was the last place that leaked the internal
+	// name, so it takes the same treatment.
+	const targetNoun = isMulti ? "folder" : "choice";
+
 	// Count the FULL subtree (flattenChoices includes the folder itself, so drop it),
 	// not just direct children — a recursive delete removes everything nested. Special-
 	// case 0 (no scary "delete all (0) choices") and pluralize correctly.
@@ -230,12 +236,12 @@ export async function deleteChoiceWithConfirmation(
 		const descendantCount = flattenChoices(multi.choices).length;
 		if (descendantCount === 0) return "";
 		const noun = descendantCount === 1 ? "choice" : "choices";
-		return `Deleting this choice will delete all (${descendantCount}) ${noun} inside it (including nested folders)!`;
+		return `Deleting this folder will also delete all (${descendantCount}) ${noun} inside it (including nested folders)!`;
 	};
 
 	const userConfirmed: boolean = await GenericYesNoPrompt.Prompt(
 		app,
-		`Confirm deletion of choice`,
+		`Confirm deletion of ${targetNoun}`,
 		`Please confirm that you wish to delete '${choice.name}'.
             ${isMulti ? buildMultiWarning(choice as IMultiChoice) : ""}
             ${isMacro


### PR DESCRIPTION
Closes #1552

## What

Deleting a folder in the choices list prompted:

```
Confirm deletion of choice
Deleting this choice will delete all (2) choices inside it (including nested folders)!
```

Folders are `Multi` choices internally, but the UI calls them folders everywhere else — "New folder", "Add folder to {name}", "Edit folder", and the rename prompt since #1539. The delete confirmation was the last place that leaked the internal name, so it gets the same treatment: the prompt picks its noun from the choice type.

```
Confirm deletion of folder
Deleting this folder will also delete all (2) choices inside it (including nested folders)!
```

Non-`Multi` choices keep their existing copy, and the macro warning is untouched.

## Note on the wording

The issue suggests "Deleting this folder will also delete the N choices inside it." I kept the existing `(N)` count, the pluralization and the "(including nested folders)" note that the current message already carries — those were deliberate (there is a comment explaining the full-subtree count and the 0 special case) and they have test coverage. Happy to switch to the literal copy from the issue if you prefer it.

## Verification

- `pnpm run test` — 339 files / 3851 tests pass (5 files, 37 tests skipped as on master)
- `pnpm exec vitest run src/services/choiceService.test.ts` — 50 pass, including the two added cases
- `pnpm run lint` — clean
- `pnpm run build` — `tsc -noEmit` clean, bundle produced
- Manually walked the repro: Settings → QuickAdd → New folder, added a choice inside, deleted the folder

`main.js` / `styles.css` are not tracked in this repo, so no generated files are included.

## Tests

Two cases added next to the existing `deleteChoiceWithConfirmation` tests: a `Multi` target says "folder" in both the title and the warning, and a non-`Multi` target still says "choice".

<sub>Independently cross-reviewed by two AI models before submission.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deletion confirmation text to distinguish Multi items as “folders” (including the confirmation title and warning message).
  * Updated the warning to use correct “folder” wording and pluralization when indicating nested items will also be deleted.
  * Kept “choice” terminology for non-Multi item types.
* **Tests**
  * Added/extended tests to verify folder-vs-choice terminology in the deletion confirmation UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->