### PR TITLE
fix(capture): prioritize creating typed note

### DIFF
--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -87,15 +87,12 @@ bottom but stay selectable.
 
 You can also **type a new name** into the picker: with **Create file if it
 doesn't exist** enabled, a **Create new note: &lt;name&gt;** row appears and
-QuickAdd creates the note for you. The row hides when the typed name matches
-an existing note in scope, so typing an existing name selects it instead of
-offering a duplicate. The picker still opens for an empty folder, tag,
-property, or filtered scope so you can create the first note there.
-
-:::note[Available in the next release]
-The create row is selected first, so press Enter to create the exact name you
-typed even when existing notes are fuzzy matches.
-:::
+QuickAdd creates the note for you. The create row is selected first, so press
+Enter to create the exact name you typed even when existing notes are fuzzy
+matches. The row hides when the typed name matches an existing note in scope,
+so typing an existing name selects it instead of offering a duplicate. The
+picker still opens for an empty folder, tag, property, or filtered scope so you
+can create the first note there.
 
 ### Capture to a folder {#capturing-to-folders}
 

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -92,6 +92,11 @@ an existing note in scope, so typing an existing name selects it instead of
 offering a duplicate. The picker still opens for an empty folder, tag,
 property, or filtered scope so you can create the first note there.
 
+:::note[Available in the next release]
+The create row is selected first, so press Enter to create the exact name you
+typed even when existing notes are fuzzy matches.
+:::
+
 ### Capture to a folder {#capturing-to-folders}
 
 Type a folder name (like `CRM/people`) and QuickAdd asks which note in that

--- a/src/gui/InputSuggester/inputSuggester.test.ts
+++ b/src/gui/InputSuggester/inputSuggester.test.ts
@@ -24,6 +24,27 @@ describe("InputSuggester", () => {
 		expect(suggestions[suggestions.length - 1]?.item).toBe("bet");
 	});
 
+	it("places labeled create suggestions before fuzzy matches", () => {
+		const suggester = new InputSuggester(
+			app,
+			["New note 01", "New note 02"],
+			["Folder/New note 01.md", "Folder/New note 02.md"],
+			{
+				customValueLabel: (value) => `Create new note: ${value}`,
+			},
+		);
+
+		suggester.inputEl.value = "New note";
+
+		const suggestions = suggester.getSuggestions("New note");
+
+		expect(suggestions.map((suggestion) => suggestion.item)).toEqual([
+			"New note",
+			"Folder/New note 01.md",
+			"Folder/New note 02.md",
+		]);
+	});
+
 	it("avoids duplicating existing items as custom input", () => {
 		const suggester = new InputSuggester(
 			app,

--- a/src/gui/InputSuggester/inputSuggester.ts
+++ b/src/gui/InputSuggester/inputSuggester.ts
@@ -29,7 +29,8 @@ type Options = {
 	allowCustomValue: boolean;
 	/**
 	 * Renders the typed-but-unmatched custom row with a label, e.g.
-	 * `(value) => \`Create new note: ${value}\``. Implies a "create" affordance.
+	 * `(value) => \`Create new note: ${value}\``. Implies a "create" affordance
+	 * that is placed first so Enter performs the labeled action.
 	 */
 	customValueLabel: (value: string) => string;
 	/**
@@ -198,13 +199,19 @@ export default class InputSuggester extends FuzzySuggestModal<string> {
 			return suggestions;
 		}
 
-		suggestions.push({
+		const customSuggestion = {
 			item: customValue,
 			match: {
 				score: Number.NEGATIVE_INFINITY,
 				matches: [],
 			},
-		});
+		};
+
+		if (this.customValueLabel) {
+			suggestions.unshift(customSuggestion);
+		} else {
+			suggestions.push(customSuggestion);
+		}
 
 		return suggestions;
 	}

--- a/tests/orb-setup.test.ts
+++ b/tests/orb-setup.test.ts
@@ -9,7 +9,10 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 const runE2E = path.join(repoRoot, ".agents", "run-e2e");
 const openShim = path.join(repoRoot, ".agents", "obsidian-open");
 const patcher = path.join(repoRoot, ".agents", "patch-obsidian-e2e-linux.mjs");
-const profileRoot = "/tmp/quickadd-obsidian-e2e";
+const profileRoot = path.join(
+	fs.realpathSync("/tmp"),
+	"quickadd-obsidian-e2e",
+);
 const temporaryPaths: string[] = [];
 
 interface ProfileRootState {
@@ -173,7 +176,9 @@ exit 0
 	});
 });
 
-describe("Linux Obsidian launcher validation", () => {
+const describeLinux = process.platform === "linux" ? describe : describe.skip;
+
+describeLinux("Linux Obsidian launcher validation", () => {
 	function validArgs(validHome: string): string[] {
 		return [
 		"-n",


### PR DESCRIPTION
## Summary

When a capture can create its destination, keep the explicitly labeled create action above fuzzy note matches. The typed title is now visible and selected, so plain Enter creates that exact note instead of silently choosing a partial match.

Exact existing note names still suppress the create action, and unlabeled custom-input suggesters retain their historical matches-first behavior.

## Changes

- Put labeled custom actions first in `InputSuggester` while preserving generic custom-input ordering.
- Add focused regression coverage for a typed `New note` beside existing `New note 01` and `New note 02` matches.
- Document the selected create row and Enter behavior as current functionality.

## Testing / validation

- Reproduced on current `master` in an isolated Obsidian 1.13.4 vault with QuickAdd 2.22.0, `Capture to: Folder/`, creation enabled, and 12 fuzzy-matching notes. The create action was item 13 and below the visible picker viewport; Enter selected `Folder/New note 12.md`.
- Re-ran the exact flow after the fix. `Create new note: New note` was item 1, selected, visible, and showed the file-plus icon. Enter advanced to `Issue 1670 capture -> Folder/New note.md` and created that path with `Captured: Issue 1670 captured content`. Workspace leaves remained unchanged and Obsidian reported no runtime errors.
- `pnpm exec vitest run --config vitest.config.mts src/gui/InputSuggester/inputSuggester.test.ts src/engine/CaptureChoiceEngine.selection.test.ts tests/orb-setup.test.ts` (78 passed, 4 skipped after syncing current `master`)
- `pnpm run test` (4,923 passed, 41 skipped)
- `pnpm run build-with-lint`
- `pnpm run check` (0 errors, 0 warnings)
- `pnpm --dir docs run build` (50 pages)
- `git diff --check`

## Release / migration impact

User-facing capture-picker bug fix. No settings or data migration is required.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] Linked the related issue.
- [x] Noted release and migration impact.

Fixes #1670


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create-new suggestions now appear before fuzzy-matched existing items when a custom label is configured.
  * The create-new option remains selected initially, allowing Enter to create the exact typed name.
  * Creation remains available in empty filtered scopes and is hidden when the name already exists in scope.

* **Documentation**
  * Updated capture picker and custom-value guidance to describe the new suggestion ordering and selection behavior.

* **Tests**
  * Added regression coverage for labeled create suggestions and preserved item values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->