### PR TITLE
docs: remove version annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,7 @@ Vitest (configured in `vitest.config.mts`) runs under jsdom and cannot load real
 Follow Conventional Commits (`feat:`, `fix:`, `test:`, ...) so the shared release pipeline can determine versions from history. Keep generated files in the same commit as the changes that produced them. Pull requests must include a concise summary, reproduction steps or screenshots for UI changes, linked issues when relevant, and explicit notes on release or migration impact. Request review from maintainers closest to the touched area.
 
 ## Documentation
-Docs live in `docs/` (Astro Starlight) and are single-version: pages in `docs/src/content/docs/docs/` serve at `/docs/` on quickadd.obsidian.guide, and edits go live when they land on `master` (deployed by Cloudflare Pages). There are no versioned snapshots - do NOT recreate `versioned_docs/` or any per-release docs copies. Historical docs states are recoverable from git tags. Every page pins its URL with a `slug:` frontmatter field; keep slugs stable, and add a 301 in `docs/public/_redirects` if one must change.
-
-Because docs track `master` while plugin releases are cut manually, docs can briefly describe features users don't have yet. The contract for that window: when documenting a feature that has not shipped in a release, add an `_Introduced in QuickAdd X.Y.Z._` line (or an `:::note[Available in the next release]` callout) at the section you're adding, in the same PR as the docs change. Fill in the real version number if it's known from the pending release.
-
-Old `/docs/<version>/...` and `/docs/next/...` URLs 301 to their current equivalents via `docs/public/_redirects` (Cloudflare Pages reads it from the build output). If a docs page is ever renamed or deleted, add a redirect for its old path there.
+Docs live in `docs/` (Astro Starlight) and are single-version: pages in `docs/src/content/docs/docs/` serve at `/docs/` on quickadd.obsidian.guide, and edits go live when they land on `master` (deployed by Cloudflare Pages). Every page pins its URL with a `slug:` frontmatter field; keep slugs stable, and add a 301 in `docs/public/_redirects` if one must change.
 
 ## Agent Playbook
 Automation or scripted work should surface disruptive operations in the PR description and rerun `pnpm run build-with-lint` to keep `main.js`, `manifest.json`, and `versions.json` synchronized. Treat unexpected diffs in those artifacts as blockers until a maintainer approves.

--- a/docs/src/content/docs/docs/AIAssistant.md
+++ b/docs/src/content/docs/docs/AIAssistant.md
@@ -163,8 +163,6 @@ If the provider a command is pinned to is later deleted, QuickAdd falls back to
 the first provider that serves a model with that name and warns you about the
 switch. Re-select the model in the command to pin it again.
 
-_Introduced in QuickAdd 2.19.0._
-
 ### Where QuickAdd gets the model list: Model source {#model-source}
 
 Each provider has a **Model source** setting:

--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -67,8 +67,6 @@ obsidian vault=dev quickadd:run-template \
 - The picker (interactive command) only lists templates inside your configured template folder(s); `path=` here is explicit, so any vault file resolves.
 - Like `quickadd:run`, name collisions on the target note still prompt (the file-exists choice is not a pre-collected input). Under `quickadd:interactive` that prompt is forwarded to you like any other.
 
-_Introduced in QuickAdd 2.14.0._
-
 ## Pass variables to a choice {#passing-variables}
 
 QuickAdd's CLI accepts variables three ways:
@@ -156,11 +154,6 @@ carries `error` instead and no `effect`, because there is no outcome to describe
 The `obsidian://quickadd` [x-callback](/docs/Advanced/TriggerQuickAddFromOutsideObsidian/)
 success callback carries the same `effect` value.
 
-:::note[Introduced in QuickAdd 2.20.0]
-`capabilities` in the `quickadd:interactive` handshake contains
-`outcome-effect` on a build that has `effect`.
-:::
-
 ## Answer run-time prompts from outside: `quickadd:interactive` {#interactive-runs-quickaddinteractive}
 
 Some choices prompt at *run time* for inputs that can't be gathered up front -
@@ -188,10 +181,7 @@ picker - are forwarded like any other. (The AI assistant's tool-confirmation dia
 the one that is not: run such a choice at the desktop, or set tool confirmation to
 "never".)
 
-:::note[Introduced in QuickAdd 2.20.0]
-Before 2.20.0, a Template or Capture run opened its own pickers in Obsidian and
-`/abort` could not reach them.
-::: They arrive as `suggester` prompts, and because the engine controls the
+They arrive as `suggester` prompts, and because the engine controls the
 list, a reply that is not one of the offered `value` tokens is refused rather than
 acted on (unless the prompt sets `allowCustomInput`, as the folder and discovery
 pickers do so you can create something new).
