### PR TITLE
fix(date-picker): stabilize month navigation

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1397,6 +1397,9 @@
 }
 
 .qa-date-picker__label {
+	flex: 1;
+	min-width: 0;
+	text-align: center;
 	font-weight: 600;
 }
 


### PR DESCRIPTION
Keep the previous and next month controls stationary when the localized month label needs more horizontal space.

The label now uses the available space between the controls, can shrink in constrained layouts, and keeps its text centered. The controls were already stable at the date picker's normal width in our reproduction, but they could move once the picker became unusually narrow.

This is intentionally limited to the layout problem. QuickAdd does not currently have an internationalization system, so the English-only date picker controls remain unchanged and the broader language request stays open.

Verified with Polish month names in a live Obsidian date prompt at both the default width and deliberately constrained widths. The full test suite, type-check, lint, and production build pass.

Refs #1680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved date picker header label layout to use available space, shrink when needed, and center its text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->