### PR TITLE
test(e2e): wait for Obsidian to index seeded files

### DIFF
--- a/tests/e2e/locked-leaf-file-opening.test.ts
+++ b/tests/e2e/locked-leaf-file-opening.test.ts
@@ -94,6 +94,18 @@ async function seedFile(path: string, content: string) {
 		waitForContent: true,
 		waitOptions: WAIT_OPTS,
 	});
+
+	const vaultPath = sandbox.path(path);
+	await obsidian.waitFor(
+		() =>
+			obsidian.dev.evalJson<boolean>(
+				`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(vaultPath)}))`,
+			),
+		{
+			...WAIT_OPTS,
+			message: `Obsidian to index "${vaultPath}"`,
+		},
+	);
 }
 
 function pinnedOriginLayoutCode({


### PR DESCRIPTION
Stabilize the split-pane file-opening E2E setup by waiting for each seeded path to appear in Obsidian’s in-memory vault index.

The 2.20.0 release-candidate run reproduced a race where `sandbox.write(..., waitForContent: true)` had confirmed the file on disk, but `app.vault.getAbstractFileByPath()` still returned null when the test immediately constructed its pane layout. The test now waits on the exact app-side condition it needs before opening the files.

Product behavior and release artifacts are unchanged. This only tightens the E2E precondition.

Verified locally:
- `pnpm run build-with-lint`
- focused isolated Obsidian 1.13.0 rerun: 2/2 passed
- full isolated Obsidian 1.13.0 E2E suite after restart: 48/48 passed
- isolated runtime `dev:errors`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability by waiting for newly created files to be indexed before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->