### PR TITLE
feat: add explicit multi-select output formats

### DIFF
--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -367,6 +367,28 @@ Variants and combinations:
 - `|multi|custom` adds a text box to the picker for values not in the list.
 - Combines with `|name:`, `|label:`, `|text:`, `|optional`, and `|trim`. `|case:` is ignored (a list isn't case-transformed).
 
+:::note[Available in the next release]
+Add `|format:` when the output shape should be intentional instead of inferred
+from where the placeholder appears:
+
+- `|format:yaml` writes a quoted YAML flow sequence. Obsidian recognizes it as
+  a native list, including in capture content inserted into a template:
+  `topics: {{VALUE:Alpha,Beta|multi|format:yaml}}` becomes
+  `topics: ["Alpha", "Beta"]`.
+- `|format:markdown` writes a vertical Markdown bullet list. Put the placeholder
+  on its own line: `{{VALUE:Alpha,Beta|multi|format:markdown}}` becomes `- Alpha`
+  followed by `- Beta`.
+- `|format:inline` always writes the existing comma-separated text form:
+  `Alpha,Beta`.
+- `|format:auto` is the default and preserves the context-sensitive behavior
+  described below.
+
+Formatting is separate from the selected item representation, so it composes
+with `|multi:linklist`, `|text:`, `|custom`, and the other multi-select options.
+For example, `|multi:linklist|format:yaml` writes a native YAML list of
+wikilinks.
+:::
+
 Good to know:
 
 - The picks become a real YAML list **inside front matter**. In a note body they become comma-separated text.
@@ -717,6 +739,13 @@ positions it writes comma-separated text. Combines with the same filters and
 defaults as single-value FIELD prompts:
 `{{FIELD:topic|multi|folder:Projects|tag:active|default:Inbox}}`.
 
+:::note[Available in the next release]
+FIELD multi-selects support the same explicit output formats as VALUE:
+`|format:yaml`, `|format:markdown`, `|format:inline`, and `|format:auto`.
+For example, `topics: {{FIELD:topic|multi|format:yaml}}` always writes a native
+YAML list, including in template-backed captures.
+:::
+
 :::note
 The one-page input form doesn't inline FIELD multi-selects yet: vault values
 can contain commas, and the one-page multi input uses commas as separators.
@@ -859,6 +888,13 @@ Good to know:
 - Markdown files only.
 - `|link` and `|path` insert characters that aren't valid in file names; in the **file name** field, use the default mode.
 - In a one-page input form, single and multi FILE pickers appear inline. Search matches the friendly title, file name, and full path. Selected files remain exact path-backed values internally, so commas in file names or labels are safe.
+
+:::note[Available in the next release]
+FILE multi-selects support `|format:yaml`, `|format:markdown`,
+`|format:inline`, and `|format:auto`. The format composes with `|link` and
+`|path`, so `{{FILE:People|multi|link|format:yaml}}` writes a native YAML list
+of links without relying on the capture context.
+:::
 
 _Introduced in QuickAdd 2.14.0._
 

--- a/src/engine/CaptureChoiceEngine.audit-capture.test.ts
+++ b/src/engine/CaptureChoiceEngine.audit-capture.test.ts
@@ -443,6 +443,13 @@ describe("CaptureChoiceEngine |multi degradation warning", () => {
 		).toBe(true);
 	});
 
+	it("warns for a |multi flag with trailing whitespace ({{FIELD:tags|multi }})", async () => {
+		const messages = await runWithFormat("{{FIELD:tags|multi }}");
+		expect(
+			messages.some((m) => m.includes("comma-separated strings")),
+		).toBe(true);
+	});
+
 	it("does not warn for non-multi FIELD tokens", async () => {
 		const messages = await runWithFormat("{{FIELD:tags}}");
 		expect(

--- a/src/engine/CaptureChoiceEngine.audit-capture.test.ts
+++ b/src/engine/CaptureChoiceEngine.audit-capture.test.ts
@@ -449,4 +449,16 @@ describe("CaptureChoiceEngine |multi degradation warning", () => {
 			messages.some((m) => m.includes("comma-separated strings")),
 		).toBe(false);
 	});
+
+	it.each(["yaml", "markdown", "inline"])(
+		"does not warn when |format:%s makes the output explicit",
+		async (format) => {
+			const messages = await runWithFormat(
+				`{{FIELD:tags|multi|format:${format}}}`,
+			);
+			expect(
+				messages.some((m) => m.includes("comma-separated strings")),
+			).toBe(false);
+		},
+	);
 });

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -110,6 +110,17 @@ function isCaptureContentEmpty(content: string): boolean {
 	return ASCII_WHITESPACE_ONLY_REGEX.test(content);
 }
 
