### PR TITLE
fix: escape values substituted into quoted frontmatter scalars

### DIFF
--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -44,6 +44,26 @@ QuickAdd creates `Books/Dune.md` from your template, with the title, date, and
 frontmatter filled in. Assign the choice a hotkey (⚡ icon, or Obsidian's
 Hotkeys settings) once it behaves the way you want.
 
+### Tokens in template properties {#tokens-in-properties}
+
+A bare token in frontmatter, like `Title: {{VALUE:fileName}}`, is not valid
+YAML, so Obsidian logs a console warning when it indexes the template file
+itself. The warning is cosmetic - QuickAdd reads the template as text and the
+created note is fine - but if you want a quiet console, wrap the token in
+quotes:
+
+```yaml
+Title: "{{VALUE:fileName}}"
+```
+
+Two things to know about the quoted form:
+
+- QuickAdd escapes the filled-in value for the surrounding quotes, so answers
+  containing `"` or `'` can't break the created note's frontmatter.
+  _Available in the next release._
+- Quotes make the property a **string**. Leave tokens unquoted on number,
+  checkbox, and date properties so Obsidian reads the typed value.
+
 ## Run a template without making a choice {#run-without-choice}
 
 If you just want to spin up a note from a template in your

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -61,8 +61,11 @@ Two things to know about the quoted form:
 - QuickAdd escapes the filled-in value for the surrounding quotes, so answers
   containing `"` or `'` can't break the created note's frontmatter.
   _Available in the next release._
-- Quotes make the property a **string**. Leave tokens unquoted on number,
-  checkbox, and date properties so Obsidian reads the typed value.
+- Quotes normally make the property a **string**. For a typed property, declare
+  the type on the token and the quotes are consumed:
+  `rating: "{{VALUE:rating|type:number}}"` writes `rating: 42`, which Obsidian
+  reads as a Number (same for `|type:checkbox` and `|type:slider`).
+  _Available in the next release._
 
 ## Run a template without making a choice {#run-without-choice}
 

--- a/src/formatters/formatter-quoted-scalar.test.ts
+++ b/src/formatters/formatter-quoted-scalar.test.ts
@@ -151,6 +151,14 @@ describe("issue #1655: values substituted into author-quoted front matter scalar
 		expect(result).toBe('---\ntitle: "he said \\"hi\\""\n---\nBody');
 	});
 
