### PR TITLE
fix: make the file-name preview tell the truth, and the FIELD filter warning readable

### DIFF
--- a/src/formatters/fileNameDisplayFormatter-1563-normalize.test.ts
+++ b/src/formatters/fileNameDisplayFormatter-1563-normalize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { App } from "obsidian";
+import { FileNameDisplayFormatter } from "./fileNameDisplayFormatter";
+import { normalizeGeneratedFilePath } from "../utils/generatedFilePath";
+
+/**
+ * Issue #1563. The run puts every generated name through
+ * `normalizeGeneratedFilePath` on the way to the vault - TemplateChoiceEngine,
+ * TemplateInsertEngine, templateNoteDiscovery, and the capture target via
+ * captureTargetResolution all call it - so a preview that skips it asserts a
+ * name the run will never create.
+ *
+ * Each case below pins the preview against the run's own normalizer rather than
+ * against a hand-written string, so the two cannot drift apart.
+ */
+const mockApp = {
+	workspace: { getActiveFile: () => null },
+	vault: { getMarkdownFiles: () => [], getAbstractFileByPath: () => null },
+	metadataCache: { getFileCache: () => null },
+} as unknown as App;
+
+function makeFormatter(): FileNameDisplayFormatter {
+	return new FileNameDisplayFormatter(mockApp);
+}
+
+async function preview(input: string) {
+	const formatter = makeFormatter();
+	const out = await formatter.format(input);
+	return { out, problems: formatter.diagnostics.list() };
+}
+
+describe("the file-name preview mirrors the run's name normalizer", () => {
+	it.each([
+		["a trailing dot", "Meeting notes."],
+		["trailing spaces", "Meeting notes   "],
+		["a backslash separator", String.raw`Notes\2026\Log`],
+		["a line break", "First\nSecond"],
+		["a run of line breaks with spaces around it", "First  \n\n  Second"],
+		["a line separator character", "Line Separator"],
+		["a leading line break", "\nName"],
+		["a tab", "Tabbed\tName"],
+	])("%s", async (_label, input) => {
+		const { out, problems } = await preview(input);
+		expect(out).toBe(normalizeGeneratedFilePath(input));
+		expect(problems).toEqual([]);
+	});
+
+	it("normalizes what the tokens produced, not just what was typed", async () => {
+		// The value placeholder is spliced in first; the normalizer then sees the
+		// finished name, exactly as the run does.
+		const { out } = await preview("Notes/{{VALUE:title}}.");
+		expect(out).toBe("Notes/Example Title");
+	});
+
+	it("says so when the run would abort instead of quietly showing a name", async () => {
+		const { out, problems } = await preview("Notes/../secret");
+		expect(problems).toEqual([
+			{
+				severity: "error",
+				message: 'File path cannot contain "." or ".." path segments.',
+			},
+		]);
+		// Still shows the best-effort text: the diagnostic is what says it is
+		// unusable, and blanking the row would hide the shape of the mistake.
+		expect(out).toBe("Notes/../secret");
+	});
+
+	it("reports an empty interior segment", async () => {
+		const { problems } = await preview("Notes//Log");
+		expect(problems).toEqual([
+			{
+				severity: "error",
+				message: "File path contains an empty path segment after formatting.",
+			},
+		]);
+	});
+
+	it("leaves a half-typed folder path alone while it is being typed", async () => {
+		const { out, problems } = await preview("Notes/");
+		expect(out).toBe("Notes/");
+		expect(problems).toEqual([]);
+	});
+
+	it("leaves a capture target's special forms untouched", async () => {
+		for (const target of [
+			"property:status=done",
+			"tag:#inbox",
+			"Daily/2026-07-27.md",
+		]) {
+			const { out, problems } = await preview(target);
+			expect(out).toBe(target);
+			expect(problems).toEqual([]);
+		}
+	});
+});

--- a/src/formatters/fileNameDisplayFormatter-1563-template.test.ts
+++ b/src/formatters/fileNameDisplayFormatter-1563-template.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+import { TFile } from "obsidian";
+import { FileNameDisplayFormatter } from "./fileNameDisplayFormatter";
+import type QuickAdd from "../main";
+import { LogManager } from "../logger/logManager";
+import type { ILogger } from "../logger/ilogger";
+
+/**
+ * If the preview ever reaches the runtime engine, these mocks record it. Real
+ * ones would open a modal / run a user script - the #1558 failure, on the field
+ * next door.
+ */
+const spies = vi.hoisted(() => ({
+	templateEngineRuns: [] as string[],
+	macroEngineRuns: [] as string[],
+	prompts: [] as string[],
+}));
+
+vi.mock("../engine/SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		constructor(
+			_app: unknown,
+			_plugin: unknown,
+			public templatePath: string,
+		) {}
+		run(): Promise<string> {
+			spies.templateEngineRuns.push(this.templatePath);
+			return Promise.resolve("RUNTIME ENGINE RAN");
+		}
+	},
+}));
+
+vi.mock("../engine/SingleMacroEngine", () => ({
+	SingleMacroEngine: class {
+		runAndGetOutput(name: string): Promise<string> {
+			spies.macroEngineRuns.push(name);
+			return Promise.resolve("MACRO RAN");
+		}
+		getVariables() {
+			return new Map();
+		}
+	},
+}));
+
+vi.mock("../gui/InputPrompt", () => ({
+	default: class {
+		factory() {
+			return {
+				Prompt: async (_app: unknown, header: string) => {
+					spies.prompts.push(header);
+					return "PROMPTED";
+				},
+			};
+		}
+	},
+}));
+
+let templates: Record<string, string> = {};
+let reported: string[] = [];
+let activeFile: { basename: string; path: string; parent: { path: string } } | null =
+	null;
+
+function makeApp(): App {
+	return {
+		workspace: { getActiveFile: () => activeFile },
+		vault: {
+			getMarkdownFiles: () => [],
+			getAbstractFileByPath: (path: string) =>
+				path in templates
+					? Object.assign(new TFile(), {
+							path,
+							extension: "md",
+							basename: path.replace(/\.md$/, ""),
+						})
+					: null,
+			cachedRead: async (file: { path: string }) => templates[file.path],
+		},
+		metadataCache: { getFileCache: () => null, getAllPropertyInfos: () => ({}) },
+	} as unknown as App;
+}
+
+const plugin = {
+	settings: { globalVariables: {}, choices: [] },
+	getTemplateFiles: () => [],
+} as unknown as QuickAdd;
+
+function makeFormatter(): FileNameDisplayFormatter {
+	return new FileNameDisplayFormatter(makeApp(), plugin);
+}
+
+beforeEach(() => {
+	templates = {};
+	reported = [];
+	activeFile = null;
+	spies.templateEngineRuns.length = 0;
+	spies.macroEngineRuns.length = 0;
+	spies.prompts.length = 0;
+	LogManager.loggers = [
+		{
+			logError: (m: string) => reported.push(`error ${m}`),
+			logWarning: (m: string) => reported.push(`warning ${m}`),
+			logMessage: () => {},
+		} as unknown as ILogger,
+	];
+});
+
+/**
+ * Issue #1563. `CompleteFormatter.formatFileName` resolves `{{TEMPLATE:...}}` -
+ * `format()` runs `replaceTemplateInString`, and path prompt scope is
+ * deliberately propagated into the child engine - but the file-name PREVIEW
+ * never called it, so the builder said `{{TEMPLATE:Naming.md}}-My Note` while the
+ * run produced whatever Naming.md rendered to.
+ */
+describe("#1563 the file-name preview resolves {{TEMPLATE:}}", () => {
+	it("shows the name the run will produce", async () => {
+		templates["Templates/Naming.md"] = "{{VALUE:title}}\n";
+
+		expect(
+			await makeFormatter().format("{{TEMPLATE:Templates/Naming.md}}"),
+		).toBe("Example Title");
+	});
+
+	it("resolves the include before {{VALUE}}, as the run does", async () => {
+		// A body whose own tokens resolve, spliced into a name that has more text
+		// after it. The template file's trailing newline collapses to one space
+		// at the seam - the run's normalizer does exactly this to the finished
+		// name, so the two agree instead of differing by a space.
+		templates["N.md"] = "Log {{VALUE:title}}\n";
+
+		expect(await makeFormatter().format("{{TEMPLATE:N.md}}-suffix")).toBe(
+			"Log Example Title -suffix",
+		);
+	});
+
+	it("joins a multi-line body into one line, and says that it did", async () => {
+		templates["Body.md"] = "---\ntitle: x\n---\n\n# Heading\n\nNotes\n";
+		const f = makeFormatter();
+
+		const out = await f.format("{{TEMPLATE:Body.md}}");
+
+		expect(out).toBe("--- title: x --- # Heading Notes");
+		expect(f.diagnostics.list()).toEqual([
+			{
+				severity: "warning",
+				message:
+					'Template "Body.md" is 5 lines; a file name is one line, so they are joined with spaces.',
+			},
+		]);
+	});
+
+	it("stays quiet about the trailing newline every one-line template has", async () => {
+		templates["N.md"] = "Just a name\n";
+		const f = makeFormatter();
+
+		expect(await f.format("{{TEMPLATE:N.md}}")).toBe("Just a name");
+		expect(f.diagnostics.list()).toEqual([]);
+	});
+
+	it("resolves an included body with CONTENT token semantics, as the run does", async () => {
+		// At run time the body goes through the child engine's formatFileContent,
+		// which resolves {{linkcurrent}} / {{linksection}}; the file-name pass
+		// deliberately leaves them literal, so an include previewed with the
+		// file-name pass list would diverge on exactly the tokens templates carry.
+		activeFile = { basename: "Active", path: "Notes/Active.md", parent: { path: "Notes" } };
+		templates["N.md"] = "{{linkcurrent}} in {{foldercurrent}}";
+
+		expect(await makeFormatter().format("{{TEMPLATE:N.md}}")).toBe(
+			"Active in Notes",
+		);
+	});
+
+	it("leaves {{linkcurrent}} typed into the field itself literal, as the run does", async () => {
+		activeFile = { basename: "Active", path: "Notes/Active.md", parent: { path: "Notes" } };
+
+		expect(await makeFormatter().format("{{linkcurrent}}-x")).toBe(
+			"{{linkcurrent}}-x",
+		);
+	});
+});
+
+describe("#1563 the file-name preview stays inert (#1558's contract)", () => {
+	it("never reaches the runtime template engine", async () => {
+		templates["N.md"] = "hello";
+
+		await makeFormatter().format("{{TEMPLATE:N.md}}");
+
+		expect(spies.templateEngineRuns).toEqual([]);
+	});
+
+	it("never prompts for a {{VALUE}} inside the included template", async () => {
+		templates["N.md"] = "Hi {{VALUE:whoAreYou}}";
+
+		const out = await makeFormatter().format("{{TEMPLATE:N.md}}");
+
+		expect(spies.prompts).toEqual([]);
+		expect(out).not.toContain("{{VALUE");
+	});
+
+	it("never runs a macro inside the included template", async () => {
+		templates["N.md"] = "x {{MACRO:DoSomething}}";
+
+		await makeFormatter().format("{{TEMPLATE:N.md}}");
+
+		expect(spies.macroEngineRuns).toEqual([]);
+	});
+
+	it("collects a bad token inside the template instead of firing a Notice", async () => {
+		templates["N.md"] = "{{VALUE:x|case:pasc}}";
+		const f = makeFormatter();
+
+		await f.format("{{TEMPLATE:N.md}}");
+
+		expect(reported).toEqual([]);
+		expect(
+			f.diagnostics.list().some((d) => d.message.includes("Unsupported |case")),
+		).toBe(true);
+	});
+});
+
+describe("#1563 the file-name preview bounds and reports include failures", () => {
+	it("says the template is missing, as an error the run would abort on", async () => {
+		const f = makeFormatter();
+
+		expect(await f.format("{{TEMPLATE:Gone.md}}")).toBe(
+			"[QuickAdd: template not found] Gone.md",
+		);
+		expect(f.diagnostics.list()).toEqual([
+			{ severity: "error", message: "Template not found: Gone.md" },
+		]);
+		expect(reported).toEqual([]);
+	});
+
+	it("reports a self-including template as a cycle", async () => {
+		templates["Loop.md"] = "before {{TEMPLATE:Loop.md}} after";
+		const f = makeFormatter();
+
+		const out = await f.format("{{TEMPLATE:Loop.md}}");
+
+		expect(out).toContain("template inclusion cycle detected");
+		expect(f.diagnostics.hasError).toBe(true);
+		expect(reported).toEqual([]);
+	});
+
+	it("stops a long include chain at the inclusion depth limit", async () => {
+		for (let i = 0; i < 15; i++) {
+			templates[`T${i}.md`] = `${i} {{TEMPLATE:T${i + 1}.md}}`;
+		}
+		templates["T15.md"] = "end";
+		const f = makeFormatter();
+
+		expect(await f.format("{{TEMPLATE:T0.md}}")).toContain(
+			"max template inclusion depth",
+		);
+		expect(reported).toEqual([]);
+	});
+
+	it("terminates when a global snippet keeps re-arming the include", async () => {
+		// The template pass runs BEFORE global expansion (matching the run), so
+		// each expansion hands `replaceTemplateInString` a fresh token with the
+		// cycle set already unwound. Only the per-pass budget ends this.
+		(plugin as unknown as { settings: { globalVariables: Record<string, string> } })
+			.settings.globalVariables = { g: "{{TEMPLATE:A.md}}" };
+		templates["A.md"] = "{{GLOBAL_VAR:g}}";
+		const f = makeFormatter();
+
+		const out = await f.format("{{TEMPLATE:A.md}}");
+
+		expect(out).toContain("too many template includes");
+		expect(f.diagnostics.hasError).toBe(true);
+		(plugin as unknown as { settings: { globalVariables: Record<string, string> } })
+			.settings.globalVariables = {};
+	});
+
+	it("leaves a {{TEMPLATE:}} produced by a global literal, as the run does", async () => {
+		// The run's template pass has already gone by when globals expand, so the
+		// token survives into the name. Resolving it here would be a new lie.
+		(plugin as unknown as { settings: { globalVariables: Record<string, string> } })
+			.settings.globalVariables = { naming: "{{TEMPLATE:N.md}}" };
+		templates["N.md"] = "resolved";
+
+		expect(await makeFormatter().format("{{GLOBAL_VAR:naming}}")).toBe(
+			"{{TEMPLATE:N.md}}",
+		);
+		(plugin as unknown as { settings: { globalVariables: Record<string, string> } })
+			.settings.globalVariables = {};
+	});
+});

