### PR TITLE
fix: a malformed folder in data.json no longer takes the plugin down with it

### DIFF
--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -26,6 +26,7 @@ import {
 	type FrontmatterPropertyTarget,
 } from "./utils/frontmatterPropertyLinks";
 import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
+import { childChoicesOf } from "./utils/choiceUtils";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
@@ -330,12 +331,16 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		// An empty folder run via command/URI would otherwise open a dead, item-less
 		// picker (no Back row is appended on this path) that reads as a broken command.
 		// Surface a Notice instead so the user knows the folder simply has nothing in it.
-		if (multiChoice.choices.length === 0) {
+		// Read through the accessor, not `.length`: a non-array value such as `{}`
+		// has an `undefined` length, so a bare `=== 0` check would slide past this
+		// guard and hand the picker a non-list to iterate (#1566).
+		const children = childChoicesOf(multiChoice);
+		if (children.length === 0) {
 			new Notice(emptyFolderNoticeText(multiChoice.name));
 			return;
 		}
 
-		ChoiceSuggester.Open(this.plugin, multiChoice.choices, {
+		ChoiceSuggester.Open(this.plugin, children, {
 			choiceExecutor: this,
 			focusedProperty: this.focusedProperty,
 			triggerContext: this.triggerContext,

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -336,7 +336,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		// guard and hand the picker a non-list to iterate (#1566).
 		const children = childChoicesOf(multiChoice);
 		if (children.length === 0) {
-			new Notice(emptyFolderNoticeText(multiChoice.name));
+			new Notice(emptyFolderNoticeText(multiChoice));
 			return;
 		}
 

--- a/src/cli/registerQuickAddCliHandlers.test.ts
+++ b/src/cli/registerQuickAddCliHandlers.test.ts
@@ -44,7 +44,7 @@ function flattenChoices(
 			byName.set(choice.name, choice);
 			byId.set(choice.id, choice);
 			if (choice.type === "Multi") {
-				walk((choice as IMultiChoice).choices);
+				walk((choice as IMultiChoice).choices!);
 			}
 		}
 	};

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -13,7 +13,11 @@ import type { FieldRequirement } from "../preflight/RequirementCollector";
 import { interactivePromptServer } from "../interactive/interactivePromptServer";
 import { RemotePromptProvider } from "../interactive/promptProvider";
 import type IChoice from "../types/choices/IChoice";
-import type IMultiChoice from "../types/choices/IMultiChoice";
+import {
+	childChoicesOf,
+	isChoiceLike,
+	rootChoicesOf,
+} from "../utils/choiceUtils";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
 import {
@@ -249,7 +253,8 @@ function flattenChoices(
 ): CliChoiceSummary[] {
 	const flattened: CliChoiceSummary[] = [];
 
-	for (const choice of choices) {
+	for (const choice of rootChoicesOf(choices)) {
+		if (!isChoiceLike(choice)) continue;
 		const pathSegments = [...segments, choice.name];
 		const path = pathSegments.join(" / ");
 		const isMulti = choice.type === "Multi";
@@ -263,8 +268,7 @@ function flattenChoices(
 		});
 
 		if (isMulti) {
-			const multiChoice = choice as IMultiChoice;
-			flattened.push(...flattenChoices(multiChoice.choices, pathSegments));
+			flattened.push(...flattenChoices(childChoicesOf(choice), pathSegments));
 		}
 	}
 

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -5,7 +5,6 @@ import GenericInputPrompt from "../GenericInputPrompt/GenericInputPrompt";
 import type IChoice from "../../types/choices/IChoice";
 import type IMacroChoice from "../../types/choices/IMacroChoice";
 import type QuickAdd from "../../main";
-import type { MultiChoice } from "src/types/choices/MultiChoice";
 import {
 	CommandSequenceEditor,
 	type CommandSequenceEditorConditionalHandlers,

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -15,6 +15,7 @@ import { ConditionalCommandSettingsModal } from "./ConditionalCommandSettingsMod
 import { ConditionalBranchEditorModal } from "./ConditionalBranchEditorModal";
 import { addChoiceIconSetting } from "../ChoiceBuilder/components/choiceIconSetting";
 import { addAutosaveFooter } from "../ChoiceBuilder/components/autosaveFooter";
+import { childChoicesOf } from "../../utils/choiceUtils";
 
 function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 	const arr: IChoice[] = [];
@@ -22,7 +23,7 @@ function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 	const recursive = (choices: IChoice[]) => {
 		choices.forEach((choice) => {
 			if (choice.type === "Multi") {
-				recursive((choice as MultiChoice).choices);
+				recursive(childChoicesOf(choice));
 			} else {
 				arr.push(choice);
 			}

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -14,13 +14,19 @@ import { ConditionalCommandSettingsModal } from "./ConditionalCommandSettingsMod
 import { ConditionalBranchEditorModal } from "./ConditionalBranchEditorModal";
 import { addChoiceIconSetting } from "../ChoiceBuilder/components/choiceIconSetting";
 import { addAutosaveFooter } from "../ChoiceBuilder/components/autosaveFooter";
-import { childChoicesOf } from "../../utils/choiceUtils";
+import {
+	childChoicesOf,
+	isChoiceLike,
+	rootChoicesOf,
+} from "../../utils/choiceUtils";
 
-function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
+/** Exported for the malformed-tree sweep (src/utils/malformedChoices.entrypoints.test.ts). */
+export function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 	const arr: IChoice[] = [];
 
 	const recursive = (choices: IChoice[]) => {
 		choices.forEach((choice) => {
+			if (!isChoiceLike(choice)) return;
 			if (choice.type === "Multi") {
 				recursive(childChoicesOf(choice));
 			} else {
@@ -29,7 +35,7 @@ function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
 		});
 	};
 
-	recursive(nestedChoices);
+	recursive(rootChoicesOf(nestedChoices));
 
 	return arr;
 }

--- a/src/gui/PackageManager/ExportPackageModal.svelte
+++ b/src/gui/PackageManager/ExportPackageModal.svelte
@@ -10,7 +10,9 @@
 		collectFileDependencies,
 	} from "../../utils/packageTraversal";
 	import {
+		childChoicesOf,
 		flattenChoicesWithPath,
+		isChoiceLike,
 		type FlatChoicePathEntry,
 	} from "../../utils/choiceUtils";
 	import {
@@ -91,11 +93,9 @@
 
 	function getDescendantIds(choice: IChoice): string[] {
 		const ids: string[] = [];
-		if (isMultiChoice(choice)) {
-			const children = (choice as IMultiChoice).choices ?? [];
-			for (const child of children) {
-				ids.push(child.id, ...getDescendantIds(child));
-			}
+		for (const child of childChoicesOf(choice)) {
+			if (!isChoiceLike(child)) continue;
+			ids.push(child.id, ...getDescendantIds(child));
 		}
 		return ids;
 	}

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -8,6 +8,7 @@
     import { baseDndOptions, stripShadow } from "../shared/dndReorder";
     import { createDragArming } from "../shared/dragArming.svelte";
     import { Platform, type App } from "obsidian";
+    import { isChoiceLike, rootChoicesOf } from "../../utils/choiceUtils";
     import type { ChoiceListActions } from "./choiceListActions";
 
     let {
@@ -45,6 +46,14 @@
         // up. False/absent at the root level.
         nested?: boolean;
     } = $props();
+
+    // Everything rendered and handed to the dnd zone is filtered to entries that
+    // are actually choices. A hole in the list (a `null` or a stray primitive from
+    // a bad hand-edit or a truncated write) has no `id`, so the keyed {#each} and
+    // svelte-dnd-action would both throw on it and blank the settings tab (#1566).
+    // Filtering is a render-time view only; the hole stays in the persisted tree
+    // unless an edit walks past it.
+    const renderable = $derived(rootChoicesOf(choices).filter(isChoiceLike));
 
     // Resolve once: at the top level there is no incoming rootReorder, so the list's
     // own handler IS the top-level handler; nested lists receive it explicitly.
@@ -128,14 +137,14 @@
 </script>
 
 <div
-        use:dndzone={baseDndOptions({items: choices, dragDisabled, flipDurationMs, dropTargetClasses: nested ? ["qa-folder-droptarget"] : []})}
+        use:dndzone={baseDndOptions({items: renderable, dragDisabled, flipDurationMs, dropTargetClasses: nested ? ["qa-folder-droptarget"] : []})}
         onconsider={handleConsider}
         onfinalize={handleSort}
         class="choiceList"
         class:qa-nested={nested}
         class:qa-folder-empty={isEmptyFolder}
-        class:qa-empty={choices.length === 0}>
-    {#each stripShadow(choices) as choice (choice.id)}
+        class:qa-empty={renderable.length === 0}>
+    {#each stripShadow(renderable) as choice (choice.id)}
         <!-- Flip wrapper: the dndzone's direct child = the animated/draggable item.
              Must stay margin/padding/border-less (the 2px inter-row margin lives on
              the inner row). data-choice-id stays on the inner row for tests/menus. -->

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -48,12 +48,22 @@
     } = $props();
 
     // Everything rendered and handed to the dnd zone is filtered to entries that
-    // are actually choices. A hole in the list (a `null` or a stray primitive from
-    // a bad hand-edit or a truncated write) has no `id`, so the keyed {#each} and
-    // svelte-dnd-action would both throw on it and blank the settings tab (#1566).
-    // Filtering is a render-time view only; the hole stays in the persisted tree
-    // unless an edit walks past it.
-    const renderable = $derived(rootChoicesOf(choices).filter(isChoiceLike));
+    // are actually renderable choices: an object with an id. `data.json` is
+    // untrusted, so the list can contain a hole (a `null` or a stray primitive
+    // from a bad hand-edit or a truncated write) or an object with no id at all.
+    // svelte-dnd-action reads `.id` on every item, and the keyed {#each} needs
+    // that id to be present AND unique - two id-less entries raise
+    // `each_key_duplicate`, the #1451 crash, which without this filter blanks the
+    // entire list (#1566).
+    //
+    // Render-time view only. Nothing here rewrites the tree; a junk entry stays in
+    // data.json until an edit walks past it. It cannot be hiding a choice - only a
+    // Multi's `choices` value can, and that is preserved separately.
+    const renderable = $derived(
+        rootChoicesOf(choices).filter(
+            (choice) => isChoiceLike(choice) && typeof choice.id === "string" && choice.id !== "",
+        ),
+    );
 
     // Resolve once: at the top level there is no incoming rootReorder, so the list's
     // own handler IS the top-level handler; nested lists receive it explicitly.

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -118,7 +118,9 @@
     // through MultiChoiceListItem's nestedActions just like a drag does.
     function moveChoice(choice: IChoice, direction: -1 | 1) {
         if (forceDragDisabled) return; // never persist a filtered/derived list
-        const list = stripShadow(choices);
+        // `renderable`, not `choices`: stripShadow reads `item.id`, so the raw
+        // list would throw on the very hole the render filter exists to hide.
+        const list = stripShadow(renderable);
         const index = list.findIndex((c) => c.id === choice.id);
         if (index === -1) return;
         const target = index + direction;

--- a/src/gui/choiceList/ChoiceView.malformed.test.ts
+++ b/src/gui/choiceList/ChoiceView.malformed.test.ts
@@ -126,6 +126,21 @@ describe("ChoiceView over a malformed tree (#1566)", () => {
 		expect(getByLabelText("Configure Survivor")).toBeInTheDocument();
 	});
 
+	it("drops entries that cannot be keyed instead of losing the whole list", () => {
+		// Two entries with no id give the keyed {#each} the same (undefined) key,
+		// which raises `each_key_duplicate` - the #1451 crash. The boundary would
+		// catch it, but the user would lose every real row with it.
+		const { getByLabelText, container } = renderChoiceView([
+			{} as IChoice,
+			{ name: "No id" } as IChoice,
+			leaf("Survivor", "survivor"),
+		]);
+
+		expect(getByLabelText("Configure Survivor")).toBeInTheDocument();
+		expect(container.querySelector(".qaChoicesUnavailable")).toBeNull();
+		expect(container.querySelectorAll("[data-choice-id]")).toHaveLength(1);
+	});
+
 	it("refuses to render, rather than to offer a CTA, when the root list is unreadable", () => {
 		// Coercing a corrupt root to [] would show the "No choices yet" hero, whose
 		// single CTA writes a fresh list straight over whatever is in data.json.

--- a/src/gui/choiceList/ChoiceView.malformed.test.ts
+++ b/src/gui/choiceList/ChoiceView.malformed.test.ts
@@ -130,13 +130,17 @@ describe("ChoiceView over a malformed tree (#1566)", () => {
 		// Two entries with no id give the keyed {#each} the same (undefined) key,
 		// which raises `each_key_duplicate` - the #1451 crash. The boundary would
 		// catch it, but the user would lose every real row with it.
-		const { getByLabelText, container } = renderChoiceView([
-			{} as IChoice,
+		const { getByLabelText, queryByText, container } = renderChoiceView([
+			{ name: "Missing id" } as IChoice,
 			{ name: "No id" } as IChoice,
 			leaf("Survivor", "survivor"),
 		]);
 
 		expect(getByLabelText("Configure Survivor")).toBeInTheDocument();
+		// Absent from the DOM entirely, not merely unkeyed: a regression that still
+		// painted them as rows without a data-choice-id would pass a count check.
+		expect(queryByText("Missing id")).toBeNull();
+		expect(queryByText("No id")).toBeNull();
 		expect(container.querySelector(".qaChoicesUnavailable")).toBeNull();
 		expect(container.querySelectorAll("[data-choice-id]")).toHaveLength(1);
 	});

--- a/src/gui/choiceList/ChoiceView.malformed.test.ts
+++ b/src/gui/choiceList/ChoiceView.malformed.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+vi.mock("../choiceRename", () => ({
+	promptRenameChoice: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { App } from "obsidian";
+import { render } from "@testing-library/svelte";
+import ChoiceView from "./ChoiceView.svelte";
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import type { Plain } from "../svelte/persist.svelte";
+import {
+	folder,
+	leaf,
+	malformedFolder,
+	malformedTree,
+	MALFORMED_CHILDREN_SHAPES,
+} from "../../utils/malformedChoices.fixture";
+
+/**
+ * #1566. A folder in data.json whose `choices` value is missing or is not an
+ * array used to throw during MOUNT, and a throw during mount does not degrade
+ * one row: it escapes `mount()` and abandons the whole declarative settings tab,
+ * so QuickAdd's settings came up as a bare heading with nothing under it.
+ */
+
+const renderChoiceView = (
+	choices: IChoice[],
+	saveChoices: (next: Plain<IChoice[]>) => void = vi.fn(),
+) =>
+	render(ChoiceView, {
+		props: {
+			app: new App() as never,
+			plugin: {} as unknown as QuickAdd,
+			choices,
+			saveChoices,
+		},
+	});
+
+describe("ChoiceView over a malformed tree (#1566)", () => {
+	it("renders every healthy row around the malformed folders", () => {
+		const { getByLabelText, queryByText } = renderChoiceView(malformedTree());
+
+		// The rows on both sides of the corruption, which is what proves the mount
+		// ran to completion rather than dying partway.
+		expect(getByLabelText("Configure Head template")).toBeInTheDocument();
+		expect(getByLabelText("Configure Tail template")).toBeInTheDocument();
+		expect(getByLabelText("Toggle Healthy folder")).toBeInTheDocument();
+		// ...and the malformed folders are present and operable, not swallowed.
+		for (const shape of MALFORMED_CHILDREN_SHAPES) {
+			expect(getByLabelText(`Toggle Broken ${shape.key}`)).toBeInTheDocument();
+		}
+		// The whole view is alive, not just the list.
+		expect(getByLabelText("New choice")).toBeInTheDocument();
+		expect(queryByText("QuickAdd couldn't display your choices")).toBeNull();
+	});
+
+	it("shows a folder that lost nothing as an ordinary empty folder", () => {
+		for (const shape of MALFORMED_CHILDREN_SHAPES.filter((s) => !s.lossy)) {
+			const { container, unmount } = renderChoiceView([
+				malformedFolder("Broken", "broken", shape.value),
+			]);
+
+			// No count badge (there is nothing to count) and no unreadable notice:
+			// it reads exactly like a folder the user emptied themselves, which is
+			// the truth for these shapes.
+			expect(container.querySelector(".qaFolderCount"), shape.key).toBeNull();
+			expect(
+				container.querySelector(".qaUnreadableFolder"),
+				shape.key,
+			).toBeNull();
+			// The empty-folder drop band is offered, so the folder can be refilled.
+			expect(
+				container.querySelector(".qa-folder-empty"),
+				shape.key,
+			).not.toBeNull();
+			unmount();
+		}
+	});
+
+	it("says so, and offers no way to overwrite it, when the value could still hold choices", () => {
+		for (const shape of MALFORMED_CHILDREN_SHAPES.filter((s) => s.lossy)) {
+			const { container, queryByLabelText, unmount } = renderChoiceView([
+				malformedFolder("Broken", "broken", shape.value),
+			]);
+
+			expect(
+				container.querySelector(".qaUnreadableFolder")?.textContent,
+				shape.key,
+			).toContain("couldn't read this folder's contents");
+			// No nested list and no add-into-folder control: both write to this
+			// folder's children, and that write would discard the value.
+			expect(container.querySelector(".qa-nested"), shape.key).toBeNull();
+			expect(
+				queryByLabelText("Add a choice to Broken"),
+				shape.key,
+			).toBeNull();
+			unmount();
+		}
+	});
+
+	it("counts only the children it can actually read", () => {
+		const collapsed = (choice: IChoice): IChoice =>
+			({ ...choice, collapsed: true }) as IChoice;
+		const { container } = renderChoiceView([
+			collapsed(folder("Two kids", "two", [leaf("a", "a"), leaf("b", "b")])),
+			collapsed(malformedFolder("Broken", "broken", {})),
+		]);
+
+		const counts = [...container.querySelectorAll(".qaFolderCount")].map(
+			(el) => el.textContent,
+		);
+		expect(counts).toEqual(["2"]);
+	});
+
+	it("steps over a hole in the list instead of blanking the tab", () => {
+		// A `null` entry has no id, so the keyed {#each} and svelte-dnd-action both
+		// threw on it before it was filtered out at render time.
+		const { getByLabelText } = renderChoiceView([
+			null as unknown as IChoice,
+			leaf("Survivor", "survivor"),
+		]);
+
+		expect(getByLabelText("Configure Survivor")).toBeInTheDocument();
+	});
+
+	it("refuses to render, rather than to offer a CTA, when the root list is unreadable", () => {
+		// Coercing a corrupt root to [] would show the "No choices yet" hero, whose
+		// single CTA writes a fresh list straight over whatever is in data.json.
+		const saveChoices = vi.fn();
+		const { getByText, queryByLabelText } = renderChoiceView(
+			{ invalid: true } as unknown as IChoice[],
+			saveChoices,
+		);
+
+		expect(
+			getByText("QuickAdd couldn't display your choices"),
+		).toBeInTheDocument();
+		expect(queryByLabelText("New choice")).toBeNull();
+		expect(queryByLabelText("New folder")).toBeNull();
+		expect(saveChoices).not.toHaveBeenCalled();
+	});
+
+	it("does not persist a fabricated [] when an unrelated folder is collapsed", () => {
+		// The regression that a naive "use the accessor everywhere" fix introduces:
+		// updateMultiById re-spreads every folder it walks past, and collapsing runs
+		// straight into save().
+		const saveChoices = vi.fn<(next: Plain<IChoice[]>) => void>();
+		const tree = [
+			folder("Healthy folder", "healthy", [leaf("Child", "child")]),
+			malformedFolder("Broken", "broken", { "0": leaf("Hidden", "hidden") }),
+		];
+		const { getByLabelText } = renderChoiceView(tree, saveChoices);
+
+		getByLabelText("Toggle Healthy folder").click();
+
+		expect(saveChoices).toHaveBeenCalled();
+		const saved = saveChoices.mock.calls.at(-1)![0] as unknown as Record<
+			string,
+			unknown
+		>[];
+		const broken = saved.find((c) => c.id === "broken")!;
+		expect(broken.choices).toEqual({ "0": leaf("Hidden", "hidden") });
+	});
+});

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -63,6 +63,11 @@
 	// render the list at all instead, which also means nothing in this view can
 	// call save() while the tree is unreadable (#1566).
 	const rootUnreadable = $derived(!Array.isArray(choices));
+	const rootUnreadableDetail = $derived(
+		`The "choices" value in data.json is ${
+			choices === null ? "null" : `of type "${typeof choices}"`
+		}, but QuickAdd expects a list.`,
+	);
 
 	// On mobile the bottom-bar controls fill the width instead of cramming right.
 	const isMobile = Platform.isMobile;
@@ -374,9 +379,7 @@
 	{#if rootUnreadable}
 	<!-- Nothing below this point may run: every branch of the list reads the tree
 	     and the add controls would write a new one over it. -->
-	<ChoicesUnavailable
-		detail={`settings.choices is ${choices === null ? "null" : typeof choices}, not a list of choices.`}
-	/>
+	<ChoicesUnavailable detail={rootUnreadableDetail} />
 	{:else}
 	<!-- A throw anywhere below used to escape mount() and abort the whole
 	     declarative settings tab, so ONE bad choice cost every QuickAdd setting

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -32,6 +32,12 @@
 	import AddChoiceControls from "./AddChoiceControls.svelte";
 	import { uniqueDefaultChoiceName } from "./choiceTypeMeta";
 	import ChoiceList from "./ChoiceList.svelte";
+	import ChoicesUnavailable from "./ChoicesUnavailable.svelte";
+	import {
+		childChoicesOf,
+		hasChildChoices,
+		isChoiceLike,
+	} from "../../utils/choiceUtils";
 	import type { ChoiceListActions } from "./choiceListActions";
 	import { type Plain, snapshot } from "../svelte/persist.svelte";
 
@@ -49,6 +55,14 @@
 	} = $props();
 
 	let filterQuery = $state(""); // not persisted
+
+	// The ROOT `choices` is untrusted too: loadSettings deliberately leaves a
+	// non-array value in place rather than replacing it with [] (which the next
+	// save would persist). Coercing it to [] here would show the "No choices yet"
+	// hero, whose one CTA writes a fresh list straight over it - so refuse to
+	// render the list at all instead, which also means nothing in this view can
+	// call save() while the tree is unreadable (#1566).
+	const rootUnreadable = $derived(!Array.isArray(choices));
 
 	// On mobile the bottom-bar controls fill the width instead of cramming right.
 	const isMobile = Platform.isMobile;
@@ -89,12 +103,13 @@
 		const match = prepareFuzzySearch(q);
 
 		const walk = (c: IChoice): IChoice | null => {
+			if (!isChoiceLike(c)) return null;
 			const selfMatches = !!match(c.name ?? "");
 			if (!isMultiChoice(c)) {
 				return selfMatches ? c : null;
 			}
 
-			const filteredChildren = (c.choices ?? [])
+			const filteredChildren = childChoicesOf(c)
 				.map((child) => walk(child))
 				.filter(Boolean) as IChoice[];
 
@@ -186,10 +201,7 @@
 	// registered via the recursive addCommandForChoice).
 	function subtreeHasCommand(choice: IChoice): boolean {
 		if (choice.command) return true;
-		if (isMultiChoice(choice)) {
-			return (choice.choices ?? []).some(subtreeHasCommand);
-		}
-		return false;
+		return childChoicesOf(choice).some(subtreeHasCommand);
 	}
 
 	async function deleteChoice(choice: IChoice) {
@@ -222,15 +234,23 @@
 	}
 
 	function updateChoiceHelper(oldChoice: IChoice, newChoice: IChoice): IChoice {
+		if (!isChoiceLike(oldChoice)) return oldChoice;
 		if (oldChoice.id === newChoice.id) {
 			return { ...oldChoice, ...newChoice };
 		}
 
-		if (isMultiChoice(oldChoice)) {
-			const updatedChoices = oldChoice.choices.map((c) =>
+		// Only rebuild a folder whose children we could actually read. This runs
+		// over the WHOLE tree on every rename/configure/toggle and is followed by
+		// save(), so spreading a folder with an unreadable `choices` value would
+		// persist [] over it the first time the user renamed anything (#1566).
+		if (hasChildChoices(oldChoice)) {
+			const updatedChoices = childChoicesOf(oldChoice).map((c) =>
 				updateChoiceHelper(c, newChoice),
 			);
-			const updated: IMultiChoice = { ...oldChoice, choices: updatedChoices };
+			const updated: IMultiChoice = {
+				...(oldChoice as IMultiChoice),
+				choices: updatedChoices,
+			};
 			return updated;
 		}
 
@@ -351,6 +371,21 @@
 
 
 <div>
+	{#if rootUnreadable}
+	<!-- Nothing below this point may run: every branch of the list reads the tree
+	     and the add controls would write a new one over it. -->
+	<ChoicesUnavailable
+		detail={`settings.choices is ${choices === null ? "null" : typeof choices}, not a list of choices.`}
+	/>
+	{:else}
+	<!-- A throw anywhere below used to escape mount() and abort the whole
+	     declarative settings tab, so ONE bad choice cost every QuickAdd setting
+	     (#1451, #1566). The boundary keeps that damage inside this view; the
+	     try/catch in quickAddSettingsTab.renderChoicesView covers the setup this
+	     boundary sits inside. -->
+	<svelte:boundary onerror={(error) => log.logError(
+		`QuickAdd could not render the choice list: ${error instanceof Error ? error.message : String(error)}`,
+	)}>
 	{#if choices.length === 0 && filterQuery.trim().length === 0}
 		<!-- First-run / empty state: the hero is the single focal CTA (the top-bar
 		     add controls are not rendered here, so there's no duplicate). -->
@@ -445,6 +480,13 @@
 			{/if}
 			<AddChoiceControls onAddChoice={addChoiceToList} fill={isMobile} />
 		</div>
+	{/if}
+	{#snippet failed(error)}
+		<ChoicesUnavailable
+			detail={error instanceof Error ? error.message : String(error)}
+		/>
+	{/snippet}
+	</svelte:boundary>
 	{/if}
 </div>
 

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -205,6 +205,7 @@
 	// registry (and so a folder with command-enabled children DOES get them
 	// registered via the recursive addCommandForChoice).
 	function subtreeHasCommand(choice: IChoice): boolean {
+		if (!isChoiceLike(choice)) return false;
 		if (choice.command) return true;
 		return childChoicesOf(choice).some(subtreeHasCommand);
 	}

--- a/src/gui/choiceList/ChoicesUnavailable.svelte
+++ b/src/gui/choiceList/ChoicesUnavailable.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import ObsidianIcon from "../components/ObsidianIcon.svelte";
+
+	let {
+		detail = "",
+	}: {
+		/** The underlying error message, when there is one. Shown verbatim: it is
+		 *  what makes a bug report actionable, and this view is otherwise a dead
+		 *  end for the user. */
+		detail?: string;
+	} = $props();
+</script>
+
+<!--
+  Shown when the choice list cannot be rendered at all: a corrupt `choices` value
+  in data.json, or an unexpected throw while mounting. The alternative - and what
+  actually shipped for #1451, #1507 and #1566 - is that the whole QuickAdd
+  settings tab comes up blank, which reads as "the plugin is broken" and gives
+  the user nothing to act on.
+
+  Deliberately offers no button. A "retry" re-renders the same data and throws
+  again, and anything that could rewrite data.json would destroy the very value
+  the user needs in order to recover. Telling them exactly where the file is, and
+  that QuickAdd has not touched it, is the whole job.
+-->
+<div class="qaChoicesUnavailable">
+	<div class="qaChoicesUnavailableHead">
+		<ObsidianIcon iconId="alert-triangle" size={16} />
+		<span class="qaChoicesUnavailableTitle">QuickAdd couldn't display your choices</span>
+	</div>
+	<p class="qaChoicesUnavailableBody">
+		Something in this vault's QuickAdd settings could not be read. Your choices
+		have not been changed or deleted, and QuickAdd will not overwrite them.
+	</p>
+	<p class="qaChoicesUnavailableBody">
+		They are stored in
+		<code>.obsidian/plugins/quickadd/data.json</code> inside this vault. Make a
+		copy of that file before editing it.
+	</p>
+	{#if detail}
+		<pre class="qaChoicesUnavailableDetail">{detail}</pre>
+	{/if}
+</div>
+
+<style>
+	.qaChoicesUnavailable {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		padding: 12px 14px;
+		margin: 4px 0 8px;
+		background: var(--background-secondary);
+	}
+
+	.qaChoicesUnavailableHead {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		color: var(--text-warning, var(--text-normal));
+	}
+
+	.qaChoicesUnavailableTitle {
+		font-weight: var(--font-semibold);
+		color: var(--text-normal);
+	}
+
+	.qaChoicesUnavailableBody {
+		margin: 8px 0 0;
+		color: var(--text-muted);
+		font-size: var(--font-ui-small, 13px);
+		max-width: 68ch;
+	}
+
+	.qaChoicesUnavailableDetail {
+		margin: 10px 0 0;
+		padding: 8px 10px;
+		border-radius: var(--radius-s);
+		background: var(--background-primary);
+		color: var(--text-faint);
+		font-size: var(--font-ui-smaller, 12px);
+		white-space: pre-wrap;
+		word-break: break-word;
+		user-select: text;
+	}
+</style>

--- a/src/gui/choiceList/MultiChoiceListItem.svelte
+++ b/src/gui/choiceList/MultiChoiceListItem.svelte
@@ -10,6 +10,7 @@
     import type IChoice from "src/types/choices/IChoice";
     import { showChoiceContextMenu, showChoiceContextMenuAtElement } from "./contextMenu";
 	import { renderChoiceName } from "./renderChoiceName";
+    import { childChoicesOf, hasUnreadableChildren } from "../../utils/choiceUtils";
     import type { ChoiceListActions } from "./choiceListActions";
 
     let {
@@ -39,6 +40,18 @@
         onMoveUp?: () => void;
         onMoveDown?: () => void;
     } = $props();
+
+    // Read the children ONCE, through the accessor: a folder in data.json can
+    // have no `choices` key at all, or a non-array value, and dereferencing it
+    // here threw during mount and took the entire settings tab with it (#1566).
+    // $derived, not a bare call: Svelte props are lazy getters, so calling the
+    // accessor per template read would hand ChoiceList a fresh [] every time and
+    // churn the dnd zone.
+    const children = $derived(childChoicesOf(choice));
+    // The one shape that can still be HOLDING choices we cannot read. Such a
+    // folder must not claim to be empty, and must not offer any affordance that
+    // would overwrite the value (the add row and the drop zone are its only two).
+    const unreadable = $derived(hasUnreadableChildren(choice));
 
     let showConfigureButton = $state(true);
     let nameElement = $state<HTMLSpanElement>();
@@ -148,10 +161,10 @@
                 <ObsidianIcon iconId="chevron-down" size={16} />
             </span>
             <span class="choiceListItemName" bind:this={nameElement}></span>
-            {#if choice.collapsed && choice.choices.length > 0}
+            {#if choice.collapsed && children.length > 0}
                 <!-- What a closed folder hides is real information: a quiet
                      count keeps the list scannable without expanding. -->
-                <span class="qaFolderCount" aria-hidden="true">{choice.choices.length}</span>
+                <span class="qaFolderCount" aria-hidden="true">{children.length}</span>
             {/if}
         </button>
 
@@ -175,12 +188,22 @@
     {#if !collapseId || (collapseId && choice.id !== collapseId)}
         {#if !choice.collapsed}
             <div class="nestedChoiceList">
+                {#if unreadable}
+                    <!-- No list and no add row: both would write to this folder's
+                         children and discard whatever is still under it. Say what
+                         happened instead, in the same slot the ordinary empty-folder
+                         hint uses, and leave rename/move/delete working. -->
+                    <p class="qaUnreadableFolder">
+                        QuickAdd couldn't read this folder's contents. They're still
+                        in <code>data.json</code>.
+                    </p>
+                {:else}
                 <ChoiceList
                     {app}
                     roots={roots}
-                    choices={choice.choices}
+                    choices={children}
                     nested={true}
-                    isEmptyFolder={choice.choices.length === 0}
+                    isEmptyFolder={children.length === 0}
                     {forceDragDisabled}
                     rootReorder={rootReorder ?? actions.onReorderChoices}
                     actions={nestedActions}
@@ -199,6 +222,7 @@
                             onAddChoice={actions.onAddChoice}
                         />
                     </div>
+                {/if}
                 {/if}
             </div>
         {/if}
@@ -262,6 +286,20 @@
        grow — it keeps its ellipsis via flex-shrink + the shared min-width: 0. */
     .multiChoiceListItemName :global(.choiceListItemName) {
         flex: 0 1 auto;
+    }
+
+    /* Same slot, weight and colour as the empty-folder hint in ChoiceList, so a
+       folder we cannot read reads as a variation of "empty" rather than an alarm. */
+    .qaUnreadableFolder {
+        margin: 0;
+        padding: 6px 8px 8px;
+        color: var(--text-faint);
+        font-size: var(--font-ui-smaller, 12px);
+        line-height: 1.4;
+    }
+
+    .qaUnreadableFolder code {
+        font-size: inherit;
     }
 
     .qaFolderCount {

--- a/src/gui/choiceList/contextMenu.ts
+++ b/src/gui/choiceList/contextMenu.ts
@@ -55,6 +55,7 @@ export function computeEligibleMultiTargets(
 
   const walk = (list: IChoice[], prefix: string[] = []) => {
     for (const c of list) {
+      if (!isChoiceLike(c)) continue;
       const name = c.name ?? "";
       if (c.type === "Multi") {
         const path = [...prefix, name];

--- a/src/gui/choiceList/contextMenu.ts
+++ b/src/gui/choiceList/contextMenu.ts
@@ -3,6 +3,7 @@ import { Menu as ObsidianMenu } from "obsidian";
 import type IChoice from "src/types/choices/IChoice";
 import {
   childChoicesOf,
+  hasUnreadableChildren,
   isChoiceLike,
   rootChoicesOf,
 } from "src/utils/choiceUtils";
@@ -74,6 +75,11 @@ export function computeEligibleMultiTargets(
 function isInvalidTarget(moving: IChoice, target: IChoice): boolean {
   if (target.type !== "Multi") return true;
   if (moving.id === target.id) return true;
+  // A folder whose existing children could not be read refuses writes (see
+  // choiceService.insertIntoMulti), so offering it here would be a menu item
+  // that silently does nothing. Same predicate as the folder's hint, its drop
+  // zone and its delete warning (#1566).
+  if (hasUnreadableChildren(target)) return true;
   if (moving.type === "Multi") {
     const ids = new Set<string>();
     const collect = (c: IChoice) => {

--- a/src/gui/choiceList/contextMenu.ts
+++ b/src/gui/choiceList/contextMenu.ts
@@ -1,7 +1,11 @@
 import type { App } from "obsidian";
 import { Menu as ObsidianMenu } from "obsidian";
 import type IChoice from "src/types/choices/IChoice";
-import type IMultiChoice from "src/types/choices/IMultiChoice";
+import {
+  childChoicesOf,
+  isChoiceLike,
+  rootChoicesOf,
+} from "src/utils/choiceUtils";
 
 export type MoveTarget = { id: string; path: string };
 
@@ -22,16 +26,15 @@ export function isChoiceNested(
   choice: IChoice,
   roots: IChoice[] | undefined,
 ): boolean {
-  const source: IChoice[] = Array.isArray(roots) ? roots : [];
-  if (source.some((c) => c.id === choice.id)) return false;
+  const source: IChoice[] = rootChoicesOf(roots);
+  if (source.some((c) => isChoiceLike(c) && c.id === choice.id)) return false;
 
   const walk = (list: IChoice[]): boolean => {
     for (const c of list) {
-      if (c.type === "Multi") {
-        const children = (c as IMultiChoice).choices ?? [];
-        if (children.some((child) => child.id === choice.id)) return true;
-        if (walk(children)) return true;
-      }
+      if (!isChoiceLike(c)) continue;
+      const children = childChoicesOf(c);
+      if (children.some((child) => child?.id === choice.id)) return true;
+      if (walk(children)) return true;
     }
     return false;
   };
@@ -58,7 +61,7 @@ export function computeEligibleMultiTargets(
         if (!isInvalidTarget(moving, c)) {
           multiNodes.push({ id: c.id, path: path.join(" / ") });
         }
-        walk((c as IMultiChoice).choices ?? [], [...prefix, name]);
+        walk(childChoicesOf(c), [...prefix, name]);
       }
     }
   };
@@ -73,10 +76,11 @@ function isInvalidTarget(moving: IChoice, target: IChoice): boolean {
   if (moving.type === "Multi") {
     const ids = new Set<string>();
     const collect = (c: IChoice) => {
+      if (!isChoiceLike(c)) return;
       ids.add(c.id);
-      if (c.type === "Multi") (c as IMultiChoice).choices?.forEach(collect);
+      childChoicesOf(c).forEach(collect);
     };
-    (moving as IMultiChoice).choices?.forEach(collect);
+    childChoicesOf(moving).forEach(collect);
     if (ids.has(target.id)) return true;
   }
   return false;

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -415,7 +415,7 @@ describe("ChoiceSuggester", () => {
 		});
 
 		it("never traverses into the back item or returns it for typed queries", () => {
-			const drilledLevel = [...work.choices, makeBack(rootChoices)];
+			const drilledLevel = [...work.choices!, makeBack(rootChoices)];
 			const suggester = makeSuggester(drilledLevel);
 
 			expect(
@@ -427,7 +427,7 @@ describe("ChoiceSuggester", () => {
 		});
 
 		it("keeps the back item in the empty-query view", () => {
-			const drilledLevel = [...work.choices, makeBack(rootChoices)];
+			const drilledLevel = [...work.choices!, makeBack(rootChoices)];
 			const suggester = makeSuggester(drilledLevel);
 
 			const ids = suggester.getSuggestions("").map((s) => s.item.id);
@@ -439,11 +439,11 @@ describe("ChoiceSuggester", () => {
 			// Drill root -> Work -> Meetings, then press Back: the restored level
 			// is back_meetings.choices, which still contains back_work. The
 			// sentinel id must catch that ancestor back item statelessly.
-			const workLevel = [...work.choices, makeBack(rootChoices)];
-			const meetingsLevel = [...meetings.choices, makeBack(workLevel)];
+			const workLevel = [...work.choices!, makeBack(rootChoices)];
+			const meetingsLevel = [...meetings.choices!, makeBack(workLevel)];
 			const backToWork = meetingsLevel[meetingsLevel.length - 1] as IMultiChoice;
 
-			const restored = makeSuggester([...backToWork.choices]);
+			const restored = makeSuggester([...backToWork.choices!]);
 			const items = restored.getSuggestions("o").map((s) => s.item);
 
 			expect(items).toContain(workLog);
@@ -570,7 +570,7 @@ describe("ChoiceSuggester", () => {
 			const openSpy = vi
 				.spyOn(ChoiceSuggester, "Open")
 				.mockImplementation(() => {});
-			const drilledLevel = [...work.choices, makeBack(rootChoices)];
+			const drilledLevel = [...work.choices!, makeBack(rootChoices)];
 			const suggester = makeSuggester(drilledLevel);
 
 			suggester.onChooseItem(
@@ -728,7 +728,7 @@ describe("ChoiceSuggester", () => {
 				IChoice[],
 			];
 			expect(passedChoices.map((c) => c.id)).toEqual([
-				...work.choices.map((c) => c.id),
+				...work.choices!.map((c) => c.id),
 				BACK_CHOICE_ID,
 			]);
 		});

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -33,6 +33,7 @@ import { runTemplateFromFolder } from "../../engine/runTemplateFromFolder";
 import type * as RunTemplateFromFolderModule from "../../engine/runTemplateFromFolder";
 import ChoiceSuggester, {
 	BACK_CHOICE_ID,
+	emptyFolderNoticeText,
 	RUN_TEMPLATE_FROM_FOLDER_ID,
 	stripInlineMarkdown,
 } from "./choiceSuggester";
@@ -998,5 +999,34 @@ describe("stripInlineMarkdown", () => {
 		["**Work** / not nested", "Work / not nested"],
 	])("reduces %s to %s", (input, expected) => {
 		expect(stripInlineMarkdown(input)).toBe(expected);
+	});
+});
+
+describe("emptyFolderNoticeText over a malformed folder (#1566)", () => {
+	const brokenFolder = (children: unknown): IChoice => {
+		const node: Record<string, unknown> = {
+			id: "broken",
+			name: "Broken",
+			type: "Multi",
+			command: false,
+			collapsed: false,
+		};
+		if (children !== undefined) node.choices = children;
+		return node as unknown as IChoice;
+	};
+
+	it("calls a folder that lost nothing empty", () => {
+		for (const value of [undefined, null, {}, []]) {
+			expect(emptyFolderNoticeText(brokenFolder(value))).toBe(
+				'Folder "Broken" is empty.',
+			);
+		}
+	});
+
+	it("does not call a folder empty when its contents merely could not be read", () => {
+		// Otherwise the picker contradicts the settings list about the same folder.
+		expect(emptyFolderNoticeText(brokenFolder({ "0": {} }))).toContain(
+			"couldn't read the contents",
+		);
 	});
 });

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -15,7 +15,7 @@ import type QuickAdd from "../../main";
 import type { IChoiceExecutor } from "../../IChoiceExecutor";
 import { log } from "../../logger/logManager";
 import { settingsStore } from "../../settingsStore";
-import { flattenChoicesWithPath } from "../../utils/choiceUtils";
+import { childChoicesOf, flattenChoicesWithPath } from "../../utils/choiceUtils";
 import type { FrontmatterPropertyTarget } from "../../utils/frontmatterPropertyLinks";
 import { getFocusedPropertyTarget } from "../../utils/frontmatterPropertyLinks";
 import type { QuickAddTriggerContext } from "../../types/QuickAddTriggerContext";
@@ -86,7 +86,7 @@ export function isEmptyFolderChoice(choice: IChoice): boolean {
 	return (
 		choice.type === "Multi" &&
 		choice.id !== BACK_CHOICE_ID &&
-		!(choice as IMultiChoice).choices?.length
+		childChoicesOf(choice).length === 0
 	);
 }
 
@@ -460,7 +460,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 			return;
 		}
 
-		const choices = [...multi.choices];
+		const choices = [...childChoicesOf(multi)];
 
 		if (!isBack) {
 			const back = new MultiChoice(backLabel).addChoices(this.choices);

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -15,7 +15,11 @@ import type QuickAdd from "../../main";
 import type { IChoiceExecutor } from "../../IChoiceExecutor";
 import { log } from "../../logger/logManager";
 import { settingsStore } from "../../settingsStore";
-import { childChoicesOf, flattenChoicesWithPath } from "../../utils/choiceUtils";
+import {
+	childChoicesOf,
+	flattenChoicesWithPath,
+	hasUnreadableChildren,
+} from "../../utils/choiceUtils";
 import type { FrontmatterPropertyTarget } from "../../utils/frontmatterPropertyLinks";
 import { getFocusedPropertyTarget } from "../../utils/frontmatterPropertyLinks";
 import type { QuickAddTriggerContext } from "../../types/QuickAddTriggerContext";
@@ -41,8 +45,14 @@ const DEFAULT_PLACEHOLDER = "Select a choice";
  * picker's drill-down and the command/URI execute path (choiceExecutor) say the
  * same thing.
  */
-export function emptyFolderNoticeText(folderName: string): string {
-	return `Folder "${folderName}" is empty.`;
+export function emptyFolderNoticeText(folder: IChoice): string {
+	// A folder whose `choices` value could still be HOLDING choices is not empty,
+	// it is unreadable, and saying "empty" here would contradict what the settings
+	// list says about the same folder. Same predicate on both surfaces (#1566).
+	if (hasUnreadableChildren(folder)) {
+		return `QuickAdd couldn't read the contents of "${folder.name}". They're still in data.json.`;
+	}
+	return `Folder "${folder.name}" is empty.`;
 }
 
 /**
@@ -315,7 +325,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 			// would stack one identical notice per repeat. Property read rather than
 			// `instanceof KeyboardEvent` — a popout window is a separate realm.
 			if ("repeat" in evt && evt.repeat) return;
-			new Notice(emptyFolderNoticeText(value.item.name));
+			new Notice(emptyFolderNoticeText(value.item));
 			// A trusted mousedown on `.suggestion-item` — a non-focusable div with no
 			// focusable ancestor, since neither `.modal` nor `.modal-container` carries
 			// a tabindex — moves focus to <body>. Obsidian never has to handle that
@@ -456,7 +466,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		// #1550's close-and-reopen is gone with the ejection it worked around: it
 		// discarded the typed query, the scroll position and the selection.
 		if (!isBack && isEmptyFolderChoice(multi)) {
-			new Notice(emptyFolderNoticeText(multi.name));
+			new Notice(emptyFolderNoticeText(multi));
 			return;
 		}
 

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -63,6 +63,22 @@ export function emptyFolderNoticeText(folder: IChoice): string {
 export const EMPTY_FOLDER_FLAIR = "Empty";
 
 /**
+ * The same marker for a folder the picker cannot drill into because its contents
+ * could not be READ, as opposed to being absent. Calling that one "Empty" would
+ * contradict the settings list, which says the contents are still in data.json
+ * (#1566).
+ */
+export const UNREADABLE_FOLDER_FLAIR = "Unreadable";
+
+/** The trailing marker for a folder row that cannot be opened, or "" for one that can. */
+export function folderFlairFor(choice: IChoice): string {
+	if (!isEmptyFolderChoice(choice)) return "";
+	return hasUnreadableChildren(choice)
+		? UNREADABLE_FOLDER_FLAIR
+		: EMPTY_FOLDER_FLAIR;
+}
+
+/**
  * Sentinel id for the synthetic "New note from template" launcher row (#1023).
  * Like {@link BACK_CHOICE_ID}, it is navigation/action — never a real choice —
  * so it is dispatched explicitly and excluded from nested search. The constant
@@ -377,7 +393,8 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 		// vanish, which is a worse, unexplained dead end. `el.empty()` above clears
 		// children but never attributes, so the marker is cleared explicitly for
 		// rows Obsidian recycles (matching the defensive `mod-complex` reset).
-		const isEmptyFolder = isEmptyFolderChoice(item.item);
+		const flairText = folderFlairFor(item.item);
+		const isEmptyFolder = flairText !== "";
 		el.classList.toggle("quickadd-choice-suggestion-empty", isEmptyFolder);
 		if (isEmptyFolder) {
 			// Not operable, but still focusable and still able to explain itself —
@@ -385,7 +402,7 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 			el.setAttribute("aria-disabled", "true");
 			const flair = createOwnedElement(row, "span");
 			flair.classList.add("quickadd-choice-suggestion-empty-flair");
-			flair.textContent = EMPTY_FOLDER_FLAIR;
+			flair.textContent = flairText;
 			row.appendChild(flair);
 		} else {
 			el.removeAttribute("aria-disabled");

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,12 @@ import { InfiniteAIAssistantCommandSettingsModal } from "./gui/MacroGUIs/AIAssis
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { interactivePromptServer } from "./interactive/interactivePromptServer";
 import { parseSemver } from "./utils/semver";
-import { dedupeChoicesById, resolveChoiceIcon } from "./utils/choiceUtils";
+import {
+	childChoicesOf,
+	dedupeChoicesById,
+	resolveChoiceIcon,
+	rootChoicesOf,
+} from "./utils/choiceUtils";
 import { isReservedVariableKey } from "./utils/reservedVariableKeys";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { autoSyncEnabledProviders } from "./ai/modelSyncService";
@@ -314,12 +319,27 @@ export default class QuickAdd extends Plugin {
 
 		this.addSettingTab(new QuickAddSettingsTab(this.app, this));
 
+		// Everything from here on reads the choice tree, i.e. untrusted data.json.
+		// Each step is isolated so a defect in that data costs one capability
+		// instead of the whole plugin: onload throwing leaves Obsidian reporting
+		// only "Plugin failure: quickadd", with no commands, no migrations, no CLI
+		// and no startup macros, and no way for the user to tell why (#1566).
+		// The accessors below handle the corrupt shapes we know about; this is the
+		// blast radius bound for the ones nobody has thought of yet.
 		this.addCommandsForChoices(this.settings.choices);
 
-		await migrate(this);
+		try {
+			await migrate(this);
+		} catch (err) {
+			reportError(err, "QuickAdd could not run its settings migrations");
+		}
 
 		const registerCli = () => {
-			registerQuickAddCliHandlers(this);
+			try {
+				registerQuickAddCliHandlers(this);
+			} catch (err) {
+				reportError(err, "QuickAdd could not register its CLI handlers");
+			}
 		};
 
 		if (this.app.workspace.layoutReady) {
@@ -329,13 +349,18 @@ export default class QuickAdd extends Plugin {
 		}
 
 		// Run startup macros after migrations are complete
-		const launchStartupMacros = () =>
-			new StartupMacroEngine(
-				this.app,
-				this,
-				this.settings.choices,
-				new ChoiceExecutor(this.app, this),
-			).run();
+		const launchStartupMacros = async () => {
+			try {
+				await new StartupMacroEngine(
+					this.app,
+					this,
+					this.settings.choices,
+					new ChoiceExecutor(this.app, this),
+				).run();
+			} catch (err) {
+				reportError(err, "QuickAdd could not run its startup macros");
+			}
+		};
 
 		if (this.app.workspace.layoutReady) {
 			void launchStartupMacros();
@@ -498,14 +523,23 @@ export default class QuickAdd extends Plugin {
 	}
 
 	private addCommandsForChoices(choices: IChoice[]) {
-		for (const choice of choices) {
-			this.addCommandForChoice(choice);
+		for (const choice of rootChoicesOf(choices)) {
+			// Fault-isolate the loop. This runs from onload against untrusted
+			// data.json, and everything after it - migrations, the CLI handlers,
+			// startup macros - used to be lost to a single bad choice (#1566: a
+			// folder with no `choices` key took the whole plugin down with
+			// "Plugin failure: quickadd"). One defect should cost one command.
+			try {
+				this.addCommandForChoice(choice);
+			} catch (err) {
+				reportError(err, `Could not add a command for a QuickAdd choice`);
+			}
 		}
 	}
 
 	public addCommandForChoice(choice: IChoice) {
 		if (choice.type === "Multi") {
-			this.addCommandsForChoices((<IMultiChoice>choice).choices);
+			this.addCommandsForChoices(childChoicesOf(choice));
 		}
 
 		if (choice.command) {
@@ -552,7 +586,7 @@ export default class QuickAdd extends Plugin {
 		targetPropertyValue: string,
 		choices: IChoice[] = this.settings.choices,
 	): IChoice | null {
-		for (const choice of choices) {
+		for (const choice of rootChoicesOf(choices)) {
 			if (choice[by] === targetPropertyValue) {
 				return choice;
 			}
@@ -560,7 +594,7 @@ export default class QuickAdd extends Plugin {
 				const subChoice = this.getChoice(
 					by,
 					targetPropertyValue,
-					(choice as IMultiChoice).choices,
+					childChoicesOf(choice),
 				);
 				if (subChoice) {
 					return subChoice;
@@ -571,19 +605,18 @@ export default class QuickAdd extends Plugin {
 		return null;
 	}
 
-	/** Count how many choices anywhere in the tree carry `name` (names aren't unique). */
+	/** Count how many choices anywhere in the tree carry `name` (names aren't unique).
+	 * Choices hidden inside an unreadable `choices` value are not counted - the
+	 * warning this feeds can only ever under-report, never mis-fire. */
 	private countChoicesByName(
 		name: string,
 		choices: IChoice[] = this.settings.choices,
 	): number {
 		let count = 0;
-		for (const choice of choices) {
+		for (const choice of rootChoicesOf(choices)) {
 			if (choice.name === name) count++;
 			if (choice.type === "Multi") {
-				count += this.countChoicesByName(
-					name,
-					(choice as IMultiChoice).choices,
-				);
+				count += this.countChoicesByName(name, childChoicesOf(choice));
 			}
 		}
 		return count;
@@ -613,7 +646,7 @@ export default class QuickAdd extends Plugin {
 		// toggling the folder's command off, or the remove half of an update): the
 		// children remain and their still-enabled commands must stay registered.
 		if (options?.recursive && choice.type === "Multi") {
-			for (const child of (<IMultiChoice>choice).choices) {
+			for (const child of childChoicesOf(choice)) {
 				this.removeCommandForChoice(child, options);
 			}
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,6 @@ import { openQuickAddSettings } from "./utils/openPluginSettings";
 import { StartupMacroEngine } from "./engine/StartupMacroEngine";
 import { ChoiceExecutor } from "./choiceExecutor";
 import type IChoice from "./types/choices/IChoice";
-import type IMultiChoice from "./types/choices/IMultiChoice";
 import {
 	deleteObsidianCommand,
 	hasTemplateExtension,

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { parseSemver } from "./utils/semver";
 import {
 	childChoicesOf,
 	dedupeChoicesById,
+	isChoiceLike,
 	resolveChoiceIcon,
 	rootChoicesOf,
 } from "./utils/choiceUtils";
@@ -523,6 +524,10 @@ export default class QuickAdd extends Plugin {
 
 	private addCommandsForChoices(choices: IChoice[]) {
 		for (const choice of rootChoicesOf(choices)) {
+			// A list entry can be a hole (`null`, a stray primitive) left by a bad
+			// edit or a truncated write; it is not a choice, so there is no command
+			// to register for it.
+			if (!isChoiceLike(choice)) continue;
 			// Fault-isolate the loop. This runs from onload against untrusted
 			// data.json, and everything after it - migrations, the CLI handlers,
 			// startup macros - used to be lost to a single bad choice (#1566: a
@@ -586,6 +591,7 @@ export default class QuickAdd extends Plugin {
 		choices: IChoice[] = this.settings.choices,
 	): IChoice | null {
 		for (const choice of rootChoicesOf(choices)) {
+			if (!isChoiceLike(choice)) continue;
 			if (choice[by] === targetPropertyValue) {
 				return choice;
 			}
@@ -613,6 +619,7 @@ export default class QuickAdd extends Plugin {
 	): number {
 		let count = 0;
 		for (const choice of rootChoicesOf(choices)) {
+			if (!isChoiceLike(choice)) continue;
 			if (choice.name === name) count++;
 			if (choice.type === "Multi") {
 				count += this.countChoicesByName(name, childChoicesOf(choice));
@@ -646,6 +653,7 @@ export default class QuickAdd extends Plugin {
 		// children remain and their still-enabled commands must stay registered.
 		if (options?.recursive && choice.type === "Multi") {
 			for (const child of childChoicesOf(choice)) {
+				if (!isChoiceLike(child)) continue;
 				this.removeCommandForChoice(child, options);
 			}
 		}

--- a/src/migrations/consolidateFileExistsBehavior.test.ts
+++ b/src/migrations/consolidateFileExistsBehavior.test.ts
@@ -208,17 +208,18 @@ describe("consolidateFileExistsBehavior migration", () => {
 		).toBeUndefined();
 	});
 
-	it("treats malformed persisted choice and macro collections as empty arrays", async () => {
-		const plugin = {
-			settings: {
-				choices: { invalid: true },
-				macros: "invalid",
-			},
-		} as any;
+	it("walks past malformed persisted collections without replacing them", async () => {
+		// It used to overwrite both with [], which the next ordinary save would
+		// persist - a migration destroying the very data a user would need to
+		// recover by hand (#1566). Walking past them is enough: the migration has
+		// nothing to normalize in a value it cannot read.
+		const choices = { invalid: true };
+		const macros = "invalid";
+		const plugin = { settings: { choices, macros } } as any;
 
 		await migration.migrate(plugin);
 
-		expect(plugin.settings.choices).toEqual([]);
-		expect(plugin.settings.macros).toEqual([]);
+		expect(plugin.settings.choices).toBe(choices);
+		expect(plugin.settings.macros).toBe(macros);
 	});
 });

--- a/src/migrations/consolidateFileExistsBehavior.ts
+++ b/src/migrations/consolidateFileExistsBehavior.ts
@@ -16,15 +16,15 @@ const consolidateFileExistsBehavior: Migration = {
 
 	migrate: async (plugin: QuickAdd): Promise<void> => {
 		const settings = plugin.settings as SettingsWithLegacyMacros;
-		const choices = Array.isArray(plugin.settings.choices)
-			? plugin.settings.choices
-			: [];
-		const macros = Array.isArray(settings.macros)
-			? settings.macros
-			: [];
-
-		plugin.settings.choices = deepClone(choices);
-		settings.macros = deepClone(macros);
+		// Only re-clone a real array. Substituting [] for a corrupt root would
+		// persist that [] on the next save and destroy whatever is still in
+		// data.json, which is the opposite of what a migration should do (#1566).
+		if (Array.isArray(plugin.settings.choices)) {
+			plugin.settings.choices = deepClone(plugin.settings.choices);
+		}
+		if (Array.isArray(settings.macros)) {
+			settings.macros = deepClone(settings.macros);
+		}
 
 		walkAllChoices(plugin, (choice) => {
 			if (isTemplateChoice(choice)) {

--- a/src/migrations/consolidateFileExistsBehavior.ts
+++ b/src/migrations/consolidateFileExistsBehavior.ts
@@ -7,6 +7,7 @@ import {
 import { walkAllChoices } from "./helpers/choice-traversal";
 import type { Migration, MigrationResult } from "./Migrations";
 import type { IMacro } from "src/types/macros/IMacro";
+import { treeHasUnreadableChildren } from "src/utils/choiceUtils";
 
 type SettingsWithLegacyMacros = QuickAdd["settings"] & { macros?: IMacro[] };
 
@@ -21,8 +22,8 @@ const consolidateFileExistsBehavior: Migration = {
 		// data.json, which is the opposite of what a migration should do (#1566).
 		// When it is unreadable the walk below covers nothing, so stay pending and
 		// re-run once the user has repaired the file.
-		const rootReadable = Array.isArray(plugin.settings.choices);
-		if (rootReadable) {
+		const treeReadable = !treeHasUnreadableChildren(plugin.settings.choices);
+		if (Array.isArray(plugin.settings.choices)) {
 			plugin.settings.choices = deepClone(plugin.settings.choices);
 		}
 		if (Array.isArray(settings.macros)) {
@@ -35,7 +36,7 @@ const consolidateFileExistsBehavior: Migration = {
 			}
 		});
 
-		if (!rootReadable) return { complete: false };
+		if (!treeReadable) return { complete: false };
 	},
 };
 

--- a/src/migrations/consolidateFileExistsBehavior.ts
+++ b/src/migrations/consolidateFileExistsBehavior.ts
@@ -5,7 +5,7 @@ import {
 	normalizeTemplateChoice,
 } from "./helpers/normalizeTemplateFileExistsBehavior";
 import { walkAllChoices } from "./helpers/choice-traversal";
-import type { Migration } from "./Migrations";
+import type { Migration, MigrationResult } from "./Migrations";
 import type { IMacro } from "src/types/macros/IMacro";
 
 type SettingsWithLegacyMacros = QuickAdd["settings"] & { macros?: IMacro[] };
@@ -14,12 +14,15 @@ const consolidateFileExistsBehavior: Migration = {
 	description:
 		"Re-run template file collision normalization for users with older migration state",
 
-	migrate: async (plugin: QuickAdd): Promise<void> => {
+	migrate: async (plugin: QuickAdd): Promise<MigrationResult | void> => {
 		const settings = plugin.settings as SettingsWithLegacyMacros;
 		// Only re-clone a real array. Substituting [] for a corrupt root would
 		// persist that [] on the next save and destroy whatever is still in
 		// data.json, which is the opposite of what a migration should do (#1566).
-		if (Array.isArray(plugin.settings.choices)) {
+		// When it is unreadable the walk below covers nothing, so stay pending and
+		// re-run once the user has repaired the file.
+		const rootReadable = Array.isArray(plugin.settings.choices);
+		if (rootReadable) {
 			plugin.settings.choices = deepClone(plugin.settings.choices);
 		}
 		if (Array.isArray(settings.macros)) {
@@ -31,6 +34,8 @@ const consolidateFileExistsBehavior: Migration = {
 				normalizeTemplateChoice(choice);
 			}
 		});
+
+		if (!rootReadable) return { complete: false };
 	},
 };
 

--- a/src/migrations/helpers/choice-traversal.ts
+++ b/src/migrations/helpers/choice-traversal.ts
@@ -6,6 +6,7 @@ import type { IConditionalCommand } from "../../types/macros/Conditional/ICondit
 import { CommandType } from "../../types/macros/CommandType";
 import type { ICommand } from "../../types/macros/ICommand";
 import type { INestedChoiceCommand } from "../../types/macros/QuickCommands/INestedChoiceCommand";
+import { rootChoicesOf } from "../../utils/choiceUtils";
 
 export type ChoiceVisitor = (choice: IChoice) => void;
 export type CommandVisitor = (command: ICommand) => void;
@@ -88,7 +89,9 @@ function walkSettings(
 ): void {
 	const visited = new Set<IChoice>();
 
-	for (const choice of settings.choices) {
+	// The ROOT `choices` is untrusted too: loadSettings deliberately leaves a
+	// non-array value in place rather than replacing it with [] (#1566).
+	for (const choice of rootChoicesOf(settings.choices)) {
 		walkChoice(choice, visitors, visited);
 	}
 

--- a/src/migrations/helpers/isCaptureChoice.ts
+++ b/src/migrations/helpers/isCaptureChoice.ts
@@ -1,6 +1,10 @@
 import type { CaptureChoice } from "src/types/choices/CaptureChoice";
 import type IChoice from "src/types/choices/IChoice";
+import { isChoiceLike } from "src/utils/choiceUtils";
 
 export function isCaptureChoice(choice: IChoice): choice is CaptureChoice {
-	return choice.type === "Capture";
+	// Null-tolerant: a choice list from data.json can contain a hole (`null`, a
+	// stray primitive) from a bad hand-edit or a truncated write, and a migration
+	// that throws on one reverts and re-fails on every launch forever (#1566).
+	return isChoiceLike(choice) && choice.type === "Capture";
 }

--- a/src/migrations/helpers/isMultiChoice.ts
+++ b/src/migrations/helpers/isMultiChoice.ts
@@ -10,5 +10,10 @@ export function isMultiChoice(choice: unknown): choice is MultiChoice {
 		return false;
 	}
 
-	return choice.type === "Multi" && choice.choices !== undefined;
+	// Array.isArray, not `!== undefined`: this predicate gates WRITE walkers that
+	// reassign `choice.choices = recursive(choice.choices)`, and `{}` passes a
+	// `!== undefined` check only to blow up on the for-of one line later. Failing
+	// the predicate makes those migrations SKIP the malformed folder, which is
+	// what preserves it (#1566).
+	return choice.type === "Multi" && Array.isArray(choice.choices);
 }

--- a/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
+++ b/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
@@ -67,13 +67,18 @@ const incrementFileNameSettingMoveToDefaultBehavior: Migration = {
 	 
 	migrate: async (plugin: QuickAdd): Promise<void> => {
 		const settings = plugin.settings as SettingsWithLegacyMacros;
-		const choicesCopy = deepClone(plugin.settings.choices);
-		const choices = recursiveRemoveIncrementFileName(choicesCopy);
+
+		// Only touch a real list - see the same guard in the sibling migrations
+		// (#1566): rewriting a corrupt root with [] would persist that [].
+		if (Array.isArray(plugin.settings.choices)) {
+			const choicesCopy = deepClone(plugin.settings.choices);
+			plugin.settings.choices = deepClone(
+				recursiveRemoveIncrementFileName(choicesCopy),
+			);
+		}
 
 		const macrosCopy = deepClone(settings.macros ?? []);
 		const macros = removeIncrementFileName(macrosCopy);
-
-		plugin.settings.choices = deepClone(choices);
 		
 		// Save the migrated macros back to settings - later migrations still need it
 		settings.macros = macros;

--- a/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
+++ b/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
@@ -4,7 +4,7 @@ import type { IMacro } from "src/types/macros/IMacro";
 import { deepClone } from "src/utils/deepClone";
 import { isMultiChoice } from "./helpers/isMultiChoice";
 import { isNestedChoiceCommand } from "./helpers/isNestedChoiceCommand";
-import type { Migration } from "./Migrations";
+import type { Migration, MigrationResult } from "./Migrations";
 
 type OldTemplateChoice = {
 	type?: string;
@@ -65,12 +65,14 @@ const incrementFileNameSettingMoveToDefaultBehavior: Migration = {
 	description:
 		"'Increment file name' setting moved to 'Set default behavior if file already exists' setting",
 	 
-	migrate: async (plugin: QuickAdd): Promise<void> => {
+	migrate: async (plugin: QuickAdd): Promise<MigrationResult | void> => {
 		const settings = plugin.settings as SettingsWithLegacyMacros;
 
-		// Only touch a real list - see the same guard in the sibling migrations
-		// (#1566): rewriting a corrupt root with [] would persist that [].
-		if (Array.isArray(plugin.settings.choices)) {
+		// See the sibling migrations (#1566): never rewrite a corrupt root with [],
+		// and stay PENDING when the choices half could not run, so a vault repaired
+		// by hand is still migrated.
+		const rootReadable = Array.isArray(plugin.settings.choices);
+		if (rootReadable) {
 			const choicesCopy = deepClone(plugin.settings.choices);
 			plugin.settings.choices = deepClone(
 				recursiveRemoveIncrementFileName(choicesCopy),
@@ -84,6 +86,8 @@ const incrementFileNameSettingMoveToDefaultBehavior: Migration = {
 		settings.macros = macros;
 		
 		// DO NOT delete macros here – later migrations still need it.
+
+		if (!rootReadable) return { complete: false };
 	},
 };
 

--- a/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
+++ b/src/migrations/incrementFileNameSettingMoveToDefaultBehavior.ts
@@ -5,6 +5,7 @@ import { deepClone } from "src/utils/deepClone";
 import { isMultiChoice } from "./helpers/isMultiChoice";
 import { isNestedChoiceCommand } from "./helpers/isNestedChoiceCommand";
 import type { Migration, MigrationResult } from "./Migrations";
+import { treeHasUnreadableChildren } from "src/utils/choiceUtils";
 
 type OldTemplateChoice = {
 	type?: string;
@@ -71,8 +72,8 @@ const incrementFileNameSettingMoveToDefaultBehavior: Migration = {
 		// See the sibling migrations (#1566): never rewrite a corrupt root with [],
 		// and stay PENDING when the choices half could not run, so a vault repaired
 		// by hand is still migrated.
-		const rootReadable = Array.isArray(plugin.settings.choices);
-		if (rootReadable) {
+		const treeReadable = !treeHasUnreadableChildren(plugin.settings.choices);
+		if (Array.isArray(plugin.settings.choices)) {
 			const choicesCopy = deepClone(plugin.settings.choices);
 			plugin.settings.choices = deepClone(
 				recursiveRemoveIncrementFileName(choicesCopy),
@@ -87,7 +88,7 @@ const incrementFileNameSettingMoveToDefaultBehavior: Migration = {
 		
 		// DO NOT delete macros here – later migrations still need it.
 
-		if (!rootReadable) return { complete: false };
+		if (!treeReadable) return { complete: false };
 	},
 };
 

--- a/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
+++ b/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
@@ -56,13 +56,18 @@ const mutualExclusionInsertAfterAndWriteToBottomOfFile: Migration = {
 	 
 	migrate: async (plugin) => {
 		const settings = plugin.settings as SettingsWithLegacyMacros;
-		const choicesCopy = deepClone(plugin.settings.choices);
-		const choices = recursiveMigrateSettingInChoices(choicesCopy);
+
+		// Only touch a real list. Rewriting a corrupt root with [] would persist
+		// that [] on the next save and destroy what a user would need to recover
+		// by hand (#1566); there is nothing here to migrate in a value we cannot
+		// read anyway.
+		if (Array.isArray(plugin.settings.choices)) {
+			const choicesCopy = deepClone(plugin.settings.choices);
+			plugin.settings.choices = recursiveMigrateSettingInChoices(choicesCopy);
+		}
 
 		const macrosCopy = deepClone(settings.macros ?? []);
 		const macros = migrateSettingsInMacros(macrosCopy);
-
-		plugin.settings.choices = choices;
 		
 		// Save the migrated macros back to settings - later migrations still need it
 		settings.macros = macros;

--- a/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
+++ b/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
@@ -3,7 +3,7 @@ import type { IMacro } from "src/types/macros/IMacro";
 import { isCaptureChoice } from "./helpers/isCaptureChoice";
 import { isMultiChoice } from "./helpers/isMultiChoice";
 import { isNestedChoiceCommand } from "./helpers/isNestedChoiceCommand";
-import type { Migration } from "./Migrations";
+import type { Migration, MigrationResult } from "./Migrations";
 import { deepClone } from "src/utils/deepClone";
 import type QuickAdd from "src/main";
 
@@ -54,14 +54,16 @@ const mutualExclusionInsertAfterAndWriteToBottomOfFile: Migration = {
 	description:
 		"Mutual exclusion of insertAfter and writeToBottomOfFile settings. If insertAfter is enabled, writeToBottomOfFile is disabled. To support changes in settings UI.",
 	 
-	migrate: async (plugin) => {
+	migrate: async (plugin): Promise<MigrationResult | void> => {
 		const settings = plugin.settings as SettingsWithLegacyMacros;
 
-		// Only touch a real list. Rewriting a corrupt root with [] would persist
-		// that [] on the next save and destroy what a user would need to recover
-		// by hand (#1566); there is nothing here to migrate in a value we cannot
-		// read anyway.
-		if (Array.isArray(plugin.settings.choices)) {
+		// Never rewrite a corrupt root with []: that [] would be persisted on the
+		// next save and destroy what a user needs to recover by hand (#1566). The
+		// choices half simply has not run, so stay PENDING - migrations are flagged
+		// once and never retried, and a vault repaired by hand deserves to be
+		// migrated. The macros half below is independent and still runs.
+		const rootReadable = Array.isArray(plugin.settings.choices);
+		if (rootReadable) {
 			const choicesCopy = deepClone(plugin.settings.choices);
 			plugin.settings.choices = recursiveMigrateSettingInChoices(choicesCopy);
 		}
@@ -73,6 +75,8 @@ const mutualExclusionInsertAfterAndWriteToBottomOfFile: Migration = {
 		settings.macros = macros;
 		
 		// DO NOT delete macros here – later migrations still need it.
+
+		if (!rootReadable) return { complete: false };
 	},
 };
 

--- a/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
+++ b/src/migrations/mutualExclusionInsertAfterAndWriteToBottomOfFile.ts
@@ -6,6 +6,7 @@ import { isNestedChoiceCommand } from "./helpers/isNestedChoiceCommand";
 import type { Migration, MigrationResult } from "./Migrations";
 import { deepClone } from "src/utils/deepClone";
 import type QuickAdd from "src/main";
+import { treeHasUnreadableChildren } from "src/utils/choiceUtils";
 
 type SettingsWithLegacyMacros = QuickAdd["settings"] & { macros?: IMacro[] };
 
@@ -62,8 +63,8 @@ const mutualExclusionInsertAfterAndWriteToBottomOfFile: Migration = {
 		// choices half simply has not run, so stay PENDING - migrations are flagged
 		// once and never retried, and a vault repaired by hand deserves to be
 		// migrated. The macros half below is independent and still runs.
-		const rootReadable = Array.isArray(plugin.settings.choices);
-		if (rootReadable) {
+		const treeReadable = !treeHasUnreadableChildren(plugin.settings.choices);
+		if (Array.isArray(plugin.settings.choices)) {
 			const choicesCopy = deepClone(plugin.settings.choices);
 			plugin.settings.choices = recursiveMigrateSettingInChoices(choicesCopy);
 		}
@@ -76,7 +77,7 @@ const mutualExclusionInsertAfterAndWriteToBottomOfFile: Migration = {
 		
 		// DO NOT delete macros here – later migrations still need it.
 
-		if (!rootReadable) return { complete: false };
+		if (!treeReadable) return { complete: false };
 	},
 };
 

--- a/src/migrations/removeMacroIndirection.test.ts
+++ b/src/migrations/removeMacroIndirection.test.ts
@@ -34,6 +34,36 @@ describe("removeMacroIndirection with an unreadable root (#1566)", () => {
 		expect(plugin.settings.choices).toEqual({ invalid: true });
 	});
 
+	it("stays pending for an unreadable folder NESTED in a readable root", async () => {
+		// The root array is fine, so a root-only guard lets the migration finish.
+		// flattenChoices then cannot see the folder's descendants, so a macro one
+		// of them references looks orphaned: it is duplicated at the root, the
+		// shared `macros` array is deleted, and the hidden choice keeps a dangling
+		// macroId forever - a completed migration never retries.
+		const macros = [legacyMacro()];
+		const plugin = {
+			settings: {
+				choices: [
+					{
+						id: "folder",
+						name: "Folder",
+						type: "Multi",
+						command: false,
+						collapsed: false,
+						choices: { "0": { id: "hidden", type: "Macro", macroId: "macro-1" } },
+					},
+				],
+				macros,
+			},
+		} as unknown as QuickAdd;
+
+		const result = await removeMacroIndirection.migrate(plugin);
+
+		expect(result).toEqual({ complete: false });
+		expect((plugin.settings as { macros?: unknown }).macros).toBe(macros);
+		expect(plugin.settings.choices).toHaveLength(1);
+	});
+
 	it("still migrates and cleans up when the root is readable", async () => {
 		const plugin = {
 			settings: { choices: [], macros: [legacyMacro()] },

--- a/src/migrations/removeMacroIndirection.test.ts
+++ b/src/migrations/removeMacroIndirection.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type QuickAdd from "src/main";
+import removeMacroIndirection from "./removeMacroIndirection";
+
+/**
+ * #1566. This migration MOVES legacy macros into the choice tree and then
+ * deletes the old `macros` array, so it is the one migration where "walk past
+ * what you cannot read and carry on" is the wrong answer: with an unreadable
+ * root there is nowhere to move them to, and finishing would delete them
+ * outright. Migrations are flagged once and never retried, so that loss would
+ * be permanent even after the user repaired data.json by hand.
+ */
+
+const legacyMacro = () => ({
+	id: "macro-1",
+	name: "Legacy macro",
+	commands: [{ id: "c1", name: "Wait", type: "Wait", time: 100 }],
+	runOnStartup: true,
+});
+
+describe("removeMacroIndirection with an unreadable root (#1566)", () => {
+	it("keeps the legacy macros and stays pending", async () => {
+		const macros = [legacyMacro()];
+		const plugin = {
+			settings: { choices: { invalid: true }, macros },
+		} as unknown as QuickAdd;
+
+		const result = await removeMacroIndirection.migrate(plugin);
+
+		// Pending, so it runs again once the root is repaired...
+		expect(result).toEqual({ complete: false });
+		// ...and nothing was destroyed in the meantime.
+		expect((plugin.settings as { macros?: unknown }).macros).toBe(macros);
+		expect(plugin.settings.choices).toEqual({ invalid: true });
+	});
+
+	it("still migrates and cleans up when the root is readable", async () => {
+		const plugin = {
+			settings: { choices: [], macros: [legacyMacro()] },
+		} as unknown as QuickAdd;
+
+		const result = await removeMacroIndirection.migrate(plugin);
+
+		expect(result).toBeUndefined();
+		expect((plugin.settings as { macros?: unknown }).macros).toBeUndefined();
+		expect(plugin.settings.choices).toHaveLength(1);
+		expect(plugin.settings.choices[0].name).toBe("Legacy macro");
+	});
+});

--- a/src/migrations/removeMacroIndirection.ts
+++ b/src/migrations/removeMacroIndirection.ts
@@ -2,7 +2,10 @@ import { log } from "src/logger/logManager";
 import type QuickAdd from "src/main";
 import type IMacroChoice from "src/types/choices/IMacroChoice";
 import { MacroChoice } from "src/types/choices/MacroChoice";
-import { flattenChoices } from "src/utils/choiceUtils";
+import {
+	flattenChoices,
+	treeHasUnreadableChildren,
+} from "src/utils/choiceUtils";
 import type { Migration, MigrationResult } from "./Migrations";
 
 type LegacySettings = QuickAdd["settings"] & { macros?: LegacyMacro[] };
@@ -21,13 +24,16 @@ const removeMacroIndirection: Migration = {
 		const settings = plugin.settings as LegacySettings;
 
 		// This migration MOVES legacy macros into the choice tree and then deletes
-		// the old `macros` array. With an unreadable root there is nowhere to move
-		// them to, so finishing would delete them outright - and being flagged
-		// complete, it would never retry. Stay pending instead, so a user who
-		// repairs data.json by hand still gets their macros migrated (#1566).
-		if (!Array.isArray(settings.choices)) {
+		// the old `macros` array, so it must see the WHOLE tree before it destroys
+		// the source. Any unreadable `choices` value - at the root or in a nested
+		// folder - hides choices from flattenChoices below, which would classify
+		// the macros they reference as orphaned, duplicate them at the root, and
+		// then delete `settings.macros`; the hidden choice would keep a dangling
+		// macroId forever, because a completed migration never retries. Stay
+		// pending instead, so a vault repaired by hand is still migrated (#1566).
+		if (treeHasUnreadableChildren(settings.choices)) {
 			log.logMessage(
-				"QuickAdd could not read the choice list, so legacy macros were left in place to be migrated later.",
+				"QuickAdd could not read part of the choice list, so legacy macros were left in place to be migrated later.",
 			);
 			return { complete: false };
 		}

--- a/src/migrations/removeMacroIndirection.ts
+++ b/src/migrations/removeMacroIndirection.ts
@@ -3,7 +3,7 @@ import type QuickAdd from "src/main";
 import type IMacroChoice from "src/types/choices/IMacroChoice";
 import { MacroChoice } from "src/types/choices/MacroChoice";
 import { flattenChoices } from "src/utils/choiceUtils";
-import type { Migration } from "./Migrations";
+import type { Migration, MigrationResult } from "./Migrations";
 
 type LegacySettings = QuickAdd["settings"] & { macros?: LegacyMacro[] };
 type LegacyMacro = {
@@ -17,8 +17,20 @@ type LegacyMacroChoice = IMacroChoice & { macroId?: string };
 const removeMacroIndirection: Migration = {
 	description:
 		"Remove macro indirection - embed macros directly in macro choices",
-	migrate: async (plugin: QuickAdd) => {
+	migrate: async (plugin: QuickAdd): Promise<MigrationResult | void> => {
 		const settings = plugin.settings as LegacySettings;
+
+		// This migration MOVES legacy macros into the choice tree and then deletes
+		// the old `macros` array. With an unreadable root there is nowhere to move
+		// them to, so finishing would delete them outright - and being flagged
+		// complete, it would never retry. Stay pending instead, so a user who
+		// repairs data.json by hand still gets their macros migrated (#1566).
+		if (!Array.isArray(settings.choices)) {
+			log.logMessage(
+				"QuickAdd could not read the choice list, so legacy macros were left in place to be migrated later.",
+			);
+			return { complete: false };
+		}
 
 		// Check if we have the old macros array
 		const oldMacros = settings.macros ?? [];
@@ -59,10 +71,7 @@ const removeMacroIndirection: Migration = {
 					commands: macro.commands || [],
 				};
 				choice.runOnStartup = macro.runOnStartup || false;
-				// A corrupt (non-array) root is left alone rather than replaced, so
-				// there is nowhere to append an orphaned macro's choice; skip it
-				// instead of throwing and reverting the migration forever (#1566).
-				if (Array.isArray(settings.choices)) settings.choices.push(choice);
+				settings.choices.push(choice);
 			} else {
 				// Embed the macro in all referencing choices
 				for (const choice of referencingChoices) {

--- a/src/migrations/removeMacroIndirection.ts
+++ b/src/migrations/removeMacroIndirection.ts
@@ -59,7 +59,10 @@ const removeMacroIndirection: Migration = {
 					commands: macro.commands || [],
 				};
 				choice.runOnStartup = macro.runOnStartup || false;
-				settings.choices.push(choice);
+				// A corrupt (non-array) root is left alone rather than replaced, so
+				// there is nowhere to append an orphaned macro's choice; skip it
+				// instead of throwing and reverting the migration forever (#1566).
+				if (Array.isArray(settings.choices)) settings.choices.push(choice);
 			} else {
 				// Embed the macro in all referencing choices
 				for (const choice of referencingChoices) {

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -14,6 +14,7 @@ import {
 import type QuickAdd from "./main";
 import type IChoice from "./types/choices/IChoice";
 import ChoiceView from "./gui/choiceList/ChoiceView.svelte";
+import ChoicesUnavailable from "./gui/choiceList/ChoicesUnavailable.svelte";
 import { mountComponent, type MountHandle } from "./gui/svelte/mountComponent";
 import type { Plain } from "./gui/svelte/persist.svelte";
 import { GenericTextSuggester } from "./gui/suggesters/genericTextSuggester";
@@ -35,6 +36,8 @@ import {
 } from "./utils/dateAliases";
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 import { createDocsLink, DOCS_URLS, openDocsUrl } from "./docs";
+import { rootChoicesOf } from "./utils/choiceUtils";
+import { reportError } from "./utils/errorUtils";
 
 /** String-named keys of {@link QuickAddSettings} — used to type the declarative
  * `control` keys so a mistyped key is caught at compile time. */
@@ -406,11 +409,44 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		setting.controlEl.addClass("qa-setting-full-width-control");
 	}
 
+	/**
+	 * Last line of defence for the whole tab. The declarative framework builds
+	 * every group by calling these `render` closures in turn, so a throw out of
+	 * one of them abandons the rest: when ChoiceView's mount threw, QuickAdd's
+	 * settings came up as a lone "Choices & packages" heading with nothing under
+	 * it, and no other section rendered at all (#1451, #1507, #1566).
+	 *
+	 * ChoiceView has its own <svelte:boundary> for reactive failures inside the
+	 * list; this catches the setup that boundary sits inside, and anything a
+	 * future view mounted here might throw.
+	 */
+	private mountSettingView<C extends Parameters<typeof mountComponent>[1]>(
+		setting: Setting,
+		component: C,
+		props: Parameters<typeof mountComponent>[2],
+	): MountHandle | null {
+		try {
+			return mountComponent(setting.controlEl, component, props);
+		} catch (error) {
+			reportError(error, "QuickAdd could not render a settings view");
+			try {
+				return mountComponent(setting.controlEl, ChoicesUnavailable, {
+					detail: error instanceof Error ? error.message : String(error),
+				});
+			} catch {
+				// The fallback is the same machinery that just failed, so it gets
+				// one plain-text last resort rather than a third layer.
+				setting.controlEl.setText("QuickAdd could not render this section.");
+				return null;
+			}
+		}
+	}
+
 	private renderChoicesView(setting: Setting): () => void {
 		this.prepareFullWidthSetting(setting);
 
 		this.choiceViewHandle?.destroy();
-		const handle = mountComponent(setting.controlEl, ChoiceView, {
+		const handle = this.mountSettingView(setting, ChoiceView, {
 			app: this.app,
 			plugin: this.plugin,
 			choices: settingsStore.getState().choices,
@@ -427,7 +463,7 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		// Capture the handle so a stale cleanup can only ever destroy its own
 		// mount (and only nulls the field while it still points at this mount).
 		return () => {
-			handle.destroy();
+			handle?.destroy();
 			if (this.choiceViewHandle === handle) {
 				this.choiceViewHandle = null;
 			}
@@ -438,15 +474,14 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.prepareFullWidthSetting(setting);
 
 		this.globalVariablesViewHandle?.destroy();
-		const handle = mountComponent(
-			setting.controlEl,
-			GlobalVariablesView,
-			{ app: this.app, plugin: this.plugin },
-		);
+		const handle = this.mountSettingView(setting, GlobalVariablesView, {
+			app: this.app,
+			plugin: this.plugin,
+		});
 		this.globalVariablesViewHandle = handle;
 
 		return () => {
-			handle.destroy();
+			handle?.destroy();
 			if (this.globalVariablesViewHandle === handle) {
 				this.globalVariablesViewHandle = null;
 			}
@@ -473,7 +508,9 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		setting.addButton((button) => {
 			exportButton = button;
 			button.setButtonText("Export package…").onClick(() => {
-				const choicesSnapshot = settingsStore.getState().choices;
+				const choicesSnapshot = rootChoicesOf(
+					settingsStore.getState().choices,
+				);
 				new ExportPackageModal(
 					this.app,
 					this.plugin,
@@ -510,12 +547,13 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 
 		// The declarative tab renders once and does NOT re-render on store changes,
 		// so subscribe to keep the state honest while the tab stays open.
-		let hasNothingToExport = settingsStore.getState().choices.length === 0;
+		let hasNothingToExport =
+			rootChoicesOf(settingsStore.getState().choices).length === 0;
 		apply(hasNothingToExport);
 
 		this.packagesUnsubscribe?.();
 		const unsubscribe = settingsStore.subscribe((settings) => {
-			const next = settings.choices.length === 0;
+			const next = rootChoicesOf(settings.choices).length === 0;
 			if (next === hasNothingToExport) return;
 			hasNothingToExport = next;
 			apply(next);

--- a/src/services/choiceService.audit-commands-choicelist.test.ts
+++ b/src/services/choiceService.audit-commands-choicelist.test.ts
@@ -77,7 +77,7 @@ describe("choiceService audit (commands-choicelist)", () => {
 			const result = insertChoiceAfter([folder], inner.id, copy) as IChoice[];
 
 			const newFolder = result[0] as IMultiChoice;
-			expect(newFolder.choices.map((x) => x.id)).toEqual([inner.id, copy.id]);
+			expect(newFolder.choices!.map((x) => x.id)).toEqual([inner.id, copy.id]);
 			// The copy lands in the SAME folder as its source, not at root.
 			expect(result).toHaveLength(1);
 		});

--- a/src/services/choiceService.insertIntoMulti.test.ts
+++ b/src/services/choiceService.insertIntoMulti.test.ts
@@ -35,14 +35,14 @@ describe("insertIntoMulti", () => {
 		const result = insertIntoMulti(roots, "f1", leaf("c", "C"));
 
 		expect(result).toBeDefined();
-		expect((result?.[0] as IMultiChoice).choices.map((c) => c.id)).toEqual([
+		expect((result?.[0] as IMultiChoice).choices!.map((c) => c.id)).toEqual([
 			"a",
 			"c",
 		]);
 		// Untouched sibling is referentially preserved.
 		expect(result?.[1]).toBe(roots[1]);
 		// Original tree is not mutated.
-		expect((roots[0] as IMultiChoice).choices.map((c) => c.id)).toEqual([
+		expect((roots[0] as IMultiChoice).choices!.map((c) => c.id)).toEqual([
 			"a",
 		]);
 	});
@@ -53,11 +53,11 @@ describe("insertIntoMulti", () => {
 		const result = insertIntoMulti(roots, "f2", leaf("c", "C"));
 
 		expect(result).toBeDefined();
-		const f2 = (result?.[0] as IMultiChoice).choices[0] as IMultiChoice;
-		expect(f2.choices.map((c) => c.id)).toEqual(["c"]);
+		const f2 = (result?.[0] as IMultiChoice).choices![0] as IMultiChoice;
+		expect(f2.choices!.map((c) => c.id)).toEqual(["c"]);
 		// Original nested folder still empty.
 		expect(
-			((roots[0] as IMultiChoice).choices[0] as IMultiChoice).choices,
+			((roots[0] as IMultiChoice).choices![0] as IMultiChoice).choices!,
 		).toHaveLength(0);
 	});
 
@@ -83,17 +83,17 @@ describe("addChoiceToTree", () => {
 
 		const res = addChoiceToTree(roots, leaf("c", "C"), "f1");
 		const f1 = res[0] as IMultiChoice;
-		expect(f1.choices.map((c) => c.id)).toEqual(["a", "c"]);
+		expect(f1.choices!.map((c) => c.id)).toEqual(["a", "c"]);
 		expect(f1.collapsed).toBe(false);
 	});
 
 	it("inserts into a nested folder (depth >= 2) and expands it", () => {
 		const roots: IChoice[] = [folder("f1", "F1", [folder("f2", "F2", [])])];
-		((roots[0] as IMultiChoice).choices[0] as IMultiChoice).collapsed = true;
+		((roots[0] as IMultiChoice).choices![0] as IMultiChoice).collapsed = true;
 
 		const res = addChoiceToTree(roots, leaf("c", "C"), "f2");
-		const f2 = (res[0] as IMultiChoice).choices[0] as IMultiChoice;
-		expect(f2.choices.map((c) => c.id)).toEqual(["c"]);
+		const f2 = (res[0] as IMultiChoice).choices![0] as IMultiChoice;
+		expect(f2.choices!.map((c) => c.id)).toEqual(["c"]);
 		expect(f2.collapsed).toBe(false);
 	});
 
@@ -124,7 +124,7 @@ describe("setMultiCollapsedById", () => {
 
 		const f1 = res[0] as IMultiChoice;
 		expect(f1.collapsed).toBe(false); // ancestor unchanged
-		expect((f1.choices[0] as IMultiChoice).collapsed).toBe(true);
+		expect((f1.choices![0] as IMultiChoice).collapsed).toBe(true);
 	});
 
 	it("is a no-op (returns an equivalent tree) when the id is absent", () => {
@@ -142,10 +142,10 @@ describe("setFolderChildrenById", () => {
 
 		const res = setFolderChildrenById(roots, "f1", [leaf("x", "X")]);
 
-		expect((res[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["x"]);
+		expect((res[0] as IMultiChoice).choices!.map((c) => c.id)).toEqual(["x"]);
 		expect(res[1]).toBe(sib);
 		// Original untouched.
-		expect((roots[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["a"]);
+		expect((roots[0] as IMultiChoice).choices!.map((c) => c.id)).toEqual(["a"]);
 	});
 
 	it("empties a folder by id at depth >= 2 (the cross-zone drag-OUT case)", () => {
@@ -155,15 +155,15 @@ describe("setFolderChildrenById", () => {
 
 		const res = setFolderChildrenById(roots, "f2", []);
 
-		const f2 = (res[0] as IMultiChoice).choices[0] as IMultiChoice;
+		const f2 = (res[0] as IMultiChoice).choices![0] as IMultiChoice;
 		expect(f2.choices).toEqual([]);
 		// Ancestor intact.
-		expect((res[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["f2"]);
+		expect((res[0] as IMultiChoice).choices!.map((c) => c.id)).toEqual(["f2"]);
 	});
 
 	it("is a no-op when the folder id is absent", () => {
 		const roots: IChoice[] = [folder("f1", "F1", [leaf("a", "A")])];
 		const res = setFolderChildrenById(roots, "nope", []);
-		expect((res[0] as IMultiChoice).choices.map((c) => c.id)).toEqual(["a"]);
+		expect((res[0] as IMultiChoice).choices!.map((c) => c.id)).toEqual(["a"]);
 	});
 });

--- a/src/services/choiceService.malformed.test.ts
+++ b/src/services/choiceService.malformed.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import type IChoice from "src/types/choices/IChoice";
+import type IMultiChoice from "src/types/choices/IMultiChoice";
+import {
+	addChoiceToTree,
+	duplicateChoice,
+	findChoiceById,
+	insertChoiceAfter,
+	insertIntoMulti,
+	moveChoice,
+	moveChoiceToRoot,
+	removeChoiceById,
+	setFolderChildrenById,
+	setMultiCollapsedById,
+} from "./choiceService";
+import {
+	HEALTHY_IDS,
+	leaf,
+	malformedFolder,
+	malformedSnapshot,
+	malformedTree,
+	MALFORMED_CHILDREN_SHAPES,
+} from "../utils/malformedChoices.fixture";
+
+/**
+ * #1566. A folder whose `choices` value is missing or is not an array is
+ * deliberately preserved on load rather than repaired, so the tree walkers have
+ * to satisfy two things at once: never throw on it, and never rewrite it.
+ *
+ * The second is the one that is easy to get wrong and impossible to notice: the
+ * settings tab saves the whole tree after every edit, so a walker that rebuilds
+ * every folder it passes would replace the preserved value with `[]` the first
+ * time the user collapses an unrelated folder. Every case below therefore
+ * asserts the malformed values are byte-identical afterwards, not just that
+ * nothing threw.
+ */
+
+describe("choice-tree walkers over a malformed tree (#1566)", () => {
+	const target = () => leaf("Moving", "moving");
+
+	// Each entry: a name, and an edit that touches something OTHER than a
+	// malformed folder. None of them should disturb the malformed values.
+	const unrelatedEdits: [string, (tree: IChoice[]) => IChoice[]][] = [
+		["collapse an unrelated folder", (t) => setMultiCollapsedById(t, "healthy", true)],
+		["expand an unrelated folder", (t) => setMultiCollapsedById(t, "healthy", false)],
+		["delete an unrelated leaf", (t) => removeChoiceById(t, "child").updated],
+		["delete a root-level leaf", (t) => removeChoiceById(t, "head").updated],
+		[
+			"insert a choice after an unrelated leaf",
+			(t) => insertChoiceAfter(t, "child", target()) ?? t,
+		],
+		["add a choice into an unrelated folder", (t) => addChoiceToTree(t, target(), "healthy")],
+		["add a choice at the root", (t) => addChoiceToTree(t, target())],
+		[
+			"commit a reorder in an unrelated folder",
+			(t) => setFolderChildrenById(t, "healthy", [target()]),
+		],
+		["move a choice into an unrelated folder", (t) => moveChoice(t, "head", "healthy")],
+		["move a nested choice back to the root", (t) => moveChoiceToRoot(t, "child")],
+	];
+
+	it.each(unrelatedEdits)("%s leaves every malformed value untouched", (_name, edit) => {
+		const tree = malformedTree();
+		const before = malformedSnapshot(tree);
+
+		const after = edit(tree);
+
+		expect(malformedSnapshot(after)).toBe(before);
+		// ...and the edit still worked: the tree is intact and walkable.
+		expect(after.length).toBeGreaterThan(0);
+	});
+
+	it("finds every healthy choice past a malformed folder", () => {
+		const tree = malformedTree();
+		for (const id of HEALTHY_IDS) {
+			expect(findChoiceById(tree, id)?.id).toBe(id);
+		}
+		expect(findChoiceById(tree, "nope")).toBeUndefined();
+	});
+
+	it("reads a malformed folder as an empty folder", () => {
+		const tree = malformedTree();
+		for (const shape of MALFORMED_CHILDREN_SHAPES) {
+			const folder = findChoiceById(tree, `broken-${shape.key}`) as IMultiChoice;
+			expect(folder).toBeDefined();
+			// Present in the tree, addressable, and carrying nothing readable.
+			expect(folder.type).toBe("Multi");
+		}
+	});
+
+	it("deletes a malformed folder without disturbing its neighbours", () => {
+		const tree = malformedTree();
+		const { updated, removed } = removeChoiceById(tree, "broken-emptyObject");
+
+		expect(removed?.id).toBe("broken-emptyObject");
+		expect(findChoiceById(updated, "broken-emptyObject")).toBeUndefined();
+		for (const id of HEALTHY_IDS) {
+			expect(findChoiceById(updated, id)?.id).toBe(id);
+		}
+	});
+
+	describe("writing into a malformed folder", () => {
+		it("repairs a folder that was carrying nothing", () => {
+			// undefined / null / {} lost nothing, so adopting a real array is a
+			// repair, not a loss - and it is what makes the folder usable again.
+			for (const shape of MALFORMED_CHILDREN_SHAPES.filter((s) => !s.lossy)) {
+				const tree = malformedTree();
+				const id = `broken-${shape.key}`;
+				const updated = insertIntoMulti(tree, id, target());
+				expect(updated, shape.key).toBeDefined();
+				const folder = findChoiceById(updated!, id) as IMultiChoice;
+				expect(folder.choices, shape.key).toEqual([target()]);
+			}
+		});
+
+		it("refuses to overwrite a value that could still hold choices", () => {
+			for (const shape of MALFORMED_CHILDREN_SHAPES.filter((s) => s.lossy)) {
+				const tree = malformedTree();
+				const before = malformedSnapshot(tree);
+				const id = `broken-${shape.key}`;
+
+				// No folder is reported as updated, so addChoiceToTree falls back to
+				// a root append rather than destroying the value.
+				expect(insertIntoMulti(tree, id, target()), shape.key).toBeUndefined();
+
+				const appended = addChoiceToTree(tree, target(), id);
+				expect(malformedSnapshot(appended), shape.key).toBe(before);
+				expect(appended.some((c) => c?.id === "moving"), shape.key).toBe(true);
+			}
+		});
+	});
+
+	describe("duplicating", () => {
+		it("copies an unreadable children value across verbatim", () => {
+			const blob = { "0": leaf("Hidden", "hidden") };
+			const copy = duplicateChoice(
+				malformedFolder("Broken", "broken", blob),
+			) as IMultiChoice;
+
+			expect(copy.name).toBe("Broken (copy)");
+			expect(copy.choices).toBe(blob);
+		});
+
+		it("copies a folder that merely has no children key", () => {
+			const copy = duplicateChoice(
+				malformedFolder("Broken", "broken", undefined),
+			) as IMultiChoice;
+
+			expect(copy.name).toBe("Broken (copy)");
+			expect(copy.choices).toBeUndefined();
+		});
+	});
+});

--- a/src/services/choiceService.test.ts
+++ b/src/services/choiceService.test.ts
@@ -224,7 +224,7 @@ describe("choiceService", () => {
 				(copy as unknown as { onePageInput?: string }).onePageInput,
 			).toBe("always");
 			// children still duplicated with fresh ids
-			expect(copy.choices[0].id).not.toBe(original.choices[0].id);
+			expect(copy.choices![0].id).not.toBe(original.choices![0].id);
 		});
 
 		it("deep clones a Macro's macro and regenerates ids", () => {
@@ -350,17 +350,17 @@ describe("choiceService", () => {
 			expect(copy.placeholder).toBe("ph");
 			expect(copy.collapsed).toBe(true);
 			expect(copy.choices).toHaveLength(2);
-			expect(copy.choices[0].name).toBe("Inner (copy)");
-			expect(copy.choices[1].name).toBe("Nested (copy)");
+			expect(copy.choices![0].name).toBe("Inner (copy)");
+			expect(copy.choices![1].name).toBe("Nested (copy)");
 
-			const copiedNested = copy.choices[1] as IMultiChoice;
+			const copiedNested = copy.choices![1] as IMultiChoice;
 			expect(copiedNested.choices).toHaveLength(1);
-			expect(copiedNested.choices[0].name).toBe("Child (copy)");
+			expect(copiedNested.choices![0].name).toBe("Child (copy)");
 
 			// New ids throughout — distinct from the originals.
 			expect(copy.id).not.toBe(root.id);
-			expect(copy.choices[0].id).not.toBe(inner.id);
-			expect(copiedNested.choices[0].id).not.toBe(innerChild.id);
+			expect(copy.choices![0].id).not.toBe(inner.id);
+			expect(copiedNested.choices![0].id).not.toBe(innerChild.id);
 		});
 	});
 
@@ -802,8 +802,8 @@ describe("choiceService", () => {
 				(c) => c.id === target.id,
 			) as IMultiChoice;
 			expect(newTarget.choices).toHaveLength(2);
-			expect(newTarget.choices[1].id).toBe(moving.id);
-			expect(newTarget.choices[0].name).toBe("Existing");
+			expect(newTarget.choices![1].id).toBe(moving.id);
+			expect(newTarget.choices![0].name).toBe("Existing");
 		});
 
 		it("does not mutate the original choices array", () => {
@@ -833,7 +833,7 @@ describe("choiceService", () => {
 			) as IMultiChoice;
 			expect(newSource.choices).toHaveLength(0);
 			expect(newDest.choices).toHaveLength(1);
-			expect(newDest.choices[0].id).toBe(moving.id);
+			expect(newDest.choices![0].id).toBe(moving.id);
 		});
 
 		it("prevents moving a Multi into itself", () => {
@@ -862,9 +862,9 @@ describe("choiceService", () => {
 			const newOuter = result.find(
 				(c) => c.id === outer.id,
 			) as IMultiChoice;
-			const newInner = newOuter.choices[0] as IMultiChoice;
+			const newInner = newOuter.choices![0] as IMultiChoice;
 			expect(newInner.choices).toHaveLength(1);
-			expect(newInner.choices[0].id).toBe(moving.id);
+			expect(newInner.choices![0].id).toBe(moving.id);
 		});
 	});
 

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -17,7 +17,13 @@ import { MacroChoice } from "../types/choices/MacroChoice";
 import { MultiChoice } from "../types/choices/MultiChoice";
 import { TemplateChoice } from "../types/choices/TemplateChoice";
 import { regenerateIds } from "../utils/macroUtils";
-import { flattenChoices } from "../utils/choiceUtils";
+import {
+	childChoicesOf,
+	flattenChoices,
+	hasChildChoices,
+	hasUnreadableChildren,
+	isChoiceLike,
+} from "../utils/choiceUtils";
 import { choiceNoun } from "../utils/choiceNoun";
 import { excludeKeys } from "../utils/excludeKeys";
 import { deepClone } from "../utils/deepClone";
@@ -59,9 +65,16 @@ export function duplicateChoice(
 		// the other choice types). `choices` is excluded here and set via the
 		// recursive map below so children get fresh ids, not the source's.
 		Object.assign(newMulti, excludeKeys(sourceMulti, ["id", "name", "choices"]));
-		newMulti.choices = sourceMulti.choices.map((child) =>
-			duplicateChoice(child, secretSanitizerOptions)
-		);
+		if (hasChildChoices(sourceMulti)) {
+			newMulti.choices = childChoicesOf(sourceMulti).map((child) =>
+				duplicateChoice(child, secretSanitizerOptions),
+			);
+		} else {
+			// The source's children are unreadable. Carry the value across
+			// verbatim rather than fabricating [], so the copy is as faithful as
+			// the original and the user has two chances to recover it by hand.
+			newMulti.choices = sourceMulti.choices;
+		}
 		return newMulti;
 	}
 
@@ -231,13 +244,18 @@ export async function deleteChoiceWithConfirmation(
 	// dialog is being fixed for. Zero descendants gets no warning at all.
 	const buildMultiWarning = (multi: IMultiChoice): string => {
 		// A malformed Multi (children missing, or not an array) is deliberately
-		// preserved on load rather than repaired — see dedupeChoicesById — and
-		// flattenChoices would throw on it. Throwing here would leave the corrupt
-		// folder undeletable, and ChoiceView awaits this function from a click
-		// handler that discards the promise, so the throw would surface as an
-		// unhandled rejection. Treat it as empty and let the delete through.
-		const children = Array.isArray(multi.choices) ? multi.choices : [];
-		const descendants = flattenChoices(children);
+		// preserved on load rather than repaired - see dedupeChoicesById. It still
+		// has to be deletable, so it must not throw here: ChoiceView awaits this
+		// function from a click handler that discards the promise, so a throw
+		// would surface as an unhandled rejection and the corrupt folder would be
+		// undeletable. But when the value could still be HOLDING choices, saying
+		// nothing would let the user delete data the UI never showed them. Same
+		// predicate as the folder's own hint, so the two surfaces cannot
+		// disagree (#1566).
+		if (hasUnreadableChildren(multi)) {
+			return "QuickAdd could not read this folder's contents. Deleting it also deletes whatever is still stored under it in data.json.";
+		}
+		const descendants = flattenChoices(childChoicesOf(multi));
 		if (descendants.length === 0) return "";
 
 		const folders = descendants.filter((c) => c.type === "Multi").length;
@@ -390,7 +408,8 @@ export function moveChoiceToRoot(
 	if (!movingId) return rootChoices;
 
 	// Already at root: nothing to do.
-	if (rootChoices.some((c) => c.id === movingId)) return rootChoices;
+	if (rootChoices.some((c) => isChoiceLike(c) && c.id === movingId))
+		return rootChoices;
 
 	const { updated: withoutMoving, removed } = removeChoiceById(
 		rootChoices,
@@ -410,11 +429,13 @@ export function moveChoiceToRoot(
  */
 export function findChoiceById(choices: IChoice[], id: string): IChoice | undefined {
 	for (const c of choices) {
+		// A list entry can be a hole (`null`, a primitive) left by a bad edit or a
+		// truncated write. Every walker below steps over one rather than throwing
+		// on it, so a single hole cannot break an unrelated edit (#1566).
+		if (!isChoiceLike(c)) continue;
 		if (c.id === id) return c;
-		if (c.type === "Multi") {
-			const found = findChoiceById((c as IMultiChoice).choices, id);
-			if (found) return found;
-		}
+		const found = findChoiceById(childChoicesOf(c), id);
+		if (found) return found;
 	}
 	return undefined;
 }
@@ -422,10 +443,11 @@ export function findChoiceById(choices: IChoice[], id: string): IChoice | undefi
 function collectDescendantIds(multi: IMultiChoice): Set<string> {
 	const ids = new Set<string>();
 	const walk = (c: IChoice) => {
+		if (!isChoiceLike(c)) return;
 		ids.add(c.id);
-		if (c.type === "Multi") (c as IMultiChoice).choices.forEach(walk);
+		childChoicesOf(c).forEach(walk);
 	};
-	(multi.choices ?? []).forEach(walk);
+	childChoicesOf(multi).forEach(walk);
 	return ids;
 }
 
@@ -436,12 +458,16 @@ export function removeChoiceById(
 	let removed: IChoice | undefined;
 	const updated = choices
 		.map((c) => {
+			if (!isChoiceLike(c)) return c;
 			if (c.id === id) {
 				removed = c;
 				return undefined;
 			}
-			if (c.type !== "Multi") return c;
-			const res = removeChoiceById((c as IMultiChoice).choices, id);
+			// Pass a folder whose children are unreadable through untouched: there
+			// is nothing to remove inside it, and rebuilding it would replace the
+			// original value with the [] this walker reads it as.
+			if (!hasChildChoices(c)) return c;
+			const res = removeChoiceById(childChoicesOf(c), id);
 			if (res.removed) removed = res.removed;
 			if (res.removed) {
 				// Only recreate object when children changed
@@ -468,13 +494,20 @@ export function insertIntoMulti(
 ): IChoice[] | undefined {
 	let changed = false;
 	const updated = choices.map((c) => {
+		if (!isChoiceLike(c)) return c;
 		if (c.id === targetId && c.type === "Multi") {
+			// Refuse to write into a folder whose existing children we could not
+			// read - that write would discard them. The UI offers no add/drop
+			// affordance on such a folder (MultiChoiceListItem), so this is the
+			// backstop for the paths that reach it another way; returning
+			// `undefined` makes the caller fall back rather than destroy.
+			if (hasUnreadableChildren(c)) return c;
 			changed = true;
 			const mc = c as IMultiChoice;
-			return { ...mc, choices: [...mc.choices, child] } as IChoice;
+			return { ...mc, choices: [...childChoicesOf(mc), child] } as IChoice;
 		}
-		if (c.type !== "Multi") return c;
-		const inner = insertIntoMulti((c as IMultiChoice).choices, targetId, child);
+		if (!hasChildChoices(c)) return c;
+		const inner = insertIntoMulti(childChoicesOf(c), targetId, child);
 		if (inner) {
 			changed = true;
 			return { ...(c as IMultiChoice), choices: inner } as IChoice;
@@ -498,7 +531,7 @@ export function insertChoiceAfter(
 	afterId: string,
 	newChoice: IChoice,
 ): IChoice[] | undefined {
-	const index = choices.findIndex((c) => c.id === afterId);
+	const index = choices.findIndex((c) => isChoiceLike(c) && c.id === afterId);
 	if (index !== -1) {
 		const updated = [...choices];
 		updated.splice(index + 1, 0, newChoice);
@@ -507,9 +540,9 @@ export function insertChoiceAfter(
 
 	let changed = false;
 	const updated = choices.map((c) => {
-		if (c.type !== "Multi") return c;
+		if (!isChoiceLike(c) || !hasChildChoices(c)) return c;
 		const inner = insertChoiceAfter(
-			(c as IMultiChoice).choices,
+			childChoicesOf(c),
 			afterId,
 			newChoice,
 		);
@@ -559,10 +592,15 @@ export function updateMultiById(
 	patch: (folder: IMultiChoice) => IMultiChoice,
 ): IChoice[] {
 	return choices.map((c) => {
-		if (c.type !== "Multi") return c;
+		if (!isChoiceLike(c) || c.type !== "Multi") return c;
 		const mc = c as IMultiChoice;
 		if (mc.id === id) return patch(mc) as IChoice;
-		return { ...mc, choices: updateMultiById(mc.choices, id, patch) } as IChoice;
+		// A folder whose children are unreadable comes out byte-identical. This
+		// walker re-spreads EVERY folder it passes, and it is on the save path
+		// (collapse a folder, rename a leaf), so substituting the read accessor
+		// here would quietly persist [] over the preserved value (#1566).
+		if (!hasChildChoices(mc)) return c;
+		return { ...mc, choices: updateMultiById(childChoicesOf(mc), id, patch) } as IChoice;
 	});
 }
 

--- a/src/services/choiceService.ts
+++ b/src/services/choiceService.ts
@@ -66,9 +66,9 @@ export function duplicateChoice(
 		// recursive map below so children get fresh ids, not the source's.
 		Object.assign(newMulti, excludeKeys(sourceMulti, ["id", "name", "choices"]));
 		if (hasChildChoices(sourceMulti)) {
-			newMulti.choices = childChoicesOf(sourceMulti).map((child) =>
-				duplicateChoice(child, secretSanitizerOptions),
-			);
+			newMulti.choices = childChoicesOf(sourceMulti)
+				.filter(isChoiceLike)
+				.map((child) => duplicateChoice(child, secretSanitizerOptions));
 		} else {
 			// The source's children are unreadable. Carry the value across
 			// verbatim rather than fabricating [], so the copy is as faithful as
@@ -253,7 +253,7 @@ export async function deleteChoiceWithConfirmation(
 		// predicate as the folder's own hint, so the two surfaces cannot
 		// disagree (#1566).
 		if (hasUnreadableChildren(multi)) {
-			return "QuickAdd could not read this folder's contents. Deleting it also deletes whatever is still stored under it in data.json.";
+			return "QuickAdd couldn't read this folder's contents. Deleting it also deletes whatever is still stored under it in data.json.";
 		}
 		const descendants = flattenChoices(childChoicesOf(multi));
 		if (descendants.length === 0) return "";

--- a/src/services/packageExportService.test.ts
+++ b/src/services/packageExportService.test.ts
@@ -328,7 +328,7 @@ describe("buildPackage", () => {
 		// The cloned Multi choice should only retain the kept child.
 		const multiEntry = result.pkg.choices.find((c) => c.choice.id === "m1");
 		const multiChoice = multiEntry?.choice as IMultiChoice;
-		expect(multiChoice.choices.map((c) => c.id)).toEqual(["keep"]);
+		expect(multiChoice.choices!.map((c) => c.id)).toEqual(["keep"]);
 
 		// Only the kept template asset is encoded.
 		const assetPaths = result.pkg.assets.map((a) => a.originalPath);
@@ -357,7 +357,7 @@ describe("buildPackage", () => {
 		);
 
 		// Source structure untouched.
-		expect(multi.choices.map((c) => c.id)).toEqual(["keep", "drop"]);
+		expect(multi.choices!.map((c) => c.id)).toEqual(["keep", "drop"]);
 	});
 
 	it("excludes a root choice entirely when its id is in excludedChoiceIds", async () => {

--- a/src/services/packageImportService.malformed.test.ts
+++ b/src/services/packageImportService.malformed.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type IChoice from "src/types/choices/IChoice";
+import type IMultiChoice from "src/types/choices/IMultiChoice";
+import { applyPackageImport } from "./packageImportService";
+import { QUICKADD_PACKAGE_SCHEMA_VERSION } from "../types/packages/QuickAddPackage";
+import {
+	folder,
+	leaf,
+	malformedFolder,
+	malformedSnapshot,
+	malformedTree,
+} from "../utils/malformedChoices.fixture";
+
+/**
+ * #1566. Package import is the one place outside the settings tab that WRITES
+ * into a folder's children, and it does it from a package's declared parent id.
+ * Its private writers were a second implementation of the same walkers, so they
+ * needed the same two properties: never dereference a hole, and never replace an
+ * unreadable value with the `[]` the rest of the app reads it as.
+ */
+
+const app = {
+	vault: { adapter: { exists: async () => false, read: async () => "" } },
+} as never;
+
+const importUnder = async (existing: IChoice[], parentId: string | null) => {
+	const imported = leaf("Imported", "imported-1");
+	return applyPackageImport({
+		app,
+		existingChoices: existing,
+		pkg: {
+			schemaVersion: QUICKADD_PACKAGE_SCHEMA_VERSION,
+			name: "Fixture",
+			description: "",
+			choices: [
+				{ choice: imported, parentChoiceId: parentId, pathHint: ["Imported"] },
+			],
+			assets: [],
+		} as never,
+		choiceDecisions: [{ choiceId: imported.id, mode: "import" }],
+		assetDecisions: [],
+	});
+};
+
+const find = (tree: IChoice[], id: string): IChoice | undefined => {
+	for (const c of tree) {
+		if (!c || typeof c !== "object") continue;
+		if (c.id === id) return c;
+		const kids = (c as IMultiChoice).choices;
+		if (Array.isArray(kids)) {
+			const hit = find(kids, id);
+			if (hit) return hit;
+		}
+	}
+	return undefined;
+};
+
+describe("package import over a malformed tree (#1566)", () => {
+	it("imports into a healthy folder without disturbing the malformed ones", async () => {
+		const tree = malformedTree();
+		const before = malformedSnapshot(tree);
+
+		const result = await importUnder(tree, "healthy");
+
+		const target = find(result.updatedChoices, "healthy") as IMultiChoice;
+		expect(target.choices?.map((c) => c.id)).toContain("imported-1");
+		expect(malformedSnapshot(result.updatedChoices)).toBe(before);
+	});
+
+	it("imports into a folder nested behind malformed siblings", async () => {
+		const tree = malformedTree();
+		const before = malformedSnapshot(tree);
+
+		const result = await importUnder(tree, "deep");
+
+		const target = find(result.updatedChoices, "deep") as IMultiChoice;
+		expect(target.choices?.map((c) => c.id)).toContain("imported-1");
+		expect(malformedSnapshot(result.updatedChoices)).toBe(before);
+	});
+
+	it("does not overwrite a folder whose contents could not be read", async () => {
+		// The import still completes - the choice falls back to the root - but the
+		// value the user needs in order to recover survives.
+		const blob = { "0": leaf("Hidden", "hidden") };
+		const tree = [
+			folder("Healthy", "healthy", []),
+			malformedFolder("Broken", "broken", blob),
+		];
+
+		const result = await importUnder(tree, "broken");
+
+		const broken = find(result.updatedChoices, "broken") as IMultiChoice;
+		expect(broken.choices).toEqual(blob);
+		expect(find(result.updatedChoices, "imported-1")).toBeDefined();
+	});
+
+	it("repairs a folder that was carrying nothing", async () => {
+		const tree = [malformedFolder("Broken", "broken", {})];
+
+		const result = await importUnder(tree, "broken");
+
+		const broken = find(result.updatedChoices, "broken") as IMultiChoice;
+		expect(broken.choices?.map((c) => c.id)).toEqual(["imported-1"]);
+	});
+
+	it("imports at the root of a tree containing a hole", async () => {
+		const tree = [null as unknown as IChoice, leaf("Leaf", "leaf")];
+
+		const result = await importUnder(tree, null);
+
+		expect(find(result.updatedChoices, "imported-1")).toBeDefined();
+	});
+});

--- a/src/services/packageImportService.test.ts
+++ b/src/services/packageImportService.test.ts
@@ -457,7 +457,7 @@ describe("parseQuickAddPackage", () => {
 		const childAppearances = pkg.choices.filter((c) => c.choice.id === "child");
 		expect(childAppearances.length).toBe(1); // one flat entry
 		const parentEntry = pkg.choices.find((c) => c.choice.id === "parent");
-		expect((parentEntry?.choice as IMultiChoice).choices[0].id).toBe("child"); // + inline
+		expect((parentEntry?.choice as IMultiChoice).choices![0].id).toBe("child"); // + inline
 		// And the consistency check accepts it.
 		expect(() => parseQuickAddPackage(JSON.stringify(pkg))).not.toThrow();
 	});
@@ -1176,7 +1176,7 @@ describe("applyPackageImport - parent/child trees", () => {
 		expect(result.updatedChoices).toHaveLength(1);
 		const insertedParent = result.updatedChoices[0] as IMultiChoice;
 		expect(insertedParent.id).toBe("parent");
-		expect(insertedParent.choices.map((c) => c.id)).toEqual(["child"]);
+		expect(insertedParent.choices!.map((c) => c.id)).toEqual(["child"]);
 	});
 
 	it("inserts a new child under an already-existing parent multi", async () => {
@@ -1197,7 +1197,7 @@ describe("applyPackageImport - parent/child trees", () => {
 
 		expect(result.addedChoiceIds).toEqual(["child"]);
 		const parent = result.updatedChoices[0] as IMultiChoice;
-		expect(parent.choices.map((c) => c.id)).toEqual(["child"]);
+		expect(parent.choices!.map((c) => c.id)).toEqual(["child"]);
 	});
 
 	it("falls back to pathHint to locate a parent multi by name", async () => {
@@ -1224,7 +1224,7 @@ describe("applyPackageImport - parent/child trees", () => {
 
 		expect(result.addedChoiceIds).toEqual(["child"]);
 		const parent = result.updatedChoices[0] as IMultiChoice;
-		expect(parent.choices.map((c) => c.id)).toEqual(["child"]);
+		expect(parent.choices!.map((c) => c.id)).toEqual(["child"]);
 	});
 
 	it("adds an orphan child to the root when its parent cannot be found", async () => {
@@ -1280,7 +1280,7 @@ describe("applyPackageImport - parent/child trees", () => {
 		const destParent = result.updatedChoices.find(
 			(c) => c.id === "parent",
 		) as IMultiChoice;
-		expect(destParent.choices.map((c) => c.id)).toEqual(["child"]);
+		expect(destParent.choices!.map((c) => c.id)).toEqual(["child"]);
 	});
 });
 
@@ -1416,7 +1416,7 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 		const insertedParent = result.updatedChoices[0] as IMultiChoice;
 		// Parent and child both get new ids.
 		expect(insertedParent.id).not.toBe("parent");
-		const insertedMacro = insertedParent.choices[0] as IMacroChoice;
+		const insertedMacro = insertedParent.choices![0] as IMacroChoice;
 		expect(insertedMacro.id).not.toBe("macroChild");
 		// Macro + command ids regenerated.
 		expect(insertedMacro.macro.id).not.toBe("macro-orig");
@@ -1495,7 +1495,7 @@ describe("applyPackageImport - duplicate mode and id remapping", () => {
 
 		const insertedParent = result.updatedChoices[0] as IMultiChoice;
 		// The skipped child must not appear inside the imported parent's tree.
-		expect(insertedParent.choices.map((c) => c.id)).toEqual(["keep"]);
+		expect(insertedParent.choices!.map((c) => c.id)).toEqual(["keep"]);
 		expect(result.skippedChoiceIds).toContain("drop");
 	});
 });

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -11,7 +11,12 @@ import {
 	isQuickAddPackage,
 	QUICKADD_PACKAGE_SCHEMA_VERSION,
 } from "../types/packages/QuickAddPackage";
-import { childChoicesOf, flattenChoices } from "../utils/choiceUtils";
+import {
+	childChoicesOf,
+	flattenChoices,
+	hasUnreadableChildren,
+	isChoiceLike,
+} from "../utils/choiceUtils";
 import type { ICommand } from "../types/macros/ICommand";
 import type { IChoiceCommand } from "../types/macros/IChoiceCommand";
 import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
@@ -710,8 +715,7 @@ export async function applyPackageImport(
 				updatedChoices,
 				entry.pathHint.slice(0, -1),
 			);
-			if (parentByPath) {
-				insertIntoMulti(parentByPath, choiceClone);
+			if (parentByPath && insertIntoMulti(parentByPath, choiceClone)) {
 				addedChoiceIds.push(finalId);
 				handledChoices.add(originalId);
 				continue;
@@ -722,7 +726,9 @@ export async function applyPackageImport(
 		}
 
 		// Default: append to root
-		const existingIndex = updatedChoices.findIndex((c) => c.id === finalId);
+		const existingIndex = updatedChoices.findIndex(
+			(c) => isChoiceLike(c) && c.id === finalId,
+		);
 		if (existingIndex !== -1) {
 			updatedChoices.splice(existingIndex, 1, choiceClone);
 			overwrittenChoiceIds.push(finalId);
@@ -989,15 +995,13 @@ function remapCommands(
 function replaceChoiceInTree(choices: IChoice[], replacement: IChoice): boolean {
 	for (let i = 0; i < choices.length; i++) {
 		const current = choices[i];
+		if (!isChoiceLike(current)) continue;
 		if (current.id === replacement.id) {
 			choices.splice(i, 1, replacement);
 			return true;
 		}
-		if (current.type === "Multi") {
-			const multi = current as IMultiChoice;
-			if (multi.choices && replaceChoiceInTree(multi.choices, replacement)) {
-				return true;
-			}
+		if (replaceChoiceInTree(childChoicesOf(current), replacement)) {
+			return true;
 		}
 	}
 	return false;
@@ -1009,30 +1013,37 @@ function insertUnderParent(
 	child: IChoice,
 ): boolean {
 	for (const choice of choices) {
+		if (!isChoiceLike(choice)) continue;
 		if (choice.id === parentId && choice.type === "Multi") {
-			insertIntoMulti(choice as IMultiChoice, child);
-			return true;
+			return insertIntoMulti(choice as IMultiChoice, child);
 		}
-		if (choice.type === "Multi") {
-			const multi = choice as IMultiChoice;
-			if (multi.choices && insertUnderParent(multi.choices, parentId, child)) {
-				return true;
-			}
+		if (insertUnderParent(childChoicesOf(choice), parentId, child)) {
+			return true;
 		}
 	}
 	return false;
 }
 
-function insertIntoMulti(parent: IMultiChoice, child: IChoice): void {
+/**
+ * Returns false when the parent's existing children could not be read: importing
+ * INTO such a folder would replace whatever data.json still holds under it with
+ * a one-element array. Callers fall back to a root append, so the imported
+ * choice still lands somewhere rather than costing the user that value (#1566).
+ */
+function insertIntoMulti(parent: IMultiChoice, child: IChoice): boolean {
 	if (!Array.isArray(parent.choices)) {
+		if (hasUnreadableChildren(parent)) return false;
 		parent.choices = [];
 	}
-	const idx = parent.choices.findIndex((choice) => choice.id === child.id);
+	const idx = parent.choices.findIndex(
+		(choice) => isChoiceLike(choice) && choice.id === child.id,
+	);
 	if (idx !== -1) {
 		parent.choices.splice(idx, 1, child);
 	} else {
 		parent.choices.push(child);
 	}
+	return true;
 }
 
 function findMultiByPath(
@@ -1045,11 +1056,14 @@ function findMultiByPath(
 
 	for (const segment of path) {
 		const next = currentChoices.find(
-			(choice) => choice.type === "Multi" && choice.name === segment,
+			(choice) =>
+				isChoiceLike(choice) &&
+				choice.type === "Multi" &&
+				choice.name === segment,
 		) as IMultiChoice | undefined;
 		if (!next) return null;
 		currentMulti = next;
-		currentChoices = next.choices ?? [];
+		currentChoices = childChoicesOf(next);
 	}
 
 	return currentMulti;

--- a/src/services/packageImportService.ts
+++ b/src/services/packageImportService.ts
@@ -11,7 +11,7 @@ import {
 	isQuickAddPackage,
 	QUICKADD_PACKAGE_SCHEMA_VERSION,
 } from "../types/packages/QuickAddPackage";
-import { flattenChoices } from "../utils/choiceUtils";
+import { childChoicesOf, flattenChoices } from "../utils/choiceUtils";
 import type { ICommand } from "../types/macros/ICommand";
 import type { IChoiceCommand } from "../types/macros/IChoiceCommand";
 import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
@@ -352,12 +352,9 @@ function findUncarriedChildChoiceId(
 		if (!parentEntry) continue;
 
 		const parent = parentEntry.choice;
-		const carriedInline =
-			parent.type === "Multi" &&
-			Array.isArray((parent as IMultiChoice).choices) &&
-			(parent as IMultiChoice).choices.some(
-				(child) => child?.id === entry.choice.id,
-			);
+		const carriedInline = childChoicesOf(parent).some(
+			(child) => child?.id === entry.choice.id,
+		);
 		if (!carriedInline) return entry.choice.id;
 	}
 

--- a/src/types/choices/IMultiChoice.ts
+++ b/src/types/choices/IMultiChoice.ts
@@ -1,7 +1,19 @@
 import type IChoice from "./IChoice";
 
 export default interface IMultiChoice extends IChoice {
-	choices: IChoice[];
+	/**
+	 * Optional because `data.json` is untrusted input and this field is where it
+	 * lies most often: a hand-edit, an imported package or a partial write can
+	 * leave it missing entirely (#1566). `strictNullChecks` is on and CI runs
+	 * `svelte-check`, so declaring the truth here turns every unguarded
+	 * `folder.choices.map(...)` — in .ts AND .svelte — into a compile error, which
+	 * is what stops the next reader from re-introducing the bug.
+	 *
+	 * Read it through `childChoicesOf()` (src/utils/choiceUtils.ts), which also
+	 * covers the shape the type system can't express: a non-array value such as
+	 * `{}`, which `?? []` and truthy guards both wave through.
+	 */
+	choices?: IChoice[];
 	collapsed: boolean;
 	placeholder?: string;
 }

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -134,7 +134,7 @@ describe("dedupeChoicesById", () => {
 		const dup = (): IChoice => withId("d", "supprimer taches dones");
 		const folder = multiWithId("folder", [withId("a"), dup(), dup()]);
 		const deduped = dedupeChoicesById([folder])[0] as IMultiChoice;
-		expect(deduped.choices.map((c) => c.id)).toEqual(["a", "d"]);
+		expect(deduped.choices!.map((c) => c.id)).toEqual(["a", "d"]);
 	});
 
 	it("re-ids a DIVERGENT same-id choice instead of dropping it (no data lost)", () => {
@@ -162,7 +162,7 @@ describe("dedupeChoicesById", () => {
 		const rebuilt = result[1] as IMultiChoice;
 		expect(rebuilt.id).not.toBe("m");
 		expect(rebuilt.id).toMatch(UUID_RE);
-		expect(rebuilt.choices.map((c) => c.id)).toEqual(["child2"]); // not lost
+		expect(rebuilt.choices!.map((c) => c.id)).toEqual(["child2"]); // not lost
 	});
 
 	it("de-dups globally across nesting levels (identical child re-using a top id -> dropped)", () => {
@@ -170,7 +170,7 @@ describe("dedupeChoicesById", () => {
 			withId("shared"),
 			multiWithId("m", [withId("shared"), withId("ok")]),
 		])[1] as IMultiChoice;
-		expect(folder.choices.map((c) => c.id)).toEqual(["ok"]);
+		expect(folder.choices!.map((c) => c.id)).toEqual(["ok"]);
 	});
 
 	it("produces a fully unique id set when there were collisions", () => {
@@ -349,7 +349,10 @@ describe("malformed `choices` values (#1566)", () => {
 	it("leaves a malformed folder's `choices` value exactly as it found it", () => {
 		const blob = { "0": choice("Hidden") };
 		const folder = brokenFolder(blob);
-		const [deduped] = dedupeChoicesById([folder]) as [Record<string, unknown>];
+		const deduped = dedupeChoicesById([folder])[0] as unknown as Record<
+			string,
+			unknown
+		>;
 		expect(deduped.choices).toBe(blob);
 	});
 });

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -3,11 +3,15 @@ import type IChoice from "src/types/choices/IChoice";
 import type IMultiChoice from "src/types/choices/IMultiChoice";
 import type { ChoiceType } from "src/types/choices/choiceType";
 import {
+	childChoicesOf,
 	dedupeChoicesById,
 	defaultIconForChoiceType,
 	flattenChoices,
 	flattenChoicesWithPath,
+	hasChildChoices,
+	hasUnreadableChildren,
 	resolveChoiceIcon,
+	rootChoicesOf,
 } from "./choiceUtils";
 
 let idCounter = 0;
@@ -256,5 +260,96 @@ describe("resolveChoiceIcon", () => {
 		};
 		expect(() => resolveChoiceIcon(bad)).not.toThrow();
 		expect(resolveChoiceIcon(bad)).toBe("file-text");
+	});
+});
+
+describe("malformed `choices` values (#1566)", () => {
+	const cases: [string, unknown][] = [
+		["missing", undefined],
+		["null", null],
+		["empty object", {}],
+		["array-like object", { "0": choice("Hidden") }],
+		["string", "nope"],
+		["number", 7],
+	];
+
+	function brokenFolder(children: unknown): IChoice {
+		const node: Record<string, unknown> = {
+			id: "broken",
+			name: "Broken",
+			type: "Multi",
+			command: false,
+			collapsed: false,
+		};
+		if (children !== undefined) node.choices = children;
+		return node as unknown as IChoice;
+	}
+
+	describe.each(cases)("children = %s", (_label, value) => {
+		const folder = brokenFolder(value);
+
+		it("reads as no children", () => {
+			expect(childChoicesOf(folder)).toEqual([]);
+		});
+
+		it("is refused by the write guard", () => {
+			expect(hasChildChoices(folder)).toBe(false);
+		});
+
+		it("does not stop a flatten from reaching later choices", () => {
+			const tail = choice("Tail");
+			expect(flattenChoices([folder, tail])).toContain(tail);
+			expect(
+				flattenChoicesWithPath([folder, tail]).map((e) => e.id),
+			).toContain(tail.id);
+		});
+	});
+
+	it("only calls a folder unreadable when the value could still hold choices", () => {
+		expect(hasUnreadableChildren(brokenFolder(undefined))).toBe(false);
+		expect(hasUnreadableChildren(brokenFolder(null))).toBe(false);
+		expect(hasUnreadableChildren(brokenFolder({}))).toBe(false);
+		expect(hasUnreadableChildren(brokenFolder([]))).toBe(false);
+		expect(hasUnreadableChildren(brokenFolder({ "0": choice("x") }))).toBe(true);
+		expect(hasUnreadableChildren(brokenFolder("nope"))).toBe(true);
+		expect(hasUnreadableChildren(choice("A leaf"))).toBe(false);
+	});
+
+	it("hands a well-formed folder back the very same array", () => {
+		const children = [choice("Kid")];
+		const healthy = multi("Healthy", children);
+		expect(childChoicesOf(healthy)).toBe(children);
+		expect(hasChildChoices(healthy)).toBe(true);
+	});
+
+	it("treats a non-array root as an empty list", () => {
+		expect(rootChoicesOf(undefined)).toEqual([]);
+		expect(rootChoicesOf({})).toEqual([]);
+		expect(rootChoicesOf(null)).toEqual([]);
+		const real = [choice("A")];
+		expect(rootChoicesOf(real)).toBe(real);
+	});
+
+	it("walks past a hole in the list instead of throwing on it", () => {
+		const tail = choice("Tail");
+		const tree = [null as unknown as IChoice, "x" as unknown as IChoice, tail];
+		expect(flattenChoices(tree)).toEqual([tail]);
+		expect(flattenChoicesWithPath(tree).map((e) => e.id)).toEqual([tail.id]);
+	});
+
+	it("keeps a hole in the list verbatim through dedupeChoicesById", () => {
+		// This runs inside loadSettings, ~200 lines before addSettingTab: a throw
+		// here costs the settings tab and every command, not just one row.
+		const a = choice("A");
+		const tree = [null as unknown as IChoice, a, undefined as unknown as IChoice];
+		const out = dedupeChoicesById(tree);
+		expect(out).toEqual([null, a, undefined]);
+	});
+
+	it("leaves a malformed folder's `choices` value exactly as it found it", () => {
+		const blob = { "0": choice("Hidden") };
+		const folder = brokenFolder(blob);
+		const [deduped] = dedupeChoicesById([folder]) as [Record<string, unknown>];
+		expect(deduped.choices).toBe(blob);
 	});
 });

--- a/src/utils/choiceUtils.test.ts
+++ b/src/utils/choiceUtils.test.ts
@@ -12,6 +12,7 @@ import {
 	hasUnreadableChildren,
 	resolveChoiceIcon,
 	rootChoicesOf,
+	treeHasUnreadableChildren,
 } from "./choiceUtils";
 
 let idCounter = 0;
@@ -354,5 +355,54 @@ describe("malformed `choices` values (#1566)", () => {
 			unknown
 		>;
 		expect(deduped.choices).toBe(blob);
+	});
+});
+
+describe("treeHasUnreadableChildren (#1566)", () => {
+	function brokenFolder(children: unknown, id = "broken"): IChoice {
+		const node: Record<string, unknown> = {
+			id,
+			name: id,
+			type: "Multi",
+			command: false,
+			collapsed: false,
+		};
+		if (children !== undefined) node.choices = children;
+		return node as unknown as IChoice;
+	}
+
+	it("is false for a tree it can read end to end", () => {
+		expect(treeHasUnreadableChildren([])).toBe(false);
+		expect(
+			treeHasUnreadableChildren([
+				choice("Leaf"),
+				multi("Folder", [multi("Nested", [choice("Deep")])]),
+			]),
+		).toBe(false);
+	});
+
+	it("is true for an unreadable root", () => {
+		expect(treeHasUnreadableChildren(undefined)).toBe(true);
+		expect(treeHasUnreadableChildren({})).toBe(true);
+	});
+
+	it("is true for an unreadable folder at any depth", () => {
+		// The whole point: a root-only check passes this, and the migration that
+		// relies on it then destroys data it could not see.
+		expect(treeHasUnreadableChildren([brokenFolder({})])).toBe(true);
+		expect(
+			treeHasUnreadableChildren([multi("Folder", [brokenFolder(undefined)])]),
+		).toBe(true);
+		expect(
+			treeHasUnreadableChildren([
+				multi("Outer", [multi("Inner", [brokenFolder(null)])]),
+			]),
+		).toBe(true);
+	});
+
+	it("steps over a hole in the list rather than calling it unreadable", () => {
+		expect(
+			treeHasUnreadableChildren([null as unknown as IChoice, choice("Leaf")]),
+		).toBe(false);
 	});
 });

--- a/src/utils/choiceUtils.ts
+++ b/src/utils/choiceUtils.ts
@@ -4,7 +4,95 @@ import type IChoice from "../types/choices/IChoice";
 import type { ChoiceType } from "../types/choices/choiceType";
 
 function isMultiChoice(choice: IChoice): choice is IMultiChoice {
-	return choice.type === "Multi";
+	// Null-tolerant: `data.json` can hand us a list with a null/primitive hole in
+	// it (see dedupeChoicesById), and every caller below is a total function.
+	return isChoiceLike(choice) && choice.type === "Multi";
+}
+
+/**
+ * Whether `value` is shaped enough like a choice to be walked: a non-null object.
+ * `data.json` is untrusted, so a list entry can be `null`, a string, or a number.
+ */
+export function isChoiceLike(value: unknown): value is IChoice {
+	return typeof value === "object" && value !== null;
+}
+
+/**
+ * The children of a choice, as an array that is always safe to iterate, map or
+ * spread. A leaf choice has none; a Multi whose `choices` is missing or is not
+ * an array reads as none too.
+ *
+ * This is the invariant `IMultiChoice.choices` claims but nothing enforces.
+ * `data.json` is untrusted input (hand-edited, imported as a package, or frozen
+ * mid-write and propagated by Obsidian Sync's whole-file last-write-wins), and
+ * `dedupeChoicesById` deliberately preserves a malformed Multi rather than
+ * fabricating `[]` for it. So every READER has to be total, and until this
+ * helper existed each one guarded (or forgot to) on its own - with two guards
+ * that look right and aren't:
+ *
+ *   `choice.choices ?? []`   passes `{}` straight through (not nullish)
+ *   `if (choice.choices)`    passes `{}` straight through (truthy)
+ *
+ * Only `Array.isArray` rejects both shapes, which is why this is a function and
+ * not a convention. Reading through it turned "one malformed folder bricks the
+ * plugin" (#1566: onload aborted before choice commands, migrations, startup
+ * macros and the CLI ever registered, and the settings tab mounted blank) into
+ * "one malformed folder reads as an empty folder".
+ *
+ * This is a READ view, never a repair: it hands back the live array when there
+ * is one and a fresh `[]` otherwise, and nothing persists that `[]`. WRITE paths
+ * must leave a malformed `choices` exactly as they found it (guard them with
+ * `hasChildChoices`), so the original value survives on disk to be recovered by
+ * hand.
+ */
+export function childChoicesOf(choice: IChoice): IChoice[] {
+	if (!isMultiChoice(choice)) return [];
+	return Array.isArray(choice.choices) ? choice.choices : [];
+}
+
+/**
+ * Whether `choice` is a Multi with a real children array, i.e. whether a WRITE
+ * path may rebuild it. Guards the `{ ...folder, choices: ... }` rebuilds so a
+ * malformed folder is passed through untouched instead of being silently
+ * rewritten to the `[]` that `childChoicesOf` reads it as. See #1566.
+ */
+export function hasChildChoices(choice: IChoice): boolean {
+	return isMultiChoice(choice) && Array.isArray(choice.choices);
+}
+
+/**
+ * A choice list that is always safe to iterate. Same argument as
+ * `childChoicesOf`, one level up: the ROOT `settings.choices` is untrusted too,
+ * and `loadSettings` deliberately leaves a non-array value in place rather than
+ * replacing it with `[]` (which the next save would persist). Use at every read
+ * of `settings.choices` / `settingsStore.getState().choices`.
+ */
+export function rootChoicesOf(value: unknown): IChoice[] {
+	return Array.isArray(value) ? value : [];
+}
+
+/**
+ * Whether a Multi's `choices` holds something we cannot read, as opposed to
+ * nothing at all. True only for the malformed shapes that can still CARRY
+ * choices: a non-empty object where an array belongs (`{"0": {...}, "1": {...}}`,
+ * the classic array-turned-object JSON artefact) or some other non-empty
+ * primitive. `undefined`, `null` and `{}` carry nothing, so for those the folder
+ * really is empty and the ordinary empty-folder hint is the honest thing to say.
+ *
+ * This is the line between "degrade quietly" and "tell the user": a folder whose
+ * contents we cannot read must not claim to be empty, must offer no affordance
+ * that would overwrite the value, and must say so before it is deleted. The
+ * hint, the drop target and the delete confirmation all read this one predicate
+ * so they cannot disagree.
+ */
+export function hasUnreadableChildren(choice: IChoice): boolean {
+	if (!isMultiChoice(choice)) return false;
+	const children: unknown = choice.choices;
+	if (children === undefined || children === null) return false;
+	if (Array.isArray(children)) return false;
+	// A non-array object is only lossy when it actually has keys; anything else
+	// non-nullish (a string, a number) was never empty either.
+	return typeof children === "object" ? Object.keys(children).length > 0 : true;
 }
 
 /**
@@ -53,19 +141,20 @@ export function resolveChoiceIcon(choice: IChoice): string {
 }
 
 /**
- * Recursively flattens the choice hierarchy into a single array.
+ * Recursively flattens the choice hierarchy into a single array. Total over a
+ * malformed tree: unreadable children read as none, and a list hole (`null`, a
+ * primitive) is skipped rather than handed on as if it were a choice.
  */
 export function flattenChoices(choices: IChoice[]): IChoice[] {
 	const result: IChoice[] = [];
 
 	const walk = (choice: IChoice) => {
+		if (!isChoiceLike(choice)) return;
 		result.push(choice);
-		if (isMultiChoice(choice) && choice.choices) {
-			choice.choices.forEach(walk);
-		}
+		childChoicesOf(choice).forEach(walk);
 	};
 
-	choices.forEach(walk);
+	rootChoicesOf(choices).forEach(walk);
 	return result;
 }
 
@@ -99,6 +188,15 @@ export function dedupeChoicesById(choices: IChoice[]): IChoice[] {
 	const walk = (list: IChoice[]): IChoice[] => {
 		const out: IChoice[] = [];
 		for (const choice of list) {
+			// A list entry can be `null` or a primitive (a truncated write, a bad
+			// hand-edit). Keep it verbatim - preserving is this function's whole
+			// point - but never dereference it: this runs inside loadSettings, ~200
+			// lines before addSettingTab, so a throw here costs the settings tab
+			// itself and every command with it.
+			if (!isChoiceLike(choice)) {
+				out.push(choice);
+				continue;
+			}
 			let current = choice;
 			const prior = firstById.get(current.id);
 			if (prior) {
@@ -148,19 +246,18 @@ export function flattenChoicesWithPath(
 	parentId: string | null = null,
 ): FlatChoicePathEntry[] {
 	const result: FlatChoicePathEntry[] = [];
-	for (const choice of choices) {
+	for (const choice of rootChoicesOf(choices)) {
+		if (!isChoiceLike(choice)) continue;
 		const path = [...parentPath, choice.name];
 		result.push({ choice, id: choice.id, path, depth, parentId });
-		if (isMultiChoice(choice)) {
-			result.push(
-				...flattenChoicesWithPath(
-					choice.choices ?? [],
-					path,
-					depth + 1,
-					choice.id,
-				),
-			);
-		}
+		result.push(
+			...flattenChoicesWithPath(
+				childChoicesOf(choice),
+				path,
+				depth + 1,
+				choice.id,
+			),
+		);
 	}
 	return result;
 }

--- a/src/utils/choiceUtils.ts
+++ b/src/utils/choiceUtils.ts
@@ -61,6 +61,28 @@ export function hasChildChoices(choice: IChoice): boolean {
 }
 
 /**
+ * Whether ANY node in the tree has children we cannot read.
+ *
+ * The distinction matters to migrations. A reader can walk past an unreadable
+ * folder and be correct; a migration that MOVES data (or deletes the source it
+ * moved from) cannot, because it is flagged complete and never retried - so the
+ * subtree it silently skipped stays un-migrated forever, even after the user
+ * repairs data.json by hand. Such a migration must stay pending instead, and
+ * this is the question it has to ask about the WHOLE tree, not just the root.
+ *
+ * See #1566, and `MigrationResult` in src/migrations/Migrations.ts.
+ */
+export function treeHasUnreadableChildren(choices: unknown): boolean {
+	if (!Array.isArray(choices)) return true;
+	return choices.some((choice) => {
+		if (!isChoiceLike(choice)) return false;
+		if (choice.type !== "Multi") return false;
+		if (!Array.isArray((choice as IMultiChoice).choices)) return true;
+		return treeHasUnreadableChildren((choice as IMultiChoice).choices);
+	});
+}
+
+/**
  * A choice list that is always safe to iterate. Same argument as
  * `childChoicesOf`, one level up: the ROOT `settings.choices` is untrusted too,
  * and `loadSettings` deliberately leaves a non-array value in place rather than

--- a/src/utils/malformedChoices.entrypoints.test.ts
+++ b/src/utils/malformedChoices.entrypoints.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import type IChoice from "src/types/choices/IChoice";
+import {
+	childChoicesOf,
+	dedupeChoicesById,
+	flattenChoices,
+	flattenChoicesWithPath,
+	hasChildChoices,
+	hasUnreadableChildren,
+	isChoiceLike,
+	resolveChoiceIcon,
+	rootChoicesOf,
+} from "./choiceUtils";
+import { collectChoiceClosure } from "./packageTraversal";
+import {
+	addChoiceToTree,
+	duplicateChoice,
+	findChoiceById,
+	insertChoiceAfter,
+	insertIntoMulti,
+	moveChoice,
+	moveChoiceToRoot,
+	removeChoiceById,
+	setFolderChildrenById,
+	setMultiCollapsedById,
+	updateMultiById,
+} from "../services/choiceService";
+import {
+	isChoiceNested,
+	computeEligibleMultiTargets,
+} from "../gui/choiceList/contextMenu";
+import { uniqueDefaultChoiceName } from "../gui/choiceList/choiceTypeMeta";
+import { isEmptyFolderChoice } from "../gui/suggesters/choiceSuggester";
+import {
+	HEALTHY_IDS,
+	leaf,
+	malformedSnapshot,
+	malformedTree,
+} from "./malformedChoices.fixture";
+
+/**
+ * The ratchet for #1566.
+ *
+ * The bug was never one unguarded dereference; it was that `data.json` is
+ * untrusted and roughly forty readers each decided for themselves whether to
+ * guard, using guards (`?? []`, `if (choice.choices)`) that look right and are
+ * not. Fixing the readers we know about does nothing to stop the next one.
+ *
+ * So: one fixture tree carrying every malformed shape, pushed through every
+ * exported entry point that walks a choice tree. Each case asserts two things -
+ * that nothing throws, AND that the malformed values are identical afterwards.
+ * The second assertion is the one that catches a "fix" that quietly repairs the
+ * tree to [] and lets the next save destroy it.
+ *
+ * A new tree walker belongs in this list. Adding it costs one line.
+ */
+
+/**
+ * `returnsTree` marks the walkers that hand a rebuilt tree back. For those the
+ * malformed values must be identical in the RESULT too, not merely in the input:
+ * that is what catches a walker which re-spreads a folder it was not targeting
+ * and quietly replaces its unreadable value with [].
+ */
+type Sweep = [
+	name: string,
+	run: (tree: IChoice[]) => unknown,
+	returnsTree?: boolean,
+];
+
+const sweeps: Sweep[] = [
+	// --- choiceUtils
+	["flattenChoices", (t) => flattenChoices(t)],
+	["flattenChoicesWithPath", (t) => flattenChoicesWithPath(t)],
+	["dedupeChoicesById", (t) => dedupeChoicesById(t), true],
+	["childChoicesOf (every node)", (t) => t.map((c) => childChoicesOf(c))],
+	["hasChildChoices (every node)", (t) => t.map((c) => hasChildChoices(c))],
+	[
+		"hasUnreadableChildren (every node)",
+		(t) => t.map((c) => hasUnreadableChildren(c)),
+	],
+	["rootChoicesOf", (t) => rootChoicesOf(t), true],
+	[
+		"resolveChoiceIcon (every readable node)",
+		(t) => flattenChoices(t).map((c) => resolveChoiceIcon(c)),
+	],
+
+	// --- choiceService: lookups
+	["findChoiceById (hit)", (t) => findChoiceById(t, "child")],
+	["findChoiceById (miss)", (t) => findChoiceById(t, "nope")],
+
+	// --- choiceService: edits elsewhere in the tree
+	["removeChoiceById (leaf)", (t) => removeChoiceById(t, "child").updated, true],
+	["removeChoiceById (malformed folder)", (t) => removeChoiceById(t, "broken-null").updated],
+	["insertChoiceAfter", (t) => insertChoiceAfter(t, "child", leaf("New", "new")), true],
+	["insertIntoMulti (healthy target)", (t) => insertIntoMulti(t, "healthy", leaf("New", "new")), true],
+	["addChoiceToTree (root)", (t) => addChoiceToTree(t, leaf("New", "new")), true],
+	["addChoiceToTree (into folder)", (t) => addChoiceToTree(t, leaf("New", "new"), "healthy"), true],
+	["setMultiCollapsedById", (t) => setMultiCollapsedById(t, "healthy", true), true],
+	["setFolderChildrenById", (t) => setFolderChildrenById(t, "healthy", []), true],
+	["updateMultiById (no match)", (t) => updateMultiById(t, "nope", (f) => f), true],
+	["moveChoice", (t) => moveChoice(t, "head", "healthy"), true],
+	["moveChoiceToRoot", (t) => moveChoiceToRoot(t, "child"), true],
+	["duplicateChoice (every node)", (t) => t.filter(isChoiceLike).map((c) => duplicateChoice(c))],
+
+	// --- packages
+	["collectChoiceClosure (healthy root)", (t) => collectChoiceClosure(t, ["healthy"])],
+	[
+		"collectChoiceClosure (every node as root)",
+		(t) => collectChoiceClosure(t, t.filter(isChoiceLike).map((c) => c.id)),
+	],
+
+	// --- settings GUI helpers
+	["isChoiceNested (every node)", (t) => t.filter(isChoiceLike).map((c) => isChoiceNested(c, t))],
+	[
+		"computeEligibleMultiTargets (every node)",
+		(t) => t.filter(isChoiceLike).map((c) => computeEligibleMultiTargets(c, t)),
+	],
+	["uniqueDefaultChoiceName", (t) => uniqueDefaultChoiceName("Multi", t)],
+
+	// --- picker
+	["isEmptyFolderChoice (every node)", (t) => t.filter(isChoiceLike).map((c) => isEmptyFolderChoice(c))],
+];
+
+describe("every choice-tree entry point over a malformed tree (#1566)", () => {
+	it.each(sweeps)("%s does not throw", (_name, run) => {
+		expect(() => run(malformedTree())).not.toThrow();
+	});
+
+	it.each(sweeps)(
+		"%s leaves every malformed value untouched",
+		(_name, run, returnsTree) => {
+			const tree = malformedTree();
+			const before = malformedSnapshot(tree);
+
+			const result = run(tree);
+
+			// The input tree is never mutated...
+			expect(malformedSnapshot(tree)).toBe(before);
+			// ...and a rebuilt tree carries the same values back out.
+			if (returnsTree) {
+				expect(malformedSnapshot(result as IChoice[])).toBe(before);
+			}
+		},
+	);
+
+	it("keeps every healthy choice reachable through the flatteners", () => {
+		const flat = flattenChoices(malformedTree()).map((c) => c.id);
+		for (const id of HEALTHY_IDS) expect(flat).toContain(id);
+
+		const withPath = flattenChoicesWithPath(malformedTree()).map((e) => e.id);
+		for (const id of HEALTHY_IDS) expect(withPath).toContain(id);
+	});
+
+	it("survives a root `choices` that is not a list at all", () => {
+		for (const root of [undefined, null, {}, "nope", 7]) {
+			const t = root as unknown as IChoice[];
+			expect(() => flattenChoices(t), String(root)).not.toThrow();
+			expect(() => flattenChoicesWithPath(t), String(root)).not.toThrow();
+			expect(() => rootChoicesOf(t), String(root)).not.toThrow();
+		}
+	});
+});

--- a/src/utils/malformedChoices.entrypoints.test.ts
+++ b/src/utils/malformedChoices.entrypoints.test.ts
@@ -33,7 +33,12 @@ import {
 	computeEligibleMultiTargets,
 } from "../gui/choiceList/contextMenu";
 import { uniqueDefaultChoiceName } from "../gui/choiceList/choiceTypeMeta";
-import { isEmptyFolderChoice } from "../gui/suggesters/choiceSuggester";
+import {
+	emptyFolderNoticeText,
+	folderFlairFor,
+	isEmptyFolderChoice,
+} from "../gui/suggesters/choiceSuggester";
+import { getChoicesAsList as macroBuilderChoiceList } from "../gui/MacroGUIs/MacroBuilder";
 import {
 	HEALTHY_IDS,
 	leaf,
@@ -122,6 +127,14 @@ const sweeps: Sweep[] = [
 
 	// --- picker
 	["isEmptyFolderChoice (every node)", (t) => t.filter(isChoiceLike).map((c) => isEmptyFolderChoice(c))],
+	["folderFlairFor (every node)", (t) => t.filter(isChoiceLike).map((c) => folderFlairFor(c))],
+	[
+		"emptyFolderNoticeText (every node)",
+		(t) => t.filter(isChoiceLike).map((c) => emptyFolderNoticeText(c)),
+	],
+
+	// --- macro builder
+	["getChoicesAsList", (t) => macroBuilderChoiceList(t)],
 ];
 
 describe("every choice-tree entry point over a malformed tree (#1566)", () => {

--- a/src/utils/malformedChoices.fixture.ts
+++ b/src/utils/malformedChoices.fixture.ts
@@ -80,23 +80,27 @@ export function malformedTree(): IChoice[] {
 /** The ids of the choices in `malformedTree()` that are perfectly well-formed. */
 export const HEALTHY_IDS = ["head", "healthy", "child", "tail"];
 
-/** Deep-freeze-free snapshot of the malformed values, for preservation asserts. */
+/**
+ * Every unreadable `choices` value still in the tree, keyed by folder id, as a
+ * comparable string. This is what the preservation assertions compare: an edit
+ * elsewhere in the tree must not rewrite, drop, or "repair" any of them.
+ *
+ * List holes (`null`, a stray primitive) are deliberately NOT tracked. They hold
+ * nothing recoverable, so a walker is free to step over one or drop it; only a
+ * folder's children value can be hiding real choices.
+ */
 export function malformedSnapshot(choices: IChoice[]): string {
 	const seen: unknown[] = [];
 	const walk = (list: unknown) => {
 		if (!Array.isArray(list)) return;
 		for (const entry of list) {
-			if (typeof entry !== "object" || entry === null) {
-				seen.push(entry);
-				continue;
-			}
+			if (typeof entry !== "object" || entry === null) continue;
 			const node = entry as Record<string, unknown>;
-			if (node.type === "Multi") {
-				if (Array.isArray(node.choices)) {
-					walk(node.choices);
-				} else {
-					seen.push([node.id, "choices" in node, node.choices]);
-				}
+			if (node.type !== "Multi") continue;
+			if (Array.isArray(node.choices)) {
+				walk(node.choices);
+			} else {
+				seen.push([node.id, "choices" in node, node.choices]);
 			}
 		}
 	};

--- a/src/utils/malformedChoices.fixture.ts
+++ b/src/utils/malformedChoices.fixture.ts
@@ -1,0 +1,105 @@
+import type IChoice from "src/types/choices/IChoice";
+import type IMultiChoice from "src/types/choices/IMultiChoice";
+
+/**
+ * The shapes `data.json` actually shows up in when it has been hand-edited,
+ * imported, half-written or merged by a sync that does not understand JSON.
+ * Shared by every resilience test so they all attack the same tree, and so a new
+ * shape is added in exactly one place. See #1566.
+ */
+
+export function leaf(name: string, id: string): IChoice {
+	return { id, name, type: "Template", command: false } as IChoice;
+}
+
+export function folder(name: string, id: string, children: IChoice[]): IChoice {
+	return {
+		id,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+		choices: children,
+	} as IMultiChoice;
+}
+
+/** A Multi whose `choices` is whatever `children` is, however wrong that is. */
+export function malformedFolder(
+	name: string,
+	id: string,
+	children: unknown,
+): IChoice {
+	const node: Record<string, unknown> = {
+		id,
+		name,
+		type: "Multi",
+		command: false,
+		collapsed: false,
+	};
+	// `undefined` must leave the key ABSENT, not present-and-undefined: that is
+	// the shape a deleted key has, and JSON.stringify would otherwise hide the
+	// difference in the preservation assertions.
+	if (children !== undefined) node.choices = children;
+	return node as unknown as IChoice;
+}
+
+export const MALFORMED_CHILDREN_SHAPES: {
+	key: string;
+	value: unknown;
+	/** Whether the value could still be holding choices we cannot read. */
+	lossy: boolean;
+}[] = [
+	{ key: "missing", value: undefined, lossy: false },
+	{ key: "null", value: null, lossy: false },
+	{ key: "emptyObject", value: {}, lossy: false },
+	{ key: "arrayLikeObject", value: { "0": leaf("Hidden", "hidden-1") }, lossy: true },
+	{ key: "string", value: "not a list", lossy: true },
+	{ key: "number", value: 7, lossy: true },
+];
+
+/**
+ * One tree carrying every malformed shape plus healthy neighbours on both sides,
+ * so a walker that dies partway through is caught by a missing TAIL choice and
+ * not just by the throw.
+ */
+export function malformedTree(): IChoice[] {
+	return [
+		leaf("Head template", "head"),
+		folder("Healthy folder", "healthy", [leaf("Child note", "child")]),
+		...MALFORMED_CHILDREN_SHAPES.map((shape) =>
+			malformedFolder(`Broken ${shape.key}`, `broken-${shape.key}`, shape.value),
+		),
+		// A hole in the list itself: `null` survives a truncated write, and it used
+		// to throw inside dedupeChoicesById during loadSettings.
+		null as unknown as IChoice,
+		"stray" as unknown as IChoice,
+		leaf("Tail template", "tail"),
+	];
+}
+
+/** The ids of the choices in `malformedTree()` that are perfectly well-formed. */
+export const HEALTHY_IDS = ["head", "healthy", "child", "tail"];
+
+/** Deep-freeze-free snapshot of the malformed values, for preservation asserts. */
+export function malformedSnapshot(choices: IChoice[]): string {
+	const seen: unknown[] = [];
+	const walk = (list: unknown) => {
+		if (!Array.isArray(list)) return;
+		for (const entry of list) {
+			if (typeof entry !== "object" || entry === null) {
+				seen.push(entry);
+				continue;
+			}
+			const node = entry as Record<string, unknown>;
+			if (node.type === "Multi") {
+				if (Array.isArray(node.choices)) {
+					walk(node.choices);
+				} else {
+					seen.push([node.id, "choices" in node, node.choices]);
+				}
+			}
+		}
+	};
+	walk(choices);
+	return JSON.stringify(seen);
+}

--- a/src/utils/malformedChoices.fixture.ts
+++ b/src/utils/malformedChoices.fixture.ts
@@ -61,14 +61,37 @@ export const MALFORMED_CHILDREN_SHAPES: {
  * One tree carrying every malformed shape plus healthy neighbours on both sides,
  * so a walker that dies partway through is caught by a missing TAIL choice and
  * not just by the throw.
+ *
+ * Corruption is placed at EVERY depth, not just the root. A first version of
+ * this fixture only had malformed folders at the top level, and a walker that
+ * guards its entry point but not its recursion passes that happily - which is
+ * exactly the bug being fixed, one level down.
  */
 export function malformedTree(): IChoice[] {
+	const broken = (suffix = "") =>
+		MALFORMED_CHILDREN_SHAPES.map((shape) =>
+			malformedFolder(
+				`Broken ${shape.key}${suffix}`,
+				`broken-${shape.key}${suffix}`,
+				shape.value,
+			),
+		);
+
 	return [
 		leaf("Head template", "head"),
 		folder("Healthy folder", "healthy", [leaf("Child note", "child")]),
-		...MALFORMED_CHILDREN_SHAPES.map((shape) =>
-			malformedFolder(`Broken ${shape.key}`, `broken-${shape.key}`, shape.value),
-		),
+		// A healthy folder is not a safe branch: its children can carry the same
+		// corruption, including a hole in ITS list.
+		folder("Nesting folder", "nesting", [
+			leaf("Nested note", "nested-note"),
+			...broken("-nested"),
+			null as unknown as IChoice,
+			folder("Deep folder", "deep", [
+				leaf("Deep note", "deep-note"),
+				...broken("-deep"),
+			]),
+		]),
+		...broken(),
 		// A hole in the list itself: `null` survives a truncated write, and it used
 		// to throw inside dedupeChoicesById during loadSettings.
 		null as unknown as IChoice,
@@ -78,7 +101,16 @@ export function malformedTree(): IChoice[] {
 }
 
 /** The ids of the choices in `malformedTree()` that are perfectly well-formed. */
-export const HEALTHY_IDS = ["head", "healthy", "child", "tail"];
+export const HEALTHY_IDS = [
+	"head",
+	"healthy",
+	"child",
+	"nesting",
+	"nested-note",
+	"deep",
+	"deep-note",
+	"tail",
+];
 
 /**
  * Every unreadable `choices` value still in the tree, keyed by folder id, as a
@@ -107,3 +139,4 @@ export function malformedSnapshot(choices: IChoice[]): string {
 	walk(choices);
 	return JSON.stringify(seen);
 }
+

--- a/src/utils/packageTraversal.ts
+++ b/src/utils/packageTraversal.ts
@@ -8,6 +8,7 @@ import type { IChoiceCommand } from "../types/macros/IChoiceCommand";
 import type { IUserScript } from "../types/macros/IUserScript";
 import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
 import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
+import { isChoiceLike, rootChoicesOf } from "./choiceUtils";
 import { CommandType } from "../types/macros/CommandType";
 
 export interface ChoiceCatalogEntry {
@@ -116,6 +117,9 @@ function buildChoiceCatalog(
 		parentPath: string[],
 	) => {
 		for (const choice of choices) {
+			// A hole in the list (null, a stray primitive) is not a choice; step over
+			// it rather than dereferencing it (#1566).
+			if (!isChoiceLike(choice)) continue;
 			const path = [...parentPath, choice.name];
 			catalog.set(choice.id, {
 				choice,
@@ -129,7 +133,7 @@ function buildChoiceCatalog(
 		}
 	};
 
-	walk(allChoices, null, []);
+	walk(rootChoicesOf(allChoices), null, []);
 
 	return catalog;
 }

--- a/src/utils/packageTraversal.ts
+++ b/src/utils/packageTraversal.ts
@@ -8,7 +8,7 @@ import type { IChoiceCommand } from "../types/macros/IChoiceCommand";
 import type { IUserScript } from "../types/macros/IUserScript";
 import type { IConditionalCommand } from "../types/macros/Conditional/IConditionalCommand";
 import type { INestedChoiceCommand } from "../types/macros/QuickCommands/INestedChoiceCommand";
-import { isChoiceLike, rootChoicesOf } from "./choiceUtils";
+import { childChoicesOf, isChoiceLike, rootChoicesOf } from "./choiceUtils";
 import { CommandType } from "../types/macros/CommandType";
 
 export interface ChoiceCatalogEntry {
@@ -141,10 +141,9 @@ function buildChoiceCatalog(
 function collectChoiceDependencies(choice: IChoice): Set<string> {
 	const dependencies = new Set<string>();
 
-	if (isMultiChoice(choice) && Array.isArray(choice.choices)) {
-		for (const child of choice.choices) {
-			dependencies.add(child.id);
-		}
+	for (const child of childChoicesOf(choice)) {
+		if (!isChoiceLike(child)) continue;
+		dependencies.add(child.id);
 	}
 
 	if (isMacroChoice(choice)) {

--- a/tests/packages/packageImportService.test.ts
+++ b/tests/packages/packageImportService.test.ts
@@ -437,7 +437,7 @@ describe("packageImportService", () => {
 			(choice) => choice.id === multi.id,
 		) as IMultiChoice | undefined;
 		expect(importedFolder).toBeTruthy();
-		expect(importedFolder?.choices.map((child) => child.id)).toEqual([childKeep.id]);
+		expect(importedFolder?.choices!.map((child) => child.id)).toEqual([childKeep.id]);
 	});
 
 	it("skips descendants marked as skip when importing multi choices", async () => {


### PR DESCRIPTION
Fixes #1566.

## The problem is bigger than the title

The issue says a malformed folder blanks the settings tab. It does — but that is the *second* thing that goes wrong. Reproducing it in an isolated Obsidian 1.13 vault showed the plugin never finishes loading at all:

```
TypeError: t is not iterable
  at addCommandsForChoices (plugin:quickadd)
  at addCommandForChoice   (plugin:quickadd)
```

`addCommandForChoice` runs straight from `onload()`, so a single folder in `data.json` with no `choices` key cost:

- every choice command (the palette loses all of them)
- migrations — never ran
- the QuickAdd CLI handlers — never registered, so `quickadd:list` was "command not found"
- startup macros — never ran
- the update announcement

Obsidian reported only **"Plugin failure: quickadd"**. The settings tab had been registered a few lines earlier, which is the only reason the bug *looks* like "the settings tab is blank".

**Before** — the whole tab, not just one row (the other eight setting groups are gone too):

![before](https://raw.githubusercontent.com/chhoumann/quickadd/28df1e2bbef0e0858e6fb447532115e33598abeb/before-blank.png)

## The real defect

`IMultiChoice.choices: IChoice[]` is an invariant the code assumes and nothing enforces. `data.json` is untrusted input: hand-edits, imported packages, Obsidian Sync's whole-file last-write-wins, partial writes. An audit found **~40 readers**, each deciding for itself whether to guard — with two guards that look right and are not:

```ts
choice.choices ?? []      // {} is not nullish → passes straight through
if (choice.choices) {}    // {} is truthy      → passes straight through
```

Only `Array.isArray` rejects both shapes. So this is a function, not a convention:

| helper | role |
| --- | --- |
| `childChoicesOf(choice)` | READ view. Always safe to iterate/map/spread. Never repairs. |
| `hasChildChoices(choice)` | WRITE guard. May this node be rebuilt? |
| `hasUnreadableChildren(c)` | Is the value lossy, or genuinely empty? |
| `rootChoicesOf(value)` | The same, one level up, for `settings.choices`. |
| `isChoiceLike(value)` | A list entry can be `null` or a primitive. |

## The part that was easy to get wrong

`dedupeChoicesById` deliberately **preserves** a malformed folder rather than fabricating `[]`. Three independent reviewers converged on the same blocking objection to the obvious fix: `updateMultiById` and `updateChoiceHelper` re-spread **every** folder they walk past — not just the one they target — and both are on the save path. Reading their children through the total accessor would have persisted `[]` over the preserved value the first time the user collapsed an unrelated folder. Exactly the data loss the preservation stance exists to prevent, triggered by an innocuous click instead of by load.

So the rule the change turns on:

> **Reads** go through the accessor. A walker that **rebuilds** a node it is not targeting returns it untouched.

Every case in `choiceService.malformed.test.ts` asserts the malformed values are byte-identical afterwards, not merely that nothing threw. That second assertion is what fails on the naive fix — I verified it does by reverting each guard in turn.

## What the user sees now

A folder that lost nothing — no key, `null`, `{}` — renders as an ordinary empty folder, with the "Empty — add a choice or drag one here." hint from #1569. It can be renamed, moved, deleted, and refilled; dropping a choice in repairs the value.

A folder whose value could still be *holding* choices (`{"0": {...}}`) is the one case where "empty" would be a lie. It says so, and offers neither the drop zone nor the add row — the two affordances that would overwrite it.

![after](https://raw.githubusercontent.com/chhoumann/quickadd/28df1e2bbef0e0858e6fb447532115e33598abeb/after-fixed.png)

The same predicate drives the hint, the picker's row marker and the delete confirmation, so the three surfaces cannot disagree about the same folder:

![delete warning](https://raw.githubusercontent.com/chhoumann/quickadd/28df1e2bbef0e0858e6fb447532115e33598abeb/after-delete-warning.png)

A corrupt **root** `choices` gets an error card rather than the "No choices yet" hero — whose single CTA would write a fresh list straight over it. The rest of the settings tab still renders:

![root corruption](https://raw.githubusercontent.com/chhoumann/quickadd/28df1e2bbef0e0858e6fb447532115e33598abeb/after-root-corrupt.png)

## Tradeoffs

**Read-layer fix, not load-time normalization.** Normalizing `choices` to `[]` in `loadSettings` would be a one-file change and make every downstream reader correct for free. Rejected: the next ordinary save would persist that `[]` over a value the user may still be able to recover by hand, and QuickAdd offers no other way to get it back. The read layer keeps the file untouched. The cost is a wider diff, which the sweep test exists to make safe.

**`IMultiChoice.choices` is now optional.** `strictNullChecks` is on and CI runs `svelte-check`, so the missing-key shape is a compile error at every unguarded read, in `.ts` and `.svelte` alike. It cost 14 source sites (all of which needed converting anyway) and some `!` in test assertions. The non-array shape can't be expressed in the type system, which is why the accessor still has to exist.

**onload fails open.** Each choice-dependent step is individually guarded, and `addCommandsForChoices` isolates per choice. The accessors handle the corrupt shapes we know about; this bounds the blast radius of the ones nobody has thought of yet. One defect should cost one command, not the plugin.

**No retry button on the error card.** A retry re-renders the same data and throws again, and anything that could rewrite `data.json` would destroy the value the user needs. The card names the file and says QuickAdd has not touched it.

**Migrations that can't finish stay pending.** `removeMacroIndirection` *moves* legacy macros into the choice tree and then deletes the old array — with an unreadable root there is nowhere to move them, so finishing would delete them outright, permanently, since migrations are flagged once and never retried. It returns `{ complete: false }` instead. (An adversarial reviewer caught this as a regression *this branch introduced*; before the fix the throw at least left the data intact.)

## What stops the 41st reader

`src/utils/malformedChoices.entrypoints.test.ts`: one fixture tree carrying every malformed shape **at every depth**, pushed through every exported walker, asserting both no-throw and blob equality. Adding a new walker costs one line.

It earned its keep twice. The first version only placed corruption at the root, and a reviewer pointed out that a walker which guards its entry point but not its recursion passes that happily. Nesting the fixture immediately caught `duplicateChoice`, `packageTraversal`, and the package-import writers — which fabricated `[]` over an unreadable value, the exact invariant the change turns on.

## Validation

`4189 tests`, `tsc`, `svelte-check` and `eslint` all clean. `main.ts` cannot be imported under vitest (it pulls in `obsidian`), so its half is proven live rather than by unit test.

Live, in an isolated Obsidian 1.13 vault seeded with a folder missing the key, one with `{}`, one with `{"0": {...a real choice...}}`, and a `null` list entry:

| check | result |
| --- | --- |
| plugin load | no "Plugin failure", 3 choice commands registered |
| `quickadd:list` | `ok:true`, all 7 choices, malformed folders listed as empty |
| migrations | 15 complete, **zero** console errors |
| settings tab | all 8 groups, 7 rows, 1 unreadable-folder hint |
| collapse + duplicate + rename | all three malformed values byte-identical in `data.json` |
| add into the `{}` folder | repaired to a real array; the lossy one untouched |
| delete the lossy folder | confirmation warns first |
| run a folder from a command | honest notice, not a dead picker |
| corrupt root | error card, rest of the tab alive, `data.json` md5-identical after open/close |

## Reviewed

An ultracode design review (3 audit passes + 3 adversarial critiques + synthesis) reshaped the design before any code was written — the read/write split, the `[null]` load-path bug, and the root-corruption case all came from it. A second adversarial pass over the implementation produced 26 findings, 18 of which survived independent verification and are fixed here, including the blocking migration regression above.

## Filed separately, not grown into this diff

- An error boundary at the `mountComponent` seam for every Svelte host (modals, package manager), which needs a per-host fallback story.
- ChoiceView's async row actions (`delete`, `duplicate`, `configure`) degrade to a silent no-op on throw; they should route through `reportError`.
- `data.json` schema validation with quarantine-and-backup on load — the general answer this deliberately does not build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness across the settings UI, command/URI handling, and editing flows when choice trees are malformed, include holes, or contain unreadable folders.
  * Prevented accidental overwrites by preserving unreadable sections and avoiding rendering/editing gaps that broke drag-and-drop or reordering.
  * Enhanced empty vs unreadable folder messaging, counts, and drill-down navigation.
* **New Features**
  * Added an “unavailable choices” screen when choices can’t be safely read.
* **Migrations**
  * Migrations now remain pending when the choices tree is unreadable instead of rewriting it.
* **Tests**
  * Expanded coverage for malformed traversal and write/read protections across key entry points and services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->