### PR TITLE
fix: refresh FIELD suggestions when the vault changes

### DIFF
--- a/src/gui/suggesters/FieldValueInputSuggest.test.ts
+++ b/src/gui/suggesters/FieldValueInputSuggest.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { App } from "obsidian";
+
+const mocks = vi.hoisted(() => ({
+	collectFieldValuesProcessed: vi.fn(),
+}));
+
+vi.mock("src/utils/FieldValueCollector", () => ({
+	collectFieldValuesProcessed: mocks.collectFieldValuesProcessed,
+}));
+
+import { FieldValueInputSuggest } from "./FieldValueInputSuggest";
+
+describe("FieldValueInputSuggest", () => {
+	beforeEach(() => {
+		mocks.collectFieldValuesProcessed.mockReset();
+	});
+
+	it("observes shared cache invalidation while the input remains open", async () => {
+		mocks.collectFieldValuesProcessed
+			.mockResolvedValueOnce(["ValueA"])
+			.mockResolvedValueOnce(["ValueD"]);
+		const input = document.createElement("input");
+		document.body.appendChild(input);
+		const app = {
+			dom: { appContainerEl: document.body },
+			keymap: { pushScope: vi.fn(), popScope: vi.fn() },
+		} as unknown as App;
+		const suggest = new FieldValueInputSuggest(app, input, "status");
+
+		await expect(suggest.getSuggestions("")).resolves.toEqual(["ValueA"]);
+		await expect(suggest.getSuggestions("")).resolves.toEqual(["ValueD"]);
+		expect(mocks.collectFieldValuesProcessed).toHaveBeenCalledTimes(2);
+
+		suggest.destroy();
+		input.remove();
+	});
+});

--- a/src/gui/suggesters/FieldValueInputSuggest.ts
+++ b/src/gui/suggesters/FieldValueInputSuggest.ts
@@ -4,7 +4,7 @@ import {
 	type FieldFilter,
 } from "src/utils/FieldSuggestionParser";
 import {
-	collectFieldValuesProcessed
+	collectFieldValuesProcessed,
 } from "src/utils/FieldValueCollector";
 import { TextInputSuggest } from "./suggest";
 
