### PR TITLE
test: prove FILENAMECURRENT nested-folder recipes in Obsidian

### DIFF
--- a/tests/e2e/filenamecurrent-nested-folder.test.ts
+++ b/tests/e2e/filenamecurrent-nested-folder.test.ts
@@ -1,0 +1,184 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	captureFailureArtifacts,
+	clearVaultRunLockMarker,
+	createSandboxApi,
+} from "obsidian-e2e";
+import type {
+	ObsidianClient,
+	PluginHandle,
+	SandboxApi,
+	VaultRunLock,
+} from "obsidian-e2e";
+import {
+	acquireQuickAddVaultRunLock,
+	createQuickAddObsidianClient,
+	PLUGIN_ID,
+	seedVaultFile,
+} from "./e2eVault";
+
+const WAIT_OPTS = { timeoutMs: 15_000, intervalMs: 200 };
+const TPL_CONTENT = "QA_1674_TEMPLATE";
+
+let obsidian: ObsidianClient;
+let sandbox: SandboxApi;
+let qa: PluginHandle;
+let lock: VaultRunLock | undefined;
+
+type QuickAddData = {
+	choices: Record<string, unknown>[];
+};
+
+function templateChoice(spec: {
+	id: string;
+	folderEnabled: boolean;
+	folders: string[];
+	fileNameFormat: string;
+}) {
+	return {
+		id: spec.id,
+		name: spec.id,
+		type: "Template",
+		command: false,
+		templatePath: sandbox.path("tpl.md"),
+		fileNameFormat: { enabled: true, format: spec.fileNameFormat },
+		folder: {
+			enabled: spec.folderEnabled,
+			folders: spec.folders,
+			chooseWhenCreatingNote: false,
+			createInSameFolderAsActiveFile: false,
+			chooseFromSubfolders: false,
+		},
+		appendLink: false,
+		openFile: false,
+		fileOpening: {
+			location: "tab",
+			direction: "vertical",
+			mode: "source",
+			focus: false,
+		},
+		fileExistsBehavior: { kind: "apply", mode: "increment" },
+	};
+}
+
+async function openNote(vaultRelativePath: string): Promise<string | null> {
+	return obsidian.dev.evalJsonAsync<string | null>(
+		`(async () => {
+			const file = app.vault.getAbstractFileByPath(${JSON.stringify(vaultRelativePath)});
+			if (!file) throw new Error("note not found: " + ${JSON.stringify(vaultRelativePath)});
+			const leaf = app.workspace.getLeaf(false);
+			await leaf.openFile(file);
+			app.workspace.setActiveLeaf(leaf, { focus: true });
+			return app.workspace.getActiveFile()?.path ?? null;
+		})()`,
+	);
+}
+
+beforeAll(async () => {
+	obsidian = createQuickAddObsidianClient();
+	lock = await acquireQuickAddVaultRunLock(obsidian);
+	await lock.publishMarker(obsidian);
+
+	qa = obsidian.plugin(PLUGIN_ID);
+	sandbox = await createSandboxApi({
+		obsidian,
+		sandboxRoot: "__obsidian_e2e__",
+		testName: "filenamecurrent-nested-folder",
+	});
+
+	await seedVaultFile(obsidian, sandbox, "tpl.md", TPL_CONTENT);
+	await seedVaultFile(
+		obsidian,
+		sandbox,
+		"Projects/Project XYZ.md",
+		"Active project note",
+	);
+
+	await qa.data<QuickAddData>().patch((data) => {
+		data.choices = data.choices.filter(
+			(choice) => !String(choice.id ?? "").startsWith("__qa-1674-"),
+		);
+		data.choices.push(
+			templateChoice({
+				id: "__qa-1674-case1",
+				folderEnabled: true,
+				folders: ["{{FOLDERCURRENT}}"],
+				fileNameFormat: "{{FILENAMECURRENT}}/{{VALUE}}",
+			}),
+			templateChoice({
+				id: "__qa-1674-case2",
+				folderEnabled: true,
+				folders: [sandbox.path("Use Cases")],
+				fileNameFormat: "{{FILENAMECURRENT}}/{{VALUE}}",
+			}),
+		);
+	});
+	await qa.reload({ waitUntilReady: true });
+}, 30_000);
+
+afterAll(async () => {
+	await qa.restoreData();
+	await qa.reload();
+	await sandbox.cleanup();
+	await clearVaultRunLockMarker(obsidian).catch(() => {});
+	await lock?.release();
+}, 15_000);
+
+beforeEach((ctx) => {
+	ctx.onTestFailed(async () => {
+		await captureFailureArtifacts(
+			{ id: ctx.task.id, name: ctx.task.name },
+			obsidian,
+			{ plugin: qa, captureOnFailure: true },
+		);
+	});
+});
+
+describe("issue 1674: nest a new note under a folder named after the active file", () => {
+	it("creates Projects/Project XYZ/Use Case 1.md from FOLDERCURRENT + FILENAMECURRENT/VALUE", async () => {
+		const active = await openNote(sandbox.path("Projects/Project XYZ.md"));
+		expect(active).toBe(sandbox.path("Projects/Project XYZ.md"));
+
+		const result = await obsidian.exec<{
+			ok: boolean;
+			path?: string;
+			effect?: string;
+		}>("quickadd:run", {
+			choice: "__qa-1674-case1",
+			vars: JSON.stringify({ value: "Use Case 1" }),
+			verify: true,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(result.path).toBe(sandbox.path("Projects/Project XYZ/Use Case 1.md"));
+		const content = await sandbox.waitForContent(
+			"Projects/Project XYZ/Use Case 1.md",
+			(body) => body.includes(TPL_CONTENT),
+			WAIT_OPTS,
+		);
+		expect(content).toContain(TPL_CONTENT);
+	});
+
+	it("creates Use Cases/Project XYZ/Use Case 1.md from a static folder + FILENAMECURRENT/VALUE", async () => {
+		const active = await openNote(sandbox.path("Projects/Project XYZ.md"));
+		expect(active).toBe(sandbox.path("Projects/Project XYZ.md"));
+
+		const result = await obsidian.exec<{
+			ok: boolean;
+			path?: string;
+		}>("quickadd:run", {
+			choice: "__qa-1674-case2",
+			vars: JSON.stringify({ value: "Use Case 1" }),
+			verify: true,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(result.path).toBe(sandbox.path("Use Cases/Project XYZ/Use Case 1.md"));
+		const content = await sandbox.waitForContent(
+			"Use Cases/Project XYZ/Use Case 1.md",
+			(body) => body.includes(TPL_CONTENT),
+			WAIT_OPTS,
+		);
+		expect(content).toContain(TPL_CONTENT);
+	});
+});

--- a/tests/e2e/filenamecurrent-nested-folder.test.ts
+++ b/tests/e2e/filenamecurrent-nested-folder.test.ts
@@ -139,9 +139,10 @@ describe("issue 1674: nest a new note under a folder named after the active file
 		const active = await openNote(sandbox.path("Projects/Project XYZ.md"));
 		expect(active).toBe(sandbox.path("Projects/Project XYZ.md"));
 
-		const result = await obsidian.exec<{
+		const result = await obsidian.execJson<{
 			ok: boolean;
-			path?: string;
+			file?: string;
+			error?: string;
 			effect?: string;
 		}>("quickadd:run", {
 			choice: "__qa-1674-case1",
@@ -149,8 +150,8 @@ describe("issue 1674: nest a new note under a folder named after the active file
 			verify: true,
 		});
 
-		expect(result.ok).toBe(true);
-		expect(result.path).toBe(sandbox.path("Projects/Project XYZ/Use Case 1.md"));
+		expect(result.ok, result.error).toBe(true);
+		expect(result.file).toBe(sandbox.path("Projects/Project XYZ/Use Case 1.md"));
 		const content = await sandbox.waitForContent(
 			"Projects/Project XYZ/Use Case 1.md",
 			(body) => body.includes(TPL_CONTENT),
@@ -163,17 +164,18 @@ describe("issue 1674: nest a new note under a folder named after the active file
 		const active = await openNote(sandbox.path("Projects/Project XYZ.md"));
 		expect(active).toBe(sandbox.path("Projects/Project XYZ.md"));
 
-		const result = await obsidian.exec<{
+		const result = await obsidian.execJson<{
 			ok: boolean;
-			path?: string;
+			file?: string;
+			error?: string;
 		}>("quickadd:run", {
 			choice: "__qa-1674-case2",
 			vars: JSON.stringify({ value: "Use Case 1" }),
 			verify: true,
 		});
 
-		expect(result.ok).toBe(true);
-		expect(result.path).toBe(sandbox.path("Use Cases/Project XYZ/Use Case 1.md"));
+		expect(result.ok, result.error).toBe(true);
+		expect(result.file).toBe(sandbox.path("Use Cases/Project XYZ/Use Case 1.md"));
 		const content = await sandbox.waitForContent(
 			"Use Cases/Project XYZ/Use Case 1.md",
 			(body) => body.includes(TPL_CONTENT),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an Obsidian e2e suite that runs the two working recipes for [issue #1674](https://github.com/chhoumann/quickadd/issues/1674): nest a new note under a folder named after the active file.

This is coverage for a workflow that already works. No plugin behavior change.

## Changes

- New `tests/e2e/filenamecurrent-nested-folder.test.ts`
- Case 1: New note location `{{FOLDERCURRENT}}`, file name `{{FILENAMECURRENT}}/{{VALUE}}`
- Case 2: New note location `Use Cases`, file name `{{FILENAMECURRENT}}/{{VALUE}}`
- Assertions use `execJson` and the verified-run `file` field

## Testing / validation

Isolated Obsidian 1.13.7, QuickAdd 2.22.0, plugin id `quickadd`.

```
pnpm exec vitest run --config vitest.e2e.config.mts tests/e2e/filenamecurrent-nested-folder.test.ts
# Test Files  1 passed (1)
# Tests  2 passed (2)
```

Same recipes then run by hand via `quickadd:run verify` from active note `__qa1674_proof__/Projects/Project XYZ.md`:

- Case 1 created `__qa1674_proof__/Projects/Project XYZ/Use Case 1.md` (`verified:true`, `effect:created`)
- Case 2 created `__qa1674_proof__/Use Cases/Project XYZ/Use Case 1.md`
- Reporter folder string `{{FOLDERCURRENT}}/{{FILENAMECURRENT}}/` created `Use Case 1.md` at the vault root

## Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue #1674
- [x] No release or migration impact (test-only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db2176e6-9bad-47ab-b165-d90a1f72ada9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db2176e6-9bad-47ab-b165-d90a1f72ada9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

