### PR TITLE
test(date): assert calendar origin offsets in local time

### DIFF
--- a/src/utils/resolveDateOrigin.test.ts
+++ b/src/utils/resolveDateOrigin.test.ts
@@ -21,13 +21,42 @@ beforeEach(() => {
 	vi.setSystemTime(new Date("2026-08-26T15:30:00"));
 });
 
+// Local Y-M-D H:m. startOf("day") is local midnight, so toISOString() is the
+// previous UTC day east of UTC.
+const localDay = (d: Date) => [
+	d.getFullYear(),
+	d.getMonth() + 1,
+	d.getDate(),
+	d.getHours(),
+	d.getMinutes(),
+];
+
 describe("addCalendarOffset", () => {
-	it("moves by week and month from the frozen now", () => {
-		const now = new Date("2026-08-26T15:30:00");
-		expect(addCalendarOffset(now, -1, "weeks").toISOString().startsWith("2026-08-19")).toBe(
-			true,
-		);
-		expect(addCalendarOffset(now, 1, "years").getFullYear()).toBe(2027);
+	it("moves by week and year to local midnight", () => {
+		const now = new Date(2026, 7, 26, 15, 30);
+		expect(localDay(addCalendarOffset(now, -1, "weeks"))).toEqual([
+			2026, 8, 19, 0, 0,
+		]);
+		expect(localDay(addCalendarOffset(now, 1, "years"))).toEqual([
+			2027, 8, 26, 0, 0,
+		]);
+	});
+
+	it("lands on local midnight across a DST change", () => {
+		// EU 2026-03-29 / 2026-10-25; US 2026-03-08 / 2026-11-01;
+		// Australia/Sydney 2026-04-05 / 2026-10-04.
+		expect(localDay(addCalendarOffset(new Date(2026, 2, 31, 15, 30), -1, "weeks"))).toEqual([
+			2026, 3, 24, 0, 0,
+		]);
+		expect(localDay(addCalendarOffset(new Date(2026, 10, 3, 15, 30), -1, "weeks"))).toEqual([
+			2026, 10, 27, 0, 0,
+		]);
+		expect(localDay(addCalendarOffset(new Date(2026, 9, 6, 15, 30), -1, "weeks"))).toEqual([
+			2026, 9, 29, 0, 0,
+		]);
+		expect(localDay(addCalendarOffset(new Date(2026, 3, 7, 15, 30), -1, "weeks"))).toEqual([
+			2026, 3, 31, 0, 0,
+		]);
 	});
 });
 


### PR DESCRIPTION
`addCalendarOffset` already snaps to local midnight via moment `startOf("day")`. The unit test asserted `toISOString().startsWith("2026-08-19")`, which is only true in UTC and UTC-west zones. East of UTC, local midnight on 19 Aug is still 18 Aug in UTC, so the test failed on a UTC+2 machine while CI (UTC) stayed green.

No production change. The DATE origin path formats with moment in local time (`getDate`), so users in Copenhagen, New York, and Sydney already got the intended calendar day, including across the 2026 DST switches those zones actually observe.

Assert local Y-M-D H:m instead, and cover week offsets that cross EU, US, and Australia/Sydney DST boundaries.

Verified `pnpm run test` (5250 passed) under `TZ=UTC`, `TZ=Europe/Copenhagen`, `TZ=America/New_York`, and `TZ=Australia/Sydney`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded calendar offset coverage across EU, US, and Australia/Sydney time zones.
  * Added validation for daylight-saving transitions and local-midnight behavior.
  * Updated assertions to verify local calendar components for week and year offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->