@@ -16,7 +16,6 @@ export class FieldValueInputSuggest extends TextInputSuggest<string> {
 	private readonly fieldInput: string;
 	private readonly fieldName: string;
 	private readonly filters: FieldFilter;
-	private cachedValues: string[] | null = null;
 
 	constructor(app: App, inputEl: HTMLInputElement, fieldInput: string) {
 		super(app, inputEl);
@@ -27,17 +26,18 @@ export class FieldValueInputSuggest extends TextInputSuggest<string> {
 	}
 
 	async getSuggestions(inputStr: string): Promise<string[]> {
-		if (!this.cachedValues) {
-			this.cachedValues = await collectFieldValuesProcessed(
-				this.app,
-				this.fieldName,
-				this.filters,
-			);
-		}
+		// FieldSuggestionCache already avoids repeated vault scans. Ask it on every
+		// refresh so a metadata event that invalidated the shared cache is visible to
+		// an already-open input instead of being shadowed by a second per-modal cache.
+		const values = await collectFieldValuesProcessed(
+			this.app,
+			this.fieldName,
+			this.filters,
+		);
 
 		const query = (inputStr || "").toLowerCase();
-		if (!query) return this.cachedValues.slice(0, 200);
-		return this.cachedValues
+		if (!query) return values.slice(0, 200);
+		return values
 			.filter((v) => v.toLowerCase().includes(query))
 			.slice(0, 200);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -196,6 +196,9 @@ export default class QuickAdd extends Plugin {
 		cache.startAutomaticCleanup((intervalId) =>
 			this.registerInterval(intervalId),
 		);
+		cache.registerInvalidationListeners(this.app, (eventRef) =>
+			this.registerEvent(eventRef),
+		);
 
 		this.addCommand({
 			id: "openQuickAddSettings",

--- a/src/utils/FieldSuggestionCache.test.ts
+++ b/src/utils/FieldSuggestionCache.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { App } from "obsidian";
 import { FieldSuggestionCache } from "./FieldSuggestionCache";
 
 describe("FieldSuggestionCache", () => {
@@ -134,6 +135,56 @@ describe("FieldSuggestionCache", () => {
 				maxSize: 100,
 				cleanupInterval: null // No interval started in test
 			});
+		});
+	});
+
+	describe("vault invalidation", () => {
+		it.each(["changed", "deleted", "rename"] as const)(
+			"clears all filtered field entries after %s",
+			(eventName) => {
+				const listeners = new Map<string, () => void>();
+				const app = {
+					metadataCache: {
+						on: vi.fn((name: string, callback: () => void) => {
+							listeners.set(name, callback);
+							return { name };
+						}),
+					},
+					vault: {
+						on: vi.fn((name: string, callback: () => void) => {
+							listeners.set(name, callback);
+							return { name };
+						}),
+					},
+				} as unknown as App;
+				const registerEvent = vi.fn();
+
+				cache.registerInvalidationListeners(app, registerEvent);
+				cache.set("status", new Set(["ValueA"]));
+				cache.set("status", new Set(["ScopedValue"]), "folder:Projects");
+
+				listeners.get(eventName)?.();
+
+				expect(cache.get("status")).toBeNull();
+				expect(cache.get("status", "folder:Projects")).toBeNull();
+				expect(registerEvent).toHaveBeenCalledTimes(3);
+			},
+		);
+
+		it("does not let an in-flight scan repopulate an invalidated cache", () => {
+			const revision = cache.getRevision();
+
+			cache.clear();
+
+			expect(
+				cache.setIfRevision(
+					"status",
+					new Set(["stale"]),
+					undefined,
+					revision,
+				),
+			).toBe(false);
+			expect(cache.get("status")).toBeNull();
 		});
 	});
 });

--- a/src/utils/FieldSuggestionCache.ts
+++ b/src/utils/FieldSuggestionCache.ts
@@ -1,4 +1,4 @@
-
+import type { App, EventRef } from "obsidian";
 
 interface CacheEntry {
 	values: Set<string>;
@@ -12,6 +12,7 @@ export class FieldSuggestionCache {
 	private readonly MAX_CACHE_ENTRIES = 100; // Maximum number of cache entries
 	private readonly MAX_VALUES_PER_ENTRY = 1000; // Maximum values per field
 	private cleanupInterval: number | null = null;
+	private revision = 0;
 
 	static getInstance(): FieldSuggestionCache {
 		if (!FieldSuggestionCache.instance) {
@@ -35,6 +36,27 @@ export class FieldSuggestionCache {
 			}, 60 * 1000);
 			this.cleanupInterval = registerInterval(intervalId);
 		}
+	}
+
+	/**
+	 * Invalidate suggestions whenever Obsidian's indexed vault state changes.
+	 * FIELD cache entries can depend on any Markdown file because folder, tag,
+	 * exclusion, and inline-field filters all share this cache. Clearing the small
+	 * bounded cache is both safer and cheaper than trying to reconstruct which
+	 * field/filter combinations a changed file might affect.
+	 */
+	registerInvalidationListeners(
+		app: App,
+		registerEvent: (eventRef: EventRef) => unknown,
+	): void {
+		const clear = () => this.clear();
+
+		registerEvent(app.metadataCache.on("changed", clear));
+		registerEvent(app.metadataCache.on("deleted", clear));
+		// MetadataCache deliberately does not emit "changed" for renames. A rename
+		// can move a note into or out of a folder filter, or change an exclude-file
+		// match, so the vault event is required even when file contents are unchanged.
+		registerEvent(app.vault.on("rename", clear));
 	}
 
 	/**
@@ -88,6 +110,25 @@ export class FieldSuggestionCache {
 	}
 
 	/**
+	 * Snapshot used to keep an in-flight vault scan from repopulating the cache
+	 * after a metadata event has invalidated it.
+	 */
+	getRevision(): number {
+		return this.revision;
+	}
+
+	setIfRevision(
+		fieldName: string,
+		values: Set<string>,
+		cacheKey: string | undefined,
+		expectedRevision: number,
+	): boolean {
+		if (this.revision !== expectedRevision) return false;
+		this.set(fieldName, values, cacheKey);
+		return true;
+	}
+
+	/**
 	 * Evict the oldest cache entries
 	 * @param count Number of entries to evict
 	 */
@@ -106,6 +147,7 @@ export class FieldSuggestionCache {
 	 * @param fieldName Optional field name to clear specific cache
 	 */
 	clear(fieldName?: string): void {
+		this.revision++;
 		if (fieldName) {
 			// Clear all entries for this field. Compare the decoded field-name
 			// component rather than a raw `${fieldName}:` prefix, which would both
@@ -165,7 +207,7 @@ export class FieldSuggestionCache {
 	 */
 	destroy(): void {
 		this.cleanupInterval = null;
-		this.cache.clear();
+		this.clear();
 	}
 
 	private makeKey(fieldName: string, cacheKey?: string): string {

--- a/src/utils/FieldValueCollector.ts
+++ b/src/utils/FieldValueCollector.ts
@@ -35,13 +35,7 @@ export async function collectFieldValuesProcessed(
 	fieldName: string,
 	filters: FieldFilter,
 ): Promise<string[]> {
-	const cache = FieldSuggestionCache.getInstance();
-	const cacheKey = generateFieldCacheKey(filters);
-	let rawValues = cache.get(fieldName, cacheKey);
-	if (!rawValues) {
-		rawValues = await collectFieldValuesRaw(app, fieldName, filters);
-		cache.set(fieldName, rawValues, cacheKey);
-	}
+	const rawValues = await collectFieldValuesCached(app, fieldName, filters);
 
 	const processed = FieldValueProcessor.processValues(rawValues, filters);
 	return processed.values;
@@ -52,19 +46,32 @@ export async function collectFieldValuesProcessedDetailed(
 	fieldName: string,
 	filters: FieldFilter,
 ): Promise<{ values: string[]; hasDefaultValue: boolean }> {
-	const cache = FieldSuggestionCache.getInstance();
-	const cacheKey = generateFieldCacheKey(filters);
-	let rawValues = cache.get(fieldName, cacheKey);
-	if (!rawValues) {
-		rawValues = await collectFieldValuesRaw(app, fieldName, filters);
-		cache.set(fieldName, rawValues, cacheKey);
-	}
+	const rawValues = await collectFieldValuesCached(app, fieldName, filters);
 
 	const processed = FieldValueProcessor.processValues(rawValues, filters);
 	return {
 		values: processed.values,
 		hasDefaultValue: processed.hasDefaultValue,
 	};
+}
+
+async function collectFieldValuesCached(
+	app: App,
+	fieldName: string,
+	filters: FieldFilter,
+): Promise<Set<string>> {
+	const cache = FieldSuggestionCache.getInstance();
+	const cacheKey = generateFieldCacheKey(filters);
+	const cachedValues = cache.get(fieldName, cacheKey);
+	if (cachedValues) return cachedValues;
+
+	const revision = cache.getRevision();
+	const collectedValues = await collectFieldValuesRaw(app, fieldName, filters);
+	// A metadata event may fire while the async vault scan is in progress. Do not
+	// let that older scan repopulate the cache after the event cleared it; the next
+	// input refresh will scan the now-current vault state again.
+	cache.setIfRevision(fieldName, collectedValues, cacheKey, revision);
+	return collectedValues;
 }
 
 export async function collectFieldValuesRaw(

--- a/src/utils/TemplatePropertyCollector.test.ts
+++ b/src/utils/TemplatePropertyCollector.test.ts
@@ -55,6 +55,23 @@ describe("TemplatePropertyCollector", () => {
     expect([...result.keys()].sort()).toEqual(["authors", "title"]);
   });
 
+  it("does not collect an empty multi-select pick (issue #1656: property stays empty, not [])", () => {
+    const c = new TemplatePropertyCollector();
+
+    const [aStart, aEnd] = idxRange(yaml, "{{VALUE:authors}}");
+    const collected = c.maybeCollect({
+      input: yaml,
+      matchStart: aStart,
+      matchEnd: aEnd,
+      rawValue: [],
+      fallbackKey: "authors",
+      collectionActive: true, heuristicEnabled: true,
+    });
+
+    expect(collected).toBeUndefined();
+    expect(c.drain().size).toBe(0);
+  });
+
   it("ignores placeholders not in a pure key-value position", () => {
     const c = new TemplatePropertyCollector();
     const [iStart, iEnd] = idxRange(yaml, "{{VALUE:inline}}");

--- a/src/utils/TemplatePropertyCollector.ts
+++ b/src/utils/TemplatePropertyCollector.ts
@@ -80,6 +80,13 @@ export class TemplatePropertyCollector {
 
     if (!isStructuredYamlValue(structuredValue)) return undefined;
 
+    // An empty multi-select pick means "no value". Skip collection so the
+    // inline fallback (`[].join(",")` -> "") leaves the property empty
+    // (`topics:`) instead of writing an explicit empty list (issue #1656).
+    if (Array.isArray(structuredValue) && structuredValue.length === 0) {
+      return undefined;
+    }
+
     // Always-on (flag-off) collection is limited to container types
     // (arrays/objects) that break when inlined as text. Scalars
     // (number/boolean/null) are already YAML-safe inline, so they are only


### PR DESCRIPTION
{{FIELD:...}} suggestions were cached for the whole session: the shared `FieldSuggestionCache` was never invalidated, and `FieldValueInputSuggest` kept a second per-input cache on top of it. Adding, editing, or renaming a note never refreshed the suggestion list until Obsidian was restarted.

**1. Event-driven cache (`3faeb976`):**

- `FieldSuggestionCache.registerInvalidationListeners()` clears the cache on `metadataCache` `changed`/`deleted` and `vault` `rename` (renames matter because they can move a note in or out of a `folder:`/exclusion filter without a content change).
- A revision counter guards against an in-flight vault scan repopulating the cache after an event already cleared it.
- `FieldValueInputSuggest` drops its private cache and asks the shared cache on every refresh, so even an already-open input observes the invalidation. Repeat keystrokes still hit the cache; a full rescan only happens after a vault change.

Clearing the whole (small, bounded) cache instead of tracking per-file dependencies is deliberate: folder, tag, exclusion, and inline-field filters all share this cache, so any Markdown change can affect any entry, and reconstruction logic would cost more than the rescan it saves.

**2. Empty multi-select pick leaves the property empty (`9164a261`)** - issue point 3: an empty pick wrote an explicit empty list (`topics: []`). The collector now skips empty arrays, so the property is left blank (`topics:`) - "no value" rather than "empty list". Verified live: an empty pick creates `tags2: ` and Obsidian reads `null`.

**Before** (vault contains `status: ValueA` and newly added `status: ValueD` - the new value never appears):

![before](https://raw.githubusercontent.com/chhoumann/quickadd/assets/issues-1649-1656/1656-before.png)

**After** (same sequence, new value appears as soon as Obsidian has indexed it):

![after](https://raw.githubusercontent.com/chhoumann/quickadd/assets/issues-1649-1656/1656-after.png)

Verified in a live isolated Obsidian instance (1.13.4): populate prompt → add `_1656/book2.md` with `status: ValueD` → reopen prompt. On master the second open shows `["ValueA"]`; with this fix it shows `["ValueA","ValueD"]`. `dev:errors` clean. `pnpm test` (4862 tests), `pnpm build-with-lint` pass.

Fixes #1656