### PR TITLE
fix: preserve typed inline script returns

### DIFF
--- a/docs/src/content/docs/docs/InlineScripts.md
+++ b/docs/src/content/docs/docs/InlineScripts.md
@@ -36,11 +36,6 @@ Good to know:
 - To insert something, `return` it. Strings, numbers, booleans, and arrays are
   supported.
 
-:::note[Available in the next release]
-Typed inline-script returns are on `master` and will ship in the next QuickAdd
-release. Released versions through 2.20.0 insert only string returns.
-:::
-
 Return values follow the same rendering contract as a typed
 [`{{VALUE:name}}`](/docs/FormatSyntax/#named-value):
 

--- a/docs/src/content/docs/docs/InlineScripts.md
+++ b/docs/src/content/docs/docs/InlineScripts.md
@@ -1,6 +1,6 @@
 ---
 title: Inline scripts
-description: Run JavaScript inside Template and Capture choices with js quickadd code blocks, returning a string to be inserted
+description: Run JavaScript inside Template and Capture choices with js quickadd code blocks, returning text or typed values to be inserted
 slug: docs/InlineScripts
 ---
 
@@ -33,7 +33,28 @@ Good to know:
 
 - Label the block `js quickadd`, not plain `js`. A plain `js` block is inserted as an ordinary code snippet and never runs.
 - The [QuickAdd API](/docs/QuickAddAPI/) is available as `this` (the same API user scripts get, where it arrives as a parameter instead).
-- To insert something, `return` it. The return value **must** be a string.
+- To insert something, `return` it. Strings, numbers, booleans, and arrays are
+  supported.
+
+:::note[Available in the next release]
+Typed inline-script returns are on `master` and will ship in the next QuickAdd
+release. Released versions through 2.20.0 insert only string returns.
+:::
+
+Return values follow the same rendering contract as a typed
+[`{{VALUE:name}}`](/docs/FormatSyntax/#named-value):
+
+| Return value | In ordinary text | As the sole value of a frontmatter property |
+| --- | --- | --- |
+| String | Inserted unchanged | Inserted unchanged |
+| Number or boolean | Inserted as scalar text | Written as a Number or Checkbox value |
+| Array | Joined with commas | Written as a native YAML list |
+| `null` or `undefined` | Inserts nothing | Leaves the property empty |
+
+Plain objects and other unsupported JavaScript values also insert nothing.
+QuickAdd does not guess how to serialize them into Markdown. Assign an object to
+`this.variables` and reference its fields explicitly, or return the exact string
+you want to insert.
 
 ## Execution order and `{{VALUE}}` {#execution-order-and-value}
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -492,18 +492,73 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 	});
 
 	it("replaces inline JavaScript with its string output", async () => {
-		mocks.inlineRunAndGetOutput.mockResolvedValue("scripted");
+		mocks.inlineRunAndGetOutput.mockResolvedValue("scripted $&");
 		const f = defaultFormatter();
 		await expect(
 			f.formatFolderPath("```js quickadd\nreturn 'x'\n```"),
-		).resolves.toBe("scripted");
+		).resolves.toBe("scripted $&");
 	});
 
