### PR TITLE
docs(format): note DATE extras only run through QuickAdd

### DIFF
--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -101,6 +101,18 @@ Put a [Moment.js format](https://momentjs.com/docs/#/displaying/format/) after
 the colon to control how the date looks. The `+N` day offset works here too:
 `{{DATE:YYYY-MM-DD+3}}`.
 
+<a id="date-quickadd-only"></a>
+
+:::note[If `+3` is left on the date]
+Day offsets and `|startof:` / `|endof:` only fill in when QuickAdd runs the
+note. **Open daily note** is a different command - even if you also have a
+QuickAdd daily-note choice. Daily notes still fills `{{DATE}}` and
+`{{DATE:YYYY-MM-DD}}` itself, so `{{DATE+3}}` can stay put and
+`{{DATE:YYYY-MM-DD+3}}` can become `2026-07-08+3`. Turning the Templates
+plugin off does not turn Daily notes off. Run the same file from a QuickAdd
+Template or Capture choice instead.
+:::
+
 | You write | You get |
 | --- | --- |
 | `{{DATE:MMMM Do, YYYY}}` | `July 8th, 2026` |
@@ -171,6 +183,7 @@ order.
 
 Good to know:
 
+- Like the `+N` offset, these pipes only fill in when QuickAdd runs the note. If **Open daily note** left them as-is, see [If `+3` is left on the date](#date-quickadd-only).
 - The `+N` day offset is applied **before** the snap, so `{{DATE:YYYY-MM-DD+7|startof:week}}` means "the start of next week".
 - `endof:` snaps to the last moment of the period (`23:59:59.999`), so `{{DATE:YYYY-MM-DD HH:mm|endof:day}}` renders `... 23:59`.
 - `|startof:`, `|endof:`, and `|case:` are special pipe options in a date format. Any other literal `|` is kept as-is: `{{DATE:YYYY|MM}}` gives `2023|06`. Put a literal `|case:lower` inside square brackets.


### PR DESCRIPTION
## Summary

Document that `{{DATE+N}}`, formatted offsets like `{{DATE:YYYY-MM-DD+3}}`, and `|startof:` / `|endof:` only fill in when QuickAdd runs the note.

**Open daily note** (Daily notes) is a different command: it still fills `{{DATE}}` and `{{DATE:YYYY-MM-DD}}` itself, so people can think QuickAdd is running when it is not. Turning the Templates plugin off does not turn Daily notes off.

The reporter of #1704 asked for this on the website after finding they were using **Open daily note** while also having a QuickAdd daily-note choice. The issue is already closed; this PR does not reopen or auto-close it.

**Refs #1704**

## Changes

- One shared note on [Format syntax](https://quickadd.obsidian.guide/docs/FormatSyntax/#date-format), next to the `{{DATE:YYYY-MM-DD+3}}` example (the `#date-format` and `#date-snap` anchors from the report).
- A one-line pointer under `#date-snap` back to that note (`#date-quickadd-only`).
- Slug stays `docs/FormatSyntax`. No formatter, bundle, or other docs pages.

## Testing / validation

- `pnpm --dir docs build` — 50 pages, success.
- `python3 docs/scripts/check-links.py` — 0 problems across 50 pages.
- Built `docs/FormatSyntax/index.html`: `#date`, `#date-format`, and `#date-snap` still present; `#date-quickadd-only` exists; Starlight `note` aside renders; snap bullet links to the note.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
      — it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s) (`Refs #1704`, not `Fixes`).
- [x] Noted release/migration impact, if any.

**Release / migration impact:** none. Docs-only; goes live on `master` via Cloudflare Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how date offsets and date-snap expressions are handled.
  * Explained that **Open daily note** resolves basic date placeholders but not offsets or snap expressions.
  * Added guidance to process files through a QuickAdd Template or Capture choice for full date evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->