### PR TITLE
test(format): lock DATE+N offsets from issue 1704

### DIFF
--- a/src/formatters/formatSyntax.docs-examples.test.ts
+++ b/src/formatters/formatSyntax.docs-examples.test.ts
@@ -297,6 +297,17 @@ describe("Format Syntax documentation examples", () => {
 		}
 	});
 
+	it("applies documented DATE +N day offsets instead of concatenating them", async () => {
+		const formatter = new DocsExampleFormatter();
+
+		await expect(formatter.render("Review on {{DATE+7}}")).resolves.toBe(
+			"Review on 2026-05-14",
+		);
+		await expect(formatter.render("{{DATE:YYYY-MM-DD+3}}")).resolves.toBe(
+			"2026-05-10",
+		);
+	});
+
 	it("collects requirements from the current and 2.12.0 examples", async () => {
 		for (const example of CURRENT_AND_2120_EXAMPLES) {
 			const collector = new RequirementCollector(makeApp(), makePlugin());

--- a/src/formatters/formatter-datesnap.test.ts
+++ b/src/formatters/formatter-datesnap.test.ts
@@ -111,6 +111,23 @@ describe("{{DATE}} snap through replaceDateInString", () => {
 		expect(f.renderDate("{{DATE:YYYY-MM-DD+7|startof:week}}")).toBe("2023-06-04");
 	});
 
+	it("renders the documented +N day offsets from issue #1704", () => {
+		expect(f.renderDate("{{DATE}}")).toBe("2023-06-01");
+		expect(f.renderDate("{{DATE:YYYY-MM-DD}}")).toBe("2023-06-01");
+		expect(f.renderDate("{{DATE+3}}")).toBe("2023-06-04");
+		expect(f.renderDate("{{DATE:YYYY-MM-DD+3}}")).toBe("2023-06-04");
+		expect(f.renderDate("{{DATE+-3}}")).toBe("2023-05-29");
+		// DATE_REGEX is case-insensitive; lowercase must not fall through to
+		// Moment as a format suffix (the 2026-08-26+3 concatenation symptom).
+		expect(f.renderDate("{{date+3}}")).toBe("2023-06-04");
+		expect(f.renderDate("{{date:YYYY-MM-DD+3}}")).toBe("2023-06-04");
+		expect(
+			f.renderDate(
+				"# works\n{{DATE:YYYY-MM-DD}}\n\n{{DATE}}\n\n# buggy\n{{DATE:YYYY-MM-DD+3}}\n\n{{DATE+3}}\n",
+			),
+		).toBe("# works\n2023-06-01\n\n2023-06-01\n\n# buggy\n2023-06-04\n\n2023-06-04\n");
+	});
+
 	it("keeps a literal pipe byte-identical and a [literal |startof: x] intact", () => {
 		expect(f.renderDate("{{DATE:YYYY|MM}}")).toBe("2023|06");
 		expect(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lock the documented `{{DATE+N}}` / `{{DATE:YYYY-MM-DD+N}}` day-offset behavior so the concatenation and leftover-token symptoms from #1704 cannot regress silently.

This does **not** change formatter production code. On current `master` (QuickAdd 2.23.0), those tokens already resolve to a shifted date.

**Refs #1704** (not `Fixes`) — the reported bug was not reproducible in this checkout, so the issue should stay open until a maintainer confirms with the reporter.

## Why

#1704 reports that, with a frozen "today" of `2026-08-26`:

- `{{DATE:YYYY-MM-DD}}` and `{{DATE}}` work
- `{{DATE:YYYY-MM-DD+3}}` becomes `2026-08-26+3` instead of `2026-08-29`
- `{{DATE+3}}` is left unparsed
- `|startof:` / `|endof:` snap examples also fail

`DATE_REGEX` / `DATE_REGEX_FORMATTED` already split format from `+N`, and `replaceDateInString` applies `getDate({ format, offset, snap })`. The previous docs-examples suite only asserted that no `{{...}}` token remained, so `2026-08-26+3` would still have passed.

## Scope

- Assert issue #1704's exact template body (and lowercase `{{date+3}}`, since the regex is `/i/`) in `formatter-datesnap.test.ts` against a frozen clock.
- Assert the documented examples `{{DATE+7}}` and `{{DATE:YYYY-MM-DD+3}}` render the shifted date in `formatSyntax.docs-examples.test.ts`.
- No `src/` production, docs, or bundle changes.

## Tradeoffs

- Test-only lock instead of a formatter change, because the matching surface already does the documented thing. Inventing a production patch would be a no-op or a behavior change we cannot justify.
- Not closing #1704 from this PR. Auto-close on a "cannot reproduce" result would hide a possible environment-specific path we did not hit.

## Blast radius

Runtime: none. Tests only. Failure mode if the lock is wrong: CI red on a date-format change, not a user-facing change.

## Testing / validation

- `pnpm run test` — 4989 passed, 37 skipped
- `pnpm run lint` — clean
- Live Obsidian 1.13.7 + QuickAdd 2.23.0 (this checkout), clock frozen to `2026-08-26 12:00`:
  - `api.format()`: `{{DATE+3}}` → `2026-08-29`, `{{DATE:YYYY-MM-DD+3}}` → `2026-08-29` (not `2026-08-26+3`)
  - Template choice `executeChoice` with the issue's markdown created a note whose "buggy" section was `2026-08-29` / `2026-08-29`; `|startof:week` resolved to `2026-08-23`

Likely reporter mix-up, not a formatter defect: Obsidian core Templates `{{date:YYYY-MM-DD+3}}` passes `YYYY-MM-DD+3` to Moment (literal `+3`) and does not parse `{{DATE+3}}`. Same two symptoms. QuickAdd only expands these tokens when *it* formats the string (Template / Capture / Macro / `api.format()`).

## Checklist

- [x] PR title follows Conventional Commits
- [x] Linked related issue (#1704 via Refs, not Fixes)
- [x] Release/migration impact: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e979e888-f2b2-4678-a7a2-67845dd3bb88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e979e888-f2b2-4678-a7a2-67845dd3bb88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for documented `DATE` day-offset formatting.
  * Verified positive and negative offsets, formatted and unformatted dates, lowercase tokens, and multiple dates in multiline text.
  * Confirmed offsets render as adjusted dates rather than appearing in the formatted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->