@@ -229,20 +219,7 @@ the run may still finish and commit its side effects. Keep polling for the termi
 event either way.
 :::
 
-:::note[Introduced in QuickAdd 2.20.0]
-`"capabilities":["abort"]` in the handshake tells you a build has `POST /abort`
-and the `info` behaviour above. Before them, cancelling an `info` prompt
-ended the run, and there was no explicit way to end one other than to stop polling
-and wait out the ~75s disconnect watchdog.
-:::
-
 ### When a reply is rejected
-
-:::note[Changed in QuickAdd 2.20.0]
-Before 2.20.0, a `cancelled` flag that was not the
-literal `true` was consumed as a cancellation, and a `confirm` prompt with no value was read as
-"No".
-:::
 
 `/reply` answers `400` and leaves the prompt **pending** when it cannot honour
 what you sent, so you can correct the reply and POST again. Two cases:
@@ -266,4 +243,3 @@ Good to know:
 - **Concurrency.** Each run gets its own `sessionId` + `token`; many can run at once without interfering.
 - If no client attaches within ~30s the run is aborted so a prompt can't hang forever.
 
-_Introduced in QuickAdd 2.16.0._

--- a/docs/src/content/docs/docs/Advanced/ObsidianUri.md
+++ b/docs/src/content/docs/docs/Advanced/ObsidianUri.md
@@ -146,8 +146,6 @@ reliably on iOS is a platform behaviour shared with Obsidian core - verify on
 your device.
 :::
 