+	it("escapes the anonymous {{NAME}} form the same way", async () => {
+		formatter.anonymousValue = 'he said "hi"';
+		const result = await formatter.testFormat(
+			'---\ntitle: "{{NAME}}"\n---\nBody',
+		);
+		expect(result).toBe('---\ntitle: "he said \\"hi\\""\n---\nBody');
+	});
+
 	it("escapes a joined multi-select FIELD fallback inside a quoted scalar", async () => {
 		formatter.seed(`${FIELD_VARIABLE_PREFIX}tags|multi`, ['say "hi"', "b"]);
 		const result = await formatter.testFormat(

--- a/src/formatters/formatter-quoted-scalar.test.ts
+++ b/src/formatters/formatter-quoted-scalar.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Formatter } from "./formatter";
+import { FIELD_VARIABLE_PREFIX } from "../constants";
+
+// Issue #1655: authors quote tokens in template front matter so the raw
+// template is valid YAML (Obsidian warns on bare `{{...}}`). The substituted
+// value must then be escaped for the surrounding quotes, or a value containing
+// the quote character corrupts the created note's front matter.
+class QuotedScalarTestFormatter extends Formatter {
+	constructor() {
+		super();
+	}
+
+	protected async format(input: string): Promise<string> {
+		let output = input;
+		output = await this.replaceVariableInString(output);
+		output = await this.replaceFieldVarInString(output);
+		return output;
+	}
+
+	protected promptForValue(): string {
+		return "";
+	}
+
+	protected getCurrentFileLink(): string | null {
+		return null;
+	}
+
+	protected getCurrentFileName(): string | null {
+		return null;
+	}
+
+	protected getVariableValue(variableName: string): string {
+		return (this.variables.get(variableName) as string) ?? "";
+	}
+
+	protected suggestForValue(
+		_suggestedValues: string[],
+		_allowCustomInput?: boolean,
+		_context?: { placeholder?: string; variableKey?: string },
+	): string {
+		return "";
+	}
+
+	protected suggestForFile(): string {
+		return "";
+	}
+
+	protected suggestForField(_variableName: string): Promise<string> {
+		return Promise.resolve("");
+	}
+
+	protected promptForMathValue(): Promise<string> {
+		return Promise.resolve("");
+	}
+
+	protected getMacroValue(
+		_macroName: string,
+		_context?: { label?: string },
+	): string {
+		return "";
+	}
+
+	protected promptForVariable(
+		_variableName: string,
+		_context?: {
+			type?: string;
+			dateFormat?: string;
+			defaultValue?: string;
+			label?: string;
+			description?: string;
+			placeholder?: string;
+			variableKey?: string;
+		},
+	): Promise<string> {
+		return Promise.resolve("");
+	}
+
+	protected getTemplateContent(_templatePath: string): Promise<string> {
+		return Promise.resolve("");
+	}
+
+	protected getSelectedText(): Promise<string> {
+		return Promise.resolve("");
+	}
+
+	protected getClipboardContent(): Promise<string> {
+		return Promise.resolve("");
+	}
+
+	protected isTemplatePropertyTypesEnabled(): boolean {
+		return false;
+	}
+
+	public async testFormat(input: string): Promise<string> {
+		return await this.format(input);
+	}
+
+	public seed(key: string, value: unknown): void {
+		this.variables.set(key, value);
+	}
+}
+
+describe("issue #1655: values substituted into author-quoted front matter scalars", () => {
+	let formatter: QuotedScalarTestFormatter;
+
+	beforeEach(() => {
+		formatter = new QuotedScalarTestFormatter();
+	});
+
+	it("escapes double quotes in a VALUE inside a double-quoted scalar", async () => {
+		formatter.seed("fileName", 'My "Great" Note');
+		const result = await formatter.testFormat(
+			'---\nTitle: "{{VALUE:fileName}}"\n---\nBody',
+		);
+		expect(result).toBe('---\nTitle: "My \\"Great\\" Note"\n---\nBody');
+	});
+
+	it("doubles apostrophes in a VALUE inside a single-quoted scalar", async () => {
+		formatter.seed("who", "O'Brien");
+		const result = await formatter.testFormat(
+			"---\nauthor: '{{VALUE:who}}'\n---\nBody",
+		);
+		expect(result).toBe("---\nauthor: 'O''Brien'\n---\nBody");
+	});
+
+	it("escapes a FIELD value inside a double-quoted scalar", async () => {
+		formatter.seed(`${FIELD_VARIABLE_PREFIX}status`, 'in "review"');
+		const result = await formatter.testFormat(
+			'---\nstatus: "{{FIELD:status}}"\n---\nBody',
+		);
+		expect(result).toBe('---\nstatus: "in \\"review\\""\n---\nBody');
+	});
+
+	it("leaves unquoted substitutions untouched", async () => {
+		formatter.seed("fileName", 'My "Great" Note');
+		const result = await formatter.testFormat(
+			"---\nTitle: {{VALUE:fileName}}\n---\nBody",
+		);
+		expect(result).toBe('---\nTitle: My "Great" Note\n---\nBody');
+	});
+
+	it("leaves body substitutions untouched even when the author wrote quotes", async () => {
+		formatter.seed("quote", 'she said "hi"');
+		const result = await formatter.testFormat(
+			'---\nTitle: x\n---\nThey wrote "{{VALUE:quote}}" today',
+		);
+		expect(result).toBe(
+			'---\nTitle: x\n---\nThey wrote "she said "hi"" today',
+		);
+	});
+});

--- a/src/formatters/formatter-quoted-scalar.test.ts
+++ b/src/formatters/formatter-quoted-scalar.test.ts
@@ -140,6 +140,46 @@ describe("issue #1655: values substituted into author-quoted front matter scalar
 		expect(result).toBe('---\nTitle: My "Great" Note\n---\nBody');
 	});
 
+	it("consumes author quotes when an explicit |type:number is declared", async () => {
+		formatter.seed("num", "42");
+		const result = await formatter.testFormat(
+			'---\nrating: "{{VALUE:num|type:number}}"\n---\nBody',
+		);
+		expect(result).toBe("---\nrating: 42\n---\nBody");
+	});
+
+	it("consumes author quotes for |type:checkbox", async () => {
+		formatter.seed("d", "true");
+		const result = await formatter.testFormat(
+			'---\ndone: "{{VALUE:d|type:checkbox}}"\n---\nBody',
+		);
+		expect(result).toBe("---\ndone: true\n---\nBody");
+	});
+
+	it("keeps quotes for |type:text (string semantics)", async () => {
+		formatter.seed("id", "0042");
+		const result = await formatter.testFormat(
+			'---\nid: "{{VALUE:id|type:text}}"\n---\nBody',
+		);
+		expect(result).toBe('---\nid: "0042"\n---\nBody');
+	});
+
+	it("keeps quotes and escapes for |type:multiline", async () => {
+		formatter.seed("n", "a\nb");
+		const result = await formatter.testFormat(
+			'---\nnotes: "{{VALUE:n|type:multiline}}"\n---\nBody',
+		);
+		expect(result).toBe('---\nnotes: "a\\nb"\n---\nBody');
+	});
+
+	it("does not consume quotes in the note body", async () => {
+		formatter.seed("num", "42");
+		const result = await formatter.testFormat(
+			'---\nTitle: x\n---\nSaid "{{VALUE:num|type:number}}" today',
+		);
+		expect(result).toBe('---\nTitle: x\n---\nSaid "42" today');
+	});
+
 	it("leaves body substitutions untouched even when the author wrote quotes", async () => {
 		formatter.seed("quote", 'she said "hi"');
 		const result = await formatter.testFormat(

--- a/src/formatters/formatter-quoted-scalar.test.ts
+++ b/src/formatters/formatter-quoted-scalar.test.ts
@@ -13,14 +13,17 @@ class QuotedScalarTestFormatter extends Formatter {
 
 	protected async format(input: string): Promise<string> {
 		let output = input;
+		output = await this.replaceValueInString(output);
 		output = await this.replaceVariableInString(output);
 		output = await this.replaceFieldVarInString(output);
 		return output;
 	}
 
 	protected promptForValue(): string {
-		return "";
+		return this.anonymousValue;
 	}
+
+	public anonymousValue = "";
 
 	protected getCurrentFileLink(): string | null {
 		return null;
@@ -138,6 +141,22 @@ describe("issue #1655: values substituted into author-quoted front matter scalar
 			"---\nTitle: {{VALUE:fileName}}\n---\nBody",
 		);
 		expect(result).toBe('---\nTitle: My "Great" Note\n---\nBody');
+	});
+
+	it("escapes the anonymous {{VALUE}} inside a double-quoted scalar", async () => {
+		formatter.anonymousValue = 'he said "hi"';
+		const result = await formatter.testFormat(
+			'---\ntitle: "{{VALUE}}"\n---\nBody',
+		);
+		expect(result).toBe('---\ntitle: "he said \\"hi\\""\n---\nBody');
+	});
+
+	it("escapes a joined multi-select FIELD fallback inside a quoted scalar", async () => {
+		formatter.seed(`${FIELD_VARIABLE_PREFIX}tags|multi`, ['say "hi"', "b"]);
+		const result = await formatter.testFormat(
+			'---\ntags: "{{FIELD:tags|multi}}"\n---\nBody',
+		);
+		expect(result).toBe('---\ntags: "say \\"hi\\",b"\n---\nBody');
 	});
 
 	it("consumes author quotes when an explicit |type:number is declared", async () => {

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -42,7 +42,11 @@ import { settingsStore } from "../settingsStore";
 import { normalizeDateInput } from "../utils/dateAliases";
 import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
-import { quoteYamlDouble, shouldQuoteTextScalar } from "../utils/yamlScalarQuoting";
+import {
+	escapeValueInsideQuotedYamlScalar,
+	quoteYamlDouble,
+	shouldQuoteTextScalar,
+} from "../utils/yamlScalarQuoting";
 import { toWikiLink } from "../utils/linkWrap";
 import { FieldSuggestionParser } from "../utils/FieldSuggestionParser";
 import {
@@ -1294,7 +1298,14 @@ export abstract class Formatter {
 						match.index,
 						match.index + match[0].length,
 					);
-				replacement = quote ? quoteYamlDouble(stringVal) : stringVal;
+				replacement = quote
+					? quoteYamlDouble(stringVal)
+					: escapeValueInsideQuotedYamlScalar(
+							output,
+							match.index,
+							match.index + match[0].length,
+							stringVal,
+						);
 			}
 
 			// Replace in output and adjust regex position
@@ -1357,7 +1368,12 @@ export abstract class Formatter {
 					replacement =
 						getYamlPlaceholder(structuredYamlValue) ?? rawValue.join(",");
 				} else {
-					replacement = String(rawValue ?? "");
+					replacement = escapeValueInsideQuotedYamlScalar(
+						input,
+						match.index,
+						match.index + match[0].length,
+						String(rawValue ?? ""),
+					);
 				}
 
 				output += replacement;

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -44,9 +44,20 @@ import { transformCase } from "../utils/caseTransform";
 import { getYamlPlaceholder } from "../utils/yamlValues";
 import {
 	escapeValueInsideQuotedYamlScalar,
+	isTokenExactlyQuotedYamlScalar,
 	quoteYamlDouble,
 	shouldQuoteTextScalar,
 } from "../utils/yamlScalarQuoting";
+
+// |type: overrides whose value is a typed YAML scalar (Number, Boolean): an
+// author-quoted token with one of these consumes the quotes so Obsidian reads
+// the typed value. "text" and "multiline" declare string semantics and keep
+// their quotes.
+const TYPED_SCALAR_OVERRIDES: ReadonlySet<string> = new Set([
+	"number",
+	"slider",
+	"checkbox",
+]);
 import { toWikiLink } from "../utils/linkWrap";
 import { FieldSuggestionParser } from "../utils/FieldSuggestionParser";
 import {
@@ -1278,6 +1289,7 @@ export abstract class Formatter {
 			// fallback replacement to a string so non-string variable values (e.g.
 			// arrays from scripts on the non-collected path) don't desync the scanner.
 			let replacement: string;
+			let consumeQuotes = false;
 			if (structuredReplacement !== undefined) {
 				replacement = structuredReplacement;
 			} else {
@@ -1298,19 +1310,40 @@ export abstract class Formatter {
 						match.index,
 						match.index + match[0].length,
 					);
-				replacement = quote
-					? quoteYamlDouble(stringVal)
-					: escapeValueInsideQuotedYamlScalar(
-							output,
-							match.index,
-							match.index + match[0].length,
-							stringVal,
-						);
+				if (quote) {
+					replacement = quoteYamlDouble(stringVal);
+				} else if (
+					TYPED_SCALAR_OVERRIDES.has(parsed.inputTypeOverride ?? "") &&
+					isTokenExactlyQuotedYamlScalar(
+						output,
+						match.index,
+						match.index + match[0].length,
+					)
+				) {
+					// An explicit typed |type: wins over the author's quotes: the
+					// quotes exist to keep the raw template valid YAML (#1655), while
+					// the |type: declares the intended property type. Consume the
+					// quotes so `rating: "{{VALUE:r|type:number}}"` writes `rating: 42`
+					// and Obsidian reads a Number. |type:text and |type:multiline keep
+					// string semantics, so their quotes stay (with escaping).
+					consumeQuotes = true;
+					replacement = stringVal;
+				} else {
+					replacement = escapeValueInsideQuotedYamlScalar(
+						output,
+						match.index,
+						match.index + match[0].length,
+						stringVal,
+					);
+				}
 			}
 
 			// Replace in output and adjust regex position
-			output = output.slice(0, match.index) + replacement + output.slice(match.index + match[0].length);
-			regex.lastIndex = match.index + replacement.length;
+			const replaceStart = consumeQuotes ? match.index - 1 : match.index;
+			const replaceEnd =
+				match.index + match[0].length + (consumeQuotes ? 1 : 0);
+			output = output.slice(0, replaceStart) + replacement + output.slice(replaceEnd);
+			regex.lastIndex = replaceStart + replacement.length;
 		}
 
 		return output;

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -533,7 +533,14 @@ export abstract class Formatter {
 			const source = args[args.length - 1] as string;
 			const inner = token.slice(2, -2);
 			const optionsIndex = inner.indexOf("|");
-			if (optionsIndex === -1) return this.value;
+			if (optionsIndex === -1) {
+				return escapeValueInsideQuotedYamlScalar(
+					source,
+					offset,
+					offset + token.length,
+					this.value,
+				);
+			}
 			const rawOptions = inner.slice(optionsIndex);
 			const parsed = parseAnonymousValueOptions(rawOptions, {
 				warn: this.warnSink,
@@ -556,7 +563,14 @@ export abstract class Formatter {
 			) {
 				return quoteYamlDouble(transformed);
 			}
-			return transformed;
+			// Same contract as the named form: a value substituted inside an
+			// author-quoted front matter scalar must be escaped for those quotes.
+			return escapeValueInsideQuotedYamlScalar(
+				source,
+				offset,
+				offset + token.length,
+				transformed,
+			);
 		});
 
 		return output;
@@ -997,7 +1011,14 @@ export abstract class Formatter {
 		});
 		const placeholder = getYamlPlaceholder(structuredYamlValue);
 		if (placeholder !== undefined) return placeholder;
-		if (Array.isArray(args.rawValue)) return args.rawValue.join(",");
+		if (Array.isArray(args.rawValue)) {
+			return escapeValueInsideQuotedYamlScalar(
+				args.input,
+				args.matchStart,
+				args.matchEnd,
+				args.rawValue.join(","),
+			);
+		}
 		return undefined;
 	}
 
@@ -1399,7 +1420,13 @@ export abstract class Formatter {
 						heuristicEnabled: false,
 					});
 					replacement =
-						getYamlPlaceholder(structuredYamlValue) ?? rawValue.join(",");
+						getYamlPlaceholder(structuredYamlValue) ??
+						escapeValueInsideQuotedYamlScalar(
+							input,
+							match.index,
+							match.index + match[0].length,
+							rawValue.join(","),
+						);
 				} else {
 					replacement = escapeValueInsideQuotedYamlScalar(
 						input,
@@ -1468,7 +1495,14 @@ export abstract class Formatter {
 					collectionActive: this.templatePropertyCollectionDepth > 0,
 					heuristicEnabled: false,
 				});
-				output += getYamlPlaceholder(structuredYamlValue) ?? renderedValue.join(",");
+				output +=
+					getYamlPlaceholder(structuredYamlValue) ??
+					escapeValueInsideQuotedYamlScalar(
+						input,
+						match.index,
+						match.index + match[0].length,
+						renderedValue.join(","),
+					);
 			} else {
 				output += renderedValue;
 			}

--- a/src/utils/yamlScalarQuoting.test.ts
+++ b/src/utils/yamlScalarQuoting.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { quoteYamlDouble, shouldQuoteTextScalar } from "./yamlScalarQuoting";
+import {
+	escapeValueInsideQuotedYamlScalar,
+	quoteYamlDouble,
+	shouldQuoteTextScalar,
+} from "./yamlScalarQuoting";
 
 const TOKEN = "{{VALUE:x}}";
 
@@ -53,5 +57,50 @@ describe("shouldQuoteTextScalar", () => {
 	it("does NOT quote in the note body (outside front matter)", () => {
 		expect(check(`---\ntitle: x\n---\nSome ${TOKEN} prose`)).toBe(false);
 		expect(check(`No front matter here ${TOKEN}`)).toBe(false);
+	});
+});
+
+describe("escapeValueInsideQuotedYamlScalar", () => {
+	/** Helper: locate the token and escape `value` for that position. */
+	function escape(input: string, value: string): string {
+		const start = input.indexOf(TOKEN);
+		return escapeValueInsideQuotedYamlScalar(
+			input,
+			start,
+			start + TOKEN.length,
+			value,
+		);
+	}
+
+	it("escapes double quotes, backslashes, and control chars inside a double-quoted scalar", () => {
+		const input = `---\ntitle: "${TOKEN}"\n---\nbody`;
+		expect(escape(input, 'My "Great" Note')).toBe('My \\"Great\\" Note');
+		expect(escape(input, "a\\b")).toBe("a\\\\b");
+		expect(escape(input, "a\nb")).toBe("a\\nb");
+	});
+
+	it("doubles apostrophes inside a single-quoted scalar", () => {
+		const input = `---\ntitle: '${TOKEN}'\n---\nbody`;
+		expect(escape(input, "O'Brien")).toBe("O''Brien");
+	});
+
+	it("escapes inside a quoted list item", () => {
+		const input = `---\ntags:\n  - "${TOKEN}"\n---\nbody`;
+		expect(escape(input, 'say "hi"')).toBe('say \\"hi\\"');
+	});
+
+	it("passes through untouched when the token is not quoted", () => {
+		const input = `---\ntitle: ${TOKEN}\n---\nbody`;
+		expect(escape(input, 'My "Great" Note')).toBe('My "Great" Note');
+	});
+
+	it("passes through untouched when quotes wrap more than the token", () => {
+		const input = `---\ntitle: "prefix ${TOKEN}"\n---\nbody`;
+		expect(escape(input, 'a "b"')).toBe('a "b"');
+	});
+
+	it("passes through untouched in the note body", () => {
+		const input = `---\ntitle: x\n---\nSaid "${TOKEN}" today`;
+		expect(escape(input, 'a "b"')).toBe('a "b"');
 	});
 });

--- a/src/utils/yamlScalarQuoting.test.ts
+++ b/src/utils/yamlScalarQuoting.test.ts
@@ -28,6 +28,14 @@ describe("quoteYamlDouble", () => {
 		expect(quoteYamlDouble("a\nb")).toBe('"a\\nb"');
 		expect(quoteYamlDouble("a\tb")).toBe('"a\\tb"');
 	});
+
+	it("escapes the remaining C0/DEL control characters as \\xNN", () => {
+		expect(quoteYamlDouble("a\x00b")).toBe('"a\\x00b"');
+		expect(quoteYamlDouble("a\bb")).toBe('"a\\x08b"');
+		expect(quoteYamlDouble("a\fb")).toBe('"a\\x0cb"');
+		expect(quoteYamlDouble("a\x1bb")).toBe('"a\\x1bb"');
+		expect(quoteYamlDouble("a\x7fb")).toBe('"a\\x7fb"');
+	});
 });
 
 describe("shouldQuoteTextScalar", () => {
@@ -77,6 +85,8 @@ describe("escapeValueInsideQuotedYamlScalar", () => {
 		expect(escape(input, 'My "Great" Note')).toBe('My \\"Great\\" Note');
 		expect(escape(input, "a\\b")).toBe("a\\\\b");
 		expect(escape(input, "a\nb")).toBe("a\\nb");
+		expect(escape(input, "a\x00b")).toBe("a\\x00b");
+		expect(escape(input, "a\x1bb")).toBe("a\\x1bb");
 	});
 
 	it("doubles apostrophes inside a single-quoted scalar", () => {

--- a/src/utils/yamlScalarQuoting.ts
+++ b/src/utils/yamlScalarQuoting.ts
@@ -37,6 +37,42 @@ export function quoteYamlDouble(value: string): string {
  * that silently retype or break an unquoted string; a single static predicate
  * for "safe plain scalar" is error-prone, while quoting is always correct.
  */
+/**
+ * Escape a value that is being substituted INSIDE an author-quoted front matter
+ * scalar (`key: "{{VALUE:x}}"` / `- '{{FIELD:y}}'`). Authors quote tokens so the
+ * raw template stays valid YAML (Obsidian's parser warns on bare `{{...}}`,
+ * issue #1655); without escaping, a value containing the surrounding quote
+ * character corrupts the created note's front matter. Applies only when the
+ * token exactly spans the quoted scalar at a sole-value position - everywhere
+ * else the value passes through untouched.
+ */
+export function escapeValueInsideQuotedYamlScalar(
+	input: string,
+	matchStart: number,
+	matchEnd: number,
+	value: string,
+): string {
+	const ctx = getYamlContextForMatch(
+		input,
+		matchStart,
+		matchEnd,
+		findYamlFrontMatterRange(input),
+	);
+	if (!ctx.isInYaml || !ctx.isQuoted) return value;
+	if (!ctx.isKeyValuePosition && !ctx.isListItemPosition) return value;
+
+	if (input[matchStart - 1] === '"') {
+		return value
+			.replace(/\\/g, "\\\\")
+			.replace(/"/g, '\\"')
+			.replace(/\n/g, "\\n")
+			.replace(/\r/g, "\\r")
+			.replace(/\t/g, "\\t");
+	}
+	// Single-quoted YAML has exactly one escape: '' for a literal apostrophe.
+	return value.replace(/'/g, "''");
+}
+
 export function shouldQuoteTextScalar(
 	input: string,
 	matchStart: number,

--- a/src/utils/yamlScalarQuoting.ts
+++ b/src/utils/yamlScalarQuoting.ts
@@ -10,42 +10,40 @@ import { findYamlFrontMatterRange, getYamlContextForMatch } from "./yamlContext"
  * double-quoted scalar guarantees it stays the exact string the user entered.
  */
 
+// C0 control characters and DEL, matched via a runtime-built class so the
+// source file contains no raw control bytes (they make ripgrep treat the file
+// as binary). \n, \r, and \t are escaped before this runs.
+const CONTROL_CHAR_REGEX = new RegExp(
+	`[${String.fromCharCode(0)}-${String.fromCharCode(31)}${String.fromCharCode(127)}]`,
+	"g",
+);
+
 /**
- * Wrap a value in a YAML double-quoted scalar, escaping `\`, `"`, and control
- * characters. VALUE tokens typed in the UI are single-line, but a value can be
- * seeded programmatically (script/CLI), so newlines/tabs are escaped to keep
- * the emitted scalar valid YAML.
+ * Escape a string for the inside of a YAML double-quoted scalar: `\`, `"`, and
+ * every C0/DEL control character. VALUE tokens typed in the UI are single-line,
+ * but a value can be seeded programmatically (script/CLI), so the full control
+ * range is escaped to keep the emitted scalar valid YAML.
  */
-export function quoteYamlDouble(value: string): string {
-	const escaped = value
+function escapeYamlDoubleQuotedContent(value: string): string {
+	return value
 		.replace(/\\/g, "\\\\")
 		.replace(/"/g, '\\"')
 		.replace(/\n/g, "\\n")
 		.replace(/\r/g, "\\r")
-		.replace(/\t/g, "\\t");
-	return `"${escaped}"`;
+		.replace(/\t/g, "\\t")
+		.replace(CONTROL_CHAR_REGEX, (c) =>
+			`\\x${c.charCodeAt(0).toString(16).padStart(2, "0")}`,
+		);
 }
 
 /**
- * Whether a `|type:text` VALUE at [matchStart, matchEnd) should be written as a
- * quoted YAML scalar. True only when the token is the SOLE value at a front
- * matter key:value or list-item position and the author has not already quoted
- * it — so quoting never corrupts body prose or a partially quoted value.
- *
- * We quote unconditionally at that position (not only for coercion-prone values)
- * because YAML has many indicator characters (`#`, `[`, `{`, `*`, `&`, `!`, …)
- * that silently retype or break an unquoted string; a single static predicate
- * for "safe plain scalar" is error-prone, while quoting is always correct.
+ * Wrap a value in a YAML double-quoted scalar, escaping `\`, `"`, and control
+ * characters.
  */
-/**
- * Escape a value that is being substituted INSIDE an author-quoted front matter
- * scalar (`key: "{{VALUE:x}}"` / `- '{{FIELD:y}}'`). Authors quote tokens so the
- * raw template stays valid YAML (Obsidian's parser warns on bare `{{...}}`,
- * issue #1655); without escaping, a value containing the surrounding quote
- * character corrupts the created note's front matter. Applies only when the
- * token exactly spans the quoted scalar at a sole-value position - everywhere
- * else the value passes through untouched.
- */
+export function quoteYamlDouble(value: string): string {
+	return `"${escapeYamlDoubleQuotedContent(value)}"`;
+}
+
 /**
  * Whether the token at [matchStart, matchEnd) exactly spans an author-quoted
  * sole-value front matter scalar (`key: "{{TOKEN}}"` / `- '{{TOKEN}}'`).
@@ -65,6 +63,15 @@ export function isTokenExactlyQuotedYamlScalar(
 	return ctx.isKeyValuePosition || ctx.isListItemPosition;
 }
 
+/**
+ * Escape a value that is being substituted INSIDE an author-quoted front matter
+ * scalar (`key: "{{VALUE:x}}"` / `- '{{FIELD:y}}'`). Authors quote tokens so the
+ * raw template stays valid YAML (Obsidian's parser warns on bare `{{...}}`,
+ * issue #1655); without escaping, a value containing the surrounding quote
+ * character corrupts the created note's front matter. Applies only when the
+ * token exactly spans the quoted scalar at a sole-value position - everywhere
+ * else the value passes through untouched.
+ */
 export function escapeValueInsideQuotedYamlScalar(
 	input: string,
 	matchStart: number,
@@ -76,17 +83,23 @@ export function escapeValueInsideQuotedYamlScalar(
 	}
 
 	if (input[matchStart - 1] === '"') {
-		return value
-			.replace(/\\/g, "\\\\")
-			.replace(/"/g, '\\"')
-			.replace(/\n/g, "\\n")
-			.replace(/\r/g, "\\r")
-			.replace(/\t/g, "\\t");
+		return escapeYamlDoubleQuotedContent(value);
 	}
 	// Single-quoted YAML has exactly one escape: '' for a literal apostrophe.
 	return value.replace(/'/g, "''");
 }
 
+/**
+ * Whether a `|type:text` VALUE at [matchStart, matchEnd) should be written as a
+ * quoted YAML scalar. True only when the token is the SOLE value at a front
+ * matter key:value or list-item position and the author has not already quoted
+ * it - so quoting never corrupts body prose or a partially quoted value.
+ *
+ * We quote unconditionally at that position (not only for coercion-prone values)
+ * because YAML has many indicator characters (`#`, `[`, `{`, `*`, `&`, `!`, ...)
+ * that silently retype or break an unquoted string; a single static predicate
+ * for "safe plain scalar" is error-prone, while quoting is always correct.
+ */
 export function shouldQuoteTextScalar(
 	input: string,
 	matchStart: number,

--- a/src/utils/yamlScalarQuoting.ts
+++ b/src/utils/yamlScalarQuoting.ts
@@ -46,20 +46,34 @@ export function quoteYamlDouble(value: string): string {
  * token exactly spans the quoted scalar at a sole-value position - everywhere
  * else the value passes through untouched.
  */
-export function escapeValueInsideQuotedYamlScalar(
+/**
+ * Whether the token at [matchStart, matchEnd) exactly spans an author-quoted
+ * sole-value front matter scalar (`key: "{{TOKEN}}"` / `- '{{TOKEN}}'`).
+ */
+export function isTokenExactlyQuotedYamlScalar(
 	input: string,
 	matchStart: number,
 	matchEnd: number,
-	value: string,
-): string {
+): boolean {
 	const ctx = getYamlContextForMatch(
 		input,
 		matchStart,
 		matchEnd,
 		findYamlFrontMatterRange(input),
 	);
-	if (!ctx.isInYaml || !ctx.isQuoted) return value;
-	if (!ctx.isKeyValuePosition && !ctx.isListItemPosition) return value;
+	if (!ctx.isInYaml || !ctx.isQuoted) return false;
+	return ctx.isKeyValuePosition || ctx.isListItemPosition;
+}
+
+export function escapeValueInsideQuotedYamlScalar(
+	input: string,
+	matchStart: number,
+	matchEnd: number,
+	value: string,
+): string {
+	if (!isTokenExactlyQuotedYamlScalar(input, matchStart, matchEnd)) {
+		return value;
+	}
 
 	if (input[matchStart - 1] === '"') {
 		return value


### PR DESCRIPTION
Investigating #1655: the console warning comes from Obsidian's own YAML parser reading the raw template file - `Title: {{VALUE:fileName}}` is not valid YAML, so Obsidian complains when it indexes the template. QuickAdd can't suppress that, and the community-suggested workaround (wrap the token in quotes) is the right call. This PR makes the quoted form fully safe and useful:

**1. Escaping (`cf9cb3e5`).** QuickAdd substituted the answer verbatim inside the author's quotes, so a value containing the quote character corrupted the created note's frontmatter - `Title: "{{VALUE:fileName}}"` answered with `My "Great" Note` wrote `Title: "My "Great" Note"`, which Obsidian cannot parse (the note loses all its properties). VALUE and FIELD substitutions are now escaped when the token exactly spans an author-quoted sole-value scalar: double-quoted scalars get the `|type:text` escaping rules (`\` `"` and control characters), single-quoted scalars get YAML's `''`. Everywhere else (unquoted scalars, partial values like `"prefix {{VALUE:x}}"`, note bodies) the value passes through byte-identical.

**2. Explicit `|type:` consumes the quotes (`b354c8a1`).** A quoted token normally writes a string - and stays that way, so released setups like `id: "{{VALUE:id}}"` keeping `0042` intact are untouched. But when the token declares `|type:number`, `|type:slider`, or `|type:checkbox`, the declared type wins: the author's quotes are consumed and `rating: "{{VALUE:r|type:number}}"` writes `rating: 42`, which Obsidian reads as a Number. So a template can be both warning-free (quoted) and correctly typed. `|type:text` and `|type:multiline` declare string semantics and keep their quotes (with escaping).

Verified live in Obsidian 1.13.4 (escaping): a template with `Title: "{{VALUE:fileName}}"` / `author: '{{VALUE:who}}'` answered with `My "Great" Note` / `O'Brien` creates `Title: "My \"Great\" Note"` / `author: 'O''Brien'`, and Obsidian reads both properties back as the exact strings. On master the same run produces unparseable frontmatter.

Also adds a docs section to the Template choice page explaining the warning, the quoting recipe, and the `|type:` interaction.

`pnpm test` (4872 tests incl. unit + formatter regression coverage for both behaviors), `pnpm build-with-lint` pass.

Refs #1655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template token substitutions within quoted YAML frontmatter values.
  * Correctly escaped quotes, backslashes, and control characters according to the surrounding quote style.
  * Preserved typed behavior for number, checkbox, and slider properties.
  * Preserved expected behavior for unquoted values, partial substitutions, array values, and note body content.

* **Documentation**
  * Added guidance for using tokens in template frontmatter, including quoting, escaping, and supported property types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->