### PR TITLE
docs: treat slashes in file name format as a path

### DIFF
--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -163,9 +163,22 @@ File Name Format, QuickAdd uses `{{VALUE}}` as the file name format, which keeps
 the default behavior of prompting for a file name when you run the choice (with
 the same `{{VALUE}}` / `{{NAME}}` behavior described in the format syntax docs).
 
-A slash in the format creates a folder. To nest a note under a folder named
-after the note you are in, see
-[Nest a note under the current file](#nest-under-current-file).
+A slash in the format creates a folder, so the name can include a path. The
+file is created under [New note location](#new-note-location).
+
+```text title="You configure"
+{{DATE:YYYY}}/{{VALUE}}
+```
+
+```text title="You get (typing Kickoff)"
+2026/Kickoff
+```
+
+`{{FILENAMECURRENT}}` names that folder after the note you are in:
+
+```text title="You configure"
+{{FILENAMECURRENT}}/{{VALUE}}
+```
 
 :::note
 If a value used in the file name contains a line break or another control
@@ -213,28 +226,6 @@ Projects/{{VALUE:client}}/{{DATE:YYYY}}
 
 This prompts for a client and creates the file under that client's folder for
 the current year.
-
-### Nest a note under the current file {#nest-under-current-file}
-
-Put the current file's name in **File name format**, not in the folder field.
-A slash in the file name creates a folder.
-
-1. Turn **File name format** on.
-2. Set it to `{{FILENAMECURRENT}}/{{VALUE}}`.
-   `{{FILENAMECURRENT}}` is the note you are in. `{{VALUE}}` is the name you
-   type.
-3. Set **New note location** to **Same folder as current file**.
-
-From `Projects/Project XYZ.md`, typing `Use Case 1` creates
-`Projects/Project XYZ/Use Case 1.md`.
-
-To put those notes under a fixed folder instead, keep that file name format.
-Set **New note location** to **In a specific folder**, then add `Use Cases`.
-From the same project note, that creates
-`Use Cases/Project XYZ/Use Case 1.md`.
-
-The folder field does not fill in `{{FILENAMECURRENT}}`. A trailing slash there
-also makes QuickAdd ignore the folder and use the vault root.
 
 ## Link to the new note: Link to created file {#link-to-created-file}
 

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -163,6 +163,10 @@ File Name Format, QuickAdd uses `{{VALUE}}` as the file name format, which keeps
 the default behavior of prompting for a file name when you run the choice (with
 the same `{{VALUE}}` / `{{NAME}}` behavior described in the format syntax docs).
 
+A slash in the format creates a folder. To nest a note under a folder named
+after the note you are in, see
+[Nest a note under the current file](#nest-under-current-file).
+
 :::note
 If a value used in the file name contains a line break or another control
 character, QuickAdd folds it to a space in the created path and strips trailing
@@ -209,6 +213,28 @@ Projects/{{VALUE:client}}/{{DATE:YYYY}}
 
 This prompts for a client and creates the file under that client's folder for
 the current year.
+
+### Nest a note under the current file {#nest-under-current-file}
+
+Put the current file's name in **File name format**, not in the folder field.
+A slash in the file name creates a folder.
+
+1. Turn **File name format** on.
+2. Set it to `{{FILENAMECURRENT}}/{{VALUE}}`.
+   `{{FILENAMECURRENT}}` is the note you are in. `{{VALUE}}` is the name you
+   type.
+3. Set **New note location** to **Same folder as current file**.
+
+From `Projects/Project XYZ.md`, typing `Use Case 1` creates
+`Projects/Project XYZ/Use Case 1.md`.
+
+To put those notes under a fixed folder instead, keep that file name format.
+Set **New note location** to **In a specific folder**, then add `Use Cases`.
+From the same project note, that creates
+`Use Cases/Project XYZ/Use Case 1.md`.
+
+The folder field does not fill in `{{FILENAMECURRENT}}`. A trailing slash there
+also makes QuickAdd ignore the folder and use the vault root.
 
 ## Link to the new note: Link to created file {#link-to-created-file}
 

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -174,11 +174,8 @@ file is created under [New note location](#new-note-location).
 2026/Kickoff
 ```
 
-`{{FILENAMECURRENT}}` names that folder after the note you are in:
-
-```text title="You configure"
-{{FILENAMECURRENT}}/{{VALUE}}
-```
+`{{FILENAMECURRENT}}` names a folder after the note you are in, for example
+`{{FILENAMECURRENT}}/{{VALUE}}`.
 
 :::note
 If a value used in the file name contains a line break or another control

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -615,6 +615,9 @@ The active note's file name, without the extension: `Notes from
 {{FILENAMECURRENT}}`. Honors the same required/optional behavior as
 `{{LINKCURRENT}}` - when optional and no note is active, it becomes empty.
 
+A slash in a Template **File name format** creates a folder. See
+[Nest a note under the current file](/docs/Choices/TemplateChoice/#nest-under-current-file).
+
 ### The note's folder: `{{FOLDERCURRENT}}` {#foldercurrent}
 
 The active note's folder, as a vault-relative path with no trailing slash
@@ -636,6 +639,8 @@ running the capture from any note inside `Projects/Alpha` targets
 
 Works in capture targets, file name formats, note bodies and capture formats,
 and Template choice folder paths (like `{{FOLDERCURRENT}}/Subnotes`).
+Template folder paths do not replace `{{FILENAMECURRENT}}`. Put that token in
+**File name format** instead.
 
 **No active note:** in paths (capture targets, file names, folder paths) a
 missing active note always stops the run with a clear error - it never falls

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -615,8 +615,9 @@ The active note's file name, without the extension: `Notes from
 {{FILENAMECURRENT}}`. Honors the same required/optional behavior as
 `{{LINKCURRENT}}` - when optional and no note is active, it becomes empty.
 
-A slash in a Template **File name format** creates a folder. See
-[Nest a note under the current file](/docs/Choices/TemplateChoice/#nest-under-current-file).
+In a Template [File name format](/docs/Choices/TemplateChoice/#optional),
+`{{FILENAMECURRENT}}/{{VALUE}}` creates the new note under a folder named after
+the active note.
 
 ### The note's folder: `{{FOLDERCURRENT}}` {#foldercurrent}
 
@@ -639,8 +640,6 @@ running the capture from any note inside `Projects/Alpha` targets
 
 Works in capture targets, file name formats, note bodies and capture formats,
 and Template choice folder paths (like `{{FOLDERCURRENT}}/Subnotes`).
-Template folder paths do not replace `{{FILENAMECURRENT}}`. Put that token in
-**File name format** instead.
 
 **No active note:** in paths (capture targets, file names, folder paths) a
 missing active note always stops the run with a clear error - it never falls


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents that a slash in Template **File name format** creates a folder. The name can be a path. The file is created under **New note location**.

This is existing behavior. The Template page only showed a flat file-name example (`{{DATE}} {{NAME}}`).

## Changes

- File name format now shows `{{DATE:YYYY}}/{{VALUE}}` creating `2026/Kickoff`.
- One line for `{{FILENAMECURRENT}}/{{VALUE}}` when the folder should take the active note's name.
- Format Syntax `{{FILENAMECURRENT}}` points at that File name format section.

No plugin behavior change. Already shipped. No `_Introduced in` line.

## Testing / validation

- `pnpm exec vitest run src/formatters/formatSyntax.docs-examples.test.ts`: 3 passed

## Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue #1674
- [x] No release or migration impact (docs-only, already-shipped behavior)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db2176e6-9bad-47ab-b165-d90a1f72ada9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db2176e6-9bad-47ab-b165-d90a1f72ada9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that slash-separated file-name formats create subfolders under the configured New note location.
  * Added examples for organizing new notes by year, selected value, or the active note’s filename.
  * Documented how to create a note inside a folder named after the active note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->