### PR TITLE
fix(mobile): align folder rows with the icon column, keep toggles inline in modals

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1552,6 +1552,32 @@
 	--icon-size: 17px;
 }
 
+/* Obsidian's mobile button chrome forces inline padding (10px) and a 40px
+   height onto the folder-name <button> hard enough that the component reset in
+   MultiChoiceListItem.svelte loses on phones, shifting the chevron 10px off
+   the shared icon column and making folder rows taller than leaf rows.
+   Matching force, tightly scoped to the one affected element. */
+body.is-mobile .multiChoiceListItemName {
+	padding: 0 !important;
+	height: auto !important;
+	min-height: 0 !important;
+}
+
+/* On phones Obsidian stacks modal .setting-items vertically. Right for the
+   builders' full-width labelled fields, wrong for a toggle-only row: its
+   checkbox lands below its own description while the settings TAB keeps
+   toggles inline on the same device. Restore the native inline layout for
+   rows whose only control is a checkbox. */
+body.is-mobile .quickAddModal .setting-item:has(> .setting-item-control .checkbox-container) {
+	flex-direction: row;
+	align-items: center;
+}
+
+body.is-mobile .quickAddModal .setting-item:has(> .setting-item-control .checkbox-container) > .setting-item-control {
+	width: auto;
+	margin-top: 0;
+}
+
 /* Reveal the per-row actions on intent (hover / keyboard focus in the row).
    Scoped to the choice rows — the macro builder's rightButtonsContainer keeps
    its always-visible icons. Opacity (not display) so hidden buttons keep their

--- a/src/styles.css
+++ b/src/styles.css
@@ -1567,13 +1567,15 @@ body.is-mobile .multiChoiceListItemName {
    builders' full-width labelled fields, wrong for a toggle-only row: its
    checkbox lands below its own description while the settings TAB keeps
    toggles inline on the same device. Restore the native inline layout for
-   rows whose only control is a checkbox. */
-body.is-mobile .quickAddModal .setting-item:has(> .setting-item-control .checkbox-container) {
+   rows whose ONLY control is a checkbox - :only-child keeps mixed rows
+   (e.g. toggle + dropdown in the insert-after fields) on the stacked
+   layout, where inline would squeeze them. */
+body.is-mobile .quickAddModal .setting-item:has(> .setting-item-control > .checkbox-container:only-child) {
 	flex-direction: row;
 	align-items: center;
 }
 
-body.is-mobile .quickAddModal .setting-item:has(> .setting-item-control .checkbox-container) > .setting-item-control {
+body.is-mobile .quickAddModal .setting-item:has(> .setting-item-control > .checkbox-container:only-child) > .setting-item-control {
 	width: auto;
 	margin-top: 0;
 }


### PR DESCRIPTION
Closes #1635. Closes #1636.

Found during the first on-device mobile pass (iPhone, master build, omd-driven scratch vault) - both are phone-only regressions invisible to desktop e2e.

## What

- **#1635**: Obsidian's mobile button chrome (10px inline padding, 40px height) out-forces the folder-name button reset in `MultiChoiceListItem.svelte`, shifting the folder chevron 10px off the shared icon column and making folder rows taller than leaf rows. Fix: a tightly-scoped `body.is-mobile` override matching the platform's force (`!important` is required - the no-important variant was tested on-device and loses).
- **#1636**: on phones Obsidian stacks modal `.setting-item`s vertically; right for the builders' full-width labelled fields (#1551), wrong for toggle-only rows, whose checkbox lands below its own description while the settings tab keeps toggles inline on the same device. Fix: restore the native inline layout for rows whose only control is a checkbox via `:has()` (verified supported in the device's WKWebView; no `!important` needed).

## On-device verification (deployed artifact, injected test styles removed)

```json
{
  "ok": true,
  "testStyleGone": true,
  "leafIconX": 44,
  "chevronX": 44,
  "btnPadding": "0px",
  "btnHeight": "36px",
  "toggleFlexDirs": ["row","row","row","row","row","row","row","row"]
}
```

Before: chevron at x=54 vs leaf icons at x=44, button padding 10px/height 40px, all builder toggle rows `column`. Before-screenshots are in the issue reports (taken by @chhoumann on the device). Desktop layout untouched (`body.is-mobile` scope); 4815 tests pass, build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile layout for choice-list rows to prevent the icon/chevron column from shifting and causing extra row height.
  * Prevented folder rows from appearing taller than expected on phones by tightening mobile padding and sizing.
  * Fixed quick-add settings alignment for checkbox-only rows by keeping them in an inline row layout and centering the checkbox with its description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->