### PR TITLE
fix(preflight): give the one-page date field the whole row

### DIFF
--- a/src/preflight/OnePageInputModal.audit-preflight-suggesters.test.ts
+++ b/src/preflight/OnePageInputModal.audit-preflight-suggesters.test.ts
@@ -140,19 +140,20 @@ vi.mock("obsidian", () => {
 	}
 
 	class Setting {
+		settingEl: HTMLElement;
 		controlEl: HTMLElement;
 		private readonly infoEl: HTMLElement;
 		private readonly nameEl: HTMLElement;
 		private readonly descEl: HTMLElement;
 		constructor(containerEl: HTMLElement) {
-			const settingEl = document.createElement("div");
+			this.settingEl = document.createElement("div");
 			this.infoEl = document.createElement("div");
 			this.nameEl = document.createElement("div");
 			this.descEl = document.createElement("div");
 			this.controlEl = document.createElement("div");
-			settingEl.appendChild(this.infoEl);
-			settingEl.appendChild(this.controlEl);
-			containerEl.appendChild(settingEl);
+			this.settingEl.appendChild(this.infoEl);
+			this.settingEl.appendChild(this.controlEl);
+			containerEl.appendChild(this.settingEl);
 		}
 		setName(name: string | DocumentFragment): this {
 			if (typeof name === "string") this.nameEl.textContent = name;

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -867,6 +867,34 @@ describe("OnePageInputModal", () => {
 			await expect(modal.waitForClose).resolves.toEqual({ due: "" });
 		});
 
+		it("stacks the date row and keeps the parsed preview next to the input", () => {
+			const requirements: FieldRequirement[] = [
+				{
+					id: "due",
+					label: "due",
+					type: "date",
+					dateFormat: "YYYY-MM-DD",
+				},
+			];
+			const modal = new OnePageInputModal({} as App, requirements, new Map());
+			const contentEl = (modal as any).contentEl as HTMLElement;
+			const row = contentEl.querySelector(".qa-onepage-date-setting");
+			expect(row).not.toBeNull();
+
+			const container = row?.querySelector(".qa-date-input");
+			const children = Array.from(container?.children ?? []);
+			const inputIndex = children.findIndex((el) => el.tagName === "INPUT");
+			const previewIndex = children.findIndex((el) =>
+				el.classList.contains("qa-date-preview-text"),
+			);
+			const pickerIndex = children.findIndex((el) =>
+				el.classList.contains("qa-date-picker-container"),
+			);
+			expect(inputIndex).toBeGreaterThanOrEqual(0);
+			expect(previewIndex).toBe(inputIndex + 1);
+			expect(pickerIndex).toBeGreaterThan(previewIndex);
+		});
+
 		it("omits a required blank date so the sequential prompt still fires", async () => {
 			const requirements: FieldRequirement[] = [
 				{

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -435,6 +435,9 @@ export class OnePageInputModal extends Modal {
 				const setting = new Setting(this.contentEl).setName(
 					this.decorateLabel(req),
 				);
+				// The input, calendar, and parsed preview do not fit beside the
+				// label the way a lone text box does, so this row stacks.
+				setting.settingEl.addClass("qa-onepage-date-setting");
 				if (req.description) setting.setDesc(req.description);
 				const container = setting.controlEl.createDiv({
 					cls: "qa-date-input",
@@ -457,6 +460,9 @@ export class OnePageInputModal extends Modal {
 
 				input.setPlaceholder(placeholder).setValue(displayValue ?? "");
 
+				const preview = container.createDiv();
+				preview.addClass("qa-date-preview-text");
+
 				const pickerContainer = container.createDiv({
 					cls: "qa-date-picker-container",
 				});
@@ -469,9 +475,6 @@ export class OnePageInputModal extends Modal {
 						else clearPickerSelection();
 					},
 				});
-
-				const preview = container.createDiv();
-				preview.addClass("qa-date-preview-text");
 
 				const aliasEntries = getOrderedDateAliases(
 					settingsStore.getState().dateAliases,

--- a/src/styles.css
+++ b/src/styles.css
@@ -464,6 +464,31 @@
 	}
 }
 
+.quickAddModal .qa-onepage-date-setting {
+	flex-direction: column;
+	align-items: stretch;
+	gap: 0.5rem;
+}
+
+.quickAddModal .qa-onepage-date-setting .setting-item-info,
+.quickAddModal .qa-onepage-date-setting .setting-item-control {
+	width: 100%;
+	margin-inline-end: 0;
+}
+
+.quickAddModal .qa-onepage-date-setting .qa-date-input {
+	width: 100%;
+}
+
+.quickAddModal .qa-onepage-date-setting .qa-date-input input[type="text"] {
+	width: 100%;
+}
+
+.quickAddModal .qa-onepage-date-setting .qa-date-preview-text {
+	margin-top: 0;
+	text-align: start;
+}
+
 .quickAddModal .qa-onepage-optional-badge {
 	color: var(--text-muted);
 	font-size: var(--font-ui-smaller);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The date field on the one-page form (used by **Which day → Ask each time**, the `(pick a day)` commands, and `{{VDATE}}` fields on the form) rendered inside the Setting row's control column, beside its label. That left the text box too narrow for its own placeholder (`Enter a date (e.g., 'today', 'next` cut off), squeezed the calendar against the right edge, and pushed the parsed preview to the bottom-right under the calendar while the left half of the row sat empty.

The row now stacks: label on top, full-width input, the parsed date directly under the input, then the calendar at the same width the standalone VDATE prompt already uses.

| Before | After |
| --- | --- |
| [Date field squeezed into the right column](https://cursor.com/agents/bc-01a05ec1-e850-72d7-8558-8b0d21377ecf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fone-page-date-field-before.png) | [Date field stacked full width with the parsed date under the input](https://cursor.com/agents/bc-01a05ec1-e850-72d7-8558-8b0d21377ecf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fone-page-date-field-after.png) |

## Changes

- `src/preflight/OnePageInputModal.ts`: the `date` case adds `qa-onepage-date-setting` to its `settingEl` and creates the preview element right after the input (before the picker) so the parsed date reads next to what you typed.
- `src/styles.css`: `.qa-onepage-date-setting` stacks the Setting row (`flex-direction: column`), gives info/control full width, stretches the text input, and left-aligns the preview.
- Tests: `OnePageInputModal.test.ts` gains a DOM-order regression test (row class present; input → preview → picker). The `Setting` stub in `OnePageInputModal.audit-preflight-suggesters.test.ts` now exposes `settingEl`, as the real Obsidian API does.

## Testing / validation

- `pnpm run build-with-lint` passes; `pnpm run test`: 421 files, 5201 tests passing (the new test fails without the fix).
- Verified live in Obsidian 1.13.7 (isolated e2e vault): opened **Daily note (pick a day)**, typed `last friday`; placeholder fully visible, preview `2026-09-04` sits under the input, calendar highlights the day, File name row updates. Screenshots above are from that run.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) — it becomes the squash-merge commit and drives the released version.
- [x] Linked any related issue(s). Follow-up to #1708 / #1724 (Which day, one-page date field).
- [x] Noted release/migration impact, if any. Ships as a patch; no settings or data changes.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05ec1-e850-72d7-8558-8b0d21377ecf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05ec1-e850-72d7-8558-8b0d21377ecf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date fields in the one-page input modal so the date input, parsed preview, and calendar picker are arranged vertically for clearer viewing.
  - Updated date field spacing, alignment, and sizing to improve readability and ensure controls use the available width.
- **Tests**
  - Added coverage confirming the date field elements appear in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->