### PR TITLE
fix(gui): preserve items dropped during placeholder window

### DIFF
--- a/src/gui/MacroGUIs/CommandList.placeholderDrop.test.ts
+++ b/src/gui/MacroGUIs/CommandList.placeholderDrop.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { SHADOW_PLACEHOLDER_ITEM_ID, TRIGGERS } from "svelte-dnd-action";
+
+// CommandList transitively imports src/main, which pulls obsidian-dataview's CJS
+// require('obsidian'); mock it as the rest of the suite does.
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+
+import { App } from "obsidian";
+import CommandList from "./CommandList.svelte";
+import { createCommandListProps } from "./commandListProps.svelte";
+import { ObsidianCommand } from "../../types/macros/ObsidianCommand";
+import type { ICommand } from "../../types/macros/ICommand";
+
+const makeProps = (commands: ICommand[], saveCommands = vi.fn()) =>
+	createCommandListProps({
+		commands,
+		app: new App() as never,
+		plugin: {} as never,
+		deleteCommand: vi.fn(),
+		saveCommands,
+	});
+
+const fireDnd = (
+	zone: Element,
+	type: "consider" | "finalize",
+	items: ICommand[],
+	trigger: string,
+	id: string,
+) =>
+	fireEvent(
+		zone,
+		new CustomEvent(type, {
+			detail: { items, info: { trigger, id, source: "pointer" } },
+		}),
+	);
+
+/**
+ * #1692 (macro-builder half): handleConsider strips the library's shadow placeholder,
+ * whose id is still SHADOW_PLACEHOLDER_ITEM_ID at DRAG_STARTED — so until a later
+ * consider re-adds the shadow under the real id, the list is missing the dragged
+ * command entirely. A mobile long-press drop inside that window reports finalize items
+ * WITHOUT the dragged command; committing that verbatim deleted it. handleSort must
+ * fall back to the pre-drag order. See ChoiceList.crosszone.test.ts for the event
+ * payload provenance (verified against the real library in E2E mobile emulation).
+ */
+describe("CommandList placeholder-window drop (#1692)", () => {
+	it("restores the pre-drag order when the finalize is missing the dragged command", async () => {
+		const a = new ObsidianCommand("Alpha", "a");
+		const b = new ObsidianCommand("Beta", "b");
+		const c = new ObsidianCommand("Gamma", "c");
+		const saveCommands = vi.fn();
+
+		const { container } = render(CommandList, {
+			props: makeProps([a, b, c], saveCommands),
+		});
+		const zone = container.querySelector(".quickAddCommandList") as Element;
+
+		const shadowOfA = { ...a, id: SHADOW_PLACEHOLDER_ITEM_ID } as ICommand;
+		await fireDnd(zone, "consider", [shadowOfA, b, c], TRIGGERS.DRAG_STARTED, a.id);
+		await fireDnd(zone, "finalize", [b, c], TRIGGERS.DROPPED_INTO_ZONE, a.id);
+
+		expect(saveCommands).toHaveBeenCalledTimes(1);
+		const saved = saveCommands.mock.calls[0][0] as ICommand[];
+		expect(saved.map((cmd) => cmd.id)).toEqual([a.id, b.id, c.id]);
+	});
+
+	it("commits a genuine reorder untouched after the same drag start", async () => {
+		const a = new ObsidianCommand("Alpha", "a");
+		const b = new ObsidianCommand("Beta", "b");
+		const c = new ObsidianCommand("Gamma", "c");
+		const saveCommands = vi.fn();
+
+		const { container } = render(CommandList, {
+			props: makeProps([a, b, c], saveCommands),
+		});
+		const zone = container.querySelector(".quickAddCommandList") as Element;
+
+		const shadowOfA = { ...a, id: SHADOW_PLACEHOLDER_ITEM_ID } as ICommand;
+		await fireDnd(zone, "consider", [shadowOfA, b, c], TRIGGERS.DRAG_STARTED, a.id);
+		await fireDnd(zone, "finalize", [b, a, c], TRIGGERS.DROPPED_INTO_ZONE, a.id);
+
+		expect(saveCommands).toHaveBeenCalledTimes(1);
+		const saved = saveCommands.mock.calls[0][0] as ICommand[];
+		expect(saved.map((cmd) => cmd.id)).toEqual([b.id, a.id, c.id]);
+	});
+});

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { ICommand } from "../../types/macros/ICommand";
 import { Platform } from "obsidian";
