### PR TITLE
fix(settings): reorder choices when Settings is a popout and the main window is hidden

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
 			"brace-expansion": "5.0.9",
 			"obsidian-calendar-ui>svelte": "^5.56.3",
 			"postcss": "8.5.25"
+		},
+		"patchedDependencies": {
+			"svelte-dnd-action@0.9.79": "patches/svelte-dnd-action@0.9.79.patch"
 		}
 	}
 }

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,16 +6,78 @@ re-creating it (`pnpm patch <pkg>@<version>` / `pnpm patch-commit`).
 
 ## svelte-dnd-action@0.9.79
 
-Obsidian 1.13 opens Settings in a popout window. The library used the
-module-global `window`/`document` (QuickAdd's main window) for a drop zone that
-lives in the popout's document, so:
+### Why
 
-- `keepOriginalElementInDom` was scheduled with the main window's
-  `requestAnimationFrame`, which is paused while that window is hidden or
-  occluded (Windows occlusion tracking). The drag never started observing, so
-  the list never reordered and the item snapped back (#1730).
-- `isElementOffDocument` compared the clone against the main document's size;
-  a popout taller than the main window ended the drag immediately.
-- The edge auto-scroller re-armed itself with the main window's frames.
+Obsidian 1.13 opens Settings in a popout window by default (`Settings → Interface →
+Open settings in new window`). QuickAdd's drop zones then live in the popout's
+`Document`, but the library resolves `window`/`document` from module globals, which
+are QuickAdd's *main* window. Three sites break under real conditions (#1730):
 
-The patch resolves the window/document from the element (`ownerDocument.defaultView`).
+- `keepOriginalElementInDom` (pointerAction.js) was scheduled with the main window's
+  `requestAnimationFrame`. Chromium pauses frames for hidden windows, and on Windows
+  a fully covered window counts as hidden (occlusion tracking), so with the settings
+  window over the main window the drag never started observing: the row followed the
+  cursor as a full-row clone, the list never opened a gap, and the item snapped back.
+- `isElementOffDocument` (helpers/intersection.js) compared the clone against the
+  main document's `scrollWidth/scrollHeight`. A popout taller than the main window
+  ended any drag that started below the main window's height immediately, with
+  `TypeError: Cannot read properties of undefined (reading 'style')` from
+  `hideElement(originalDragTarget)` after the synchronous drop.
+- `scrollContainer` (helpers/scroller.js) re-armed edge auto-scroll with the main
+  window's frames, so auto-scroll stopped under the same occlusion.
+
+The patch resolves the window/document from the element
+(`el.ownerDocument.defaultView || window`) at those three sites, in `src/` and both
+`dist/` builds (esbuild bundles `dist/index.mjs`; vitest also resolves `dist/index.mjs`).
+
+### Evidence
+
+Reproduced on Linux (Obsidian 1.13.7, Xvfb, CDP) with `settingsPopoutWindow: true`
+and the main `BrowserWindow` hidden (`document.visibilityState === "hidden"`, main
+`requestAnimationFrame` confirmed paused). Before: clone `class=""`, no pill, order
+unchanged, `settings.choices` unchanged. After: `qa-drag-clone` pill, live reorder,
+persisted. Tall-popout case and edge auto-scroll verified the same way; classic
+in-window Settings unchanged. `tests/dnd-popout-window.test.ts` covers the first two
+sites against the real library with the zone in a second jsdom window.
+
+### Same class, not patched (no failing before/after in Obsidian)
+
+Every remaining module-global `window`/`document` use in 0.9.79 is the same mistake.
+None of these misbehave in Obsidian today; they are listed so nobody re-derives this.
+Patch one only with a reproduced before/after, as above.
+
+- `window.addEventListener("mousemove" | "mouseup" | "touchmove" | "touchend" | …)`
+  and the `draggedLeftDocument` window event: registered on the main window. Works
+  because Obsidian re-dispatches popout window-level events to the main window
+  (probed: 5 popout `mousemove`s → 5 main-window listener calls, 0 main-`document`
+  calls). Any host without that forwarding would never start a drag.
+- `window.scrollX/scrollY` in `getReferencePoint`, `getAbsoluteRect`,
+  `getAbsoluteRectNoTransforms`: both the cursor and the zone rects get the *main*
+  window's offset, so they stay consistent with each other. Obsidian's main document
+  is not scrollable (measured `documentElement.scrollHeight === innerHeight`), so
+  the offset is 0 anyway.
+- `getVisibleRectRecursive` walks ancestors until main `document.body`; in a popout
+  it walks to `null` instead, passing the popout's `body`/`html`. Harmless unless a
+  theme gives those `overflow: auto | scroll`, and even then they are the viewport.
+- `findRelevantScrollContainers` adds main `document.scrollingElement` when it is
+  scrollable; it is not in Obsidian.
+- `scheduleDZForRemovalAfterDrop` (zone destroyed mid-drag, e.g. a nested folder
+  zone inside the dragged row): main-window `requestAnimationFrame` plus
+  `document.body.appendChild(dz)`, which would adopt the popout element into the
+  main document. With the main window hidden the frame never runs and the zone is
+  cleaned up at drop instead; no visible difference found.
+- `aria.js` writes live regions to main `document.body`; QuickAdd sets
+  `autoAriaDisabled: true`.
+
+### Full fix (upstream)
+
+Resolve `doc = zoneEl.ownerDocument` / `win = doc.defaultView` once per drag in
+`handleDragStart` (and per zone in `configure`) and thread them through
+`pointerAction.js`, `helpers/observer.js`, `helpers/intersection.js`,
+`helpers/scroller.js`, `helpers/multiScroller.js`, `helpers/aria.js` in place of
+the globals. Roughly fifteen sites, no API change; the clone already does this via
+`originDropZone.getRootNode()`. The `src/` hunks of this patch are that change for
+the three proven sites. Not filed upstream as of this writing.
+
+Workaround for users without the patch: turn off `Settings → Interface → Open
+settings in new window`, or keep the main Obsidian window visible while reordering.

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,21 @@
+# Dependency patches
+
+Applied by pnpm via `pnpm.patchedDependencies` in `package.json`. If a version bump
+makes a patch fail to apply, re-check whether upstream fixed the issue before
+re-creating it (`pnpm patch <pkg>@<version>` / `pnpm patch-commit`).
+
+## svelte-dnd-action@0.9.79
+
+Obsidian 1.13 opens Settings in a popout window. The library used the
+module-global `window`/`document` (QuickAdd's main window) for a drop zone that
+lives in the popout's document, so:
+
+- `keepOriginalElementInDom` was scheduled with the main window's
+  `requestAnimationFrame`, which is paused while that window is hidden or
+  occluded (Windows occlusion tracking). The drag never started observing, so
+  the list never reordered and the item snapped back (#1730).
+- `isElementOffDocument` compared the clone against the main document's size;
+  a popout taller than the main window ended the drag immediately.
+- The edge auto-scroller re-armed itself with the main window's frames.
+
+The patch resolves the window/document from the element (`ownerDocument.defaultView`).

--- a/patches/svelte-dnd-action@0.9.79.patch
+++ b/patches/svelte-dnd-action@0.9.79.patch
@@ -1,0 +1,181 @@
+diff --git a/dist/index.js b/dist/index.js
+index 77979aed2cb7da18dd282156faecc2d209fa673c..445f9981ddba0534159133237eb44edc8761b6da 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -513,8 +513,14 @@
+    * @returns {boolean} - true if the element in its entirety is off-screen including the scrollable area (the normal dom events look at the mouse rather than the element)
+    */
+   function isElementOffDocument(el) {
+-    var rect = getAbsoluteRect(el);
+-    return rect.right < 0 || rect.left > document.documentElement.scrollWidth || rect.bottom < 0 || rect.top > document.documentElement.scrollHeight;
++    // Measure against the element's own document: in a multi-window host (e.g. an Electron
++    // popout) the module-global `document` is a different, possibly smaller, window.
++    var doc = el.ownerDocument;
++    var win = doc.defaultView || window;
++    var rect = el.getBoundingClientRect();
++    var top = rect.top + win.scrollY;
++    var left = rect.left + win.scrollX;
++    return rect.right + win.scrollX < 0 || left > doc.documentElement.scrollWidth || rect.bottom + win.scrollY < 0 || top > doc.documentElement.scrollHeight;
+   }
+ 
+   /**
+@@ -912,7 +918,10 @@
+         stepPx = _scrollingInfo.stepPx;
+       if (directionObj) {
+         containerEl.scrollBy(directionObj.x * stepPx, directionObj.y * stepPx);
+-        window.requestAnimationFrame(function () {
++        // Use the container's own window: the module-global window may be hidden/occluded
++        // (frames paused) while the container lives in a popout window.
++        var win = containerEl.ownerDocument.defaultView || window;
++        win.requestAnimationFrame(function () {
+           return scrollContainer(containerEl);
+         });
+       }
+@@ -2015,6 +2024,9 @@
+       // creating the draggable element
+       draggedEl = createDraggedElementFrom(originalDragTarget, centreDraggedOnCursor && currentMousePosition);
+       originDropZoneRoot.appendChild(draggedEl);
++      // The zone may live in another window (e.g. an Electron popout); its own window's
++      // animation frames keep running while the main window is hidden or occluded.
++      var originWindow = originalDragTarget.ownerDocument.defaultView || window;
+       // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after the framework removes it
+       function keepOriginalElementInDom() {
+         // Once the drop starts finalizing, handleDrop has stopped observation and this loop
+@@ -2032,10 +2044,10 @@
+           // to prevent the outline from disappearing
+           draggedEl.focus();
+         } else {
+-          window.requestAnimationFrame(keepOriginalElementInDom);
++          originWindow.requestAnimationFrame(keepOriginalElementInDom);
+         }
+       }
+-      window.requestAnimationFrame(keepOriginalElementInDom);
++      originWindow.requestAnimationFrame(keepOriginalElementInDom);
+       styleActiveDropZones(Array.from(typeToDropZones$1.get(config.type)).filter(function (dz) {
+         return dz === originDropZone || !dzToConfig$1.get(dz).dropFromOthersDisabled;
+       }), function (dz) {
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 98eb194a6f49bd432ccf1d517fa19cb77e3ca0ba..2c4f1520844ba203349fc8fd9ca08173c86640da 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -507,8 +507,14 @@ function calcDistanceFromPointToCenter(point, el) {
+  * @returns {boolean} - true if the element in its entirety is off-screen including the scrollable area (the normal dom events look at the mouse rather than the element)
+  */
+ function isElementOffDocument(el) {
+-  var rect = getAbsoluteRect(el);
+-  return rect.right < 0 || rect.left > document.documentElement.scrollWidth || rect.bottom < 0 || rect.top > document.documentElement.scrollHeight;
++  // Measure against the element's own document: in a multi-window host (e.g. an Electron
++  // popout) the module-global `document` is a different, possibly smaller, window.
++  var doc = el.ownerDocument;
++  var win = doc.defaultView || window;
++  var rect = el.getBoundingClientRect();
++  var top = rect.top + win.scrollY;
++  var left = rect.left + win.scrollX;
++  return rect.right + win.scrollX < 0 || left > doc.documentElement.scrollWidth || rect.bottom + win.scrollY < 0 || top > doc.documentElement.scrollHeight;
+ }
+ 
+ /**
+@@ -906,7 +912,10 @@ function makeScroller() {
+       stepPx = _scrollingInfo.stepPx;
+     if (directionObj) {
+       containerEl.scrollBy(directionObj.x * stepPx, directionObj.y * stepPx);
+-      window.requestAnimationFrame(function () {
++      // Use the container's own window: the module-global window may be hidden/occluded
++      // (frames paused) while the container lives in a popout window.
++      var win = containerEl.ownerDocument.defaultView || window;
++      win.requestAnimationFrame(function () {
+         return scrollContainer(containerEl);
+       });
+     }
+@@ -2009,6 +2018,9 @@ function dndzone$2(node, options) {
+     // creating the draggable element
+     draggedEl = createDraggedElementFrom(originalDragTarget, centreDraggedOnCursor && currentMousePosition);
+     originDropZoneRoot.appendChild(draggedEl);
++    // The zone may live in another window (e.g. an Electron popout); its own window's
++    // animation frames keep running while the main window is hidden or occluded.
++    var originWindow = originalDragTarget.ownerDocument.defaultView || window;
+     // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after the framework removes it
+     function keepOriginalElementInDom() {
+       // Once the drop starts finalizing, handleDrop has stopped observation and this loop
+@@ -2026,10 +2038,10 @@ function dndzone$2(node, options) {
+         // to prevent the outline from disappearing
+         draggedEl.focus();
+       } else {
+-        window.requestAnimationFrame(keepOriginalElementInDom);
++        originWindow.requestAnimationFrame(keepOriginalElementInDom);
+       }
+     }
+-    window.requestAnimationFrame(keepOriginalElementInDom);
++    originWindow.requestAnimationFrame(keepOriginalElementInDom);
+     styleActiveDropZones(Array.from(typeToDropZones$1.get(config.type)).filter(function (dz) {
+       return dz === originDropZone || !dzToConfig$1.get(dz).dropFromOthersDisabled;
+     }), function (dz) {
+diff --git a/src/helpers/intersection.js b/src/helpers/intersection.js
+index 40c992ef019c59bc6959e5ff8bf7d41b7f3feae4..53feef88f437cf0cc3b558698a41d9e5148c5524 100644
+--- a/src/helpers/intersection.js
++++ b/src/helpers/intersection.js
+@@ -143,8 +143,19 @@ export function calcDistanceFromPointToCenter(point, el) {
+  * @returns {boolean} - true if the element in its entirety is off-screen including the scrollable area (the normal dom events look at the mouse rather than the element)
+  */
+ export function isElementOffDocument(el) {
+-    const rect = getAbsoluteRect(el);
+-    return rect.right < 0 || rect.left > document.documentElement.scrollWidth || rect.bottom < 0 || rect.top > document.documentElement.scrollHeight;
++    // Measure against the element's own document: in a multi-window host (e.g. an Electron
++    // popout) the module-global `document` is a different, possibly smaller, window.
++    const doc = el.ownerDocument;
++    const win = doc.defaultView || window;
++    const rect = el.getBoundingClientRect();
++    const top = rect.top + win.scrollY;
++    const left = rect.left + win.scrollX;
++    return (
++        rect.right + win.scrollX < 0 ||
++        left > doc.documentElement.scrollWidth ||
++        rect.bottom + win.scrollY < 0 ||
++        top > doc.documentElement.scrollHeight
++    );
+ }
+ 
+ /**
+diff --git a/src/helpers/scroller.js b/src/helpers/scroller.js
+index d3d9e726a3ab1a277d535f1b3e95799011cd0eac..44eacbc829fd7e45479c07bfc2ee1088cf1076d8 100644
+--- a/src/helpers/scroller.js
++++ b/src/helpers/scroller.js
+@@ -16,7 +16,10 @@ export function makeScroller() {
+         const {directionObj, stepPx} = scrollingInfo;
+         if (directionObj) {
+             containerEl.scrollBy(directionObj.x * stepPx, directionObj.y * stepPx);
+-            window.requestAnimationFrame(() => scrollContainer(containerEl));
++            // Use the container's own window: the module-global window may be hidden/occluded
++            // (frames paused) while the container lives in a popout window.
++            const win = containerEl.ownerDocument.defaultView || window;
++            win.requestAnimationFrame(() => scrollContainer(containerEl));
+         }
+     }
+     function calcScrollStepPx(distancePx) {
+diff --git a/src/pointerAction.js b/src/pointerAction.js
+index 61408baedb77a6eb60ee772a5b161bed9b269013..e693cabe1c7d040ae8839137131a81f7648d4f8f 100644
+--- a/src/pointerAction.js
++++ b/src/pointerAction.js
+@@ -535,6 +535,9 @@ export function dndzone(node, options) {
+         // creating the draggable element
+         draggedEl = createDraggedElementFrom(originalDragTarget, centreDraggedOnCursor && currentMousePosition);
+         originDropZoneRoot.appendChild(draggedEl);
++        // The zone may live in another window (e.g. an Electron popout); its own window's
++        // animation frames keep running while the main window is hidden or occluded.
++        const originWindow = originalDragTarget.ownerDocument.defaultView || window;
+         // We will keep the original dom node in the dom because touch events keep firing on it, we want to re-add it after the framework removes it
+         function keepOriginalElementInDom() {
+             // Once the drop starts finalizing, handleDrop has stopped observation and this loop
+@@ -552,10 +555,10 @@ export function dndzone(node, options) {
+                 // to prevent the outline from disappearing
+                 draggedEl.focus();
+             } else {
+-                window.requestAnimationFrame(keepOriginalElementInDom);
++                originWindow.requestAnimationFrame(keepOriginalElementInDom);
+             }
+         }
+-        window.requestAnimationFrame(keepOriginalElementInDom);
++        originWindow.requestAnimationFrame(keepOriginalElementInDom);
+ 
+         styleActiveDropZones(
+             Array.from(typeToDropZones.get(config.type)).filter(dz => dz === originDropZone || !dzToConfig.get(dz).dropFromOthersDisabled),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ overrides:
   obsidian-calendar-ui>svelte: ^5.56.3
   postcss: 8.5.25
 
+patchedDependencies:
+  svelte-dnd-action@0.9.79:
+    hash: bf197fcb7e108ea2eb73e1e2fb425297dbe2af136ada4d515964d300867abd1f
+    path: patches/svelte-dnd-action@0.9.79.patch
+
 importers:
 
   .:
@@ -27,7 +32,7 @@ importers:
         version: 0.5.68(@typescript-eslint/types@8.68.0)
       svelte-dnd-action:
         specifier: 0.9.79
-        version: 0.9.79(svelte@5.56.10(@typescript-eslint/types@8.68.0))
+        version: 0.9.79(patch_hash=bf197fcb7e108ea2eb73e1e2fb425297dbe2af136ada4d515964d300867abd1f)(svelte@5.56.10(@typescript-eslint/types@8.68.0))
       three-way-merge:
         specifier: ^0.1.0
         version: 0.1.0
@@ -3851,7 +3856,7 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-dnd-action@0.9.79(svelte@5.56.10(@typescript-eslint/types@8.68.0)):
+  svelte-dnd-action@0.9.79(patch_hash=bf197fcb7e108ea2eb73e1e2fb425297dbe2af136ada4d515964d300867abd1f)(svelte@5.56.10(@typescript-eslint/types@8.68.0)):
     dependencies:
       svelte: 5.56.10(@typescript-eslint/types@8.68.0)
 

--- a/tests/dnd-popout-window.test.ts
+++ b/tests/dnd-popout-window.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression coverage for patches/svelte-dnd-action@0.9.79.patch (issue #1730).
+ *
+ * Obsidian 1.13 can show Settings in a popout window while the main window is
+ * hidden. The drop zone then lives in a second document, but svelte-dnd-action
+ * keeps using the module-global `window`/`document` (the main window):
+ *  - the rAF that re-arms observation after Svelte removes the dragged item is
+ *    scheduled on the hidden main window, whose frames never fire, so the list
+ *    never reorders;
+ *  - the off-document check measures the clone against the main document, so a
+ *    drag positioned below the main window's height is finalized immediately.
+ *
+ * A jsdom iframe stands in for the popout: separate Window, separate Document,
+ * own requestAnimationFrame. The main window's rAF is stubbed to never fire.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DRAGGED_ELEMENT_ID, TRIGGERS, dndzone } from "svelte-dnd-action";
+
+const ITEM_HEIGHT = 30;
+const ZONE_WIDTH = 200;
+const MAIN_DOCUMENT_HEIGHT = 800;
+const POPOUT_DOCUMENT_HEIGHT = 2000;
+const CURSOR = { x: 20, y: 45 };
+
+let frame: HTMLIFrameElement;
+let popoutWindow: Window & typeof globalThis;
+let popoutFrames: FrameRequestCallback[];
+let mainFrames: FrameRequestCallback[];
+let zone: HTMLElement;
+let action: { destroy?: () => void };
+let considerTriggers: string[];
+let finalizeTriggers: string[];
+let cloneTop = 0;
+
+function stackedRect(top: number, height: number, width = ZONE_WIDTH): DOMRect {
+	return {
+		top,
+		left: 0,
+		width,
+		height,
+		right: width,
+		bottom: top + height,
+		x: 0,
+		y: top,
+		toJSON: () => ({}),
+	};
+}
+
+function rectOf(el: Element): DOMRect {
+	if (el.id === DRAGGED_ELEMENT_ID) return stackedRect(cloneTop, ITEM_HEIGHT);
+	if (el === zone) return stackedRect(0, ITEM_HEIGHT * 3);
+	const slot = el.getAttribute("data-slot");
+	if (slot === null) return stackedRect(0, 0, 0);
+	return stackedRect(Number(slot) * ITEM_HEIGHT, ITEM_HEIGHT);
+}
+
+function setScrollHeight(doc: Document, value: number): void {
+	Object.defineProperty(doc.documentElement, "scrollHeight", {
+		value,
+		configurable: true,
+	});
+}
+
+function mouseMoveOnMainWindow(x: number, y: number): void {
+	window.dispatchEvent(
+		new MouseEvent("mousemove", { bubbles: true, clientX: x, clientY: y }),
+	);
+}
+
+function startDragOnFirstItem(): void {
+	zone.children[0].dispatchEvent(
+		new popoutWindow.MouseEvent("mousedown", {
+			bubbles: true,
+			cancelable: true,
+			button: 0,
+			clientX: CURSOR.x,
+			clientY: ITEM_HEIGHT / 2,
+		}),
+	);
+	mouseMoveOnMainWindow(CURSOR.x, CURSOR.y);
+}
+
+function svelteRemovesDraggedItem(): void {
+	zone.children[0].remove();
+}
+
+function flushFrames(frames: FrameRequestCallback[]): void {
+	for (const cb of frames.splice(0)) cb(0);
+}
+
+beforeEach(() => {
+	frame = document.createElement("iframe");
+	document.body.appendChild(frame);
+	popoutWindow = frame.contentWindow as Window & typeof globalThis;
+	const popoutDocument = popoutWindow.document;
+
+	popoutFrames = [];
+	mainFrames = [];
+	popoutWindow.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) =>
+		popoutFrames.push(cb),
+	);
+	vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) =>
+		mainFrames.push(cb),
+	);
+
+	popoutWindow.Element.prototype.getBoundingClientRect = function (
+		this: Element,
+	) {
+		return rectOf(this);
+	};
+	setScrollHeight(document, MAIN_DOCUMENT_HEIGHT);
+	setScrollHeight(popoutDocument, POPOUT_DOCUMENT_HEIGHT);
+	// jsdom has no document.scrollingElement; the library reads it while
+	// building its auto-scroller.
+	Object.defineProperty(document, "scrollingElement", {
+		value: document.documentElement,
+		configurable: true,
+	});
+
+	zone = popoutDocument.createElement("div");
+	for (const [slot, id] of ["a", "b", "c"].entries()) {
+		const item = popoutDocument.createElement("div");
+		item.setAttribute("data-slot", String(slot));
+		item.textContent = id;
+		zone.appendChild(item);
+	}
+	popoutDocument.body.appendChild(zone);
+
+	considerTriggers = [];
+	finalizeTriggers = [];
+	zone.addEventListener("consider", (e) =>
+		considerTriggers.push((e as CustomEvent).detail.info.trigger),
+	);
+	zone.addEventListener("finalize", (e) =>
+		finalizeTriggers.push((e as CustomEvent).detail.info.trigger),
+	);
+	cloneTop = 0;
+	action = dndzone(zone, {
+		items: [{ id: "a" }, { id: "b" }, { id: "c" }],
+		flipDurationMs: 0,
+		dropAnimationDisabled: true,
+		useCursorForDetection: true,
+	});
+});
+
+afterEach(() => {
+	window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+	action.destroy?.();
+	frame.remove();
+	vi.restoreAllMocks();
+	delete (document as { scrollingElement?: Element }).scrollingElement;
+	delete (document.documentElement as { scrollHeight?: number }).scrollHeight;
+});
+
+describe("svelte-dnd-action with the drop zone in a popout window", () => {
+	it("re-arms observation through the popout window's animation frames", () => {
+		startDragOnFirstItem();
+
+		expect(considerTriggers).toEqual([TRIGGERS.DRAG_STARTED]);
+		expect(popoutFrames).toHaveLength(1);
+		expect(mainFrames).toHaveLength(0);
+
+		const original = zone.children[0];
+		svelteRemovesDraggedItem();
+		flushFrames(popoutFrames);
+
+		expect(original.parentElement).toBe(popoutWindow.document.body);
+		expect(original.hasAttribute("data-is-dnd-original-dragged-item")).toBe(
+			true,
+		);
+		expect(considerTriggers).toEqual([
+			TRIGGERS.DRAG_STARTED,
+			TRIGGERS.DRAGGED_ENTERED,
+		]);
+	});
+
+	it("measures off-document against the popout document, not the main one", () => {
+		cloneTop = MAIN_DOCUMENT_HEIGHT + 100;
+		startDragOnFirstItem();
+		svelteRemovesDraggedItem();
+		// Flush both windows so this test isolates the off-document check from
+		// the rAF-window bug covered above.
+		flushFrames(popoutFrames);
+		flushFrames(mainFrames);
+
+		expect(finalizeTriggers).toEqual([]);
+		expect(
+			popoutWindow.document.getElementById(DRAGGED_ELEMENT_ID),
+		).not.toBeNull();
+		expect(considerTriggers).toContain(TRIGGERS.DRAGGED_ENTERED);
+	});
+});


### PR DESCRIPTION
Reordering choices (settings tab) or macro commands by drag-and-drop silently failed for users on Obsidian 1.13: the row lifted and followed the cursor, but the list never opened a gap and the item snapped back on drop.

Root cause is in `svelte-dnd-action@0.9.79`, not in QuickAdd's zones. Obsidian 1.13 opens Settings in a **popout window** by default (`Settings → Interface → Open settings in new window`). The library resolves `window`/`document` from module globals, i.e. QuickAdd's *main* window, while the drop zone lives in the popout's document:

- `handleDragStart` schedules `keepOriginalElementInDom` with the **main window's** `requestAnimationFrame`. When the main window is hidden or occluded (Windows occlusion tracking marks a fully covered window hidden; minimised windows everywhere), its frames are paused, `watchDraggedElement()` never runs, and no positional `consider` events are dispatched. That is exactly the reporter's screenshot: full-row clone (no `transformDraggedElement`), no gap, snap back.
- `isElementOffDocument` compared the clone against the **main** document's `scrollWidth/scrollHeight`. With a popout taller than the main window, any drag starting below the main window's height was treated as "left the document" and dropped immediately (with a `TypeError: Cannot read properties of undefined (reading 'style')`).
- The edge auto-scroller re-armed itself via the main window's `requestAnimationFrame` too.

This PR adds a pnpm patch (`patches/svelte-dnd-action@0.9.79.patch`) that resolves the window/document from the element (`ownerDocument.defaultView`) in those three places, and a Vitest regression test that drives the real library with a zone in a second jsdom window.

## Repro / verification (Linux, Obsidian 1.13.7, Xvfb + CDP)

Settings in popout (`settingsPopoutWindow: true`), main `BrowserWindow.hide()` → `document.visibilityState === "hidden"`, main `requestAnimationFrame` confirmed paused. Drag last row → top in the popout:

| | before fix | after fix |
|---|---|---|
| clone | full row, `class=""`, no pill | `qa-drag-clone` with pill |
| mid-drag order | unchanged, dragged row gone | reordered live |
| after drop / `settings.choices` | unchanged | persisted new order |

Also verified after the fix: popout taller than the main window, dragging a row positioned below the main window's height (previously aborted immediately) → reorders; edge auto-scroll in the popout with main hidden (`scrollTop 0 → 1144`); classic in-main-window Settings drag still reorders and persists. Not reproducible with Settings in the main window, Minimal theme, zoom, long lists, nested folders, real X11 input, or the 1.8.10 installer (Electron 34) — all tested before the popout lead.

## Notes for release / maintenance

- No QuickAdd source changes; `main.js` picks up the patched dependency on build.
- Dependabot bumps of `svelte-dnd-action` will fail `pnpm install` until the patch is re-created or dropped; see `patches/README.md`. Worth upstreaming to `isaacHagoel/svelte-dnd-action` (the `src/` hunks of the patch are the proposed change).
- Users can also work around it today by turning off `Settings → Interface → Open settings in new window`.

Fixes #1730


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed drag-and-drop behavior in popout windows when the main window is hidden.
  - Improved element visibility checks and animation handling across separate windows.
  - Restored reliable auto-scrolling and drop-zone updates in popout settings windows.

- **Documentation**
  - Added guidance for the popout-window compatibility fix, including troubleshooting information and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->