-	it("replaces inline JavaScript with empty string when output is non-string", async () => {
+	it("renders number and boolean outputs as scalar text", async () => {
 		mocks.inlineRunAndGetOutput.mockResolvedValue(42);
 		const f = defaultFormatter();
 		await expect(
 			f.formatFolderPath("[```js quickadd\n1+1\n```]"),
+		).resolves.toBe("[42]");
+
+		mocks.inlineRunAndGetOutput.mockResolvedValue(true);
+		await expect(
+			f.formatFolderPath("[```js quickadd\nreturn true\n```]"),
+		).resolves.toBe("[true]");
+	});
+
+	it("collects an array output in a sole frontmatter property position", async () => {
+		mocks.inlineRunAndGetOutput.mockResolvedValue(["alpha", "beta"]);
+		const f = defaultFormatter();
+		const template = [
+			"---",
+			"items: ```js quickadd",
+			"return ['alpha', 'beta'];",
+			"```",
+			"---",
+		].join("\n");
+
+		const result = await f.withTemplatePropertyCollection(() =>
+			f.formatFileContent(template),
+		);
+		const vars = f.getAndClearTemplatePropertyVars();
+
+		expect(result).toBe("---\nitems: []\n---");
+		expect(vars.get("items")).toEqual(["alpha", "beta"]);
+	});
+
+	it("renders an array output as comma-joined ordinary text", async () => {
+		mocks.inlineRunAndGetOutput.mockResolvedValue(["alpha", "beta"]);
+		const f = defaultFormatter();
+
+		await expect(
+			f.formatFileContent(
+				"Body: ```js quickadd\nreturn ['alpha', 'beta'];\n```",
+			),
+		).resolves.toBe("Body: alpha,beta");
+	});
+
+	it.each([null, undefined])(
+		"keeps nullish output empty (%s)",
+		async (value) => {
+			mocks.inlineRunAndGetOutput.mockResolvedValue(value);
+			const f = defaultFormatter();
+			await expect(
+				f.formatFolderPath("[```js quickadd\nnoop\n```]"),
+			).resolves.toBe("[]");
+		},
+	);
+
+	it("keeps unsupported object output empty", async () => {
+		mocks.inlineRunAndGetOutput.mockResolvedValue({ answer: 42 });
+		const f = defaultFormatter();
+		await expect(
+			f.formatFolderPath("[```js quickadd\nnoop\n```]"),
 		).resolves.toBe("[]");
 	});
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -532,6 +532,46 @@ describe("CompleteFormatter - macro / template / inline-script integration", () 
 		expect(vars.get("items")).toEqual(["alpha", "beta"]);
 	});
 
+	it("does not collect an array when text follows the closing fence", async () => {
+		mocks.inlineRunAndGetOutput.mockResolvedValue(["alpha", "beta"]);
+		const f = defaultFormatter();
+		const template = [
+			"---",
+			"items: ```js quickadd",
+			"return ['alpha', 'beta'];",
+			"``` suffix",
+			"---",
+		].join("\n");
+
+		const result = await f.withTemplatePropertyCollection(() =>
+			f.formatFileContent(template),
+		);
+		const vars = f.getAndClearTemplatePropertyVars();
+
+		expect(result).toBe("---\nitems: alpha,beta suffix\n---");
+		expect(vars.has("items")).toBe(false);
+	});
+
+	it("collects an array when only a comment follows the closing fence", async () => {
+		mocks.inlineRunAndGetOutput.mockResolvedValue(["alpha", "beta"]);
+		const f = defaultFormatter();
+		const template = [
+			"---",
+			"items: ```js quickadd",
+			"return ['alpha', 'beta'];",
+			"``` # keep this comment",
+			"---",
+		].join("\n");
+
+		const result = await f.withTemplatePropertyCollection(() =>
+			f.formatFileContent(template),
+		);
+		const vars = f.getAndClearTemplatePropertyVars();
+
+		expect(result).toBe("---\nitems: [] # keep this comment\n---");
+		expect(vars.get("items")).toEqual(["alpha", "beta"]);
+	});
+
 	it("renders an array output as comma-joined ordinary text", async () => {
 		mocks.inlineRunAndGetOutput.mockResolvedValue(["alpha", "beta"]);
 		const f = defaultFormatter();

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -1304,7 +1304,8 @@ export class CompleteFormatter extends Formatter {
 
 		while (INLINE_JAVASCRIPT_REGEX.test(output)) {
 			const match = INLINE_JAVASCRIPT_REGEX.exec(output);
-			const code = match?.at(1)?.trim();
+			if (!match) break;
+			const code = match.at(1)?.trim();
 
 			if (code) {
 				// Imported lazily to avoid the completeFormatter ⇄ engine cycle (#1249).
@@ -1324,10 +1325,36 @@ export class CompleteFormatter extends Formatter {
 					this.variables.set(key, executor.params.variables[key]);
 				}
 
-				output =
-					typeof outVal === "string"
-						? this.replacer(output, INLINE_JAVASCRIPT_REGEX, outVal)
-						: this.replacer(output, INLINE_JAVASCRIPT_REGEX, "");
+				let replacement = "";
+				if (typeof outVal === "string") {
+					// Keep string insertion byte-for-byte compatible, including the
+					// later formatter passes that may process tokens in the result.
+					replacement = outVal;
+				} else if (
+					typeof outVal === "number" ||
+					typeof outVal === "boolean" ||
+					Array.isArray(outVal)
+				) {
+					// Reuse the same typed-value route as {{VALUE:key}}: containers in a
+					// sole frontmatter position are collected for processFrontMatter,
+					// arrays elsewhere join with commas, and scalars render directly.
+					replacement =
+						this.renderCollectedOrArrayValue({
+							input: output,
+							matchStart: match.index,
+							matchEnd: match.index + match[0].length,
+							rawValue: outVal,
+							fallbackKey: "inlineScript",
+							heuristicEnabled: this.isTemplatePropertyTypesEnabled(),
+						}) ?? String(outVal);
+				}
+				// null/undefined and unsupported values intentionally keep the
+				// legacy empty-output behavior rather than inventing serialization.
+				output = this.replacer(
+					output,
+					INLINE_JAVASCRIPT_REGEX,
+					replacement,
+				);
 			} else {
 				// Empty/whitespace-only fence (e.g. ```js quickadd\n```): consume the
 				// matched block so the loop terminates instead of spinning forever.

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -961,6 +961,32 @@ export abstract class Formatter {
 	}
 
 	/**
+	 * Renders the shared structured-value part of a typed replacement.
+	 *
+	 * A sole frontmatter value is first offered to TemplatePropertyCollector so
+	 * Obsidian can write containers through processFrontMatter. Arrays outside a
+	 * collected position use the established {{VALUE:key}} text contract and join
+	 * with commas. Callers retain control of scalar and unsupported-value policy.
+	 */
+	protected renderCollectedOrArrayValue(args: {
+		input: string;
+		matchStart: number;
+		matchEnd: number;
+		rawValue: unknown;
+		fallbackKey: string;
+		heuristicEnabled: boolean;
+	}): string | undefined {
+		const structuredYamlValue = this.propertyCollector.maybeCollect({
+			...args,
+			collectionActive: this.templatePropertyCollectionDepth > 0,
+		});
+		const placeholder = getYamlPlaceholder(structuredYamlValue);
+		if (placeholder !== undefined) return placeholder;
+		if (Array.isArray(args.rawValue)) return args.rawValue.join(",");
+		return undefined;
+	}
+
+	/**
 	 * Runs a formatting operation in a scope where structured YAML values should
 	 * be collected and replaced with temporary placeholders for later
 	 * `processFrontMatter()` post-processing.
@@ -1228,20 +1254,18 @@ export abstract class Formatter {
 			// processFrontMatter pass is always-on inside a collection scope so that
 			// scripts returning real arrays produce valid YAML regardless of the
 			// beta toggle. Only the string -> structured *heuristic* is flag-gated.
-			const collectionActive = this.templatePropertyCollectionDepth > 0;
-			const structuredYamlValue = this.propertyCollector.maybeCollect({
+			const structuredReplacement = this.renderCollectedOrArrayValue({
 				input: output,
 				matchStart: match.index,
 				matchEnd: match.index + match[0].length,
 				rawValue: effectiveRawValue,
 				fallbackKey: variableName,
-				collectionActive,
 				// |type:text forces a string: never run the string->structured
 				// heuristic on it, or a comma/bracket value (`a,b`, `[x]`) would be
 				// collected as a List and bypass the quoting path below.
 				heuristicEnabled:
 					propertyTypesEnabled &&
-					collectionActive &&
+					this.templatePropertyCollectionDepth > 0 &&
 					parsed.inputTypeOverride !== "text",
 			});
 
@@ -1249,15 +1273,9 @@ export abstract class Formatter {
 			// writes the real structured value back through Obsidian. Coerce the
 			// fallback replacement to a string so non-string variable values (e.g.
 			// arrays from scripts on the non-collected path) don't desync the scanner.
-			const placeholder = getYamlPlaceholder(structuredYamlValue);
 			let replacement: string;
-			if (placeholder !== undefined) {
-				replacement = placeholder;
-			} else if (Array.isArray(effectiveRawValue)) {
-				// A |multi (or script) array that was NOT collected (body text, or a
-				// capture flow that suppresses frontmatter collection): join with
-				// commas. Guards against transformCase()/String() on an array.
-				replacement = effectiveRawValue.join(",");
+			if (structuredReplacement !== undefined) {
+				replacement = structuredReplacement;
 			} else {
 				const stringVal = String(
 					this.applyValueTextOptions(

--- a/src/utils/yamlContext.ts
+++ b/src/utils/yamlContext.ts
@@ -48,7 +48,11 @@ export function getYamlContextForMatch(
   }
 
   const lineStart = input.lastIndexOf("\n", matchStart - 1) + 1;
-  const lineEndIdx = input.indexOf("\n", matchStart);
+  // A match may span several lines, as an inline `js quickadd` fence does.
+  // Find the end of the line containing the match's END so sole-value checks
+  // can see a suffix after the closing fence. Using matchStart here silently
+  // treated `key: <multiline match> suffix` as a sole property value.
+  const lineEndIdx = input.indexOf("\n", Math.max(matchStart, matchEnd));
   const lineEnd = lineEndIdx === -1 ? input.length : lineEndIdx;
 
   const before = input.slice(lineStart, matchStart);

--- a/src/utils/yamlContext.ts
+++ b/src/utils/yamlContext.ts
@@ -48,11 +48,11 @@ export function getYamlContextForMatch(
   }
 
   const lineStart = input.lastIndexOf("\n", matchStart - 1) + 1;
-  // A match may span several lines, as an inline `js quickadd` fence does.
-  // Find the end of the line containing the match's END so sole-value checks
-  // can see a suffix after the closing fence. Using matchStart here silently
-  // treated `key: <multiline match> suffix` as a sole property value.
-  const lineEndIdx = input.indexOf("\n", Math.max(matchStart, matchEnd));
+	// A match may span several lines, as an inline `js quickadd` fence does.
+	// Find the end of the line containing the match's END so sole-value checks
+	// can see a suffix after the closing fence. Using matchStart here silently
+	// treated `key: <multiline match> suffix` as a sole property value.
+	const lineEndIdx = input.indexOf("\n", Math.max(matchStart, matchEnd));
   const lineEnd = lineEndIdx === -1 ? input.length : lineEndIdx;
 
   const before = input.slice(lineStart, matchStart);


### PR DESCRIPTION
## Summary

Preserve supported typed values returned by inline `js quickadd` scripts instead of silently deleting every non-string result.

Inline scripts now share the established typed rendering path used by `{{VALUE:key}}` and `TemplatePropertyCollector`. Strings retain their existing literal behavior, numbers and booleans render as scalars, and arrays become native YAML lists when they are the sole value of a frontmatter property.

## Reproduction and behavior

On unmodified master at `945498a5`, an isolated Obsidian 1.13.0 Template choice returned `42` and `["alpha", "beta"]` from inline scripts. The generated note was:

```markdown
---
number:
items:
---

Body array:
```

Obsidian parsed both properties as `null`, and QuickAdd logged zero collected template property values.

With this change, the same choice generates:

```markdown
---
number: 42
items:
  - alpha
  - beta
---

Body array: alpha,beta
```

Obsidian reads `number` as `42` and `items` as `["alpha", "beta"]`. QuickAdd collects the typed values and reports no developer errors.

## Compatibility boundaries

- String returns keep the existing literal insertion and downstream formatter pass behavior byte-for-byte.
- Number and boolean returns render as scalar text.
- Arrays follow the existing typed `{{VALUE:key}}` contract: native YAML lists in sole frontmatter-property positions and comma-joined ordinary text elsewhere.
- `null` and `undefined` remain empty output.
- Plain objects and other unsupported values remain empty. This change does not introduce arbitrary Markdown or object serialization.
- Inline scripts still run first in the formatting pipeline, and values assigned through `params.variables` keep their existing handoff behavior.

## Validation

- Focused regression tests failed on master for number output, array frontmatter output, and array body output, then passed with the fix.
- `pnpm exec vitest run src/formatters/completeFormatter.test.ts src/utils/TemplatePropertyCollector.test.ts` - 128 passed.
- `pnpm run test` - 4,841 passed, 37 skipped.
- `pnpm run build-with-lint`.
- `pnpm --dir docs run build`.
- `git diff --check`.
- Live isolated Obsidian 1.13.0 verification through `quickadd:run`, including exact before/after content, parsed frontmatter, fixture cleanup, and a clean `dev:errors` buffer.
- Live review-boundary verification confirmed that non-comment text after a multiline closing fence stays ordinary text, while a trailing YAML comment still permits native list collection.

## Release and migration impact

This is a user-visible bug fix for the next QuickAdd release. No data migration or settings migration is required. The inline-scripts documentation includes the supported return-value contract and a next-release availability note.

Fixes #1644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline scripts now support string, numeric, boolean, and array results.
  * Typed results render correctly in text and frontmatter, including structured values and arrays.

* **Bug Fixes**
  * Null and undefined results remain empty, while unsupported objects are omitted.
  * Improved handling of missing matches and multiline YAML values.
  * Corrected array collection behavior when content follows a closing code fence.

* **Documentation**
  * Updated inline script documentation with supported return types and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->