### PR TITLE
test(e2e): seed files through the vault API

### DIFF
--- a/tests/e2e/apply-template-to-active-note.test.ts
+++ b/tests/e2e/apply-template-to-active-note.test.ts
@@ -39,12 +39,7 @@ async function applyTemplate(
 
 	return obsidian.dev.evalJsonAsync<ApplyResult>(`(async () => {
 		try {
-			// The vault index can lag behind sandbox writes; poll for the note.
-			let file = null;
-			for (let attempt = 0; attempt < 50 && !file; attempt++) {
-				file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
-				if (!file) await new Promise((resolve) => setTimeout(resolve, 100));
-			}
+			const file = app.vault.getAbstractFileByPath(${JSON.stringify(notePath)});
 			if (!file) throw new Error("note not found: " + ${JSON.stringify(notePath)});
 			const leaf = app.workspace.getLeaf(false);
 			await leaf.openFile(file);

--- a/tests/e2e/apply-template-to-active-note.test.ts
+++ b/tests/e2e/apply-template-to-active-note.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import type { ObsidianClient, SandboxApi } from "obsidian-e2e";
-import { createQuickAddE2EHarness, PLUGIN_ID } from "./e2eVault";
+import { createQuickAddE2EHarness, PLUGIN_ID, seedVaultFile } from "./e2eVault";
 
 // ---------------------------------------------------------------------------
 // Constants & types
@@ -19,12 +19,9 @@ const getContext = createQuickAddE2EHarness("apply-template");
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Write a file into the sandbox and wait for Obsidian to index it. */
 async function seedFile(sandbox: SandboxApi, name: string, content: string) {
-	await sandbox.write(name, content, {
-		waitForContent: true,
-		waitOptions: WAIT_OPTS,
-	});
+	const { obsidian } = getContext();
+	await seedVaultFile(obsidian, sandbox, name, content);
 }
 
 /**

--- a/tests/e2e/e2eVault.ts
+++ b/tests/e2e/e2eVault.ts
@@ -6,6 +6,7 @@ import {
 } from "obsidian-e2e";
 import type { ObsidianClient, SandboxApi, VaultRunLock } from "obsidian-e2e";
 import { createPluginHarness } from "obsidian-e2e/vitest";
+import { seedVaultFileInApp } from "./seedVaultFileInApp";
 
 export const PLUGIN_ID = "quickadd";
 
@@ -53,31 +54,7 @@ export async function seedVaultFile(
 ): Promise<string> {
 	const vaultPath = sandbox.path(relativePath);
 	const createdPath = await obsidian.dev.evalJsonAsync<string | null>(
-		`(async () => {
-			const path = ${JSON.stringify(vaultPath)};
-			const content = ${JSON.stringify(content)};
-			const segments = path.split("/").filter(Boolean);
-			segments.pop();
-			let folder = "";
-			for (const segment of segments) {
-				folder = folder ? folder + "/" + segment : segment;
-				if (!app.vault.getAbstractFileByPath(folder)) {
-					try {
-						await app.vault.createFolder(folder);
-					} catch (error) {
-						if (!app.vault.getAbstractFileByPath(folder)) throw error;
-					}
-				}
-			}
-			const existing = app.vault.getAbstractFileByPath(path);
-			if (existing) {
-				await app.vault.modify(existing, content);
-			} else {
-				await app.vault.create(path, content);
-			}
-			const file = app.vault.getAbstractFileByPath(path);
-			return file ? file.path : null;
-		})()`,
+		`(${seedVaultFileInApp.toString()})(app, ${JSON.stringify(vaultPath)}, ${JSON.stringify(content)})`,
 	);
 	if (!createdPath) {
 		throw new Error(`Failed to seed vault file: ${vaultPath}`);

--- a/tests/e2e/e2eVault.ts
+++ b/tests/e2e/e2eVault.ts
@@ -4,7 +4,7 @@ import {
 	resolveObsidianEnvOptions,
 	verifyVaultPath,
 } from "obsidian-e2e";
-import type { ObsidianClient, VaultRunLock } from "obsidian-e2e";
+import type { ObsidianClient, SandboxApi, VaultRunLock } from "obsidian-e2e";
 import { createPluginHarness } from "obsidian-e2e/vitest";
 
 export const PLUGIN_ID = "quickadd";
@@ -37,6 +37,52 @@ export async function acquireQuickAddVaultRunLock(
 ): Promise<VaultRunLock> {
 	const vaultPath = await verifyE2EVault(obsidian);
 	return acquireVaultRunLock({ vaultName: E2E_VAULT, vaultPath });
+}
+
+/**
+ * Create or overwrite a sandbox file through `app.vault` so the in-memory
+ * index sees it as soon as the call returns. `sandbox.write` only hits disk;
+ * `waitForContent` then re-reads those same bytes and never waits for
+ * `getAbstractFileByPath`.
+ */
+export async function seedVaultFile(
+	obsidian: ObsidianClient,
+	sandbox: SandboxApi,
+	relativePath: string,
+	content = "",
+): Promise<string> {
+	const vaultPath = sandbox.path(relativePath);
+	const createdPath = await obsidian.dev.evalJsonAsync<string | null>(
+		`(async () => {
+			const path = ${JSON.stringify(vaultPath)};
+			const content = ${JSON.stringify(content)};
+			const segments = path.split("/").filter(Boolean);
+			segments.pop();
+			let folder = "";
+			for (const segment of segments) {
+				folder = folder ? folder + "/" + segment : segment;
+				if (!app.vault.getAbstractFileByPath(folder)) {
+					try {
+						await app.vault.createFolder(folder);
+					} catch (error) {
+						if (!app.vault.getAbstractFileByPath(folder)) throw error;
+					}
+				}
+			}
+			const existing = app.vault.getAbstractFileByPath(path);
+			if (existing) {
+				await app.vault.modify(existing, content);
+			} else {
+				await app.vault.create(path, content);
+			}
+			const file = app.vault.getAbstractFileByPath(path);
+			return file ? file.path : null;
+		})()`,
+	);
+	if (!createdPath) {
+		throw new Error(`Failed to seed vault file: ${vaultPath}`);
+	}
+	return createdPath;
 }
 
 /**

--- a/tests/e2e/file-exists-behavior.test.ts
+++ b/tests/e2e/file-exists-behavior.test.ts
@@ -8,6 +8,7 @@ import type { ObsidianClient, SandboxApi, PluginHandle, VaultRunLock } from "obs
 import {
 	acquireQuickAddVaultRunLock,
 	createQuickAddObsidianClient,
+	seedVaultFile,
 } from "./e2eVault";
 
 // ---------------------------------------------------------------------------
@@ -75,15 +76,8 @@ function templateChoice(
 	};
 }
 
-/** Write a file into the sandbox and wait for Obsidian to index it. */
 async function seedFile(name: string, content = "EXISTING") {
-	await sandbox.write(name, content, { waitForContent: true, waitOptions: WAIT_OPTS });
-	const path = sandbox.path(name);
-	await obsidian.waitFor(async () => {
-		return await obsidian.dev.evalJson<boolean>(
-			`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(path)}))`,
-		);
-	}, WAIT_OPTS);
+	await seedVaultFile(obsidian, sandbox, name, content);
 }
 
 /** Run a QuickAdd choice. */

--- a/tests/e2e/locked-leaf-file-opening.test.ts
+++ b/tests/e2e/locked-leaf-file-opening.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
 	acquireQuickAddVaultRunLock,
 	createQuickAddObsidianClient,
+	seedVaultFile,
 } from "./e2eVault";
 
 const PLUGIN_ID = "quickadd";
@@ -90,22 +91,7 @@ function clearTestChoices(data: QuickAddData) {
 }
 
 async function seedFile(path: string, content: string) {
-	await sandbox.write(path, content, {
-		waitForContent: true,
-		waitOptions: WAIT_OPTS,
-	});
-
-	const vaultPath = sandbox.path(path);
-	await obsidian.waitFor(
-		() =>
-			obsidian.dev.evalJson<boolean>(
-				`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(vaultPath)}))`,
-			),
-		{
-			...WAIT_OPTS,
-			message: `Obsidian to index "${vaultPath}"`,
-		},
-	);
+	await seedVaultFile(obsidian, sandbox, path, content);
 }
 
 function pinnedOriginLayoutCode({

--- a/tests/e2e/macro-member-access.test.ts
+++ b/tests/e2e/macro-member-access.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
 	acquireQuickAddVaultRunLock,
 	createQuickAddObsidianClient,
+	seedVaultFile,
 } from "./e2eVault";
 
 const PLUGIN_ID = "quickadd";
@@ -87,10 +88,7 @@ function clearTestChoices(data: QuickAddData) {
 }
 
 async function seedFile(path: string, content: string) {
-	await sandbox.write(path, content, {
-		waitForContent: true,
-		waitOptions: WAIT_OPTS,
-	});
+	await seedVaultFile(obsidian, sandbox, path, content);
 }
 
 async function runChoice(name: string) {

--- a/tests/e2e/multi-select-formatting.test.ts
+++ b/tests/e2e/multi-select-formatting.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
 	acquireQuickAddVaultRunLock,
 	createQuickAddObsidianClient,
+	seedVaultFile,
 } from "./e2eVault";
 
 const PLUGIN_ID = "quickadd";
@@ -95,10 +96,12 @@ beforeAll(async () => {
 	});
 
 	const templatePath = sandbox.path("template.md");
-	await sandbox.write("template.md", "---\nkind: capture\n---\n# Template body\n", {
-		waitForContent: true,
-		waitOptions: WAIT_OPTS,
-	});
+	await seedVaultFile(
+		obsidian,
+		sandbox,
+		"template.md",
+		"---\nkind: capture\n---\n# Template body\n",
+	);
 
 	await qa.data<QuickAddData>().patch((data) => {
 		data.choices = data.choices.filter((choice) => choice.id !== CHOICE_ID);

--- a/tests/e2e/scorecard-composed-flows.test.ts
+++ b/tests/e2e/scorecard-composed-flows.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
 	acquireQuickAddVaultRunLock,
 	createQuickAddObsidianClient,
+	seedVaultFile,
 } from "./e2eVault";
 
 const PLUGIN_ID = "quickadd";
@@ -197,10 +198,12 @@ describe("scorecard final acceptance composed flows", () => {
 		const multiId = `${TEST_PREFIX}multi`;
 		const multiCaptureId = `${TEST_PREFIX}multi-capture`;
 
-		await sandbox.write("scorecard-template.md", "scorecard template body", {
-			waitForContent: true,
-			waitOptions: WAIT_OPTS,
-		});
+		await seedVaultFile(
+			obsidian,
+			sandbox,
+			"scorecard-template.md",
+			"scorecard template body",
+		);
 		await sandbox.delete("scorecard-template-output.md");
 		await sandbox.delete("scorecard-capture-target.md");
 

--- a/tests/e2e/seedVaultFileInApp.ts
+++ b/tests/e2e/seedVaultFileInApp.ts
@@ -1,0 +1,89 @@
+/**
+ * In-app body for `seedVaultFile`. Kept as a standalone function so
+ * `Function.prototype.toString()` can send it through `evalJsonAsync`, and so
+ * unit tests can exercise the on-disk-but-unindexed folder path without
+ * importing the e2e env resolver.
+ *
+ * `createSandboxApi` mkdir's the sandbox root on disk. If the vault watcher is
+ * delayed, `getAbstractFileByPath` is still null and `createFolder` rejects
+ * because the directory already exists. `reconcileFolderCreation` (or
+ * `reconcileFile`) registers that folder in the in-memory index without
+ * waiting for fsevents.
+ */
+export interface SeedVaultFile {
+	path: string;
+}
+
+export interface SeedVaultAdapter {
+	exists(path: string): Promise<boolean>;
+	reconcileFolderCreation?(path: string, newPath: string): Promise<void> | void;
+	reconcileFile?(path: string): Promise<void> | void;
+}
+
+export interface SeedVaultApp {
+	vault: {
+		getAbstractFileByPath(path: string): SeedVaultFile | null;
+		createFolder(path: string): Promise<unknown>;
+		create(path: string, content: string): Promise<unknown>;
+		modify(file: SeedVaultFile, content: string): Promise<unknown>;
+		adapter: SeedVaultAdapter;
+	};
+}
+
+export async function seedVaultFileInApp(
+	app: SeedVaultApp,
+	path: string,
+	content: string,
+): Promise<string | null> {
+	const adapter = app.vault.adapter;
+
+	const indexed = (target: string) => app.vault.getAbstractFileByPath(target);
+
+	const reconcileFolder = async (folder: string) => {
+		if (typeof adapter.reconcileFolderCreation === "function") {
+			await adapter.reconcileFolderCreation(folder, folder);
+			return;
+		}
+		if (typeof adapter.reconcileFile === "function") {
+			await adapter.reconcileFile(folder);
+		}
+	};
+
+	const ensureFolder = async (folder: string) => {
+		if (indexed(folder)) return;
+
+		if (await adapter.exists(folder)) {
+			await reconcileFolder(folder);
+			if (indexed(folder)) return;
+		}
+
+		try {
+			await app.vault.createFolder(folder);
+		} catch (error) {
+			if (indexed(folder)) return;
+			if (await adapter.exists(folder)) {
+				await reconcileFolder(folder);
+				if (indexed(folder)) return;
+			}
+			throw error;
+		}
+	};
+
+	const segments = path.split("/").filter(Boolean);
+	segments.pop();
+	let folder = "";
+	for (const segment of segments) {
+		folder = folder ? `${folder}/${segment}` : segment;
+		await ensureFolder(folder);
+	}
+
+	const existing = indexed(path);
+	if (existing) {
+		await app.vault.modify(existing, content);
+	} else {
+		await app.vault.create(path, content);
+	}
+
+	const file = indexed(path);
+	return file ? file.path : null;
+}

--- a/tests/e2e/template-property-links.test.ts
+++ b/tests/e2e/template-property-links.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
 	acquireQuickAddVaultRunLock,
 	createQuickAddObsidianClient,
+	seedVaultFile,
 } from "./e2eVault";
 
 const PLUGIN_ID = "quickadd";
@@ -62,10 +63,7 @@ function clearTestChoices(data: QuickAddData) {
 }
 
 async function seedTemplate(path: string, content: string) {
-	await sandbox.write(path, content, {
-		waitForContent: true,
-		waitOptions: WAIT_OPTS,
-	});
+	await seedVaultFile(obsidian, sandbox, path, content);
 }
 
 async function runChoice(name: string, vars: Record<string, unknown>) {

--- a/tests/seedVaultFileInApp.test.ts
+++ b/tests/seedVaultFileInApp.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	seedVaultFileInApp,
+	type SeedVaultApp,
+	type SeedVaultFile,
+} from "./e2e/seedVaultFileInApp";
+
+interface MockVaultState {
+	files: Map<string, SeedVaultFile>;
+	disk: Set<string>;
+}
+
+function createMockApp(state: MockVaultState, options?: {
+	createFolderError?: Error;
+	reconcile?: "folder" | "file" | "none";
+}): SeedVaultApp {
+	const createFolder = vi.fn(async (folder: string) => {
+		if (options?.createFolderError) throw options.createFolderError;
+		state.files.set(folder, { path: folder });
+		state.disk.add(folder);
+	});
+	const create = vi.fn(async (path: string, _content: string) => {
+		const file = { path };
+		state.files.set(path, file);
+		state.disk.add(path);
+		return file;
+	});
+	const modify = vi.fn(async (_file: SeedVaultFile, _content: string) => undefined);
+	const exists = vi.fn(async (path: string) => state.disk.has(path));
+	const reconcileFolderCreation = vi.fn(async (folder: string) => {
+		state.files.set(folder, { path: folder });
+	});
+	const reconcileFile = vi.fn(async (folder: string) => {
+		state.files.set(folder, { path: folder });
+	});
+
+	const adapter: SeedVaultApp["vault"]["adapter"] = { exists };
+	if (options?.reconcile === "folder" || options?.reconcile === undefined) {
+		adapter.reconcileFolderCreation = reconcileFolderCreation;
+	}
+	if (options?.reconcile === "file") {
+		adapter.reconcileFile = reconcileFile;
+	}
+
+	return {
+		vault: {
+			getAbstractFileByPath: (path: string) => state.files.get(path) ?? null,
+			createFolder,
+			create,
+			modify,
+			adapter,
+		},
+	};
+}
+
+describe("seedVaultFileInApp", () => {
+	it("creates missing parent folders, then creates the file", async () => {
+		const state: MockVaultState = { files: new Map(), disk: new Set() };
+		const app = createMockApp(state);
+
+		await expect(
+			seedVaultFileInApp(app, "sandbox/note.md", "hello"),
+		).resolves.toBe("sandbox/note.md");
+
+		expect(app.vault.createFolder).toHaveBeenCalledWith("sandbox");
+		expect(app.vault.create).toHaveBeenCalledWith("sandbox/note.md", "hello");
+		expect(app.vault.modify).not.toHaveBeenCalled();
+		expect(app.vault.adapter.reconcileFolderCreation).not.toHaveBeenCalled();
+	});
+
+	it("skips createFolder when the parent is already indexed", async () => {
+		const state: MockVaultState = {
+			files: new Map([["sandbox", { path: "sandbox" }]]),
+			disk: new Set(["sandbox"]),
+		};
+		const app = createMockApp(state);
+
+		await seedVaultFileInApp(app, "sandbox/note.md", "hello");
+
+		expect(app.vault.createFolder).not.toHaveBeenCalled();
+		expect(app.vault.adapter.reconcileFolderCreation).not.toHaveBeenCalled();
+	});
+
+	it("registers an on-disk unindexed parent without calling createFolder", async () => {
+		const state: MockVaultState = {
+			files: new Map(),
+			disk: new Set(["sandbox"]),
+		};
+		const alreadyExists = new Error("Folder already exists.");
+		const app = createMockApp(state, { createFolderError: alreadyExists });
+
+		await expect(
+			seedVaultFileInApp(app, "sandbox/note.md", "hello"),
+		).resolves.toBe("sandbox/note.md");
+
+		expect(app.vault.adapter.reconcileFolderCreation).toHaveBeenCalledWith(
+			"sandbox",
+			"sandbox",
+		);
+		expect(app.vault.createFolder).not.toHaveBeenCalled();
+		expect(app.vault.create).toHaveBeenCalledWith("sandbox/note.md", "hello");
+	});
+
+	it("falls back to reconcileFile when reconcileFolderCreation is missing", async () => {
+		const state: MockVaultState = {
+			files: new Map(),
+			disk: new Set(["sandbox"]),
+		};
+		const app = createMockApp(state, { reconcile: "file" });
+
+		await expect(
+			seedVaultFileInApp(app, "sandbox/note.md", "hello"),
+		).resolves.toBe("sandbox/note.md");
+
+		expect(app.vault.adapter.reconcileFile).toHaveBeenCalledWith("sandbox");
+		expect(app.vault.createFolder).not.toHaveBeenCalled();
+	});
+
+	it("reconciles after createFolder throws if the parent is on disk", async () => {
+		const state: MockVaultState = { files: new Map(), disk: new Set() };
+		const alreadyExists = new Error("Folder already exists.");
+		const app = createMockApp(state, { createFolderError: alreadyExists });
+		// Folder appears on disk between the exists() probe and createFolder.
+		vi.mocked(app.vault.adapter.exists).mockResolvedValueOnce(false);
+		vi.mocked(app.vault.adapter.exists).mockImplementation(async (path) => {
+			state.disk.add(path);
+			return true;
+		});
+
+		await expect(
+			seedVaultFileInApp(app, "sandbox/note.md", "hello"),
+		).resolves.toBe("sandbox/note.md");
+
+		expect(app.vault.createFolder).toHaveBeenCalledWith("sandbox");
+		expect(app.vault.adapter.reconcileFolderCreation).toHaveBeenCalledWith(
+			"sandbox",
+			"sandbox",
+		);
+	});
+
+	it("rethrows createFolder errors when the parent is neither indexed nor on disk", async () => {
+		const state: MockVaultState = { files: new Map(), disk: new Set() };
+		const failure = new Error("permission denied");
+		const app = createMockApp(state, { createFolderError: failure });
+
+		await expect(
+			seedVaultFileInApp(app, "sandbox/note.md", "hello"),
+		).rejects.toThrow("permission denied");
+		expect(app.vault.create).not.toHaveBeenCalled();
+	});
+
+	it("modifies an already-indexed file", async () => {
+		const existing = { path: "sandbox/note.md" };
+		const state: MockVaultState = {
+			files: new Map([
+				["sandbox", { path: "sandbox" }],
+				["sandbox/note.md", existing],
+			]),
+			disk: new Set(["sandbox", "sandbox/note.md"]),
+		};
+		const app = createMockApp(state);
+
+		await expect(
+			seedVaultFileInApp(app, "sandbox/note.md", "updated"),
+		).resolves.toBe("sandbox/note.md");
+
+		expect(app.vault.modify).toHaveBeenCalledWith(existing, "updated");
+		expect(app.vault.create).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Why

Issue #1669 tracks a residual e2e flake after obsidian-e2e 0.10.0. Seeded files written with `sandbox.write` plus `waitForContent: true` can sit on disk while `app.vault.getAbstractFileByPath` stays null.

`VaultApi.write` uses Node `writeFile`. `waitForContent` then re-reads those same bytes. It never asks the vault index. PR #1639 already hit this race and added a 10s `evalJson` poll. That poll still depends on fsevents, and each iteration rides recoverable `exec()`. A lost CLI reply costs `DISPATCH_ATTEMPT_TIMEOUT_MS` (5s) inside the 10s `WAIT_OPTS` budget. Two losses exhaust the wait with no transport error, which matches the T05/T07 artifacts.

QuickAdd then reads templates and collision targets through `getAbstractFileByPath`. A seed that is only on disk is invisible to those paths.

## Scope

`seedVaultFile` in `tests/e2e/e2eVault.ts` creates or overwrites the file with `app.vault.create` / `app.vault.modify` via `evalJsonAsync`. Parent folders use `createFolder`. The helper returns only after `getAbstractFileByPath` sees the file.

Local `seedFile` / `seedTemplate` wrappers in the e2e suites now call it. Post-run `waitForContent` / `waitForExists` assertions stay on disk. Those wait for plugin writes, not seeds.

This does not implement obsidian-e2e#28 (in-app grace period). It does not change `verify()`'s direct `obsidian --help` transport.

## Tradeoffs

A shared helper beats copying the eval into each suite. Putting vault create into obsidian-e2e's `VaultApi` would break that package's "vault stays filesystem-only" rule, so the consumer owns the index-visible seed.

## Blast Radius

Test-only. No plugin behavior, settings, or release artifacts change. The next person who adds an e2e file should seed through `seedVaultFile` when the test later calls `getAbstractFileByPath`.

## Verification

Isolated worktree vault `quickadd-quickadd` on Obsidian 1.13.7.

Before the change, a 5-loop full suite at load ~8 reproduced a different flake on loop 4. `apply-template-to-active-note` `beforeAll` died with `ObsidianCommandTimeoutError: Command timed out after 30000ms: obsidian --help`. That is `verify()` on the direct transport, not the vault-index class. Loops 1-3 were 49/49. A 20-iteration fs-then-index probe stayed under 182ms, so the 10s index stall did not fire in this window.

After the change, three consecutive full-suite runs were 49/49 (27.6s, 27.9s, 38.5s). `pnpm run lint` and `pnpm run test` were 4915 passed / 41 skipped. `dev:errors` was clean after the instance recovered.

- [x] PR title follows Conventional Commits
- [x] Linked related issue
- [x] No release or migration impact

Fixes #1669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup for creating and indexing vault files.
  * Added shared handling for creating required folders, reconciling existing folders, and updating test files.
  * Updated template, note, file-opening, formatting, and scorecard scenarios to use consistent vault seeding.
  * Added coverage for folder creation, existing files, reconciliation, errors, and file updates.
  * Simplified template lookups while preserving existing not-found error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->