+const MULTI_SELECT_TOKEN_REGEX =
+	/\{\{(?:VALUE|FILE|FIELD):[^}]*\|\s*multi(?=[:}|]|$)[^}]*\}\}/gi;
+const EXPLICIT_MULTI_FORMAT_REGEX =
+	/\|\s*format\s*:\s*(?:inline|yaml|markdown)\s*(?=\||}})/i;
+
+function hasContextualMultiSelectToken(input: string): boolean {
+	return Array.from(input.matchAll(MULTI_SELECT_TOKEN_REGEX)).some(
+		(match) => !EXPLICIT_MULTI_FORMAT_REGEX.test(match[0]),
+	);
+}
+
 type NormalizedAppendLinkOptions = ReturnType<typeof normalizeAppendLinkOptions>;
 
 type CaptureWriteResult = {
@@ -495,12 +506,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				// `|multi1`, `|multi-select`, etc. FIELD is included because
 				// {{FIELD:…|multi}} degrades to a comma-joined string in the exact
 				// same way VALUE/FILE do (see formatter.ts replaceFieldVarInString).
-				/\{\{(?:VALUE|FILE|FIELD):[^}]*\|\s*multi(?=[:}|]|$)/i.test(
-					this.choice?.format?.format ?? "",
-				)
+				hasContextualMultiSelectToken(this.choice?.format?.format ?? "")
 			) {
 				log.logWarning(
-					"QuickAdd: {{VALUE:…|multi}}, {{FILE:…|multi}} and {{FIELD:…|multi}} in this capture write comma-separated strings, not YAML lists. Multi-select produces a real list only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template).",
+					"QuickAdd: {{VALUE:…|multi}}, {{FILE:…|multi}} and {{FIELD:…|multi}} in this capture write comma-separated strings by default. Add |format:yaml, |format:markdown or |format:inline to choose the output explicitly.",
 				);
 			}
 

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -111,7 +111,7 @@ function isCaptureContentEmpty(content: string): boolean {
 }
 
 const MULTI_SELECT_TOKEN_REGEX =
-	/\{\{(?:VALUE|FILE|FIELD):[^}]*\|\s*multi(?=[:}|]|$)[^}]*\}\}/gi;
+	/\{\{(?:VALUE|FILE|FIELD):[^}]*\|\s*multi\s*(?=[:}|]|$)[^}]*\}\}/gi;
 const EXPLICIT_MULTI_FORMAT_REGEX =
 	/\|\s*format\s*:\s*(?:inline|yaml|markdown)\s*(?=\||}})/i;
 

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1813,6 +1813,21 @@ describe("CompleteFormatter - remote prompt provider routing", () => {
 		expect(out).toContain("c");
 	});
 