-_Introduced in QuickAdd 2.14.0._
-
 ## Watch out for sync services {#important-sync-service-limitations}
 
 :::caution

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -128,8 +128,6 @@ Capture still writes to **one** destination per run. To select several related
 notes for metadata, use the [`{{FILE:<folder>|multi}}`](/docs/FormatSyntax/#file)
 placeholder in the capture format instead.
 
-_Introduced in QuickAdd 2.14.0._
-
 ### Capture to notes with a matching property {#capturing-to-a-property}
 
 Type `property:<field>=<value>` to limit the picker to notes whose frontmatter
@@ -155,8 +153,6 @@ Good to know:
 - Only the `folder:` / `tag:` / `exclude-folder:` / `exclude-tag:` / `exclude-file:` pipe filters are applied here.
 - Because `|` starts a filter, a property value cannot itself contain `|`.
 - Typing a new note name (with **Create file if it doesn't exist**) creates the note, but does not automatically give it the property.
-
-_Introduced in QuickAdd 2.14.0._
 
 ### Send one entry to several notes {#capturing-the-same-entry-to-multiple-files}
 
@@ -520,8 +516,6 @@ first`.
 - Ordered placement positions the **new** section only; it doesn't re-sort existing ones.
 - **Ordered** is for headings and can't be combined with **Inline insertion**.
 
-_Introduced in QuickAdd 2.14.0._
-
 ### Choose the heading when capturing {#choose-heading-when-capturing}
 
 Instead of typing the target line when you build the choice, enable **Choose
@@ -540,8 +534,6 @@ Good to know:
 - You can type a heading that doesn't exist yet; enable `Create line if not found` to have QuickAdd create it (type it with its `#` markers, e.g. `## Tasks`).
 - The dropdown lists ATX headings (lines starting with `#`). For a brand-new note created from a template, the picker can't list the template's headings (the note doesn't exist at pick time) - type the heading and use `Create line if not found`.
 - With the one-page input form, the heading dropdown still appears as a separate step after the form.
-
-_Introduced in QuickAdd 2.14.0._
 
 ### Consider subsections {#consider-subsections--option}
 

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -60,12 +60,10 @@ Two things to know about the quoted form:
 
 - QuickAdd escapes the filled-in value for the surrounding quotes, so answers
   containing `"` or `'` can't break the created note's frontmatter.
-  _Introduced in QuickAdd 2.22.0._
 - Quotes normally make the property a **string**. For a typed property, declare
   the type on the token and the quotes are consumed:
   `rating: "{{VALUE:rating|type:number}}"` writes `rating: 42`, which Obsidian
   reads as a Number (same for `|type:checkbox` and `|type:slider`).
-  _Introduced in QuickAdd 2.22.0._
 
 ## Run a template without making a choice {#run-without-choice}
 

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -156,8 +156,6 @@ Good to know:
 - `|startof:` and `|endof:` are the only special pipe options in a date format. Any other literal `|` is kept as-is: `{{DATE:YYYY|MM}}` gives `2023|06`.
 - An unknown unit (like `|startof:fortnight`) shows an error listing the valid units.
 
-_Introduced in QuickAdd 2.14.0._
-
 ### The current time: `{{TIME}}` {#time}
 
 `{{TIME}}` becomes the current time in `HH:mm` format. `{{TIME:<format>}}`
@@ -234,8 +232,6 @@ start: {{VDATE:start,YYYY-MM-DDTHH:mm|time}}
 Combines with a default and `optional` in any order:
 `{{VDATE:meeting,YYYY-MM-DD HH:mm|tomorrow at 3pm|time|optional}}`. Without
 `|time`, the picker stays date-only.
-
-_Introduced in QuickAdd 2.14.0._
 
 ## Ask for input
 
@@ -367,7 +363,6 @@ Variants and combinations:
 - `|multi|custom` adds a text box to the picker for values not in the list.
 - Combines with `|name:`, `|label:`, `|text:`, `|optional`, and `|trim`. `|case:` is ignored (a list isn't case-transformed).
 
-:::note[Introduced in QuickAdd 2.22.0]
 Add `|format:` when the output shape should be intentional instead of inferred
 from where the placeholder appears:
 
@@ -387,15 +382,12 @@ Formatting is separate from the selected item representation, so it composes
 with `|multi:linklist`, `|text:`, `|custom`, and the other multi-select options.
 For example, `|multi:linklist|format:yaml` writes a native YAML list of
 wikilinks.
-:::
 
 Good to know:
 
 - The picks become a real YAML list **inside front matter**. In a note body they become comma-separated text.
 - In a **Capture**, multi-select becomes a list only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template). Other capture shapes write comma-separated text.
 - With the [one-page input form](/docs/Advanced/onePageInputs/), avoid commas inside a single option (like `|text:"High, urgent"`) on a `|multi` placeholder - the one-page picker can't round-trip them. The default one-prompt-at-a-time picker handles them correctly.
-
-_Introduced in QuickAdd 2.14.0._
 
 #### Reuse the pick elsewhere: `|name:` {#value-name}
 
@@ -421,8 +413,6 @@ Good to know:
 - `value` and `title` are reserved and can't be used as names.
 - Names match case-insensitively: `{{VALUE:Category}}` reuses a pick named `category`.
 - **First definition wins.** If the same `|name` appears twice with different options in one run, the first definition's pick is reused and the second is never shown (a warning is logged to the developer console). Use distinct names for separate prompts.
-
-_Introduced in QuickAdd 2.14.0._
 
 ### Fine-tune any prompt
 
@@ -501,8 +491,6 @@ Good to know:
 - Dates like `2025-12-25` are always kept as text by Obsidian, so they never need `|type:text`.
 - `|min:`, `|max:`, and `|step:` are only treated as numeric options together with `|type:number` or `|type:slider`. Without those, they keep their old meaning as ordinary text.
 
-_Introduced in QuickAdd 2.14.0._
-
 #### Change the casing: `|case:` {#value-case}
 
 Transforms the answer's casing. Styles: `kebab`, `snake`, `camel`, `pascal`,
@@ -532,8 +520,6 @@ answer can be used raw in one place and trimmed in another. It composes with
 other options (`{{VALUE:title|trim|case:slug}}`). For `|multi` values, each
 entry is trimmed while the value stays a list. The keyed form `|trim:false`
 turns trimming off when a shared snippet adds it.
-
-_Introduced in QuickAdd 2.14.0._
 
 ### Make a prompt skippable: `|optional` {#optional-fields}
 
@@ -607,8 +593,6 @@ disambiguating ancestor path (`[[Note#Parent#Heading]]`); if even that isn't
 unique, it falls back to a whole-file link rather than linking to the wrong
 section. Honors the same required/optional behavior as `{{LINKCURRENT}}`.
 
-_Introduced in QuickAdd 2.14.0._
-
 ### The note's file name: `{{FILENAMECURRENT}}` {#filenamecurrent}
 
 The active note's file name, without the extension: `Notes from
@@ -646,8 +630,6 @@ missing active note always stops the run with a clear error - it never falls
 back to the vault root. In note bodies it honors the same required/optional
 behavior as `{{LINKCURRENT}}`.
 
-_Introduced in QuickAdd 2.18.0._
-
 <a id="foldercurrentname---just-the-folder-name"></a>
 
 #### Just the folder's name: `{{FOLDERCURRENT|name}}` {#foldercurrent-name}
@@ -679,8 +661,6 @@ Where it has a value:
 Where it stays empty: the capture **Capture to** field (that field is what
 *chooses* the folder, so there is nothing to reference yet), the `format`
 JavaScript API, and macro file-path commands.
-
-_Introduced in QuickAdd 2.14.0._
 
 <a id="foldername--just-the-folder-name"></a>
 
@@ -743,12 +723,10 @@ positions it writes comma-separated text. Combines with the same filters and
 defaults as single-value FIELD prompts:
 `{{FIELD:topic|multi|folder:Projects|tag:active|default:Inbox}}`.
 
-:::note[Introduced in QuickAdd 2.22.0]
 FIELD multi-selects support the same explicit output formats as VALUE:
 `|format:yaml`, `|format:markdown`, `|format:inline`, and `|format:auto`.
 For example, `topics: {{FIELD:topic|multi|format:yaml}}` always writes a native
 YAML list, including in template-backed captures.
-:::
 
 :::note
 The one-page input form doesn't inline FIELD multi-selects yet: vault values
@@ -757,8 +735,6 @@ When a format contains `{{FIELD:...|multi}}`, QuickAdd collects the other
 one-page inputs first, then opens the regular multi-select for the FIELD
 value.
 :::
-
-_Introduced in QuickAdd 2.14.0._
 
 #### Default to the active note's value: `|default-from:active` {#field-default-from-active}
 
@@ -798,8 +774,6 @@ Combine with `|multi` to inherit a list property:
 ```md
 topics: {{FIELD:topics|multi|default-from:active}}
 ```
-
-_Introduced in QuickAdd 2.14.0._
 
 #### Filter where suggestions come from {#field-filters}
 
@@ -887,14 +861,10 @@ Good to know:
 - `|link` and `|path` insert characters that aren't valid in file names; in the **file name** field, use the default mode.
 - In a one-page input form, single and multi FILE pickers appear inline. Search matches the friendly title, file name, and full path. Selected files remain exact path-backed values internally, so commas in file names or labels are safe.
 
-:::note[Introduced in QuickAdd 2.22.0]
 FILE multi-selects support `|format:yaml`, `|format:markdown`,
 `|format:inline`, and `|format:auto`. The format composes with `|link` and
 `|path`, so `{{FILE:People|multi|link|format:yaml}}` writes a native YAML list
 of links without relying on the capture context.
-:::
-
-_Introduced in QuickAdd 2.14.0._
 
 ## Insert other content
 

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -53,7 +53,6 @@ tR += result;
 %>
 ```
 
-
 ## User Input Methods
 
 ### `requestInputs(inputs: Array<{ id: string; label?: string; type: "text" | "number" | "textarea" | "dropdown" | "date" | "field-suggest" | "suggester" | "slider"; placeholder?: string; defaultValue?: string; numericConfig?: { min?: number; max?: number; step?: number }; sliderConfig?: { min: number; max: number; step?: number }; options?: string[]; dateFormat?: string; description?: string; optional?: boolean; suggesterConfig?: { allowCustomInput?: boolean; caseSensitive?: boolean; multiSelect?: boolean; } }>): Promise<Record<string, string>>`
@@ -651,8 +650,6 @@ are capped automatically.
 
 ### Give the model tools to call: `ai.agent(config)` {#tool--function-calling--aiagentconfig}
 
-_Introduced in QuickAdd 2.14.0._
-
 Build an **agent**: give the model a prompt and a set of *tools* (JS functions), and it
 will call them in a bounded multi-step loop until it has an answer. Works across your
 configured OpenAI-compatible, Anthropic, and Gemini providers.
@@ -807,8 +804,6 @@ Gets the maximum token limit for a model.
 
 ### `estimateTokens(text: string): number`
 
-_Introduced in QuickAdd 2.14.0._
-
 Estimates the token count for text using QuickAdd's provider-agnostic estimator.
 This is useful for rough prompt sizing, but the configured AI provider remains
 the source of truth for exact context limits and usage.
@@ -948,11 +943,6 @@ module.exports = async (params) => {
 ```
 
 ## Error Handling Best Practices
-
-:::note[Changed in QuickAdd 2.20.0]
-Before 2.20.0, a prompt that failed for a reason other than the user cancelling resolved
-`undefined` instead of rejecting, so a script could not tell a failure from an empty answer.
-:::
 
 A prompt has exactly two non-happy outcomes, and they are different things:
 


### PR DESCRIPTION
Removes all "Introduced in QuickAdd X.Y.Z" / "Changed in QuickAdd X.Y.Z" version annotations from the docs, along with the AGENTS.md paragraphs that prescribed the convention.

The docs are single-version and track master, so per-section version markers add noise without helping readers. Historical behavior notes ("Before 2.20.0 ...") only made sense under that convention and go with it. The three FormatSyntax callouts that were the sole documentation of the `|format:` option are unwrapped into plain prose rather than deleted, so no current-behavior content is lost.

The versioned-URL 301s in `docs/public/_redirects` are intentionally untouched - they serve live inbound links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation guidelines to use stable URLs and require permanent redirects when links change.
  * Removed outdated version-introduction notes across AI Assistant, CLI, URI, capture, template, format syntax, and API documentation.
  * Streamlined documentation by removing historical compatibility annotations while preserving current usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->