### PR TITLE
feat(date): add a run-level calendar origin for DATE tokens

### DIFF
--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -33,9 +33,9 @@ obsidian vault=dev quickadd:run id="choice-id"
 obsidian vault=dev quickadd:run choice="Weekly review" date=lw
 ```
 
-`date=` sets the run's calendar origin for `{{DATE}}`. It accepts `YYYY-MM-DD`,
-natural language (`last friday`), or aliases (`lw`, `ly`, `nw`). The choice's
-**Date origin** setting is skipped when `date=` is present.
+`date=` sets the day `{{DATE}}` uses. It accepts `YYYY-MM-DD`, natural language
+(`last friday`), or aliases (`lw`, `ly`, `nw`). The choice's **Which day**
+setting is skipped when `date=` is present.
 
 ### List your choices: `quickadd:list` {#quickaddlist}
 

--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -33,9 +33,9 @@ obsidian vault=dev quickadd:run id="choice-id"
 obsidian vault=dev quickadd:run choice="Weekly review" date=lw
 ```
 
-`date=` sets the day `{{DATE}}` uses. It accepts `YYYY-MM-DD`, natural language
-(`last friday`), aliases (`lw`, `ly`, `nw`), or `ask` to open the date picker.
-The choice's **Which day** setting is skipped when `date=` is a concrete day.
+`date=` is the day for `{{DATE}}`. Pass a real day (`2026-08-21`,
+`last friday`, `lw`) and the choice's Which day setting is skipped. Pass
+`ask` to open the date picker instead.
 
 ### List your choices: `quickadd:list` {#quickaddlist}
 

--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -34,8 +34,8 @@ obsidian vault=dev quickadd:run choice="Weekly review" date=lw
 ```
 
 `date=` sets the day `{{DATE}}` uses. It accepts `YYYY-MM-DD`, natural language
-(`last friday`), or aliases (`lw`, `ly`, `nw`). The choice's **Which day**
-setting is skipped when `date=` is present.
+(`last friday`), aliases (`lw`, `ly`, `nw`), or `ask` to open the date picker.
+The choice's **Which day** setting is skipped when `date=` is a concrete day.
 
 ### List your choices: `quickadd:list` {#quickaddlist}
 

--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -30,7 +30,12 @@ Run a QuickAdd choice from the CLI, by name or by id:
 ```bash
 obsidian vault=dev quickadd choice="Daily log"
 obsidian vault=dev quickadd:run id="choice-id"
+obsidian vault=dev quickadd:run choice="Weekly review" date=lw
 ```
+
+`date=` sets the run's calendar origin for `{{DATE}}`. It accepts `YYYY-MM-DD`,
+natural language (`last friday`), or aliases (`lw`, `ly`, `nw`). The choice's
+**Date origin** setting is skipped when `date=` is present.
 
 ### List your choices: `quickadd:list` {#quickaddlist}
 
@@ -93,8 +98,8 @@ that format string, for example `{{VALUE:project|trim}}`.
 ### Names the CLI reserves {#reserved-flag-names}
 
 The bare `key=value` form (pattern 2) ignores names that a command already uses
-as flags or selectors: `choice`, `id`, `vars`, `ui`, `verify` (on `quickadd` /
-`quickadd:run`), `fields` (on `quickadd:check`), and `path` (on
+as flags or selectors: `choice`, `id`, `vars`, `ui`, `verify`, `date` (on
+`quickadd` / `quickadd:run`), `fields` (on `quickadd:check`), and `path` (on
 `quickadd:run-template`). If a choice has a variable named after one of these
 (for example `{{VALUE:verify}}`), pass it with the `value-` prefix or via
 `vars` instead - neither is ever treated as a flag:

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -273,12 +273,12 @@ setting.
 
 _Task_ formats your captured text as a task (`- [ ] ...`).
 
-### Date origin {#date-origin}
+### Which day {#date-origin}
 
-**Date origin** is the same setting as on a [Template](/docs/Choices/TemplateChoice/#date-origin).
-Use it to capture into yesterday or last Friday while the capture line's clock
-stays now. `Daily/{{DATE}}.md` follows the origin. `- {{DATE:HH:mm}} {{VALUE}}`
-stamps the current time.
+**Which day** is the same setting as on a [Template](/docs/Choices/TemplateChoice/#date-origin).
+Use Yesterday to catch up a daily note, or Ask each time to pick last Friday.
+`Daily/{{DATE}}.md` follows that day. `- {{DATE:HH:mm}} {{VALUE}}` still stamps
+the current time.
 
 ### Use your selection as the answer {#use-editor-selection}
 

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -285,6 +285,7 @@ want the note's day.
 For a daily you usually open today, leave Which day on Today. Use
 **Daily log (another day)** in the command palette, or hold Shift in the
 QuickAdd menu, when you want a different day. You do not need a second choice.
+The original command id is unchanged, so an existing hotkey still runs today.
 
 ### Use your selection as the answer {#use-editor-selection}
 

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -276,9 +276,15 @@ _Task_ formats your captured text as a task (`- [ ] ...`).
 ### Which day {#date-origin}
 
 **Which day** is the same setting as on a [Template](/docs/Choices/TemplateChoice/#date-origin).
-Use Yesterday to catch up a daily note, or Ask each time to pick last Friday.
-`Daily/{{DATE}}.md` follows that day. `- {{DATE:HH:mm}} {{VALUE}}` still stamps
-the current time.
+
+`Daily/{{DATE}}.md` is which note. A line like `- {{TIME}} bought milk` is when
+you wrote it, even if that note is yesterday. `{{DATE:HH:mm}}` also shows the
+clock because that format has no day in it. Put `{{DATE}}` on the line if you
+want the note's day.
+
+For a daily you usually open today, leave Which day on Today. Use
+**Daily log (another day)** in the command palette, or hold Shift in the
+QuickAdd menu, when you want a different day. You do not need a second choice.
 
 ### Use your selection as the answer {#use-editor-selection}
 

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -273,6 +273,13 @@ setting.
 
 _Task_ formats your captured text as a task (`- [ ] ...`).
 
+### Date origin {#date-origin}
+
+**Date origin** is the same setting as on a [Template](/docs/Choices/TemplateChoice/#date-origin).
+Use it to capture into yesterday or last Friday while the capture line's clock
+stays now. `Daily/{{DATE}}.md` follows the origin. `- {{DATE:HH:mm}} {{VALUE}}`
+stamps the current time.
+
 ### Use your selection as the answer {#use-editor-selection}
 
 _Use editor selection as default value_ controls whether selected text in the

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -275,17 +275,20 @@ _Task_ formats your captured text as a task (`- [ ] ...`).
 
 ### Which day {#date-origin}
 
-**Which day** is the same setting as on a [Template](/docs/Choices/TemplateChoice/#date-origin).
+Same [Which day](/docs/Choices/TemplateChoice/#date-origin) setting as a
+Template.
 
-`Daily/{{DATE}}.md` is which note. A line like `- {{TIME}} bought milk` is when
-you wrote it, even if that note is yesterday. `{{DATE:HH:mm}}` also shows the
-clock because that format has no day in it. Put `{{DATE}}` on the line if you
-want the note's day.
+Imagine you capture into `Daily/{{DATE}}.md` at 3pm. The path picks the note.
+The line `- {{TIME}} bought milk` is 3pm, even if that note is yesterday.
+That's the useful split: the note is the day, the stamp is when you wrote it.
 
-For a daily you usually open today, leave Which day on Today. Use
-**Daily log (another day)** in the command palette, or hold Shift in the
-QuickAdd menu, when you want a different day. You do not need a second choice.
-The original command id is unchanged, so an existing hotkey still runs today.
+`{{DATE:HH:mm}}` looks like it should print yesterday, but `HH:mm` only
+prints the clock, so you still get `15:00`. Put `{{DATE}}` on the line if
+you want the note's day next to the text.
+
+Most people leave this on Today and use **Daily log (another day)**, or hold
+Shift in the QuickAdd menu, for the days that aren't today. Your existing
+hotkey still captures to today.
 
 ### Use your selection as the answer {#use-editor-selection}
 

--- a/docs/src/content/docs/docs/Choices/MacroChoice.md
+++ b/docs/src/content/docs/docs/Choices/MacroChoice.md
@@ -282,6 +282,12 @@ commands share the same name, rename one before using the selector form.
 
 ![The Macro builder, including the Run on startup toggle](../Images/choices/macro-builder.png)
 
+### Which day {#date-origin}
+
+Same [Which day](/docs/Choices/TemplateChoice/#date-origin) setting as a
+Template. Child choices in the macro inherit that day, so a weekly pack can
+ask once and then write every template for last week.
+
 ### Run on startup {#run-on-startup}
 
 Enable this to run a macro automatically when Obsidian starts. Handy for:

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -207,13 +207,18 @@ now. The template file does not change.
 - **Custom…**. Any other number of days, weeks, months, or years from today.
 - **A variable…**. A `{{VDATE}}` or script value that already has the day.
 
-Two choices can share one template file. One stays Today. One asks each time. A
-weekly note that uses `|startof:week` still files the picked day under the
-right week.
+Leave Which day on Today for a daily you usually open today. The same choice
+also gets **Name (another day)** in the command palette. Hold Shift in the
+QuickAdd menu for the same pick. You do not need a second choice.
+
+Two choices can still share one template file if you want one that always asks
+and one that never does. A weekly note that uses `|startof:week` files the
+picked day under the right week.
 
 Scripts and the CLI can set the day without the picker:
 `executeChoice("Weekly review", {}, { date: "last week" })` and
 `quickadd:run choice="Weekly review" date="last week"`.
+`date=ask` or `{ date: "ask" }` opens the picker on a Today choice.
 
 ## Decide where the note is created: New note location {#new-note-location}
 

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -194,27 +194,26 @@ Selecting an existing note opens it unchanged and does **not** apply the
 template, append template content, insert links, or copy links. Selecting the
 explicit **Create new note** row continues with normal Template creation.
 
-## Pick the day `{{DATE}}` is about: Date origin {#date-origin}
+## Which day `{{DATE}}` is about {#date-origin}
 
-**Date origin** tells a run which calendar day `{{DATE}}` formats, offsets, and
-snaps from. The template does not change. `{{TIME}}` and `{{DATE:HH:mm}}` stay
-the current clock.
+**Which day** is the calendar day `{{DATE}}` uses. The clock (`{{TIME}}`) stays
+now. The template file does not change.
 
 - **Today** (default). Same as before this setting existed.
-- **Ask**. Opens the date picker. Type `lw`, `last friday`, or click a day.
-  Existing aliases (`yd`, `nw`, `ly`, …) work. An optional default such as
-  `today` or `last week` fills the picker.
-- **Relative**. Move from today by a number of days, weeks, months, or years.
-  Use this for a "last week's review" hotkey.
-- **From variable**. Read a `{{VDATE}}` or script variable that already holds
-  the day.
+- **Ask each time**. Opens a date picker so you can file the note for another
+  day. **Picker starts on** sets the first day in that picker.
+- **Yesterday**, **Last week**, **Next week**, **Last month**. For a catch-up
+  daily, last week's review, or next week's plan.
+- **Custom…**. Any other number of days, weeks, months, or years from today.
+- **A variable…**. A `{{VDATE}}` or script value that already has the day.
 
-Two choices can share one template file. One stays Today. One is Ask. A weekly
-note that uses `|startof:week` still files the picked day under the right week.
+Two choices can share one template file. One stays Today. One asks each time. A
+weekly note that uses `|startof:week` still files the picked day under the
+right week.
 
-Scripts and the CLI can set the same origin without the picker:
-`executeChoice("Weekly review", {}, { date: "lw" })` and
-`quickadd:run choice="Weekly review" date=lw`.
+Scripts and the CLI can set the day without the picker:
+`executeChoice("Weekly review", {}, { date: "last week" })` and
+`quickadd:run choice="Weekly review" date="last week"`.
 
 ## Decide where the note is created: New note location {#new-note-location}
 

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -194,6 +194,28 @@ Selecting an existing note opens it unchanged and does **not** apply the
 template, append template content, insert links, or copy links. Selecting the
 explicit **Create new note** row continues with normal Template creation.
 
+## Pick the day `{{DATE}}` is about: Date origin {#date-origin}
+
+**Date origin** tells a run which calendar day `{{DATE}}` formats, offsets, and
+snaps from. The template does not change. `{{TIME}}` and `{{DATE:HH:mm}}` stay
+the current clock.
+
+- **Today** (default). Same as before this setting existed.
+- **Ask**. Opens the date picker. Type `lw`, `last friday`, or click a day.
+  Existing aliases (`yd`, `nw`, `ly`, …) work. An optional default such as
+  `today` or `last week` fills the picker.
+- **Relative**. Move from today by a number of days, weeks, months, or years.
+  Use this for a "last week's review" hotkey.
+- **From variable**. Read a `{{VDATE}}` or script variable that already holds
+  the day.
+
+Two choices can share one template file. One stays Today. One is Ask. A weekly
+note that uses `|startof:week` still files the picked day under the right week.
+
+Scripts and the CLI can set the same origin without the picker:
+`executeChoice("Weekly review", {}, { date: "lw" })` and
+`quickadd:run choice="Weekly review" date=lw`.
+
 ## Decide where the note is created: New note location {#new-note-location}
 
 **New note location** is a dropdown that controls where the note is created.

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -209,7 +209,9 @@ now. The template file does not change.
 
 Leave Which day on Today for a daily you usually open today. The same choice
 also gets **Name (another day)** in the command palette. Hold Shift in the
-QuickAdd menu for the same pick. You do not need a second choice.
+QuickAdd menu for the same pick. You do not need a second choice. The original
+command id stays `quickadd:choice:<id>`, so an existing hotkey keeps working.
+**Name (another day)** is a new command you can bind separately.
 
 Two choices can still share one template file if you want one that always asks
 and one that never does. A weekly note that uses `|startof:week` files the

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -196,31 +196,32 @@ explicit **Create new note** row continues with normal Template creation.
 
 ## Which day `{{DATE}}` is about {#date-origin}
 
-**Which day** is the calendar day `{{DATE}}` uses. The clock (`{{TIME}}`) stays
-now. The template file does not change.
+Most of the time you want today. That's the default, and you can leave it
+alone.
 
-- **Today** (default). Same as before this setting existed.
-- **Ask each time**. Opens a date picker so you can file the note for another
-  day. **Picker starts on** sets the first day in that picker.
-- **Yesterday**, **Last week**, **Next week**, **Last month**. For a catch-up
-  daily, last week's review, or next week's plan.
-- **Custom…**. Any other number of days, weeks, months, or years from today.
-- **A variable…**. A `{{VDATE}}` or script value that already has the day.
+Sometimes you don't. Last week's review, yesterday's daily, the Friday you
+forgot to write. **Which day** is the calendar day `{{DATE}}` uses. The
+template file stays the same. `{{TIME}}` is still the time you ran the
+choice, so a "written at" stamp stays honest.
 
-Leave Which day on Today for a daily you usually open today. The same choice
-also gets **Name (another day)** in the command palette. Hold Shift in the
-QuickAdd menu for the same pick. You do not need a second choice. The original
-command id stays `quickadd:choice:<id>`, so an existing hotkey keeps working.
-**Name (another day)** is a new command you can bind separately.
+- **Today** is the default.
+- **Ask each time** opens a date picker. **Picker starts on** is only the
+  first value in that picker. You can still click another day.
+- **Yesterday**, **Last week**, **Next week**, and **Last month** cover the
+  usual jobs. A weekly note with `|startof:week` still lands in the right
+  week.
+- **Custom…** is any other jump from today, like three days back or last
+  year.
+- **A variable…** is for a `{{VDATE}}` or a script that already has the day.
 
-Two choices can still share one template file if you want one that always asks
-and one that never does. A weekly note that uses `|startof:week` files the
-picked day under the right week.
+If the choice has a command, QuickAdd also adds **Name (another day)** next
+to it. Same choice. Your existing hotkey still opens today. Use the extra
+command, or hold Shift in the QuickAdd menu, when it isn't today. You don't
+need a second Daily Note choice.
 
-Scripts and the CLI can set the day without the picker:
-`executeChoice("Weekly review", {}, { date: "last week" })` and
-`quickadd:run choice="Weekly review" date="last week"`.
-`date=ask` or `{ date: "ask" }` opens the picker on a Today choice.
+Scripts and the CLI can pass a day too:
+`executeChoice("Weekly review", {}, { date: "last week" })`, or `date=ask`
+if you want the picker.
 
 ## Decide where the note is created: New note location {#new-note-location}
 

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -82,12 +82,11 @@ You describe the shape once; QuickAdd fills in the blanks every run.
 
 `{{DATE}}` becomes today's date in `YYYY-MM-DD` format.
 
-A Template, Capture, or Macro can set a **date origin** so the same tokens
-follow another day. Offsets and snaps still apply. `{{TIME}}` and
-`{{DATE:HH:mm}}` stay the current clock. See
-[Date origin](/docs/Choices/TemplateChoice/#date-origin).
+A Template, Capture, or Macro can pick another day for these tokens. Offsets
+and snaps still apply. `{{TIME}}` and `{{DATE:HH:mm}}` stay the current clock.
+See [Which day](/docs/Choices/TemplateChoice/#date-origin).
 
-Add `+N` to move the date: `{{DATE+3}}` is three days from the origin,
+Add `+N` to move the date: `{{DATE+3}}` is three days from that day,
 `{{DATE+-3}}` is three days before it.
 
 ```markdown title="You write"

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -82,8 +82,13 @@ You describe the shape once; QuickAdd fills in the blanks every run.
 
 `{{DATE}}` becomes today's date in `YYYY-MM-DD` format.
 
