### PR TITLE
feat(builder): advertise the format-token autocomplete

### DIFF
--- a/src/docs.ts
+++ b/src/docs.ts
@@ -17,6 +17,7 @@ export const DOCS_BASE_URL = "https://quickadd.obsidian.guide";
 
 export const DOCS_URLS = {
 	gettingStarted: `${DOCS_BASE_URL}/docs/`,
+	formatSyntax: `${DOCS_BASE_URL}/docs/FormatSyntax/`,
 	onePageInputs: `${DOCS_BASE_URL}/docs/Advanced/onePageInputs/`,
 	userScripts: `${DOCS_BASE_URL}/docs/Choices/MacroChoice/#user-scripts`,
 	packages: `${DOCS_BASE_URL}/docs/Choices/Packages/`,

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -12,6 +12,7 @@ import ChoiceNameHeader from "./components/ChoiceNameHeader.svelte";
 import ValidatedInput from "./components/ValidatedInput.svelte";
 import LabeledField from "./components/LabeledField.svelte";
 import FormatPreviewField from "./components/FormatPreviewField.svelte";
+import FormatTokenHint from "./components/FormatTokenHint.svelte";
 import AppendLinkSetting from "./components/AppendLinkSetting.svelte";
 import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
@@ -170,6 +171,7 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 			requiredMessage="Capture format is required when enabled"
 			makeSuggesters={formatSuggesters}
 		/>
+		<FormatTokenHint value={choice.format.format} />
 		<FormatPreviewField value={choice.format.format} {app} {plugin} />
 	{/snippet}
 </LabeledField>

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -34,6 +34,7 @@ import ChoiceNameHeader from "./components/ChoiceNameHeader.svelte";
 import ValidatedInput from "./components/ValidatedInput.svelte";
 import LabeledField from "./components/LabeledField.svelte";
 import FormatPreviewField from "./components/FormatPreviewField.svelte";
+import FormatTokenHint from "./components/FormatTokenHint.svelte";
 import AppendLinkSetting from "./components/AppendLinkSetting.svelte";
 import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
@@ -222,6 +223,7 @@ function onModeChange(value: string) {
 			placeholder="File name format"
 			makeSuggesters={fileNameSuggesters}
 		/>
+		<FormatTokenHint value={choice.fileNameFormat.format} />
 		<FormatPreviewField
 			value={choice.fileNameFormat.format}
 			formatterKind="fileName"

--- a/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CaptureTargetSetting.svelte
@@ -11,6 +11,7 @@ import Toggle from "../../components/Toggle.svelte";
 import ValidatedInput from "./ValidatedInput.svelte";
 import LabeledField from "./LabeledField.svelte";
 import FormatPreviewField from "./FormatPreviewField.svelte";
+import FormatTokenHint from "./FormatTokenHint.svelte";
 import CanvasNodePicker from "./CanvasNodePicker.svelte";
 import { getCaptureTargetFeedback } from "./captureTargetFeedback";
 
@@ -146,6 +147,7 @@ function validateCaptureTo(value: string) {
 				validator={validateCaptureTo}
 				onChange={onCaptureToChange}
 			/>
+			<FormatTokenHint value={choice.captureTo} />
 			{#if !usesPickerTargetSyntax}
 				<FormatPreviewField value={choice.captureTo} formatterKind="fileName" {app} {plugin} />
 			{/if}

--- a/src/gui/ChoiceBuilder/components/FormatTokenHint.svelte
+++ b/src/gui/ChoiceBuilder/components/FormatTokenHint.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { DOCS_URLS } from "../../../docs";
+
+/**
+ * Advertises the format-token autocomplete under a format field (issue #1542).
+ *
+ * Typing `{{` opens a list of every token, each with a one-line description, and
+ * nothing in the UI said so — the reporter only found it on a hunch. The
+ * affordance is two characters, so the cheapest honest fix is to name the two
+ * characters, right below the caret. It doubles as the docs entry point #1541
+ * deferred to this issue: the format language is the one thing you cannot guess
+ * from the builder alone.
+ *
+ * Hidden once the value contains `{{`: the hint has done its job, and a line
+ * that never goes away is the permanent chrome an "Insert token" button was
+ * rejected for. Deliberately NOT persisted in settings — a per-vault flag would
+ * mean a disk write from a keystroke, would not be reactive, and one stray `{{`
+ * would delete the affordance vault-wide with no way back.
+ */
+let { value }: { value: string } = $props();
+
+const shown = $derived(!value.includes("{{"));
+</script>
+
+{#if shown}
+	<div class="qa-token-hint">
+		Type <code>&#123;&#123;</code> to insert a token &middot;
+		<a
+			class="quickadd-docs-link"
+			href={DOCS_URLS.formatSyntax}
+			target="_blank"
+			rel="noopener noreferrer">Format syntax</a
+		>
+	</div>
+{/if}

--- a/src/gui/ChoiceBuilder/components/FormatTokenHint.test.ts
+++ b/src/gui/ChoiceBuilder/components/FormatTokenHint.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import FormatTokenHint from "./FormatTokenHint.svelte";
+import { DOCS_URLS } from "../../../docs";
+
+const hint = (container: HTMLElement) =>
+	container.querySelector(".qa-token-hint");
+
+/**
+ * Issue #1542, ask 1. The token autocomplete opens on `{{` and nothing said so.
+ */
+describe("FormatTokenHint", () => {
+	it("names the two characters that open the autocomplete", async () => {
+		const { container } = render(FormatTokenHint, { props: { value: "" } });
+		await tick();
+
+		const text = hint(container as HTMLElement)?.textContent ?? "";
+		expect(text).toContain("{{");
+		expect(text).toContain("to insert a token");
+	});
+
+	it("links the format syntax reference", async () => {
+		const { container } = render(FormatTokenHint, { props: { value: "" } });
+		await tick();
+
+		const link = container.querySelector("a.quickadd-docs-link");
+		expect(link?.getAttribute("href")).toBe(DOCS_URLS.formatSyntax);
+		expect(link?.getAttribute("target")).toBe("_blank");
+		expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+	});
+
+	it("stays out of the way once the field uses a token", async () => {
+		const { container } = render(FormatTokenHint, {
+			props: { value: "- [ ] {{VALUE}}" },
+		});
+		await tick();
+		expect(hint(container as HTMLElement)).toBeNull();
+	});
+
+	it("shows again if the user removes every token", async () => {
+		const { container, rerender } = render(FormatTokenHint, {
+			props: { value: "{{DATE}}" },
+		});
+		await tick();
+		expect(hint(container as HTMLElement)).toBeNull();
+
+		await rerender({ value: "plain text" });
+		await tick();
+		expect(hint(container as HTMLElement)).not.toBeNull();
+	});
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -232,6 +232,19 @@
 	border: 0;
 }
 
+/* "Type {{ to insert a token" under a format field (#1542). A quiet secondary
+   line, matching .qa-preview-row: it is a teaching aid, not part of the field. */
+.quickAddModal .qa-token-hint {
+	margin: -4px 0 8px;
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+}
+.quickAddModal .qa-token-hint code {
+	font-size: inherit;
+	padding: 1px 4px;
+	border-radius: var(--radius-s, 4px);
+}
+
 /* Problems the preview pass ran into, shown here instead of as a Notice per
    keystroke (#1558). Colour carries severity — no glyph — matching
    .qa-folder-mode-warning. Clamped with the full text in `title`, because the


### PR DESCRIPTION
Closes #1542. Supersedes #1561, which GitHub closed permanently when its base
branch (#1560) was merged and deleted — same commit, rebased onto master.

## The problem

Typing `{{` in a format field opens a list of every token, each with a one-line
description (that part shipped in #1549). Nothing in the UI said so. The reporter
found it by typing `{{` on a hunch while looking for the syntax; a new user has
no reason to try that, and no other in-app way to learn which tokens exist.

Ask 1 was deliberately left out of #1549 because its two natural homes belonged
to siblings from the same walkthrough: #1541 (docs links in the UI) and #1544 (a
worked-example placeholder). Both have now shipped, and #1541 explicitly left
"docs links inside the builders" to this issue. So this closes #1542.

## The change

The affordance is two characters, so the honest fix is to name the two
characters, right below the caret:

> Type `{{` to insert a token · [Format syntax](https://quickadd.obsidian.guide/docs/FormatSyntax/)

"Format syntax" is the docs entry point #1541 deferred here: the token language
is the one part of the builder you cannot work out by looking at it.

![hint](https://raw.githubusercontent.com/chhoumann/quickadd/278c8a4344cce2af3f4d5398dd7795efb74d3d0c/after-hint.png)

## Decisions worth arguing with

**It hides once the value contains `{{`.** The hint has done its job, and a line
that never goes away is exactly the permanent chrome an "Insert token" button
was rejected for in the issue thread. Stateless — no setting, no migration.

**Three of the five token fields, not all five.** Capture format, File name
format, and Capture to — the last being the only format field a brand-new
Capture builder renders, since the other two sit behind default-off toggles.

Deliberately **not** on insert-after / insert-before: their own descriptions tell
you to type a literal heading like `## Tasks`, so a token-less value is the
documented normal state there and the hint would nag forever. Not on the template
path field either — it has no token autocomplete at all.

**Not a persisted "you've seen this" flag.** It was the obvious alternative and
it is worse in four ways: `settingsStore` mutations rewrite the whole
`data.json`, so the suggester would write to disk on a keystroke; no Svelte
component subscribes to the store, so the flag would not be reactive and the
hint would linger until the builder was reopened; settings are per-vault, so
"user lifetime" is false; and one stray `{{` would delete the affordance
vault-wide with no way to bring it back.

**Not the placeholder alone.** It vanishes on the first keystroke and on every
existing choice, and cannot carry the docs link. #1544 already shipped that
pattern on "Capture to" without closing this ask.

**Not `{` as the trigger, and not open-on-focus.** Both were rejected in the
issue thread: `{` + Enter would insert a token instead of a newline in a capture
format holding JSON or code, and open-on-focus fires on every builder open and
races the file suggester on "Capture to".

## Validation

- Rebased onto `5e18213e` (master, post-#1560/#1562/#1569). Cherry-picked clean —
  the only overlap with the merged preview work was `styles.css`, and the two
  blocks are adjacent, not conflicting.
- `pnpm run build`, `pnpm lint`, `tsc --noEmit`, full suite: **4068 passed**, 0 failed.
- 4 component tests (copy, docs link + `rel`/`target`, hide-on-`{{`,
  show-again-when-tokens-removed).
- Re-verified end to end in this worktree's isolated Obsidian 1.13.0 vault on top
  of merged master, not just in tests:
  - 2 hints on a fresh Capture builder, correct copy, both linking the live docs URL
  - typing `{{DATE}}` into the format field drops it to 1; clearing back to plain
    text restores it to 2
  - the merged #1560 behaviour still holds underneath: `{{VALUE:title|case:pasc}}`
    produces 0 Notices, one inline diagnostic, and the visually-hidden
    `"Warning: "` severity is still in the DOM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline guidance for inserting format tokens in capture format, file name format, and capture destination fields.
  * Hints link to the relevant format syntax documentation and disappear once a token is entered.
  * Added styling for clearer, unobtrusive token guidance.

* **Documentation**
  * Added a link to the canonical format syntax documentation.

* **Tests**
  * Added coverage for token hint visibility, documentation links, and dynamic updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->