--- a/src/formatters/fileNameDisplayFormatter-1563-template.test.ts
+++ b/src/formatters/fileNameDisplayFormatter-1563-template.test.ts
@@ -286,3 +286,34 @@ describe("#1563 the file-name preview bounds and reports include failures", () =
 			.settings.globalVariables = {};
 	});
 });
+
+describe("#1563 the template pass respects inline script fences", () => {
+	it("does not expand a {{TEMPLATE:}} written inside a script's source", async () => {
+		// The run consumes the fence FIRST (replaceInlineJavascriptInString is its
+		// first pass), so this token is never an include there. The preview has no
+		// inline-JS pass at all, so without the span guard it would read N.md,
+		// splice the body into the middle of the source, and report a bogus
+		// "Template not found" for a format that is fine.
+		templates["N.md"] = "SPLICED";
+		const fence = 'a\n```js quickadd\nconst p = "{{TEMPLATE:Gone.md}}";\n```\nb';
+		const f = makeFormatter();
+
+		const out = await f.format(fence);
+
+		expect(out).toContain('"{{TEMPLATE:Gone.md}}"');
+		expect(out).not.toContain("template not found");
+		expect(f.diagnostics.list()).toEqual([]);
+	});
+
+	it("still expands an include that sits outside the fence", async () => {
+		templates["N.md"] = "SPLICED";
+		const f = makeFormatter();
+
+		const out = await f.format(
+			'{{TEMPLATE:N.md}}\n```js quickadd\nconst p = "{{TEMPLATE:N.md}}";\n```',
+		);
+
+		expect(out.startsWith("SPLICED")).toBe(true);
+		expect(out).toContain('"{{TEMPLATE:N.md}}"');
+	});
+});

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -13,17 +13,26 @@ import {
 	getVariablePromptExample,
 	getSuggestionPreview,
 	getCurrentFileLinkPreview,
+	getCurrentFileLinkToSectionPreview,
 	getCurrentFileNamePreview,
 	getCurrentFolderPathPreview,
 	DateFormatPreviewGenerator
 } from "./helpers/previewHelpers";
 import { previewGeneratedFilePath } from "../utils/generatedFilePath";
+import { getTemplateFile } from "../utils/templateFolderUtils";
 import { getValueVariableBaseName } from "../utils/valueSyntax";
 import { parseVDateOptions } from "../utils/vdateSyntax";
 import { EnhancedFieldSuggestionFileFilter } from "../utils/EnhancedFieldSuggestionFileFilter";
 import { FILE_CUSTOM_PREFIX, FILE_PICK_PREFIX, type ParsedFileToken } from "../utils/fileSyntax";
 
 import type QuickAdd from "../main";