-Add `+N` to move the date: `{{DATE+3}}` is three days from now, `{{DATE+-3}}`
-is three days ago.
+A Template, Capture, or Macro can set a **date origin** so the same tokens
+follow another day. Offsets and snaps still apply. `{{TIME}}` and
+`{{DATE:HH:mm}}` stay the current clock. See
+[Date origin](/docs/Choices/TemplateChoice/#date-origin).
+
+Add `+N` to move the date: `{{DATE+3}}` is three days from the origin,
+`{{DATE+-3}}` is three days before it.
 
 ```markdown title="You write"
 Daily/{{DATE}}.md

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -82,9 +82,10 @@ You describe the shape once; QuickAdd fills in the blanks every run.
 
 `{{DATE}}` becomes today's date in `YYYY-MM-DD` format.
 
-A Template, Capture, or Macro can pick another day for these tokens. Offsets
-and snaps still apply. `{{TIME}}` and `{{DATE:HH:mm}}` stay the current clock.
-See [Which day](/docs/Choices/TemplateChoice/#date-origin).
+A Template, Capture, or Macro can pick another day for `{{DATE}}`. Offsets
+and snaps still apply. The current time of day is kept, so `{{DATE:HH:mm}}`
+looks like the clock even though the day is the chosen one. `{{TIME}}` never
+uses that day. See [Which day](/docs/Choices/TemplateChoice/#date-origin).
 
 Add `+N` to move the date: `{{DATE+3}}` is three days from that day,
 `{{DATE+-3}}` is three days before it.

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -82,10 +82,13 @@ You describe the shape once; QuickAdd fills in the blanks every run.
 
 `{{DATE}}` becomes today's date in `YYYY-MM-DD` format.
 
-A Template, Capture, or Macro can pick another day for `{{DATE}}`. Offsets
-and snaps still apply. The current time of day is kept, so `{{DATE:HH:mm}}`
-looks like the clock even though the day is the chosen one. `{{TIME}}` never
-uses that day. See [Which day](/docs/Choices/TemplateChoice/#date-origin).
+A choice can aim that token at another day, so the same
+`Daily/{{DATE}}.md` template opens yesterday when you ask it to. `{{DATE+3}}`
+is still three days later. `{{TIME}}` is always the time you ran the choice.
+See [Which day](/docs/Choices/TemplateChoice/#date-origin).
+
+`{{DATE:HH:mm}}` only prints the clock, so it looks like `{{TIME}}`. The day
+is still the chosen one. Write `{{DATE:YYYY-MM-DD HH:mm}}` if you want both.
 
 Add `+N` to move the date: `{{DATE+3}}` is three days from that day,
 `{{DATE+-3}}` is three days before it.

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -415,8 +415,8 @@ For the Macro data-flow implications, see [`executeChoice` is a trigger](/docs/V
 **Parameters:**
 - `choiceName`: Name of the choice to execute
 - `variables`: (Optional) Variables to pass to the choice
-- `options.date`: (Optional) Calendar origin for `{{DATE}}`. A `Date`, an
-  `@date:` ISO string, or natural language (`lw`, `last friday`).
+- `options.date`: (Optional) The day `{{DATE}}` should use. A `Date`, an
+  `@date:` ISO string, or natural language (`last week`, `last friday`).
 
 **Example:**
 ```javascript

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -407,7 +407,7 @@ console.log("Enabled features:", features);
 
 ## Choice Execution
 
-### `executeChoice(choiceName: string, variables?: {[key: string]: any}): Promise<void>`
+### `executeChoice(choiceName: string, variables?: {[key: string]: any}, options?: { date?: string | Date }): Promise<void>`
 Executes another QuickAdd choice programmatically. This is a one-way trigger: it passes variables into the target choice, waits for that choice to finish, and resolves with `undefined`. It does not return data from the target choice to the caller. After the target choice finishes, QuickAdd clears the temporary variable map used by that API execution. If you call it from inside a Macro script, do not expect the caller's current `params.variables` values to still be available afterward unless you saved or restored them yourself.
 
 For the Macro data-flow implications, see [`executeChoice` is a trigger](/docs/VariablesDataFlow/#executechoice-is-a-trigger).
@@ -415,6 +415,8 @@ For the Macro data-flow implications, see [`executeChoice` is a trigger](/docs/V
 **Parameters:**
 - `choiceName`: Name of the choice to execute
 - `variables`: (Optional) Variables to pass to the choice
+- `options.date`: (Optional) Calendar origin for `{{DATE}}`. A `Date`, an
+  `@date:` ISO string, or natural language (`lw`, `last friday`).
 
 **Example:**
 ```javascript
@@ -425,6 +427,8 @@ await quickAddApi.executeChoice("Create Meeting Note", {
     date: "2024-01-15",
     value: "Main agenda content"  // Special: maps to {{VALUE}}
 });
+
+await quickAddApi.executeChoice("Weekly review", {}, { date: "lw" });
 ```
 
 Batch processing example:

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -416,7 +416,8 @@ For the Macro data-flow implications, see [`executeChoice` is a trigger](/docs/V
 - `choiceName`: Name of the choice to execute
 - `variables`: (Optional) Variables to pass to the choice
 - `options.date`: (Optional) The day `{{DATE}}` should use. A `Date`, an
-  `@date:` ISO string, or natural language (`last week`, `last friday`).
+  `@date:` ISO string, natural language (`last week`, `last friday`), or
+  `"ask"` to open the date picker.
 
 **Example:**
 ```javascript

--- a/docs/src/content/docs/docs/QuickAddAPI.md
+++ b/docs/src/content/docs/docs/QuickAddAPI.md
@@ -415,9 +415,8 @@ For the Macro data-flow implications, see [`executeChoice` is a trigger](/docs/V
 **Parameters:**
 - `choiceName`: Name of the choice to execute
 - `variables`: (Optional) Variables to pass to the choice
-- `options.date`: (Optional) The day `{{DATE}}` should use. A `Date`, an
-  `@date:` ISO string, natural language (`last week`, `last friday`), or
-  `"ask"` to open the date picker.
+- `options.date`: (Optional) The day `{{DATE}}` should use. Pass a `Date`,
+  `last week`, or `"ask"` if you want the picker.
 
 **Example:**
 ```javascript

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -43,6 +43,11 @@ export interface IChoiceExecutor {
 	 */
 	clocks?: RunClocks;
 	/**
+	 * When true, this run asks for a day even if the choice is set to Today
+	 * (or another fixed day). Used by `{name} (another day)` and `date=ask`.
+	 */
+	pickDate?: boolean;
+	/**
 	 * Whether this execution may open blocking interactive UI (suggesters/modals)
 	 * for inputs the requirement collector cannot pre-satisfy — e.g. the
 	 * "file already exists" prompt, the folder chooser, or the heading picker.

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -4,6 +4,7 @@ import type ICaptureChoice from "./types/choices/ICaptureChoice";
 import type { MacroAbortError } from "./errors/MacroAbortError";
 import type { ChoiceOutcome } from "./types/ChoiceOutcome";
 import type { FrontmatterPropertyTarget } from "./utils/frontmatterPropertyLinks";
+import type { RunClocks } from "./types/dateOrigin";
 import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
 import type { PromptProvider } from "./interactive/promptProvider";
 
@@ -36,6 +37,11 @@ export interface IChoiceExecutor {
 		choice: ITemplateChoice | ICaptureChoice,
 	): Promise<ChoiceOutcome>;
 	variables: Map<string, unknown>;
+	/**
+	 * Frozen wall clock and optional calendar origin for this outermost run.
+	 * `{{DATE}}` reads `date` (or `now`'s day). `{{TIME}}` reads `now`.
+	 */
+	clocks?: RunClocks;
 	/**
 	 * Whether this execution may open blocking interactive UI (suggesters/modals)
 	 * for inputs the requirement collector cannot pre-satisfy — e.g. the

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -27,7 +27,13 @@ import {
 	type FrontmatterPropertyTarget,
 } from "./utils/frontmatterPropertyLinks";
 import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
+import type { RunClocks } from "./types/dateOrigin";
+import { normalizeDateOrigin } from "./types/dateOrigin";
 import { childChoicesOf } from "./utils/choiceUtils";
+import { QA_INTERNAL_DATE_ORIGIN } from "./constants";
+import VDateInputPrompt from "./gui/VDateInputPrompt/VDateInputPrompt";
+import { planDateOrigin, dateFromStoredValue } from "./utils/resolveDateOrigin";
+import { log } from "./logger/logManager";
 
 export class ChoiceExecutor implements IChoiceExecutor {
 	public variables: Map<string, unknown> = new Map<string, unknown>();
@@ -46,6 +52,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	public readonly preloadedUserScripts = new Map<string, unknown>();
 	public focusedProperty: FrontmatterPropertyTarget | null = null;
 	public triggerContext: QuickAddTriggerContext | null = null;
+	public clocks?: RunClocks;
 	private pendingAbort: MacroAbortError | null = null;
 	private pendingResult: ChoiceOutcome | null = null;
 	private executionDepth = 0;
@@ -92,6 +99,10 @@ export class ChoiceExecutor implements IChoiceExecutor {
 				this.triggerContextOverride !== undefined
 					? this.triggerContextOverride
 					: { activeFile: this.app.workspace.getActiveFile() };
+			this.clocks = {
+				now: this.clocks?.now ?? new Date(),
+				date: this.clocks?.date,
+			};
 		}
 		this.executionDepth++;
 	}
@@ -101,6 +112,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		if (this.executionDepth === 0) {
 			this.focusedProperty = null;
 			this.triggerContext = null;
+			this.clocks = undefined;
 			// Preloaded script modules are scoped to ONE outermost execution: a
 			// cancelled/aborted run must not strand its entries, or a later
 			// trigger on a long-lived executor (api.executeChoice callers reuse
@@ -124,6 +136,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		promptDraftStore.beginExecutionScope();
 		try {
 			await this.runOnePagePreflightIfEnabled(choice);
+			await this.applyDateOrigin(choice);
 
 			switch (choice.type) {
 				case "Template": {
@@ -208,6 +221,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 		promptDraftStore.beginExecutionScope();
 		try {
 			await this.runOnePagePreflightIfEnabled(choice);
+			await this.applyDateOrigin(choice);
 
 			if (choice.type === "Template") {
 				await this.onChooseTemplateType(choice as ITemplateChoice, originLeaf);
@@ -250,6 +264,70 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			};
 		} finally {
 			this.endExecutionContext();
+		}
+	}
+
+	private async applyDateOrigin(choice: IChoice): Promise<void> {
+		const setting = normalizeDateOrigin(choice.dateOrigin);
+		const reservedSeed =
+			setting?.kind === "ask"
+				? this.variables.get(QA_INTERNAL_DATE_ORIGIN)
+				: undefined;
+		const plan = planDateOrigin({
+			setting,
+			clocks: this.clocks,
+			variables: this.variables,
+			reservedSeed,
+		});
+
+		if (plan.status === "inherit") return;
+
+		if (plan.status === "error") {
+			log.logError(plan.message);
+			throw new ChoiceAbortError(plan.message);
+		}
+
+		if (plan.status === "set") {
+			this.clocks = {
+				now: this.clocks?.now ?? new Date(),
+				date: plan.date,
+			};
+			return;
+		}
+
+		if (this.interactive === false && !this.promptProvider) {
+			throw new ChoiceAbortError(
+				`"${choice.name}" asks for a date origin. Re-run with date= or the ui flag.`,
+			);
+		}
+
+		const header = `Date for ${choice.name}`;
+		try {
+			const raw = this.promptProvider
+				? await this.promptProvider.datePrompt(header, {
+						defaultValue: plan.defaultValue,
+						dateFormat: "YYYY-MM-DD",
+					})
+				: await VDateInputPrompt.Prompt(
+						this.app,
+						header,
+						undefined,
+						plan.defaultValue,
+						"YYYY-MM-DD",
+					);
+			const date = dateFromStoredValue(raw);
+			if (!date) {
+				throw new ChoiceAbortError("Could not parse the date origin.");
+			}
+			this.clocks = {
+				now: this.clocks?.now ?? new Date(),
+				date,
+			};
+		} catch (error) {
+			if (isCancellationError(error)) {
+				throw new UserCancelError("Date origin cancelled by user");
+			}
+			throw error;
 		}
 	}
 

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -297,7 +297,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 
 		if (this.interactive === false && !this.promptProvider) {
 			throw new ChoiceAbortError(
-				`"${choice.name}" asks for a date origin. Re-run with date= or the ui flag.`,
+				`"${choice.name}" needs a date. Re-run with date= or the ui flag.`,
 			);
 		}
 

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -29,6 +29,7 @@ import {
 import type { QuickAddTriggerContext } from "./types/QuickAddTriggerContext";
 import type { RunClocks } from "./types/dateOrigin";
 import { normalizeDateOrigin } from "./types/dateOrigin";
+import { dateOriginForPick } from "./types/dateOriginPresets";
 import { childChoicesOf } from "./utils/choiceUtils";
 import { QA_INTERNAL_DATE_ORIGIN } from "./constants";
 import VDateInputPrompt from "./gui/VDateInputPrompt/VDateInputPrompt";
@@ -53,6 +54,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	public focusedProperty: FrontmatterPropertyTarget | null = null;
 	public triggerContext: QuickAddTriggerContext | null = null;
 	public clocks?: RunClocks;
+	public pickDate = false;
 	private pendingAbort: MacroAbortError | null = null;
 	private pendingResult: ChoiceOutcome | null = null;
 	private executionDepth = 0;
@@ -113,6 +115,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 			this.focusedProperty = null;
 			this.triggerContext = null;
 			this.clocks = undefined;
+			this.pickDate = false;
 			// Preloaded script modules are scoped to ONE outermost execution: a
 			// cancelled/aborted run must not strand its entries, or a later
 			// trigger on a long-lived executor (api.executeChoice callers reuse
@@ -268,7 +271,9 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	}
 
 	private async applyDateOrigin(choice: IChoice): Promise<void> {
-		const setting = normalizeDateOrigin(choice.dateOrigin);
+		const setting = this.pickDate
+			? dateOriginForPick(normalizeDateOrigin(choice.dateOrigin))
+			: normalizeDateOrigin(choice.dateOrigin);
 		const reservedSeed =
 			setting?.kind === "ask"
 				? this.variables.get(QA_INTERNAL_DATE_ORIGIN)

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -21,7 +21,7 @@ import {
 } from "../utils/choiceUtils";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
-import { dateFromStoredValue } from "../utils/resolveDateOrigin";
+import { applyInvocationDate } from "../utils/resolveDateOrigin";
 import {
 	analysePackagePreview,
 	readQuickAddPackage,
@@ -86,7 +86,7 @@ const RUN_FLAGS: CliFlags = {
 	date: {
 		value: "<when>",
 		description:
-			"Day for {{DATE}} (YYYY-MM-DD, last week, last friday, @date:ISO)",
+			"Day for {{DATE}} (YYYY-MM-DD, last week, last friday, ask, @date:ISO)",
 	},
 };
 
@@ -115,7 +115,7 @@ const RUN_TEMPLATE_FLAGS: CliFlags = {
 	date: {
 		value: "<when>",
 		description:
-			"Day for {{DATE}} (YYYY-MM-DD, last week, last friday, @date:ISO)",
+			"Day for {{DATE}} (YYYY-MM-DD, last week, last friday, ask, @date:ISO)",
 	},
 };
 
@@ -396,17 +396,13 @@ async function runResolvedChoice(
 			plugin,
 		) as IChoiceExecutor;
 		setExecutorVariables(choiceExecutor, variables);
-		if (typeof params.date === "string" && params.date.trim()) {
-			const date = dateFromStoredValue(params.date);
-			if (!date) {
-				return serialize({
-					ok: false,
-					command,
-					error: `Could not parse date origin '${params.date}'.`,
-					choice: describeChoice(choice),
-				});
-			}
-			choiceExecutor.clocks = { now: new Date(), date };
+		if (!applyInvocationDate(choiceExecutor, params.date)) {
+			return serialize({
+				ok: false,
+				command,
+				error: `Could not parse date origin '${params.date}'.`,
+				choice: describeChoice(choice),
+			});
 		}
 
 		const interactiveMode = isTruthy(params.ui);

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -13,6 +13,7 @@ import type { FieldRequirement } from "../preflight/RequirementCollector";
 import { interactivePromptServer } from "../interactive/interactivePromptServer";
 import { RemotePromptProvider } from "../interactive/promptProvider";
 import type IChoice from "../types/choices/IChoice";
+import { QA_INTERNAL_DATE_ORIGIN } from "../constants";
 import {
 	childChoicesOf,
 	isChoiceLike,
@@ -20,6 +21,7 @@ import {
 } from "../utils/choiceUtils";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import { dateFromStoredValue } from "../utils/resolveDateOrigin";
 import {
 	analysePackagePreview,
 	readQuickAddPackage,
@@ -81,6 +83,11 @@ const RUN_FLAGS: CliFlags = {
 		description:
 			"Report the verified outcome for Template/Capture choices (file path and effect on success, honest failure when the engine swallows an error)",
 	},
+	date: {
+		value: "<when>",
+		description:
+			"Calendar origin for {{DATE}} (YYYY-MM-DD, last friday, lw, @date:ISO)",
+	},
 };
 
 const LIST_FLAGS: CliFlags = {
@@ -104,6 +111,11 @@ const RUN_TEMPLATE_FLAGS: CliFlags = {
 	},
 	ui: {
 		description: "Allow interactive prompts",
+	},
+	date: {
+		value: "<when>",
+		description:
+			"Calendar origin for {{DATE}} (YYYY-MM-DD, last friday, lw, @date:ISO)",
 	},
 };
 
@@ -163,8 +175,14 @@ const RESERVED_RUN_PARAMS = new Set<string>([
 	"vars",
 	"ui",
 	"verify",
+	"date",
 ]);
-const RESERVED_RUN_TEMPLATE_PARAMS = new Set<string>(["path", "vars", "ui"]);
+const RESERVED_RUN_TEMPLATE_PARAMS = new Set<string>([
+	"path",
+	"vars",
+	"ui",
+	"date",
+]);
 const RESERVED_CHECK_PARAMS = new Set<string>(["choice", "id", "vars", "fields"]);
 const RESERVED_INTERACTIVE_PARAMS = new Set<string>(["choice", "id", "vars"]);
 
@@ -378,6 +396,18 @@ async function runResolvedChoice(
 			plugin,
 		) as IChoiceExecutor;
 		setExecutorVariables(choiceExecutor, variables);
+		if (typeof params.date === "string" && params.date.trim()) {
+			const date = dateFromStoredValue(params.date);
+			if (!date) {
+				return serialize({
+					ok: false,
+					command,
+					error: `Could not parse date origin '${params.date}'.`,
+					choice: describeChoice(choice),
+				});
+			}
+			choiceExecutor.clocks = { now: new Date(), date };
+		}
 
 		const interactiveMode = isTruthy(params.ui);
 		// Without `ui`, engine prompts the requirement collector can't pre-satisfy
@@ -407,8 +437,10 @@ async function runResolvedChoice(
 					error: "Missing required inputs for non-interactive CLI run.",
 					choice: describeChoice(choice),
 					missing: unresolved.map(toMissingFieldSummary),
-					missingFlags: unresolved.map(
-						(requirement) => `value-${requirement.id}=<value>`,
+					missingFlags: unresolved.map((requirement) =>
+						requirement.id === QA_INTERNAL_DATE_ORIGIN
+							? "date=<when>"
+							: `value-${requirement.id}=<value>`,
 					),
 				});
 			}

--- a/src/cli/registerQuickAddCliHandlers.ts
+++ b/src/cli/registerQuickAddCliHandlers.ts
@@ -86,7 +86,7 @@ const RUN_FLAGS: CliFlags = {
 	date: {
 		value: "<when>",
 		description:
-			"Calendar origin for {{DATE}} (YYYY-MM-DD, last friday, lw, @date:ISO)",
+			"Day for {{DATE}} (YYYY-MM-DD, last week, last friday, @date:ISO)",
 	},
 };
 
@@ -115,7 +115,7 @@ const RUN_TEMPLATE_FLAGS: CliFlags = {
 	date: {
 		value: "<when>",
 		description:
-			"Calendar origin for {{DATE}} (YYYY-MM-DD, last friday, lw, @date:ISO)",
+			"Day for {{DATE}} (YYYY-MM-DD, last week, last friday, @date:ISO)",
 	},
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -229,6 +229,7 @@ export const TIME_FORMAT_SYNTAX_SUGGEST_REGEX = new RegExp(
 // boundary (obsidian:// URI, CLI, AI tool output). See isReservedVariableKey.
 export const RESERVED_VARIABLE_PREFIX = "__qa.";
 export const QA_INTERNAL_CAPTURE_TARGET_FILE_PATH = `${RESERVED_VARIABLE_PREFIX}captureTargetFilePath`;
+export const QA_INTERNAL_DATE_ORIGIN = `${RESERVED_VARIABLE_PREFIX}dateOrigin`;
 
 // == MISC == //
 export const WIKI_LINK_REGEX = new RegExp(/\[\[([^\]]*)\]\]/);

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -5,6 +5,7 @@ import InputSuggester from "src/gui/InputSuggester/inputSuggester";
 import MultiSuggester from "src/gui/MultiSuggester/multiSuggester";
 import VDateInputPrompt from "src/gui/VDateInputPrompt/VDateInputPrompt";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
+import type { RunClocks } from "../types/dateOrigin";
 import {
 	GLOBAL_VAR_REGEX,
 	INLINE_JAVASCRIPT_REGEX,
@@ -79,7 +80,7 @@ export class CompleteFormatter extends Formatter {
 		}
 	}
 
-	protected runClocks(): { now?: Date; date?: Date } | undefined {
+	protected runClocks(): RunClocks | undefined {
 		return this.choiceExecutor?.clocks ?? this.clocks;
 	}
 

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -79,6 +79,10 @@ export class CompleteFormatter extends Formatter {
 		}
 	}
 
+	protected runClocks(): { now?: Date; date?: Date } | undefined {
+		return this.choiceExecutor?.clocks ?? this.clocks;
+	}
+
 	protected async format(input: string): Promise<string> {
 		let output: string = input;
 

--- a/src/formatters/formatter-datesnap.test.ts
+++ b/src/formatters/formatter-datesnap.test.ts
@@ -224,6 +224,7 @@ describe("{{DATE}} run origin through replaceDateInString", () => {
 		expect(f.renderDate("{{DATE:YYYY-MM-DD}}")).toBe("2023-05-26");
 		expect(f.renderDate("{{DATE+1}}")).toBe("2023-05-27");
 		expect(f.renderDate("{{DATE:YYYY-MM-DD|startof:week}}")).toBe("2023-05-21");
+		expect(f.renderDate("{{DATE:YYYY-MM-DD HH:mm}}")).toBe("2023-05-26 12:00");
 		expect(f.renderTime("{{TIME}}")).toBe("12:00");
 		expect(f.renderDate("{{DATE:HH:mm}}")).toBe("12:00");
 	});

--- a/src/formatters/formatter-datesnap.test.ts
+++ b/src/formatters/formatter-datesnap.test.ts
@@ -34,6 +34,9 @@ class TestFormatter extends Formatter {
 	public seed(name: string, value: unknown) {
 		this.variables.set(name, value);
 	}
+	public seedClocks(clocks: { now: Date; date?: Date }) {
+		this.clocks = clocks;
+	}
 	public renderDate(input: string) {
 		return this.replaceDateInString(input);
 	}
@@ -207,5 +210,20 @@ describe("date and time case transforms", () => {
 		expect(f.warnings).toEqual([
 			'QuickAdd: Unsupported |case style "lowre" in token "{{DATE:MMMM|case:lowre}}". Supported styles: kebab, snake, camel, pascal, title, lower, upper, slug.',
 		]);
+	});
+});
+
+describe("{{DATE}} run origin through replaceDateInString", () => {
+	it("formats and offsets from the origin day and keeps TIME on now", () => {
+		const f = new TestFormatter();
+		f.seedClocks({
+			now: new Date("2023-06-01T12:00:00"),
+			date: new Date(2023, 4, 26),
+		});
+		expect(f.renderDate("{{DATE:YYYY-MM-DD}}")).toBe("2023-05-26");
+		expect(f.renderDate("{{DATE+1}}")).toBe("2023-05-27");
+		expect(f.renderDate("{{DATE:YYYY-MM-DD|startof:week}}")).toBe("2023-05-21");
+		expect(f.renderTime("{{TIME}}")).toBe("12:00");
+		expect(f.renderDate("{{DATE:HH:mm}}")).toBe("12:00");
 	});
 });

--- a/src/formatters/formatter-datesnap.test.ts
+++ b/src/formatters/formatter-datesnap.test.ts
@@ -1,6 +1,7 @@
 import realMoment from "moment";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { Formatter, type PromptContext } from "./formatter";
+import type { RunClocks } from "../types/dateOrigin";
 
 // Integration test for the issue #511 snap wiring THROUGH the formatter passes
 // (not just the regex/unit helpers). Uses real moment + a frozen clock so the
@@ -34,7 +35,7 @@ class TestFormatter extends Formatter {
 	public seed(name: string, value: unknown) {
 		this.variables.set(name, value);
 	}
-	public seedClocks(clocks: { now: Date; date?: Date }) {
+	public seedClocks(clocks: RunClocks) {
 		this.clocks = clocks;
 	}
 	public renderDate(input: string) {

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -35,6 +35,7 @@ import {
 	type PromptScopeKind,
 } from "./promptScope";
 import { getDate } from "../utilityObsidian";
+import type { RunClocks } from "../types/dateOrigin";
 import type { IDateParser } from "../parsers/IDateParser";
 import { log } from "../logger/logManager";
 import { TemplatePropertyCollector } from "../utils/TemplatePropertyCollector";
@@ -323,9 +324,9 @@ export abstract class Formatter {
 	protected promptScopeSoleValue = false;
 	/** Which choice is asking and, once known, where the answer lands. */
 	protected promptRunContext?: PromptRunContext;
-	protected clocks?: { now: Date; date?: Date };
+	protected clocks?: RunClocks;
 
-	protected runClocks(): { now?: Date; date?: Date } | undefined {
+	protected runClocks(): RunClocks | undefined {
 		return this.clocks;
 	}
 

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -323,7 +323,6 @@ export abstract class Formatter {
 	protected promptScopeSoleValue = false;
 	/** Which choice is asking and, once known, where the answer lands. */
 	protected promptRunContext?: PromptRunContext;
-	/** Frozen run clocks. DATE uses `date` + `now` time-of-day. TIME uses `now`. */
 	protected clocks?: { now: Date; date?: Date };
 
 	protected runClocks(): { now?: Date; date?: Date } | undefined {

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -323,6 +323,12 @@ export abstract class Formatter {
 	protected promptScopeSoleValue = false;
 	/** Which choice is asking and, once known, where the answer lands. */
 	protected promptRunContext?: PromptRunContext;
+	/** Frozen run clocks. DATE uses `date` + `now` time-of-day. TIME uses `now`. */
+	protected clocks?: { now: Date; date?: Date };
+
+	protected runClocks(): { now?: Date; date?: Date } | undefined {
+		return this.clocks;
+	}
 
 	// Tracks variables collected for YAML property post-processing
 	private readonly propertyCollector: TemplatePropertyCollector;
@@ -474,7 +480,13 @@ export abstract class Formatter {
 			const snap = dateMatch?.[2]
 				? parseDateSnapSegment(dateMatch[2]) ?? undefined
 				: undefined;
-			const rendered = getDate({ offset, snap });
+			const clocks = this.runClocks();
+			const rendered = getDate({
+				offset,
+				snap,
+				origin: clocks?.date,
+				now: clocks?.now,
+			});
 			output = this.replacer(
 				output,
 				DATE_REGEX,
@@ -499,7 +511,14 @@ export abstract class Formatter {
 				? parseDateSnapSegment(dateMatch[3]) ?? undefined
 				: undefined;
 
-			const rendered = getDate({ format, offset, snap });
+			const clocks = this.runClocks();
+			const rendered = getDate({
+				format,
+				offset,
+				snap,
+				origin: clocks?.date,
+				now: clocks?.now,
+			});
 			output = this.replacer(
 				output,
 				DATE_REGEX_FORMATTED,
@@ -517,7 +536,10 @@ export abstract class Formatter {
 			const timeMatch = TIME_REGEX.exec(output);
 			if (!timeMatch) throw new Error(`Unable to parse time format. Invalid syntax in: "${output.substring(Math.max(0, output.search(TIME_REGEX) - 10), Math.min(output.length, output.search(TIME_REGEX) + 30))}..."`);
 
-			const rendered = getDate({ format: "HH:mm" });
+			const rendered = getDate({
+				format: "HH:mm",
+				now: this.runClocks()?.now,
+			});
 			output = this.replacer(
 				output,
 				TIME_REGEX,
@@ -531,7 +553,10 @@ export abstract class Formatter {
 
 			const format = timeMatch[1];
 
-			const rendered = getDate({ format });
+			const rendered = getDate({
+				format,
+				now: this.runClocks()?.now,
+			});
 			output = this.replacer(
 				output,
 				TIME_REGEX_FORMATTED,

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -17,6 +17,7 @@ import AppendLinkSetting from "./components/AppendLinkSetting.svelte";
 import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
 import OnePageOverrideSetting from "./components/OnePageOverrideSetting.svelte";
+import DateOriginSetting from "./components/DateOriginSetting.svelte";
 import CaptureTargetSetting from "./components/CaptureTargetSetting.svelte";
 import WritePositionSetting from "./components/WritePositionSetting.svelte";
 import ChoiceIconSetting from "./components/ChoiceIconSetting.svelte";
@@ -208,6 +209,8 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 		/>
 	{/snippet}
 </SettingItem>
+
+<DateOriginSetting bind:dateOrigin={choice.dateOrigin} />
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
 

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -39,6 +39,7 @@ import AppendLinkSetting from "./components/AppendLinkSetting.svelte";
 import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
 import OnePageOverrideSetting from "./components/OnePageOverrideSetting.svelte";
+import DateOriginSetting from "./components/DateOriginSetting.svelte";
 import ChoiceIconSetting from "./components/ChoiceIconSetting.svelte";
 import { suggester } from "./components/suggesterAction";
 import { VALUE_SYNTAX } from "../../constants";
@@ -356,6 +357,8 @@ function onModeChange(value: string) {
 {#if choice.openFile}
 	<FileOpeningSetting bind:fileOpening={choice.fileOpening} contextLabel="created" />
 {/if}
+
+<DateOriginSetting bind:dateOrigin={choice.dateOrigin} />
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
 

--- a/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+import type { DateOrigin, DateOriginUnit } from "../../../types/dateOrigin";
+import { DATE_ORIGIN_UNITS } from "../../../types/dateOrigin";
+import SettingItem from "../../components/SettingItem.svelte";
+import Dropdown from "../../components/Dropdown.svelte";
+
+let {
+	dateOrigin = $bindable(),
+}: {
+	dateOrigin: DateOrigin | undefined;
+} = $props();
+
+const kindOptions = [
+	{ value: "", label: "Today" },
+	{ value: "ask", label: "Ask" },
+	{ value: "relative", label: "Relative" },
+	{ value: "variable", label: "From variable" },
+];
+
+const unitOptions = DATE_ORIGIN_UNITS.map((unit) => ({
+	value: unit,
+	label: unit,
+}));
+
+const selectedKind = $derived(dateOrigin?.kind === "now" ? "" : (dateOrigin?.kind ?? ""));
+
+function onKindChange(value: string) {
+	if (value === "ask") {
+		dateOrigin = { kind: "ask" };
+		return;
+	}
+	if (value === "relative") {
+		dateOrigin = { kind: "relative", offset: -1, unit: "weeks" };
+		return;
+	}
+	if (value === "variable") {
+		dateOrigin = { kind: "variable", name: "" };
+		return;
+	}
+	dateOrigin = undefined;
+}
+
+function onDefaultChange(value: string) {
+	if (dateOrigin?.kind !== "ask") return;
+	const trimmed = value.trim();
+	dateOrigin = trimmed ? { kind: "ask", defaultValue: trimmed } : { kind: "ask" };
+}
+
+function onOffsetChange(value: string) {
+	if (dateOrigin?.kind !== "relative") return;
+	const offset = Number.parseInt(value, 10);
+	if (!Number.isInteger(offset)) return;
+	dateOrigin = { ...dateOrigin, offset };
+}
+
+function onUnitChange(value: string) {
+	if (dateOrigin?.kind !== "relative") return;
+	if (!(DATE_ORIGIN_UNITS as readonly string[]).includes(value)) return;
+	dateOrigin = { ...dateOrigin, unit: value as DateOriginUnit };
+}
+
+function onVariableChange(value: string) {
+	if (dateOrigin?.kind !== "variable") return;
+	dateOrigin = { kind: "variable", name: value };
+}
+</script>
+
+<SettingItem
+	name="Date origin"
+	desc={"Which day {{DATE}} formats and offsets from. Time tokens stay the current clock. Today is the default. Ask uses the date picker (lw, last week, a calendar click). Relative is for a last-week or next-year hotkey. From variable reads a VDATE or script value."}
+>
+	{#snippet control()}
+		<Dropdown value={selectedKind} options={kindOptions} onchange={onKindChange} />
+	{/snippet}
+</SettingItem>
+
+{#if dateOrigin?.kind === "ask"}
+	<SettingItem
+		name="Date origin default"
+		desc="Natural language shown in the picker, such as today or last week. Leave empty for today."
+	>
+		{#snippet control()}
+			<input
+				type="text"
+				class="qa-validated-input-full-width"
+				value={dateOrigin.defaultValue ?? ""}
+				placeholder="today"
+				aria-label="Date origin default"
+				oninput={(event) =>
+					onDefaultChange((event.currentTarget as HTMLInputElement).value)}
+			/>
+		{/snippet}
+	</SettingItem>
+{/if}
+
+{#if dateOrigin?.kind === "relative"}
+	<SettingItem
+		name="Date origin offset"
+		desc="Move the origin from today. −1 week is last week."
+	>
+		{#snippet control()}
+			<input
+				type="text"
+				class="qa-validated-input-full-width"
+				value={String(dateOrigin.offset)}
+				placeholder="-1"
+				aria-label="Date origin offset"
+				oninput={(event) =>
+					onOffsetChange((event.currentTarget as HTMLInputElement).value)}
+			/>
+			<Dropdown
+				value={dateOrigin.unit}
+				options={unitOptions}
+				onchange={onUnitChange}
+			/>
+		{/snippet}
+	</SettingItem>
+{/if}
+
+{#if dateOrigin?.kind === "variable"}
+	<SettingItem
+		name="Date origin variable"
+		desc="Name of a VDATE or script variable that already holds the day."
+	>
+		{#snippet control()}
+			<input
+				type="text"
+				class="qa-validated-input-full-width"
+				value={dateOrigin.name}
+				placeholder="day"
+				aria-label="Date origin variable"
+				oninput={(event) =>
+					onVariableChange((event.currentTarget as HTMLInputElement).value)}
+			/>
+		{/snippet}
+	</SettingItem>
+{/if}

--- a/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
@@ -1,6 +1,23 @@
 <script lang="ts">
-import type { DateOrigin, DateOriginUnit } from "../../../types/dateOrigin";
-import { DATE_ORIGIN_UNITS } from "../../../types/dateOrigin";
+import type { DateOrigin } from "../../../types/dateOrigin";
+import { DATE_ORIGIN_UNITS, isDateOriginUnit } from "../../../types/dateOrigin";
+import {
+	ASK_DEFAULT_SETTING_DESC,
+	ASK_DEFAULT_SETTING_NAME,
+	CUSTOM_OFFSET_SETTING_DESC,
+	CUSTOM_OFFSET_SETTING_NAME,
+	DATE_ORIGIN_PRESET_OPTIONS,
+	DATE_ORIGIN_SETTING_DESC,
+	DATE_ORIGIN_SETTING_NAME,
+	VARIABLE_SETTING_DESC,
+	VARIABLE_SETTING_NAME,
+	askDefaultFromPresetId,
+	askDefaultOptions,
+	askDefaultToPresetId,
+	dateOriginFromPreset,
+	dateOriginToPreset,
+	isDateOriginPreset,
+} from "../../../types/dateOriginPresets";
 import SettingItem from "../../components/SettingItem.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
 
@@ -10,47 +27,38 @@ let {
 	dateOrigin: DateOrigin | undefined;
 } = $props();
 
-const kindOptions = [
-	{ value: "", label: "Today" },
-	{ value: "ask", label: "Ask" },
-	{ value: "relative", label: "Relative" },
-	{ value: "variable", label: "From variable" },
-];
-
 const unitOptions = DATE_ORIGIN_UNITS.map((unit) => ({
 	value: unit,
 	label: unit,
 }));
 
-const selectedKind = $derived(dateOrigin?.kind === "now" ? "" : (dateOrigin?.kind ?? ""));
+const selectedPreset = $derived(dateOriginToPreset(dateOrigin));
 const askOrigin = $derived(dateOrigin?.kind === "ask" ? dateOrigin : undefined);
-const relativeOrigin = $derived(
-	dateOrigin?.kind === "relative" ? dateOrigin : undefined,
+const customOrigin = $derived(
+	selectedPreset === "custom" && dateOrigin?.kind === "relative"
+		? dateOrigin
+		: undefined,
 );
 const variableOrigin = $derived(
 	dateOrigin?.kind === "variable" ? dateOrigin : undefined,
 );
+const askDefaultId = $derived(askDefaultToPresetId(askOrigin?.defaultValue));
+const askDefaultChoices = $derived(askDefaultOptions(askOrigin?.defaultValue));
 
-function onKindChange(value: string) {
-	if (value === "ask") {
-		dateOrigin = { kind: "ask" };
-		return;
-	}
-	if (value === "relative") {
-		dateOrigin = { kind: "relative", offset: -1, unit: "weeks" };
-		return;
-	}
-	if (value === "variable") {
-		dateOrigin = { kind: "variable", name: "" };
-		return;
-	}
-	dateOrigin = undefined;
+function onPresetChange(value: string) {
+	if (!isDateOriginPreset(value)) return;
+	dateOrigin = dateOriginFromPreset({
+		preset: value,
+		previous: dateOrigin,
+	});
 }
 
-function onDefaultChange(value: string) {
+function onAskDefaultChange(value: string) {
 	if (dateOrigin?.kind !== "ask") return;
-	const trimmed = value.trim();
-	dateOrigin = trimmed ? { kind: "ask", defaultValue: trimmed } : { kind: "ask" };
+	const defaultValue = askDefaultFromPresetId(value, dateOrigin.defaultValue);
+	dateOrigin = defaultValue
+		? { kind: "ask", defaultValue }
+		: { kind: "ask" };
 }
 
 function onOffsetChange(value: string) {
@@ -62,8 +70,8 @@ function onOffsetChange(value: string) {
 
 function onUnitChange(value: string) {
 	if (dateOrigin?.kind !== "relative") return;
-	if (!(DATE_ORIGIN_UNITS as readonly string[]).includes(value)) return;
-	dateOrigin = { ...dateOrigin, unit: value as DateOriginUnit };
+	if (!isDateOriginUnit(value)) return;
+	dateOrigin = { ...dateOrigin, unit: value };
 }
 
 function onVariableChange(value: string) {
@@ -72,51 +80,48 @@ function onVariableChange(value: string) {
 }
 </script>
 
-<SettingItem
-	name="Date origin"
-	desc={"Which day {{DATE}} formats and offsets from. Time tokens stay the current clock. Today is the default. Ask uses the date picker (lw, last week, a calendar click). Relative is for a last-week or next-year hotkey. From variable reads a VDATE or script value."}
->
+<SettingItem name={DATE_ORIGIN_SETTING_NAME} desc={DATE_ORIGIN_SETTING_DESC}>
 	{#snippet control()}
-		<Dropdown value={selectedKind} options={kindOptions} onchange={onKindChange} />
+		<Dropdown
+			value={selectedPreset}
+			options={DATE_ORIGIN_PRESET_OPTIONS}
+			onchange={onPresetChange}
+		/>
 	{/snippet}
 </SettingItem>
 
 {#if askOrigin}
-	<SettingItem
-		name="Date origin default"
-		desc="Natural language shown in the picker, such as today or last week. Leave empty for today."
-	>
+	<SettingItem name={ASK_DEFAULT_SETTING_NAME} desc={ASK_DEFAULT_SETTING_DESC}>
 		{#snippet control()}
-			<input
-				type="text"
-				class="qa-validated-input-full-width"
-				value={askOrigin.defaultValue ?? ""}
-				placeholder="today"
-				aria-label="Date origin default"
-				oninput={(event) =>
-					onDefaultChange((event.currentTarget as HTMLInputElement).value)}
+			<Dropdown
+				value={askDefaultId}
+				options={askDefaultChoices}
+				onchange={onAskDefaultChange}
 			/>
 		{/snippet}
 	</SettingItem>
 {/if}
 
-{#if relativeOrigin}
+{#if customOrigin}
 	<SettingItem
-		name="Date origin offset"
-		desc="Move the origin from today. −1 week is last week."
+		name={CUSTOM_OFFSET_SETTING_NAME}
+		desc={CUSTOM_OFFSET_SETTING_DESC}
 	>
 		{#snippet control()}
 			<input
 				type="text"
 				class="qa-validated-input-full-width"
-				value={String(relativeOrigin.offset)}
-				placeholder="-1"
-				aria-label="Date origin offset"
-				oninput={(event) =>
-					onOffsetChange((event.currentTarget as HTMLInputElement).value)}
+				value={String(customOrigin.offset)}
+				placeholder="-2"
+				aria-label={CUSTOM_OFFSET_SETTING_NAME}
+				oninput={(event) => {
+					const target = event.currentTarget;
+					if (!(target instanceof HTMLInputElement)) return;
+					onOffsetChange(target.value);
+				}}
 			/>
 			<Dropdown
-				value={relativeOrigin.unit}
+				value={customOrigin.unit}
 				options={unitOptions}
 				onchange={onUnitChange}
 			/>
@@ -125,19 +130,19 @@ function onVariableChange(value: string) {
 {/if}
 
 {#if variableOrigin}
-	<SettingItem
-		name="Date origin variable"
-		desc="Name of a VDATE or script variable that already holds the day."
-	>
+	<SettingItem name={VARIABLE_SETTING_NAME} desc={VARIABLE_SETTING_DESC}>
 		{#snippet control()}
 			<input
 				type="text"
 				class="qa-validated-input-full-width"
 				value={variableOrigin.name}
 				placeholder="day"
-				aria-label="Date origin variable"
-				oninput={(event) =>
-					onVariableChange((event.currentTarget as HTMLInputElement).value)}
+				aria-label={VARIABLE_SETTING_NAME}
+				oninput={(event) => {
+					const target = event.currentTarget;
+					if (!(target instanceof HTMLInputElement)) return;
+					onVariableChange(target.value);
+				}}
 			/>
 		{/snippet}
 	</SettingItem>

--- a/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
@@ -23,6 +23,13 @@ const unitOptions = DATE_ORIGIN_UNITS.map((unit) => ({
 }));
 
 const selectedKind = $derived(dateOrigin?.kind === "now" ? "" : (dateOrigin?.kind ?? ""));
+const askOrigin = $derived(dateOrigin?.kind === "ask" ? dateOrigin : undefined);
+const relativeOrigin = $derived(
+	dateOrigin?.kind === "relative" ? dateOrigin : undefined,
+);
+const variableOrigin = $derived(
+	dateOrigin?.kind === "variable" ? dateOrigin : undefined,
+);
 
 function onKindChange(value: string) {
 	if (value === "ask") {
@@ -48,9 +55,9 @@ function onDefaultChange(value: string) {
 
 function onOffsetChange(value: string) {
 	if (dateOrigin?.kind !== "relative") return;
-	const offset = Number.parseInt(value, 10);
-	if (!Number.isInteger(offset)) return;
-	dateOrigin = { ...dateOrigin, offset };
+	const trimmed = value.trim();
+	if (!/^[+-]?\d+$/.test(trimmed)) return;
+	dateOrigin = { ...dateOrigin, offset: Number(trimmed) };
 }
 
 function onUnitChange(value: string) {
@@ -74,7 +81,7 @@ function onVariableChange(value: string) {
 	{/snippet}
 </SettingItem>
 
-{#if dateOrigin?.kind === "ask"}
+{#if askOrigin}
 	<SettingItem
 		name="Date origin default"
 		desc="Natural language shown in the picker, such as today or last week. Leave empty for today."
@@ -83,7 +90,7 @@ function onVariableChange(value: string) {
 			<input
 				type="text"
 				class="qa-validated-input-full-width"
-				value={dateOrigin.defaultValue ?? ""}
+				value={askOrigin.defaultValue ?? ""}
 				placeholder="today"
 				aria-label="Date origin default"
 				oninput={(event) =>
@@ -93,7 +100,7 @@ function onVariableChange(value: string) {
 	</SettingItem>
 {/if}
 
-{#if dateOrigin?.kind === "relative"}
+{#if relativeOrigin}
 	<SettingItem
 		name="Date origin offset"
 		desc="Move the origin from today. −1 week is last week."
@@ -102,14 +109,14 @@ function onVariableChange(value: string) {
 			<input
 				type="text"
 				class="qa-validated-input-full-width"
-				value={String(dateOrigin.offset)}
+				value={String(relativeOrigin.offset)}
 				placeholder="-1"
 				aria-label="Date origin offset"
 				oninput={(event) =>
 					onOffsetChange((event.currentTarget as HTMLInputElement).value)}
 			/>
 			<Dropdown
-				value={dateOrigin.unit}
+				value={relativeOrigin.unit}
 				options={unitOptions}
 				onchange={onUnitChange}
 			/>
@@ -117,7 +124,7 @@ function onVariableChange(value: string) {
 	</SettingItem>
 {/if}
 
-{#if dateOrigin?.kind === "variable"}
+{#if variableOrigin}
 	<SettingItem
 		name="Date origin variable"
 		desc="Name of a VDATE or script variable that already holds the day."
@@ -126,7 +133,7 @@ function onVariableChange(value: string) {
 			<input
 				type="text"
 				class="qa-validated-input-full-width"
-				value={dateOrigin.name}
+				value={variableOrigin.name}
 				placeholder="day"
 				aria-label="Date origin variable"
 				oninput={(event) =>

--- a/src/gui/MacroGUIs/MacroBuilder.test.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.test.ts
@@ -33,11 +33,44 @@ describe("MacroBuilder", () => {
 		);
 		const children = Array.from(modal.contentEl.children);
 
+		expect(modal.contentEl.textContent).toContain("Which day");
+		expect(modal.contentEl.textContent).toContain("Ask each time");
 		expect(children.at(-2)?.textContent).toContain("Run on startup");
 		expect(children.at(-1)?.textContent).toContain("Icon");
 		expect(children.at(-1)?.textContent).toContain(
 			"Lucide/Obsidian icon id",
 		);
+	});
+
+	it("shows the ask picker default and keeps icon last", () => {
+		const choice = new MacroChoice("Macro under test");
+		choice.dateOrigin = { kind: "ask", defaultValue: "last week" };
+		const modal = new MacroBuilder(
+			new App(),
+			{ settings: { choices: [] } } as unknown as QuickAdd,
+			choice,
+			[],
+		);
+		const children = Array.from(modal.contentEl.children);
+
+		expect(modal.contentEl.textContent).toContain("Picker starts on");
+		expect(modal.contentEl.textContent).toContain("Last week");
+		expect(children.at(-2)?.textContent).toContain("Run on startup");
+		expect(children.at(-1)?.textContent).toContain("Icon");
+	});
+
+	it("shows a custom offset only for unmatched relatives", () => {
+		const choice = new MacroChoice("Macro under test");
+		choice.dateOrigin = { kind: "relative", offset: -3, unit: "days" };
+		const modal = new MacroBuilder(
+			new App(),
+			{ settings: { choices: [] } } as unknown as QuickAdd,
+			choice,
+			[],
+		);
+
+		expect(modal.contentEl.textContent).toContain("How far from today");
+		expect(modal.contentEl.textContent).toContain("Custom…");
 	});
 
 	// #1545: the builder autosaves on close but never said so, and had no

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -87,6 +87,7 @@ export class MacroBuilder extends Modal {
 		this.contentEl.empty();
 		this.addCenteredHeader(this.choice.name);
 		this.addCommandEditor();
+		this.addDateOriginSetting();
 		this.addRunOnStartupSetting();
 		this.addIconSetting();
 	}
@@ -125,6 +126,38 @@ export class MacroBuilder extends Modal {
 				}
 			})();
 		});
+	}
+
+	private addDateOriginSetting(): void {
+		const current = this.choice.dateOrigin;
+		new Setting(this.contentEl)
+			.setName("Date origin")
+			.setDesc(
+				"Which day {{DATE}} in this macro and its child choices formats from. Today is the default.",
+			)
+			.addDropdown((dropdown) => {
+				dropdown.addOption("", "Today");
+				dropdown.addOption("ask", "Ask");
+				dropdown.addOption("relative", "Relative (−1 week)");
+				dropdown.setValue(
+					current?.kind === "ask" || current?.kind === "relative"
+						? current.kind
+						: "",
+				);
+				dropdown.onChange((value) => {
+					if (value === "ask") {
+						this.choice.dateOrigin = { kind: "ask" };
+					} else if (value === "relative") {
+						this.choice.dateOrigin = {
+							kind: "relative",
+							offset: -1,
+							unit: "weeks",
+						};
+					} else {
+						this.choice.dateOrigin = undefined;
+					}
+				});
+			});
 	}
 
 	private addRunOnStartupSetting(): void {

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -25,6 +25,24 @@ import {
 } from "../../utils/macroUtils";
 import type { ICommand } from "../../types/macros/ICommand";
 import { v4 as uuidv4 } from "uuid";
+import { DATE_ORIGIN_UNITS, isDateOriginUnit } from "../../types/dateOrigin";
+import {
+	ASK_DEFAULT_SETTING_DESC,
+	ASK_DEFAULT_SETTING_NAME,
+	CUSTOM_OFFSET_SETTING_DESC,
+	CUSTOM_OFFSET_SETTING_NAME,
+	DATE_ORIGIN_PRESET_OPTIONS,
+	DATE_ORIGIN_SETTING_DESC,
+	DATE_ORIGIN_SETTING_NAME,
+	VARIABLE_SETTING_DESC,
+	VARIABLE_SETTING_NAME,
+	askDefaultFromPresetId,
+	askDefaultOptions,
+	askDefaultToPresetId,
+	dateOriginFromPreset,
+	dateOriginToPreset,
+	isDateOriginPreset,
+} from "../../types/dateOriginPresets";
 
 /** Exported for the malformed-tree sweep (src/utils/malformedChoices.entrypoints.test.ts). */
 export function getChoicesAsList(nestedChoices: IChoice[]): IChoice[] {
@@ -130,34 +148,91 @@ export class MacroBuilder extends Modal {
 
 	private addDateOriginSetting(): void {
 		const current = this.choice.dateOrigin;
+		const preset = dateOriginToPreset(current);
+
 		new Setting(this.contentEl)
-			.setName("Date origin")
-			.setDesc(
-				"Which day {{DATE}} in this macro and its child choices formats from. Today is the default.",
-			)
+			.setName(DATE_ORIGIN_SETTING_NAME)
+			.setDesc(DATE_ORIGIN_SETTING_DESC)
 			.addDropdown((dropdown) => {
-				dropdown.addOption("", "Today");
-				dropdown.addOption("ask", "Ask");
-				dropdown.addOption("relative", "Relative (−1 week)");
-				dropdown.setValue(
-					current?.kind === "ask" || current?.kind === "relative"
-						? current.kind
-						: "",
-				);
+				for (const option of DATE_ORIGIN_PRESET_OPTIONS) {
+					dropdown.addOption(option.value, option.label);
+				}
+				dropdown.setValue(preset);
 				dropdown.onChange((value) => {
-					if (value === "ask") {
-						this.choice.dateOrigin = { kind: "ask" };
-					} else if (value === "relative") {
-						this.choice.dateOrigin = {
-							kind: "relative",
-							offset: -1,
-							unit: "weeks",
-						};
-					} else {
-						this.choice.dateOrigin = undefined;
-					}
+					if (!isDateOriginPreset(value)) return;
+					this.choice.dateOrigin = dateOriginFromPreset({
+						preset: value,
+						previous: this.choice.dateOrigin,
+					});
+					this.reload();
 				});
 			});
+
+		if (preset === "ask") {
+			const defaultValue =
+				current?.kind === "ask" ? current.defaultValue : undefined;
+			new Setting(this.contentEl)
+				.setName(ASK_DEFAULT_SETTING_NAME)
+				.setDesc(ASK_DEFAULT_SETTING_DESC)
+				.addDropdown((dropdown) => {
+					for (const option of askDefaultOptions(defaultValue)) {
+						dropdown.addOption(option.value, option.label);
+					}
+					dropdown.setValue(askDefaultToPresetId(defaultValue));
+					dropdown.onChange((value) => {
+						const next = askDefaultFromPresetId(value, defaultValue);
+						this.choice.dateOrigin = next
+							? { kind: "ask", defaultValue: next }
+							: { kind: "ask" };
+					});
+				});
+		}
+
+		if (preset === "custom" && current?.kind === "relative") {
+			new Setting(this.contentEl)
+				.setName(CUSTOM_OFFSET_SETTING_NAME)
+				.setDesc(CUSTOM_OFFSET_SETTING_DESC)
+				.addText((text) => {
+					text.setValue(String(current.offset));
+					text.setPlaceholder("-2");
+					text.onChange((value) => {
+						const origin = this.choice.dateOrigin;
+						if (origin?.kind !== "relative") return;
+						const trimmed = value.trim();
+						if (!/^[+-]?\d+$/.test(trimmed)) return;
+						this.choice.dateOrigin = {
+							...origin,
+							offset: Number(trimmed),
+						};
+					});
+				})
+				.addDropdown((dropdown) => {
+					for (const unit of DATE_ORIGIN_UNITS) {
+						dropdown.addOption(unit, unit);
+					}
+					dropdown.setValue(current.unit);
+					dropdown.onChange((value) => {
+						const origin = this.choice.dateOrigin;
+						if (origin?.kind !== "relative") return;
+						if (!isDateOriginUnit(value)) return;
+						this.choice.dateOrigin = { ...origin, unit: value };
+					});
+				});
+		}
+
+		if (preset === "variable") {
+			const name = current?.kind === "variable" ? current.name : "";
+			new Setting(this.contentEl)
+				.setName(VARIABLE_SETTING_NAME)
+				.setDesc(VARIABLE_SETTING_DESC)
+				.addText((text) => {
+					text.setValue(name);
+					text.setPlaceholder("day");
+					text.onChange((value) => {
+						this.choice.dateOrigin = { kind: "variable", name: value };
+					});
+				});
+		}
 	}
 
 	private addRunOnStartupSetting(): void {

--- a/src/gui/suggesters/choiceSuggester.test.ts
+++ b/src/gui/suggesters/choiceSuggester.test.ts
@@ -1026,6 +1026,16 @@ describe("ChoiceSuggester", () => {
 			expect(completion).toHaveBeenCalledWith();
 		});
 
+		it("holds Shift to pick a day on a Today choice", () => {
+			const suggester = makeSuggester(rootChoices);
+			suggester.onChooseItem(
+				topNote,
+				new MouseEvent("click", { shiftKey: true }),
+			);
+			expect(executor.pickDate).toBe(true);
+			expect(executed).toEqual([topNote]);
+		});
+
 		it("rejects with the leaf's own error instance", async () => {
 			const leafError = new Error("leaf blew up");
 			executor.execute = () => Promise.reject(leafError);

--- a/src/gui/suggesters/choiceSuggester.ts
+++ b/src/gui/suggesters/choiceSuggester.ts
@@ -525,6 +525,9 @@ export default class ChoiceSuggester extends FuzzySuggestModal<IChoice> {
 			// leaf inherits the executor's still-live context, which holds the same
 			// values this level was handed. Falls back to execute() only for stub
 			// executors without the method.
+			if ("shiftKey" in evt && evt.shiftKey) {
+				this.choiceExecutor.pickDate = true;
+			}
 			const execute = this.choiceExecutor.executeWithFocusedProperty
 				? this.choiceExecutor.executeWithFocusedProperty(
 						item,

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,7 +284,13 @@ export default class QuickAdd extends Plugin {
 			}
 
 			const choiceExecutor = new ChoiceExecutor(this.app, this);
-			this.applyUriValueParameters(choiceExecutor, parameters);
+			if (!this.applyUriValueParameters(choiceExecutor, parameters)) {
+				log.logWarning(
+					`QuickAdd URI: could not parse date origin '${parameters.date}'.`,
+				);
+				this.fireUriError(targets, "execution-failed");
+				return;
+			}
 
 			const outcome = await choiceExecutor.executeWithOutcome(
 				choice as ITemplateChoice | ICaptureChoice,
@@ -406,7 +412,13 @@ export default class QuickAdd extends Plugin {
 		// wrong choice is at least diagnosable.
 		this.warnIfChoiceNameAmbiguous(parameters.choice);
 		const choiceExecutor = new ChoiceExecutor(this.app, this);
-		this.applyUriValueParameters(choiceExecutor, parameters);
+		if (!this.applyUriValueParameters(choiceExecutor, parameters)) {
+			reportError(
+				new Error(`Could not parse date origin '${parameters.date}'`),
+				"URI handler error",
+			);
+			return;
+		}
 		try {
 			await choiceExecutor.execute(choice);
 		} catch (err) {
@@ -419,7 +431,7 @@ export default class QuickAdd extends Plugin {
 	private applyUriValueParameters(
 		choiceExecutor: ChoiceExecutor,
 		parameters: UriParameters,
-	): void {
+	): boolean {
 		Object.entries(parameters)
 			.filter(([key]) => key.startsWith("value-"))
 			.forEach(([key, value]) => {
@@ -439,10 +451,10 @@ export default class QuickAdd extends Plugin {
 			});
 		if (typeof parameters.date === "string" && parameters.date.trim()) {
 			const date = dateFromStoredValue(parameters.date);
-			if (date) {
-				choiceExecutor.clocks = { now: new Date(), date };
-			}
+			if (!date) return false;
+			choiceExecutor.clocks = { now: new Date(), date };
 		}
+		return true;
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ import {
 	rootChoicesOf,
 } from "./utils/choiceUtils";
 import { isReservedVariableKey } from "./utils/reservedVariableKeys";
+import { dateFromStoredValue } from "./utils/resolveDateOrigin";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { autoSyncEnabledProviders } from "./ai/modelSyncService";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
@@ -64,6 +65,7 @@ type CaptureValueParameters = { [key in `value-${string}`]?: string };
 
 interface DefinedUriParameters {
 	choice?: string; // Name
+	date?: string;
 }
 
 // x-callback-url parameters (Apple Shortcuts, etc.). The hyphenated keys arrive
@@ -435,6 +437,12 @@ export default class QuickAdd extends Plugin {
 					choiceExecutor.variables.set(variableName, value);
 				}
 			});
+		if (typeof parameters.date === "string" && parameters.date.trim()) {
+			const date = dateFromStoredValue(parameters.date);
+			if (date) {
+				choiceExecutor.clocks = { now: new Date(), date };
+			}
+		}
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,12 @@ import {
 	rootChoicesOf,
 } from "./utils/choiceUtils";
 import { isReservedVariableKey } from "./utils/reservedVariableKeys";
-import { dateFromStoredValue } from "./utils/resolveDateOrigin";
+import { applyInvocationDate } from "./utils/resolveDateOrigin";
+import {
+	anotherDayCommandId,
+	anotherDayCommandName,
+	shouldRegisterAnotherDayCommand,
+} from "./types/dateOriginPresets";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { autoSyncEnabledProviders } from "./ai/modelSyncService";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
@@ -449,10 +454,8 @@ export default class QuickAdd extends Plugin {
 					choiceExecutor.variables.set(variableName, value);
 				}
 			});
-		if (typeof parameters.date === "string" && parameters.date.trim()) {
-			const date = dateFromStoredValue(parameters.date);
-			if (!date) return false;
-			choiceExecutor.clocks = { now: new Date(), date };
+		if (!applyInvocationDate(choiceExecutor, parameters.date)) {
+			return false;
 		}
 		return true;
 	}
@@ -593,26 +596,44 @@ export default class QuickAdd extends Plugin {
 				id: `choice:${choiceId}`,
 				name: choice.name,
 				icon: resolveChoiceIcon(choice),
-				callback: async () => {
-					// Resolved outside the try so the failure can name the choice the user
-					// actually ran; a bare UUID tells them nothing. Falls back to the name
-					// captured at registration when the lookup itself is what failed.
-					let current: IChoice | undefined;
-					try {
-						current = this.getChoiceById(choiceId);
-						await new ChoiceExecutor(this.app, this).execute(current);
-					} catch (err) {
-						// The outermost handler: the last chance to say which choice failed.
-						// It reports only what nothing below it already reported (#1601), and
-						// stays silent when the user simply dismissed a prompt - Escape on the
-						// one-page input modal used to raise a 15-second ERROR notice here.
-						reportUnlessCancelled(
-							err,
-							`Could not run "${current?.name ?? choice.name}"`,
-						);
-					}
-				},
+				callback: () => this.runRegisteredChoice(choiceId, choice.name),
 			});
+
+			if (shouldRegisterAnotherDayCommand(choice.dateOrigin)) {
+				this.addCommand({
+					id: anotherDayCommandId(choiceId),
+					name: anotherDayCommandName(choice.name),
+					icon: resolveChoiceIcon(choice),
+					callback: () =>
+						this.runRegisteredChoice(choiceId, choice.name, true),
+				});
+			}
+		}
+	}
+
+	private async runRegisteredChoice(
+		choiceId: string,
+		fallbackName: string,
+		pickDate = false,
+	): Promise<void> {
+		// Resolved outside the try so the failure can name the choice the user
+		// actually ran; a bare UUID tells them nothing. Falls back to the name
+		// captured at registration when the lookup itself is what failed.
+		let current: IChoice | undefined;
+		try {
+			current = this.getChoiceById(choiceId);
+			const executor = new ChoiceExecutor(this.app, this);
+			executor.pickDate = pickDate;
+			await executor.execute(current);
+		} catch (err) {
+			// The outermost handler: the last chance to say which choice failed.
+			// It reports only what nothing below it already reported (#1601), and
+			// stays silent when the user simply dismissed a prompt - Escape on the
+			// one-page input modal used to raise a 15-second ERROR notice here.
+			reportUnlessCancelled(
+				err,
+				`Could not run "${current?.name ?? fallbackName}"`,
+			);
 		}
 	}
 
@@ -710,6 +731,10 @@ export default class QuickAdd extends Plugin {
 		}
 
 		deleteObsidianCommand(this.app, `quickadd:choice:${choice.id}`);
+		deleteObsidianCommand(
+			this.app,
+			`quickadd:${anotherDayCommandId(choice.id)}`,
+		);
 	}
 
 	public getTemplateFiles(): TFile[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import { applyInvocationDate } from "./utils/resolveDateOrigin";
 import {
 	anotherDayCommandId,
 	anotherDayCommandName,
+	choiceCommandId,
 	shouldRegisterAnotherDayCommand,
 } from "./types/dateOriginPresets";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
@@ -593,7 +594,7 @@ export default class QuickAdd extends Plugin {
 			const choiceId = choice.id;
 
 			this.addCommand({
-				id: `choice:${choiceId}`,
+				id: choiceCommandId(choiceId),
 				name: choice.name,
 				icon: resolveChoiceIcon(choice),
 				callback: () => this.runRegisteredChoice(choiceId, choice.name),
@@ -730,7 +731,7 @@ export default class QuickAdd extends Plugin {
 			}
 		}
 
-		deleteObsidianCommand(this.app, `quickadd:choice:${choice.id}`);
+		deleteObsidianCommand(this.app, `quickadd:${choiceCommandId(choice.id)}`);
 		deleteObsidianCommand(
 			this.app,
 			`quickadd:${anotherDayCommandId(choice.id)}`,

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -6,7 +6,10 @@ import type IMacroChoice from "src/types/choices/IMacroChoice";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { CommandType } from "src/types/macros/CommandType";
 import type { IUserScript } from "src/types/macros/IUserScript";
-import { QA_INTERNAL_CAPTURE_TARGET_FILE_PATH } from "src/constants";
+import {
+	QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+	QA_INTERNAL_DATE_ORIGIN,
+} from "src/constants";
 import {
 	collectChoiceRequirements,
 	getUnresolvedRequirements,
@@ -1686,5 +1689,52 @@ describe("collectChoiceRequirements - path-context memo (issue #1484 review fix)
 
 		const mvalue = requirements.find((req) => req.id === "mvalue");
 		expect(mvalue?.pathContext).toBeUndefined();
+	});
+});
+
+describe("collectChoiceRequirements - pickDate", () => {
+	const app = {
+		vault: { cachedRead: vi.fn(async () => "") },
+		metadataCache: { getFileCache: vi.fn(() => null) },
+	} as unknown as App;
+	const plugin = {
+		settings: {
+			inputPrompt: "single-line",
+			globalVariables: {},
+			useSelectionAsCaptureValue: true,
+		},
+	} as never;
+
+	it("collects a date field when pickDate is set on a Today choice", async () => {
+		const choice = createCaptureChoice("Inbox.md");
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			{
+				execute: vi.fn(),
+				variables: new Map<string, unknown>(),
+				pickDate: true,
+			},
+			choice,
+		);
+		expect(
+			requirements.some((requirement) => requirement.id === QA_INTERNAL_DATE_ORIGIN),
+		).toBe(true);
+	});
+
+	it("does not collect a date field for a Today choice without pickDate", async () => {
+		const choice = createCaptureChoice("Inbox.md");
+		const requirements = await collectChoiceRequirements(
+			app,
+			plugin,
+			{
+				execute: vi.fn(),
+				variables: new Map<string, unknown>(),
+			},
+			choice,
+		);
+		expect(
+			requirements.some((requirement) => requirement.id === QA_INTERNAL_DATE_ORIGIN),
+		).toBe(false);
 	});
 });

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -9,6 +9,7 @@ import {
 	TEMPLATE_REGEX,
 } from "src/constants";
 import { normalizeDateOrigin } from "src/types/dateOrigin";
+import { dateOriginForPick } from "src/types/dateOriginPresets";
 import type QuickAdd from "src/main";
 import type ICaptureChoice from "src/types/choices/ICaptureChoice";
 import type IChoice from "src/types/choices/IChoice";
@@ -589,7 +590,9 @@ export async function collectChoiceRequirements(
 	}
 
 	const mergedMap = new Map<string, FieldRequirement>();
-	const dateOrigin = normalizeDateOrigin(choice.dateOrigin);
+	const dateOrigin = choiceExecutor.pickDate
+		? dateOriginForPick(normalizeDateOrigin(choice.dateOrigin))
+		: normalizeDateOrigin(choice.dateOrigin);
 	if (dateOrigin?.kind === "ask" && !choiceExecutor.clocks?.date) {
 		mergedMap.set(QA_INTERNAL_DATE_ORIGIN, {
 			id: QA_INTERNAL_DATE_ORIGIN,

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -5,8 +5,10 @@ import { MAX_TEMPLATE_INCLUSION_DEPTH } from "src/formatters/formatter";
 import type { IChoiceExecutor } from "src/IChoiceExecutor";
 import {
 	QA_INTERNAL_CAPTURE_TARGET_FILE_PATH,
+	QA_INTERNAL_DATE_ORIGIN,
 	TEMPLATE_REGEX,
 } from "src/constants";
+import { normalizeDateOrigin } from "src/types/dateOrigin";
 import type QuickAdd from "src/main";
 import type ICaptureChoice from "src/types/choices/ICaptureChoice";
 import type IChoice from "src/types/choices/IChoice";
@@ -587,6 +589,17 @@ export async function collectChoiceRequirements(
 	}
 
 	const mergedMap = new Map<string, FieldRequirement>();
+	const dateOrigin = normalizeDateOrigin(choice.dateOrigin);
+	if (dateOrigin?.kind === "ask" && !choiceExecutor.clocks?.date) {
+		mergedMap.set(QA_INTERNAL_DATE_ORIGIN, {
+			id: QA_INTERNAL_DATE_ORIGIN,
+			label: `Date for ${choice.name}`,
+			type: "date",
+			dateFormat: "YYYY-MM-DD",
+			defaultValue: dateOrigin.defaultValue,
+			source: "collected",
+		});
+	}
 	for (const requirement of collector
 		? Array.from(collector.requirements.values())
 		: []) {

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -1001,6 +1001,14 @@ describe("executeChoice", () => {
 		await api.executeChoice("C");
 		expect(executor.execute).toHaveBeenCalled();
 	});
+
+	it("rejects an invalid Date origin and does not execute", async () => {
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+		await api.executeChoice("C", undefined, { date: new Date("bad") });
+		expect(executor.execute).not.toHaveBeenCalled();
+		expect(mocks.reportError).toHaveBeenCalled();
+	});
 });
 
 // ===========================================================================

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -182,6 +182,8 @@ function makeChoiceExecutor() {
 		consumeAbortSignal: vi.fn(
 			(): InstanceType<typeof MacroAbortError> | null => null,
 		),
+		pickDate: false as boolean | undefined,
+		clocks: undefined as { now: Date; date?: Date } | undefined,
 	};
 }
 
@@ -1000,6 +1002,15 @@ describe("executeChoice", () => {
 		const { api } = getApi(makeApp(), makePlugin(), executor);
 		await api.executeChoice("C");
 		expect(executor.execute).toHaveBeenCalled();
+	});
+
+	it("treats date ask as pickDate and still executes", async () => {
+		const executor = makeChoiceExecutor();
+		const { api } = getApi(makeApp(), makePlugin(), executor);
+		await api.executeChoice("C", {}, { date: "ask" });
+		expect(executor.execute).toHaveBeenCalled();
+		expect(executor.pickDate).toBe(true);
+		expect(executor.clocks).toBeUndefined();
 	});
 
 	it("rejects an invalid Date origin and does not execute", async () => {

--- a/src/quickAddApi.test.ts
+++ b/src/quickAddApi.test.ts
@@ -1005,9 +1005,12 @@ describe("executeChoice", () => {
 	it("rejects an invalid Date origin and does not execute", async () => {
 		const executor = makeChoiceExecutor();
 		const { api } = getApi(makeApp(), makePlugin(), executor);
-		await api.executeChoice("C", undefined, { date: new Date("bad") });
+		executor.variables.set("keep", "caller");
+		await api.executeChoice("C", { leak: "nope" }, { date: new Date("bad") });
 		expect(executor.execute).not.toHaveBeenCalled();
 		expect(mocks.reportError).toHaveBeenCalled();
+		expect(executor.variables.get("keep")).toBe("caller");
+		expect(executor.variables.has("leak")).toBe(false);
 	});
 });
 

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -50,7 +50,7 @@ import { settingsStore } from "./settingsStore";
 import { log } from "./logger/logManager";
 import type IChoice from "./types/choices/IChoice";
 import { getDate } from "./utilityObsidian";
-import { dateFromStoredValue } from "./utils/resolveDateOrigin";
+import { applyInvocationDate } from "./utils/resolveDateOrigin";
 import { isCancellationError, reportError } from "./utils/errorUtils";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { FieldSuggestionFileFilter } from "./utils/FieldSuggestionFileFilter";
@@ -414,19 +414,12 @@ export class QuickAddApi {
 					return;
 				}
 
-				if (options?.date !== undefined) {
-					const date = dateFromStoredValue(options.date);
-					if (!date) {
-						reportError(
-							new Error(`Could not parse date origin '${String(options.date)}'`),
-							"API executeChoice error",
-						);
-						return;
-					}
-					choiceExecutor.clocks = {
-						now: choiceExecutor.clocks?.now ?? new Date(),
-						date,
-					};
+				if (!applyInvocationDate(choiceExecutor, options?.date)) {
+					reportError(
+						new Error(`Could not parse date origin '${String(options?.date)}'`),
+						"API executeChoice error",
+					);
+					return;
 				}
 
 				if (variables) {

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -414,12 +414,6 @@ export class QuickAddApi {
 					return;
 				}
 
-				if (variables) {
-					Object.keys(variables).forEach((key) => {
-						choiceExecutor.variables.set(key, variables[key]);
-					});
-				}
-
 				if (options?.date !== undefined) {
 					const date = dateFromStoredValue(options.date);
 					if (!date) {
@@ -433,6 +427,12 @@ export class QuickAddApi {
 						now: choiceExecutor.clocks?.now ?? new Date(),
 						date,
 					};
+				}
+
+				if (variables) {
+					Object.keys(variables).forEach((key) => {
+						choiceExecutor.variables.set(key, variables[key]);
+					});
 				}
 
 				// The clear stays on the non-throw path only, deliberately: this

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -50,6 +50,7 @@ import { settingsStore } from "./settingsStore";
 import { log } from "./logger/logManager";
 import type IChoice from "./types/choices/IChoice";
 import { getDate } from "./utilityObsidian";
+import { dateFromStoredValue } from "./utils/resolveDateOrigin";
 import { isCancellationError, reportError } from "./utils/errorUtils";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { FieldSuggestionFileFilter } from "./utils/FieldSuggestionFileFilter";
@@ -391,6 +392,7 @@ export class QuickAddApi {
 			executeChoice: async (
 				choiceName: string,
 				variables?: Record<string, unknown>,
+				options?: { date?: string | Date },
 			) => {
 				// getChoiceByName THROWS when the name doesn't match a choice, so
 				// look it up defensively: report + return (don't abort the macro)
@@ -416,6 +418,24 @@ export class QuickAddApi {
 					Object.keys(variables).forEach((key) => {
 						choiceExecutor.variables.set(key, variables[key]);
 					});
+				}
+
+				if (options?.date !== undefined) {
+					const date =
+						options.date instanceof Date
+							? options.date
+							: dateFromStoredValue(options.date);
+					if (!date) {
+						reportError(
+							new Error(`Could not parse date origin '${String(options.date)}'`),
+							"API executeChoice error",
+						);
+						return;
+					}
+					choiceExecutor.clocks = {
+						now: choiceExecutor.clocks?.now ?? new Date(),
+						date,
+					};
 				}
 
 				// The clear stays on the non-throw path only, deliberately: this

--- a/src/quickAddApi.ts
+++ b/src/quickAddApi.ts
@@ -421,10 +421,7 @@ export class QuickAddApi {
 				}
 
 				if (options?.date !== undefined) {
-					const date =
-						options.date instanceof Date
-							? options.date
-							: dateFromStoredValue(options.date);
+					const date = dateFromStoredValue(options.date);
 					if (!date) {
 						reportError(
 							new Error(`Could not parse date origin '${String(options.date)}'`),

--- a/src/types/choices/Choice.ts
+++ b/src/types/choices/Choice.ts
@@ -1,12 +1,14 @@
 import type { ChoiceType } from "./choiceType";
 import { v4 as uuidv4 } from "uuid";
 import type IChoice from "./IChoice";
+import type { DateOrigin } from "../dateOrigin";
 
 export abstract class Choice implements IChoice {
 	id: string;
 	name: string;
 	type: ChoiceType;
 	command: boolean;
+	dateOrigin?: DateOrigin;
 	onePageInput?: "always" | "never" | undefined;
 	icon?: string;
 

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -7,8 +7,7 @@ export default interface IChoice {
 	type: ChoiceType;
 	command: boolean;
 	/**
-	 * How this choice picks the run's calendar origin for `{{DATE}}`.
-	 * Undefined means inherit the run (or today).
+	 * Which day `{{DATE}}` uses. Undefined means today (or a parent run).
 	 */
 	dateOrigin?: DateOrigin;
 	/** Per-choice override for one-page flow. undefined = follow global setting */

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -1,3 +1,4 @@
+import type { DateOrigin } from "../dateOrigin";
 import type { ChoiceType } from "./choiceType";
 
 export default interface IChoice {
@@ -5,6 +6,11 @@ export default interface IChoice {
 	id: string;
 	type: ChoiceType;
 	command: boolean;
+	/**
+	 * How this choice picks the run's calendar origin for `{{DATE}}`.
+	 * Undefined means inherit the run (or today).
+	 */
+	dateOrigin?: DateOrigin;
 	/** Per-choice override for one-page flow. undefined = follow global setting */
 	onePageInput?: "always" | "never" | undefined;
 	/**

--- a/src/types/dateOrigin.test.ts
+++ b/src/types/dateOrigin.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDateOrigin } from "./dateOrigin";
+
+describe("normalizeDateOrigin", () => {
+	it("accepts each kind", () => {
+		expect(normalizeDateOrigin({ kind: "now" })).toEqual({ kind: "now" });
+		expect(normalizeDateOrigin({ kind: "ask" })).toEqual({ kind: "ask" });
+		expect(
+			normalizeDateOrigin({ kind: "ask", defaultValue: " last week " }),
+		).toEqual({ kind: "ask", defaultValue: "last week" });
+		expect(
+			normalizeDateOrigin({ kind: "relative", offset: -1, unit: "weeks" }),
+		).toEqual({ kind: "relative", offset: -1, unit: "weeks" });
+		expect(normalizeDateOrigin({ kind: "variable", name: " day " })).toEqual({
+			kind: "variable",
+			name: "day",
+		});
+	});
+
+	it("rejects illegal combinations", () => {
+		expect(normalizeDateOrigin(undefined)).toBeUndefined();
+		expect(normalizeDateOrigin({ kind: "relative", offset: 1.5, unit: "weeks" })).toBeUndefined();
+		expect(normalizeDateOrigin({ kind: "relative", offset: -1, unit: "hours" })).toBeUndefined();
+		expect(normalizeDateOrigin({ kind: "variable", name: "" })).toBeUndefined();
+		expect(normalizeDateOrigin({ kind: "prompt" })).toBeUndefined();
+	});
+});

--- a/src/types/dateOrigin.ts
+++ b/src/types/dateOrigin.ts
@@ -1,0 +1,58 @@
+export const DATE_ORIGIN_UNITS = ["days", "weeks", "months", "years"] as const;
+
+export type DateOriginUnit = (typeof DATE_ORIGIN_UNITS)[number];
+
+export type DateOrigin =
+	| { kind: "now" }
+	| { kind: "ask"; defaultValue?: string }
+	| { kind: "relative"; offset: number; unit: DateOriginUnit }
+	| { kind: "variable"; name: string };
+
+export interface RunClocks {
+	now: Date;
+	date?: Date;
+}
+
+export function isDateOriginUnit(value: unknown): value is DateOriginUnit {
+	return (
+		typeof value === "string" &&
+		(DATE_ORIGIN_UNITS as readonly string[]).includes(value)
+	);
+}
+
+export function normalizeDateOrigin(raw: unknown): DateOrigin | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const record = raw as Record<string, unknown>;
+
+	switch (record.kind) {
+		case "now":
+			return { kind: "now" };
+		case "ask": {
+			const defaultValue =
+				typeof record.defaultValue === "string"
+					? record.defaultValue.trim()
+					: "";
+			return defaultValue
+				? { kind: "ask", defaultValue }
+				: { kind: "ask" };
+		}
+		case "relative": {
+			if (
+				typeof record.offset !== "number" ||
+				!Number.isInteger(record.offset) ||
+				!isDateOriginUnit(record.unit)
+			) {
+				return undefined;
+			}
+			return { kind: "relative", offset: record.offset, unit: record.unit };
+		}
+		case "variable": {
+			if (typeof record.name !== "string" || !record.name.trim()) {
+				return undefined;
+			}
+			return { kind: "variable", name: record.name.trim() };
+		}
+		default:
+			return undefined;
+	}
+}

--- a/src/types/dateOriginPresets.test.ts
+++ b/src/types/dateOriginPresets.test.ts
@@ -5,6 +5,8 @@ import {
 	askDefaultFromPresetId,
 	askDefaultOptions,
 	askDefaultToPresetId,
+	anotherDayCommandId,
+	choiceCommandId,
 	dateOriginForPick,
 	dateOriginFromPreset,
 	dateOriginToPreset,
@@ -186,5 +188,14 @@ describe("another-day command", () => {
 		expect(isPickDateToken("ask")).toBe(true);
 		expect(isPickDateToken("ASK")).toBe(true);
 		expect(isPickDateToken("last week")).toBe(false);
+	});
+
+	it("keeps the existing choice command id so hotkeys stay bound", () => {
+		const id = "weekly-review-ask";
+		expect(choiceCommandId(id)).toBe("choice:weekly-review-ask");
+		expect(anotherDayCommandId(id)).toBe(
+			"choice:weekly-review-ask:another-day",
+		);
+		expect(anotherDayCommandId(id)).not.toBe(choiceCommandId(id));
 	});
 });

--- a/src/types/dateOriginPresets.test.ts
+++ b/src/types/dateOriginPresets.test.ts
@@ -74,6 +74,22 @@ describe("dateOrigin presets", () => {
 		});
 	});
 
+	it("seeds Ask from the named day you just left", () => {
+		expect(
+			dateOriginFromPreset({
+				preset: "ask",
+				previous: { kind: "relative", offset: -1, unit: "weeks" },
+			}),
+		).toEqual({ kind: "ask", defaultValue: "last week" });
+		expect(
+			dateOriginFromPreset({
+				preset: "ask",
+				previous: { kind: "relative", offset: -1, unit: "days" },
+			}),
+		).toEqual({ kind: "ask", defaultValue: "yesterday" });
+		expect(dateOriginFromPreset({ preset: "ask" })).toEqual({ kind: "ask" });
+	});
+
 	it("keeps Ask and variable extras when the preset does not change", () => {
 		expect(
 			dateOriginFromPreset({

--- a/src/types/dateOriginPresets.test.ts
+++ b/src/types/dateOriginPresets.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+	ASK_DEFAULT_PRESETS,
+	DATE_ORIGIN_PRESETS,
+	askDefaultFromPresetId,
+	askDefaultOptions,
+	askDefaultToPresetId,
+	dateOriginFromPreset,
+	dateOriginToPreset,
+} from "./dateOriginPresets";
+
+describe("dateOrigin presets", () => {
+	it("treats missing and now as Today", () => {
+		expect(dateOriginToPreset(undefined)).toBe("today");
+		expect(dateOriginToPreset({ kind: "now" })).toBe("today");
+		expect(dateOriginFromPreset({ preset: "today" })).toBeUndefined();
+	});
+
+	it("round-trips every named job", () => {
+		expect(dateOriginFromPreset({ preset: "yesterday" })).toEqual({
+			kind: "relative",
+			offset: -1,
+			unit: "days",
+		});
+		expect(dateOriginFromPreset({ preset: "last-week" })).toEqual({
+			kind: "relative",
+			offset: -1,
+			unit: "weeks",
+		});
+		expect(dateOriginFromPreset({ preset: "next-week" })).toEqual({
+			kind: "relative",
+			offset: 1,
+			unit: "weeks",
+		});
+		expect(dateOriginFromPreset({ preset: "last-month" })).toEqual({
+			kind: "relative",
+			offset: -1,
+			unit: "months",
+		});
+
+		expect(
+			dateOriginToPreset({ kind: "relative", offset: -1, unit: "days" }),
+		).toBe("yesterday");
+		expect(
+			dateOriginToPreset({ kind: "relative", offset: -1, unit: "weeks" }),
+		).toBe("last-week");
+		expect(
+			dateOriginToPreset({ kind: "relative", offset: 1, unit: "weeks" }),
+		).toBe("next-week");
+		expect(
+			dateOriginToPreset({ kind: "relative", offset: -1, unit: "months" }),
+		).toBe("last-month");
+	});
+
+	it("keeps an unmatched relative offset as Custom", () => {
+		const custom = { kind: "relative" as const, offset: -3, unit: "days" as const };
+		expect(dateOriginToPreset(custom)).toBe("custom");
+		expect(
+			dateOriginFromPreset({ preset: "custom", previous: custom }),
+		).toEqual(custom);
+	});
+
+	it("starts Custom on −2 days so it does not collapse into Yesterday", () => {
+		expect(
+			dateOriginFromPreset({
+				preset: "custom",
+				previous: { kind: "relative", offset: -1, unit: "weeks" },
+			}),
+		).toEqual({ kind: "relative", offset: -2, unit: "days" });
+		expect(dateOriginFromPreset({ preset: "custom" })).toEqual({
+			kind: "relative",
+			offset: -2,
+			unit: "days",
+		});
+	});
+
+	it("keeps Ask and variable extras when the preset does not change", () => {
+		expect(
+			dateOriginFromPreset({
+				preset: "ask",
+				previous: { kind: "ask", defaultValue: "last week" },
+			}),
+		).toEqual({ kind: "ask", defaultValue: "last week" });
+		expect(
+			dateOriginFromPreset({
+				preset: "variable",
+				previous: { kind: "variable", name: "day" },
+			}),
+		).toEqual({ kind: "variable", name: "day" });
+	});
+
+	it("maps every preset to a stored origin except Today", () => {
+		for (const preset of DATE_ORIGIN_PRESETS) {
+			const origin = dateOriginFromPreset({ preset });
+			if (preset === "today") {
+				expect(origin).toBeUndefined();
+			} else {
+				expect(origin).toBeDefined();
+			}
+		}
+	});
+});
+
+describe("ask picker defaults", () => {
+	it("maps plain language and aliases onto the named days", () => {
+		expect(askDefaultToPresetId(undefined)).toBe("today");
+		expect(askDefaultToPresetId("today")).toBe("today");
+		expect(askDefaultToPresetId("yd")).toBe("yesterday");
+		expect(askDefaultToPresetId("lw")).toBe("last-week");
+		expect(askDefaultToPresetId(" last week ")).toBe("last-week");
+		expect(askDefaultToPresetId("nw")).toBe("next-week");
+		expect(askDefaultToPresetId("lm")).toBe("last-month");
+	});
+
+	it("keeps an unknown stored default so it is not wiped", () => {
+		expect(askDefaultToPresetId("last friday")).toBe("kept");
+		expect(askDefaultOptions("last friday")).toEqual(
+			expect.arrayContaining([{ value: "kept", label: "last friday" }]),
+		);
+		expect(askDefaultFromPresetId("kept", "last friday")).toBe("last friday");
+	});
+
+	it("writes readable picker values, not aliases", () => {
+		expect(askDefaultFromPresetId("today")).toBeUndefined();
+		expect(askDefaultFromPresetId("yesterday")).toBe("yesterday");
+		expect(askDefaultFromPresetId("last-week")).toBe("last week");
+		expect(askDefaultFromPresetId("next-week")).toBe("next week");
+		expect(askDefaultFromPresetId("last-month")).toBe("last month");
+	});
+
+	it("lists every named ask default", () => {
+		expect(ASK_DEFAULT_PRESETS.map((item) => item.id)).toEqual([
+			"today",
+			"yesterday",
+			"last-week",
+			"next-week",
+			"last-month",
+		]);
+	});
+});

--- a/src/types/dateOriginPresets.test.ts
+++ b/src/types/dateOriginPresets.test.ts
@@ -5,8 +5,11 @@ import {
 	askDefaultFromPresetId,
 	askDefaultOptions,
 	askDefaultToPresetId,
+	dateOriginForPick,
 	dateOriginFromPreset,
 	dateOriginToPreset,
+	isPickDateToken,
+	shouldRegisterAnotherDayCommand,
 } from "./dateOriginPresets";
 
 describe("dateOrigin presets", () => {
@@ -152,5 +155,36 @@ describe("ask picker defaults", () => {
 			"next-week",
 			"last-month",
 		]);
+	});
+});
+
+describe("another-day command", () => {
+	it("registers for every job except Ask each time", () => {
+		expect(shouldRegisterAnotherDayCommand(undefined)).toBe(true);
+		expect(shouldRegisterAnotherDayCommand({ kind: "now" })).toBe(true);
+		expect(
+			shouldRegisterAnotherDayCommand({
+				kind: "relative",
+				offset: -1,
+				unit: "days",
+			}),
+		).toBe(true);
+		expect(shouldRegisterAnotherDayCommand({ kind: "ask" })).toBe(false);
+	});
+
+	it("seeds the picker from the named day you are overriding", () => {
+		expect(
+			dateOriginForPick({ kind: "relative", offset: -1, unit: "weeks" }),
+		).toEqual({ kind: "ask", defaultValue: "last week" });
+		expect(dateOriginForPick(undefined)).toEqual({ kind: "ask" });
+		expect(
+			dateOriginForPick({ kind: "ask", defaultValue: "last friday" }),
+		).toEqual({ kind: "ask", defaultValue: "last friday" });
+	});
+
+	it("treats ask as a pick-date token", () => {
+		expect(isPickDateToken("ask")).toBe(true);
+		expect(isPickDateToken("ASK")).toBe(true);
+		expect(isPickDateToken("last week")).toBe(false);
 	});
 });

--- a/src/types/dateOriginPresets.ts
+++ b/src/types/dateOriginPresets.ts
@@ -113,7 +113,8 @@ export function dateOriginFromPreset(input: {
 	if (preset === "today") return undefined;
 
 	if (preset === "ask") {
-		return previous?.kind === "ask" ? previous : { kind: "ask" };
+		if (previous?.kind === "ask") return previous;
+		return askOriginFromNamedDay(dateOriginToPreset(previous));
 	}
 
 	if (preset === "variable") {
@@ -143,6 +144,15 @@ export function dateOriginFromPreset(input: {
 	}
 
 	return undefined;
+}
+
+function askOriginFromNamedDay(preset: DateOriginPreset): DateOrigin {
+	for (const item of ASK_DEFAULT_PRESETS) {
+		if (item.id === preset && item.defaultValue) {
+			return { kind: "ask", defaultValue: item.defaultValue };
+		}
+	}
+	return { kind: "ask" };
 }
 
 export function askDefaultToPresetId(defaultValue?: string): string {

--- a/src/types/dateOriginPresets.ts
+++ b/src/types/dateOriginPresets.ts
@@ -15,15 +15,15 @@ export type DateOriginPreset = (typeof DATE_ORIGIN_PRESETS)[number];
 
 export const DATE_ORIGIN_SETTING_NAME = "Which day";
 export const DATE_ORIGIN_SETTING_DESC =
-	"{{DATE}} uses this day. {{TIME}} is when you run it. A command also gets (another day) so you can pick without a second choice.";
+	"The day {{DATE}} writes. The clock stays now. A command also adds (another day) so you can pick without making a copy of this choice.";
 
 export const ASK_DEFAULT_SETTING_NAME = "Picker starts on";
 export const ASK_DEFAULT_SETTING_DESC =
-	"What the date picker shows first. You can still pick another day.";
+	"The date the picker suggests first. You can still pick a different day.";
 
 export const CUSTOM_OFFSET_SETTING_NAME = "How far from today";
 export const CUSTOM_OFFSET_SETTING_DESC =
-	"Negative is in the past. −1 week is last week.";
+	"How many days, weeks, months, or years from today. Negative is the past.";
 
 export const VARIABLE_SETTING_NAME = "Variable name";
 export const VARIABLE_SETTING_DESC =

--- a/src/types/dateOriginPresets.ts
+++ b/src/types/dateOriginPresets.ts
@@ -207,8 +207,12 @@ export function shouldRegisterAnotherDayCommand(
 	return dateOriginToPreset(origin) !== "ask";
 }
 
+export function choiceCommandId(choiceId: string): string {
+	return `choice:${choiceId}`;
+}
+
 export function anotherDayCommandId(choiceId: string): string {
-	return `choice:${choiceId}:another-day`;
+	return `${choiceCommandId(choiceId)}:another-day`;
 }
 
 export function anotherDayCommandName(choiceName: string): string {

--- a/src/types/dateOriginPresets.ts
+++ b/src/types/dateOriginPresets.ts
@@ -1,0 +1,188 @@
+import type { DateOrigin, DateOriginUnit } from "./dateOrigin";
+
+export const DATE_ORIGIN_PRESETS = [
+	"today",
+	"ask",
+	"yesterday",
+	"last-week",
+	"next-week",
+	"last-month",
+	"custom",
+	"variable",
+] as const;
+
+export type DateOriginPreset = (typeof DATE_ORIGIN_PRESETS)[number];
+
+export const DATE_ORIGIN_SETTING_NAME = "Which day";
+export const DATE_ORIGIN_SETTING_DESC =
+	"{{DATE}} uses this day. The clock stays now.";
+
+export const ASK_DEFAULT_SETTING_NAME = "Picker starts on";
+export const ASK_DEFAULT_SETTING_DESC =
+	"What the date picker shows first. You can still pick another day.";
+
+export const CUSTOM_OFFSET_SETTING_NAME = "How far from today";
+export const CUSTOM_OFFSET_SETTING_DESC =
+	"Negative is in the past. −1 week is last week.";
+
+export const VARIABLE_SETTING_NAME = "Variable name";
+export const VARIABLE_SETTING_DESC =
+	"A VDATE or script value that already has the day.";
+
+export const NAMED_RELATIVE_PRESETS = [
+	{ id: "yesterday", label: "Yesterday", offset: -1, unit: "days" },
+	{ id: "last-week", label: "Last week", offset: -1, unit: "weeks" },
+	{ id: "next-week", label: "Next week", offset: 1, unit: "weeks" },
+	{ id: "last-month", label: "Last month", offset: -1, unit: "months" },
+] as const satisfies readonly {
+	id: DateOriginPreset;
+	label: string;
+	offset: number;
+	unit: DateOriginUnit;
+}[];
+
+export const DATE_ORIGIN_PRESET_OPTIONS: {
+	value: DateOriginPreset;
+	label: string;
+}[] = [
+	{ value: "today", label: "Today" },
+	{ value: "ask", label: "Ask each time" },
+	...NAMED_RELATIVE_PRESETS.map((item) => ({
+		value: item.id,
+		label: item.label,
+	})),
+	{ value: "custom", label: "Custom…" },
+	{ value: "variable", label: "A variable…" },
+];
+
+export const ASK_DEFAULT_PRESETS = [
+	{ id: "today", label: "Today", defaultValue: undefined, aliases: ["", "today"] },
+	{
+		id: "yesterday",
+		label: "Yesterday",
+		defaultValue: "yesterday",
+		aliases: ["yesterday", "yd"],
+	},
+	{
+		id: "last-week",
+		label: "Last week",
+		defaultValue: "last week",
+		aliases: ["last week", "lw"],
+	},
+	{
+		id: "next-week",
+		label: "Next week",
+		defaultValue: "next week",
+		aliases: ["next week", "nw"],
+	},
+	{
+		id: "last-month",
+		label: "Last month",
+		defaultValue: "last month",
+		aliases: ["last month", "lm"],
+	},
+] as const;
+
+const DATE_ORIGIN_PRESET_IDS = new Set<string>(DATE_ORIGIN_PRESETS);
+
+export function isDateOriginPreset(value: string): value is DateOriginPreset {
+	return DATE_ORIGIN_PRESET_IDS.has(value);
+}
+
+export function dateOriginToPreset(
+	origin: DateOrigin | undefined,
+): DateOriginPreset {
+	if (!origin || origin.kind === "now") return "today";
+	if (origin.kind === "ask") return "ask";
+	if (origin.kind === "variable") return "variable";
+
+	for (const named of NAMED_RELATIVE_PRESETS) {
+		if (origin.offset === named.offset && origin.unit === named.unit) {
+			return named.id;
+		}
+	}
+	return "custom";
+}
+
+export function dateOriginFromPreset(input: {
+	preset: DateOriginPreset;
+	previous?: DateOrigin;
+}): DateOrigin | undefined {
+	const { preset, previous } = input;
+
+	if (preset === "today") return undefined;
+
+	if (preset === "ask") {
+		return previous?.kind === "ask" ? previous : { kind: "ask" };
+	}
+
+	if (preset === "variable") {
+		return previous?.kind === "variable"
+			? previous
+			: { kind: "variable", name: "" };
+	}
+
+	if (preset === "custom") {
+		if (
+			previous?.kind === "relative" &&
+			dateOriginToPreset(previous) === "custom"
+		) {
+			return previous;
+		}
+		return { kind: "relative", offset: -2, unit: "days" };
+	}
+
+	for (const named of NAMED_RELATIVE_PRESETS) {
+		if (named.id === preset) {
+			return {
+				kind: "relative",
+				offset: named.offset,
+				unit: named.unit,
+			};
+		}
+	}
+
+	return undefined;
+}
+
+export function askDefaultToPresetId(defaultValue?: string): string {
+	const normalized = (defaultValue ?? "").trim().toLowerCase();
+	for (const item of ASK_DEFAULT_PRESETS) {
+		if (item.aliases.some((alias) => alias === normalized)) {
+			return item.id;
+		}
+	}
+	return "kept";
+}
+
+export function askDefaultOptions(
+	defaultValue?: string,
+): { value: string; label: string }[] {
+	const options: { value: string; label: string }[] = ASK_DEFAULT_PRESETS.map(
+		(item) => ({
+			value: item.id,
+			label: item.label,
+		}),
+	);
+	if (askDefaultToPresetId(defaultValue) === "kept") {
+		const kept = defaultValue?.trim();
+		if (kept) {
+			options.push({ value: "kept", label: kept });
+		}
+	}
+	return options;
+}
+
+export function askDefaultFromPresetId(
+	id: string,
+	previous?: string,
+): string | undefined {
+	if (id === "kept") {
+		const trimmed = previous?.trim();
+		return trimmed ? trimmed : undefined;
+	}
+	for (const item of ASK_DEFAULT_PRESETS) {
+		if (item.id === id) return item.defaultValue;
+	}
+	return undefined;
+}

--- a/src/types/dateOriginPresets.ts
+++ b/src/types/dateOriginPresets.ts
@@ -15,7 +15,7 @@ export type DateOriginPreset = (typeof DATE_ORIGIN_PRESETS)[number];
 
 export const DATE_ORIGIN_SETTING_NAME = "Which day";
 export const DATE_ORIGIN_SETTING_DESC =
-	"{{DATE}} uses this day. The clock stays now.";
+	"{{DATE}} uses this day. {{TIME}} is when you run it. A command also gets (another day) so you can pick without a second choice.";
 
 export const ASK_DEFAULT_SETTING_NAME = "Picker starts on";
 export const ASK_DEFAULT_SETTING_DESC =
@@ -195,4 +195,29 @@ export function askDefaultFromPresetId(
 		if (item.id === id) return item.defaultValue;
 	}
 	return undefined;
+}
+
+export function isPickDateToken(value: unknown): boolean {
+	return typeof value === "string" && value.trim().toLowerCase() === "ask";
+}
+
+export function shouldRegisterAnotherDayCommand(
+	origin: DateOrigin | undefined,
+): boolean {
+	return dateOriginToPreset(origin) !== "ask";
+}
+
+export function anotherDayCommandId(choiceId: string): string {
+	return `choice:${choiceId}:another-day`;
+}
+
+export function anotherDayCommandName(choiceName: string): string {
+	return `${choiceName} (another day)`;
+}
+
+export function dateOriginForPick(
+	origin: DateOrigin | undefined,
+): DateOrigin {
+	if (origin?.kind === "ask") return origin;
+	return askOriginFromNamedDay(dateOriginToPreset(origin));
 }

--- a/src/utils/dates.origin.test.ts
+++ b/src/utils/dates.origin.test.ts
@@ -25,30 +25,30 @@ function freeze(isoLocal: string) {
 describe("getDate origin — calendar day plus wall-clock time", () => {
 	beforeEach(() => freeze("2026-08-26T15:30:00"));
 
-	const lastFriday = new Date(2026, 7, 21);
+	const originDay = new Date(2026, 7, 21);
 
 	it("formats the origin day when only a date is requested", () => {
-		expect(getDate({ format: "YYYY-MM-DD", origin: lastFriday })).toBe(
+		expect(getDate({ format: "YYYY-MM-DD", origin: originDay })).toBe(
 			"2026-08-21",
 		);
 	});
 
 	it("keeps the wall-clock time when the format is a clock", () => {
-		expect(getDate({ format: "HH:mm", origin: lastFriday })).toBe("15:30");
+		expect(getDate({ format: "HH:mm", origin: originDay })).toBe("15:30");
 	});
 
 	it("joins origin day and wall-clock time in a combined format", () => {
-		expect(getDate({ format: "YYYY-MM-DD HH:mm", origin: lastFriday })).toBe(
+		expect(getDate({ format: "YYYY-MM-DD HH:mm", origin: originDay })).toBe(
 			"2026-08-21 15:30",
 		);
 	});
 
 	it("applies +N days to the origin, not to today", () => {
 		expect(
-			getDate({ format: "YYYY-MM-DD", origin: lastFriday, offset: 1 }),
+			getDate({ format: "YYYY-MM-DD", origin: originDay, offset: 1 }),
 		).toBe("2026-08-22");
 		expect(
-			getDate({ format: "YYYY-MM-DD", origin: lastFriday, offset: -1 }),
+			getDate({ format: "YYYY-MM-DD", origin: originDay, offset: -1 }),
 		).toBe("2026-08-20");
 	});
 
@@ -56,7 +56,7 @@ describe("getDate origin — calendar day plus wall-clock time", () => {
 		expect(
 			getDate({
 				format: "YYYY-MM-DD",
-				origin: lastFriday,
+				origin: originDay,
 				snap: { boundary: "start", unit: "week" },
 			}),
 		).toBe("2026-08-16");
@@ -67,7 +67,7 @@ describe("getDate origin — calendar day plus wall-clock time", () => {
 		expect(
 			getDate({
 				format: "YYYY-MM-DD HH:mm",
-				origin: lastFriday,
+				origin: originDay,
 				now: morning,
 			}),
 		).toBe("2026-08-21 09:05");

--- a/src/utils/dates.origin.test.ts
+++ b/src/utils/dates.origin.test.ts
@@ -1,0 +1,86 @@
+import realMoment from "moment";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDate } from "./dates";
+
+const originalMoment = (window as unknown as { moment?: unknown }).moment;
+const previousLocale = realMoment.locale();
+
+beforeAll(() => {
+	realMoment.locale("en");
+	(window as unknown as { moment: unknown }).moment = realMoment;
+});
+afterAll(() => {
+	(window as unknown as { moment?: unknown }).moment = originalMoment;
+	realMoment.locale(previousLocale);
+});
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function freeze(isoLocal: string) {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(isoLocal));
+}
+
+describe("getDate origin — calendar day plus wall-clock time", () => {
+	beforeEach(() => freeze("2026-08-26T15:30:00")); // Wednesday
+
+	const lastFriday = new Date(2026, 7, 21); // local calendar day, no clock
+
+	it("formats the origin day when only a date is requested", () => {
+		expect(getDate({ format: "YYYY-MM-DD", origin: lastFriday })).toBe(
+			"2026-08-21",
+		);
+	});
+
+	it("keeps the wall-clock time when the format is a clock", () => {
+		expect(getDate({ format: "HH:mm", origin: lastFriday })).toBe("15:30");
+	});
+
+	it("joins origin day and wall-clock time in a combined format", () => {
+		expect(getDate({ format: "YYYY-MM-DD HH:mm", origin: lastFriday })).toBe(
+			"2026-08-21 15:30",
+		);
+	});
+
+	it("applies +N days to the origin, not to today", () => {
+		expect(
+			getDate({ format: "YYYY-MM-DD", origin: lastFriday, offset: 1 }),
+		).toBe("2026-08-22");
+		expect(
+			getDate({ format: "YYYY-MM-DD", origin: lastFriday, offset: -1 }),
+		).toBe("2026-08-20");
+	});
+
+	it("snaps the origin week, not today's week", () => {
+		expect(
+			getDate({
+				format: "YYYY-MM-DD",
+				origin: lastFriday,
+				snap: { boundary: "start", unit: "week" },
+			}),
+		).toBe("2026-08-16");
+	});
+
+	it("lets an explicit now override the wall clock without changing the origin day", () => {
+		const morning = new Date(2026, 7, 26, 9, 5, 0);
+		expect(
+			getDate({
+				format: "YYYY-MM-DD HH:mm",
+				origin: lastFriday,
+				now: morning,
+			}),
+		).toBe("2026-08-21 09:05");
+	});
+
+	it("uses now alone when no origin is set (TIME path)", () => {
+		const morning = new Date(2026, 7, 26, 9, 5, 0);
+		expect(getDate({ format: "HH:mm", now: morning })).toBe("09:05");
+		expect(getDate({ format: "YYYY-MM-DD", now: morning })).toBe("2026-08-26");
+	});
+
+	it("defaults to today when origin is omitted", () => {
+		expect(getDate({ format: "YYYY-MM-DD" })).toBe("2026-08-26");
+		expect(getDate({ format: "HH:mm" })).toBe("15:30");
+	});
+});

--- a/src/utils/dates.origin.test.ts
+++ b/src/utils/dates.origin.test.ts
@@ -23,9 +23,9 @@ function freeze(isoLocal: string) {
 }
 
 describe("getDate origin — calendar day plus wall-clock time", () => {
-	beforeEach(() => freeze("2026-08-26T15:30:00")); // Wednesday
+	beforeEach(() => freeze("2026-08-26T15:30:00"));
 
-	const lastFriday = new Date(2026, 7, 21); // local calendar day, no clock
+	const lastFriday = new Date(2026, 7, 21);
 
 	it("formats the origin day when only a date is requested", () => {
 		expect(getDate({ format: "YYYY-MM-DD", origin: lastFriday })).toBe(

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -6,7 +6,6 @@ export interface GetDateInput {
 	snap?: DateSnap;
 	/** Calendar-day origin. Time-of-day comes from `now` unless a snap moves it. */
 	origin?: Date;
-	/** Wall clock. Defaults to the live instant. TIME tokens pass this and omit origin. */
 	now?: Date;
 }
 

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,10 +1,32 @@
 import { applyDateSnap, type DateSnap } from "./dateModifiers";
 
-export function getDate(input?: {
+export interface GetDateInput {
 	format?: string;
 	offset?: number;
 	snap?: DateSnap;
-}) {
+	/** Calendar-day origin. Time-of-day comes from `now` unless a snap moves it. */
+	origin?: Date;
+	/** Wall clock. Defaults to the live instant. TIME tokens pass this and omit origin. */
+	now?: Date;
+}
+
+function wallClock(now?: Date) {
+	return now === undefined ? window.moment() : window.moment(now);
+}
+
+function instantForDate(input?: GetDateInput) {
+	const wall = wallClock(input?.now);
+	if (!input?.origin) return wall;
+
+	return window
+		.moment(input.origin)
+		.hour(wall.hour())
+		.minute(wall.minute())
+		.second(wall.second())
+		.millisecond(wall.millisecond());
+}
+
+export function getDate(input?: GetDateInput) {
 	let duration;
 
 	if (
@@ -15,8 +37,7 @@ export function getDate(input?: {
 		duration = window.moment.duration(input.offset, "days");
 	}
 
-	// Order: base instant -> +N days offset -> snap to period boundary -> format.
-	const moment = applyDateSnap(window.moment().add(duration), input?.snap);
+	const moment = applyDateSnap(instantForDate(input).add(duration), input?.snap);
 
 	return moment.format(input?.format ?? "YYYY-MM-DD");
 }

--- a/src/utils/resolveDateOrigin.test.ts
+++ b/src/utils/resolveDateOrigin.test.ts
@@ -39,6 +39,11 @@ describe("dateFromStoredValue", () => {
 		expect(dateFromStoredValue("lw")).toBeInstanceOf(Date);
 		expect(dateFromStoredValue("")).toBeUndefined();
 	});
+
+	it("rejects an invalid Date and unparseable text", () => {
+		expect(dateFromStoredValue(new Date("bad"))).toBeUndefined();
+		expect(dateFromStoredValue("not-a-date-xyz")).toBeUndefined();
+	});
 });
 
 describe("planDateOrigin", () => {

--- a/src/utils/resolveDateOrigin.test.ts
+++ b/src/utils/resolveDateOrigin.test.ts
@@ -2,6 +2,7 @@ import realMoment from "moment";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	addCalendarOffset,
+	applyInvocationDate,
 	dateFromStoredValue,
 	planDateOrigin,
 } from "./resolveDateOrigin";
@@ -110,5 +111,27 @@ describe("planDateOrigin", () => {
 				variables: new Map(),
 			}).status,
 		).toBe("error");
+	});
+});
+
+describe("applyInvocationDate", () => {
+	it("treats ask as pickDate and leaves clocks unset", () => {
+		const executor: { clocks?: { now: Date; date?: Date }; pickDate?: boolean } =
+			{};
+		expect(applyInvocationDate(executor, "ask")).toBe(true);
+		expect(executor.pickDate).toBe(true);
+		expect(executor.clocks).toBeUndefined();
+	});
+
+	it("parses a concrete day onto clocks", () => {
+		const executor: { clocks?: { now: Date; date?: Date }; pickDate?: boolean } =
+			{};
+		expect(applyInvocationDate(executor, "2026-08-21")).toBe(true);
+		expect(executor.pickDate).toBeUndefined();
+		expect(executor.clocks?.date).toBeInstanceOf(Date);
+	});
+
+	it("rejects an unreadable value", () => {
+		expect(applyInvocationDate({}, "not-a-day")).toBe(false);
 	});
 });

--- a/src/utils/resolveDateOrigin.test.ts
+++ b/src/utils/resolveDateOrigin.test.ts
@@ -1,0 +1,109 @@
+import realMoment from "moment";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	addCalendarOffset,
+	dateFromStoredValue,
+	planDateOrigin,
+} from "./resolveDateOrigin";
+
+const originalMoment = (window as unknown as { moment?: unknown }).moment;
+
+beforeAll(() => {
+	(window as unknown as { moment: unknown }).moment = realMoment;
+});
+afterAll(() => {
+	(window as unknown as { moment?: unknown }).moment = originalMoment;
+	vi.useRealTimers();
+});
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date("2026-08-26T15:30:00"));
+});
+
+describe("addCalendarOffset", () => {
+	it("moves by week and month from the frozen now", () => {
+		const now = new Date("2026-08-26T15:30:00");
+		expect(addCalendarOffset(now, -1, "weeks").toISOString().startsWith("2026-08-19")).toBe(
+			true,
+		);
+		expect(addCalendarOffset(now, 1, "years").getFullYear()).toBe(2027);
+	});
+});
+
+describe("dateFromStoredValue", () => {
+	it("reads @date, Date, and natural-language aliases", () => {
+		expect(dateFromStoredValue(new Date(2026, 7, 21))?.getDate()).toBe(21);
+		expect(
+			dateFromStoredValue("@date:2026-08-21T00:00:00.000Z") instanceof Date,
+		).toBe(true);
+		expect(dateFromStoredValue("lw")).toBeInstanceOf(Date);
+		expect(dateFromStoredValue("")).toBeUndefined();
+	});
+});
+
+describe("planDateOrigin", () => {
+	const now = new Date("2026-08-26T15:30:00");
+
+	it("inherits when a date is already on the run", () => {
+		expect(
+			planDateOrigin({
+				setting: { kind: "ask" },
+				clocks: { now, date: new Date(2026, 7, 21) },
+			}),
+		).toEqual({ status: "inherit" });
+	});
+
+	it("inherits today when the setting is missing or now", () => {
+		expect(planDateOrigin({ clocks: { now } })).toEqual({ status: "inherit" });
+		expect(
+			planDateOrigin({ setting: { kind: "now" }, clocks: { now } }),
+		).toEqual({ status: "inherit" });
+	});
+
+	it("plans ask and relative", () => {
+		expect(
+			planDateOrigin({
+				setting: { kind: "ask", defaultValue: "lw" },
+				clocks: { now },
+			}),
+		).toEqual({ status: "ask", defaultValue: "lw" });
+
+		const planned = planDateOrigin({
+			setting: { kind: "relative", offset: -1, unit: "weeks" },
+			clocks: { now },
+		});
+		expect(planned.status).toBe("set");
+		if (planned.status === "set") {
+			expect(planned.date.getDate()).toBe(19);
+		}
+	});
+
+	it("reads a variable and a reserved seed", () => {
+		const variables = new Map<string, unknown>([
+			["day", "@date:2026-08-21T00:00:00.000Z"],
+		]);
+		const fromVar = planDateOrigin({
+			setting: { kind: "variable", name: "day" },
+			clocks: { now },
+			variables,
+		});
+		expect(fromVar.status).toBe("set");
+
+		const fromSeed = planDateOrigin({
+			setting: { kind: "ask" },
+			clocks: { now },
+			reservedSeed: "@date:2026-08-21T00:00:00.000Z",
+		});
+		expect(fromSeed.status).toBe("set");
+	});
+
+	it("errors when the variable is missing", () => {
+		expect(
+			planDateOrigin({
+				setting: { kind: "variable", name: "day" },
+				clocks: { now },
+				variables: new Map(),
+			}).status,
+		).toBe("error");
+	});
+});

--- a/src/utils/resolveDateOrigin.ts
+++ b/src/utils/resolveDateOrigin.ts
@@ -1,0 +1,102 @@
+import { NLDParser } from "../parsers/NLDParser";
+import type { DateOrigin, DateOriginUnit, RunClocks } from "../types/dateOrigin";
+import { parseNaturalLanguageDate } from "./dateParser";
+import { resolveExistingVariableKey } from "./valueSyntax";
+
+export type DateOriginPlan =
+	| { status: "inherit" }
+	| { status: "set"; date: Date }
+	| { status: "ask"; defaultValue?: string }
+	| { status: "error"; message: string };
+
+export function addCalendarOffset(
+	now: Date,
+	offset: number,
+	unit: DateOriginUnit,
+): Date {
+	return window.moment(now).add(offset, unit).startOf("day").toDate();
+}
+
+export function dateFromStoredValue(stored: unknown): Date | undefined {
+	if (stored instanceof Date && !Number.isNaN(stored.getTime())) {
+		return stored;
+	}
+	if (typeof stored !== "string") return undefined;
+
+	const trimmed = stored.trim();
+	if (!trimmed) return undefined;
+
+	if (trimmed.toLowerCase().startsWith("@date:")) {
+		const iso = trimmed.slice("@date:".length);
+		const parsed = window.moment(iso);
+		return parsed.isValid() ? parsed.toDate() : undefined;
+	}
+
+	const nl = parseNaturalLanguageDate(trimmed, undefined, NLDParser);
+	if (nl.isValid && nl.isoString) {
+		const parsed = window.moment(nl.isoString);
+		return parsed.isValid() ? parsed.toDate() : undefined;
+	}
+
+	return undefined;
+}
+
+export function planDateOrigin(input: {
+	setting?: DateOrigin;
+	clocks?: RunClocks;
+	variables?: Map<string, unknown>;
+	reservedSeed?: unknown;
+}): DateOriginPlan {
+	if (input.clocks?.date) return { status: "inherit" };
+
+	if (input.reservedSeed !== undefined) {
+		const date = dateFromStoredValue(input.reservedSeed);
+		if (date) return { status: "set", date };
+		return {
+			status: "error",
+			message: "Could not parse the seeded date origin.",
+		};
+	}
+
+	const setting = input.setting;
+	if (!setting || setting.kind === "now") return { status: "inherit" };
+
+	if (setting.kind === "ask") {
+		return { status: "ask", defaultValue: setting.defaultValue };
+	}
+
+	if (setting.kind === "relative") {
+		const now = input.clocks?.now ?? new Date();
+		return {
+			status: "set",
+			date: addCalendarOffset(now, setting.offset, setting.unit),
+		};
+	}
+
+	const variables = input.variables;
+	if (!variables) {
+		return {
+			status: "error",
+			message: `Date origin variable "${setting.name}" is not available.`,
+		};
+	}
+	const key = resolveExistingVariableKey(variables, setting.name);
+	if (!key) {
+		return {
+			status: "error",
+			message: `Date origin variable "${setting.name}" is not set.`,
+		};
+	}
+	const date = dateFromStoredValue(variables.get(key));
+	if (!date) {
+		return {
+			status: "error",
+			message: `Date origin variable "${setting.name}" is not a date.`,
+		};
+	}
+	return { status: "set", date };
+}
+
+export function parseDateOriginInput(input: string): Date | undefined {
+	return dateFromStoredValue(input);
+}

--- a/src/utils/resolveDateOrigin.ts
+++ b/src/utils/resolveDateOrigin.ts
@@ -1,5 +1,6 @@
 import { NLDParser } from "../parsers/NLDParser";
 import type { DateOrigin, DateOriginUnit, RunClocks } from "../types/dateOrigin";
+import { isPickDateToken } from "../types/dateOriginPresets";
 import { parseNaturalLanguageDate } from "./dateParser";
 import { resolveExistingVariableKey } from "./valueSyntax";
 
@@ -99,4 +100,23 @@ export function planDateOrigin(input: {
 
 export function parseDateOriginInput(input: string): Date | undefined {
 	return dateFromStoredValue(input);
+}
+
+export function applyInvocationDate(
+	executor: { clocks?: RunClocks; pickDate?: boolean },
+	raw: unknown,
+): boolean {
+	if (raw === undefined || raw === null) return true;
+	if (typeof raw === "string" && !raw.trim()) return true;
+	if (isPickDateToken(raw)) {
+		executor.pickDate = true;
+		return true;
+	}
+	const date = dateFromStoredValue(raw);
+	if (!date) return false;
+	executor.clocks = {
+		now: executor.clocks?.now ?? new Date(),
+		date,
+	};
+	return true;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Opening a daily or weekly note for another day meant swapping `{{DATE}}` for `{{VDATE}}`. Body tokens still meant today, and `{{DATE+N}}` prev/next could not follow the pick.

A run now has a calendar day for `{{DATE}}`. Existing format, offset, and snap tokens follow that day. `{{TIME}}` is when you ran the choice.

Closes #1708.

## Scope

- `getDate` in `src/utils/dates.ts` accepts `origin` and `now`. Calendar day comes from `origin`. Time of day comes from `now`.
- `DateOrigin` on `IChoice` (`now` / `ask` / `relative` / `variable`). Stored shape is unchanged.
- Settings UI is **Which day**, with named jobs: Today, Ask each time, Yesterday, Last week, Next week, Last month, Custom…, A variable….
- A command-enabled choice that is not Ask also registers **Name (another day)**. Shift in the QuickAdd menu does the same. `date=ask` / `{ date: "ask" }` open the picker on a Today choice.
- Nested choices inherit a day already on the run. A child Ask does not fire again.
- Docs: Format Syntax, Template, Capture, CLI, QuickAdd API.

Out of scope: new token syntax, VDATE arithmetic, a periodic-note choice type.

## Tradeoffs

`{{DATE:HH:mm}}` uses the chosen day plus the current time of day. A time-only format hides the day, so it looks like the clock. `{{TIME}}` never uses the chosen day. That is so a catch-up capture line stays "when I wrote this" while `Daily/{{DATE}}.md` is yesterday.

`undefined` date origin means inherit, then today. Existing `data.json` choices do not change.

## Blast Radius

`getDate` is shared by DATE, TIME, `quickAddApi.date.*`, and the AI `get_date` tool. Default call sites are unchanged.

New choice JSON is additive. Old choices keep today's DATE. Command-enabled choices gain a second palette command until Which day is Ask.

## Land notes

Merged latest `master` (#1699 nested macro preflight) into this branch. Date-origin collection now prepends onto the per-type collector so Template, Capture, and Macro still get **Which day** on the one-page form.

## Verification

- `pnpm run check` clean
- `pnpm run lint` clean
- `pnpm run test`: 5090 passed, 37 skipped
- Unit tests for presets, `date=ask`, Shift in the choice picker, pickDate preflight, and Ask on a Macro

## Checklist

- [x] PR title follows Conventional Commits
- [x] Linked #1708
- [x] Release/migration: additive setting. No migration. Existing choices stay on today. Command-enabled choices get an extra **(another day)** command.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae1db14e-580a-433a-abc1-9f4885bfd372?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae1db14e-580a-433a-abc1-9f4885bfd372&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable date origins for Template, Capture, and Macro choices, including today, prompted, relative, custom, and variable-based dates.
  - `{{DATE}}` now supports selected calendar origins, offsets, and snaps, while `{{TIME}}` remains based on the current clock.
  - Added date support to CLI, QuickAdd API, and URI commands, including natural-language dates and aliases.
- **Documentation**
  - Updated guides and API references with configuration details, supported formats, aliases, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->