### PR TITLE
chore(e2e): retire lost-reply workarounds obsolete since obsidian-e2e 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"jsdom": "30",
 		"moment": "2.30.1",
 		"obsidian": "1.13.1",
-		"obsidian-e2e": "^0.9.0",
+		"obsidian-e2e": "^0.10.0",
 		"svelte": "^5",
 		"svelte-check": "^4",
 		"svelte-eslint-parser": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@codemirror/language@git+https://git@github.com:lishid/cm-language.git#b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
-    resolution: {commit: b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3, repo: git@github.com:lishid/cm-language.git, type: git}
+  '@codemirror/language@https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
+    resolution: {tarball: https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3}
     version: 6.12.3
 
   '@codemirror/state@6.5.0':
@@ -1755,8 +1755,8 @@ packages:
       '@codemirror/state': 6.5.0
       '@codemirror/view': 6.38.6
 
-  obsidian@git+https://git@github.com:obsidianmd/obsidian-api.git#cc1744324150c632416857c98964f87b1574a5fc:
-    resolution: {commit: cc1744324150c632416857c98964f87b1574a5fc, repo: git@github.com:obsidianmd/obsidian-api.git, type: git}
+  obsidian@https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc:
+    resolution: {tarball: https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc}
     version: 1.13.2
     peerDependencies:
       '@codemirror/state': 6.7.0
@@ -2359,7 +2359,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@codemirror/language@git+https://git@github.com:lishid/cm-language.git#b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
+  '@codemirror/language@https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
     dependencies:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
@@ -3594,7 +3594,7 @@ snapshots:
 
   obsidian-daily-notes-interface@0.8.4(@codemirror/state@6.6.0)(@codemirror/view@6.43.1):
     dependencies:
-      obsidian: git+https://git@github.com:obsidianmd/obsidian-api.git#cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
+      obsidian: https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
       tslib: 2.1.0
     transitivePeerDependencies:
       - '@codemirror/state'
@@ -3602,7 +3602,7 @@ snapshots:
 
   obsidian-dataview@0.5.68(@typescript-eslint/types@8.66.0):
     dependencies:
-      '@codemirror/language': git+https://git@github.com:lishid/cm-language.git#b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3
+      '@codemirror/language': https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
       emoji-regex: 10.6.0
@@ -3630,7 +3630,7 @@ snapshots:
       '@types/codemirror': 5.60.8
       moment: 2.29.4
 
-  obsidian@git+https://git@github.com:obsidianmd/obsidian-api.git#cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1):
+  obsidian@https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1):
     dependencies:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: 1.13.1
         version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
       obsidian-e2e:
-        specifier: ^0.9.0
-        version: 0.9.0(vite-plus@0.1.24(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@30.0.1)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.10)
+        specifier: ^0.10.0
+        version: 0.10.0(vite-plus@0.1.24(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@30.0.1)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.10)
       svelte:
         specifier: ^5
         version: 5.56.8(@typescript-eslint/types@8.66.0)
@@ -160,8 +160,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@codemirror/language@https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
-    resolution: {tarball: https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3}
+  '@codemirror/language@git+https://git@github.com:lishid/cm-language.git#b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
+    resolution: {commit: b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3, repo: git@github.com:lishid/cm-language.git, type: git}
     version: 6.12.3
 
   '@codemirror/state@6.5.0':
@@ -1738,8 +1738,8 @@ packages:
   obsidian-dataview@0.5.68:
     resolution: {integrity: sha512-eoYVxqgeAUM64fV6/YXWuXvmm9DaVoR1h/O+vBIHS0yQ+n9x5MaVndD3WjcVWuaJmrMM9iwvutkbZ0aCWpLmHw==}
 
