### PR TITLE
fix: dismissing a Yes/No confirmation is an answer, not an error

### DIFF
--- a/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.test.ts
+++ b/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.test.ts
@@ -2,6 +2,11 @@ import type { App } from "obsidian";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import GenericYesNoPrompt from "./GenericYesNoPrompt";
 
+// Obsidian routes Esc, the close button and a click outside through the same
+// Modal.close(), so the test hook onto the live instance is how a dismissal is
+// reproduced faithfully without a real Obsidian.
+const modals = vi.hoisted(() => ({ last: null as { close(): void } | null }));
+
 vi.mock("obsidian", () => {
 	class Modal {
 		containerEl: HTMLElement;
@@ -14,6 +19,7 @@ vi.mock("obsidian", () => {
 			this.titleEl = document.createElement("h1");
 			this.containerEl.append(this.titleEl, this.contentEl);
 			document.body.appendChild(this.containerEl);
+			modals.last = this;
 		}
 
 		open() {}
@@ -96,9 +102,64 @@ function installObsidianElementHelpers(): void {
 
 installObsidianElementHelpers();
 
+function clickButton(text: string): void {
+	const button = Array.from(document.querySelectorAll("button")).find(
+		(buttonEl) => buttonEl.textContent === text,
+	);
+	button?.click();
+}
+
+/** Esc / the close button / a click outside — Obsidian closes the modal. */
+function dismiss(): void {
+	modals.last?.close();
+}
+
 describe("GenericYesNoPrompt", () => {
 	afterEach(() => {
 		document.body.replaceChildren();
+		modals.last = null;
+	});
+
+	// The contract, in one place: walking away from the dialog is an answer, not
+	// an error. It used to reject with a bare "No answer given." string, which
+	// turned every cancelled confirmation into an unhandled rejection at the
+	// call sites that (reasonably) just awaited a boolean (#1567).
+	describe("contract", () => {
+		it.each([
+			["Yes", true],
+			["No", false],
+		])("Ask resolves %s as %s", async (buttonText, expected) => {
+			const answer = GenericYesNoPrompt.Ask({} as App, "Confirm", "Continue?");
+			clickButton(buttonText);
+			await expect(answer).resolves.toBe(expected);
+		});
+
+		it("Ask resolves null when the dialog is dismissed", async () => {
+			const answer = GenericYesNoPrompt.Ask({} as App, "Confirm", "Continue?");
+			dismiss();
+			await expect(answer).resolves.toBeNull();
+		});
+
+		it("Prompt resolves false when the dialog is dismissed", async () => {
+			const answer = GenericYesNoPrompt.Prompt(
+				{} as App,
+				"Confirm",
+				"Continue?",
+			);
+			dismiss();
+			await expect(answer).resolves.toBe(false);
+		});
+
+		it.each([
+			["Ask", () => GenericYesNoPrompt.Ask({} as App, "Confirm")],
+			["Prompt", () => GenericYesNoPrompt.Prompt({} as App, "Confirm")],
+		])("%s never rejects on dismissal", async (_name, open) => {
+			const onRejected = vi.fn();
+			const answer = open().catch(onRejected);
+			dismiss();
+			await answer;
+			expect(onRejected).not.toHaveBeenCalled();
+		});
 	});
 
 	it.each([

--- a/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.ts
+++ b/src/gui/GenericYesNoPrompt/GenericYesNoPrompt.ts
@@ -1,20 +1,44 @@
 import type { App } from "obsidian";
 import { ButtonComponent, Modal } from "obsidian";
 
+/**
+ * A yes/no dialog. Walking away from it is an answer, not an error: dismissing
+ * the dialog (Esc, the close button, clicking outside) never rejects.
+ *
+ * Use {@link GenericYesNoPrompt.Prompt} for confirmations, where a dismissal is
+ * simply "no". Use {@link GenericYesNoPrompt.Ask} only where a dismissal has to
+ * be told apart from an explicit "No".
+ */
 export default class GenericYesNoPrompt extends Modal {
-	private resolvePromise: (input: boolean) => void;
-	private rejectPromise: (reason?: unknown) => void;
-	private input: boolean;
-	public waitForClose: Promise<boolean>;
-	private didSubmit = false;
+	private resolvePromise: (input: boolean | null) => void;
+	/** `null` until an answer is given, which is what a dismissal resolves. */
+	private input: boolean | null = null;
+	public waitForClose: Promise<boolean | null>;
 
-	public static Prompt(
+	/**
+	 * Ask a yes/no question, keeping "No" and "the user walked away" apart.
+	 *
+	 * Yes = `true`, No = `false`, dismissed = `null`. Never rejects.
+	 */
+	public static Ask(
+		app: App,
+		header: string,
+		text?: string
+	): Promise<boolean | null> {
+		const newPromptModal = new GenericYesNoPrompt(app, header, text);
+		return newPromptModal.waitForClose;
+	}
+
+	/**
+	 * Ask for confirmation. Only an explicit "Yes" confirms, so dismissing the
+	 * dialog counts as "No". Never rejects.
+	 */
+	public static async Prompt(
 		app: App,
 		header: string,
 		text?: string
 	): Promise<boolean> {
-		const newPromptModal = new GenericYesNoPrompt(app, header, text);
-		return newPromptModal.waitForClose;
+		return (await GenericYesNoPrompt.Ask(app, header, text)) === true;
 	}
 
 	private constructor(
@@ -24,9 +48,8 @@ export default class GenericYesNoPrompt extends Modal {
 	) {
 		super(app);
 
-		this.waitForClose = new Promise<boolean>((resolve, reject) => {
+		this.waitForClose = new Promise<boolean | null>((resolve) => {
 			this.resolvePromise = resolve;
-			this.rejectPromise = reject;
 		});
 
 		this.open();
@@ -61,15 +84,13 @@ export default class GenericYesNoPrompt extends Modal {
 
 	private submit(input: boolean) {
 		this.input = input;
-		this.didSubmit = true;
 		this.close();
 	}
 
 	onClose() {
 		super.onClose();
 
-		if (!this.didSubmit) this.rejectPromise("No answer given.");
-		else this.resolvePromise(this.input);
+		this.resolvePromise(this.input);
 	}
 }
 

--- a/src/quickAddApi.audit-api-prompts.test.ts
+++ b/src/quickAddApi.audit-api-prompts.test.ts
@@ -19,7 +19,7 @@ vi.mock("./gui/GenericWideInputPrompt/GenericWideInputPrompt", () => ({
 	default: { Prompt: vi.fn() },
 }));
 vi.mock("./gui/GenericYesNoPrompt/GenericYesNoPrompt", () => ({
-	default: { Prompt: vi.fn() },
+	default: { Ask: vi.fn(), Prompt: vi.fn() },
 }));
 vi.mock("./gui/GenericInfoDialog/GenericInfoDialog", () => ({
 	default: { Show: vi.fn() },

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
 	// GUI prompts
 	genericInputPrompt: vi.fn(),
 	genericWideInputPrompt: vi.fn(),
-	genericYesNoPrompt: vi.fn(),
+	genericYesNoPromptAsk: vi.fn(),
 	genericInfoDialog: vi.fn(),
 	genericCheckboxPrompt: vi.fn(),
 	genericSuggester: vi.fn(),
@@ -53,7 +53,7 @@ vi.mock("./gui/GenericWideInputPrompt/GenericWideInputPrompt", () => ({
 	default: { Prompt: mocks.genericWideInputPrompt },
 }));
 vi.mock("./gui/GenericYesNoPrompt/GenericYesNoPrompt", () => ({
-	default: { Prompt: mocks.genericYesNoPrompt },
+	default: { Ask: mocks.genericYesNoPromptAsk },
 }));
 vi.mock("./gui/GenericInfoDialog/GenericInfoDialog", () => ({
 	default: { Show: mocks.genericInfoDialog },
@@ -306,18 +306,30 @@ describe("static prompt wrappers", () => {
 		});
 	});
 
+	// Scripts are the one caller that needs "No" and "dismissed" kept apart:
+	// answering No is a value the script acts on, dismissing aborts the macro.
 	describe("yesNoPrompt", () => {
 		it("returns the boolean answer", async () => {
-			mocks.genericYesNoPrompt.mockResolvedValue(true);
+			mocks.genericYesNoPromptAsk.mockResolvedValue(true);
 			expect(await QuickAddApi.yesNoPrompt(app, "H", "txt")).toBe(true);
-			expect(mocks.genericYesNoPrompt).toHaveBeenCalledWith(app, "H", "txt");
+			expect(mocks.genericYesNoPromptAsk).toHaveBeenCalledWith(app, "H", "txt");
 		});
 
-		it("treats 'No answer given.' as a cancellation abort", async () => {
-			mocks.genericYesNoPrompt.mockRejectedValue("No answer given.");
+		it("returns false for an explicit No rather than aborting", async () => {
+			mocks.genericYesNoPromptAsk.mockResolvedValue(false);
+			expect(await QuickAddApi.yesNoPrompt(app, "H")).toBe(false);
+		});
+
+		it("treats a dismissal as a cancellation abort", async () => {
+			mocks.genericYesNoPromptAsk.mockResolvedValue(null);
 			await expect(QuickAddApi.yesNoPrompt(app, "H")).rejects.toBeInstanceOf(
 				MacroAbortError,
 			);
+		});
+
+		it("swallows generic errors as undefined", async () => {
+			mocks.genericYesNoPromptAsk.mockRejectedValue(new Error("x"));
+			expect(await QuickAddApi.yesNoPrompt(app, "H")).toBeUndefined();
 		});
 	});
 

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -933,12 +933,19 @@ export class QuickAddApi {
 	}
 
 	public static async yesNoPrompt(app: App, header: string, text?: string) {
+		// Scripts are the one caller that must tell "No" from "the user walked
+		// away": answering No returns false and the script carries on, while
+		// dismissing the dialog aborts the macro like every other prompt does.
+		let answer: boolean | null;
 		try {
-			return await GenericYesNoPrompt.Prompt(app, header, text);
+			answer = await GenericYesNoPrompt.Ask(app, header, text);
 		} catch (error) {
 			throwIfPromptCancelled(error);
 			return undefined;
 		}
+
+		if (answer === null) throw new UserCancelError("Input cancelled by user");
+		return answer;
 	}
 
 	public static async infoDialog(

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -479,31 +479,17 @@ describe("choiceService", () => {
 			expect(message).toContain("everything inside it: 2 choices and 1 folder.");
 		});
 
-		// GenericYesNoPrompt REJECTS on Esc/close instead of resolving false, and
-		// the Svelte call sites discard the promise — so this used to surface as
-		// an unhandled rejection in the console on every cancelled delete.
+		// A dismissal reaches this call site as a plain `false` (GenericYesNoPrompt
+		// resolves rather than rejects, #1567), so it takes the declined path with
+		// no error of any kind — this used to be an unhandled rejection.
 		it("treats a dismissed prompt as 'no' without logging an error", async () => {
-			mocks.yesNoPrompt.mockRejectedValue("No answer given.");
+			mocks.yesNoPrompt.mockResolvedValue(false);
 			const result = await deleteChoiceWithConfirmation(
 				createChoice("Multi", "Journal"),
 				fakeApp,
 			);
 			expect(result).toBe(false);
 			expect(mocks.logError).not.toHaveBeenCalled();
-		});
-
-		it("reports a genuine prompt failure, in the target's own noun", async () => {
-			mocks.yesNoPrompt.mockRejectedValue(new Error("boom"));
-			const result = await deleteChoiceWithConfirmation(
-				createChoice("Multi", "Journal"),
-				fakeApp,
-			);
-			expect(result).toBe(false);
-			// reportError surfaces as a Notice via GuiLogger, so this string is
-			// user-visible and must use the same vocabulary as the dialog above it.
-			expect(String(mocks.logError.mock.calls[0][0])).toContain(
-				"folder deletion",
-			);
 		});
 
 		// dedupeChoicesById deliberately preserves a malformed Multi (children

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -494,7 +494,7 @@ describe("choiceService", () => {
 
 		// dedupeChoicesById deliberately preserves a malformed Multi (children
 		// missing or not an array) instead of fabricating []. The delete must stay
-		// usable for such a folder rather than throwing past the cancel guard.
+		// usable for such a folder rather than throwing out of the delete handler.
 		it.each([
 			["missing children", undefined],
 			["non-array children", {} as unknown as IChoice[]],

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -233,8 +233,9 @@ export async function deleteChoiceWithConfirmation(
 		// A malformed Multi (children missing, or not an array) is deliberately
 		// preserved on load rather than repaired — see dedupeChoicesById — and
 		// flattenChoices would throw on it. Throwing here would leave the corrupt
-		// folder undeletable AND raise the unhandled rejection the catch below
-		// exists to prevent, so treat it as empty and let the delete through.
+		// folder undeletable, and ChoiceView awaits this function from a click
+		// handler that discards the promise, so the throw would surface as an
+		// unhandled rejection. Treat it as empty and let the delete through.
 		const children = Array.isArray(multi.choices) ? multi.choices : [];
 		const descendants = flattenChoices(children);
 		if (descendants.length === 0) return "";

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -19,7 +19,6 @@ import { TemplateChoice } from "../types/choices/TemplateChoice";
 import { regenerateIds } from "../utils/macroUtils";
 import { flattenChoices } from "../utils/choiceUtils";
 import { choiceNoun } from "../utils/choiceNoun";
-import { isCancellationError, reportError } from "../utils/errorUtils";
 import { excludeKeys } from "../utils/excludeKeys";
 import { deepClone } from "../utils/deepClone";
 import {
@@ -257,26 +256,11 @@ export async function deleteChoiceWithConfirmation(
 		.filter(Boolean)
 		.join(" ");
 
-	// GenericYesNoPrompt REJECTS with a bare "No answer given." string when the
-	// user dismisses it (Esc / the close button) rather than answering. The call
-	// sites are Svelte `onclick` handlers that discard the promise, so without
-	// this catch a cancelled delete surfaced as an unhandled rejection.
-	let userConfirmed: boolean;
-	try {
-		userConfirmed = await GenericYesNoPrompt.Prompt(
-			app,
-			`Delete ${choiceNoun(choice.type)}`,
-			body,
-		);
-	} catch (error) {
-		if (!isCancellationError(error)) {
-			reportError(
-				error,
-				`Could not confirm ${choiceNoun(choice.type)} deletion`,
-			);
-		}
-		return false;
-	}
+	const userConfirmed = await GenericYesNoPrompt.Prompt(
+		app,
+		`Delete ${choiceNoun(choice.type)}`,
+		body,
+	);
 
 	if (!userConfirmed) return false;
 

--- a/src/services/packageExportService.ts
+++ b/src/services/packageExportService.ts
@@ -257,16 +257,11 @@ async function defaultConfirmOverwrite(
 	app: App,
 	normalizedPath: string,
 ): Promise<boolean> {
-	try {
-		return await GenericYesNoPrompt.Prompt(
-			app,
-			"Overwrite existing file?",
-			`A file already exists at '${normalizedPath}'. Saving the package will overwrite it. Continue?`,
-		);
-	} catch {
-		// Dismissing the prompt (Esc) is treated as "do not overwrite".
-		return false;
-	}
+	return GenericYesNoPrompt.Prompt(
+		app,
+		"Overwrite existing file?",
+		`A file already exists at '${normalizedPath}'. Saving the package will overwrite it. Continue?`,
+	);
 }
 
 export async function writePackageToVault(

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -79,7 +79,8 @@ export function isCancellationError(error: unknown): boolean {
 	const cancellationMessages = [
 		"no input given.",      // GenericSuggester, InputSuggester, GenericCheckboxPrompt
 		"No input given.",      // GenericInputPrompt, MathModal
-		"No answer given.",     // GenericYesNoPrompt
+		// GenericYesNoPrompt is deliberately absent: it resolves a dismissal
+		// instead of rejecting, so it never reaches this check (#1567).
 		"cancelled"             // OnePagePreflight
 	];
 	


### PR DESCRIPTION
Fixes #1567.

## The problem behind the issue

`GenericYesNoPrompt.Prompt` rejected with the bare string `"No answer given."` when the user dismissed the dialog (Esc, the close button, a click outside). That makes the single most common user action on a confirmation - walking away from it - the *exceptional* path, and nothing in the signature (`Promise<boolean>`) says so. The result is a call site that is **wrong by default**: three of them logged `Uncaught (in promise) No answer given.` on every cancelled delete, and the next one added would have too.

The issue proposed wrapping the three offenders in `try/catch`. I don't think that's the fix. The repo already contains three independently hand-written copies of that same "dismiss = no" workaround, added on three different dates, and the bug still existed - the boilerplate was not converging. So this PR fixes the contract instead.

## The contract

```ts
/** Yes = true, No = false, dismissed = null. Never rejects. */
static Ask(app, header, text?): Promise<boolean | null>

/** Confirmation: only an explicit "Yes" confirms, so a dismissal is "No". Never rejects. */
static async Prompt(app, header, text?): Promise<boolean>
```

The modal no longer rejects at all. Of the seven call sites, six are confirmations that want dismiss = No; they keep calling `Prompt` and are now correct by construction, so the hand-rolled guards in `choiceService` (#1562) and `packageExportService` are deleted rather than replicated.

Exactly one caller needs the distinction: **`quickAddApi.yesNoPrompt`**, the script-facing API. There, answering *No* is a value the script acts on, while *dismissing* must abort the macro - otherwise `if (await yesNoPrompt(...)) {...} else {...}` would run its else-branch when the user meant "get me out of here". That caller uses `Ask` and maps `null` to `UserCancelError`, so the observable script behaviour is unchanged.

`"No answer given."` is removed from `isCancellationError`'s string list; nothing produces it any more.

### Why this shape, and what it doesn't do

- **Why not "always resolve false"?** It would silently convert a script's Escape into a `false` and let the macro carry on. That's a real regression for the one caller that cares.
- **Does it fit the codebase?** Yes - `AIToolConfirmModal` already documents *"Dismissing (Esc / click-out) resolves to 'deny'"*, and `ModelDirectoryModal` / `AIAssistantCommandSettingsModal` already resolve `null` on dismissal. Sentinel-on-dismiss is already the house style for confirmations; `GenericYesNoPrompt` was the outlier.
- **Scope.** The sibling prompts (`GenericInputPrompt`, `GenericSuggester`, `GenericCheckboxPrompt`, …) still reject with bare strings, and that is deliberately left alone: their return types (`string`, `T`, `string[]`) have no natural "cancelled" value, so rejection is a legitimate signal there. `GenericYesNoPrompt` is genuinely the different one. Follow-ups are filed rather than folded in (listed below).

## Validation

All checks below were run in this worktree's own isolated Obsidian 1.13.0 e2e vault, with real DOM clicks and a real `Escape` keydown, and a `window.addEventListener("unhandledrejection", …)` listener attached.

**Reproduced first, on the pre-fix build** - Settings → QuickAdd → Configure a Macro → Delete command → Esc:

![before](https://raw.githubusercontent.com/chhoumann/quickadd/c75a37e8dc851ebc4daa85980f5e4a431e84de79/shots/before.png)

**After** - identical UI, identical outcome (the command is kept), no console noise:

![after](https://raw.githubusercontent.com/chhoumann/quickadd/c75a37e8dc851ebc4daa85980f5e4a431e84de79/shots/after.png)

*(The panel is a test overlay printing the real captured `unhandledrejection` events; the harness's own `dev:errors` buffer agrees - `No answer given.` before, `No errors captured.` after.)*

| Path | Before | After |
|---|---|---|
| Macro → Delete command → Esc | `["No answer given."]`, command kept | `[]`, command kept |
| AI Assistant → Edit providers → delete → Esc | `["No answer given."]` | `[]` |
| Delete command → **Yes** | deletes | deletes (`["Wait"]` → `[]`) |
| Delete command → **No** | keeps | keeps |
| `api.yesNoPrompt` → Esc | throws `MacroAbortError` | throws `MacroAbortError` |
| `api.yesNoPrompt` → No / Yes | `false` / `true` | `false` / `true` |
| Real macro (UserScript + a second command) → Esc | aborts, second command never runs | identical |
| Real macro → No | script gets `false`, macro continues | identical |

Plus: full suite `4075 passed / 37 skipped`, `tsc --noEmit` clean, `eslint` clean. The four new dismissal tests were mutation-checked - reverting `onClose` to throw makes exactly those four fail and nothing else.

## Tests

The contract is pinned on the **real modal** (`GenericYesNoPrompt.test.ts`), not on a mock, so a future refactor can't quietly break it while the suite stays green: `Ask` resolves `true`/`false`/`null`, `Prompt` resolves `false` on dismissal, and neither rejects. `quickAddApi.test.ts` pins the script-side contract, including that an explicit *No* is **not** an abort.

## Follow-ups (filed, not folded in)

- #1574 - `RemotePromptProvider.yesNoPrompt` cannot express a dismissal at all, while its file docstring claims exact parity with the in-app method.
- #1575 - `throwIfPromptCancelled` swallows genuine errors into `undefined` at all nine `quickAddApi` prompt wrappers.
- #1576 - async click handlers across the settings UI discard their promises, so *any* throw inside one is an unhandled rejection. That wants one uniform seam, not per-handler `try/catch` - which is precisely the boilerplate that failed to converge here.
- #1577 - the rest of the prompt family still signals cancellation with hardcoded English strings matched by equality.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dismissing yes/no dialogs now completes safely without causing unexpected promise errors.
  * Explicit “No” responses remain distinct from closing or dismissing a dialog.
  * Quick Add prompts now correctly treat dismissal as user cancellation.
  * Choice deletion confirmations handle dismissed dialogs consistently without logging spurious errors.
  * Overwrite confirmations continue to prevent overwriting when the prompt is dismissed.
* **Tests**
  * Expanded coverage for dialog dismissal, cancellation, and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->