### PR TITLE
fix: the settings surface fails partially and visibly, never totally and silently

### DIFF
--- a/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/captureChoiceBuilder.ts
@@ -71,9 +71,18 @@ export class CaptureChoiceBuilder extends ChoiceBuilder {
 			app: this.app,
 			plugin: this.plugin,
 		});
-		this.svelteElements.push(
-			mountComponent(this.contentEl, CaptureChoiceForm, this.formProps),
+		const handle = mountComponent(
+			this.contentEl,
+			CaptureChoiceForm,
+			this.formProps,
+			{ what: "this capture choice's settings" },
 		);
+		// The form never rendered, so its $state clone of the choice holds no edits
+		// — only whatever normalizeChoice() and $state.snapshot() made of it. Drop it
+		// so onClose resolves the ORIGINAL choice and a form the user never saw can't
+		// write itself back over their data (#1584).
+		if (!handle.ok) this.formProps = undefined;
+		this.svelteElements.push(handle);
 	}
 
 	protected getResultChoice(): IChoice {

--- a/src/gui/ChoiceBuilder/components/mountFormatPreview.svelte.ts
+++ b/src/gui/ChoiceBuilder/components/mountFormatPreview.svelte.ts
@@ -65,7 +65,9 @@ export function mountFormatPreview(
 		targetFolderPath: null,
 	});
 
-	const mounted: MountHandle = mountComponent(host, FormatPreviewField, props);
+	const mounted: MountHandle = mountComponent(host, FormatPreviewField, props, {
+		what: "the preview for this field",
+	});
 	let destroyed = false;
 
 	return {

--- a/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
+++ b/src/gui/ChoiceBuilder/templateChoiceBuilder.ts
@@ -65,9 +65,18 @@ export class TemplateChoiceBuilder extends ChoiceBuilder {
 			app: this.app,
 			plugin: this.plugin,
 		});
