### PR TITLE
test: cover both insertion paths on a folder QuickAdd cannot read

### DIFF
--- a/src/gui/choiceList/ChoiceView.malformed.test.ts
+++ b/src/gui/choiceList/ChoiceView.malformed.test.ts
@@ -93,8 +93,15 @@ describe("ChoiceView over a malformed tree (#1566)", () => {
 			// No nested list and no add-into-folder control: both write to this
 			// folder's children, and that write would discard the value.
 			expect(container.querySelector(".qa-nested"), shape.key).toBeNull();
+			// Both insertion CTAs write to the same children value, so both must be
+			// absent - covering only one would leave the other destructive path
+			// unguarded by this test.
 			expect(
 				queryByLabelText("Add a choice to Broken"),
+				shape.key,
+			).toBeNull();
+			expect(
+				queryByLabelText("Add a folder to Broken"),
 				shape.key,
 			).toBeNull();
 			unmount();


### PR DESCRIPTION
Test-only follow-up to #1583, from a CodeRabbit thread that landed just as it merged. Closes nothing.

**The gap**

A folder whose `choices` value could still be *holding* choices offers neither of the two controls that would write to that value, because either write would discard it. The regression test in #1583 asserted only one of them:

```ts
expect(queryByLabelText("Add a choice to Broken"), shape.key).toBeNull();
```

"Add folder" (`AddChoiceControls` renders both) writes to the same array, through the same `insertIntoMulti` path. So the second destructive insertion path was live behaviour with no test behind it — a regression that restored just that button would have shipped green.

**The change**

One extra assertion, plus a comment saying why both belong together.

**Validation**

Confirmed it guards something rather than just reading like it does: forcing `MultiChoiceListItem`'s unreadable branch off (`{#if unreadable}` → `{#if false}`) makes the test fail, restoring it makes it pass. Full suite green (4305 passed), `tsc`, `svelte-check` and `eslint` clean.

No source change, so no behaviour change and nothing to verify in a vault.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented “Add a choice” and “Add a folder” actions from appearing for malformed folders when they could overwrite existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->