+	it.each([
+		["yaml", '["a", "c"]'],
+		["markdown", "- a\n- c"],
+		["inline", "a,c"],
+	] as const)("renders VALUE multi-selects with |format:%s", async (format, expected) => {
+		const suggesterMulti = vi.fn(
+			async (_display: string[], _actual: string[]) => ["a", "c"],
+		);
+		const f = providerFormatter({ suggesterMulti });
+
+		await expect(
+			f.formatFileContent(`{{VALUE:a,b,c|multi|format:${format}}}`),
+		).resolves.toBe(expected);
+	});
+
 	it("routes anonymous {{VALUE|type:checkbox}} to the provider's suggester, not the Obsidian modal", async () => {
 		mocks.genericSuggesterSuggest.mockResolvedValue("false"); // modal answer (should be unused)
 		const suggester = vi.fn(async () => "true");

--- a/src/formatters/formatter-field-title-regression.test.ts
+++ b/src/formatters/formatter-field-title-regression.test.ts
@@ -198,6 +198,39 @@ describe("Formatter FIELD and TITLE namespace handling", () => {
 		expect(formatter.getAndClearTemplatePropertyVars().size).toBe(0);
 	});
 
+	it("writes an explicit YAML list without property collection", async () => {
+		formatter.setMockFieldResponse("topic|multi|format:yaml", ["0042", "a: b"]);
+
+		await expect(
+			formatter.runFormat("topics: {{FIELD:topic|multi|format:yaml}}"),
+		).resolves.toBe('topics: ["0042", "a: b"]');
+	});
+
+	it("writes an explicit vertical Markdown list", async () => {
+		formatter.setMockFieldResponse("topic|multi|format:markdown", [
+			"Alpha",
+			"Beta",
+		]);
+
+		await expect(
+			formatter.runFormat("  {{FIELD:topic|multi|format:markdown}}"),
+		).resolves.toBe("  - Alpha\n  - Beta");
+	});
+
+	it("keeps explicit inline output textual inside a collection scope", async () => {
+		formatter.setMockFieldResponse("topic|multi|format:inline", [
+			"Alpha",
+			"Beta",
+		]);
+
+		await expect(
+			formatter.runFormatWithPropertyCollection(
+				"---\ntopics: {{FIELD:topic|multi|format:inline}}\n---\n",
+			),
+		).resolves.toBe("---\ntopics: Alpha,Beta\n---\n");
+		expect(formatter.getAndClearTemplatePropertyVars().size).toBe(0);
+	});
+
 	it("collects FIELD multi arrays from YAML list item token positions", async () => {
 		formatter.setMockFieldResponse("topic|multi", ["Alpha", "Beta"]);
 

--- a/src/formatters/formatter-file.test.ts
+++ b/src/formatters/formatter-file.test.ts
@@ -261,6 +261,32 @@ describe("Formatter {{FILE:...}} token", () => {
 		);
 	});
 
+	it("renders FILE multi-selects in an explicit YAML format", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md", "People/Jack.md"]),
+			() => [
+				`${FILE_PICK_PREFIX}People/Tom.md`,
+				`${FILE_PICK_PREFIX}People/Jack.md`,
+			],
+		);
+		expect(
+			await f.run("people: {{FILE:People|multi|link|format:yaml}}"),
+		).toBe('people: ["[[Tom@]]", "[[Jack@]]"]');
+	});
+
+	it("renders FILE multi-selects as a vertical Markdown list", async () => {
+		const f = new FileTestFormatter(
+			makeApp(["People/Tom.md", "People/Jack.md"]),
+			() => [
+				`${FILE_PICK_PREFIX}People/Tom.md`,
+				`${FILE_PICK_PREFIX}People/Jack.md`,
+			],
+		);
+		expect(
+			await f.run("{{FILE:People|multi|format:markdown}}"),
+		).toBe("- Tom\n- Jack");
+	});
+
 	it("collects FILE multi-select arrays as YAML list properties", async () => {
 		const f = new FileTestFormatter(
 			makeApp(["People/Tom.md", "People/Jack.md"]),

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -43,6 +43,10 @@ import { normalizeDateInput } from "../utils/dateAliases";
 import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
 import { quoteYamlDouble, shouldQuoteTextScalar } from "../utils/yamlScalarQuoting";
+import {
+	renderExplicitMultiValue,
+	type MultiValueFormat,
+} from "../utils/multiValueFormat";
 import { toWikiLink } from "../utils/linkWrap";
 import { FieldSuggestionParser } from "../utils/FieldSuggestionParser";
 import {
@@ -975,7 +979,18 @@ export abstract class Formatter {
 		rawValue: unknown;
 		fallbackKey: string;
 		heuristicEnabled: boolean;
+		multiFormat?: MultiValueFormat;
 	}): string | undefined {
+		if (Array.isArray(args.rawValue) && args.multiFormat) {
+			const explicit = renderExplicitMultiValue({
+				input: args.input,
+				matchStart: args.matchStart,
+				values: args.rawValue,
+				format: args.multiFormat,
+			});
+			if (explicit !== undefined) return explicit;
+		}
+
 		const structuredYamlValue = this.propertyCollector.maybeCollect({
 			...args,
 			collectionActive: this.templatePropertyCollectionDepth > 0,
@@ -1267,6 +1282,7 @@ export abstract class Formatter {
 					propertyTypesEnabled &&
 					this.templatePropertyCollectionDepth > 0 &&
 					parsed.inputTypeOverride !== "text",
+				multiFormat: parsed.multiFormat,
 			});
 
 			// Keep the interim frontmatter YAML-parseable until post-processing
@@ -1345,17 +1361,16 @@ export abstract class Formatter {
 				let replacement: string;
 
 				if (Array.isArray(rawValue)) {
-					const structuredYamlValue = this.propertyCollector.maybeCollect({
+					replacement =
+						this.renderCollectedOrArrayValue({
 						input,
 						matchStart: match.index,
 						matchEnd: match.index + match[0].length,
 						rawValue,
 						fallbackKey: parsed.fieldName,
-						collectionActive: this.templatePropertyCollectionDepth > 0,
 						heuristicEnabled: false,
-					});
-					replacement =
-						getYamlPlaceholder(structuredYamlValue) ?? rawValue.join(",");
+						multiFormat: parsed.multiFormat ?? "auto",
+						}) ?? rawValue.join(",");
 				} else {
 					replacement = String(rawValue ?? "");
 				}
@@ -1391,7 +1406,9 @@ export abstract class Formatter {
 		while ((match = regex.exec(input)) !== null) {
 			output += input.slice(lastIndex, match.index);
 
-			const parsed = parseFileToken(match[1] ?? "");
+			const parsed = parseFileToken(match[1] ?? "", {
+				warn: this.warnSink,
+			});
 			if (!parsed) {
 				// Empty folder / malformed: leave the token literal and move on.
 				output += match[0];
@@ -1410,16 +1427,16 @@ export abstract class Formatter {
 				(stored) => this.getFileLinkForStoredValue(stored),
 			);
 			if (Array.isArray(renderedValue)) {
-				const structuredYamlValue = this.propertyCollector.maybeCollect({
+				const replacement = this.renderCollectedOrArrayValue({
 					input,
 					matchStart: match.index,
 					matchEnd: match.index + match[0].length,
 					rawValue: renderedValue,
 					fallbackKey: parsed.aliasName ?? parsed.folderPath,
-					collectionActive: this.templatePropertyCollectionDepth > 0,
 					heuristicEnabled: false,
+					multiFormat: parsed.multiFormat,
 				});
-				output += getYamlPlaceholder(structuredYamlValue) ?? renderedValue.join(",");
+				output += replacement ?? renderedValue.join(",");
 			} else {
 				output += renderedValue;
 			}

--- a/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
+++ b/src/utils/FieldSuggestionParser-1564-unknown-filter.test.ts
@@ -35,7 +35,7 @@ const SUGGESTIONS: Array<[typed: string, expected: string[]]> = [
 	["inline-code", ["inline-code-blocks", "inline"]],
 	["multi-select", ["multi"]],
 	// Half-typed, which is most of what a live preview sees.
-	["fo", ["folder"]],
+	["fo", ["folder", "format"]],
 	["de", ["default", "default-from", "default-empty"]],
 	// Not a typo of anything: no guess, fall back to the vocabulary.
 	["filter", []],
@@ -86,7 +86,7 @@ describe("describeUnknownFieldFilter", () => {
 	it("keeps the full vocabulary when nothing is close", () => {
 		const message = describeUnknownFieldFilter("sortby", "status|sortby:x");
 		expect(message).toBe(
-			'Unknown FIELD filter "sortby" in {{FIELD:status|sortby:x}} was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-from, default-empty, default-always, case-sensitive, multi.',
+			'Unknown FIELD filter "sortby" in {{FIELD:status|sortby:x}} was ignored. Supported filters: folder, tag, inline, inline-code-blocks, exclude-folder, exclude-tag, exclude-file, default, default-from, default-empty, default-always, case-sensitive, multi, format.',
 		);
 	});
 

--- a/src/utils/FieldSuggestionParser.test.ts
+++ b/src/utils/FieldSuggestionParser.test.ts
@@ -121,6 +121,15 @@ describe("FieldSuggestionParser", () => {
 			expect(result.multiFormat).toBe("markdown");
 		});
 
+		it("warns on |format: without |multi, even |format:auto", () => {
+			const warnings: string[] = [];
+			const result = FieldSuggestionParser.parse("topics|format:auto", {
+				warn: (msg) => warnings.push(msg),
+			});
+			expect(result.multiFormat).toBeUndefined();
+			expect(warnings.some((m) => m.includes("needs |multi"))).toBe(true);
+		});
+
 		it("should handle tags with # prefix", () => {
 			const result = FieldSuggestionParser.parse("fieldname|tag:#work");
 			expect(result).toEqual({

--- a/src/utils/FieldSuggestionParser.test.ts
+++ b/src/utils/FieldSuggestionParser.test.ts
@@ -113,6 +113,14 @@ describe("FieldSuggestionParser", () => {
 			});
 		});
 
+		it("parses an explicit multi-select format", () => {
+			const result = FieldSuggestionParser.parse(
+				"topics|multi|format:markdown",
+			);
+			expect(result.multiSelect).toBe(true);
+			expect(result.multiFormat).toBe("markdown");
+		});
+
 		it("should handle tags with # prefix", () => {
 			const result = FieldSuggestionParser.parse("fieldname|tag:#work");
 			expect(result).toEqual({

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -174,6 +174,7 @@ export class FieldSuggestionParser {
 		const filters: FieldFilter = {};
 		let multiSelect = false;
 		let multiFormat: MultiValueFormat = "auto";
+		let multiFormatExplicit = false;
 
 		for (let i = 1; i < parts.length; i++) {
 			const filterPart = parts[i];
@@ -225,6 +226,7 @@ export class FieldSuggestionParser {
 					multiSelect = parseBooleanFlag(filterValue);
 					break;
 				case "format":
+					multiFormatExplicit = true;
 					multiFormat =
 						parseMultiValueFormat(
 							filterValue,
@@ -311,9 +313,11 @@ export class FieldSuggestionParser {
 			}
 		}
 
-		if (!multiSelect && multiFormat !== "auto") {
+		// Warn on ANY explicit |format: without |multi - including |format:auto,
+		// which is a no-op the author probably didn't intend.
+		if (!multiSelect && multiFormatExplicit) {
 			options?.warn?.(
-				`QuickAdd: |format:${multiFormat} needs |multi in "{{FIELD:${input}}}"; ignoring.`,
+				`QuickAdd: |format: needs |multi in "{{FIELD:${input}}}"; ignoring.`,
 			);
 			multiFormat = "auto";
 		}

--- a/src/utils/FieldSuggestionParser.ts
+++ b/src/utils/FieldSuggestionParser.ts
@@ -5,6 +5,10 @@ import {
 	splitPipeParts,
 } from "./pipeSyntax";
 import { suggestSimilarKeys } from "./suggestSimilarKeys";
+import {
+	parseMultiValueFormat,
+	type MultiValueFormat,
+} from "./multiValueFormat";
 
 /**
  * Every filter key the `{{FIELD:...}}` grammar recognises, in the order the
@@ -30,6 +34,7 @@ export const FIELD_FILTER_KEYS = [
 	"default-always",
 	"case-sensitive",
 	"multi",
+	"format",
 ] as const;
 
 /**
@@ -162,11 +167,13 @@ export class FieldSuggestionParser {
 		fieldName: string;
 		filters: FieldFilter;
 		multiSelect?: boolean;
+		multiFormat?: MultiValueFormat;
 	} {
 		const parts = splitPipeParts(input).map((p) => p.trim());
 		const fieldName = parts[0];
 		const filters: FieldFilter = {};
 		let multiSelect = false;
+		let multiFormat: MultiValueFormat = "auto";
 
 		for (let i = 1; i < parts.length; i++) {
 			const filterPart = parts[i];
@@ -216,6 +223,14 @@ export class FieldSuggestionParser {
 			switch (filterType) {
 				case "multi":
 					multiSelect = parseBooleanFlag(filterValue);
+					break;
+				case "format":
+					multiFormat =
+						parseMultiValueFormat(
+							filterValue,
+							`{{FIELD:${input}}}`,
+							options?.warn,
+						) ?? "auto";
 					break;
 				case "folder":
 					if (!filters.folders) {
@@ -296,8 +311,18 @@ export class FieldSuggestionParser {
 			}
 		}
 
-		return multiSelect
-			? { fieldName, filters, multiSelect }
-			: { fieldName, filters };
+		if (!multiSelect && multiFormat !== "auto") {
+			options?.warn?.(
+				`QuickAdd: |format:${multiFormat} needs |multi in "{{FIELD:${input}}}"; ignoring.`,
+			);
+			multiFormat = "auto";
+		}
+
+		return {
+			fieldName,
+			filters,
+			...(multiSelect ? { multiSelect } : {}),
+			...(multiFormat !== "auto" ? { multiFormat } : {}),
+		};
 	}
 }

--- a/src/utils/fileSyntax.test.ts
+++ b/src/utils/fileSyntax.test.ts
@@ -52,6 +52,15 @@ describe("parseFileToken", () => {
 		expect(parsed?.multiFormat).toBe("yaml");
 	});
 
+	it("warns on |format: without |multi, even |format:auto", () => {
+		const warnings: string[] = [];
+		const parsed = parseFileToken("People|format:auto", {
+			warn: (msg) => warnings.push(msg),
+		});
+		expect(parsed?.multiFormat).toBe("auto");
+		expect(warnings.some((m) => m.includes("needs |multi"))).toBe(true);
+	});
+
 	it("parses label and the |name: alias", () => {
 		const parsed = parseFileToken("People|link|label:Pick a person|name:reviewer");
 		expect(parsed?.label).toBe("Pick a person");

--- a/src/utils/fileSyntax.test.ts
+++ b/src/utils/fileSyntax.test.ts
@@ -42,7 +42,14 @@ describe("parseFileToken", () => {
 	it("parses multi-select as FILE behavior", () => {
 		const parsed = parseFileToken("People|multi");
 		expect(parsed?.multiSelect).toBe(true);
+		expect(parsed?.multiFormat).toBe("auto");
 		expect(parsed?.variableKey).toContain("|multi");
+	});
+
+	it("parses an explicit multi-select format", () => {
+		const parsed = parseFileToken("People|multi|format:yaml");
+		expect(parsed?.multiSelect).toBe(true);
+		expect(parsed?.multiFormat).toBe("yaml");
 	});
 
 	it("parses label and the |name: alias", () => {

--- a/src/utils/fileSyntax.ts
+++ b/src/utils/fileSyntax.ts
@@ -8,6 +8,8 @@ import {
 	parsePipeKeyValue,
 	splitPipeParts,
 } from "./pipeSyntax";
+import type { MultiValueFormat } from "./multiValueFormat";
+import type { WarnSink } from "./warnSink";
 
 // Namespaces FILE variable values in the variables map, separate from plain
 // VALUE/FIELD variables (parallel to FIELD_VARIABLE_PREFIX in constants.ts).
@@ -38,6 +40,8 @@ export type ParsedFileToken = {
 	filter: FieldFilter;
 	/** Pick several files and store/render them as a list. */
 	multiSelect: boolean;
+	/** Explicit output shape for a multi-select; auto preserves legacy behavior. */
+	multiFormat: MultiValueFormat;
 	/** Variables-map key. Full token identity by default; `|name:` shares it. */
 	variableKey: string;
 };
@@ -126,7 +130,10 @@ function buildFileSignature(parsed: {
  *
  * Returns `null` for an empty folder (the token is left literal by the caller).
  */
-export function parseFileToken(raw: string): ParsedFileToken | null {
+export function parseFileToken(
+	raw: string,
+	options?: { warn?: WarnSink },
+): ParsedFileToken | null {
 	if (!raw) return null;
 
 	const allParts = splitPipeParts(raw);
@@ -173,8 +180,11 @@ export function parseFileToken(raw: string): ParsedFileToken | null {
 	// like label/name and bare flags), then force the scope folder. The first
 	// segment is the folder, so any `|folder:` sub-option the parser picks up is
 	// intentionally discarded below (the positional folder always wins).
-	const fieldParsed = FieldSuggestionParser.parse(raw);
+	const fieldParsed = FieldSuggestionParser.parse(raw, {
+		warn: options?.warn,
+	});
 	const multiSelect = bareMultiSelect || (fieldParsed.multiSelect ?? false);
+	const multiFormat = fieldParsed.multiFormat ?? "auto";
 	const filter: FieldFilter = {
 		folder: folderPath,
 		tags: fieldParsed.filters.tags,
@@ -210,6 +220,7 @@ export function parseFileToken(raw: string): ParsedFileToken | null {
 		allowCustomInput,
 		filter,
 		multiSelect,
+		multiFormat,
 		variableKey,
 	};
 }

--- a/src/utils/multiValueFormat.test.ts
+++ b/src/utils/multiValueFormat.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	parseMultiValueFormat,
+	renderExplicitMultiValue,
+} from "./multiValueFormat";
+
+describe("multi-select output formatting", () => {
+	it.each(["auto", "inline", "yaml", "markdown"] as const)(
+		"parses %s",
+		(format) => {
+			expect(parseMultiValueFormat(format, "token")).toBe(format);
+		},
+	);
+
+	it("warns and ignores unsupported formats", () => {
+		const warn = vi.fn();
+		expect(parseMultiValueFormat("table", "token", warn)).toBeUndefined();
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("auto, inline, yaml, markdown"),
+		);
+	});
+
+	it("keeps auto available to the legacy context-sensitive renderer", () => {
+		expect(
+			renderExplicitMultiValue({
+				input: "{{VALUE:a,b|multi}}",
+				matchStart: 0,
+				values: ["a", "b"],
+				format: "auto",
+			}),
+		).toBeUndefined();
+	});
+
+	it("renders inline output with the legacy comma separator", () => {
+		expect(
+			renderExplicitMultiValue({
+				input: "value",
+				matchStart: 0,
+				values: ["Alpha", "Beta"],
+				format: "inline",
+			}),
+		).toBe("Alpha,Beta");
+	});
+
+	it("renders a quoted YAML flow sequence that preserves string values", () => {
+		expect(
+			renderExplicitMultiValue({
+				input: "topics: token",
+				matchStart: 8,
+				values: ["0042", "a: b", 'quoted "value"'],
+				format: "yaml",
+			}),
+		).toBe('["0042", "a: b", "quoted \\"value\\""]');
+	});
+
+	it("renders an empty YAML selection as an empty list", () => {
+		expect(
+			renderExplicitMultiValue({
+				input: "topics: token",
+				matchStart: 8,
+				values: [],
+				format: "yaml",
+			}),
+		).toBe("[]");
+	});
+
+	it("renders an indented vertical Markdown list", () => {
+		expect(
+			renderExplicitMultiValue({
+				input: "  token",
+				matchStart: 2,
+				values: ["Alpha", "Beta\ncontinued"],
+				format: "markdown",
+			}),
+		).toBe("- Alpha\n  - Beta\n  continued");
+	});
+});

--- a/src/utils/multiValueFormat.ts
+++ b/src/utils/multiValueFormat.ts
@@ -1,0 +1,60 @@
+import { quoteYamlDouble } from "./yamlScalarQuoting";
+import type { WarnSink } from "./warnSink";
+
+export type MultiValueFormat = "auto" | "inline" | "yaml" | "markdown";
+
+const MULTI_VALUE_FORMATS = new Set<MultiValueFormat>([
+	"auto",
+	"inline",
+	"yaml",
+	"markdown",
+]);
+
+export function parseMultiValueFormat(
+	raw: string,
+	tokenDisplay: string,
+	warn?: WarnSink,
+): MultiValueFormat | undefined {
+	const normalized = raw.trim().toLowerCase();
+	if (MULTI_VALUE_FORMATS.has(normalized as MultiValueFormat)) {
+		return normalized as MultiValueFormat;
+	}
+
+	warn?.(
+		`QuickAdd: Unsupported multi-select format "${raw}" in "${tokenDisplay}". Supported formats: auto, inline, yaml, markdown.`,
+	);
+	return undefined;
+}
+
+function currentLineIndent(input: string, matchStart: number): string {
+	const lineStart = input.lastIndexOf("\n", matchStart - 1) + 1;
+	return input.slice(lineStart, matchStart).match(/^\s*/)?.[0] ?? "";
+}
+
+function renderMarkdownItem(value: string): string {
+	return `- ${value.replace(/\r\n?|\n/g, "\n  ")}`;
+}
+
+/**
+ * Renders an explicitly requested multi-select output shape. `undefined` means
+ * the caller should retain the legacy context-sensitive `auto` behavior.
+ */
+export function renderExplicitMultiValue(args: {
+	input: string;
+	matchStart: number;
+	values: readonly unknown[];
+	format: MultiValueFormat;
+}): string | undefined {
+	const { input, matchStart, values, format } = args;
+	if (format === "auto") return undefined;
+
+	const strings = values.map((value) => String(value));
+	if (format === "inline") return strings.join(",");
+	if (format === "yaml") {
+		return `[${strings.map(quoteYamlDouble).join(", ")}]`;
+	}
+
+	if (strings.length === 0) return "";
+	const indent = currentLineIndent(input, matchStart);
+	return strings.map(renderMarkdownItem).join(`\n${indent}`);
+}

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -267,6 +267,12 @@ describe("parseValueToken", () => {
 		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("needs |multi"));
 	});
 
+	it("warns on an explicit |format:auto without |multi (a silent no-op otherwise)", () => {
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		expect(parseValueToken("Only|format:auto")?.multiFormat).toBe("auto");
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("needs |multi"));
+	});
+
 	it("warns and ignores |multi without an option list", () => {
 		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		expect(parseValueToken("Only|multi")?.multiSelect).toBe(false);

--- a/src/utils/valueSyntax.test.ts
+++ b/src/utils/valueSyntax.test.ts
@@ -249,6 +249,24 @@ describe("parseValueToken", () => {
 		expect(parsed?.multiEmit).toBe("linklist");
 	});
 
+	it.each(["yaml", "markdown", "inline"] as const)(
+		"parses |format:%s separately from |multi item emission",
+		(format) => {
+			const parsed = parseValueToken(
+				`Alice,Bob|multi:linklist|format:${format}`,
+			);
+			expect(parsed?.multiSelect).toBe(true);
+			expect(parsed?.multiEmit).toBe("linklist");
+			expect(parsed?.multiFormat).toBe(format);
+		},
+	);
+
+	it("warns and ignores an explicit format without |multi", () => {
+		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
+		expect(parseValueToken("Only|format:yaml")?.multiFormat).toBe("auto");
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("needs |multi"));
+	});
+
 	it("warns and ignores |multi without an option list", () => {
 		const warnSpy = vi.spyOn(log, "logWarning").mockImplementation(() => {});
 		expect(parseValueToken("Only|multi")?.multiSelect).toBe(false);

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -821,9 +821,11 @@ export function parseValueToken(
 		);
 		caseStyle = undefined;
 	}
-	if (!multiSelect && multiFormat !== "auto") {
+	// Warn on ANY explicit |format: without |multi - including |format:auto,
+	// which is a no-op the author probably didn't intend.
+	if (!multiSelect && options.multiFormat !== undefined) {
 		warn(
-			`QuickAdd: |format:${multiFormat} needs |multi in "${tokenDisplay}"; ignoring.`,
+			`QuickAdd: |format: needs |multi in "${tokenDisplay}"; ignoring.`,
 		);
 		multiFormat = "auto";
 	}

--- a/src/utils/valueSyntax.ts
+++ b/src/utils/valueSyntax.ts
@@ -6,6 +6,10 @@ import {
 	stripLeadingPipe,
 } from "./pipeSyntax";
 import { isSupportedCaseStyle, SUPPORTED_CASE_STYLES } from "./caseTransform";
+import {
+	parseMultiValueFormat,
+	type MultiValueFormat,
+} from "./multiValueFormat";
 import { NOTICE_WARN, SILENT_WARN, type WarnSink } from "./warnSink";
 
 // Internal-only delimiter for scoping labeled VALUE lists. Unlikely to appear in user input.
@@ -52,6 +56,7 @@ const VALUE_OPTION_KEYS = new Set([
 	"optional",
 	"trim",
 	"multi",
+	"format",
 ]);
 
 export type MultiEmit = "text" | "linklist";
@@ -87,6 +92,8 @@ export type ParsedValueToken = {
 	multiSelect: boolean;
 	/** |multi:linklist wraps each pick as [[name]]; defaults to plain text. */
 	multiEmit: MultiEmit;
+	/** Explicit output shape for a multi-select; auto preserves legacy behavior. */
+	multiFormat: MultiValueFormat;
 };
 
 export function buildValueVariableKey(
@@ -160,6 +167,7 @@ type ParsedOptions = {
 	name?: string;
 	multiSelect?: boolean;
 	multiEmit?: MultiEmit;
+	multiFormat?: MultiValueFormat;
 };
 
 /**
@@ -265,6 +273,7 @@ function parseOptions(
 	let name: string | undefined;
 	let multiSelect = false;
 	let multiEmit: MultiEmit | undefined;
+	let multiFormat: MultiValueFormat | undefined;
 
 	for (const part of optionParts) {
 		const trimmed = part.trim();
@@ -328,6 +337,9 @@ function parseOptions(
 				multiEmit =
 					value.trim().toLowerCase() === "linklist" ? "linklist" : "text";
 				break;
+			case "format":
+				multiFormat = parseMultiValueFormat(value, tokenDisplay, warn);
+				break;
 			case "name":
 				// Gated to the named grammar via optionKeys; empty `|name:` is a
 				// no-op alias and warns so the author notices the typo. Names the
@@ -360,6 +372,7 @@ function parseOptions(
 		trimExplicit,
 		multiSelect,
 		multiEmit,
+		multiFormat,
 	};
 }
 
@@ -702,6 +715,7 @@ export function parseValueToken(
 	let { label, caseStyle, defaultValue, allowCustomInput } = options;
 	let multiSelect = options.multiSelect ?? false;
 	const multiEmit: MultiEmit = options.multiEmit ?? "text";
+	let multiFormat: MultiValueFormat = options.multiFormat ?? "auto";
 	const optional = options.optionalExplicit ?? bareOptional;
 	const trim = options.trimExplicit ?? bareTrim;
 
@@ -807,6 +821,12 @@ export function parseValueToken(
 		);
 		caseStyle = undefined;
 	}
+	if (!multiSelect && multiFormat !== "auto") {
+		warn(
+			`QuickAdd: |format:${multiFormat} needs |multi in "${tokenDisplay}"; ignoring.`,
+		);
+		multiFormat = "auto";
+	}
 
 	// A bare `|custom` only enables free-text-with-autocomplete on an option-list
 	// token (2+ values). On a single value it falls through to being parsed as the
@@ -847,6 +867,7 @@ export function parseValueToken(
 		trim,
 		multiSelect,
 		multiEmit,
+		multiFormat,
 	};
 }
 

--- a/tests/e2e/multi-select-formatting.test.ts
+++ b/tests/e2e/multi-select-formatting.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	captureFailureArtifacts,
+	clearVaultRunLockMarker,
+	createSandboxApi,
+} from "obsidian-e2e";
+import type {
+	ObsidianClient,
+	PluginHandle,
+	SandboxApi,
+	VaultRunLock,
+} from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+} from "./e2eVault";
+
+const PLUGIN_ID = "quickadd";
+const CHOICE_ID = "__qa-1649-template-frontmatter";
+const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
+
+let obsidian: ObsidianClient;
+let sandbox: SandboxApi;
+let qa: PluginHandle;
+let lock: VaultRunLock | undefined;
+
+type QuickAddData = {
+	choices: Record<string, unknown>[];
+};
+
+function captureChoice(templatePath: string, outputPath: string) {
+	return {
+		id: CHOICE_ID,
+		name: CHOICE_ID,
+		type: "Capture",
+		command: false,
+		captureTo: outputPath,
+		captureToActiveFile: false,
+		activeFileWritePosition: "cursor",
+		createFileIfItDoesntExist: {
+			enabled: true,
+			createWithTemplate: true,
+			template: templatePath,
+		},
+		format: {
+			enabled: true,
+			format:
+				"topics: {{VALUE:Alpha,Beta|multi|name:topics|format:yaml}}",
+		},
+		prepend: false,
+		appendLink: false,
+		task: false,
+		insertAfter: {
+			enabled: true,
+			after: "kind: capture",
+			insertAtEnd: false,
+			considerSubsections: false,
+			createIfNotFound: false,
+			createIfNotFoundLocation: "",
+		},
+		newLineCapture: { enabled: true, direction: "below" },
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "default",
+			focus: false,
+		},
+	};
+}
+
+async function runTeardownStep(
+	label: string,
+	step: () => Promise<unknown> | unknown,
+	errors: unknown[],
+) {
+	try {
+		await step();
+	} catch (error) {
+		errors.push(error);
+		console.warn(`multi-select formatting teardown failed during ${label}`, error);
+	}
+}
+
+beforeAll(async () => {
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
+	await lock.publishMarker(obsidian);
+
+	qa = obsidian.plugin(PLUGIN_ID);
+	sandbox = await createSandboxApi({
+		obsidian,
+		sandboxRoot: "__obsidian_e2e__",
+		testName: "multi-select-formatting",
+	});
+
+	const templatePath = sandbox.path("template.md");
+	await sandbox.write("template.md", "---\nkind: capture\n---\n# Template body\n", {
+		waitForContent: true,
+		waitOptions: WAIT_OPTS,
+	});
+
+	await qa.data<QuickAddData>().patch((data) => {
+		data.choices = data.choices.filter((choice) => choice.id !== CHOICE_ID);
+		data.choices.push(captureChoice(templatePath, sandbox.path("output.md")));
+	});
+	await qa.reload({ waitUntilReady: true });
+}, 30_000);
+
+afterAll(async () => {
+	const errors: unknown[] = [];
+	await runTeardownStep("restoreData", () => qa?.restoreData?.(), errors);
+	await runTeardownStep("reload", () => qa?.reload?.(), errors);
+	await runTeardownStep("sandbox cleanup", () => sandbox?.cleanup?.(), errors);
+	await runTeardownStep(
+		"clear vault run lock marker",
+		() => (obsidian ? clearVaultRunLockMarker(obsidian) : undefined),
+		errors,
+	);
+	await runTeardownStep("release vault lock", () => lock?.release(), errors);
+
+	if (errors.length > 0) throw errors[0];
+}, 15_000);
+
+beforeEach((ctx) => {
+	ctx.onTestFailed(async () => {
+		await captureFailureArtifacts(
+			{ id: ctx.task.id, name: ctx.task.name },
+			obsidian,
+			{ plugin: qa, captureOnFailure: true },
+		);
+	});
+});
+
+describe("issue 1649: explicit multi-select formatting", () => {
+	it("writes a native YAML list into template-backed capture frontmatter", async () => {
+		await obsidian.exec("quickadd:run", {
+			choice: CHOICE_ID,
+			vars: JSON.stringify({ topics: ["Alpha", "Beta"] }),
+		});
+		await sandbox.waitForExists("output.md", WAIT_OPTS);
+
+		const frontmatter = await obsidian.metadata.waitForFrontmatter<{
+			kind: string;
+			topics: string[];
+		}>(
+			sandbox.path("output.md"),
+			(value) => Array.isArray(value.topics) && value.topics.length === 2,
+			WAIT_OPTS,
+		);
+		const content = await sandbox.read("output.md");
+
+		expect(frontmatter).toMatchObject({
+			kind: "capture",
+			topics: ["Alpha", "Beta"],
+		});
+		expect(content).toContain('topics: ["Alpha", "Beta"]');
+	});
+});


### PR DESCRIPTION
Multi-select output shape was inferred from context: picks became a real YAML list only when capturing into a brand-new note's front matter without a template; every other shape wrote comma-separated text. Users who capture into template-backed notes (the most common setup for people who want list properties) could not get a list at all, and nobody could get a vertical Markdown list in a note body (#1649).

This adds an explicit, opt-in `|format:` option to all three multi-select tokens ({{VALUE:...|multi}}, {{FILE:...|multi}}, {{FIELD:...|multi}}):

- `|format:yaml` - quoted YAML flow sequence (`topics: ["Alpha", "Beta"]`); Obsidian reads it as a native list in any front matter, including template-backed captures.
- `|format:markdown` - vertical bullet list, preserving the line's indentation.
- `|format:inline` - the existing comma-separated text, now nameable.
- `|format:auto` (default) - the legacy context-sensitive behavior, byte-for-byte unchanged. Nothing changes for existing setups.

It composes with the existing item options (`|multi:linklist`, `|link`, `|path`, `|text:`, `|custom`), and `|format:` without `|multi` warns and is ignored. The capture-time warning that previously just said "this writes comma-separated text" now points at the new flags.

**Before** (capture into a template-backed note - `topics` is a single string):

![before](https://raw.githubusercontent.com/chhoumann/quickadd/assets/issues-1649-1656/1649-before.png)

**After** (`|format:yaml` in front matter, `|format:markdown` in the body):

![after](https://raw.githubusercontent.com/chhoumann/quickadd/assets/issues-1649-1656/1649-after.png)

Includes docs (with "Available in the next release" callouts), unit coverage for the parser/renderer/formatter paths, and a live e2e test (`tests/e2e/multi-select-formatting.test.ts`) that drives a template-backed capture and asserts Obsidian's metadata cache reads a native list. Also verified interactively in Obsidian 1.13.4 (screenshots above). `pnpm test` (4883 tests), `pnpm build-with-lint` pass.

Fixes #1649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit formatting options for multi-select values, fields, and files: inline, YAML, Markdown, and automatic formatting.
  * Supports formatted output with links, labels, custom values, and other selection options.
  * Added validation and helpful warnings for unsupported or incorrectly used formatting options.
* **Documentation**
  * Documented multi-select formatting syntax and available options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->