-  obsidian-e2e@0.9.0:
-    resolution: {integrity: sha512-eolHF8eiwidRmT8JK+KLzv2o28ckKLUvBhwfiz5rfxx5mmbGqaJyNnne8uQ5YaURowX9u7T7Jga1Q6jihUv2eQ==}
+  obsidian-e2e@0.10.0:
+    resolution: {integrity: sha512-MEMljU5IqVSVq3QKKUBpSj1a+AIkhi9TQoJjWBQof18FDadixc4XrPTFVaBJ54R1zsi1NV4c86w//NmG5OeWfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1755,8 +1755,8 @@ packages:
       '@codemirror/state': 6.5.0
       '@codemirror/view': 6.38.6
 
-  obsidian@https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc:
-    resolution: {tarball: https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc}
+  obsidian@git+https://git@github.com:obsidianmd/obsidian-api.git#cc1744324150c632416857c98964f87b1574a5fc:
+    resolution: {commit: cc1744324150c632416857c98964f87b1574a5fc, repo: git@github.com:obsidianmd/obsidian-api.git, type: git}
     version: 1.13.2
     peerDependencies:
       '@codemirror/state': 6.7.0
@@ -2359,7 +2359,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@codemirror/language@https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
+  '@codemirror/language@git+https://git@github.com:lishid/cm-language.git#b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3':
     dependencies:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
@@ -2378,7 +2378,7 @@ snapshots:
 
   '@codemirror/view@6.38.6':
     dependencies:
-      '@codemirror/state': 6.5.0
+      '@codemirror/state': 6.6.0
       crelt: 1.0.7
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -3594,7 +3594,7 @@ snapshots:
 
   obsidian-daily-notes-interface@0.8.4(@codemirror/state@6.6.0)(@codemirror/view@6.43.1):
     dependencies:
-      obsidian: https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
+      obsidian: git+https://git@github.com:obsidianmd/obsidian-api.git#cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
       tslib: 2.1.0
     transitivePeerDependencies:
       - '@codemirror/state'
@@ -3602,7 +3602,7 @@ snapshots:
 
   obsidian-dataview@0.5.68(@typescript-eslint/types@8.66.0):
     dependencies:
-      '@codemirror/language': https://codeload.github.com/lishid/cm-language/tar.gz/b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3
+      '@codemirror/language': git+https://git@github.com:lishid/cm-language.git#b817e72a9861b3f8a50a92a2ea53cbafc4f88eb3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1
       emoji-regex: 10.6.0
@@ -3616,7 +3616,7 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
-  obsidian-e2e@0.9.0(vite-plus@0.1.24(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@30.0.1)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.10):
+  obsidian-e2e@0.10.0(vite-plus@0.1.24(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@30.0.1)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0))(vitest@4.1.10):
     dependencies:
       vite-plus: 0.1.24(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(jiti@2.6.1)(jsdom@30.0.1)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(yaml@2.9.0)
       yaml: 2.9.0
@@ -3630,7 +3630,7 @@ snapshots:
       '@types/codemirror': 5.60.8
       moment: 2.29.4
 
-  obsidian@https://codeload.github.com/obsidianmd/obsidian-api/tar.gz/cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1):
+  obsidian@git+https://git@github.com:obsidianmd/obsidian-api.git#cc1744324150c632416857c98964f87b1574a5fc(@codemirror/state@6.6.0)(@codemirror/view@6.43.1):
     dependencies:
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.43.1

--- a/tests/e2e/apply-template-to-active-note.test.ts
+++ b/tests/e2e/apply-template-to-active-note.test.ts
@@ -29,14 +29,8 @@ async function seedFile(sandbox: SandboxApi, name: string, content: string) {
 
 /**
  * Opens the note in the active leaf, then calls the public API seam
- * `applyTemplateToActiveFile`. Results land in a window global we poll for
- * rather than awaiting `evalJsonAsync`'s return. The original reason (QuickAdd
- * notices corrupting the JSON envelope) is fixed by obsidian-e2e >= 0.8.2's
- * per-call envelope framing (obsidian-e2e#18) - see the A00 regression below.
- * What remains is a transport-level flake: a long-awaited eval can stall and
- * time out even after the in-app operation completed (artifacts show the
- * template fully applied while the CLI response never arrived), so the
- * long-running work stays decoupled from short, reliable JSON reads.
+ * `applyTemplateToActiveFile`. Failures come back as `{ ok: false, error }`
+ * so tests can assert on the rejection message.
  */
 async function applyTemplate(
 	obsidian: ObsidianClient,
@@ -46,8 +40,7 @@ async function applyTemplate(
 ): Promise<ApplyResult> {
 	const options = mode ? `{ mode: ${JSON.stringify(mode)} }` : "undefined";
 
-	await obsidian.dev.evalRaw(`(async () => {
-		window.__qaApplyTplResult = null;
+	return obsidian.dev.evalJsonAsync<ApplyResult>(`(async () => {
 		try {
 			// The vault index can lag behind sandbox writes; poll for the note.
 			let file = null;
@@ -63,20 +56,11 @@ async function applyTemplate(
 				${JSON.stringify(templatePath)},
 				${options},
 			);
-			window.__qaApplyTplResult = { ok: true, path: result ? result.path : null };
+			return { ok: true, path: result ? result.path : null };
 		} catch (e) {
-			window.__qaApplyTplResult = { ok: false, error: String((e && e.message) || e) };
+			return { ok: false, error: String((e && e.message) || e) };
 		}
 	})()`);
-
-	const result = await obsidian.waitFor(async () => {
-		const value = await obsidian.dev.evalJson<ApplyResult | null>(
-			"window.__qaApplyTplResult ?? null",
-		);
-		return value ?? false;
-	}, WAIT_OPTS);
-
-	return result as ApplyResult;
 }
 
 function expectOrderedSubstrings(


### PR DESCRIPTION
obsidian-e2e 0.10.0 (obsidian-e2e#25, PR #26) made `exec()` - and everything riding it: `dev.eval*`, `plugin.reload()`, `quickadd:*` CLI calls - recover lost CLI replies via a nonce-registry dispatch shim, and `evalJsonAsync` already runs kickoff-and-poll internally with exactly-once semantics. This retires the hand-rolled defense quickadd carried for that failure mode.

## Removed / updated

- **`tests/e2e/apply-template-to-active-note.test.ts` - `applyTemplate` fire-and-poll helper**: replaced `evalRaw` + `window.__qaApplyTplResult` + `waitFor(evalJson)` polling with a single awaited `evalJsonAsync` call. The comment justifying the decoupling ("a long-awaited eval can stall and time out even after the in-app operation completed") describes exactly the lost-reply mode 0.10.0's recoverable exec fixes; `evalJsonAsync` is now that fire-and-poll pattern, managed by the package. The in-app `{ ok, error }` catch stays so A07/A08 keep asserting on rejection messages, and the vault-index poll loop stays (index lag is real and unrelated to the transport).
- **`package.json` + `pnpm-lock.yaml`**: `obsidian-e2e` `^0.9.0` → `^0.10.0`, the version that ships the recovery. Lockfile regenerated and verified consistent with `--frozen-lockfile`.

## Deliberately kept

- **`vitest.e2e.config.mts` `testTimeout: 60s` / `hookTimeout: 30s`**: predate the transport-hang era entirely (set at suite creation in #1153, March 2026) - they are generic e2e budgets, not lost-reply padding, and hooks still need headroom for the ~5s-scale recovery poll latency on top of reload/lock work.
- **Per-test `30_000` timeouts and all 10-15s `WAIT_OPTS` / `waitForContent` / `waitUi` polls**: these wait on vault-content writes, metadata indexing, and UI state - real in-app latencies the recoverable transport does not remove.
- **`exec("quickadd:run", ...)` call sites**: unchanged; they gain recovery automatically in 0.10.0, which explicitly keeps non-idempotent `quickadd:run`-style commands exactly-once.
- **A00 regression test**: still pins the obsidian-e2e#18 envelope-corruption fix; unrelated to the transport recovery.

Sweep covered `tests/e2e/`, `docs/`, configs, and inline comments for fire-and-poll, window-global, evalJsonAsync-guidance, 30s/transport/lost-reply language (via `git grep`, avoiding the known ripgrep NUL-byte blindspot). The helper above was the only workaround found.

## Verification

- Full fresh-launch loop run twice (`stop:e2e-obsidian` → `start --print-env` → `test:e2e`): 49/49 e2e tests green both rounds.
- Unit suite: 4913 passed / 37 skipped. `tsc -noEmit` and eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development tooling to improve compatibility and reliability.
  - Improved automated validation for template application workflows.
- **User Experience**
  - No direct changes to end-user functionality or interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->