### PR TITLE
docs: resolve 2.22.0 release callouts

### DIFF
--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -60,12 +60,12 @@ Two things to know about the quoted form:
 
 - QuickAdd escapes the filled-in value for the surrounding quotes, so answers
   containing `"` or `'` can't break the created note's frontmatter.
-  _Available in the next release._
+  _Introduced in QuickAdd 2.22.0._
 - Quotes normally make the property a **string**. For a typed property, declare
   the type on the token and the quotes are consumed:
   `rating: "{{VALUE:rating|type:number}}"` writes `rating: 42`, which Obsidian
   reads as a Number (same for `|type:checkbox` and `|type:slider`).
-  _Available in the next release._
+  _Introduced in QuickAdd 2.22.0._
 
 ## Run a template without making a choice {#run-without-choice}
 

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -367,7 +367,7 @@ Variants and combinations:
 - `|multi|custom` adds a text box to the picker for values not in the list.
 - Combines with `|name:`, `|label:`, `|text:`, `|optional`, and `|trim`. `|case:` is ignored (a list isn't case-transformed).
 
-:::note[Available in the next release]
+:::note[Introduced in QuickAdd 2.22.0]
 Add `|format:` when the output shape should be intentional instead of inferred
 from where the placeholder appears:
 
@@ -739,7 +739,7 @@ positions it writes comma-separated text. Combines with the same filters and
 defaults as single-value FIELD prompts:
 `{{FIELD:topic|multi|folder:Projects|tag:active|default:Inbox}}`.
 
-:::note[Available in the next release]
+:::note[Introduced in QuickAdd 2.22.0]
 FIELD multi-selects support the same explicit output formats as VALUE:
 `|format:yaml`, `|format:markdown`, `|format:inline`, and `|format:auto`.
 For example, `topics: {{FIELD:topic|multi|format:yaml}}` always writes a native
@@ -883,7 +883,7 @@ Good to know:
 - `|link` and `|path` insert characters that aren't valid in file names; in the **file name** field, use the default mode.
 - In a one-page input form, single and multi FILE pickers appear inline. Search matches the friendly title, file name, and full path. Selected files remain exact path-backed values internally, so commas in file names or labels are safe.
 
-:::note[Available in the next release]
+:::note[Introduced in QuickAdd 2.22.0]
 FILE multi-selects support `|format:yaml`, `|format:markdown`,
 `|format:inline`, and `|format:auto`. The format composes with `|link` and
 `|path`, so `{{FILE:People|multi|link|format:yaml}}` writes a native YAML list


### PR DESCRIPTION
2.22.0 shipped, so the "Available in the next release" callouts for the explicit multi-select formats (FormatSyntax x3) and the quoted-token escaping / |type: notes (TemplateChoice x2) now read "Introduced in QuickAdd 2.22.0". Same post-release chore as #1660.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to indicate that quoted tokens and typed properties were introduced in QuickAdd 2.22.0.
  * Updated multi-select formatting examples for VALUE, FIELD, and FILE to reflect their introduction in QuickAdd 2.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->