### PR TITLE
docs: resolve 2.21.0 release callouts

### DIFF
--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -156,7 +156,7 @@ carries `error` instead and no `effect`, because there is no outcome to describe
 The `obsidian://quickadd` [x-callback](/docs/Advanced/TriggerQuickAddFromOutsideObsidian/)
 success callback carries the same `effect` value.
 
-:::note[Introduced in QuickAdd 2.21.0]
+:::note[Introduced in QuickAdd 2.20.0]
 `capabilities` in the `quickadd:interactive` handshake contains
 `outcome-effect` on a build that has `effect`.
 :::
@@ -188,8 +188,8 @@ picker - are forwarded like any other. (The AI assistant's tool-confirmation dia
 the one that is not: run such a choice at the desktop, or set tool confirmation to
 "never".)
 
-:::note[Introduced in QuickAdd 2.21.0]
-Before 2.21.0, a Template or Capture run opened its own pickers in Obsidian and
+:::note[Introduced in QuickAdd 2.20.0]
+Before 2.20.0, a Template or Capture run opened its own pickers in Obsidian and
 `/abort` could not reach them.
 ::: They arrive as `suggester` prompts, and because the engine controls the
 list, a reply that is not one of the offered `value` tokens is refused rather than
@@ -229,7 +229,7 @@ the run may still finish and commit its side effects. Keep polling for the termi
 event either way.
 :::
 
-:::note[Introduced in QuickAdd 2.21.0]
+:::note[Introduced in QuickAdd 2.20.0]
 `"capabilities":["abort"]` in the handshake tells you a build has `POST /abort`
 and the `info` behaviour above. Before them, cancelling an `info` prompt
 ended the run, and there was no explicit way to end one other than to stop polling
@@ -238,8 +238,8 @@ and wait out the ~75s disconnect watchdog.
 
 ### When a reply is rejected
 
-:::note[Changed in QuickAdd 2.21.0]
-Before 2.21.0, a `cancelled` flag that was not the
+:::note[Changed in QuickAdd 2.20.0]
+Before 2.20.0, a `cancelled` flag that was not the
 literal `true` was consumed as a cancellation, and a `confirm` prompt with no value was read as
 "No".
 :::

--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -156,9 +156,9 @@ carries `error` instead and no `effect`, because there is no outcome to describe
 The `obsidian://quickadd` [x-callback](/docs/Advanced/TriggerQuickAddFromOutsideObsidian/)
 success callback carries the same `effect` value.
 
-:::note[Available in the next release]
-`effect` is new. `capabilities` in the `quickadd:interactive` handshake contains
-`outcome-effect` on a build that has it.
+:::note[Introduced in QuickAdd 2.21.0]
+`capabilities` in the `quickadd:interactive` handshake contains
+`outcome-effect` on a build that has `effect`.
 :::
 
 ## Answer run-time prompts from outside: `quickadd:interactive` {#interactive-runs-quickaddinteractive}
@@ -188,9 +188,9 @@ picker - are forwarded like any other. (The AI assistant's tool-confirmation dia
 the one that is not: run such a choice at the desktop, or set tool confirmation to
 "never".)
 
