### PR TITLE
docs: describe the Cloudflare Pages watch paths and informational check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Vitest (configured in `vitest.config.mts`) runs under jsdom and cannot load real
 Follow Conventional Commits (`feat:`, `fix:`, `test:`, ...) so the shared release pipeline can determine versions from history. Keep generated files in the same commit as the changes that produced them. Pull requests must include a concise summary, reproduction steps or screenshots for UI changes, linked issues when relevant, and explicit notes on release or migration impact. Request review from maintainers closest to the touched area.
 
 ## Documentation
-Docs live in `docs/` (Astro Starlight) and are single-version: pages in `docs/src/content/docs/docs/` serve at `/docs/` on quickadd.obsidian.guide, and edits go live when they land on `master` (deployed by Cloudflare Pages). Every page pins its URL with a `slug:` frontmatter field; keep slugs stable, and add a 301 in `docs/public/_redirects` if one must change.
+Docs live in `docs/` (Astro Starlight) and are single-version: pages in `docs/src/content/docs/docs/` serve at `/docs/` on quickadd.obsidian.guide, and edits go live when they land on `master` (deployed by Cloudflare Pages; only pushes touching `docs/` trigger a build, and the Cloudflare check is informational, not required for merge). Every page pins its URL with a `slug:` frontmatter field; keep slugs stable, and add a 301 in `docs/public/_redirects` if one must change.
 
 ## Agent Playbook
 Automation or scripted work should surface disruptive operations in the PR description and rerun `pnpm run build-with-lint` to keep `main.js`, `manifest.json`, and `versions.json` synchronized. Treat unexpected diffs in those artifacts as blockers until a maintainer approves.

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,17 @@ Built artifacts for AI tooling, all served from the same deployment:
 
 ## Deployment
 
-Cloudflare Pages (GitHub integration) builds this directory on every push and
-publishes `build/`. Pull requests get preview deployments automatically.
+Cloudflare Pages (GitHub integration) builds this directory and publishes
+`build/`. Build watch paths are set to `docs/*`, so only pushes that touch
+`docs/` trigger a build; `src`-only commits, release PRs, and dependency bumps
+produce no Cloudflare check at all. Pull requests that change docs get preview
+deployments, except on `dependabot/*` and `release-run/*` branches.
+
+The "Cloudflare Pages" check is informational and not required for merge. The
+account runs one build at a time, so a build can sit at "Build in progress"
+while an earlier one runs or is queued; a normal build takes about two
+minutes. Cloudflare does not update its PR comment after the PR is closed, so a
+comment still reading "Build in progress" on a merged PR is expected.
 
 Docs are single-version: pages go live when they land on `master`. When
 documenting a feature that has not shipped in a plugin release yet, add an


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the Cloudflare Pages investigation after the 30+ minute "Build in progress" on #1727. The Pages project settings changed today: build watch paths `docs/*` (include), preview branch control excluding `dependabot/*` and `release-run/*`. This updates the two places in the repo that described the old behaviour.

- `docs/README.md` "Deployment": builds run only for pushes touching `docs/`; src-only commits, release PRs, and dependency bumps produce no Cloudflare check; previews skip `dependabot/*` and `release-run/*`. Also notes that the check is informational and not required for merge, that the account runs one build at a time (so "Build in progress" can mean queued), that a normal build is ~2 minutes, and that the bot comment stays stale on merged PRs.
- `AGENTS.md` "Documentation": one clause saying the same, so agents do not wait on the Cloudflare check.

## Testing / validation

Docs-only. Because this PR touches `docs/README.md` it should still trigger a Cloudflare preview build, which doubles as a check that the `docs/*` watch path matches.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) — `docs:` is not a releasable type.
- [x] Linked any related issue(s). Relates to #1727.
- [x] Noted release/migration impact, if any. None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05ec1-e850-72d7-8558-8b0d21377ecf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05ec1-e850-72d7-8558-8b0d21377ecf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Cloudflare Pages deployment behavior, including documentation-only build triggers and skipped previews for certain automated branches.
  - Documented that Cloudflare checks are informational and not required for merging.
  - Added guidance on build timing, serialized deployments, and expected comments on merged pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->