-import { alertToScreenReader, type DndEvent, dndzone, SHADOW_PLACEHOLDER_ITEM_ID, SOURCES, TRIGGERS } from "svelte-dnd-action";
-import { baseDndOptions, replaceById, stripShadow } from "../shared/dndReorder";
+import { alertToScreenReader, type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
+import { baseDndOptions, capturePlaceholderRecovery, type PlaceholderRecovery, replaceById, stripShadow } from "../shared/dndReorder";
 import { createDragArming } from "../shared/dragArming.svelte";
 import { getCommandDisplayName } from "../../utils/macroHelpers";
 import { snapshot } from "../svelte/persist.svelte";
@@ -117,25 +117,20 @@ function persist() {
 	saveCommands(snapshot(commands));
 }
 
-// Pre-drag order, captured at DRAG_STARTED. stripShadow removes the library's
-// placeholder, whose id stays SHADOW_PLACEHOLDER_ITEM_ID until a later consider
-// re-adds the shadow under the real id — so a drop inside that window (mobile
-// long-press with little or no movement) would commit the list without the
-// dragged command (#1692, same window as ChoiceList's). handleSort re-inserts
-// the dragged command then — at the index the stripped placeholder last
-// occupied, because the first DRAGGED_ENTERED can already carry the user's
-// intended position, and restoring the pre-drag order would silently cancel it.
-let preDragCommands: ICommand[] | null = null;
-let placeholderIndex = 0;
+// The dragged command, reconstructed from the last placeholder-id shadow that
+// stripShadow discarded (see capturePlaceholderRecovery). A drop inside that
+// window (mobile long-press with little or no movement) would otherwise commit
+// the list without the dragged command (#1692, same window as ChoiceList's).
+// handleSort re-inserts the payload then, at the index the placeholder last
+// occupied — the first DRAGGED_ENTERED can already carry the user's intended
+// position, and a pre-drag-order restore would silently cancel it.
+let placeholderRecovery: PlaceholderRecovery<ICommand> | null = null;
 
 function handleConsider(e: CustomEvent<DndEvent>) {
 	drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
 	const items = e.detail.items as ICommand[];
-	if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED) {
-		preDragCommands = renderable; // still the pre-drag list at this point
-	}
-	const shadowIdx = items.findIndex((it) => it.id === SHADOW_PLACEHOLDER_ITEM_ID);
-	if (shadowIdx !== -1) placeholderIndex = shadowIdx;
+	placeholderRecovery =
+		capturePlaceholderRecovery(items, e.detail.info.id) ?? placeholderRecovery;
 	// Strip svelte-dnd-action's shadow placeholder so a command can't linger in
 	// state and vanish on reorder (ghost gap) — see [[svelte-dnd-action-shadow-placeholder]].
 	commands = stripShadow(items);
@@ -144,17 +139,14 @@ function handleConsider(e: CustomEvent<DndEvent>) {
 function handleSort(e: CustomEvent<DndEvent>) {
 	let next = stripShadow(e.detail.items as ICommand[]);
 	const draggedId = e.detail.info.id;
-	if (!next.some((c) => c.id === draggedId)) {
-		const dragged = preDragCommands?.find((c) => c.id === draggedId);
-		if (dragged) {
-			// Dropped inside the placeholder window (see preDragCommands): committing
-			// `next` would delete the dragged command. Re-insert it where the
-			// stripped placeholder last stood.
-			next = [...next];
-			next.splice(Math.min(placeholderIndex, next.length), 0, dragged);
-		}
+	if (placeholderRecovery?.item.id === draggedId && !next.some((c) => c.id === draggedId)) {
+		// Dropped inside the placeholder window (see placeholderRecovery):
+		// committing `next` would delete the dragged command. Re-insert it
+		// where the stripped placeholder last stood.
+		next = [...next];
+		next.splice(Math.min(placeholderRecovery.index, next.length), 0, placeholderRecovery.item);
 	}
-	preDragCommands = null;
+	placeholderRecovery = null;
 	commands = next;
 
 	// Desktop: disarm after a pointer drag so the handle must be grabbed again.

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ICommand } from "../../types/macros/ICommand";
 import { Platform } from "obsidian";
-import { alertToScreenReader, type DndEvent, dndzone, SOURCES, TRIGGERS } from "svelte-dnd-action";
+import { alertToScreenReader, type DndEvent, dndzone, SHADOW_PLACEHOLDER_ITEM_ID, SOURCES, TRIGGERS } from "svelte-dnd-action";
 import { baseDndOptions, replaceById, stripShadow } from "../shared/dndReorder";
 import { createDragArming } from "../shared/dragArming.svelte";
 import { getCommandDisplayName } from "../../utils/macroHelpers";
@@ -121,30 +121,38 @@ function persist() {
 // placeholder, whose id stays SHADOW_PLACEHOLDER_ITEM_ID until a later consider
 // re-adds the shadow under the real id — so a drop inside that window (mobile
 // long-press with little or no movement) would commit the list without the
-// dragged command (#1692, same window as ChoiceList's). handleSort falls back
-// to this snapshot then: no reorder was registered, so it is the correct commit.
+// dragged command (#1692, same window as ChoiceList's). handleSort re-inserts
+// the dragged command then — at the index the stripped placeholder last
+// occupied, because the first DRAGGED_ENTERED can already carry the user's
+// intended position, and restoring the pre-drag order would silently cancel it.
 let preDragCommands: ICommand[] | null = null;
+let placeholderIndex = 0;
 
 function handleConsider(e: CustomEvent<DndEvent>) {
 	drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
+	const items = e.detail.items as ICommand[];
 	if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED) {
 		preDragCommands = renderable; // still the pre-drag list at this point
 	}
+	const shadowIdx = items.findIndex((it) => it.id === SHADOW_PLACEHOLDER_ITEM_ID);
+	if (shadowIdx !== -1) placeholderIndex = shadowIdx;
 	// Strip svelte-dnd-action's shadow placeholder so a command can't linger in
 	// state and vanish on reorder (ghost gap) — see [[svelte-dnd-action-shadow-placeholder]].
-	commands = stripShadow(e.detail.items as ICommand[]);
+	commands = stripShadow(items);
 }
 
 function handleSort(e: CustomEvent<DndEvent>) {
 	let next = stripShadow(e.detail.items as ICommand[]);
 	const draggedId = e.detail.info.id;
-	if (
-		preDragCommands?.some((c) => c.id === draggedId) &&
-		!next.some((c) => c.id === draggedId)
-	) {
-		// Dropped inside the placeholder window (see preDragCommands): committing
-		// `next` would delete the dragged command. Restore the pre-drag order.
-		next = preDragCommands;
+	if (!next.some((c) => c.id === draggedId)) {
+		const dragged = preDragCommands?.find((c) => c.id === draggedId);
+		if (dragged) {
+			// Dropped inside the placeholder window (see preDragCommands): committing
+			// `next` would delete the dragged command. Re-insert it where the
+			// stripped placeholder last stood.
+			next = [...next];
+			next.splice(Math.min(placeholderIndex, next.length), 0, dragged);
+		}
 	}
 	preDragCommands = null;
 	commands = next;

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { ICommand } from "../../types/macros/ICommand";
 import { Platform } from "obsidian";
-import { alertToScreenReader, type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
+import { alertToScreenReader, type DndEvent, dndzone, SOURCES, TRIGGERS } from "svelte-dnd-action";
 import { baseDndOptions, replaceById, stripShadow } from "../shared/dndReorder";
 import { createDragArming } from "../shared/dragArming.svelte";
 import { getCommandDisplayName } from "../../utils/macroHelpers";
@@ -117,15 +117,37 @@ function persist() {
 	saveCommands(snapshot(commands));
 }
 
+// Pre-drag order, captured at DRAG_STARTED. stripShadow removes the library's
+// placeholder, whose id stays SHADOW_PLACEHOLDER_ITEM_ID until a later consider
+// re-adds the shadow under the real id — so a drop inside that window (mobile
+// long-press with little or no movement) would commit the list without the
+// dragged command (#1692, same window as ChoiceList's). handleSort falls back
+// to this snapshot then: no reorder was registered, so it is the correct commit.
+let preDragCommands: ICommand[] | null = null;
+
 function handleConsider(e: CustomEvent<DndEvent>) {
 	drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
+	if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED) {
+		preDragCommands = renderable; // still the pre-drag list at this point
+	}
 	// Strip svelte-dnd-action's shadow placeholder so a command can't linger in
 	// state and vanish on reorder (ghost gap) — see [[svelte-dnd-action-shadow-placeholder]].
 	commands = stripShadow(e.detail.items as ICommand[]);
 }
 
 function handleSort(e: CustomEvent<DndEvent>) {
-	commands = stripShadow(e.detail.items as ICommand[]);
+	let next = stripShadow(e.detail.items as ICommand[]);
+	const draggedId = e.detail.info.id;
+	if (
+		preDragCommands?.some((c) => c.id === draggedId) &&
+		!next.some((c) => c.id === draggedId)
+	) {
+		// Dropped inside the placeholder window (see preDragCommands): committing
+		// `next` would delete the dragged command. Restore the pre-drag order.
+		next = preDragCommands;
+	}
+	preDragCommands = null;
+	commands = next;
 
 	// Desktop: disarm after a pointer drag so the handle must be grabbed again.
 	// Mobile: dragDisabled ignores `armed`, so this is a no-op.

--- a/src/gui/choiceList/ChoiceList.crosszone.test.ts
+++ b/src/gui/choiceList/ChoiceList.crosszone.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/svelte";
-import { TRIGGERS } from "svelte-dnd-action";
+import { SHADOW_PLACEHOLDER_ITEM_ID, TRIGGERS } from "svelte-dnd-action";
 
 // ChoiceListItem -> renderChoiceName/contextMenu reach src/main -> obsidian-dataview.
 vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
@@ -55,6 +55,21 @@ function fireFinalize(
 	return fireEvent(
 		zone,
 		new CustomEvent("finalize", {
+			detail: { items, info: { trigger, id, source: "pointer" } },
+		}),
+	);
+}
+
+/** Dispatch the dndzone `consider` CustomEvent the library emits mid-drag. */
+function fireConsider(
+	zone: Element,
+	items: IChoice[],
+	trigger: string,
+	id: string,
+): Promise<unknown> {
+	return fireEvent(
+		zone,
+		new CustomEvent("consider", {
 			detail: { items, info: { trigger, id, source: "pointer" } },
 		}),
 	);
@@ -125,5 +140,97 @@ describe("ChoiceList cross-zone de-dup (handleSort)", () => {
 		);
 
 		expect(committedIds(actions.onReorderChoices)).toEqual(["A", "C"]);
+	});
+});
+
+/**
+ * #1692: the placeholder-window drop. handleConsider strips the library's shadow
+ * placeholder, whose id is still SHADOW_PLACEHOLDER_ITEM_ID at DRAG_STARTED (and on
+ * the first synchronous DRAGGED_ENTERED) — so until a later consider re-adds the
+ * shadow under the real id, the list is missing the dragged choice entirely. Mobile
+ * long-press drags start stationary and routinely drop inside that window (hold-and-
+ * release, a small nudge, or a touchend before the next ~20ms observation tick), and
+ * the finalize then reports items WITHOUT the dragged choice. Committing that verbatim
+ * deleted the choice on Android. handleSort must fall back to the pre-drag order.
+ * Event payloads mirror a real drag, verified against svelte-dnd-action 0.9.78 in the
+ * E2E Obsidian instance under mobile emulation.
+ */
+describe("ChoiceList placeholder-window drop (#1692)", () => {
+	const shadowOf = (choice: IChoice): IChoice =>
+		({ ...choice, id: SHADOW_PLACEHOLDER_ITEM_ID }) as IChoice;
+
+	it("restores the pre-drag order when the finalize is missing the dragged choice", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("A"), normal("B"), normal("C")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		// Long-press drag start: the library replaces A with its placeholder shadow.
+		await fireConsider(
+			zone,
+			[shadowOf(normal("A")), normal("B"), normal("C")],
+			TRIGGERS.DRAG_STARTED,
+			"A",
+		);
+		// Drop before any index-change consider: A is gone from the reported items.
+		await fireFinalize(
+			zone,
+			[normal("B"), normal("C")],
+			TRIGGERS.DROPPED_INTO_ZONE,
+			"A",
+		);
+
+		expect(committedIds(actions.onReorderChoices)).toEqual(["A", "B", "C"]);
+	});
+
+	it("commits a genuine reorder untouched after the same drag start", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("A"), normal("B"), normal("C")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		await fireConsider(
+			zone,
+			[shadowOf(normal("A")), normal("B"), normal("C")],
+			TRIGGERS.DRAG_STARTED,
+			"A",
+		);
+		await fireFinalize(
+			zone,
+			[normal("B"), normal("A"), normal("C")],
+			TRIGGERS.DROPPED_INTO_ZONE,
+			"A",
+		);
+
+		expect(committedIds(actions.onReorderChoices)).toEqual(["B", "A", "C"]);
+	});
+
+	it("still strips the dragged choice on DROPPED_INTO_ANOTHER after a drag start", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("A"), normal("B"), normal("C")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		await fireConsider(
+			zone,
+			[shadowOf(normal("A")), normal("B"), normal("C")],
+			TRIGGERS.DRAG_STARTED,
+			"A",
+		);
+		// The drop landed in another zone; the snapshot must NOT resurrect A here.
+		await fireFinalize(
+			zone,
+			[normal("A"), normal("B"), normal("C")],
+			TRIGGERS.DROPPED_INTO_ANOTHER,
+			"A",
+		);
+
+		expect(committedIds(actions.onReorderChoices)).toEqual(["B", "C"]);
 	});
 });

--- a/src/gui/choiceList/ChoiceList.crosszone.test.ts
+++ b/src/gui/choiceList/ChoiceList.crosszone.test.ts
@@ -157,7 +157,11 @@ describe("ChoiceList cross-zone de-dup (handleSort)", () => {
  */
 describe("ChoiceList placeholder-window drop (#1692)", () => {
 	const shadowOf = (choice: IChoice): IChoice =>
-		({ ...choice, id: SHADOW_PLACEHOLDER_ITEM_ID }) as IChoice;
+		({
+			...choice,
+			id: SHADOW_PLACEHOLDER_ITEM_ID,
+			isDndShadowItem: true,
+		}) as IChoice;
 
 	it("restores the pre-drag order when the finalize is missing the dragged choice", async () => {
 		const actions = actionsSpy();
@@ -216,6 +220,32 @@ describe("ChoiceList placeholder-window drop (#1692)", () => {
 
 		// The reorder the user made inside the window is preserved, not reverted.
 		expect(committedIds(actions.onReorderChoices)).toEqual(["B", "C", "A"]);
+	});
+
+	it("recovers in the DESTINATION zone of a cross-zone drop, sans the library marker", async () => {
+		const actions = actionsSpy();
+		// This zone never saw DRAG_STARTED: the drag began in another zone.
+		const choices = [normal("X"), normal("Y")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		// The dragged item enters while its shadow still has the placeholder id.
+		await fireConsider(
+			zone,
+			[normal("X"), shadowOf(normal("A")), normal("Y")],
+			TRIGGERS.DRAGGED_ENTERED,
+			"A",
+		);
+		await fireFinalize(zone, [normal("X"), normal("Y")], TRIGGERS.DROPPED_INTO_ZONE, "A");
+
+		expect(committedIds(actions.onReorderChoices)).toEqual(["X", "A", "Y"]);
+		const committed = (actions.onReorderChoices as ReturnType<typeof vi.fn>).mock
+			.calls[0][0] as Record<string, unknown>[];
+		// The recovered item is rebuilt from the shadow payload; the library's
+		// marker must not leak into state (it would persist into data.json).
+		expect(committed[1]).not.toHaveProperty("isDndShadowItem");
 	});
 
 	it("commits a genuine reorder untouched after the same drag start", async () => {

--- a/src/gui/choiceList/ChoiceList.crosszone.test.ts
+++ b/src/gui/choiceList/ChoiceList.crosszone.test.ts
@@ -185,6 +185,39 @@ describe("ChoiceList placeholder-window drop (#1692)", () => {
 		expect(committedIds(actions.onReorderChoices)).toEqual(["A", "B", "C"]);
 	});
 
+	it("re-inserts at the index the stripped placeholder last held (fast move into the window)", async () => {
+		const actions = actionsSpy();
+		const choices = [normal("A"), normal("B"), normal("C")];
+		const { container } = render(ChoiceList, {
+			props: { app: new App() as never, roots: choices, choices, actions },
+		});
+		const zone = container.querySelector(".choiceList") as Element;
+
+		await fireConsider(
+			zone,
+			[shadowOf(normal("A")), normal("B"), normal("C")],
+			TRIGGERS.DRAG_STARTED,
+			"A",
+		);
+		// The first DRAGGED_ENTERED (still placeholder-id: it fires before the
+		// library swaps in the real id) already reports the user's new position.
+		await fireConsider(
+			zone,
+			[normal("B"), normal("C"), shadowOf(normal("A"))],
+			TRIGGERS.DRAGGED_ENTERED,
+			"A",
+		);
+		await fireFinalize(
+			zone,
+			[normal("B"), normal("C")],
+			TRIGGERS.DROPPED_INTO_ZONE,
+			"A",
+		);
+
+		// The reorder the user made inside the window is preserved, not reverted.
+		expect(committedIds(actions.onReorderChoices)).toEqual(["B", "C", "A"]);
+	});
+
 	it("commits a genuine reorder untouched after the same drag start", async () => {
 		const actions = actionsSpy();
 		const choices = [normal("A"), normal("B"), normal("C")];

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -3,9 +3,9 @@
     import type IMultiChoice from "../../types/choices/IMultiChoice";
     import ChoiceListItem from "./ChoiceListItem.svelte";
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
-    import { alertToScreenReader, type DndEvent, dndzone, SHADOW_PLACEHOLDER_ITEM_ID, TRIGGERS } from "svelte-dnd-action";
+    import { alertToScreenReader, type DndEvent, dndzone, TRIGGERS } from "svelte-dnd-action";
     import { flip } from "svelte/animate";
-    import { baseDndOptions, stripShadow } from "../shared/dndReorder";
+    import { baseDndOptions, capturePlaceholderRecovery, type PlaceholderRecovery, stripShadow } from "../shared/dndReorder";
     import { createDragArming } from "../shared/dragArming.svelte";
     import { Platform, type App } from "obsidian";
     import { isChoiceLike, rootChoicesOf } from "../../utils/choiceUtils";
@@ -94,31 +94,25 @@
     const drag = createDragArming();
     const dragDisabled = $derived(forceDragDisabled || (!isMobile && !drag.armed));
 
-    // Pre-drag order, captured at DRAG_STARTED. The stripShadow below removes the
-    // library's placeholder, whose id is still SHADOW_PLACEHOLDER_ITEM_ID both at
-    // drag start and on the first DRAGGED_ENTERED (dispatched synchronously before
-    // the library swaps in the real id) — so until a later consider re-adds the
-    // shadow under the REAL id, `choices` is missing the dragged item entirely. A
-    // drop inside that window commits — and persists — the list without the dragged
-    // choice (#1692). Mouse drags always move enough to close the window; mobile
-    // long-press drags start stationary and routinely drop inside it (a hold-and-
-    // release, a small nudge, or a touchend before the next ~20ms observation
-    // tick). handleSort re-inserts the dragged choice then — at the index the
-    // stripped placeholder last occupied, because the first DRAGGED_ENTERED can
-    // already carry the user's intended position (a fast move during the swap
-    // window), and restoring the pre-drag order there would silently cancel it.
-    let preDragChoices: IChoice[] | null = null;
-    let placeholderIndex = 0;
+    // The dragged choice, reconstructed from the last placeholder-id shadow that
+    // stripShadow discarded (see capturePlaceholderRecovery: stripping it leaves
+    // the zone with no trace of the dragged item until a later consider re-adds
+    // the shadow under the REAL id). A drop inside that window commits — and
+    // persists — the list without the dragged choice (#1692). Mouse drags always
+    // move enough to close the window; mobile long-press drags start stationary
+    // and routinely drop inside it (a hold-and-release, a small nudge, or a
+    // touchend before the next ~20ms observation tick). handleSort re-inserts
+    // the payload then, at the index the placeholder last occupied — the first
+    // DRAGGED_ENTERED can already carry the user's intended position, and a
+    // pre-drag-order restore would silently cancel it.
+    let placeholderRecovery: PlaceholderRecovery<IChoice> | null = null;
 
     function handleConsider(e: CustomEvent<DndEvent>) {
         if (forceDragDisabled) return; // filtered view: never mutate a derived list
         drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
         const items = e.detail.items as IChoice[];
-        if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED) {
-            preDragChoices = renderable; // still the pre-drag list at this point
-        }
-        const shadowIdx = items.findIndex((it) => it.id === SHADOW_PLACEHOLDER_ITEM_ID);
-        if (shadowIdx !== -1) placeholderIndex = shadowIdx;
+        placeholderRecovery =
+            capturePlaceholderRecovery(items, e.detail.info.id) ?? placeholderRecovery;
         collapseId = e.detail.info.id;
         // Strip the dnd shadow placeholder so it can't linger and cause ghost gaps
         // (bugs #1244/#883) — see [[svelte-dnd-action-shadow-placeholder]].
@@ -138,17 +132,21 @@
         // strip alone is insufficient at depth >= 2; both are load-bearing.
         if (e.detail.info.trigger === TRIGGERS.DROPPED_INTO_ANOTHER) {
             next = next.filter((c) => c.id !== draggedId);
-        } else if (!next.some((c) => c.id === draggedId)) {
-            const dragged = preDragChoices?.find((c) => c.id === draggedId);
-            if (dragged) {
-                // Dropped inside the placeholder window (see preDragChoices):
-                // committing `next` would delete the dragged choice. Re-insert it
-                // where the stripped placeholder last stood.
-                next = [...next];
-                next.splice(Math.min(placeholderIndex, next.length), 0, dragged);
-            }
+        } else if (
+            placeholderRecovery?.item.id === draggedId &&
+            !next.some((c) => c.id === draggedId)
+        ) {
+            // Dropped inside the placeholder window (see placeholderRecovery):
+            // committing `next` would delete the dragged choice. Re-insert it
+            // where the stripped placeholder last stood.
+            next = [...next];
+            next.splice(
+                Math.min(placeholderRecovery.index, next.length),
+                0,
+                placeholderRecovery.item,
+            );
         }
-        preDragChoices = null;
+        placeholderRecovery = null;
         choices = next;
         // Desktop: disarm so a subsequent row interaction doesn't drag (handle must be
         // grabbed again). Mobile: dragDisabled ignores `armed`, so this is a no-op.

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -94,9 +94,25 @@
     const drag = createDragArming();
     const dragDisabled = $derived(forceDragDisabled || (!isMobile && !drag.armed));
 
+    // Pre-drag order, captured at DRAG_STARTED. The stripShadow below removes the
+    // library's placeholder, whose id is still SHADOW_PLACEHOLDER_ITEM_ID both at
+    // drag start and on the first DRAGGED_ENTERED (dispatched synchronously before
+    // the library swaps in the real id) — so until a later consider re-adds the
+    // shadow under the REAL id, `choices` is missing the dragged item entirely. A
+    // drop inside that window commits — and persists — the list without the dragged
+    // choice (#1692). Mouse drags always move enough to close the window; mobile
+    // long-press drags start stationary and routinely drop inside it (a hold-and-
+    // release, a small nudge, or a touchend before the next ~20ms observation
+    // tick). handleSort falls back to this snapshot then: the library registered
+    // no reorder in that window, so the pre-drag order is the correct commit.
+    let preDragChoices: IChoice[] | null = null;
+
     function handleConsider(e: CustomEvent<DndEvent>) {
         if (forceDragDisabled) return; // filtered view: never mutate a derived list
         drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
+        if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED) {
+            preDragChoices = renderable; // still the pre-drag list at this point
+        }
         collapseId = e.detail.info.id;
         // Strip the dnd shadow placeholder so it can't linger and cause ghost gaps
         // (bugs #1244/#883) — see [[svelte-dnd-action-shadow-placeholder]].
@@ -107,6 +123,7 @@
         if (forceDragDisabled) return;
         collapseId = "";
         let next = stripShadow(e.detail.items as IChoice[]);
+        const draggedId = e.detail.info.id;
         // Cross-zone de-dupe: on DROPPED_INTO_ANOTHER the dragged item landed in a
         // DIFFERENT zone, yet svelte-dnd can still report it in THIS (source) list — so
         // committing this list verbatim would persist a copy in BOTH the source and the
@@ -114,8 +131,16 @@
         // CO-DEPENDENT with setFolderChildrenById's by-id commit (choiceService) — the
         // strip alone is insufficient at depth >= 2; both are load-bearing.
         if (e.detail.info.trigger === TRIGGERS.DROPPED_INTO_ANOTHER) {
-            next = next.filter((c) => c.id !== e.detail.info.id);
+            next = next.filter((c) => c.id !== draggedId);
+        } else if (
+            preDragChoices?.some((c) => c.id === draggedId) &&
+            !next.some((c) => c.id === draggedId)
+        ) {
+            // Dropped inside the placeholder window (see preDragChoices): committing
+            // `next` would delete the dragged choice. Restore the pre-drag order.
+            next = preDragChoices;
         }
+        preDragChoices = null;
         choices = next;
         // Desktop: disarm so a subsequent row interaction doesn't drag (handle must be
         // grabbed again). Mobile: dragDisabled ignores `armed`, so this is a no-op.

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -3,7 +3,7 @@
     import type IMultiChoice from "../../types/choices/IMultiChoice";
     import ChoiceListItem from "./ChoiceListItem.svelte";
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
-    import { alertToScreenReader, type DndEvent, dndzone, TRIGGERS } from "svelte-dnd-action";
+    import { alertToScreenReader, type DndEvent, dndzone, SHADOW_PLACEHOLDER_ITEM_ID, TRIGGERS } from "svelte-dnd-action";
     import { flip } from "svelte/animate";
     import { baseDndOptions, stripShadow } from "../shared/dndReorder";
     import { createDragArming } from "../shared/dragArming.svelte";
@@ -103,20 +103,26 @@
     // choice (#1692). Mouse drags always move enough to close the window; mobile
     // long-press drags start stationary and routinely drop inside it (a hold-and-
     // release, a small nudge, or a touchend before the next ~20ms observation
-    // tick). handleSort falls back to this snapshot then: the library registered
-    // no reorder in that window, so the pre-drag order is the correct commit.
+    // tick). handleSort re-inserts the dragged choice then — at the index the
+    // stripped placeholder last occupied, because the first DRAGGED_ENTERED can
+    // already carry the user's intended position (a fast move during the swap
+    // window), and restoring the pre-drag order there would silently cancel it.
     let preDragChoices: IChoice[] | null = null;
+    let placeholderIndex = 0;
 
     function handleConsider(e: CustomEvent<DndEvent>) {
         if (forceDragDisabled) return; // filtered view: never mutate a derived list
         drag.markStarted(); // a genuine drag is underway (see the arming failsafe)
+        const items = e.detail.items as IChoice[];
         if (e.detail.info.trigger === TRIGGERS.DRAG_STARTED) {
             preDragChoices = renderable; // still the pre-drag list at this point
         }
+        const shadowIdx = items.findIndex((it) => it.id === SHADOW_PLACEHOLDER_ITEM_ID);
+        if (shadowIdx !== -1) placeholderIndex = shadowIdx;
         collapseId = e.detail.info.id;
         // Strip the dnd shadow placeholder so it can't linger and cause ghost gaps
         // (bugs #1244/#883) — see [[svelte-dnd-action-shadow-placeholder]].
-        choices = stripShadow(e.detail.items as IChoice[]);
+        choices = stripShadow(items);
     }
 
     function handleSort(e: CustomEvent<DndEvent>) {
@@ -132,13 +138,15 @@
         // strip alone is insufficient at depth >= 2; both are load-bearing.
         if (e.detail.info.trigger === TRIGGERS.DROPPED_INTO_ANOTHER) {
             next = next.filter((c) => c.id !== draggedId);
-        } else if (
-            preDragChoices?.some((c) => c.id === draggedId) &&
-            !next.some((c) => c.id === draggedId)
-        ) {
-            // Dropped inside the placeholder window (see preDragChoices): committing
-            // `next` would delete the dragged choice. Restore the pre-drag order.
-            next = preDragChoices;
+        } else if (!next.some((c) => c.id === draggedId)) {
+            const dragged = preDragChoices?.find((c) => c.id === draggedId);
+            if (dragged) {
+                // Dropped inside the placeholder window (see preDragChoices):
+                // committing `next` would delete the dragged choice. Re-insert it
+                // where the stripped placeholder last stood.
+                next = [...next];
+                next.splice(Math.min(placeholderIndex, next.length), 0, dragged);
+            }
         }
         preDragChoices = null;
         choices = next;

--- a/src/gui/shared/dndReorder.ts
+++ b/src/gui/shared/dndReorder.ts
@@ -1,4 +1,4 @@
-import { SHADOW_PLACEHOLDER_ITEM_ID } from "svelte-dnd-action";
+import { SHADOW_ITEM_MARKER_PROPERTY_NAME, SHADOW_PLACEHOLDER_ITEM_ID } from "svelte-dnd-action";
 import { transformDragPill } from "./dragPill";
 
 /** Anything svelte-dnd-action can reorder in QuickAdd: it has a stable string id. */
@@ -18,6 +18,34 @@ type DragItem = Reorderable & { name?: string; type?: string };
  */
 export function stripShadow<T extends Reorderable>(items: readonly T[]): T[] {
 	return items.filter((item) => item.id !== SHADOW_PLACEHOLDER_ITEM_ID);
+}
+
+/** What a drop needs to undo an over-eager placeholder strip: the item and where it stood. */
+export interface PlaceholderRecovery<T> {
+	item: T;
+	index: number;
+}
+
+/**
+ * Capture a recovery payload from the shadow placeholder BEFORE stripShadow
+ * discards it. The placeholder still carries SHADOW_PLACEHOLDER_ITEM_ID at
+ * DRAG_STARTED and on the first DRAGGED_ENTERED (dispatched before the library
+ * swaps in the real id), so stripping it leaves the zone with no trace of the
+ * dragged item — a drop inside that window would commit, and persist, the list
+ * without it (#1692). The shadow is a spread-copy of the dragged item, so
+ * restoring the real id (the event's `info.id`) and dropping the library's
+ * marker yields a faithful stand-in — in ANY zone, including the destination of
+ * a cross-zone drag, which has no pre-drag snapshot of its own to recover from.
+ */
+export function capturePlaceholderRecovery<T extends Reorderable>(
+	items: readonly T[],
+	draggedId: string,
+): PlaceholderRecovery<T> | null {
+	const index = items.findIndex((item) => item.id === SHADOW_PLACEHOLDER_ITEM_ID);
+	if (index === -1) return null;
+	const shadow = { ...(items[index] as T & Record<string, unknown>) };
+	delete shadow[SHADOW_ITEM_MARKER_PROPERTY_NAME];
+	return { item: { ...shadow, id: draggedId } as T, index };
 }
 
 /**

--- a/src/gui/shared/dndReorder.ts
+++ b/src/gui/shared/dndReorder.ts
@@ -70,6 +70,13 @@ export function baseDndOptions<T extends DragItem>(opts: {
 			transformDragPill(el, data ? resolveLabel(data) : "", data?.type === "Multi"),
 		dropTargetStyle: {},
 		dropTargetClasses: opts.dropTargetClasses ?? [],
+		// With flipDurationMs 0 the drop "animation" was already invisible; disabling
+		// it entirely also removes the library's finalize-time animation-target lookup
+		// (`children[originIndex]`), which THROWS when the LAST row is dropped during
+		// the placeholder window (stripShadow left the zone one child short) — the
+		// finalize then never fires, the drag never cleans up, and the list renders
+		// without the row until the settings tab is rebuilt (#1692, second wave).
+		dropAnimationDisabled: true,
 		autoAriaDisabled: true,
 		zoneItemTabIndex: -1,
 		delayTouchStart: 200,


### PR DESCRIPTION
## Summary

Prevent mobile drag-and-drop operations from deleting commands or choices when a drop occurs before the placeholder is replaced with the dragged item.

## Changes

- Capture the pre-drag order when a drag starts.
- Restore the pre-drag order if a finalize event omits the dragged item during the placeholder window.
- Preserve genuine reorders and cross-zone de-duplication behavior.
- Add regression tests for command and choice lists.

## Testing / validation

- Added Vitest coverage for placeholder-window drops, genuine reorders, and cross-zone drops.
- E2E verification confirmed the relevant `svelte-dnd-action` event payloads under mobile emulation.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) - it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s): #1692.
- [x] Noted release/migration impact, if any: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop handling for command and choice lists.
  * Preserved item positions when dropping during brief placeholder transitions.
  * Prevented dragged items from being accidentally removed or reset.
  * Ensured genuine reordering continues to save correctly.
  * Maintained expected behavior when moving items between lists.
  * Removed drop animations for more consistent drag-and-drop results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->