-		this.svelteElements.push(
-			mountComponent(this.contentEl, TemplateChoiceForm, this.formProps),
+		const handle = mountComponent(
+			this.contentEl,
+			TemplateChoiceForm,
+			this.formProps,
+			{ what: "this template choice's settings" },
 		);
+		// The form never rendered, so its $state clone of the choice holds no edits
+		// — only whatever normalizeChoice() and $state.snapshot() made of it. Drop it
+		// so onClose resolves the ORIGINAL choice and a form the user never saw can't
+		// write itself back over their data (#1584).
+		if (!handle.ok) this.formProps = undefined;
+		this.svelteElements.push(handle);
 	}
 
 	protected getResultChoice(): IChoice {

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -182,7 +182,8 @@ export class CommandSequenceEditor {
 		this.commandListHandle = mountComponent(
 			commandListEl,
 			CommandList,
-			this.commandListProps
+			this.commandListProps,
+			{ what: "this macro's commands" }
 		);
 	}
 

--- a/src/gui/MacroGUIs/CommandSequenceEditor.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.ts
@@ -103,7 +103,17 @@ export class CommandSequenceEditor {
 		containerEl.empty();
 		containerEl.addClass("quickAddCommandEditor");
 
-		this.renderCommandList(containerEl);
+		// A list we could not draw must not be edited blind. Every control below
+		// appends to `commandsRef` and persists through onCommandsChange, so with the
+		// list invisible the user would be adding commands they cannot see, reorder or
+		// delete — and with a `null`/non-iterable `commands` the same controls throw
+		// silently instead. Before #1584 this was unreachable (the throw escaped and
+		// the modal never opened at all); now that the editor survives, it has to stop
+		// offering the affordances the failed view was the only way to review.
+		// The card explains what happened; the macro's name, "run on startup" and icon
+		// stay editable around it.
+		if (!this.renderCommandList(containerEl)) return;
+
 		this.renderCommandBar(containerEl);
 		this.renderAddObsidianCommandSetting(containerEl);
 		this.renderAddEditorCommandSetting(containerEl);
@@ -132,7 +142,8 @@ export class CommandSequenceEditor {
 		this.scriptCandidates = loadScriptCandidates(this.app);
 	}
 
-	private renderCommandList(parent: HTMLElement) {
+	/** @returns whether the list actually rendered (see render()). */
+	private renderCommandList(parent: HTMLElement): boolean {
 		const commandListEl = parent.createDiv("commandList");
 
 		this.commandListProps = createCommandListProps({
@@ -185,6 +196,8 @@ export class CommandSequenceEditor {
 			this.commandListProps,
 			{ what: "this macro's commands" }
 		);
+
+		return this.commandListHandle.ok;
 	}
 
 	private renderCommandBar(parent: HTMLElement) {

--- a/src/gui/MacroGUIs/CommandSequenceEditor.unrenderable.test.ts
+++ b/src/gui/MacroGUIs/CommandSequenceEditor.unrenderable.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App } from "obsidian";
+import type QuickAdd from "../../main";
+import type { ICommand } from "../../types/macros/ICommand";
+import { CommandSequenceEditor } from "./CommandSequenceEditor";
+import { log } from "../../logger/logManager";
+
+function testApp(): App {
+	const app = new App() as App & {
+		dom: { appContainerEl: HTMLElement };
+		keymap: { pushScope: () => void; popScope: () => void };
+	};
+	app.dom = { appContainerEl: document.body };
+	app.keymap = { pushScope: vi.fn(), popScope: vi.fn() };
+	return app;
+}
+
+function renderEditor(commands: unknown, onCommandsChange = vi.fn()) {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+	const editor = new CommandSequenceEditor({
+		app: testApp(),
+		plugin: {} as unknown as QuickAdd,
+		commands: commands as ICommand[],
+		choices: [],
+		onCommandsChange,
+	});
+	editor.render(container);
+	return { container, editor, onCommandsChange };
+}
+
+/**
+ * #1584 follow-through. Once mountComponent stopped letting a broken CommandList
+ * take the macro builder down with it, the builder started OPENING over a list it
+ * could not draw - and every add control was still live. Two ways that goes wrong:
+ *
+ *   - `commands: null` (the issue's own live repro): every add control throws
+ *     `[...null]` inside its click handler. Dead buttons, silently.
+ *   - a valid array with duplicate ids: `{#each ... (command.id)}` throws
+ *     `each_key_duplicate`, so the list is invisible - but the add controls WORK,
+ *     appending commands the user cannot see, review or delete, and persisting
+ *     them on close.
+ *
+ * A list we could not draw must not be edited blind.
+ */
+describe("CommandSequenceEditor over an unrenderable command list (#1584)", () => {
+	const addControlCount = (container: HTMLElement) =>
+		container.querySelectorAll("button").length;
+
+	it("shows the error card instead of the list", () => {
+		vi.spyOn(log, "logError").mockImplementation(() => {});
+		const { container } = renderEditor(null);
+
+		const card = container.querySelector(".qaMountFailed");
+		expect(card?.textContent).toContain(
+			"QuickAdd couldn't display this macro's commands",
+		);
+		vi.restoreAllMocks();
+	});
+
+	it("offers no control that would edit the list it could not draw", () => {
+		vi.spyOn(log, "logError").mockImplementation(() => {});
+		const { container } = renderEditor(null);
+
+		// The quick-command bar and the four "Add …" rows are all gone.
+		expect(addControlCount(container)).toBe(0);
+		expect(container.querySelector(".quickCommandContainer")).toBeNull();
+		expect(container.textContent).not.toContain("Obsidian command");
+		expect(container.textContent).not.toContain("User scripts");
+		vi.restoreAllMocks();
+	});
+
+	it("cannot append to a list the user cannot see", () => {
+		vi.spyOn(log, "logError").mockImplementation(() => {});
+		// A valid array, so nothing throws on append - only the RENDER fails. This is
+		// the shape where an ungated editor silently persists invisible commands.
+		const duplicateIds = [
+			{ id: "dup", name: "One", type: "Wait" },
+			{ id: "dup", name: "Two", type: "Wait" },
+		];
+		const { container, onCommandsChange } = renderEditor(duplicateIds);
+
+		expect(container.querySelector(".qaMountFailed")).not.toBeNull();
+		expect(addControlCount(container)).toBe(0);
+		expect(onCommandsChange).not.toHaveBeenCalled();
+		vi.restoreAllMocks();
+	});
+
+	it("still builds the whole editor when the list renders", () => {
+		const { container } = renderEditor([
+			{ id: "wait-1", name: "Wait", type: "Wait", time: 100 },
+		]);
+
+		expect(container.querySelector(".qaMountFailed")).toBeNull();
+		expect(container.querySelector(".quickCommandContainer")).not.toBeNull();
+		expect(addControlCount(container)).toBeGreaterThan(0);
+	});
+});

--- a/src/gui/PackageManager/ExportPackageModal.ts
+++ b/src/gui/PackageManager/ExportPackageModal.ts
@@ -18,12 +18,17 @@ export class ExportPackageModal extends Modal {
 
 	onOpen(): void {
 		this.modalEl.addClass("quickAddModal", "packageExportModal");
-		this.handle = mountComponent(this.contentEl, ExportPackageModalComponent, {
-			app: this.app,
-			plugin: this.plugin,
-			allChoices: this.choices,
-			close: () => this.close(),
-		});
+		this.handle = mountComponent(
+			this.contentEl,
+			ExportPackageModalComponent,
+			{
+				app: this.app,
+				plugin: this.plugin,
+				allChoices: this.choices,
+				close: () => this.close(),
+			},
+			{ what: "the package exporter" },
+		);
 	}
 
 	onClose(): void {

--- a/src/gui/PackageManager/ImportPackageModal.ts
+++ b/src/gui/PackageManager/ImportPackageModal.ts
@@ -12,10 +12,15 @@ export class ImportPackageModal extends Modal {
 
 	onOpen(): void {
 		this.modalEl.addClass("quickAddModal", "packageImportModal");
-		this.handle = mountComponent(this.contentEl, ImportPackageModalComponent, {
-			app: this.app,
-			close: () => this.close(),
-		});
+		this.handle = mountComponent(
+			this.contentEl,
+			ImportPackageModalComponent,
+			{
+				app: this.app,
+				close: () => this.close(),
+			},
+			{ what: "the package importer" },
+		);
 	}
 
 	onClose(): void {

--- a/src/gui/choiceList/ChoiceView.rowActions.test.ts
+++ b/src/gui/choiceList/ChoiceView.rowActions.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+vi.mock("../choiceRename", () => ({
+	promptRenameChoice: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { App } from "obsidian";
+import { fireEvent, render } from "@testing-library/svelte";
+import ChoiceView from "./ChoiceView.svelte";
+import { log } from "../../logger/logManager";
+import type QuickAdd from "../../main";
+import type IChoice from "../../types/choices/IChoice";
+import type { Plain } from "../svelte/persist.svelte";
+
+/**
+ * #1585. The row actions are `async` handlers with no `catch`. Svelte re-throws an
+ * event handler's error to the window and a rejected promise is an unhandled
+ * rejection, so a failing action produced NOTHING: no Notice, no visual change,
+ * no message the user would ever think to look for. The button just did not work.
+ *
+ * The fixture is the shape that reproduces it live: a choice whose `type` is not a
+ * known choice type (a hand-edit, or an import from a newer QuickAdd). Configure
+ * routes to `getChoiceBuilder`, which throws "Invalid choice type".
+ */
+const choiceWithUnknownType = (): IChoice =>
+	({
+		id: "bogus-type",
+		name: "Choice with a bad type",
+		type: "Templat",
+		command: false,
+	}) as unknown as IChoice;
+
+const renderChoiceView = (choices: IChoice[]) =>
+	render(ChoiceView, {
+		props: {
+			app: new App() as never,
+			plugin: {} as unknown as QuickAdd,
+			choices,
+			saveChoices: vi.fn<(next: Plain<IChoice[]>) => void>(),
+		},
+	});
+
+describe("ChoiceView row actions that fail (#1585)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("reports the failure through the plugin's own error channel", async () => {
+		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
+		const { getByLabelText } = renderChoiceView([choiceWithUnknownType()]);
+
+		await fireEvent.click(getByLabelText("Configure Choice with a bad type"));
+
+		await vi.waitFor(() => expect(logError).toHaveBeenCalled());
+		// GuiLogger turns exactly this into the Notice the user sees.
+		expect((logError.mock.calls[0][0] as Error).message).toBe(
+			"Couldn't open the settings for that choice: Invalid choice type",
+		);
+	});
+
+	it("keeps the rest of the list alive after the failure", async () => {
+		vi.spyOn(log, "logError").mockImplementation(() => {});
+		const healthy = {
+			id: "ok",
+			name: "Healthy template",
+			type: "Template",
+			command: false,
+		} as unknown as IChoice;
+		const { getByLabelText } = renderChoiceView([
+			choiceWithUnknownType(),
+			healthy,
+		]);
+
+		await fireEvent.click(getByLabelText("Configure Choice with a bad type"));
+
+		expect(getByLabelText("Configure Healthy template")).toBeInTheDocument();
+		expect(getByLabelText("New choice")).toBeInTheDocument();
+	});
+});

--- a/src/gui/choiceList/ChoiceView.rowActions.test.ts
+++ b/src/gui/choiceList/ChoiceView.rowActions.test.ts
@@ -55,7 +55,31 @@ describe("ChoiceView row actions that fail (#1585)", () => {
 		await vi.waitFor(() => expect(logError).toHaveBeenCalled());
 		// GuiLogger turns exactly this into the Notice the user sees.
 		expect((logError.mock.calls[0][0] as Error).message).toBe(
-			"Couldn't open the settings for that choice: Invalid choice type",
+			"Couldn't open the settings for the choice “Choice with a bad type”: Invalid choice type",
+		);
+	});
+
+	// #1552's vocabulary rule reaches the error copy too: "Multi" is the internal
+	// type id for what every user-facing surface calls a folder. Duplicating a
+	// folder recurses into its children, so a bad child makes the FOLDER's row
+	// action fail - and the message has to name a folder, not a choice.
+	it("calls a folder a folder", async () => {
+		const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
+		const folder = {
+			id: "folder",
+			name: "My folder",
+			type: "Multi",
+			command: false,
+			collapsed: false,
+			choices: [choiceWithUnknownType()],
+		} as unknown as IChoice;
+		const { getByLabelText } = renderChoiceView([folder]);
+
+		await fireEvent.click(getByLabelText("Duplicate My folder"));
+
+		await vi.waitFor(() => expect(logError).toHaveBeenCalled());
+		expect((logError.mock.calls[0][0] as Error).message).toBe(
+			"Couldn't duplicate the folder “My folder”: Unknown choice type: Templat",
 		);
 	});
 

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -357,17 +357,21 @@
 	// wrapping it here is what makes a failing row action impossible to miss —
 	// hand-wrapping the call sites would silently skip the nested and menu paths.
 	//
-	// The verb is completed with the ROW's own noun so a folder is never called a
-	// choice in the message (see choiceNoun; #1552).
+	// The message is built from the ROW: its own noun, so a folder is never called
+	// a choice (see choiceNoun; #1552), and its name, so a user with a long list
+	// knows which row the Notice is about. A malformed entry can have neither, so
+	// both degrade rather than printing "undefined".
 	function rowAction<Rest extends unknown[]>(
 		verb: string,
 		fn: (choice: IChoice, ...rest: Rest) => unknown,
 	): (choice: IChoice, ...rest: Rest) => void {
-		return (choice, ...rest) =>
-			reportingHandler(
-				`Couldn't ${verb} that ${choiceNoun(choice?.type)}`,
-				fn,
-			)(choice, ...rest);
+		return (choice, ...rest) => {
+			const noun = choiceNoun(choice?.type);
+			const subject = choice?.name
+				? `the ${noun} “${choice.name}”`
+				: `that ${noun}`;
+			reportingHandler(`Couldn't ${verb} ${subject}`, fn)(choice, ...rest);
+		};
 	}
 
 	const actions: ChoiceListActions = {

--- a/src/gui/choiceList/ChoiceView.svelte
+++ b/src/gui/choiceList/ChoiceView.svelte
@@ -39,6 +39,8 @@
 		isChoiceLike,
 	} from "../../utils/choiceUtils";
 	import type { ChoiceListActions } from "./choiceListActions";
+	import { choiceNoun } from "../../utils/choiceNoun";
+	import { reportingHandler } from "../../utils/errorUtils";
 	import { type Plain, snapshot } from "../svelte/persist.svelte";
 
 	let {
@@ -350,29 +352,66 @@
 		save();
 	}
 
+	// Every row button, context-menu item and nested list reaches these handlers
+	// through this one bag (MultiChoiceListItem's nestedActions spreads it), so
+	// wrapping it here is what makes a failing row action impossible to miss —
+	// hand-wrapping the call sites would silently skip the nested and menu paths.
+	//
+	// The verb is completed with the ROW's own noun so a folder is never called a
+	// choice in the message (see choiceNoun; #1552).
+	function rowAction<Rest extends unknown[]>(
+		verb: string,
+		fn: (choice: IChoice, ...rest: Rest) => unknown,
+	): (choice: IChoice, ...rest: Rest) => void {
+		return (choice, ...rest) =>
+			reportingHandler(
+				`Couldn't ${verb} that ${choiceNoun(choice?.type)}`,
+				fn,
+			)(choice, ...rest);
+	}
+
 	const actions: ChoiceListActions = {
-		onDeleteChoice: deleteChoice,
-		onConfigureChoice: handleConfigureChoice,
-		onToggleCommand: toggleCommandForChoice,
-		onDuplicateChoice: handleDuplicateChoice,
-		onRenameChoice: handleRenameChoice,
-		onMoveChoice: handleMoveChoice,
-		onReorderChoices: handleReorderChoices,
-		onAddChoice: addChoiceToList,
-		onToggleCollapsed: handleToggleCollapsed,
-		onCommitFolder: handleCommitFolder,
+		onDeleteChoice: rowAction("delete", deleteChoice),
+		onConfigureChoice: rowAction("open the settings for", handleConfigureChoice),
+		onToggleCommand: rowAction(
+			"update the command palette entry for",
+			toggleCommandForChoice,
+		),
+		onDuplicateChoice: rowAction("duplicate", handleDuplicateChoice),
+		onRenameChoice: rowAction("rename", handleRenameChoice),
+		onMoveChoice: rowAction("move", handleMoveChoice),
+		onToggleCollapsed: rowAction("open or close", handleToggleCollapsed),
+		onReorderChoices: reportingHandler(
+			"Couldn't save the new order",
+			handleReorderChoices,
+		),
+		onCommitFolder: reportingHandler(
+			"Couldn't save that folder's contents",
+			handleCommitFolder,
+		),
+		// Same noun rule, from the type being added rather than an existing row.
+		onAddChoice: (name, type, targetFolderId, skipConfigure) =>
+			reportingHandler(`Couldn't add that ${choiceNoun(type)}`, addChoiceToList)(
+				name,
+				type,
+				targetFolderId,
+				skipConfigure,
+			),
 	};
 
-	async function openAISettings() {
-		const newSettings = await new AIAssistantSettingsModal(
-			app,
-			settingsStore.getState().ai,
-		).waitForClose;
+	const openAISettings = reportingHandler(
+		"Couldn't open the AI assistant settings",
+		async () => {
+			const newSettings = await new AIAssistantSettingsModal(
+				app,
+				settingsStore.getState().ai,
+			).waitForClose;
 
-		if (newSettings) {
-			settingsStore.setState((state) => ({ ...state, ai: newSettings }));
-		}
-	}
+			if (newSettings) {
+				settingsStore.setState((state) => ({ ...state, ai: newSettings }));
+			}
+		},
+	);
 </script>
 
 
@@ -409,7 +448,7 @@
 				>
 			</p>
 			<div class="choiceEmptyActions">
-				<AddChoiceControls onAddChoice={addChoiceToList} />
+				<AddChoiceControls onAddChoice={actions.onAddChoice} />
 			</div>
 		</div>
 	{:else}
@@ -482,7 +521,7 @@
 					<ObsidianIcon iconId="sparkles" size={16} />
 				</button>
 			{/if}
-			<AddChoiceControls onAddChoice={addChoiceToList} fill={isMobile} />
+			<AddChoiceControls onAddChoice={actions.onAddChoice} fill={isMobile} />
 		</div>
 	{/if}
 	{#snippet failed(error)}

--- a/src/gui/choiceList/ChoicesUnavailable.svelte
+++ b/src/gui/choiceList/ChoicesUnavailable.svelte
@@ -2,8 +2,13 @@
 	import ObsidianIcon from "../components/ObsidianIcon.svelte";
 
 	let {
+		what = "your choices",
 		detail = "",
 	}: {
+		/** Noun phrase naming what could not be displayed. Defaults to the only
+		 *  thing this card is ever about; it exists so the component satisfies
+		 *  mountComponent's MountFallbackComponent contract (see mountComponent.ts). */
+		what?: string;
 		/** The underlying error message, when there is one. Shown verbatim: it is
 		 *  what makes a bug report actionable, and this view is otherwise a dead
 		 *  end for the user. */
@@ -26,7 +31,7 @@
 <div class="qaChoicesUnavailable">
 	<div class="qaChoicesUnavailableHead">
 		<ObsidianIcon iconId="alert-triangle" size={16} />
-		<span class="qaChoicesUnavailableTitle">QuickAdd couldn't display your choices</span>
+		<span class="qaChoicesUnavailableTitle">QuickAdd couldn't display {what}</span>
 	</div>
 	<p class="qaChoicesUnavailableBody">
 		Something in this vault's QuickAdd settings could not be read. Your choices

--- a/src/gui/svelte/MountFailed.svelte
+++ b/src/gui/svelte/MountFailed.svelte
@@ -29,9 +29,20 @@
 		<ObsidianIcon iconId="alert-triangle" size={16} />
 		<span class="qaMountFailedTitle">QuickAdd couldn't display {what}</span>
 	</div>
+	<!--
+	  The body claims only what this card can actually vouch for. Two earlier
+	  drafts overreached and both were wrong somewhere:
+	    "nothing in your vault has been changed" - an action earlier in the same
+	      flow may well have written something (adding a choice saves it, THEN
+	      opens the builder).
+	    "everything else on this screen still works" - not for a host whose
+	      remaining controls only made sense alongside the view that failed.
+	  A card that can be wrong is worse than one that says less, so this one says
+	  what happened, that the failure itself changed nothing, and what to report.
+	-->
 	<p class="qaMountFailedBody">
-		This part of QuickAdd ran into an error and has been left out. Everything
-		else on this screen still works, and nothing in your vault has been changed.
+		This part of QuickAdd could not be drawn, so it has been left out. Nothing
+		was changed by the error. Include the message below if you report this.
 	</p>
 	{#if detail}
 		<pre class="qaMountFailedDetail">{detail}</pre>

--- a/src/gui/svelte/MountFailed.svelte
+++ b/src/gui/svelte/MountFailed.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import ObsidianIcon from "../components/ObsidianIcon.svelte";
+
+	let {
+		what,
+		detail = "",
+	}: {
+		/** Noun phrase naming what could not be displayed ("the command list"). */
+		what: string;
+		/** The underlying error message, when there is one. Shown verbatim: it is
+		 *  what makes a bug report actionable, and this card is otherwise a dead
+		 *  end for the user. */
+		detail?: string;
+	} = $props();
+</script>
+
+<!--
+  The default fallback for a Svelte mount that threw (see mountComponent.ts). Its
+  whole job is to turn a total, silent failure — a modal that never opens, a
+  settings tab that comes up blank — into a partial, visible one: this part of the
+  screen is gone, everything around it still works, and here is the error text to
+  put in a bug report.
+
+  Deliberately offers no retry: re-mounting runs the same code over the same data
+  and throws again.
+-->
+<div class="qaMountFailed">
+	<div class="qaMountFailedHead">
+		<ObsidianIcon iconId="alert-triangle" size={16} />
+		<span class="qaMountFailedTitle">QuickAdd couldn't display {what}</span>
+	</div>
+	<p class="qaMountFailedBody">
+		This part of QuickAdd ran into an error and has been left out. Everything
+		else on this screen still works, and nothing in your vault has been changed.
+	</p>
+	{#if detail}
+		<pre class="qaMountFailedDetail">{detail}</pre>
+	{/if}
+</div>
+
+<style>
+	.qaMountFailed {
+		border: 1px solid var(--background-modifier-border);
+		border-radius: var(--radius-m);
+		padding: 12px 14px;
+		margin: 4px 0 8px;
+		background: var(--background-secondary);
+	}
+
+	.qaMountFailedHead {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		color: var(--text-warning, var(--text-normal));
+	}
+
+	.qaMountFailedTitle {
+		font-weight: var(--font-semibold);
+		color: var(--text-normal);
+	}
+
+	.qaMountFailedBody {
+		margin: 8px 0 0;
+		color: var(--text-muted);
+		font-size: var(--font-ui-small, 13px);
+		max-width: 68ch;
+	}
+
+	.qaMountFailedDetail {
+		margin: 10px 0 0;
+		padding: 8px 10px;
+		border-radius: var(--radius-s);
+		background: var(--background-primary);
+		color: var(--text-faint);
+		font-size: var(--font-ui-smaller, 12px);
+		white-space: pre-wrap;
+		word-break: break-word;
+		user-select: text;
+	}
+</style>

--- a/src/gui/svelte/mountComponent.test.ts
+++ b/src/gui/svelte/mountComponent.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { flushSync } from "svelte";
 import { mountComponent } from "./mountComponent";
 import ObsidianIcon from "../components/ObsidianIcon.svelte";
+import MountThrows from "./mountThrows.fixture.svelte";
+import MountThrowsDeep from "./mountThrowsDeep.fixture.svelte";
+import ChoicesUnavailable from "../choiceList/ChoicesUnavailable.svelte";
+import { log } from "../../logger/logManager";
 
 describe("mountComponent", () => {
 	it("mounts a component into the target and renders it", () => {
 		const target = document.createElement("div");
 		const handle = mountComponent(target, ObsidianIcon, { iconId: "trash", size: 16 });
 		expect(target.querySelector(".quickadd-icon")).not.toBeNull();
+		expect(handle.ok).toBe(true);
 		handle.destroy();
 	});
 
@@ -25,6 +30,104 @@ describe("mountComponent", () => {
 		const handle = mountComponent(target, ObsidianIcon, { iconId: "trash", size: 16 });
 		handle.destroy();
 		flushSync();
+		expect(() => handle.destroy()).not.toThrow();
+	});
+});
+
+/**
+ * The seam's real job (#1584): a component that throws during mount used to take
+ * its whole host down with it - a Modal that never opened, or a settings tab that
+ * abandoned every remaining group. These pin the "partial and visible, never total
+ * and silent" contract.
+ */
+describe("mountComponent: a failed mount", () => {
+	const logError = vi.spyOn(log, "logError").mockImplementation(() => {});
+
+	afterEach(() => {
+		logError.mockClear();
+	});
+
+	it("does not throw, so the host keeps building", () => {
+		const target = document.createElement("div");
+		expect(() =>
+			mountComponent(target, MountThrows, { commands: null }),
+		).not.toThrow();
+	});
+
+	it("reports the error once, naming what could not be displayed", () => {
+		const target = document.createElement("div");
+		mountComponent(target, MountThrows, { commands: null }, {
+			what: "this macro's commands",
+		});
+
+		expect(logError).toHaveBeenCalledTimes(1);
+		const reported = logError.mock.calls[0][0] as Error;
+		// No "QuickAdd" prefix — GuiLogger adds one, and "QuickAdd: (ERROR) QuickAdd
+		// couldn't ..." is what the Notice read before.
+		expect(reported.message).toContain("Couldn't display this macro's commands");
+		expect(reported.message).not.toContain("QuickAdd couldn't");
+		// The underlying cause survives - it is what makes a bug report actionable.
+		expect(reported.message).toContain("filter");
+	});
+
+	it("renders the fallback card in the component's place", () => {
+		const target = document.createElement("div");
+		mountComponent(target, MountThrows, { commands: null }, {
+			what: "this macro's commands",
+		});
+
+		const card = target.querySelector(".qaMountFailed");
+		expect(card).not.toBeNull();
+		expect(card?.textContent).toContain("QuickAdd couldn't display this macro's commands");
+		expect(target.querySelector(".qaMountFailedDetail")?.textContent).toContain("filter");
+	});
+
+	it("uses the host's own fallback card when one is given", () => {
+		const target = document.createElement("div");
+		mountComponent(target, MountThrows, { commands: null }, {
+			what: "your choices",
+			fallbackComponent: ChoicesUnavailable,
+		});
+
+		expect(target.querySelector(".qaMountFailed")).toBeNull();
+		const card = target.querySelector(".qaChoicesUnavailable");
+		expect(card?.textContent).toContain("QuickAdd couldn't display your choices");
+		// The settings card's whole reason to exist: the recovery instructions.
+		expect(card?.textContent).toContain("data.json");
+	});
+
+	it("reports ok:false so hosts can tell a rendered view from a card", () => {
+		const target = document.createElement("div");
+		expect(mountComponent(target, MountThrows, { commands: null }).ok).toBe(false);
+	});
+
+	it("leaves the host's own content alone and clears the failed mount's debris", () => {
+		const target = document.createElement("div");
+		const hostOwned = document.createElement("p");
+		hostOwned.textContent = "built by the host";
+		target.appendChild(hostOwned);
+
+		// Throws BELOW some markup, so mount() gets part-way in before it fails.
+		mountComponent(target, MountThrowsDeep, { commands: null });
+
+		// The host's node is untouched (target belongs to the host - a Setting's
+		// controlEl, a Modal's contentEl - so emptying it would be destructive).
+		expect(target.firstChild).toBe(hostOwned);
+		// Nothing survives from the half-built tree, only the fallback host.
+		expect(target.querySelector(".mount-throws-deep-fixture")).toBeNull();
+		expect(target.childNodes.length).toBe(2);
+		expect(target.lastElementChild?.className).toBe("qa-mount-failed-host");
+	});
+
+	it("destroy() removes the fallback, idempotently", () => {
+		const target = document.createElement("div");
+		const handle = mountComponent(target, MountThrows, { commands: null });
+		expect(target.querySelector(".qaMountFailed")).not.toBeNull();
+
+		handle.destroy();
+		flushSync();
+		expect(target.querySelector(".qa-mount-failed-host")).toBeNull();
+		expect(target.childNodes.length).toBe(0);
 		expect(() => handle.destroy()).not.toThrow();
 	});
 });

--- a/src/gui/svelte/mountComponent.ts
+++ b/src/gui/svelte/mountComponent.ts
@@ -1,4 +1,6 @@
 import { type Component, type ComponentProps, mount, unmount } from "svelte";
+import { reportError, toError } from "../../utils/errorUtils";
+import MountFailed from "./MountFailed.svelte";
 
 /**
  * A handle to a Svelte 5 component mounted imperatively into an Obsidian host
@@ -8,7 +10,41 @@ import { type Component, type ComponentProps, mount, unmount } from "svelte";
 export interface MountHandle {
 	/** Unmount the component. Idempotent — safe to call from both onClose() and reload(). */
 	destroy(): void;
+	/**
+	 * False when the mount threw and the fallback card is showing in its place.
+	 * Hosts that would otherwise treat a mounted component's state as authoritative
+	 * (the choice builders resolve `formProps.choice` at close) must check this, so a
+	 * form the user never saw cannot write itself back over their data.
+	 */
+	readonly ok: boolean;
 }
+
+/**
+ * The prop contract every fallback card implements: what could not be displayed,
+ * and the underlying error text. Two components implement it — {@link MountFailed}
+ * (the default) and ChoicesUnavailable (the settings choice list, which adds
+ * data.json recovery instructions).
+ */
+// The props position is the one that matters (it is what makes a card missing
+// `what`/`detail` a compile error); the exports position mirrors Svelte's own
+// default for a `.svelte` component and gets the same `any` as `mountComponent`.
+export type MountFallbackComponent = Component<
+	{ what: string; detail: string },
+	any
+>;
+
+export interface MountOptions {
+	/**
+	 * Noun phrase naming what could not be displayed ("the command list"), used in
+	 * both the reported error and the fallback card. Defaults to a generic phrase:
+	 * a host that forgets still fails visibly, just less specifically.
+	 */
+	what?: string;
+	/** Fallback card for this host. Defaults to {@link MountFailed}. */
+	fallbackComponent?: MountFallbackComponent;
+}
+
+const DEFAULT_WHAT = "this part of QuickAdd";
 
 /**
  * Mount a Svelte 5 component into `target` and return an idempotent handle.
@@ -17,6 +53,20 @@ export interface MountHandle {
  * ChoiceBuilder, CommandSequenceEditor, the PackageManager modals and the settings
  * tab. The idempotent `destroy()` guards the double-teardown that arises when a
  * Modal's `onClose()` runs after a `reload()` already tore the component down.
+ *
+ * **This function never throws.** A throw during mount used to escape into the host,
+ * where it costs far more than the component: a Modal that mounts from `onOpen()` or
+ * its constructor never opens at all, and the declarative settings tab — which builds
+ * every group by calling `render` closures in turn — abandons every remaining QuickAdd
+ * setting (#1451, #1507, #1566). Instead the error is reported once (one Notice, via
+ * `reportError`) and a card takes the component's place, so the failure is partial and
+ * visible rather than total and silent (#1584).
+ *
+ * What this does NOT cover: a throw from an `$effect`. Svelte flushes effects on a
+ * later tick, so it never reaches this try/catch — it surfaces as an uncaught error
+ * and the component renders anyway (verified against svelte 5 in a scratch probe).
+ * That case belongs to `<svelte:boundary>`, which ChoiceView already has. This seam
+ * owns the synchronous setup the boundary itself sits inside.
  *
  * To feed reactive updates after mount, pass a `$state`-backed props object and
  * mutate its properties (see createCommandListProps) — the documented Svelte 5
@@ -31,15 +81,80 @@ export function mountComponent<C extends Component<any, any>>(
 	target: HTMLElement,
 	component: C,
 	props: ComponentProps<C>,
+	options: MountOptions = {},
 ): MountHandle {
-	const instance = mount(component, { target, props });
+	// Snapshotted so a failed mount can be cleaned up precisely (see below).
+	const preexisting = new Set<ChildNode>(target.childNodes);
+
+	let instance: ReturnType<typeof mount>;
+	try {
+		instance = mount(component, { target, props });
+	} catch (error) {
+		return renderMountFailure(target, preexisting, toError(error), options);
+	}
+
 	let destroyed = false;
 
 	return {
+		ok: true,
 		destroy() {
 			if (destroyed) return;
 			destroyed = true;
 			void unmount(instance);
+		},
+	};
+}
+
+function renderMountFailure(
+	target: HTMLElement,
+	preexisting: Set<ChildNode>,
+	error: Error,
+	options: MountOptions,
+): MountHandle {
+	const what = options.what ?? DEFAULT_WHAT;
+
+	// `mount()` appends as it renders, so a throw part-way through leaves anchors and
+	// half-built nodes behind. Remove exactly the nodes THIS mount added — never empty
+	// `target`, which belongs to the host (a Setting's controlEl, a Modal's contentEl)
+	// and can already hold rows the host built itself.
+	for (const node of Array.from(target.childNodes)) {
+		if (!preexisting.has(node)) node.remove();
+	}
+
+	// No "QuickAdd" prefix: GuiLogger already renders this as
+	// "QuickAdd: (ERROR) <context>: <cause>". The CARD says the full sentence,
+	// because it stands alone on screen.
+	reportError(error, `Couldn't display ${what}`);
+
+	// The card gets its own container so `destroy()` is uniform with the success
+	// path: remove what we added, and nothing else.
+	const container = target.ownerDocument.createElement("div");
+	container.className = "qa-mount-failed-host";
+	target.appendChild(container);
+
+	let fallback: ReturnType<typeof mount> | null = null;
+	try {
+		// Deliberately NOT a recursive mountComponent() call: a fallback that throws
+		// would report a second time and mount a fallback of its own, forever.
+		fallback = mount(options.fallbackComponent ?? MountFailed, {
+			target: container,
+			props: { what, detail: error.message },
+		});
+	} catch {
+		// The fallback is the same machinery that just failed, so it gets one
+		// plain-text last resort rather than a third layer of the same bet.
+		container.textContent = `QuickAdd couldn't display ${what}.`;
+	}
+
+	let destroyed = false;
+
+	return {
+		ok: false,
+		destroy() {
+			if (destroyed) return;
+			destroyed = true;
+			if (fallback) void unmount(fallback);
+			container.remove();
 		},
 	};
 }

--- a/src/gui/svelte/mountThrows.fixture.svelte
+++ b/src/gui/svelte/mountThrows.fixture.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { untrack } from "svelte";
+
+	// Test fixture for mountComponent's failure path: reproduces the shape that
+	// actually shipped (#1584) - a malformed value from data.json dereferenced
+	// during setup, which throws out of mount(). untrack because the read is
+	// deliberately one-shot at setup time (and silences state_referenced_locally).
+	let { commands }: { commands?: unknown } = $props();
+
+	const count = untrack(() => (commands as unknown[]).filter(Boolean).length);
+</script>
+
+<div class="mount-throws-fixture">{count}</div>

--- a/src/gui/svelte/mountThrowsDeep.fixture.svelte
+++ b/src/gui/svelte/mountThrowsDeep.fixture.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import MountThrows from "./mountThrows.fixture.svelte";
+
+	// The throw happens BELOW some markup, so mount() gets part-way through before
+	// it fails - the case that leaves stray nodes in the host.
+	let { commands }: { commands?: unknown } = $props();
+</script>
+
+<div class="mount-throws-deep-fixture">
+	<p>header</p>
+	<MountThrows {commands} />
+</div>

--- a/src/quickAddSettingsTab.ts
+++ b/src/quickAddSettingsTab.ts
@@ -37,7 +37,6 @@ import {
 import { renderDevelopmentInfo } from "./quickAddSettingsDevelopmentInfo";
 import { createDocsLink, DOCS_URLS, openDocsUrl } from "./docs";
 import { rootChoicesOf } from "./utils/choiceUtils";
-import { reportError } from "./utils/errorUtils";
 
 /** String-named keys of {@link QuickAddSettings} — used to type the declarative
  * `control` keys so a mistyped key is caught at compile time. */
@@ -409,61 +408,48 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		setting.controlEl.addClass("qa-setting-full-width-control");
 	}
 
-	/**
-	 * Last line of defence for the whole tab. The declarative framework builds
-	 * every group by calling these `render` closures in turn, so a throw out of
-	 * one of them abandons the rest: when ChoiceView's mount threw, QuickAdd's
-	 * settings came up as a lone "Choices & packages" heading with nothing under
-	 * it, and no other section rendered at all (#1451, #1507, #1566).
-	 *
-	 * ChoiceView has its own <svelte:boundary> for reactive failures inside the
-	 * list; this catches the setup that boundary sits inside, and anything a
-	 * future view mounted here might throw.
-	 */
-	private mountSettingView<C extends Parameters<typeof mountComponent>[1]>(
-		setting: Setting,
-		component: C,
-		props: Parameters<typeof mountComponent>[2],
-	): MountHandle | null {
-		try {
-			return mountComponent(setting.controlEl, component, props);
-		} catch (error) {
-			reportError(error, "QuickAdd could not render a settings view");
-			try {
-				return mountComponent(setting.controlEl, ChoicesUnavailable, {
-					detail: error instanceof Error ? error.message : String(error),
-				});
-			} catch {
-				// The fallback is the same machinery that just failed, so it gets
-				// one plain-text last resort rather than a third layer.
-				setting.controlEl.setText("QuickAdd could not render this section.");
-				return null;
-			}
-		}
-	}
+	// The declarative framework builds every group by calling these `render`
+	// closures in turn, so a throw out of one of them abandons the rest: when
+	// ChoiceView's mount threw, QuickAdd's settings came up as a lone "Choices &
+	// packages" heading with nothing under it, and no other section rendered at
+	// all (#1451, #1507, #1566). That guard now lives in mountComponent itself, so
+	// every Svelte host in the plugin gets it (#1584) — here we only choose which
+	// card takes the view's place.
+	//
+	// ChoiceView has its own <svelte:boundary> for reactive failures inside the
+	// list; mountComponent catches the setup that boundary sits inside.
 
 	private renderChoicesView(setting: Setting): () => void {
 		this.prepareFullWidthSetting(setting);
 
 		this.choiceViewHandle?.destroy();
-		const handle = this.mountSettingView(setting, ChoiceView, {
-			app: this.app,
-			plugin: this.plugin,
-			choices: settingsStore.getState().choices,
-			// Typed Plain<IChoice[]> (not IChoice[]) so a forgotten $state.snapshot at
-			// the call site is a COMPILE error here — this is the real persistence sink
-			// that must never receive a live Svelte $state proxy. Plain<T> is assignable
-			// to T, so setState still accepts it.
-			saveChoices: (choices: Plain<IChoice[]>) => {
-				settingsStore.setState({ choices });
+		const handle = mountComponent(
+			setting.controlEl,
+			ChoiceView,
+			{
+				app: this.app,
+				plugin: this.plugin,
+				choices: settingsStore.getState().choices,
+				// Typed Plain<IChoice[]> (not IChoice[]) so a forgotten $state.snapshot at
+				// the call site is a COMPILE error here — this is the real persistence sink
+				// that must never receive a live Svelte $state proxy. Plain<T> is assignable
+				// to T, so setState still accepts it.
+				saveChoices: (choices: Plain<IChoice[]>) => {
+					settingsStore.setState({ choices });
+				},
 			},
-		});
+			// The choice list is the one view whose failure has a recovery story worth
+			// spelling out (the data.json advice in ChoicesUnavailable), and the same
+			// card the view itself shows when the tree is unreadable — so a mount
+			// failure and a render failure look identical to the user.
+			{ what: "your choices", fallbackComponent: ChoicesUnavailable },
+		);
 		this.choiceViewHandle = handle;
 
 		// Capture the handle so a stale cleanup can only ever destroy its own
 		// mount (and only nulls the field while it still points at this mount).
 		return () => {
-			handle?.destroy();
+			handle.destroy();
 			if (this.choiceViewHandle === handle) {
 				this.choiceViewHandle = null;
 			}
@@ -474,14 +460,19 @@ export class QuickAddSettingsTab extends PluginSettingTab {
 		this.prepareFullWidthSetting(setting);
 
 		this.globalVariablesViewHandle?.destroy();
-		const handle = this.mountSettingView(setting, GlobalVariablesView, {
-			app: this.app,
-			plugin: this.plugin,
-		});
+		const handle = mountComponent(
+			setting.controlEl,
+			GlobalVariablesView,
+			{
+				app: this.app,
+				plugin: this.plugin,
+			},
+			{ what: "your global variables" },
+		);
 		this.globalVariablesViewHandle = handle;
 
 		return () => {
-			handle?.destroy();
+			handle.destroy();
 			if (this.globalVariablesViewHandle === handle) {
 				this.globalVariablesViewHandle = null;
 			}

--- a/src/utils/errorUtils.test.ts
+++ b/src/utils/errorUtils.test.ts
@@ -94,7 +94,10 @@ describe("reportingHandler", () => {
 		);
 	});
 
-	it("catches a thenable that is not a native promise", async () => {
+	// A thenable is only required to have `.then`. Calling `.catch` on one directly
+	// reports "result.catch is not a function" INSTEAD of the real failure — which
+	// is the same lost error this helper exists to prevent, so assert the cause.
+	it("reports the real rejection of a thenable that is not a native promise", async () => {
 		const logError = spyOnLogError();
 		const wrapped = reportingHandler("Couldn't move that choice", () => ({
 			then: (_ok: unknown, fail: (err: unknown) => void) => fail(new Error("boom")),
@@ -102,8 +105,12 @@ describe("reportingHandler", () => {
 
 		wrapped();
 		await Promise.resolve();
+		await Promise.resolve();
 
 		expect(logError).toHaveBeenCalledTimes(1);
+		expect((logError.mock.calls[0][0] as Error).message).toBe(
+			"Couldn't move that choice: boom",
+		);
 	});
 
 	it("stays quiet for a cancelled prompt, which is an answer and not a failure", async () => {

--- a/src/utils/errorUtils.test.ts
+++ b/src/utils/errorUtils.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { toError } from "./errorUtils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { log } from "../logger/logManager";
+import { reportingHandler, toError } from "./errorUtils";
 
 describe("toError", () => {
 	it("returns the same Error instance when no context is provided", () => {
@@ -41,5 +42,91 @@ describe("toError", () => {
 		expect(toError("plain").message).toBe("plain");
 		expect(toError("plain", "ctx").message).toBe("ctx: plain");
 		expect(toError(42, "ctx").message).toBe("ctx: 42");
+	});
+});
+
+/**
+ * #1585. Svelte re-throws event-handler errors to the window and an `async`
+ * handler's rejection is an unhandled rejection, so a failing row action was a
+ * button that simply did nothing - no Notice, no message the user would look for.
+ */
+describe("reportingHandler", () => {
+	const spyOnLogError = () =>
+		vi.spyOn(log, "logError").mockImplementation(() => {});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("passes arguments through and returns nothing on the happy path", () => {
+		const logError = spyOnLogError();
+		const fn = vi.fn();
+
+		reportingHandler("Couldn't delete that choice", fn)("a", 2);
+
+		expect(fn).toHaveBeenCalledWith("a", 2);
+		expect(logError).not.toHaveBeenCalled();
+	});
+
+	it("reports a synchronous throw instead of letting it reach the window", () => {
+		const logError = spyOnLogError();
+		const wrapped = reportingHandler("Couldn't delete that choice", () => {
+			throw new Error("Invalid choice type");
+		});
+
+		expect(() => wrapped()).not.toThrow();
+		expect((logError.mock.calls[0][0] as Error).message).toBe(
+			"Couldn't delete that choice: Invalid choice type",
+		);
+	});
+
+	it("reports a rejected promise instead of an unhandled rejection", async () => {
+		const logError = spyOnLogError();
+		const wrapped = reportingHandler("Couldn't duplicate that choice", () =>
+			Promise.reject(new Error("boom")),
+		);
+
+		wrapped();
+		await Promise.resolve();
+
+		expect((logError.mock.calls[0][0] as Error).message).toBe(
+			"Couldn't duplicate that choice: boom",
+		);
+	});
+
+	it("catches a thenable that is not a native promise", async () => {
+		const logError = spyOnLogError();
+		const wrapped = reportingHandler("Couldn't move that choice", () => ({
+			then: (_ok: unknown, fail: (err: unknown) => void) => fail(new Error("boom")),
+		}));
+
+		wrapped();
+		await Promise.resolve();
+
+		expect(logError).toHaveBeenCalledTimes(1);
+	});
+
+	it("stays quiet for a cancelled prompt, which is an answer and not a failure", async () => {
+		const logError = spyOnLogError();
+
+		// The exact rejection GenericInputPrompt uses when the user presses Escape.
+		reportingHandler("Couldn't rename that choice", () =>
+			Promise.reject("No input given."),
+		)();
+		reportingHandler("Couldn't rename that choice", () => {
+			throw "no input given.";
+		})();
+		await Promise.resolve();
+
+		expect(logError).not.toHaveBeenCalled();
+	});
+
+	it("does not treat a non-promise return value as a promise", () => {
+		const logError = spyOnLogError();
+
+		expect(() => reportingHandler("ctx", () => 0)()).not.toThrow();
+		expect(() => reportingHandler("ctx", () => null)()).not.toThrow();
+		expect(() => reportingHandler("ctx", () => "done")()).not.toThrow();
+		expect(logError).not.toHaveBeenCalled();
 	});
 });

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -157,6 +157,56 @@ export function withErrorHandling<T>(
 }
 
 /**
+ * Wraps a UI event handler so a failure is REPORTED instead of vanishing.
+ *
+ * Svelte re-throws event-handler errors to the window
+ * (`internal/client/dom/elements/events.js`), and an `async` handler's rejection
+ * is an unhandled rejection - Obsidian surfaces neither. The result is a button
+ * that simply does nothing, with no Notice and no message the user would ever
+ * think to look for, which reads as "the plugin is broken" and gives them nothing
+ * to report (#1585). `<svelte:boundary>` does not help: it catches render and
+ * effect errors, not event handlers.
+ *
+ * Handles both halves of the problem - a synchronous throw and a rejected promise
+ * - and stays quiet for the cancellations that are an answer rather than a
+ * failure (see {@link isCancellationError}).
+ *
+ * The wrapper returns `void`: it is for handlers whose result nobody awaits. Keep
+ * calling the unwrapped function anywhere the caller needs its value or wants to
+ * handle the failure itself.
+ *
+ * @param contextMessage - Names the action that failed, e.g. "Couldn't delete that choice"
+ * @param fn - The handler to wrap
+ *
+ * @example
+ * ```ts
+ * const actions = { onDelete: reportingHandler("Couldn't delete that choice", deleteChoice) };
+ * ```
+ */
+export function reportingHandler<A extends unknown[]>(
+  contextMessage: string,
+  fn: (...args: A) => unknown,
+): (...args: A) => void {
+  const report = (err: unknown): void => {
+    if (isCancellationError(err)) return;
+    reportError(err, contextMessage);
+  };
+
+  return (...args: A): void => {
+    try {
+      const result = fn(...args);
+      // Duck-typed rather than `instanceof Promise`: a thenable, or a promise from
+      // another realm, still needs its rejection caught.
+      if (typeof (result as { then?: unknown } | null | undefined)?.then === "function") {
+        void (result as Promise<unknown>).catch(report);
+      }
+    } catch (err) {
+      report(err);
+    }
+  };
+}
+
+/**
  * Async error boundary - wraps an async function and reports any errors it throws
  * 
  * @param fn - Async function to execute

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -196,9 +196,13 @@ export function reportingHandler<A extends unknown[]>(
     try {
       const result = fn(...args);
       // Duck-typed rather than `instanceof Promise`: a thenable, or a promise from
-      // another realm, still needs its rejection caught.
+      // another realm, still needs its rejection caught. Assimilated with
+      // Promise.resolve rather than calling `.catch` on it directly — a thenable is
+      // only required to have `.then`, so `.catch` can be undefined, and reporting
+      // "result.catch is not a function" in place of the real failure is exactly the
+      // kind of lost error this helper exists to prevent.
       if (typeof (result as { then?: unknown } | null | undefined)?.then === "function") {
-        void (result as Promise<unknown>).catch(report);
+        void Promise.resolve(result).catch(report);
       }
     } catch (err) {
       report(err);


### PR DESCRIPTION
Closes #1584. Closes #1585.

Two ways the settings surface could fail **totally and silently**. Both were reproduced live in this worktree's isolated Obsidian 1.13.0 vault before the fix, and re-verified after.

## #1584 — a broken view took its whole screen with it

`mountComponent` is the single place every Svelte view enters an Obsidian host. If the component threw during `mount()`, the throw escaped into the host: a Modal that mounts from its constructor or `onOpen()` never opened, and the declarative settings tab — which builds every group by calling `render` closures in turn — abandoned every remaining QuickAdd setting. #1583 caught this at the settings tab's own two call sites; the other five hosts had nothing.

**Repro:** a Macro choice whose `macro.commands` is `null` in `data.json`. Clicking Configure threw `TypeError: Cannot read properties of null (reading 'filter')` out of CommandList's mount, and the macro builder simply did not appear.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/chhoumann/quickadd/c31c5014ca0038897ffc1d7acbbbb1c5f010d901/before-1584-macro-builder.png" width="460"> | <img src="https://raw.githubusercontent.com/chhoumann/quickadd/c31c5014ca0038897ffc1d7acbbbb1c5f010d901/after-1584-macro-builder.png" width="460"> |
| Clicked Configure on "Broken macro". No modal, no Notice, no change. | The builder opens, names what it couldn't display and why, and the macro's name, "run on startup" and icon stay editable. |

## #1585 — a failing row action was a dead button

`ChoiceView`'s row actions are `async` handlers with no `catch`. Svelte re-throws an event handler's error to the window, and a rejected promise is an unhandled rejection — Obsidian surfaces neither. A failing Delete, Configure, Duplicate, Rename or Move produced nothing at all.

**Repro:** a choice whose `type` is not a known choice type (a hand-edit, or an import from a newer QuickAdd). Configure routes to `getChoiceBuilder`, which throws `Invalid choice type`.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/chhoumann/quickadd/c31c5014ca0038897ffc1d7acbbbb1c5f010d901/before-1585-dead-button.png" width="460"> | <img src="https://raw.githubusercontent.com/chhoumann/quickadd/c31c5014ca0038897ffc1d7acbbbb1c5f010d901/after-1585-notice.png" width="460"> |
| Clicked Configure on "Choice with a bad type". `document.querySelectorAll(".notice")` → `[]`. | `QuickAdd: (ERROR) Couldn't open the settings for the choice "Choice with a bad type": Invalid choice type` |

## Design

**`mountComponent` never throws.** It reports the error once (one Notice, through the plugin's own `reportError`), removes the debris the half-finished mount left in the host — tracked by diffing `target.childNodes`, never by emptying `target`, which belongs to the host — and mounts a card where the component would have been. It always returns a handle, so no call site grew a null check.

Each of the seven hosts names what it is showing, so the message is specific ("this macro's commands", "your choices", "the package importer"). The settings choice list keeps its own card, `ChoicesUnavailable`, which carries the `data.json` recovery instructions a generic card has no business claiming; that card and the default now share one prop contract. `quickAddSettingsTab.mountSettingView`'s ad-hoc try/catch is deleted in favour of the seam.

The handle reports whether the component actually rendered (`ok`), and two kinds of host use it:
- the **choice builders** drop a form the user never saw, so it cannot resolve its untouched `$state` clone of the choice back over their data at close;
- the **command editor** stops offering the controls that mutate a list it could not draw (see "what review caught" below).

**A failing row action says so.** `reportingHandler` covers both halves — a synchronous throw and a rejected promise — and reports through the same `reportError` as the rest of the plugin. Cancellations stay silent: a dismissed prompt is an answer, not a failure (#1567). It is applied to the whole `ChoiceListActions` bag rather than to individual buttons, because every row button, context-menu item and nested list reaches the handlers through that one object (`MultiChoiceListItem` spreads it) — wrapping it there makes the coverage structural instead of a list someone has to remember to extend. The message names the row and takes its noun from it, so a folder is never called a choice (#1552).

### Tradeoffs and things deliberately not done

- **`<svelte:boundary>` does not solve #1585.** It catches render and effect errors; Svelte re-throws event-handler errors to the window. Confirmed by the repro — `ChoiceView` already has a boundary and the Configure throw sailed past it.
- **A global `unhandledrejection` listener** would catch other plugins' rejections too and produce context-free Notices. Rejected.
- **`mountComponent` returning `null` on failure** (the issue's own suggestion) forces every call site to grow a null check for a case that should be invisible to them. A handle that owns its fallback is less code and cannot be forgotten.
- **A throw from an `$effect` is still not covered**, and this is now documented at the seam. Svelte flushes effects on a later tick, so it never reaches the try/catch; that case belongs to `<svelte:boundary>`. Verified against svelte 5 with a scratch probe.
- **`MountFailed` and `ChoicesUnavailable` duplicate ~40 lines of CSS.** Left alone: they are deliberately different messages, and restructuring an already-shipped component to share a style block is a bigger change than the duplication costs.
- **`macro.commands` still has no read-accessor guard** of the kind #1583 gave `Multi.choices`. Out of scope here; filed separately.

### What adversarial review caught

An ultracode review (4 lenses → 28 independent refutation passes) killed most findings but landed one that mattered: once the builder survived a broken mount, it *opened over a list it could not draw with every add control still live*. With `commands: null` those controls throw silently; with a valid array holding duplicate ids the list is invisible but the controls **work**, appending commands the user cannot see, review or delete, and persisting them on close. Neither was reachable before, because the modal never opened. The third commit fixes that and tightens two copy claims the review showed could be false.

## Validation

- `pnpm run build-with-lint` clean; `pnpm run check` 0 errors; **4325 unit tests pass**.
- New coverage: `mountComponent` failure path (reports once, renders the card, host content preserved, debris cleared, `destroy()` idempotent, custom card honoured); `reportingHandler` (sync throw, rejection, foreign thenable, cancellation silence, non-promise returns); `ChoiceView` row-action reporting incl. the folder noun; `CommandSequenceEditor` over an unrenderable list.
- Live in the isolated vault: both repros fixed; and regression-checked that a healthy Template builder, a healthy Macro builder (full command bar), and the import/export package modals all still mount with no errors captured.

## Release impact

Three `fix:` commits — patch release. No migration, no settings change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standard mount-failure fallback card for “QuickAdd couldn’t display …” scenarios, with contextual titles and optional error details.
* **Bug Fixes**
  * Prevented failed or unrendered form/preview/choice states from overwriting saved choices.
  * Command sequence editor now stops rendering remaining UI when commands fail to render, avoiding unusable controls.
  * Choice row actions and assistant settings failures are now reported without breaking the rest of the interface.
* **Tests**
  * Expanded coverage for mount failure recovery, error reporting behavior, and UI cleanup/idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->