### PR TITLE
fix(date): make the pick-a-day command opt-in from a Command palette group

### DIFF
--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -286,9 +286,10 @@ That's the useful split: the note is the day, the stamp is when you wrote it.
 prints the clock, so you still get `15:00`. Put `{{DATE}}` on the line if
 you want the note's day next to the text.
 
-Most people leave this on Today and use **Daily log (another day)**, or hold
-Shift in the QuickAdd menu, for the days that aren't today. Your existing
-hotkey still captures to today.
+Most people leave this on Today. Turn on **Also add (another day)** if you
+want a **Daily log (another day)** palette command, or hold Shift in the
+QuickAdd menu for the days that aren't today. Your existing hotkey still
+captures to today.
 
 ### Use your selection as the answer {#use-editor-selection}
 

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -286,10 +286,10 @@ That's the useful split: the note is the day, the stamp is when you wrote it.
 prints the clock, so you still get `15:00`. Put `{{DATE}}` on the line if
 you want the note's day next to the text.
 
-Most people leave this on Today. Turn on **Also add (another day)** if you
-want a **Daily log (another day)** palette command, or hold Shift in the
-QuickAdd menu for the days that aren't today. Your existing hotkey still
-captures to today.
+Most people leave this on Today and hold Shift in the QuickAdd menu for the
+days that aren't today. If you'd rather have a hotkey for that, see
+[Command palette](#command-palette). Your existing hotkey still captures to
+today.
 
 ### Use your selection as the answer {#use-editor-selection}
 
@@ -393,6 +393,15 @@ When QuickAdd opens and focuses a Markdown target in an editable mode, it
 places the cursor at the end of the inserted capture so you can keep typing.
 This is skipped for preview/unfocused opens and when Templater cursor markers
 take over.
+
+### Run it from a hotkey: Command palette {#command-palette}
+
+**Add to command palette** registers the capture as an Obsidian command, the
+same switch as the lightning bolt in the choice list. Once it is on, and
+[Which day](#date-origin) isn't **Ask each time**, **Also add "Name (pick a
+day)"** registers a second command that asks which day first. One hotkey
+captures to today, the other to whichever day you pick, from the same
+choice.
 
 ### Run Templater on the whole file afterwards {#run-templater-on-entire-destination-file-after-capture}
 

--- a/docs/src/content/docs/docs/Choices/MacroChoice.md
+++ b/docs/src/content/docs/docs/Choices/MacroChoice.md
@@ -296,6 +296,15 @@ Enable this to run a macro automatically when Obsidian starts. Handy for:
 - Setting up your workspace
 - Running maintenance tasks
 
+### Command palette {#command-palette}
+
+**Add to command palette** is the same switch as the lightning bolt in the
+choice list. Once it is on, and Which day isn't **Ask each time**, **Also add
+"Name (pick a day)"** registers a second command that asks which day before
+the macro runs. See
+[Command palette](/docs/Choices/TemplateChoice/#command-palette) on the
+Template page.
+
 ## Practical examples {#practical-examples}
 
 ### Example 1: Log a book to your daily note {#example-1-book-logging-macro}

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -214,10 +214,12 @@ choice, so a "written at" stamp stays honest.
   year.
 - **A variable…** is for a `{{VDATE}}` or a script that already has the day.
 
-If the choice has a command, QuickAdd also adds **Name (another day)** next
-to it. Same choice. Your existing hotkey still opens today. Use the extra
-command, or hold Shift in the QuickAdd menu, when it isn't today. You don't
-need a second Daily Note choice.
+**Also add (another day)** is off by default. Turn it on when the choice is
+a command and you want a second palette entry, **Name (another day)**. Same
+choice; your existing hotkey still opens today. Hold Shift in the QuickAdd
+menu always opens the picker, with or without that extra command. You don't
+need a second Daily Note choice. The toggle is hidden for **Ask each time**
+because the main command already opens the picker.
 
 Scripts and the CLI can pass a day too:
 `executeChoice("Weekly review", {}, { date: "last week" })`, or `date=ask`

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -214,12 +214,10 @@ choice, so a "written at" stamp stays honest.
   year.
 - **A variable…** is for a `{{VDATE}}` or a script that already has the day.
 
-**Also add (another day)** is off by default. Turn it on when the choice is
-a command and you want a second palette entry, **Name (another day)**. Same
-choice; your existing hotkey still opens today. Hold Shift in the QuickAdd
-menu always opens the picker, with or without that extra command. You don't
-need a second Daily Note choice. The toggle is hidden for **Ask each time**
-because the main command already opens the picker.
+When it isn't today, hold Shift in the QuickAdd menu and the same choice asks
+for the day. If you want a hotkey for that, see
+[Command palette](#command-palette) below. You don't need a second Daily
+Note choice.
 
 Scripts and the CLI can pass a day too:
 `executeChoice("Weekly review", {}, { date: "last week" })`, or `date=ask`
@@ -359,6 +357,18 @@ appear (these are shared with the Capture choice):
   **Live Preview**, or **Default**.
 - **Focus new pane** - shown for every location except **Reuse current tab**.
   Focus the opened tab immediately after opening.
+
+## Run it from a hotkey: Command palette {#command-palette}
+
+**Add to command palette** registers the choice as an Obsidian command, so
+you can bind a hotkey to it. It is the same switch as the lightning bolt in
+the choice list.
+
+Once it is on, and [Which day](#date-origin) isn't **Ask each time**, a
+second toggle appears: **Also add "Name (pick a day)"**. That registers one
+more command that asks which day before it runs, so you can have one hotkey
+for today's note and another for any other day, from the same choice. Your
+main hotkey keeps using Which day.
 
 ## When the note already exists {#file-already-exists-behavior}
 

--- a/src/IChoiceExecutor.ts
+++ b/src/IChoiceExecutor.ts
@@ -44,7 +44,7 @@ export interface IChoiceExecutor {
 	clocks?: RunClocks;
 	/**
 	 * When true, this run asks for a day even if the choice is set to Today
-	 * (or another fixed day). Used by `{name} (another day)` and `date=ask`.
+	 * (or another fixed day). Used by `{name} (pick a day)` and `date=ask`.
 	 */
 	pickDate?: boolean;
 	/**

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -18,6 +18,7 @@ import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
 import OnePageOverrideSetting from "./components/OnePageOverrideSetting.svelte";
 import DateOriginSetting from "./components/DateOriginSetting.svelte";
+import CommandPaletteSetting from "./components/CommandPaletteSetting.svelte";
 import CaptureTargetSetting from "./components/CaptureTargetSetting.svelte";
 import WritePositionSetting from "./components/WritePositionSetting.svelte";
 import ChoiceIconSetting from "./components/ChoiceIconSetting.svelte";
@@ -210,11 +211,15 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 	{/snippet}
 </SettingItem>
 
-<DateOriginSetting
-	bind:dateOrigin={choice.dateOrigin}
-	bind:anotherDayCommand={choice.anotherDayCommand}
-/>
+<DateOriginSetting bind:dateOrigin={choice.dateOrigin} />
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
+
+<CommandPaletteSetting
+	bind:command={choice.command}
+	bind:pickDayCommand={choice.pickDayCommand}
+	name={choice.name}
+	dateOrigin={choice.dateOrigin}
+/>
 
 <ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -210,7 +210,10 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 	{/snippet}
 </SettingItem>
 
-<DateOriginSetting bind:dateOrigin={choice.dateOrigin} />
+<DateOriginSetting
+	bind:dateOrigin={choice.dateOrigin}
+	bind:anotherDayCommand={choice.anotherDayCommand}
+/>
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
 

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -358,7 +358,10 @@ function onModeChange(value: string) {
 	<FileOpeningSetting bind:fileOpening={choice.fileOpening} contextLabel="created" />
 {/if}
 
-<DateOriginSetting bind:dateOrigin={choice.dateOrigin} />
+<DateOriginSetting
+	bind:dateOrigin={choice.dateOrigin}
+	bind:anotherDayCommand={choice.anotherDayCommand}
+/>
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
 

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -40,6 +40,7 @@ import OpenFileSetting from "./components/OpenFileSetting.svelte";
 import FileOpeningSetting from "./components/FileOpeningSetting.svelte";
 import OnePageOverrideSetting from "./components/OnePageOverrideSetting.svelte";
 import DateOriginSetting from "./components/DateOriginSetting.svelte";
+import CommandPaletteSetting from "./components/CommandPaletteSetting.svelte";
 import ChoiceIconSetting from "./components/ChoiceIconSetting.svelte";
 import { suggester } from "./components/suggesterAction";
 import { VALUE_SYNTAX } from "../../constants";
@@ -358,11 +359,15 @@ function onModeChange(value: string) {
 	<FileOpeningSetting bind:fileOpening={choice.fileOpening} contextLabel="created" />
 {/if}
 
-<DateOriginSetting
-	bind:dateOrigin={choice.dateOrigin}
-	bind:anotherDayCommand={choice.anotherDayCommand}
-/>
+<DateOriginSetting bind:dateOrigin={choice.dateOrigin} />
 
 <OnePageOverrideSetting bind:onePageInput={choice.onePageInput} />
+
+<CommandPaletteSetting
+	bind:command={choice.command}
+	bind:pickDayCommand={choice.pickDayCommand}
+	name={choice.name}
+	dateOrigin={choice.dateOrigin}
+/>
 
 <ChoiceIconSetting bind:icon={choice.icon} type={choice.type} {app} />

--- a/src/gui/ChoiceBuilder/components/CommandPaletteSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/CommandPaletteSetting.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import type { DateOrigin } from "../../../types/dateOrigin";
+import {
+	COMMAND_SETTING_DESC,
+	COMMAND_SETTING_NAME,
+	PICK_DAY_SETTING_DESC,
+	canOfferPickDayCommand,
+	pickDaySettingName,
+} from "../../../types/choiceCommands";
+import SettingItem from "../../components/SettingItem.svelte";
+import Toggle from "../../components/Toggle.svelte";
+
+/**
+ * The choice's command palette entries. The same `command` flag is toggled
+ * from the choice list; this is its home in the settings modal, so the
+ * pick-a-day sub-option can sit under the parent it depends on.
+ */
+let {
+	command = $bindable(),
+	pickDayCommand = $bindable(),
+	name,
+	dateOrigin,
+}: {
+	command: boolean;
+	pickDayCommand?: boolean;
+	name: string;
+	dateOrigin: DateOrigin | undefined;
+} = $props();
+
+const showPickDay = $derived(command && canOfferPickDayCommand(dateOrigin));
+</script>
+
+<SettingItem name={COMMAND_SETTING_NAME} desc={COMMAND_SETTING_DESC}>
+	{#snippet control()}
+		<Toggle bind:checked={command} ariaLabel={COMMAND_SETTING_NAME} />
+	{/snippet}
+</SettingItem>
+
+{#if showPickDay}
+	<SettingItem name={pickDaySettingName(name)} desc={PICK_DAY_SETTING_DESC}>
+		{#snippet control()}
+			<Toggle
+				bind:checked={pickDayCommand}
+				ariaLabel={pickDaySettingName(name)}
+			/>
+		{/snippet}
+	</SettingItem>
+{/if}

--- a/src/gui/ChoiceBuilder/components/CommandPaletteSetting.test.ts
+++ b/src/gui/ChoiceBuilder/components/CommandPaletteSetting.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { flushSync } from "svelte";
+import CommandPaletteSetting from "./CommandPaletteSetting.svelte";
+import type { DateOrigin } from "../../../types/dateOrigin";
+
+function settingNames(container: HTMLElement): string[] {
+	return Array.from(container.querySelectorAll(".setting-item-name")).map(
+		(el) => el.textContent ?? "",
+	);
+}
+
+function mount(input: {
+	command: boolean;
+	pickDayCommand?: boolean;
+	dateOrigin?: DateOrigin;
+}) {
+	return render(CommandPaletteSetting, {
+		props: {
+			command: input.command,
+			pickDayCommand: input.pickDayCommand,
+			name: "Daily note",
+			dateOrigin: input.dateOrigin,
+		},
+	});
+}
+
+describe("CommandPaletteSetting", () => {
+	it("hides the pick-a-day option until the choice is a command", () => {
+		const { container } = mount({ command: false });
+		expect(settingNames(container)).toEqual(["Add to command palette"]);
+	});
+
+	it("shows the pick-a-day option with the live command name", () => {
+		const { container } = mount({ command: true });
+		expect(settingNames(container)).toEqual([
+			"Add to command palette",
+			'Also add "Daily note (pick a day)"',
+		]);
+	});
+
+	it("hides the pick-a-day option for Ask each time", () => {
+		const { container } = mount({
+			command: true,
+			dateOrigin: { kind: "ask" },
+		});
+		expect(settingNames(container)).toEqual(["Add to command palette"]);
+	});
+
+	it("reveals the pick-a-day option when the command toggle flips on", async () => {
+		const { container } = mount({ command: false });
+		const toggle = container.querySelector<HTMLElement>(
+			'[role="switch"][aria-label="Add to command palette"]',
+		);
+		if (!toggle) throw new Error("command toggle not found");
+
+		await fireEvent.click(toggle);
+		flushSync();
+
+		expect(toggle.getAttribute("aria-checked")).toBe("true");
+		expect(settingNames(container)).toContain(
+			'Also add "Daily note (pick a day)"',
+		);
+	});
+});

--- a/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
@@ -2,6 +2,8 @@
 import type { DateOrigin } from "../../../types/dateOrigin";
 import { DATE_ORIGIN_UNITS, isDateOriginUnit } from "../../../types/dateOrigin";
 import {
+	ANOTHER_DAY_COMMAND_SETTING_DESC,
+	ANOTHER_DAY_COMMAND_SETTING_NAME,
 	ASK_DEFAULT_SETTING_DESC,
 	ASK_DEFAULT_SETTING_NAME,
 	CUSTOM_OFFSET_SETTING_DESC,
@@ -20,11 +22,14 @@ import {
 } from "../../../types/dateOriginPresets";
 import SettingItem from "../../components/SettingItem.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
+import Toggle from "../../components/Toggle.svelte";
 
 let {
 	dateOrigin = $bindable(),
+	anotherDayCommand = $bindable(),
 }: {
 	dateOrigin: DateOrigin | undefined;
+	anotherDayCommand?: boolean;
 } = $props();
 
 const unitOptions = DATE_ORIGIN_UNITS.map((unit) => ({
@@ -44,6 +49,7 @@ const variableOrigin = $derived(
 );
 const askDefaultId = $derived(askDefaultToPresetId(askOrigin?.defaultValue));
 const askDefaultChoices = $derived(askDefaultOptions(askOrigin?.defaultValue));
+const showAnotherDayToggle = $derived(selectedPreset !== "ask");
 
 function onPresetChange(value: string) {
 	if (!isDateOriginPreset(value)) return;
@@ -143,6 +149,20 @@ function onVariableChange(value: string) {
 					if (!(target instanceof HTMLInputElement)) return;
 					onVariableChange(target.value);
 				}}
+			/>
+		{/snippet}
+	</SettingItem>
+{/if}
+
+{#if showAnotherDayToggle}
+	<SettingItem
+		name={ANOTHER_DAY_COMMAND_SETTING_NAME}
+		desc={ANOTHER_DAY_COMMAND_SETTING_DESC}
+	>
+		{#snippet control()}
+			<Toggle
+				bind:checked={anotherDayCommand}
+				ariaLabel={ANOTHER_DAY_COMMAND_SETTING_NAME}
 			/>
 		{/snippet}
 	</SettingItem>

--- a/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/DateOriginSetting.svelte
@@ -2,8 +2,6 @@
 import type { DateOrigin } from "../../../types/dateOrigin";
 import { DATE_ORIGIN_UNITS, isDateOriginUnit } from "../../../types/dateOrigin";
 import {
-	ANOTHER_DAY_COMMAND_SETTING_DESC,
-	ANOTHER_DAY_COMMAND_SETTING_NAME,
 	ASK_DEFAULT_SETTING_DESC,
 	ASK_DEFAULT_SETTING_NAME,
 	CUSTOM_OFFSET_SETTING_DESC,
@@ -22,14 +20,11 @@ import {
 } from "../../../types/dateOriginPresets";
 import SettingItem from "../../components/SettingItem.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
-import Toggle from "../../components/Toggle.svelte";
 
 let {
 	dateOrigin = $bindable(),
-	anotherDayCommand = $bindable(),
 }: {
 	dateOrigin: DateOrigin | undefined;
-	anotherDayCommand?: boolean;
 } = $props();
 
 const unitOptions = DATE_ORIGIN_UNITS.map((unit) => ({
@@ -49,7 +44,6 @@ const variableOrigin = $derived(
 );
 const askDefaultId = $derived(askDefaultToPresetId(askOrigin?.defaultValue));
 const askDefaultChoices = $derived(askDefaultOptions(askOrigin?.defaultValue));
-const showAnotherDayToggle = $derived(selectedPreset !== "ask");
 
 function onPresetChange(value: string) {
 	if (!isDateOriginPreset(value)) return;
@@ -149,20 +143,6 @@ function onVariableChange(value: string) {
 					if (!(target instanceof HTMLInputElement)) return;
 					onVariableChange(target.value);
 				}}
-			/>
-		{/snippet}
-	</SettingItem>
-{/if}
-
-{#if showAnotherDayToggle}
-	<SettingItem
-		name={ANOTHER_DAY_COMMAND_SETTING_NAME}
-		desc={ANOTHER_DAY_COMMAND_SETTING_DESC}
-	>
-		{#snippet control()}
-			<Toggle
-				bind:checked={anotherDayCommand}
-				ariaLabel={ANOTHER_DAY_COMMAND_SETTING_NAME}
 			/>
 		{/snippet}
 	</SettingItem>

--- a/src/gui/MacroGUIs/MacroBuilder.test.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.test.ts
@@ -35,12 +35,29 @@ describe("MacroBuilder", () => {
 
 		expect(modal.contentEl.textContent).toContain("Which day");
 		expect(modal.contentEl.textContent).toContain("Ask each time");
-		expect(modal.contentEl.textContent).toContain("Also add (another day)");
-		expect(children.at(-2)?.textContent).toContain("Run on startup");
+		expect(children.at(-3)?.textContent).toContain("Run on startup");
+		expect(children.at(-2)?.textContent).toContain("Add to command palette");
 		expect(children.at(-1)?.textContent).toContain("Icon");
 		expect(children.at(-1)?.textContent).toContain(
 			"Lucide/Obsidian icon id",
 		);
+	});
+
+	it("offers the pick-a-day command only once the macro is a command", () => {
+		const choice = new MacroChoice("Macro under test");
+		const plugin = { settings: { choices: [] } } as unknown as QuickAdd;
+		const off = new MacroBuilder(new App(), plugin, choice, []);
+		expect(off.contentEl.textContent).not.toContain("(pick a day)");
+
+		choice.command = true;
+		const on = new MacroBuilder(new App(), plugin, choice, []);
+		expect(on.contentEl.textContent).toContain(
+			'Also add "Macro under test (pick a day)"',
+		);
+
+		choice.dateOrigin = { kind: "ask" };
+		const ask = new MacroBuilder(new App(), plugin, choice, []);
+		expect(ask.contentEl.textContent).not.toContain("(pick a day)");
 	});
 
 	it("shows the ask picker default and keeps icon last", () => {
@@ -56,10 +73,7 @@ describe("MacroBuilder", () => {
 
 		expect(modal.contentEl.textContent).toContain("Picker starts on");
 		expect(modal.contentEl.textContent).toContain("Last week");
-		expect(modal.contentEl.textContent).not.toContain(
-			"Also add (another day)",
-		);
-		expect(children.at(-2)?.textContent).toContain("Run on startup");
+		expect(children.at(-2)?.textContent).toContain("Add to command palette");
 		expect(children.at(-1)?.textContent).toContain("Icon");
 	});
 

--- a/src/gui/MacroGUIs/MacroBuilder.test.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.test.ts
@@ -35,6 +35,7 @@ describe("MacroBuilder", () => {
 
 		expect(modal.contentEl.textContent).toContain("Which day");
 		expect(modal.contentEl.textContent).toContain("Ask each time");
+		expect(modal.contentEl.textContent).toContain("Also add (another day)");
 		expect(children.at(-2)?.textContent).toContain("Run on startup");
 		expect(children.at(-1)?.textContent).toContain("Icon");
 		expect(children.at(-1)?.textContent).toContain(
@@ -55,6 +56,9 @@ describe("MacroBuilder", () => {
 
 		expect(modal.contentEl.textContent).toContain("Picker starts on");
 		expect(modal.contentEl.textContent).toContain("Last week");
+		expect(modal.contentEl.textContent).not.toContain(
+			"Also add (another day)",
+		);
 		expect(children.at(-2)?.textContent).toContain("Run on startup");
 		expect(children.at(-1)?.textContent).toContain("Icon");
 	});

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -27,8 +27,13 @@ import type { ICommand } from "../../types/macros/ICommand";
 import { v4 as uuidv4 } from "uuid";
 import { DATE_ORIGIN_UNITS, isDateOriginUnit } from "../../types/dateOrigin";
 import {
-	ANOTHER_DAY_COMMAND_SETTING_DESC,
-	ANOTHER_DAY_COMMAND_SETTING_NAME,
+	COMMAND_SETTING_DESC,
+	COMMAND_SETTING_NAME,
+	PICK_DAY_SETTING_DESC,
+	canOfferPickDayCommand,
+	pickDaySettingName,
+} from "../../types/choiceCommands";
+import {
 	ASK_DEFAULT_SETTING_DESC,
 	ASK_DEFAULT_SETTING_NAME,
 	CUSTOM_OFFSET_SETTING_DESC,
@@ -109,6 +114,7 @@ export class MacroBuilder extends Modal {
 		this.addCommandEditor();
 		this.addDateOriginSetting();
 		this.addRunOnStartupSetting();
+		this.addCommandPaletteSettings();
 		this.addIconSetting();
 	}
 
@@ -235,16 +241,31 @@ export class MacroBuilder extends Modal {
 					});
 				});
 		}
+	}
 
-		if (preset !== "ask") {
+	private addCommandPaletteSettings(): void {
+		new Setting(this.contentEl)
+			.setName(COMMAND_SETTING_NAME)
+			.setDesc(COMMAND_SETTING_DESC)
+			.addToggle((toggle) => {
+				toggle.setValue(this.choice.command).onChange((value) => {
+					this.choice.command = value;
+					this.reload();
+				});
+			});
+
+		if (
+			this.choice.command &&
+			canOfferPickDayCommand(this.choice.dateOrigin)
+		) {
 			new Setting(this.contentEl)
-				.setName(ANOTHER_DAY_COMMAND_SETTING_NAME)
-				.setDesc(ANOTHER_DAY_COMMAND_SETTING_DESC)
+				.setName(pickDaySettingName(this.choice.name))
+				.setDesc(PICK_DAY_SETTING_DESC)
 				.addToggle((toggle) => {
 					toggle
-						.setValue(this.choice.anotherDayCommand ?? false)
+						.setValue(this.choice.pickDayCommand ?? false)
 						.onChange((value) => {
-							this.choice.anotherDayCommand = value || undefined;
+							this.choice.pickDayCommand = value;
 						});
 				});
 		}

--- a/src/gui/MacroGUIs/MacroBuilder.ts
+++ b/src/gui/MacroGUIs/MacroBuilder.ts
@@ -27,6 +27,8 @@ import type { ICommand } from "../../types/macros/ICommand";
 import { v4 as uuidv4 } from "uuid";
 import { DATE_ORIGIN_UNITS, isDateOriginUnit } from "../../types/dateOrigin";
 import {
+	ANOTHER_DAY_COMMAND_SETTING_DESC,
+	ANOTHER_DAY_COMMAND_SETTING_NAME,
 	ASK_DEFAULT_SETTING_DESC,
 	ASK_DEFAULT_SETTING_NAME,
 	CUSTOM_OFFSET_SETTING_DESC,
@@ -231,6 +233,19 @@ export class MacroBuilder extends Modal {
 					text.onChange((value) => {
 						this.choice.dateOrigin = { kind: "variable", name: value };
 					});
+				});
+		}
+
+		if (preset !== "ask") {
+			new Setting(this.contentEl)
+				.setName(ANOTHER_DAY_COMMAND_SETTING_NAME)
+				.setDesc(ANOTHER_DAY_COMMAND_SETTING_DESC)
+				.addToggle((toggle) => {
+					toggle
+						.setValue(this.choice.anotherDayCommand ?? false)
+						.onChange((value) => {
+							this.choice.anotherDayCommand = value || undefined;
+						});
 				});
 		}
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -605,7 +605,12 @@ export default class QuickAdd extends Plugin {
 				callback: () => this.runRegisteredChoice(choiceId, choice.name),
 			});
 
-			if (shouldRegisterAnotherDayCommand(choice.dateOrigin)) {
+			if (
+				shouldRegisterAnotherDayCommand({
+					origin: choice.dateOrigin,
+					enabled: choice.anotherDayCommand,
+				})
+			) {
 				this.addCommand({
 					id: anotherDayCommandId(choiceId),
 					name: anotherDayCommandName(choice.name),

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,11 +42,11 @@ import {
 import { isReservedVariableKey } from "./utils/reservedVariableKeys";
 import { applyInvocationDate } from "./utils/resolveDateOrigin";
 import {
-	anotherDayCommandId,
-	anotherDayCommandName,
 	choiceCommandId,
-	shouldRegisterAnotherDayCommand,
-} from "./types/dateOriginPresets";
+	pickDayCommandId,
+	pickDayCommandName,
+	shouldRegisterPickDayCommand,
+} from "./types/choiceCommands";
 import { registerQuickAddCliHandlers } from "./cli/registerQuickAddCliHandlers";
 import { autoSyncEnabledProviders } from "./ai/modelSyncService";
 import { QUICK_ADD_COMMAND_LABELS } from "./commandLabels";
@@ -606,14 +606,14 @@ export default class QuickAdd extends Plugin {
 			});
 
 			if (
-				shouldRegisterAnotherDayCommand({
+				shouldRegisterPickDayCommand({
 					origin: choice.dateOrigin,
-					enabled: choice.anotherDayCommand,
+					enabled: choice.pickDayCommand,
 				})
 			) {
 				this.addCommand({
-					id: anotherDayCommandId(choiceId),
-					name: anotherDayCommandName(choice.name),
+					id: pickDayCommandId(choiceId),
+					name: pickDayCommandName(choice.name),
 					icon: resolveChoiceIcon(choice),
 					callback: () =>
 						this.runRegisteredChoice(choiceId, choice.name, true),
@@ -744,7 +744,7 @@ export default class QuickAdd extends Plugin {
 		deleteObsidianCommand(this.app, `quickadd:${choiceCommandId(choice.id)}`);
 		deleteObsidianCommand(
 			this.app,
-			`quickadd:${anotherDayCommandId(choice.id)}`,
+			`quickadd:${pickDayCommandId(choice.id)}`,
 		);
 	}
 

--- a/src/types/choiceCommands.test.ts
+++ b/src/types/choiceCommands.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+	canOfferPickDayCommand,
+	choiceCommandId,
+	pickDayCommandId,
+	pickDayCommandName,
+	pickDaySettingName,
+	shouldRegisterPickDayCommand,
+} from "./choiceCommands";
+
+describe("pick-a-day command", () => {
+	it("is off by default and only registers when opted in", () => {
+		expect(shouldRegisterPickDayCommand({ origin: undefined })).toBe(false);
+		expect(
+			shouldRegisterPickDayCommand({
+				origin: { kind: "now" },
+				enabled: false,
+			}),
+		).toBe(false);
+		expect(
+			shouldRegisterPickDayCommand({ origin: undefined, enabled: true }),
+		).toBe(true);
+		expect(
+			shouldRegisterPickDayCommand({
+				origin: { kind: "relative", offset: -1, unit: "days" },
+				enabled: true,
+			}),
+		).toBe(true);
+	});
+
+	it("is never offered or registered for Ask each time", () => {
+		expect(canOfferPickDayCommand({ kind: "ask" })).toBe(false);
+		expect(canOfferPickDayCommand(undefined)).toBe(true);
+		expect(
+			shouldRegisterPickDayCommand({
+				origin: { kind: "ask" },
+				enabled: true,
+			}),
+		).toBe(false);
+	});
+
+	it("names the command after the choice", () => {
+		expect(pickDayCommandName("Daily note")).toBe("Daily note (pick a day)");
+		expect(pickDaySettingName("Daily note")).toBe(
+			'Also add "Daily note (pick a day)"',
+		);
+	});
+
+	it("keeps the existing choice command id so hotkeys stay bound", () => {
+		const id = "weekly-review";
+		expect(choiceCommandId(id)).toBe("choice:weekly-review");
+		expect(pickDayCommandId(id)).toBe("choice:weekly-review:pick-day");
+		expect(pickDayCommandId(id)).not.toBe(choiceCommandId(id));
+	});
+});

--- a/src/types/choiceCommands.ts
+++ b/src/types/choiceCommands.ts
@@ -1,0 +1,40 @@
+import type { DateOrigin } from "./dateOrigin";
+import { dateOriginToPreset } from "./dateOriginPresets";
+
+export const COMMAND_SETTING_NAME = "Add to command palette";
+export const COMMAND_SETTING_DESC =
+	"Run this choice from the command palette or a hotkey.";
+
+export const PICK_DAY_SETTING_DESC =
+	"A second command that asks which day first. Your hotkey for the main command still uses Which day.";
+
+export function pickDaySettingName(choiceName: string): string {
+	return `Also add "${pickDayCommandName(choiceName)}"`;
+}
+
+export function choiceCommandId(choiceId: string): string {
+	return `choice:${choiceId}`;
+}
+
+export function pickDayCommandId(choiceId: string): string {
+	return `${choiceCommandId(choiceId)}:pick-day`;
+}
+
+export function pickDayCommandName(choiceName: string): string {
+	return `${choiceName} (pick a day)`;
+}
+
+/**
+ * The pick-a-day toggle only makes sense when the main command does not
+ * already prompt, so Ask each time hides it.
+ */
+export function canOfferPickDayCommand(origin: DateOrigin | undefined): boolean {
+	return dateOriginToPreset(origin) !== "ask";
+}
+
+export function shouldRegisterPickDayCommand(input: {
+	origin?: DateOrigin;
+	enabled?: boolean;
+}): boolean {
+	return Boolean(input.enabled) && canOfferPickDayCommand(input.origin);
+}

--- a/src/types/choices/Choice.ts
+++ b/src/types/choices/Choice.ts
@@ -9,6 +9,7 @@ export abstract class Choice implements IChoice {
 	type: ChoiceType;
 	command: boolean;
 	dateOrigin?: DateOrigin;
+	anotherDayCommand?: boolean;
 	onePageInput?: "always" | "never" | undefined;
 	icon?: string;
 

--- a/src/types/choices/Choice.ts
+++ b/src/types/choices/Choice.ts
@@ -9,7 +9,7 @@ export abstract class Choice implements IChoice {
 	type: ChoiceType;
 	command: boolean;
 	dateOrigin?: DateOrigin;
-	anotherDayCommand?: boolean;
+	pickDayCommand?: boolean;
 	onePageInput?: "always" | "never" | undefined;
 	icon?: string;
 

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -10,6 +10,12 @@ export default interface IChoice {
 	 * Which day `{{DATE}}` uses. Undefined means today (or a parent run).
 	 */
 	dateOrigin?: DateOrigin;
+	/**
+	 * When true and `command` is on, also register `Name (another day)` in the
+	 * command palette. Undefined/false = off. Ask-each-time choices never get
+	 * the extra command (the main one already opens the picker).
+	 */
+	anotherDayCommand?: boolean;
 	/** Per-choice override for one-page flow. undefined = follow global setting */
 	onePageInput?: "always" | "never" | undefined;
 	/**

--- a/src/types/choices/IChoice.ts
+++ b/src/types/choices/IChoice.ts
@@ -11,11 +11,11 @@ export default interface IChoice {
 	 */
 	dateOrigin?: DateOrigin;
 	/**
-	 * When true and `command` is on, also register `Name (another day)` in the
-	 * command palette. Undefined/false = off. Ask-each-time choices never get
-	 * the extra command (the main one already opens the picker).
+	 * When true and `command` is on, also register `Name (pick a day)`, which
+	 * asks for the day before running. Undefined/false = off. Ask-each-time
+	 * choices never get it (the main command already prompts).
 	 */
-	anotherDayCommand?: boolean;
+	pickDayCommand?: boolean;
 	/** Per-choice override for one-page flow. undefined = follow global setting */
 	onePageInput?: "always" | "never" | undefined;
 	/**

--- a/src/types/dateOriginPresets.test.ts
+++ b/src/types/dateOriginPresets.test.ts
@@ -5,13 +5,10 @@ import {
 	askDefaultFromPresetId,
 	askDefaultOptions,
 	askDefaultToPresetId,
-	anotherDayCommandId,
-	choiceCommandId,
 	dateOriginForPick,
 	dateOriginFromPreset,
 	dateOriginToPreset,
 	isPickDateToken,
-	shouldRegisterAnotherDayCommand,
 } from "./dateOriginPresets";
 
 describe("dateOrigin presets", () => {
@@ -160,37 +157,7 @@ describe("ask picker defaults", () => {
 	});
 });
 
-describe("another-day command", () => {
-	it("is off by default and only registers when opted in", () => {
-		expect(
-			shouldRegisterAnotherDayCommand({ origin: undefined }),
-		).toBe(false);
-		expect(
-			shouldRegisterAnotherDayCommand({
-				origin: { kind: "now" },
-				enabled: false,
-			}),
-		).toBe(false);
-		expect(
-			shouldRegisterAnotherDayCommand({
-				origin: undefined,
-				enabled: true,
-			}),
-		).toBe(true);
-		expect(
-			shouldRegisterAnotherDayCommand({
-				origin: { kind: "relative", offset: -1, unit: "days" },
-				enabled: true,
-			}),
-		).toBe(true);
-		expect(
-			shouldRegisterAnotherDayCommand({
-				origin: { kind: "ask" },
-				enabled: true,
-			}),
-		).toBe(false);
-	});
-
+describe("pick a day", () => {
 	it("seeds the picker from the named day you are overriding", () => {
 		expect(
 			dateOriginForPick({ kind: "relative", offset: -1, unit: "weeks" }),
@@ -205,14 +172,5 @@ describe("another-day command", () => {
 		expect(isPickDateToken("ask")).toBe(true);
 		expect(isPickDateToken("ASK")).toBe(true);
 		expect(isPickDateToken("last week")).toBe(false);
-	});
-
-	it("keeps the existing choice command id so hotkeys stay bound", () => {
-		const id = "weekly-review-ask";
-		expect(choiceCommandId(id)).toBe("choice:weekly-review-ask");
-		expect(anotherDayCommandId(id)).toBe(
-			"choice:weekly-review-ask:another-day",
-		);
-		expect(anotherDayCommandId(id)).not.toBe(choiceCommandId(id));
 	});
 });

--- a/src/types/dateOriginPresets.test.ts
+++ b/src/types/dateOriginPresets.test.ts
@@ -161,17 +161,34 @@ describe("ask picker defaults", () => {
 });
 
 describe("another-day command", () => {
-	it("registers for every job except Ask each time", () => {
-		expect(shouldRegisterAnotherDayCommand(undefined)).toBe(true);
-		expect(shouldRegisterAnotherDayCommand({ kind: "now" })).toBe(true);
+	it("is off by default and only registers when opted in", () => {
+		expect(
+			shouldRegisterAnotherDayCommand({ origin: undefined }),
+		).toBe(false);
 		expect(
 			shouldRegisterAnotherDayCommand({
-				kind: "relative",
-				offset: -1,
-				unit: "days",
+				origin: { kind: "now" },
+				enabled: false,
+			}),
+		).toBe(false);
+		expect(
+			shouldRegisterAnotherDayCommand({
+				origin: undefined,
+				enabled: true,
 			}),
 		).toBe(true);
-		expect(shouldRegisterAnotherDayCommand({ kind: "ask" })).toBe(false);
+		expect(
+			shouldRegisterAnotherDayCommand({
+				origin: { kind: "relative", offset: -1, unit: "days" },
+				enabled: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldRegisterAnotherDayCommand({
+				origin: { kind: "ask" },
+				enabled: true,
+			}),
+		).toBe(false);
 	});
 
 	it("seeds the picker from the named day you are overriding", () => {

--- a/src/types/dateOriginPresets.ts
+++ b/src/types/dateOriginPresets.ts
@@ -15,11 +15,7 @@ export type DateOriginPreset = (typeof DATE_ORIGIN_PRESETS)[number];
 
 export const DATE_ORIGIN_SETTING_NAME = "Which day";
 export const DATE_ORIGIN_SETTING_DESC =
-	"The day {{DATE}} writes. The clock stays now.";
-
-export const ANOTHER_DAY_COMMAND_SETTING_NAME = "Also add (another day)";
-export const ANOTHER_DAY_COMMAND_SETTING_DESC =
-	"Registers Name (another day) in the command palette when this choice is a command. Hold Shift in the QuickAdd menu always opens the picker, with or without this.";
+	"The day {{DATE}} writes. The clock stays now. Hold Shift in the QuickAdd menu to pick a different day.";
 
 export const ASK_DEFAULT_SETTING_NAME = "Picker starts on";
 export const ASK_DEFAULT_SETTING_DESC =
@@ -203,26 +199,6 @@ export function askDefaultFromPresetId(
 
 export function isPickDateToken(value: unknown): boolean {
 	return typeof value === "string" && value.trim().toLowerCase() === "ask";
-}
-
-export function shouldRegisterAnotherDayCommand(input: {
-	origin?: DateOrigin;
-	enabled?: boolean;
-}): boolean {
-	if (!input.enabled) return false;
-	return dateOriginToPreset(input.origin) !== "ask";
-}
-
-export function choiceCommandId(choiceId: string): string {
-	return `choice:${choiceId}`;
-}
-
-export function anotherDayCommandId(choiceId: string): string {
-	return `${choiceCommandId(choiceId)}:another-day`;
-}
-
-export function anotherDayCommandName(choiceName: string): string {
-	return `${choiceName} (another day)`;
 }
 
 export function dateOriginForPick(

--- a/src/types/dateOriginPresets.ts
+++ b/src/types/dateOriginPresets.ts
@@ -15,7 +15,11 @@ export type DateOriginPreset = (typeof DATE_ORIGIN_PRESETS)[number];
 
 export const DATE_ORIGIN_SETTING_NAME = "Which day";
 export const DATE_ORIGIN_SETTING_DESC =
-	"The day {{DATE}} writes. The clock stays now. A command also adds (another day) so you can pick without making a copy of this choice.";
+	"The day {{DATE}} writes. The clock stays now.";
+
+export const ANOTHER_DAY_COMMAND_SETTING_NAME = "Also add (another day)";
+export const ANOTHER_DAY_COMMAND_SETTING_DESC =
+	"Registers Name (another day) in the command palette when this choice is a command. Hold Shift in the QuickAdd menu always opens the picker, with or without this.";
 
 export const ASK_DEFAULT_SETTING_NAME = "Picker starts on";
 export const ASK_DEFAULT_SETTING_DESC =
@@ -201,10 +205,12 @@ export function isPickDateToken(value: unknown): boolean {
 	return typeof value === "string" && value.trim().toLowerCase() === "ask";
 }
 
-export function shouldRegisterAnotherDayCommand(
-	origin: DateOrigin | undefined,
-): boolean {
-	return dateOriginToPreset(origin) !== "ask";
+export function shouldRegisterAnotherDayCommand(input: {
+	origin?: DateOrigin;
+	enabled?: boolean;
+}): boolean {
+	if (!input.enabled) return false;
+	return dateOriginToPreset(input.origin) !== "ask";
 }
 
 export function choiceCommandId(choiceId: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#1710 registered a second `Name (another day)` palette command for every command-enabled choice. That's too noisy as a default, and "(another day)" describes a situation rather than an action.

This makes the second command opt-in and gives it a proper home. Each builder (Template, Capture, Macro) gets a **Command palette** group near the icon setting:

- **Add to command palette** — the same `command` flag the choice list's lightning bolt toggles, now also editable in the settings modal.
- **Also add "Name (pick a day)"** — shown only when the above is on and Which day isn't Ask each time. Registers one extra command that asks which day first. The label renders the live command name so you see exactly what lands in the palette.

Which day goes back to being only about the day (its description now mentions Shift). Shift in the QuickAdd menu still works with nothing enabled.

## Changes

- `pickDayCommand?: boolean` on `IChoice` (undefined/false = off)
- New `src/types/choiceCommands.ts` (`choiceCommandId`, `pickDayCommandId` → `:pick-day`, `pickDayCommandName`, `shouldRegisterPickDayCommand`, `canOfferPickDayCommand`, setting strings)
- New `CommandPaletteSetting.svelte` used by Template and Capture forms; equivalent `addCommandPaletteSettings()` in `MacroBuilder`
- `DateOriginSetting.svelte` back to master (date only)
- Docs: Command palette sections on Template, Capture, Macro; Which day text updated

## Testing / validation

- `pnpm run test` — 5184 passed, 37 skipped (new `choiceCommands.test.ts`, `CommandPaletteSetting.test.ts`, MacroBuilder visibility cases)
- `pnpm run build-with-lint`, `pnpm run check` — clean
- Manual, Obsidian 1.13.7 (Linux) with the built plugin:
  - Baseline: command-enabled `Daily note` registers only `quickadd:choice:<id>`
  - Toggle on in the builder → `quickadd:choice:<id>:pick-day` "QuickAdd: Daily note (pick a day)" appears; `pickDayCommand: true` persisted
  - Running it, typing `yesterday` → `Daily/2026-08-31.md` with heading "Monday, August 31, 2026" and `{{DATE+-1}}`/`{{DATE+1}}` following the picked day
  - Which day = Ask each time hides the pick-a-day toggle
  - `dev:errors`: none

[Command palette group in the Template choice builder, pick-a-day toggle on](https://cursor.com/agents/bc-01a05d7d-cc58-72da-85a6-e49bcb53a4fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpick-a-day-toggle-on.webp)
[Command palette showing QuickAdd: Daily note (pick a day)](https://cursor.com/agents/bc-01a05d7d-cc58-72da-85a6-e49bcb53a4fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpick-a-day-command-palette.webp)

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Linked any related issue(s).
- [x] Noted release/migration impact, if any.

## Release / migration

Additive, unreleased (#1710 hasn't shipped; latest release is 2.23.0). Existing choices keep today and gain no extra command. The `:another-day` id from #1710 is replaced by `:pick-day`; nothing on disk references it.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05d7d-cc58-72da-85a6-e49bcb53a4fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05d7d-cc58-72da-85a6-e49bcb53a4fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Add to command palette** setting for capture, template, and macro choices.
  * Added an optional **“Name (pick a day)”** command that prompts for a date before running.
  * Updated command registration so date-picking commands are available only when supported and enabled.
* **Documentation**
  * Updated guidance for choosing dates, including Shift-click behavior in the QuickAdd menu.
  * Documented command palette and hotkey usage for choices.
* **Bug Fixes**
  * Clarified command naming from “another day” to “pick a day.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->