### PR TITLE
fix(settings): use sentence case for labels

### DIFF
--- a/src/engine/runTemplateFromFolder.ts
+++ b/src/engine/runTemplateFromFolder.ts
@@ -105,7 +105,7 @@ export async function runTemplateFromFolder(
 		if (!templatePath) {
 			if (!hasConfiguredTemplateFolders(plugin)) {
 				new Notice(
-					"QuickAdd: Set a template folder in Settings → QuickAdd → Templates & Properties to use “New note from template”.",
+					"QuickAdd: Set a template folder in Settings → QuickAdd → Templates & properties to use “New note from template”.",
 					8000,
 				);
 				tryOpenPluginSettings(app, plugin.manifest.id);

--- a/src/quickAddSettingsTab.test.ts
+++ b/src/quickAddSettingsTab.test.ts
@@ -284,7 +284,7 @@ describe("QuickAddSettingsTab declarative bridge", () => {
 			"Choices",
 			"Packages",
 		]);
-		expect(choicePickerGroup.heading).toBe("Choice Picker");
+		expect(choicePickerGroup.heading).toBe("Choice picker");
 		expect(choicePickerGroup.items?.map((item) => item.name)).toEqual([
 			"Search nested choices",
 			"“New note from template” in the launcher",

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -137,7 +137,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	private choicesAndPackagesGroup(): SettingDefinitionGroup<SettingsKey> {
 		return {
 			type: "group",
-			heading: "Choices & Packages",
+			heading: "Choices & packages",
 			items: [
 				{
 					name: "Choices",
@@ -155,7 +155,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	private choicePickerGroup(): SettingDefinitionGroup<SettingsKey> {
 		return {
 			type: "group",
-			heading: "Choice Picker",
+			heading: "Choice picker",
 			items: [
 				{
 					name: "Search nested choices",
@@ -186,12 +186,12 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			heading: "Input",
 			items: [
 				{
-					name: "Use Multi-line Input Prompt",
+					name: "Use multi-line input prompt",
 					desc: "Use multi-line input prompt instead of single-line input prompt. Submit multi-line prompts with Ctrl/Cmd+Enter; Enter inserts a newline.",
 					control: { type: "toggle", key: "inputPrompt" },
 				},
 				{
-					name: "Persist Input Prompt Drafts",
+					name: "Persist input prompt drafts",
 					desc: "Keep drafts when closing input prompts so they can be restored on reopen. Drafts are stored only for this session.",
 					control: { type: "toggle", key: "persistInputPromptDrafts" },
 				},
@@ -219,7 +219,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	private templatesGroup(): SettingDefinitionGroup<SettingsKey> {
 		return {
 			type: "group",
-			heading: "Templates & Properties",
+			heading: "Templates & properties",
 			items: [
 				{
 					name: "Template folder paths",
@@ -244,7 +244,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			heading: "Notifications",
 			items: [
 				{
-					name: "Announce Updates",
+					name: "Announce updates",
 					desc: "Display release notes when a new version is installed. This includes new features, demo videos, and bug fixes.",
 					control: {
 						type: "dropdown",
@@ -259,12 +259,12 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 					},
 				},
 				{
-					name: "Show Capture Notifications",
+					name: "Show capture notifications",
 					desc: "Display a notification when content is captured successfully to confirm the operation completed.",
 					control: { type: "toggle", key: "showCaptureNotification" },
 				},
 				{
-					name: "Show Input Cancellation Notifications",
+					name: "Show input cancellation notifications",
 					desc: "Display a notification when an input prompt is cancelled without submitting. Disable this to avoid extra notices when dismissing prompts.",
 					control: {
 						type: "toggle",
@@ -278,10 +278,10 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	private globalVariablesGroup(): SettingDefinitionGroup<SettingsKey> {
 		return {
 			type: "group",
-			heading: "Global Variables",
+			heading: "Global variables",
 			items: [
 				{
-					name: "Global Variables",
+					name: "Global variables",
 					render: (setting) => this.renderGlobalVariablesView(setting),
 				},
 			],
@@ -291,10 +291,10 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 	private aiAndOnlineGroup(): SettingDefinitionGroup<SettingsKey> {
 		return {
 			type: "group",
-			heading: "AI & Online",
+			heading: "AI & online",
 			items: [
 				{
-					name: "Disable AI & Online features",
+					name: "Disable AI & online features",
 					desc: "This prevents the plugin from making requests to external providers like OpenAI. You can still use User Scripts to execute arbitrary code, including contacting external providers. However, this setting disables plugin features like the AI Assistant from doing so. You need to disable this setting to use the AI Assistant.",
 					control: { type: "toggle", key: "disableOnlineFeatures" },
 				},
@@ -327,7 +327,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 			heading: "Developer",
 			items: [
 				{
-					name: "Development Information",
+					name: "Development information",
 					desc: "Git information for developers.",
 					render: (setting) => this.renderDevInfo(setting),
 				},


### PR DESCRIPTION
Closes #1553

## Summary
- convert QuickAdd settings group headings and Title Case row labels to sentence case, matching Obsidian core settings
- keep proper names and initialisms such as QuickAdd and AI capitalized
- update the template-folder guidance notice so its referenced settings heading matches the UI
- update the existing choice-picker heading assertion

This is copy-only and does not change stored setting keys or behavior.

## Validation
- `pnpm test -- src/quickAddSettingsTab.test.ts src/engine/runTemplateFromFolder.test.ts` (the repository test script runs the full suite): 339 files passed, 3849 tests passed; 5 files / 37 tests skipped
- `pnpm lint`: passed
- `pnpm build`: TypeScript check and production bundle passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized capitalization across settings group headings and labels for a more consistent interface.
  * Updated template-related notices to use the revised “Templates & properties” capitalization.
* **Tests**
  * Updated settings display checks to reflect the revised heading capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->