-:::note[Available in the next release]
-Forwarding the run's own pickers is new. Before it, a Template or Capture run opened
-them in Obsidian and `/abort` could not reach them.
+:::note[Introduced in QuickAdd 2.21.0]
+Before 2.21.0, a Template or Capture run opened its own pickers in Obsidian and
+`/abort` could not reach them.
 ::: They arrive as `suggester` prompts, and because the engine controls the
 list, a reply that is not one of the offered `value` tokens is refused rather than
 acted on (unless the prompt sets `allowCustomInput`, as the folder and discovery
@@ -229,17 +229,17 @@ the run may still finish and commit its side effects. Keep polling for the termi
 event either way.
 :::
 
-:::note[Available in the next release]
-`POST /abort` and the `info` behaviour above are new; `"capabilities":["abort"]` in
-the handshake tells you a build has them. Before them, cancelling an `info` prompt
+:::note[Introduced in QuickAdd 2.21.0]
+`"capabilities":["abort"]` in the handshake tells you a build has `POST /abort`
+and the `info` behaviour above. Before them, cancelling an `info` prompt
 ended the run, and there was no explicit way to end one other than to stop polling
 and wait out the ~75s disconnect watchdog.
 :::
 
 ### When a reply is rejected
 
-:::note[Available in the next release]
-The `400`-and-retry semantics below are new. Before them, a `cancelled` flag that was not the
+:::note[Changed in QuickAdd 2.21.0]
+Before 2.21.0, a `cancelled` flag that was not the
 literal `true` was consumed as a cancellation, and a `confirm` prompt with no value was read as
 "No".
 :::

--- a/docs/src/content/docs/docs/Advanced/onePageInputs.md
+++ b/docs/src/content/docs/docs/Advanced/onePageInputs.md
@@ -54,15 +54,12 @@ QuickAdd scans the choice for placeholders and turns each one into a field:
 
 ### How FILE inputs behave {#file-ux}
 
-:::note[Available in the next release]
-The inline searchable FILE picker described below is on `master` and will ship
-in the next QuickAdd release.
-:::
-
 - `{{FILE:folder}}` appears as a searchable picker in the form. Search matches the friendly note title, file name, and full vault path.
 - The selected file is shown above the search field and can be removed or replaced. Single-select fields keep the same first-file default as the previous dropdown.
 - `{{FILE:folder|multi}}` stays in the same form. Pick several files without opening a second modal, and remove the last pick by pressing Backspace in an empty search field.
 - Multi-select results keep the folder's file order. File names and friendly labels containing commas are handled as complete values.
+
+_Inline FILE pickers introduced in QuickAdd 2.21.0._
 
 ## Fields you can leave empty {#optional-fields}
 

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -803,12 +803,6 @@ FIELD filtering is in beta and the syntax can change - leave your thoughts
 
 ### Pick a note from a folder: `{{FILE:<folder>}}` {#file}
 
-:::note[Available in the next release]
-When one-page inputs are enabled, FILE placeholders use the inline searchable
-picker described below. This improvement is on `master` and will ship in the
-next QuickAdd release.
-:::
-
 `{{FILE:People}}` opens a picker listing the Markdown files in your `People`
 folder and inserts your pick. Where [`{{FIELD}}`](#field) suggests the
 *values* of a property, `{{FILE}}` suggests the notes themselves - made for

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -949,8 +949,8 @@ module.exports = async (params) => {
 
 ## Error Handling Best Practices
 
-:::note[Available in the next release]
-Until then, a prompt that failed for a reason other than the user cancelling resolved
+:::note[Changed in QuickAdd 2.21.0]
+Before 2.21.0, a prompt that failed for a reason other than the user cancelling resolved
 `undefined` instead of rejecting, so a script could not tell a failure from an empty answer.
 :::
 

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -949,8 +949,8 @@ module.exports = async (params) => {
 
 ## Error Handling Best Practices
 
-:::note[Changed in QuickAdd 2.21.0]
-Before 2.21.0, a prompt that failed for a reason other than the user cancelling resolved
+:::note[Changed in QuickAdd 2.20.0]
+Before 2.20.0, a prompt that failed for a reason other than the user cancelling resolved
 `undefined` instead of rejecting, so a script could not tell a failure from an empty answer.
 :::
 


### PR DESCRIPTION
2.21.0 shipped on 2026-08-01, but seven ":::note[Available in the next release]" callouts were still live on master - and since the docs site deploys from master, they were telling users that already-released features (one-page FILE pickers, the CLI interactive/abort protocol, the prompt rejection contract) are not out yet.

- The two callouts that only announced the release window (FormatSyntax FILE picker, one-page inputs) are removed; the one-page FILE picker section gets an "_Introduced in QuickAdd 2.21.0._" marker instead.
- The four CLI protocol notes and the QuickAddAPI error-contract note carry real capability-detection / before-after context for integrators, so they stay - retitled to "Introduced/Changed in QuickAdd 2.21.0" with tenses fixed.

Follow-up from the 2.21.0 release: the prior sessions prepared similar cleanup commits for the InlineScripts and checkboxPrompt callouts, but those turned out to already be resolved in the merged PRs' final states - these seven were the ones actually left behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CLI documentation to identify features introduced in QuickAdd 2.21.0, including outcome effects, picker forwarding, abort support, and stricter reply validation.
  - Clarified that inline FILE pickers are available in QuickAdd 2.21.0.
  - Updated API documentation to reflect revised prompt failure handling in version 2.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->