+
+/**
+ * Includes one preview pass may expand, across the whole format string.
+ * Generous next to any real naming template (which includes one file, or none),
+ * and small enough that a pathological include tree cannot stall a keystroke.
+ */
+const MAX_PREVIEW_TEMPLATE_INCLUDES = 25;
 
 export class FileNameDisplayFormatter extends Formatter {
 	constructor(
@@ -57,32 +66,18 @@ export class FileNameDisplayFormatter extends Formatter {
 		this.diagnostics.add("error", message);
 	}
 
+	/**
+	 * Includes this pass may still expand. See {@link getTemplateContent}.
+	 */
+	private templateIncludeBudget = MAX_PREVIEW_TEMPLATE_INCLUDES;
+
 	public async format(input: string): Promise<string> {
 		let output: string = input;
 		this.diagnostics = new PreviewDiagnostics();
+		this.templateIncludeBudget = MAX_PREVIEW_TEMPLATE_INCLUDES;
 
 		try {
-			// Expand globals first to preview inserted snippets
-			output = await this.replaceGlobalVarInString(output);
-			output = await this.replaceMacrosInString(output);
-			output = this.replaceDateInString(output);
-			output = this.replaceTimeInString(output);
-			output = await this.replaceValueInString(output);
-			output = await this.replaceSelectedInString(output);
-			output = await this.replaceClipboardInString(output);
-			output = await this.replaceDateVariableInString(output);
-			output = await this.replaceVariableInString(output);
-			output = await this.replaceFieldVarInString(output);
-			output = await this.replaceFileInString(output);
-			// {{filenamecurrent}} + {{folder}} + {{foldercurrent}} in one pass so no
-			// token re-scans another's output (#1358). The preview resolver below
-			// never returns null, so "path" mode cannot throw here.
-			output = this.replaceCurrentFileTokensInString(output, {
-				fileName: true,
-				folder: true,
-				activeFolder: "path",
-			});
-			output = this.replaceRandomInString(output);
+			output = await this.formatInternal(input, { included: false });
 		} catch (error) {
 			// Return the input as-is if formatting fails during preview. The failure
 			// itself is the most useful thing the preview can say, so it goes on the
@@ -106,6 +101,58 @@ export class FileNameDisplayFormatter extends Formatter {
 			this.diagnostics.add("error", problem);
 		}
 		return normalized.path;
+	}
+
+	/**
+	 * The preview pass list.
+	 *
+	 * `included` marks a `{{TEMPLATE:}}` body being resolved for splicing into
+	 * the name. At run time that body goes through a child engine's
+	 * `formatFileContent` (SingleTemplateEngine.run), which resolves the
+	 * note-derived tokens with CONTENT semantics - so an included body previewed
+	 * with the file-name pass list would leave literal exactly the tokens people
+	 * put in templates ({{linkcurrent}}, {{linksection}}). `{{title}}` stays out
+	 * of both: the run resolves it to the empty string here (the title is derived
+	 * from the name being built, so it is not known yet), and neither a blank nor
+	 * this formatter's example title is a preview worth showing.
+	 */
+	private async formatInternal(
+		input: string,
+		{ included }: { included: boolean },
+	): Promise<string> {
+		let output = input;
+
+		// {{TEMPLATE:}} FIRST, mirroring the run (CompleteFormatter.format resolves
+		// includes before globals and before {{VALUE}}). Resolving it later would
+		// make the preview splice in a body for a token that a global snippet or a
+		// value produced - which the run leaves literal, because its template pass
+		// has already gone by. (The globals/macros order below is older than this
+		// and is left as it was.)
+		output = await this.replaceTemplateInString(output);
+		// Expand globals to preview inserted snippets
+		output = await this.replaceGlobalVarInString(output);
+		output = await this.replaceMacrosInString(output);
+		output = this.replaceDateInString(output);
+		output = this.replaceTimeInString(output);
+		output = await this.replaceValueInString(output);
+		output = await this.replaceSelectedInString(output);
+		output = await this.replaceClipboardInString(output);
+		output = await this.replaceDateVariableInString(output);
+		output = await this.replaceVariableInString(output);
+		output = await this.replaceFieldVarInString(output);
+		output = await this.replaceFileInString(output);
+		// Note-derived tokens in ONE pass so no token re-scans another's output
+		// (#1358). Every preview resolver returns a placeholder rather than null,
+		// so neither mode can hit the runtime's missing-active-file throw.
+		output = this.replaceCurrentFileTokensInString(
+			output,
+			included
+				? { links: true, fileName: true, folder: true, activeFolder: "content" }
+				: { fileName: true, folder: true, activeFolder: "path" },
+		);
+		output = this.replaceRandomInString(output);
+
+		return output;
 	}
 
 	protected async replaceGlobalVarInString(input: string): Promise<string> {
@@ -177,20 +224,104 @@ export class FileNameDisplayFormatter extends Formatter {
 	}
 
 	/**
-	 * Unreachable today: this formatter's pass list (see `format()`) never calls
-	 * `replaceTemplateInString`, so `{{TEMPLATE:}}` stays literal in a file-name
-	 * preview. `getTemplateContent` is abstract on `Formatter`, so the override has
-	 * to exist.
+	 * Previews an included template's body WITHOUT the runtime engine (#1563).
 	 *
-	 * It used to return a fabricated `[<name> template content...]`, which would
-	 * have spliced text that READS like a real part of the file name the moment
-	 * anyone wired the pass up. It now names what actually happened. Run-time
-	 * `formatFileName` does resolve the include (`format()` ->
-	 * `replaceTemplateInString`); closing that gap needs a real inert reader, not
-	 * a stub.
+	 * `formatFileName` really does resolve `{{TEMPLATE:}}` - `format()` runs
+	 * `replaceTemplateInString`, and path prompt scope is deliberately propagated
+	 * into the child engine - so leaving the token literal made the preview say
+	 * `{{TEMPLATE:Naming.md}}-My Note` while the run produced whatever Naming.md
+	 * rendered to. The one-page input form contradicted itself even harder: its
+	 * preflight scans INTO the include for that same field, so it would prompt
+	 * for a variable it could only have found inside the template, and then
+	 * preview the unresolved token beside the answer.
+	 *
+	 * Reading it through THIS formatter is what keeps the preview inert: the same
+	 * substitutions the top level gets, no prompts, no macro engine, no inline JS
+	 * (issue #1558). Building a `SingleTemplateEngine` here would construct a real
+	 * `CompleteFormatter` and open blocking modals on every keystroke, which is
+	 * the bug #1560 fixed on the content field.
 	 */
 	protected async getTemplateContent(templatePath: string): Promise<string> {
-		return `[QuickAdd: template not resolved in a file name] ${templatePath}`;
+		const app = this.app;
+		if (!app) {
+			this.reportProblem(`Template preview unavailable: ${templatePath}`);
+			return `[QuickAdd: template preview unavailable] ${templatePath}`;
+		}
+
+		// Depth and cycle detection (in the shared `replaceTemplateInString`) both
+		// unwind per include, so neither bounds a format string that keeps
+		// producing NEW includes - and it can, now that the template pass runs
+		// before global expansion: a global snippet holding a {{TEMPLATE:}} token
+		// re-arms the loop with an empty `visited` set. One budget for the whole
+		// pass terminates that, and bounds the fan-out of a wide include tree on a
+		// field that resolves on every keystroke.
+		if (this.templateIncludeBudget <= 0) {
+			const placeholder = `[QuickAdd: too many template includes to preview]`;
+			this.reportProblem(placeholder);
+			return placeholder;
+		}
+
+		const file = getTemplateFile(app, templatePath);
+		if (!file) {
+			// An error, not a quiet placeholder: the run THROWS here
+			// (TemplateEngine.getTemplateContent) and the choice dies, so the row
+			// must read "Unresolved:" rather than presenting a name.
+			this.reportProblem(`Template not found: ${templatePath}`);
+			return `[QuickAdd: template not found] ${templatePath}`;
+		}
+
+		this.templateIncludeBudget--;
+		// The depth counter is preview-LOCAL on purpose. At run time
+		// `CompleteFormatter.getTemplateContent` hands the child engine a COPY of
+		// the state with depth + 1, while `visited` is shared by reference - so
+		// incrementing depth inside the shared `replaceTemplateInString` would
+		// advance the runtime by two per level and halve its inclusion limit. The
+		// preview has no child formatter to carry it, so it counts here.
+		this.templateInclusion ??= { visited: new Set<string>(), depth: 0 };
+		this.templateInclusion.depth++;
+		try {
+			const body = await app.vault.cachedRead(file);
+			const resolved = await this.formatInternal(body, { included: true });
+			this.warnIfJoinedIntoOneLine(templatePath, resolved);
+			return resolved;
+		} catch (error) {
+			// Contained here rather than by format()'s catch, so one bad token
+			// inside an included template does not blank the whole field's preview.
+			const described = describePreviewFailure(error);
+			if (described) this.diagnostics.add("error", described);
+			return `[QuickAdd: template preview failed] ${templatePath}`;
+		} finally {
+			this.templateInclusion.depth--;
+		}
+	}
+
+	/**
+	 * A template body is many lines and a file name is one, so the normalizer at
+	 * the end of `format()` joins them with spaces - which is what the run does
+	 * too, and is therefore the honest preview. But a name assembled out of
+	 * someone's whole note template reads as a puzzle, and the preview is the only
+	 * thing here that knows those were separate lines.
+	 *
+	 * Deliberately NOT fired for a body that merely ends in a newline: every
+	 * well-formed one-line naming template does, and warning about those would be
+	 * the per-keystroke noise #1558 removed.
+	 */
+	private warnIfJoinedIntoOneLine(templatePath: string, resolved: string): void {
+		const lines = resolved.split(/\r?\n/).filter((line) => line.trim());
+		if (lines.length < 2) return;
+		this.warn(
+			`Template "${templatePath}" is ${lines.length} lines; a file name is one line, so they are joined with spaces.`,
+		);
+	}
+
+	protected getCurrentFileLinkToSection(): string | null {
+		// Only reachable for an INCLUDED body (the file-name pass leaves links
+		// literal, as the run does). Mirrors FormatDisplayFormatter's static
+		// example so the two previews describe the token the same way.
+		if (!this.app) return getCurrentFileLinkToSectionPreview(null);
+		return getCurrentFileLinkToSectionPreview(
+			this.app.workspace.getActiveFile(),
+		);
 	}
 
 	protected async getSelectedText(): Promise<string> {

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -17,6 +17,7 @@ import {
 	getCurrentFolderPathPreview,
 	DateFormatPreviewGenerator
 } from "./helpers/previewHelpers";
+import { previewGeneratedFilePath } from "../utils/generatedFilePath";
 import { getValueVariableBaseName } from "../utils/valueSyntax";
 import { parseVDateOptions } from "../utils/vdateSyntax";
 import { EnhancedFieldSuggestionFileFilter } from "../utils/EnhancedFieldSuggestionFileFilter";
@@ -91,7 +92,20 @@ export class FileNameDisplayFormatter extends Formatter {
 			return input;
 		}
 
-		return output;
+		// The run puts every generated name through this normalizer on the way to
+		// the vault (TemplateChoiceEngine, TemplateInsertEngine,
+		// templateNoteDiscovery, and the capture target via
+		// captureTargetResolution), so a preview that skips it asserts a name the
+		// run will never create: a trailing "." or space is stripped, a backslash is
+		// a path separator, and a run of line breaks - the shape a {{TEMPLATE:}}
+		// body arrives in - collapses to one space (#1563). Non-throwing here: a
+		// preview evaluates incomplete input on every keystroke, so the rejections
+		// the run would abort on become diagnostics instead.
+		const normalized = previewGeneratedFilePath(output);
+		for (const problem of normalized.problems) {
+			this.diagnostics.add("error", problem);
+		}
+		return normalized.path;
 	}
 
 	protected async replaceGlobalVarInString(input: string): Promise<string> {

--- a/src/formatters/fileNameDisplayFormatter.ts
+++ b/src/formatters/fileNameDisplayFormatter.ts
@@ -1,4 +1,8 @@
-import { Formatter, type PromptContext } from "./formatter";
+import {
+	findInlineScriptSpans,
+	Formatter,
+	type PromptContext,
+} from "./formatter";
 import {
 	describePreviewFailure,
 	PreviewDiagnostics,
@@ -128,7 +132,7 @@ export class FileNameDisplayFormatter extends Formatter {
 		// value produced - which the run leaves literal, because its template pass
 		// has already gone by. (The globals/macros order below is older than this
 		// and is left as it was.)
-		output = await this.replaceTemplateInString(output);
+		output = await this.replaceTemplateOutsideScripts(output);
 		// Expand globals to preview inserted snippets
 		output = await this.replaceGlobalVarInString(output);
 		output = await this.replaceMacrosInString(output);
@@ -221,6 +225,36 @@ export class FileNameDisplayFormatter extends Formatter {
 		context?: PromptContext
 	): Promise<string> {
 		return getVariablePromptExample(variableName);
+	}
+
+	/**
+	 * The template pass, skipping inline script fences.
+	 *
+	 * A fence is verbatim JavaScript source, and the run consumes it BEFORE its
+	 * template pass (`replaceInlineJavascriptInString` is the run's first pass), so
+	 * a `"{{TEMPLATE:N.md}}"` written as a string literal inside a script is never
+	 * an include at run time. The preview has no inline-JS pass at all - by design,
+	 * it must not execute anything - so without this it would read that path,
+	 * splice the body into the middle of the displayed source, and report a
+	 * "Template not found" ERROR for a format that is fine.
+	 *
+	 * Same protection, same helper, and the same reason as
+	 * `expandLinebreakEscapesOutsideTokens` (#1467).
+	 */
+	private async replaceTemplateOutsideScripts(input: string): Promise<string> {
+		const spans = findInlineScriptSpans(input);
+		if (spans.length === 0) return this.replaceTemplateInString(input);
+
+		let output = "";
+		let index = 0;
+		for (const span of spans) {
+			output += await this.replaceTemplateInString(
+				input.slice(index, span.start),
+			);
+			output += input.slice(span.start, span.end);
+			index = span.end;
+		}
+		return output + (await this.replaceTemplateInString(input.slice(index)));
 	}
 
 	/**

--- a/src/formatters/formatDisplayFormatter.ts
+++ b/src/formatters/formatDisplayFormatter.ts
@@ -224,11 +224,20 @@ export class FormatDisplayFormatter extends Formatter {
 	protected async getTemplateContent(templatePath: string): Promise<string> {
 		const app = this.app;
 		if (!app) {
+			this.reportProblem(`Template preview unavailable: ${templatePath}`);
 			return `[QuickAdd: template preview unavailable] ${templatePath}`;
 		}
 
 		const file = getTemplateFile(app, templatePath);
-		if (!file) return `[QuickAdd: template not found] ${templatePath}`;
+		if (!file) {
+			// An error, not a quiet placeholder: the run THROWS here
+			// (TemplateEngine.getTemplateContent) and the choice dies, so the row
+			// must read "Unresolved:" rather than presenting a preview. The cycle
+			// and max-depth branches in replaceTemplateInString already report;
+			// not-found was the odd one out.
+			this.reportProblem(`Template not found: ${templatePath}`);
+			return `[QuickAdd: template not found] ${templatePath}`;
+		}
 
 		// The depth counter is preview-LOCAL on purpose. At run time
 		// `CompleteFormatter.getTemplateContent` hands the child engine a COPY of

--- a/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
+++ b/src/gui/ChoiceBuilder/components/FormatPreviewField.svelte
@@ -128,7 +128,15 @@ $effect(() => {
 </script>
 
 {#if hasValue}
-	<div class="qa-preview-row">
+	<!-- A file name is one line, and since #1563 this row can hold a whole
+	     included template - which would wrap to fifteen lines of muted text under
+	     a single-line input and push the rest of the builder down on every
+	     keystroke. Clamped like .qa-preview-issue, with the full text in `title`. -->
+	<div
+		class="qa-preview-row"
+		class:qa-preview-row--one-line={formatterKind === "fileName"}
+		title={formatterKind === "fileName" ? preview : undefined}
+	>
 		<span class="qa-preview-label">{isUnresolved ? "Unresolved: " : "Preview: "}</span
 		><span class="qa-preview-value" aria-live="polite">{preview}</span>
 	</div>

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -718,7 +718,16 @@ export class OnePageInputModal extends Modal {
 					text: `${k}:`,
 					cls: "qa-preview-key",
 				});
-				row.createEl("div", { text: String(v), cls: "qa-preview-val" });
+				// Clamped in CSS, with the whole string on the element: this block
+				// sits ABOVE every input and re-renders as you type, and since #1563
+				// a file-name preview can be a whole included template joined onto
+				// one line - unclamped it would push the fields and Submit down and
+				// shift them under the caret.
+				const valueEl = row.createEl("div", {
+					text: String(v),
+					cls: "qa-preview-val",
+				});
+				valueEl.setAttribute("title", String(v));
 			});
 		} catch {
 			// Ignore preview errors

--- a/src/preflight/runOnePagePreflight.filenamePreview.test.ts
+++ b/src/preflight/runOnePagePreflight.filenamePreview.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TFile } from "obsidian";
 import type { App } from "obsidian";
 import { runOnePagePreflight } from "./runOnePagePreflight";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
@@ -51,15 +52,24 @@ vi.mock("src/utilityObsidian", async () => {
 	};
 });
 
-const createApp = () =>
+const createApp = (templates: Record<string, string> = {}) =>
 	({
 		workspace: {
 			getActiveViewOfType: vi.fn().mockReturnValue(null),
 			getActiveFile: () => null,
 		},
 		vault: {
-			getAbstractFileByPath: vi.fn().mockReturnValue(null),
+			getAbstractFileByPath: vi.fn((path: string) =>
+				path in templates
+					? Object.assign(new TFile(), {
+							path,
+							extension: "md",
+							basename: path.replace(/\.md$/, ""),
+						})
+					: null,
+			),
 			getMarkdownFiles: () => [],
+			cachedRead: async (file: { path: string }) => templates[file.path],
 		},
 		metadataCache: { getFileCache: () => null, getAllPropertyInfos: () => ({}) },
 	}) as unknown as App;
@@ -135,15 +145,33 @@ describe("one-page preflight previews the file name with the file-name formatter
 		expect(out.fileName).not.toContain("\n");
 	});
 
-	it("leaves a {{TEMPLATE:}} include literal rather than splicing a body into a path", async () => {
+	it("resolves a {{TEMPLATE:}} include the way the run does", async () => {
+		// The requirement scan behind this same modal already walks into the
+		// include, so leaving the token literal here made the form ask for a
+		// variable and then preview the question instead of the answer (#1563).
+		await runOnePagePreflight(
+			createApp({ "Naming.md": "Log-{{VALUE:title}}\n" }),
+			createPlugin(),
+			createExecutor(),
+			createChoice("{{TEMPLATE:Naming.md}}-{{VALUE:title}}"),
+		);
+
+		const out = await computePreview!({ title: "My Note" });
+		// The template file's trailing newline is not part of the name: the run's
+		// normalizer collapses the control run and the space around it, so the
+		// seam between the include and "-My Note" reads the same in both.
+		expect(out.fileName).toBe("Log-My Note -My Note");
+	});
+
+	it("says the run would abort when the include does not exist", async () => {
 		await runOnePagePreflight(
 			createApp(),
 			createPlugin(),
 			createExecutor(),
-			createChoice("{{TEMPLATE:Some.md}}-{{VALUE:title}}"),
+			createChoice("{{TEMPLATE:Gone.md}}-{{VALUE:title}}"),
 		);
 
 		const out = await computePreview!({ title: "My Note" });
-		expect(out.fileName).toBe("{{TEMPLATE:Some.md}}-My Note");
+		expect(out.fileName).toBe("[QuickAdd: template not found] Gone.md-My Note");
 	});
 });

--- a/src/preflight/runOnePagePreflight.filenamePreview.test.ts
+++ b/src/preflight/runOnePagePreflight.filenamePreview.test.ts
@@ -115,14 +115,9 @@ beforeEach(() => {
  * escapes into real linebreaks, which are not linebreaks in a path.
  * `FileNameDisplayFormatter` is what `formatFileName` mirrors at run time, and
  * what the builder's own file-name preview already uses.
- *
- * Note the second case is a DIVERGENCE from run time, not parity with it:
- * `formatFileName` does resolve `{{TEMPLATE:}}` (see
- * completeFormatter.promptContext.test.ts). Neither file-name preview does, and
- * pinning that here keeps the gap visible rather than accidental.
  */
 describe("one-page preflight previews the file name with the file-name formatter", () => {
-	it("leaves a backslash-n in the name alone instead of splitting the path", async () => {
+	it("treats a backslash-n as a path separator, not as a linebreak", async () => {
 		await runOnePagePreflight(
 			createApp(),
 			createPlugin(),
@@ -132,7 +127,11 @@ describe("one-page preflight previews the file name with the file-name formatter
 
 		expect(computePreview).not.toBeNull();
 		const out = await computePreview!({ title: "My Note" });
-		expect(out.fileName).toBe(String.raw`Notes\name-My Note`);
+		// Not a linebreak (that is the content formatter's rule, and this is a
+		// path); a separator, because that is what the run makes of it -
+		// `normalizeGeneratedFilePath` rewrites "\" to "/" before the note is
+		// created, exactly as Obsidian's own `normalizePath` does (#1563).
+		expect(out.fileName).toBe("Notes/name-My Note");
 		expect(out.fileName).not.toContain("\n");
 	});
 

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -125,12 +125,13 @@ export async function runOnePagePreflight(
 				// literal. It is also the class the builder's own file-name preview
 				// uses.
 				//
-				// One deliberate divergence: `formatFileName` DOES resolve
-				// {{TEMPLATE:}} at run time (format() -> replaceTemplateInString, with
-				// path prompt scope propagated in CompleteFormatter.getTemplateContent).
-				// Neither file-name preview does - a multi-line template body is not a
-				// name, and the only inert reader available here returns a fabricated
-				// stub. Same gap the builder's file-name field already has.
+				// It resolves {{TEMPLATE:}} the way the run does (#1563) - which
+				// matters most here, because the requirement scan behind this very
+				// modal already walks INTO the include (collectChoiceRequirements,
+				// scope "noteTitle"), so the form asks for variables it found inside
+				// the template. What stays literal in the preview is what the
+				// formatter has no inert stand-in for: inline `js quickadd` fences and
+				// macros, which the run really does execute inside an included body.
 				const formatter = new FileNameDisplayFormatter(app, plugin);
 				const out: Record<string, string> = {};
 				// File name preview for Template

--- a/src/styles.css
+++ b/src/styles.css
@@ -273,6 +273,21 @@
 .quickAddModal .qa-preview-value {
 	color: var(--text-normal);
 }
+/* A file name is one line. Since #1563 this row can hold a whole included
+   template, which would otherwise wrap to fifteen lines of muted text under a
+   single-line input and push the rest of the builder down on every keystroke.
+   Two lines, so a long-but-real name still shows whole; the full text is in
+   `title`, as on .qa-preview-issue. Clamped on the ROW, not the value span:
+   -webkit-box is block-level, and clamping the span would drop the value onto
+   its own line. The content field is deliberately left unclamped - a multi-line
+   preview is the point there. */
+.quickAddModal .qa-preview-row--one-line {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	overflow: hidden;
+}
 
 .quickAddModal .qa-onepage-title {
 	text-align: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -401,6 +401,19 @@
 	font-family: var(--font-monospace);
 }
 
+/* Same bound as .qa-preview-row--one-line in the builder, for the same reason:
+   since #1563 this row can hold a whole included template joined onto one line,
+   and it sits above every input in a modal that re-renders it as you type. */
+.quickAddModal .qa-preview-val {
+	min-width: 0;
+	overflow-wrap: anywhere;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	overflow: hidden;
+}
+
 .quickAddModal .qa-onepage-preview-row {
 	display: flex;
 	gap: 0.5rem;

--- a/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
+++ b/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
@@ -120,6 +120,33 @@ describe("FieldSuggestionParser warns through the new message", () => {
 		]);
 	});
 
+	it("never answers a prototype member as if it were a hint", () => {
+		// The hint table is keyed by whatever the user typed after a pipe, and an
+		// object lookup would answer `constructor` with Object itself - stringified
+		// into the warning as "function Object() { [native code] }".
+		for (const key of ["constructor", "__proto__", "tostring", "valueof"]) {
+			const message = describeUnknownFieldFilter(key, `status|${key}:x`);
+			expect(message).not.toContain("native code");
+			expect(message).not.toContain("[object Object]");
+			expect(message).toContain(`Unknown FIELD filter "${key}"`);
+		}
+	});
+
+	it("tells a correctly spelled filter it is missing its value, not that it is unknown", () => {
+		// `|folder` is one keystroke short of `|folder:`, which a live preview sees
+		// constantly. Calling it unknown and then listing `folder` among the
+		// supported filters contradicts itself; running it through the suggester
+		// answers it with a sibling key, because the suggester excludes the exact
+		// match from its own pool.
+		for (const key of FIELD_FILTER_KEYS) {
+			if (key === "multi") continue; // the one legal bare flag
+			const { warnings } = parse(`status|${key}`);
+			expect(warnings).toEqual([
+				`FIELD filter "${key}" needs a value - write "${key}:value". Ignored in {{FIELD:status|${key}}}.`,
+			]);
+		}
+	});
+
 	it("warns about a mistyped bare flag, which used to vanish silently", () => {
 		// `|mutli` parses as no filter at all: the prompt quietly stays
 		// single-select and nothing anywhere says why.

--- a/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
+++ b/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+	describeUnknownFieldFilter,
+	FIELD_FILTER_KEYS,
+	FieldSuggestionParser,
+} from "./FieldSuggestionParser";
+import { suggestSimilarKeys } from "./suggestSimilarKeys";
+
+/**
+ * Issue #1564. The warning used to answer every mistyped filter key by reciting
+ * all thirteen supported keys - 256 characters, of which the last 180 were a
+ * list you had to read to the end to discover the answer was `folder` all along.
+ *
+ * The table below is the contract. It is deliberately exhaustive about what is
+ * NOT suggested too: a confidently wrong "did you mean" is worse than the list,
+ * and one of them (`case-insensitive` -> `case-sensitive`) would invert the
+ * user's own request. A new filter key must be added to this table, which is the
+ * point - it is the only place that would notice the addition changing an
+ * existing answer.
+ */
+const SUGGESTIONS: Array<[typed: string, expected: string[]]> = [
+	// Typos: transposition, doubled/dropped letter, missing separator.
+	["fodler", ["folder"]],
+	["foldr", ["folder"]],
+	["mutli", ["multi"]],
+	["inlne", ["inline"]],
+	["dafault", ["default"]],
+	["excludetag", ["exclude-tag"]],
+	["case-sensitve", ["case-sensitive"]],
+	// Right family, wrong key.
+	["tags", ["tag"]],
+	["folders", ["folder"]],
+	["exclude", ["exclude-folder", "exclude-tag", "exclude-file"]],
+	["case", ["case-sensitive"]],
+	["inline-code", ["inline-code-blocks", "inline"]],
+	["multi-select", ["multi"]],
+	// Half-typed, which is most of what a live preview sees.
+	["fo", ["folder"]],
+	["de", ["default", "default-from", "default-empty"]],
+	// Not a typo of anything: no guess, fall back to the vocabulary.
+	["filter", []],
+	["sortby", []],
+	["limit", []],
+	["path", []],
+	["f", []],
+];
+
+describe("suggestSimilarKeys over the real FIELD filter vocabulary", () => {
+	it.each(SUGGESTIONS)("%s -> %j", (typed, expected) => {
+		expect(suggestSimilarKeys(typed, FIELD_FILTER_KEYS)).toEqual(expected);
+	});
+
+	it("never answers a negation with the key it negates", () => {
+		// The distance rule alone WOULD reach case-sensitive from here; the message
+		// layer must not let it, because obeying the suggestion inverts the request.
+		expect(
+			describeUnknownFieldFilter("case-insensitive", "status|case-insensitive:true"),
+		).toBe(
+			'Unknown FIELD filter "case-insensitive" - matching is already case-insensitive; use "case-sensitive:true" to match exactly. Ignored in "{{FIELD:status|case-insensitive:true}}".',
+		);
+	});
+
+	it("suggests nothing for a key it already recognises", () => {
+		for (const key of FIELD_FILTER_KEYS) {
+			expect(suggestSimilarKeys(key, FIELD_FILTER_KEYS)).not.toContain(key);
+		}
+	});
+});
+
+describe("describeUnknownFieldFilter", () => {
+	it("leads with the fix, not with the vocabulary", () => {
+		const message = describeUnknownFieldFilter("fodler", "status|fodler:abc");
+		expect(message).toBe(
+			'Unknown FIELD filter "fodler" - did you mean "folder"? Ignored in "{{FIELD:status|fodler:abc}}".',
+		);
+		// The message this replaced was 256 characters.
+		expect(message.length).toBeLessThan(120);
+	});
+
+	it("lists several candidates when the family is ambiguous", () => {
+		expect(describeUnknownFieldFilter("exclude", "status|exclude:x")).toBe(
+			'Unknown FIELD filter "exclude" - did you mean "exclude-folder", "exclude-tag" or "exclude-file"? Ignored in "{{FIELD:status|exclude:x}}".',
+		);
+	});
+
+	it("keeps the full vocabulary when nothing is close", () => {
+		const message = describeUnknownFieldFilter("sortby", "status|sortby:x");
+		expect(message).toBe(
+			'Unknown FIELD filter "sortby" in "{{FIELD:status|sortby:x}}" was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-from, default-empty, default-always, case-sensitive, multi.',
+		);
+	});
+
+	it("bounds the message no matter how long the key and the token are", () => {
+		const message = describeUnknownFieldFilter(
+			"x".repeat(400),
+			`status|${"y".repeat(400)}:z`,
+		);
+		// Only the fixed vocabulary is left; the two user-controlled parts are
+		// clamped, so an absurd token cannot re-inflate what #1564 shrank.
+		expect(message).toContain(`"${"x".repeat(32)}…"`);
+		expect(message).toContain(`{{FIELD:status|${"y".repeat(41)}…}}`);
+		expect(message.length).toBeLessThan(340);
+	});
+});
+
+describe("FieldSuggestionParser warns through the new message", () => {
+	function parse(input: string, warnUnknown = true) {
+		const warnings: string[] = [];
+		const result = FieldSuggestionParser.parse(input, {
+			warnUnknown,
+			warn: (message) => warnings.push(message),
+		});
+		return { result, warnings };
+	}
+
+	it("diagnoses a mistyped filter key", () => {
+		const { warnings } = parse("status|fodler:abc");
+		expect(warnings).toEqual([
+			'Unknown FIELD filter "fodler" - did you mean "folder"? Ignored in "{{FIELD:status|fodler:abc}}".',
+		]);
+	});
+
+	it("warns about a mistyped bare flag, which used to vanish silently", () => {
+		// `|mutli` parses as no filter at all: the prompt quietly stays
+		// single-select and nothing anywhere says why.
+		const { result, warnings } = parse("status|mutli");
+		expect(result.multiSelect).toBeUndefined();
+		expect(warnings).toEqual([
+			'Unknown FIELD filter "mutli" - did you mean "multi"? Ignored in "{{FIELD:status|mutli}}".',
+		]);
+	});
+
+	it("stays silent for every recognised filter, bare flag included", () => {
+		const { warnings } = parse(
+			"status|folder:a|tag:b|inline:true|inline-code-blocks:c|exclude-folder:d|exclude-tag:e|exclude-file:f|default:g|default-from:active|default-empty:true|default-always:true|case-sensitive:true|multi",
+		);
+		expect(warnings).toEqual([]);
+	});
+
+	it("stays silent for an empty trailing pipe part", () => {
+		expect(parse("status|").warnings).toEqual([]);
+	});
+
+	it("stays silent for the grammars that legitimately carry foreign keys", () => {
+		expect(parse("status|__capture_scope:x|label:y", false).warnings).toEqual([]);
+	});
+
+	it("still parses every recognised filter after the membership gate", () => {
+		const { result } = parse("status|folder:Work|tag:#a|exclude-tag:b|multi:true");
+		expect(result.fieldName).toBe("status");
+		expect(result.filters.folder).toBe("Work");
+		expect(result.filters.folders).toEqual(["Work"]);
+		expect(result.filters.tags).toEqual(["a"]);
+		expect(result.filters.excludeTags).toEqual(["b"]);
+		expect(result.multiSelect).toBe(true);
+	});
+});

--- a/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
+++ b/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
@@ -56,7 +56,7 @@ describe("suggestSimilarKeys over the real FIELD filter vocabulary", () => {
 		expect(
 			describeUnknownFieldFilter("case-insensitive", "status|case-insensitive:true"),
 		).toBe(
-			'Unknown FIELD filter "case-insensitive" - matching is already case-insensitive; use "case-sensitive:true" to match exactly. Ignored in "{{FIELD:status|case-insensitive:true}}".',
+			'Unknown FIELD filter "case-insensitive" - matching is already case-insensitive; use "case-sensitive:true" to match exactly. Ignored in {{FIELD:status|case-insensitive:true}}.',
 		);
 	});
 
@@ -71,7 +71,7 @@ describe("describeUnknownFieldFilter", () => {
 	it("leads with the fix, not with the vocabulary", () => {
 		const message = describeUnknownFieldFilter("fodler", "status|fodler:abc");
 		expect(message).toBe(
-			'Unknown FIELD filter "fodler" - did you mean "folder"? Ignored in "{{FIELD:status|fodler:abc}}".',
+			'Unknown FIELD filter "fodler" - did you mean "folder"? Ignored in {{FIELD:status|fodler:abc}}.',
 		);
 		// The message this replaced was 256 characters.
 		expect(message.length).toBeLessThan(120);
@@ -79,14 +79,14 @@ describe("describeUnknownFieldFilter", () => {
 
 	it("lists several candidates when the family is ambiguous", () => {
 		expect(describeUnknownFieldFilter("exclude", "status|exclude:x")).toBe(
-			'Unknown FIELD filter "exclude" - did you mean "exclude-folder", "exclude-tag" or "exclude-file"? Ignored in "{{FIELD:status|exclude:x}}".',
+			'Unknown FIELD filter "exclude" - did you mean "exclude-folder", "exclude-tag" or "exclude-file"? Ignored in {{FIELD:status|exclude:x}}.',
 		);
 	});
 
 	it("keeps the full vocabulary when nothing is close", () => {
 		const message = describeUnknownFieldFilter("sortby", "status|sortby:x");
 		expect(message).toBe(
-			'Unknown FIELD filter "sortby" in "{{FIELD:status|sortby:x}}" was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-from, default-empty, default-always, case-sensitive, multi.',
+			'Unknown FIELD filter "sortby" in {{FIELD:status|sortby:x}} was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-from, default-empty, default-always, case-sensitive, multi.',
 		);
 	});
 
@@ -116,7 +116,7 @@ describe("FieldSuggestionParser warns through the new message", () => {
 	it("diagnoses a mistyped filter key", () => {
 		const { warnings } = parse("status|fodler:abc");
 		expect(warnings).toEqual([
-			'Unknown FIELD filter "fodler" - did you mean "folder"? Ignored in "{{FIELD:status|fodler:abc}}".',
+			'Unknown FIELD filter "fodler" - did you mean "folder"? Ignored in {{FIELD:status|fodler:abc}}.',
 		]);
 	});
 
@@ -126,7 +126,7 @@ describe("FieldSuggestionParser warns through the new message", () => {
 		const { result, warnings } = parse("status|mutli");
 		expect(result.multiSelect).toBeUndefined();
 		expect(warnings).toEqual([
-			'Unknown FIELD filter "mutli" - did you mean "multi"? Ignored in "{{FIELD:status|mutli}}".',
+			'Unknown FIELD filter "mutli" - did you mean "multi"? Ignored in {{FIELD:status|mutli}}.',
 		]);
 	});
 

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -40,10 +40,12 @@ export const FIELD_FILTER_KEYS = [
  * `case-sensitive:true` - silently inverting what they asked for. A negation is
  * not a typo, so it gets an explicit answer instead of a guess.
  */
-const FIELD_FILTER_HINTS: Record<string, string> = {
-	"case-insensitive":
+const FIELD_FILTER_HINTS = new Map<string, string>([
+	[
+		"case-insensitive",
 		'matching is already case-insensitive; use "case-sensitive:true" to match exactly',
-};
+	],
+]);
 
 /** Keeps one absurd key or one very long token from re-inflating the warning. */
 function clampForMessage(value: string, max: number): string {
@@ -73,7 +75,11 @@ export function describeUnknownFieldFilter(
 	// dangling `"` at a line break in the inline diagnostic.
 	const token = `{{FIELD:${clampForMessage(input, 48)}}}`;
 
-	const hint = FIELD_FILTER_HINTS[filterKey];
+	// A Map, not an object literal: `filterKey` is whatever the user typed after a
+	// pipe, and an object lookup would answer `constructor` or `__proto__` with a
+	// member of Object.prototype - stringified into the warning as
+	// "function Object() { [native code] }".
+	const hint = FIELD_FILTER_HINTS.get(filterKey);
 	if (hint) {
 		return `Unknown FIELD filter "${key}" - ${hint}. Ignored in ${token}.`;
 	}
@@ -84,6 +90,24 @@ export function describeUnknownFieldFilter(
 	}
 
 	return `Unknown FIELD filter "${key}" in ${token} was ignored. Supported filters: ${FIELD_FILTER_KEYS.join(", ")}.`;
+}
+
+/**
+ * A RECOGNISED filter written without its value, e.g. `{{FIELD:status|folder}}`.
+ *
+ * It is not an unknown key and must not be described as one: calling `folder`
+ * unknown and then listing `folder` among the supported filters is a
+ * self-contradiction, and running it through the typo suggester - which excludes
+ * the exact match from its own pool - answers a correctly spelled key with one of
+ * its siblings. This is also what a live preview sees for the one keystroke
+ * between `|folder` and `|folder:`, so it has to read as "not finished yet".
+ */
+export function describeValuelessFieldFilter(
+	filterKey: string,
+	input: string,
+): string {
+	const key = clampForMessage(filterKey, 32);
+	return `FIELD filter "${key}" needs a value - write "${key}:value". Ignored in {{FIELD:${clampForMessage(input, 48)}}}.`;
 }
 
 export interface FieldFilter {
@@ -154,11 +178,18 @@ export class FieldSuggestionParser {
 			const parsed = parsePipeKeyValue(filterPart);
 			if (!parsed) {
 				// A pipe part with no colon. `multi` is the only legal bare flag and
-				// was consumed above, so anything left here is a mistyped filter that
-				// would otherwise vanish without a trace - including `|mutli`, which
-				// quietly downgrades a multi-select prompt to a single-select one.
-				if (options?.warnUnknown && filterPart) {
-					warnUnknownFilter(filterPart.toLowerCase(), input, options);
+				// was consumed above, so anything left here does nothing at all and
+				// would otherwise vanish without a trace - `|mutli` quietly
+				// downgrades a multi-select prompt to a single-select one. A
+				// correctly spelled key is a different mistake (a missing value) and
+				// gets a different sentence.
+				const bareKey = filterPart.toLowerCase();
+				if (options?.warnUnknown && bareKey) {
+					(options.warn ?? NOTICE_WARN)(
+						(FIELD_FILTER_KEYS as readonly string[]).includes(bareKey)
+							? describeValuelessFieldFilter(bareKey, input)
+							: describeUnknownFieldFilter(bareKey, input),
+					);
 				}
 				continue;
 			}

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -4,6 +4,85 @@ import {
 	parsePipeKeyValue,
 	splitPipeParts,
 } from "./pipeSyntax";
+import { suggestSimilarKeys } from "./suggestSimilarKeys";
+
+/**
+ * Every filter key the `{{FIELD:...}}` grammar recognises, in the order the
+ * fallback warning lists them.
+ *
+ * Authoritative, not descriptive: {@link FieldSuggestionParser.parse} tests
+ * membership here BEFORE dispatching, so a `case` added to the switch without an
+ * entry here stops working rather than silently drifting away from what the
+ * warning advertises and what the typo suggester matches against. (`multi` is
+ * both a bare flag and a `multi:true` key, and is spelled once for both.)
+ */
+export const FIELD_FILTER_KEYS = [
+	"folder",
+	"tag",
+	"inline",
+	"inline-code-blocks",
+	"exclude-folder",
+	"exclude-tag",
+	"exclude-file",
+	"default",
+	"default-from",
+	"default-empty",
+	"default-always",
+	"case-sensitive",
+	"multi",
+] as const;
+
+/**
+ * Wrong keys whose nearest neighbour is a worse answer than a sentence.
+ *
+ * `case-insensitive` is one edit family away from `case-sensitive`, so a plain
+ * "did you mean" would tell someone who asked for insensitive matching to write
+ * `case-sensitive:true` - silently inverting what they asked for. A negation is
+ * not a typo, so it gets an explicit answer instead of a guess.
+ */
+const FIELD_FILTER_HINTS: Record<string, string> = {
+	"case-insensitive":
+		'matching is already case-insensitive; use "case-sensitive:true" to match exactly',
+};
+
+/** Keeps one absurd key or one very long token from re-inflating the warning. */
+function clampForMessage(value: string, max: number): string {
+	return value.length <= max ? value : `${value.slice(0, max)}…`;
+}
+
+function quoteList(values: string[]): string {
+	const quoted = values.map((value) => `"${value}"`);
+	if (quoted.length <= 1) return quoted.join("");
+	return `${quoted.slice(0, -1).join(", ")} or ${quoted[quoted.length - 1]}`;
+}
+
+/**
+ * Names the mistake instead of reciting the vocabulary (issue #1564).
+ *
+ * The actionable clause comes BEFORE the echoed token so the three-line clamp on
+ * the inline preview diagnostic (styles.css `.qa-preview-issue`) can never cut
+ * the fix off. The full list survives only where it is genuinely the most useful
+ * thing left to say: when nothing is close enough to name.
+ */
+export function describeUnknownFieldFilter(
+	filterKey: string,
+	input: string,
+): string {
+	const key = clampForMessage(filterKey, 32);
+	const token = `"{{FIELD:${clampForMessage(input, 48)}}}"`;
+
+	const hint = FIELD_FILTER_HINTS[filterKey];
+	if (hint) {
+		return `Unknown FIELD filter "${key}" - ${hint}. Ignored in ${token}.`;
+	}
+
+	const suggestions = suggestSimilarKeys(filterKey, FIELD_FILTER_KEYS);
+	if (suggestions.length > 0) {
+		return `Unknown FIELD filter "${key}" - did you mean ${quoteList(suggestions)}? Ignored in ${token}.`;
+	}
+
+	return `Unknown FIELD filter "${key}" in ${token} was ignored. Supported filters: ${FIELD_FILTER_KEYS.join(", ")}.`;
+}
 
 export interface FieldFilter {
 	/**
@@ -32,6 +111,14 @@ export interface FieldFilter {
 	excludeFolders?: string[];
 	excludeTags?: string[];
 	excludeFiles?: string[];
+}
+
+function warnUnknownFilter(
+	filterKey: string,
+	input: string,
+	options: { warn?: WarnSink },
+): void {
+	(options.warn ?? NOTICE_WARN)(describeUnknownFieldFilter(filterKey, input));
 }
 
 export class FieldSuggestionParser {
@@ -63,10 +150,35 @@ export class FieldSuggestionParser {
 			}
 
 			const parsed = parsePipeKeyValue(filterPart);
-			if (!parsed) continue; // Skip invalid filter format
+			if (!parsed) {
+				// A pipe part with no colon. `multi` is the only legal bare flag and
+				// was consumed above, so anything left here is a mistyped filter that
+				// would otherwise vanish without a trace - including `|mutli`, which
+				// quietly downgrades a multi-select prompt to a single-select one.
+				if (options?.warnUnknown && filterPart) {
+					warnUnknownFilter(filterPart.toLowerCase(), input, options);
+				}
+				continue;
+			}
 
 			const filterType = parsed.key;
 			const filterValue = parsed.value;
+
+			// The key set - not the switch - decides what is recognised, so the
+			// warning, the typo suggester and the dispatch below can never disagree
+			// about the vocabulary.
+			if (!(FIELD_FILTER_KEYS as readonly string[]).includes(filterType)) {
+				// ONLY for the {{FIELD}} grammar (warnUnknown). This parser is also
+				// shared by the {{FILE:...|label:/name:}}, property:, and
+				// capture-scope grammars, which legitimately carry keys this switch
+				// does not know and peel off elsewhere; warning there would emit
+				// false "Unknown FIELD filter" notices and leak internal sentinels
+				// like __capture_scope.
+				if (options?.warnUnknown) {
+					warnUnknownFilter(filterType, input, options);
+				}
+				continue;
+			}
 
 			switch (filterType) {
 				case "multi":
@@ -147,24 +259,6 @@ export class FieldSuggestionParser {
 						filters.excludeFiles = [];
 					}
 					filters.excludeFiles.push(filterValue);
-					break;
-				default:
-					// An unrecognized pipe key (typically a typo like
-					// `exclud-tag` or `fodler`) would otherwise be dropped
-					// silently, leaving the user with unfiltered suggestions and
-					// no indication the filter did nothing. Surface a warning so
-					// the mistake is discoverable — but ONLY for the {{FIELD}}
-					// grammar (warnUnknown). This parser is also shared by the
-					// {{FILE:...|label:/name:}}, property:, and capture-scope
-					// grammars, which legitimately carry keys this switch does
-					// not know and peel off elsewhere; warning there would emit
-					// false "Unknown FIELD filter" notices and leak internal
-					// sentinels like __capture_scope.
-					if (options?.warnUnknown) {
-						(options.warn ?? NOTICE_WARN)(
-							`Unknown FIELD filter "${filterType}" in "{{FIELD:${input}}}" was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-from, default-empty, default-always, case-sensitive, multi.`,
-						);
-					}
 					break;
 			}
 		}

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -69,7 +69,9 @@ export function describeUnknownFieldFilter(
 	input: string,
 ): string {
 	const key = clampForMessage(filterKey, 32);
-	const token = `"{{FIELD:${clampForMessage(input, 48)}}}"`;
+	// The braces already delimit the token; wrapping it in quotes too left a
+	// dangling `"` at a line break in the inline diagnostic.
+	const token = `{{FIELD:${clampForMessage(input, 48)}}}`;
 
 	const hint = FIELD_FILTER_HINTS[filterKey];
 	if (hint) {

--- a/src/utils/generatedFilePath.ts
+++ b/src/utils/generatedFilePath.ts
@@ -63,10 +63,55 @@ function trimTrailingCharsLinear(value: string, chars: string): string {
 	return value.slice(0, end);
 }
 
+/**
+ * The normalized path plus the reasons the strict entry point would have
+ * rejected it. See {@link previewGeneratedFilePath}.
+ */
+export type GeneratedFilePathPreview = {
+	path: string;
+	problems: string[];
+};
+
 export function normalizeGeneratedFilePath(
 	path: string,
 	label = "File path",
 ): string {
+	const { path: normalized, problems } = normalizeGeneratedFilePathCore(
+		path,
+		label,
+	);
+	// Problems are collected left to right, so the first one is the one the
+	// historical throw-on-sight implementation would have raised.
+	if (problems.length > 0) throw new Error(problems[0]);
+	return normalized;
+}
+
+/**
+ * What {@link normalizeGeneratedFilePath} would make of this path, without
+ * throwing - for the file-name PREVIEW, which is a speculative evaluation of
+ * incomplete input and must never throw its way out of a keystroke (#1558).
+ *
+ * The preview needs this because the run applies the normalizer to every
+ * generated name (TemplateChoiceEngine, TemplateInsertEngine,
+ * templateNoteDiscovery, and the capture target via captureTargetResolution),
+ * so it is the last thing standing between the formatted string and the file
+ * that appears in the vault. Without it a preview showing `Daily/Note.` or a
+ * multi-line `{{TEMPLATE:}}` body claims a name the run will never create
+ * (#1563). The rejections come back as `problems` instead of an exception, so
+ * the preview can show the best-effort name AND say that the run would abort.
+ */
+export function previewGeneratedFilePath(
+	path: string,
+	label = "File path",
+): GeneratedFilePathPreview {
+	return normalizeGeneratedFilePathCore(path, label);
+}
+
+function normalizeGeneratedFilePathCore(
+	path: string,
+	label: string,
+): GeneratedFilePathPreview {
+	const problems: string[] = [];
 	// Treat a backslash as a path separator BEFORE the per-segment "." / ".."
 	// rejection below. Obsidian's own `normalizePath` converts "\\" -> "/" before
 	// any path is touched on disk, so a formatted name like "..\\..\\..\\evil"
@@ -78,26 +123,28 @@ export function normalizeGeneratedFilePath(
 	// (createFileWithInput -> escapesVaultBoundary) is the authoritative boundary
 	// for absolute / drive / UNC paths.
 	const segments = path.replace(/\\/g, "/").split("/");
-	return segments
-		.map((segment, index) => {
-			if (
-				segment.length === 0
-				&& index !== 0
-				&& index !== segments.length - 1
-			) {
-				throw new Error(
-					`${label} contains an empty path segment after formatting.`,
-				);
-			}
+	const normalized = segments.map((segment, index) => {
+		if (
+			segment.length === 0
+			&& index !== 0
+			&& index !== segments.length - 1
+		) {
+			problems.push(
+				`${label} contains an empty path segment after formatting.`,
+			);
+			return segment;
+		}
 
-			return normalizeGeneratedFilePathSegment(segment, label);
-		})
-		.join("/");
+		return normalizeGeneratedFilePathSegment(segment, label, problems);
+	});
+
+	return { path: normalized.join("/"), problems };
 }
 
 function normalizeGeneratedFilePathSegment(
 	segment: string,
 	label: string,
+	problems: string[],
 ): string {
 	if (segment.length === 0) return segment;
 
@@ -111,13 +158,14 @@ function normalizeGeneratedFilePathSegment(
 
 	const withoutTrailingSpaces = trimTrailingCharsLinear(normalized, " ");
 	if (withoutTrailingSpaces === "." || withoutTrailingSpaces === "..") {
-		throw new Error(`${label} cannot contain "." or ".." path segments.`);
+		problems.push(`${label} cannot contain "." or ".." path segments.`);
+		return withoutTrailingSpaces;
 	}
 
 	normalized = trimTrailingCharsLinear(normalized, ". ");
 
 	if (!normalized) {
-		throw new Error(`${label} contains an empty path segment after formatting.`);
+		problems.push(`${label} contains an empty path segment after formatting.`);
 	}
 
 	return normalized;

--- a/src/utils/suggestSimilarKeys.ts
+++ b/src/utils/suggestSimilarKeys.ts
@@ -1,0 +1,139 @@
+/**
+ * "Did you mean" for a closed vocabulary of option keys.
+ *
+ * Written for the `{{FIELD:...|key:value}}` filter list (issue #1564), where the
+ * alternative - printing all thirteen keys and letting the reader find the one
+ * they meant - produced a 256-character warning that is unreadable as a Notice
+ * and needs a three-line clamp inline under a settings field.
+ *
+ * Three rules, in order, because they catch different mistakes:
+ *
+ * 1. ONE EDIT AWAY (Damerau, so an adjacent transposition costs 1). The
+ *    strongest signal there is, and it goes first: `inlne` shares a prefix with
+ *    both `inline` and `inline-code-blocks`, but it is one edit from exactly one
+ *    of them. Also `fodler` -> `folder`, `mutli` -> `multi`, `tags` -> `tag`,
+ *    `excludetag` -> `exclude-tag`.
+ * 2. SHARED PREFIX. Covers "I remembered the family, not the key":
+ *    `exclude` -> the three `exclude-*`, `case` -> `case-sensitive`,
+ *    `inline-code` -> `inline-code-blocks`. Also covers a half-typed key, which
+ *    is most of what a live preview sees.
+ * 3. TWO EDITS, long keys only. A second slip is plausible in
+ *    `inline-code-blocks`; in a six-letter key it means a different word. That
+ *    is what keeps `filter` from being answered with `folder` (distance 2),
+ *    which is the sort of confidently-wrong suggestion that is worse than none.
+ */
+
+/** Beyond this the input is not a mistyped key, and the matrix is not worth building. */
+const MAX_COMPARABLE_LENGTH = 64;
+
+function commonPrefixLength(a: string, b: string): number {
+	const max = Math.min(a.length, b.length);
+	let i = 0;
+	while (i < max && a[i] === b[i]) i++;
+	return i;
+}
+
+/**
+ * Optimal string alignment distance: Levenshtein plus adjacent transposition.
+ * Bounded by `max` so a long input exits before filling the matrix - every
+ * caller here only cares whether the distance is small.
+ */
+export function damerauLevenshtein(a: string, b: string, max: number): number {
+	if (a === b) return 0;
+	if (Math.abs(a.length - b.length) > max) return max + 1;
+	if (a.length > MAX_COMPARABLE_LENGTH || b.length > MAX_COMPARABLE_LENGTH) {
+		return max + 1;
+	}
+
+	let twoRowsBack: number[] = [];
+	let previous: number[] = Array.from({ length: b.length + 1 }, (_, i) => i);
+	let current: number[] = [];
+
+	for (let i = 1; i <= a.length; i++) {
+		current = new Array<number>(b.length + 1);
+		current[0] = i;
+		let rowMin = current[0];
+		for (let j = 1; j <= b.length; j++) {
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+			let value = Math.min(
+				previous[j] + 1, // deletion
+				current[j - 1] + 1, // insertion
+				previous[j - 1] + cost, // substitution
+			);
+			if (
+				i > 1 &&
+				j > 1 &&
+				a[i - 1] === b[j - 2] &&
+				a[i - 2] === b[j - 1]
+			) {
+				value = Math.min(value, twoRowsBack[j - 2] + 1); // transposition
+			}
+			current[j] = value;
+			if (value < rowMin) rowMin = value;
+		}
+		// Every remaining row can only add to the minimum, so once a whole row is
+		// past the budget the answer is "further than max".
+		if (rowMin > max) return max + 1;
+		twoRowsBack = previous;
+		previous = current;
+	}
+
+	return previous[b.length];
+}
+
+/**
+ * The candidates worth showing for an unrecognised key, best first, or an empty
+ * list when nothing is close enough to name.
+ *
+ * `limit` caps the list because the point is to be shorter than the vocabulary:
+ * suggesting five of thirteen keys is just the dump with extra words.
+ */
+export function suggestSimilarKeys(
+	typed: string,
+	candidates: readonly string[],
+	limit = 3,
+): string[] {
+	const needle = typed.trim().toLowerCase();
+	if (!needle) return [];
+
+	// Ties keep the vocabulary's own order - the one the fallback message and the
+	// docs list them in - rather than an arbitrary alphabetical or length order.
+	const pool = candidates
+		.map((candidate, index) => ({ candidate, index }))
+		.filter((entry) => entry.candidate !== needle);
+
+	const near = pool
+		.map((entry) => ({
+			...entry,
+			distance: damerauLevenshtein(needle, entry.candidate, 2),
+		}))
+		.filter((entry) => entry.distance <= 1)
+		.sort((a, b) => a.distance - b.distance || a.index - b.index);
+	if (near.length > 0) {
+		return near.slice(0, limit).map((entry) => entry.candidate);
+	}
+
+	if (needle.length >= 2) {
+		const byPrefix = pool
+			.map((entry) => ({
+				...entry,
+				shared: commonPrefixLength(needle, entry.candidate),
+			}))
+			.filter((entry) => entry.shared >= 2)
+			.sort((a, b) => b.shared - a.shared || a.index - b.index);
+		if (byPrefix.length > 0) {
+			return byPrefix.slice(0, limit).map((entry) => entry.candidate);
+		}
+	}
+
+	const byDistance = pool
+		.map((entry) => ({
+			...entry,
+			distance: damerauLevenshtein(needle, entry.candidate, 2),
+		}))
+		// A longer key has room for a second slip; a short one does not.
+		.filter((entry) => entry.distance <= 2 && entry.candidate.length >= 10)
+		.sort((a, b) => a.distance - b.distance || a.index - b.index);
+
+	return byDistance.slice(0, limit).map((entry) => entry.candidate);
+}


### PR DESCRIPTION
Closes #1563. Closes #1564.

Two formatter output surfaces that were telling users things that were not true.

## #1563 - the file-name preview left `{{TEMPLATE:}}` literal

`CompleteFormatter.formatFileName` resolves `{{TEMPLATE:...}}`: `format()` runs
`replaceTemplateInString`, and path prompt scope is deliberately propagated into the child
engine. The preview never called it, so the builder said one thing and the run did another.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/chhoumann/quickadd/421bd18d6be215bcac2a562b2e9305d60cf113c3/shots/before-1563.png) | ![after](https://raw.githubusercontent.com/chhoumann/quickadd/421bd18d6be215bcac2a562b2e9305d60cf113c3/shots/after-1563.png) |

Measured in this worktree's isolated vault (Obsidian 1.13.0). `Naming.md` contains
`{{DATE:YYYY-MM-DD}} {{VALUE:title}}`:

```
preview (before): {{TEMPLATE:Templates/Naming.md}}
preview (after):  2026-07-27 Example Title
run:              created "2026-07-27 My Note.md"
```

The one-page input form contradicted itself harder still: its preflight scan already walks
**into** the include for this same field (`collectChoiceRequirements`, scope `noteTitle`), so
it prompted for a variable it could only have found inside the template, then previewed the
unresolved token beside the answer. That is why the issue's cheaper alternative - a one-line
note saying "resolves at run time, not previewed" - was declined: this is not a missing
feature, it is two surfaces disagreeing.

### What the include is read through

The preview's own pass list, never `SingleTemplateEngine`. Building one would construct a real
`CompleteFormatter` and open blocking prompt modals on every keystroke - exactly the bug #1560
fixed on the content field. The inert-preview contract holds: no prompts, no macro engine, no
inline JS, no Notices. Pinned by tests that fail if any of those are reached.

### The multi-line question

The issue asks what a multi-line body should look like in a name. The run already has an
answer: `normalizeGeneratedFilePath` collapses a run of line breaks, with the spaces around
it, to a single space - and every generated name goes through it (`TemplateChoiceEngine`,
`TemplateInsertEngine`, `templateNoteDiscovery`, and the capture target via
`captureTargetResolution`). So the preview now runs the same normalizer, once, at the end.

Doing the collapse there rather than inside the include matters: preview and run then splice
first and normalize second, in the same order, and agree byte for byte instead of differing by
a space at the seam. Verified:

```
format "{{TEMPLATE:Templates/Naming.md}}-suffix"
  preview: 2026-07-27 Example Title -suffix
  run:     created "2026-07-27 My Note -suffix.md"
```

That also closed three older divergences for every token, not just includes: a trailing `.` or
space is stripped as the run strips it, a backslash is a path separator as Obsidian's own
`normalizePath` makes it, and a `.`/`..` or empty segment now reports the error the run aborts
with instead of showing a name.

A body that really is many lines gets joined - and says so once, rather than presenting
someone's whole note template as an unexplained run-on name. It stays quiet about the trailing
newline every well-formed one-line naming template has.

![multi-line](https://raw.githubusercontent.com/chhoumann/quickadd/421bd18d6be215bcac2a562b2e9305d60cf113c3/shots/after-1563-multiline.png)

### Three things this needed beyond the reader

- **The template pass runs first**, where the run has it (before globals and `{{VALUE}}`).
  Resolving it later would splice a body in for a token a global snippet produced, which the
  run leaves literal - trading one lie for another.
- **A per-pass include budget**, because that ordering makes a global snippet holding a
  `{{TEMPLATE:}}` token re-arm the include loop with an unwound cycle set. It also caps the
  fan-out of a wide include tree on a field that resolves on every keystroke. There is a test
  that hangs forever without it.
- **An included body resolves with CONTENT token semantics**, because at run time it goes
  through the child engine's `formatFileContent`. The file-name pass list would leave literal
  exactly the tokens people put in templates (`{{linkcurrent}}`, `{{linksection}}`).

A missing template is now an error diagnostic rather than a quiet placeholder - the run throws
there and the choice dies, so the row must read "Unresolved:". Fixed in the content preview's
reader too, where not-found was the odd branch out (cycle and max-depth already reported).

### And a layout bound

The preview row had no clamp, which was fine while it could only hold what you typed. A 40-line
include put 468px of muted text under a single-line input. Two lines now, full string in
`title`; the content field is left alone, where a multi-line preview is the point. The one-page
form's row needed the same treatment - it sits *above* every input and re-renders as you type,
so unclamped it pushed the fields and Submit down under the caret (371px -> 39px).

![one-page](https://raw.githubusercontent.com/chhoumann/quickadd/421bd18d6be215bcac2a562b2e9305d60cf113c3/shots/after-onepage-clamp.png)

## #1564 - the 256-character "Unknown FIELD filter" warning

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/chhoumann/quickadd/421bd18d6be215bcac2a562b2e9305d60cf113c3/shots/before-1564.png) | ![after](https://raw.githubusercontent.com/chhoumann/quickadd/421bd18d6be215bcac2a562b2e9305d60cf113c3/shots/after-1564.png) |

```
before: Unknown FIELD filter "fodler" in "{{FIELD:status|fodler:abc}}" was ignored. Supported
        filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag,
        exclude-file, default, default-from, default-empty, default-always, case-sensitive,
        multi.
after:  Unknown FIELD filter "fodler" - did you mean "folder"? Ignored in
        {{FIELD:status|fodler:abc}}.
```

The actionable clause comes before the echoed token, so the three-line clamp on the inline
diagnostic can never cut the fix off, and both user-controlled parts are length-bounded so an
absurd key cannot re-inflate the message. The full vocabulary survives in the one case where it
is still the most useful thing to say: when nothing is close enough to name.

Three matching rules, in order - one edit away (Damerau, so `mutli` -> `multi` costs 1), then a
shared prefix (`exclude` -> the three `exclude-*`), then two edits but only into a long key.
That last bound is what stops `filter` being answered with `folder`, and `case-insensitive`
gets a sentence rather than a guess, because obeying "did you mean case-sensitive?" would
silently invert the request. `FieldSuggestionParser-1564-unknown-filter.test.ts` pins the full
answer for a 21-probe table, including everything that must NOT be suggested.

Two supporting fixes in the same parser:

- `FIELD_FILTER_KEYS` is authoritative now - membership is tested before the switch dispatches,
  so a case added without an entry stops working instead of drifting away from what the warning
  advertises.
- A pipe part with no colon was dropped in total silence, so `{{FIELD:status|mutli}}` quietly
  downgraded a multi-select prompt to single-select with nothing anywhere saying why.

## Tradeoffs and known divergences

- **Not the full normalizer for capture-target special forms.** `vault`, `filter:`,
  `property:` targets are classified before normalization at run time. They contain no control
  characters or trailing dots, so the preview is unchanged for them.
- **`{{title}}` inside an included body stays literal.** The run resolves it to the empty
  string (the title is derived from the name being built, so it is not known yet). Neither a
  blank nor this formatter's example title is a preview worth showing, so the token is left
  visible. Happy to change it if you disagree - it is one line.
- **Inline `js quickadd` fences and macros inside an included body stay literal.** The run
  executes them; a preview must not. Pre-existing for a fence typed at the top level of the
  field, and unchanged. A `{{TEMPLATE:...}}` written as a string literal *inside* a fence is
  now skipped rather than expanded, since the run consumes the fence before its template pass
  (caught in review, `caffb4b2`).

## Validation

- 4131 unit tests pass (+31 new), `tsc`, `eslint` and `svelte-check` clean.
- Everything above measured live in this worktree's isolated vault on Obsidian 1.13.0, with the
  **run** cross-checked against the preview for each case rather than the preview alone.
- Design reviewed adversarially before coding (it caught a false premise about the capture path
  and the include-loop hazard), and the implementation reviewed again after: that pass found
  three real defects of mine - a prototype-chain leak in the hint table
  (`{{FIELD:x|constructor:y}}`), the colon-less warning calling a correctly spelled filter
  unknown, and the unclamped one-page row - all fixed with regression tests, plus a fourth
  (the inline-script fence) from the review on this PR.

## Filed rather than folded in

- #1578 - the preview still shows names Obsidian refuses (`Bad: {{VALUE:title}}`); same family,
  but it affects every token, not includes.
- #1579 - the `{{FIELD:}}` preview placeholder repeats the filter syntax back at you.
- #1580 - `fileNameDisplayFormatter.test.ts` tests a mock of itself.
