### PR TITLE
feat(template): drag-reorder specific-folder path list

### DIFF
--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -231,8 +231,10 @@ Pick one of four modes:
 - **Obsidian default** - use Obsidian's "Default location for new notes" setting.
 - **In a specific folder** - create the note in the folder(s) you configure
   below. One folder creates the note there; several folders open a suggester
-  asking which to use. An **Include subfolders** toggle (shown only in this
-  mode) lets the suggester offer the selected folders *and* their subfolders.
+  asking which to use. Drag a folder's handle, or focus the handle and press
+  ArrowUp / ArrowDown, to change the suggester order. An **Include subfolders**
+  toggle (shown only in this mode) lets the suggester offer the selected
+  folders *and* their subfolders.
 - **Same folder as current file** - create the note next to the currently active
   file (falls back to the vault root if no file is open).
 - **Ask for folder each time** - prompt you to pick any folder in the vault each

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -231,10 +231,11 @@ Pick one of four modes:
 - **Obsidian default** - use Obsidian's "Default location for new notes" setting.
 - **In a specific folder** - create the note in the folder(s) you configure
   below. One folder creates the note there; several folders open a suggester
-  asking which to use. Drag a folder's handle, or focus the handle and press
-  ArrowUp / ArrowDown, to change the suggester order. An **Include subfolders**
-  toggle (shown only in this mode) lets the suggester offer the selected
-  folders *and* their subfolders.
+  asking which to use. With **Include subfolders** off, drag a folder's handle,
+  or focus the handle and press ArrowUp / ArrowDown, to change the suggester
+  order. An **Include subfolders** toggle (shown only in this mode) lets the
+  suggester offer the selected folders *and* their subfolders in vault tree
+  order; configured-list order does not apply in that mode.
 - **Same folder as current file** - create the note next to the currently active
   file (falls back to the vault root if no file is open).
 - **Ask for folder each time** - prompt you to pick any folder in the vault each

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -233,9 +233,8 @@ Pick one of four modes:
   below. One folder creates the note there; several folders open a suggester
   asking which to use. Drag a folder's handle, or focus the handle and press
   ArrowUp / ArrowDown, to change the suggester order. An **Include subfolders**
-  toggle (shown only in this mode) also offers each selected folder's
-  subfolders (vault tree order within that folder); selected folders themselves
-  still follow the list order above.
+  toggle (shown only in this mode) lets the suggester offer the selected folders
+  *and* their subfolders.
 - **Same folder as current file** - create the note next to the currently active
   file (falls back to the vault root if no file is open).
 - **Ask for folder each time** - prompt you to pick any folder in the vault each

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -231,11 +231,11 @@ Pick one of four modes:
 - **Obsidian default** - use Obsidian's "Default location for new notes" setting.
 - **In a specific folder** - create the note in the folder(s) you configure
   below. One folder creates the note there; several folders open a suggester
-  asking which to use. With **Include subfolders** off, drag a folder's handle,
-  or focus the handle and press ArrowUp / ArrowDown, to change the suggester
-  order. An **Include subfolders** toggle (shown only in this mode) lets the
-  suggester offer the selected folders *and* their subfolders in vault tree
-  order; configured-list order does not apply in that mode.
+  asking which to use. Drag a folder's handle, or focus the handle and press
+  ArrowUp / ArrowDown, to change the suggester order. An **Include subfolders**
+  toggle (shown only in this mode) also offers each selected folder's
+  subfolders (vault tree order within that folder); selected folders themselves
+  still follow the list order above.
 - **Same folder as current file** - create the note next to the currently active
   file (falls back to the vault root if no file is open).
 - **Ask for folder each time** - prompt you to pick any folder in the vault each

--- a/src/engine/TemplateChoiceEngine.folderSorting.test.ts
+++ b/src/engine/TemplateChoiceEngine.folderSorting.test.ts
@@ -184,6 +184,36 @@ describe("TemplateChoiceEngine folder suggestions", () => {
 		]);
 	});
 
+	it("walks included subfolders in configured-root order", async () => {
+		const engine = createEngine(
+			createChoice({
+				folders: ["B", "A"],
+				chooseFromSubfolders: true,
+			}),
+			[
+				"A/B2",
+				"A",
+				"A/B1",
+				"B/C2",
+				"B",
+				"B/C1",
+				"C",
+			],
+		);
+
+		await engine.run();
+
+		expect(inputSuggestMock).toHaveBeenCalledTimes(1);
+		expect(getSuggestedItems()).toEqual([
+			"B",
+			"B/C1",
+			"B/C2",
+			"A",
+			"A/B1",
+			"A/B2",
+		]);
+	});
+
 	it("keeps the current-folder suggestion before sorted vault folders", async () => {
 		const engine = createEngine(
 			createChoice({

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -37,7 +37,7 @@ import {
 	failureReason,
 } from "./choiceOutcomeRecorder";
 import {
-	filterFolderPathsWithinRoots,
+	orderFolderPathsByConfiguredRoots,
 	sortFolderPathsByTree,
 } from "../utils/folder-sorting";
 import { normalizeFileOpening } from "../utils/fileOpeningDefaults";
@@ -721,7 +721,9 @@ export class TemplateChoiceEngine extends TemplateEngine {
 				getAllFolderPathsInVault(this.app),
 			);
 
-			const subfolders = filterFolderPathsWithinRoots(
+			// Walk configured roots in list order; tree-sort only within each root
+			// so FolderList reorder still ranks which root's subtree appears first.
+			const subfolders = orderFolderPathsByConfiguredRoots(
 				allFoldersInVault,
 				folders,
 			);

--- a/src/gui/ChoiceBuilder/FolderList.reorder.test.ts
+++ b/src/gui/ChoiceBuilder/FolderList.reorder.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { SHADOW_PLACEHOLDER_ITEM_ID, TRIGGERS } from "svelte-dnd-action";
+import FolderList from "./FolderList.svelte";
+
+type FolderItem = { id: string };
+
+const fireDnd = (
+	zone: Element,
+	type: "consider" | "finalize",
+	items: FolderItem[],
+	trigger: string,
+	id: string,
+) =>
+	fireEvent(
+		zone,
+		new CustomEvent(type, {
+			detail: { items, info: { trigger, id, source: "pointer" } },
+		}),
+	);
+
+const paths = (...ids: string[]): FolderItem[] => ids.map((id) => ({ id }));
+
+describe("FolderList reorder", () => {
+	it("does not call onChange from consider", async () => {
+		const onChange = vi.fn();
+		const { container } = render(FolderList, {
+			props: { folders: ["Notes", "Daily", "Inbox"], onChange },
+		});
+		const zone = container.querySelector(".qa-folder-list") as Element;
+
+		await fireDnd(
+			zone,
+			"consider",
+			[{ id: SHADOW_PLACEHOLDER_ITEM_ID }, { id: "Daily" }, { id: "Inbox" }],
+			TRIGGERS.DRAG_STARTED,
+			"Notes",
+		);
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("recovers membership when finalize is missing the dragged folder", async () => {
+		const onChange = vi.fn();
+		const { container } = render(FolderList, {
+			props: { folders: ["Notes", "Daily", "Inbox"], onChange },
+		});
+		const zone = container.querySelector(".qa-folder-list") as Element;
+
+		await fireDnd(
+			zone,
+			"consider",
+			[{ id: SHADOW_PLACEHOLDER_ITEM_ID }, { id: "Daily" }, { id: "Inbox" }],
+			TRIGGERS.DRAG_STARTED,
+			"Notes",
+		);
+		await fireDnd(
+			zone,
+			"finalize",
+			paths("Daily", "Inbox"),
+			TRIGGERS.DROPPED_INTO_ZONE,
+			"Notes",
+		);
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0]).toEqual(["Notes", "Daily", "Inbox"]);
+	});
+
+	it("commits a genuine reorder after the same drag start", async () => {
+		const onChange = vi.fn();
+		const { container } = render(FolderList, {
+			props: { folders: ["Notes", "Daily", "Inbox"], onChange },
+		});
+		const zone = container.querySelector(".qa-folder-list") as Element;
+
+		await fireDnd(
+			zone,
+			"consider",
+			[{ id: SHADOW_PLACEHOLDER_ITEM_ID }, { id: "Daily" }, { id: "Inbox" }],
+			TRIGGERS.DRAG_STARTED,
+			"Notes",
+		);
+		await fireDnd(
+			zone,
+			"finalize",
+			paths("Daily", "Notes", "Inbox"),
+			TRIGGERS.DROPPED_INTO_ZONE,
+			"Notes",
+		);
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0]).toEqual(["Daily", "Notes", "Inbox"]);
+	});
+
+	it("ArrowDown on a row's drag handle moves it down", async () => {
+		const onChange = vi.fn();
+		const { getByLabelText } = render(FolderList, {
+			props: { folders: ["Notes", "Daily", "Inbox"], onChange },
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Notes"), { key: "ArrowDown" });
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0]).toEqual(["Daily", "Notes", "Inbox"]);
+	});
+
+	it("ArrowUp on the last row moves it up", async () => {
+		const onChange = vi.fn();
+		const { getByLabelText } = render(FolderList, {
+			props: { folders: ["Notes", "Daily", "Inbox"], onChange },
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Inbox"), { key: "ArrowUp" });
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0]).toEqual(["Notes", "Inbox", "Daily"]);
+	});
+
+	it("clamps at the ends — ArrowUp on the first row is a no-op", async () => {
+		const onChange = vi.fn();
+		const { getByLabelText } = render(FolderList, {
+			props: { folders: ["Notes", "Daily"], onChange },
+		});
+
+		await fireEvent.keyDown(getByLabelText("Reorder Notes"), { key: "ArrowUp" });
+		await Promise.resolve();
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("trash reports the remaining folders through onChange", async () => {
+		const onChange = vi.fn();
+		const { getByLabelText } = render(FolderList, {
+			props: { folders: ["Notes", "Daily"], onChange },
+		});
+
+		await fireEvent.click(getByLabelText("Remove folder Notes"));
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0]).toEqual(["Daily"]);
+	});
+});

--- a/src/gui/ChoiceBuilder/FolderList.reorder.test.ts
+++ b/src/gui/ChoiceBuilder/FolderList.reorder.test.ts
@@ -66,6 +66,33 @@ describe("FolderList reorder", () => {
 		expect(onChange.mock.calls[0][0]).toEqual(["Notes", "Daily", "Inbox"]);
 	});
 
+
+	it("recovers membership at the placeholder index when it had already moved", async () => {
+		const onChange = vi.fn();
+		const { container } = render(FolderList, {
+			props: { folders: ["Notes", "Daily", "Inbox"], onChange },
+		});
+		const zone = container.querySelector(".qa-folder-list") as Element;
+
+		await fireDnd(
+			zone,
+			"consider",
+			[{ id: "Daily" }, { id: SHADOW_PLACEHOLDER_ITEM_ID }, { id: "Inbox" }],
+			TRIGGERS.DRAG_STARTED,
+			"Notes",
+		);
+		await fireDnd(
+			zone,
+			"finalize",
+			paths("Daily", "Inbox"),
+			TRIGGERS.DROPPED_INTO_ZONE,
+			"Notes",
+		);
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0]).toEqual(["Daily", "Notes", "Inbox"]);
+	});
+
 	it("commits a genuine reorder after the same drag start", async () => {
 		const onChange = vi.fn();
 		const { container } = render(FolderList, {
@@ -114,6 +141,38 @@ describe("FolderList reorder", () => {
 
 		expect(onChange).toHaveBeenCalledTimes(1);
 		expect(onChange.mock.calls[0][0]).toEqual(["Notes", "Inbox", "Daily"]);
+	});
+
+
+	it("keeps focus on the handle across successive ArrowDown presses", async () => {
+		let folders = ["Notes", "Daily", "Inbox"];
+		let view: ReturnType<typeof render>;
+		const onChange = vi.fn(async (next: string[]) => {
+			folders = next;
+			// Parent commits before the post-move tick so refocus targets the new DOM.
+			await view.rerender({ folders, onChange });
+		});
+		view = render(FolderList, {
+			props: { folders, onChange },
+		});
+
+		const first = view.getByLabelText("Reorder Notes") as HTMLElement;
+		first.focus();
+		await fireEvent.keyDown(first, { key: "ArrowDown" });
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0]).toEqual(["Daily", "Notes", "Inbox"]);
+
+		await vi.waitFor(() => {
+			expect(document.activeElement).toBe(
+				view.getByLabelText("Reorder Notes") as HTMLElement,
+			);
+		});
+
+		await fireEvent.keyDown(document.activeElement as HTMLElement, {
+			key: "ArrowDown",
+		});
+		expect(onChange).toHaveBeenCalledTimes(2);
+		expect(onChange.mock.calls[1][0]).toEqual(["Daily", "Inbox", "Notes"]);
 	});
 
 	it("clamps at the ends — ArrowUp on the first row is a no-op", async () => {

--- a/src/gui/ChoiceBuilder/FolderList.svelte
+++ b/src/gui/ChoiceBuilder/FolderList.svelte
@@ -1,40 +1,127 @@
 <script lang="ts">
-    import IconButton from "../components/IconButton.svelte";
-    import type { FolderListProps } from "./folderListProps.svelte";
+	import { Platform } from "obsidian";
+	import { alertToScreenReader, type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
+	import {
+		applyOrder,
+		baseDndOptions,
+		capturePlaceholderRecovery,
+		moveById,
+		type PlaceholderRecovery,
+		type Reorderable,
+		stripShadow,
+	} from "../shared/dndReorder";
+	import { createDragArming } from "../shared/dragArming.svelte";
+	import DragHandle from "../components/DragHandle.svelte";
+	import IconButton from "../components/IconButton.svelte";
+	import type { FolderListProps } from "./folderListProps.svelte";
 
-    let { folders, deleteFolder }: FolderListProps = $props();
+	interface FolderDragItem extends Reorderable {
+		id: string;
+	}
+
+	let { folders, onChange }: FolderListProps = $props();
+
+	const zoneId = $props.id();
+	const zoneType = `folder:${zoneId}`;
+	const isMobile = Platform.isMobile;
+	const drag = createDragArming();
+	const dragDisabled = $derived(!isMobile && !drag.armed);
+
+	function toItems(paths: readonly string[]): FolderDragItem[] {
+		return paths.map((id) => ({ id }));
+	}
+
+	let preview = $state<FolderDragItem[] | null>(null);
+	const items = $derived(preview ?? toItems(folders));
+
+	let placeholderRecovery: PlaceholderRecovery<FolderDragItem> | null = null;
+
+	function handleConsider(e: CustomEvent<DndEvent<FolderDragItem>>) {
+		drag.markStarted();
+		const reported = e.detail.items;
+		placeholderRecovery =
+			capturePlaceholderRecovery(reported, e.detail.info.id) ?? placeholderRecovery;
+		preview = stripShadow(reported);
+	}
+
+	function handleFinalize(e: CustomEvent<DndEvent<FolderDragItem>>) {
+		let next = stripShadow(e.detail.items);
+		const draggedId = e.detail.info.id;
+		if (
+			placeholderRecovery?.item.id === draggedId &&
+			!next.some((item) => item.id === draggedId)
+		) {
+			next = [...next];
+			next.splice(
+				Math.min(placeholderRecovery.index, next.length),
+				0,
+				placeholderRecovery.item,
+			);
+		}
+		onChange(applyOrder(toItems(folders), next).map((item) => item.id));
+		preview = null;
+		placeholderRecovery = null;
+		if (e.detail.info.source === SOURCES.POINTER) {
+			drag.reset();
+		}
+	}
+
+	function moveFolder(id: string, delta: -1 | 1) {
+		const next = moveById(toItems(folders), id, delta);
+		if (!next) return;
+		onChange(next.map((item) => item.id));
+		const target = next.findIndex((item) => item.id === id);
+		alertToScreenReader(`Moved ${id} to position ${target + 1} of ${next.length}`);
+	}
+
+	function removeFolder(path: string) {
+		onChange(folders.filter((folder) => folder !== path));
+	}
+
+	let startDrag = () => {
+		drag.startDrag();
+	};
 </script>
 
-<div class="quickAddFolderListGrid quickAddCommandList">
-    {#each folders as folder (folder)}
-        <div class="quickAddCommandListItem">
-            <span>{folder}</span>
-            <IconButton
-                iconId="trash-2"
-                label={`Remove folder ${folder}`}
-                onclick={() => deleteFolder(folder)}
-            />
-        </div>
-    {/each}
-</div>
+<ol
+	class="qa-folder-list"
+	use:dndzone={baseDndOptions({
+		items,
+		dragDisabled,
+		type: zoneType,
+		resolveLabel: (item) => item.id,
+	})}
+	onconsider={handleConsider}
+	onfinalize={handleFinalize}
+>
+	{#each stripShadow(items) as folder (folder.id)}
+		<li class="quickAddCommandListItem">
+			<span class="quickAddCommandLabel">{folder.id}</span>
+			<div class="quickAddCommandControls">
+				<IconButton
+					iconId="trash-2"
+					label={`Remove folder ${folder.id}`}
+					onclick={() => removeFolder(folder.id)}
+				/>
+				<DragHandle
+					label={`Reorder ${folder.id}`}
+					{dragDisabled}
+					onDragStart={startDrag}
+					onMoveUp={() => moveFolder(folder.id, -1)}
+					onMoveDown={() => moveFolder(folder.id, 1)}
+				/>
+			</div>
+		</li>
+	{/each}
+</ol>
 
 <style>
-.quickAddCommandListItem {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-@media (min-width: 768px) {
-     .quickAddFolderListGrid {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        column-gap: 20px;
-    }
-}
-
-.quickAddCommandList {
-    max-width: 50%;
-    margin: 12px auto;
-}
+	.qa-folder-list {
+		display: grid;
+		grid-template-columns: auto;
+		width: auto;
+		margin: 12px 0;
+		padding: 0;
+		list-style: none;
+	}
 </style>

--- a/src/gui/ChoiceBuilder/FolderList.svelte
+++ b/src/gui/ChoiceBuilder/FolderList.svelte
@@ -2,7 +2,6 @@
 	import { Platform } from "obsidian";
 	import { alertToScreenReader, type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
 	import {
-		applyOrder,
 		baseDndOptions,
 		capturePlaceholderRecovery,
 		moveById,
@@ -11,9 +10,15 @@
 		stripShadow,
 	} from "../shared/dndReorder";
 	import { createDragArming } from "../shared/dragArming.svelte";
+	import { refocusDragHandle } from "../shared/refocusDragHandle";
 	import DragHandle from "../components/DragHandle.svelte";
 	import IconButton from "../components/IconButton.svelte";
-	import type { FolderListProps } from "./folderListProps.svelte";
+
+	/** Committed membership + order; `onChange` fires once per completed edit. */
+	interface FolderListProps {
+		folders: readonly string[];
+		onChange: (next: string[]) => void;
+	}
 
 	interface FolderDragItem extends Reorderable {
 		id: string;
@@ -26,6 +31,8 @@
 	const isMobile = Platform.isMobile;
 	const drag = createDragArming();
 	const dragDisabled = $derived(!isMobile && !drag.armed);
+
+	let listEl: HTMLOListElement | undefined = $state();
 
 	function toItems(paths: readonly string[]): FolderDragItem[] {
 		return paths.map((id) => ({ id }));
@@ -47,6 +54,9 @@
 	function handleFinalize(e: CustomEvent<DndEvent<FolderDragItem>>) {
 		let next = stripShadow(e.detail.items);
 		const draggedId = e.detail.info.id;
+		// Mirror CommandList / ChoiceList: recover the dragged row if finalize
+		// omitted it during the placeholder window. Do not also re-rank against
+		// the pre-drag list — that can silently cancel an intended move.
 		if (
 			placeholderRecovery?.item.id === draggedId &&
 			!next.some((item) => item.id === draggedId)
@@ -58,7 +68,7 @@
 				placeholderRecovery.item,
 			);
 		}
-		onChange(applyOrder(toItems(folders), next).map((item) => item.id));
+		onChange(next.map((item) => item.id));
 		preview = null;
 		placeholderRecovery = null;
 		if (e.detail.info.source === SOURCES.POINTER) {
@@ -67,11 +77,13 @@
 	}
 
 	function moveFolder(id: string, delta: -1 | 1) {
+		const label = document.activeElement?.getAttribute("aria-label");
 		const next = moveById(toItems(folders), id, delta);
 		if (!next) return;
 		onChange(next.map((item) => item.id));
 		const target = next.findIndex((item) => item.id === id);
 		alertToScreenReader(`Moved ${id} to position ${target + 1} of ${next.length}`);
+		if (label) void refocusDragHandle(listEl, label);
 	}
 
 	function removeFolder(path: string) {
@@ -84,6 +96,7 @@
 </script>
 
 <ol
+	bind:this={listEl}
 	class="qa-folder-list"
 	use:dndzone={baseDndOptions({
 		items,

--- a/src/gui/ChoiceBuilder/FolderList.zoneType.test.ts
+++ b/src/gui/ChoiceBuilder/FolderList.zoneType.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type * as DndAction from "svelte-dnd-action";
+
+/**
+ * Two template builders can be open at once (nested choice inside a macro).
+ * svelte-dnd-action groups drop zones by `type` and hit-tests every zone in the
+ * group geometrically, so a shared `folder` type would let one list steal a
+ * drop from the other. The type is invisible in the DOM; wrap `dndzone` and
+ * record the options each list registers with.
+ *
+ * Own file because `vi.mock` is module-graph-wide.
+ */
+
+const registeredTypes: (string | undefined)[] = [];
+
+vi.mock("svelte-dnd-action", async () => {
+	const actual = await vi.importActual<typeof DndAction>("svelte-dnd-action");
+	return {
+		...actual,
+		dndzone: (node: HTMLElement, options: { type?: string }) => {
+			registeredTypes.push(options?.type);
+			return actual.dndzone(node, options as never);
+		},
+	};
+});
+
+import { render } from "@testing-library/svelte";
+import FolderList from "./FolderList.svelte";
+
+describe("FolderList's drop-zone type", () => {
+	it("is unique per list, so two folder lists are never targets for each other", () => {
+		registeredTypes.length = 0;
+
+		render(FolderList, {
+			props: { folders: ["Notes"], onChange: vi.fn() },
+		});
+		render(FolderList, {
+			props: { folders: ["Daily"], onChange: vi.fn() },
+		});
+
+		expect(registeredTypes).toHaveLength(2);
+		expect(registeredTypes).not.toContain("folder");
+		expect(registeredTypes[0]).not.toBe(registeredTypes[1]);
+		for (const type of registeredTypes) {
+			expect(type).toMatch(/^folder:/);
+		}
+	});
+});

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -277,7 +277,7 @@ function onModeChange(value: string) {
 
 	<SettingItem
 		name="Include subfolders"
-		desc="Get prompted to choose from both the selected folders and their subfolders when creating the note."
+		desc="Prompt for the selected folders and their subfolders in vault tree order. The folder list order above does not apply while this is on."
 	>
 		{#snippet control()}
 			<Toggle bind:checked={choice.folder.chooseFromSubfolders} />

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -155,10 +155,6 @@ function addFolder() {
 	folderInputValue = "";
 }
 
-function deleteFolder(folder: string) {
-	choice.folder.folders = choice.folder.folders.filter((f) => f !== folder);
-}
-
 function onFolderInputKeypress(event: KeyboardEvent) {
 	if (event.key === "Enter") addFolder();
 }
@@ -253,7 +249,10 @@ function onModeChange(value: string) {
 {#if folderMode === "specified"}
 	<div class="folderSelectionContainer">
 		<div class="folderList">
-			<FolderList folders={choice.folder.folders} {deleteFolder} />
+			<FolderList
+				folders={choice.folder.folders}
+				onChange={(next) => (choice.folder.folders = next)}
+			/>
 		</div>
 		<div class="folderInputContainer">
 			<input

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -277,7 +277,7 @@ function onModeChange(value: string) {
 
 	<SettingItem
 		name="Include subfolders"
-		desc="Prompt for the selected folders and their subfolders in vault tree order. The folder list order above does not apply while this is on."
+		desc="Prompt for the selected folders and their subfolders. Each selected folder's subtree stays in vault tree order; the selected folders themselves keep the list order above."
 	>
 		{#snippet control()}
 			<Toggle bind:checked={choice.folder.chooseFromSubfolders} />

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -277,7 +277,7 @@ function onModeChange(value: string) {
 
 	<SettingItem
 		name="Include subfolders"
-		desc="Prompt for the selected folders and their subfolders. Each selected folder's subtree stays in vault tree order; the selected folders themselves keep the list order above."
+		desc="Get prompted to choose from both the selected folders and their subfolders when creating the note."
 	>
 		{#snippet control()}
 			<Toggle bind:checked={choice.folder.chooseFromSubfolders} />

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.test.ts
@@ -226,6 +226,21 @@ describe("TemplateChoiceForm", () => {
 		expect(container.querySelector(".qa-folder-path-input")).toBeNull();
 	});
 
+	it("writes FolderList onChange onto the choice.folder.folders proxy", async () => {
+		const { getByLabelText, props } = mountForm();
+		props.choice.folder.enabled = true;
+		props.choice.folder.folders = ["Notes", "Daily"];
+		flushSync();
+
+		await fireEvent.keyDown(getByLabelText("Reorder Notes"), { key: "ArrowDown" });
+		flushSync();
+		expect(props.choice.folder.folders).toEqual(["Daily", "Notes"]);
+
+		await fireEvent.click(getByLabelText("Remove folder Daily"));
+		flushSync();
+		expect(props.choice.folder.folders).toEqual(["Notes"]);
+	});
+
 	it("warns when 'specific folder' mode has no folders configured", () => {
 		const { container, props } = mountForm();
 		props.choice.folder.enabled = true; // -> specified mode, empty list

--- a/src/gui/ChoiceBuilder/folderListProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/folderListProps.svelte.ts
@@ -1,15 +1,9 @@
 /**
- * Props for FolderList, shared with its imperative host (templateChoiceBuilder).
- * The host owns a $state-backed instance and mutates `folders` to push add/remove
- * updates into the mounted component — replacing FolderList's old exported
- * `updateFolders()` bridge (which reassigned a prop, illegal under runes).
+ * Props for the template-choice folder path list.
+ * `folders` is committed membership + order; `onChange` fires once per completed
+ * edit (trash, drop finalize, ArrowUp/Down) and never from consider.
  */
 export interface FolderListProps {
-	folders: string[];
-	deleteFolder: (folder: string) => void;
-}
-
-export function createFolderListProps(initial: FolderListProps): FolderListProps {
-	const props = $state(initial);
-	return props;
+	folders: readonly string[];
+	onChange: (next: string[]) => void;
 }

--- a/src/gui/ChoiceBuilder/folderListProps.svelte.ts
+++ b/src/gui/ChoiceBuilder/folderListProps.svelte.ts
@@ -1,9 +1,0 @@
-/**
- * Props for the template-choice folder path list.
- * `folders` is committed membership + order; `onChange` fires once per completed
- * edit (trash, drop finalize, ArrowUp/Down) and never from consider.
- */
-export interface FolderListProps {
-	folders: readonly string[];
-	onChange: (next: string[]) => void;
-}

--- a/src/gui/MacroGUIs/CommandList.svelte
+++ b/src/gui/MacroGUIs/CommandList.svelte
@@ -2,7 +2,8 @@
 import type { ICommand } from "../../types/macros/ICommand";
 import { Platform } from "obsidian";
 import { alertToScreenReader, type DndEvent, dndzone, SOURCES } from "svelte-dnd-action";
-import { baseDndOptions, capturePlaceholderRecovery, type PlaceholderRecovery, replaceById, stripShadow } from "../shared/dndReorder";
+import { baseDndOptions, capturePlaceholderRecovery, moveById, type PlaceholderRecovery, replaceById, stripShadow } from "../shared/dndReorder";
+import { refocusDragHandle } from "../shared/refocusDragHandle";
 import { createDragArming } from "../shared/dragArming.svelte";
 import { getCommandDisplayName } from "../../utils/macroHelpers";
 import { snapshot } from "../svelte/persist.svelte";
@@ -102,6 +103,8 @@ const isMobile = Platform.isMobile;
 const drag = createDragArming();
 const dragDisabled = $derived(!isMobile && !drag.armed);
 
+let listEl: HTMLOListElement | undefined = $state();
+
 // Narrowing helpers: the {#each} discriminates on command.type, so each child
 // receives the matching subtype. Passed one-way — children report edits via the
 // onUpdateCommand / onConfigure* callbacks, not via two-way binding.
@@ -170,21 +173,20 @@ let startDrag = () => {
 function moveCommand(id: string, direction: -1 | 1) {
 	// `renderable`, not `commands`: stripShadow reads `item.id`, so the raw list
 	// would throw on the very hole the render filter exists to hide.
+	const label = document.activeElement?.getAttribute("aria-label");
 	const list = stripShadow(renderable);
-	const index = list.findIndex((c) => c.id === id);
-	if (index === -1) return;
-	const target = index + direction;
-	if (target < 0 || target >= list.length) return; // clamp at the ends
-	const next = [...list];
-	const [moved] = next.splice(index, 1);
-	next.splice(target, 0, moved);
+	const next = moveById(list, id, direction);
+	if (!next) return;
+	const target = next.findIndex((c) => c.id === id);
+	const moved = next[target];
 	commands = next;
 	persist();
 	// autoAriaDisabled silences the library's own move alerts, so announce the
 	// keyboard reorder ourselves.
 	alertToScreenReader(
-		`Moved ${getCommandDisplayName(moved)} to position ${target + 1} of ${list.length}`,
+		`Moved ${getCommandDisplayName(moved)} to position ${target + 1} of ${next.length}`,
 	);
+	if (label) void refocusDragHandle(listEl, label);
 }
 
 function updateCommand(command: ICommand) {
@@ -274,6 +276,7 @@ async function configureOpenFile(command: IOpenFileCommand) {
 </script>
 
 <ol
+	bind:this={listEl}
 	class="quickAddCommandList"
 	use:dndzone={baseDndOptions({
 		items: renderable,

--- a/src/gui/choiceList/ChoiceList.svelte
+++ b/src/gui/choiceList/ChoiceList.svelte
@@ -5,7 +5,8 @@
     import MultiChoiceListItem from "./MultiChoiceListItem.svelte";
     import { alertToScreenReader, type DndEvent, dndzone, TRIGGERS } from "svelte-dnd-action";
     import { flip } from "svelte/animate";
-    import { baseDndOptions, capturePlaceholderRecovery, type PlaceholderRecovery, stripShadow } from "../shared/dndReorder";
+    import { baseDndOptions, capturePlaceholderRecovery, moveById, type PlaceholderRecovery, stripShadow } from "../shared/dndReorder";
+    import { refocusDragHandle } from "../shared/refocusDragHandle";
     import { createDragArming } from "../shared/dragArming.svelte";
     import { Platform, type App } from "obsidian";
     import { isChoiceLike, rootChoicesOf } from "../../utils/choiceUtils";
@@ -93,6 +94,7 @@
     // filtering.
     const drag = createDragArming();
     const dragDisabled = $derived(forceDragDisabled || (!isMobile && !drag.armed));
+    let listEl: HTMLDivElement | undefined = $state();
 
     // The dragged choice, reconstructed from the last placeholder-id shadow that
     // stripShadow discarded (see capturePlaceholderRecovery: stripping it leaves
@@ -170,25 +172,24 @@
         if (forceDragDisabled) return; // never persist a filtered/derived list
         // `renderable`, not `choices`: stripShadow reads `item.id`, so the raw
         // list would throw on the very hole the render filter exists to hide.
+        const label = document.activeElement?.getAttribute("aria-label");
         const list = stripShadow(renderable);
-        const index = list.findIndex((c) => c.id === choice.id);
-        if (index === -1) return;
-        const target = index + direction;
-        if (target < 0 || target >= list.length) return; // clamp at the ends
-        const next = [...list];
-        const [moved] = next.splice(index, 1);
-        next.splice(target, 0, moved);
+        const next = moveById(list, choice.id, direction);
+        if (!next) return;
+        const target = next.findIndex((c) => c.id === choice.id);
         choices = next;
         actions.onReorderChoices(choices);
         // autoAriaDisabled silences the library's own move alerts, so announce the
         // keyboard reorder ourselves (cross-zone moves stay mouse-only).
         alertToScreenReader(
-            `Moved ${choice.name} to position ${target + 1} of ${list.length}`,
+            `Moved ${choice.name} to position ${target + 1} of ${next.length}`,
         );
+        if (label) void refocusDragHandle(listEl, label);
     }
 </script>
 
 <div
+        bind:this={listEl}
         use:dndzone={baseDndOptions({items: renderable, dragDisabled, flipDurationMs, dropTargetClasses: nested ? ["qa-folder-droptarget"] : []})}
         onconsider={handleConsider}
         onfinalize={handleSort}

--- a/src/gui/shared/dndReorder.test.ts
+++ b/src/gui/shared/dndReorder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SHADOW_PLACEHOLDER_ITEM_ID } from "svelte-dnd-action";
-import { baseDndOptions, replaceById, stripShadow } from "./dndReorder";
+import { applyOrder, baseDndOptions, moveById, replaceById, stripShadow } from "./dndReorder";
 
 const item = (id: string, extra: Record<string, unknown> = {}) => ({ id, ...extra });
 
@@ -56,6 +56,130 @@ describe("replaceById", () => {
 		const input = [item("a"), item("b")];
 		const out = replaceById(input, item("z", { v: 1 }));
 		expect(out.map((i) => i.id)).toEqual(["a", "b"]);
+	});
+});
+
+describe("applyOrder", () => {
+	const ids = (items: { id: string }[]) => items.map((i) => i.id);
+	const sameMultiset = (a: { id: string }[], b: { id: string }[]) => {
+		expect([...ids(a)].sort()).toEqual([...ids(b)].sort());
+		expect(a).toHaveLength(b.length);
+	};
+
+	it.each([
+		{
+			name: "keeps identity when reported matches current",
+			current: ["a", "b", "c"],
+			reported: ["a", "b", "c"],
+			expected: ["a", "b", "c"],
+		},
+		{
+			name: "applies a genuine reorder",
+			current: ["a", "b", "c"],
+			reported: ["b", "a", "c"],
+			expected: ["b", "a", "c"],
+		},
+		{
+			name: "restores an omitted item at its prior index, not appended",
+			current: ["a", "b", "c"],
+			reported: ["c", "a"],
+			expected: ["c", "b", "a"],
+		},
+		{
+			name: "restores several omitted items at their prior indexes",
+			current: ["a", "b", "c", "d"],
+			reported: ["d"],
+			expected: ["a", "b", "c", "d"],
+		},
+		{
+			name: "skips unknown ids",
+			current: ["a", "b"],
+			reported: ["x", "b", "a"],
+			expected: ["b", "a"],
+		},
+		{
+			name: "skips the shadow placeholder id",
+			current: ["a", "b", "c"],
+			reported: ["b", SHADOW_PLACEHOLDER_ITEM_ID, "c"],
+			expected: ["a", "b", "c"],
+		},
+		{
+			name: "takes each current id at most once when reported repeats it",
+			current: ["a", "b", "c"],
+			reported: ["c", "a", "c", "b"],
+			expected: ["c", "a", "b"],
+		},
+		{
+			name: "restores the full current list when reported is empty",
+			current: ["a", "b"],
+			reported: [],
+			expected: ["a", "b"],
+		},
+		{
+			name: "returns empty when current is empty",
+			current: [],
+			reported: ["a", "b"],
+			expected: [],
+		},
+	])("$name", ({ current, reported, expected }) => {
+		const currentItems = current.map((id) => item(id));
+		const reportedItems = reported.map((id) => item(id));
+		const out = applyOrder(currentItems, reportedItems);
+		expect(ids(out)).toEqual(expected);
+		sameMultiset(out, currentItems);
+	});
+
+	it("returns the current objects, not the reported copies", () => {
+		const a = item("a", { v: 1 });
+		const b = item("b", { v: 2 });
+		const reportedA = item("a", { v: 99 });
+		const out = applyOrder([a, b], [b, reportedA]);
+		expect(out).toEqual([b, a]);
+		expect(out[1]).toBe(a);
+		expect((out[1] as { v?: number }).v).toBe(1);
+	});
+
+	it("returns a NEW array without mutating either input", () => {
+		const current = [item("a"), item("b")];
+		const reported = [item("b"), item("a")];
+		const out = applyOrder(current, reported);
+		expect(out).not.toBe(current);
+		expect(out).not.toBe(reported);
+		expect(ids(current)).toEqual(["a", "b"]);
+		expect(ids(reported)).toEqual(["b", "a"]);
+	});
+});
+
+describe("moveById", () => {
+	it("moves the item one step down", () => {
+		const a = item("a");
+		const b = item("b");
+		const c = item("c");
+		expect(moveById([a, b, c], "a", 1)?.map((i) => i.id)).toEqual(["b", "a", "c"]);
+	});
+
+	it("moves the item one step up", () => {
+		const a = item("a");
+		const b = item("b");
+		const c = item("c");
+		expect(moveById([a, b, c], "c", -1)?.map((i) => i.id)).toEqual(["a", "c", "b"]);
+	});
+
+	it("returns null when the move would leave the list", () => {
+		const input = [item("a"), item("b")];
+		expect(moveById(input, "a", -1)).toBeNull();
+		expect(moveById(input, "b", 1)).toBeNull();
+	});
+
+	it("returns null for an unknown id", () => {
+		expect(moveById([item("a"), item("b")], "z", 1)).toBeNull();
+	});
+
+	it("returns a NEW array without mutating the input", () => {
+		const input = [item("a"), item("b")];
+		const out = moveById(input, "a", 1);
+		expect(out).not.toBe(input);
+		expect(input.map((i) => i.id)).toEqual(["a", "b"]);
 	});
 });
 

--- a/src/gui/shared/dndReorder.test.ts
+++ b/src/gui/shared/dndReorder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SHADOW_PLACEHOLDER_ITEM_ID } from "svelte-dnd-action";
-import { applyOrder, baseDndOptions, moveById, replaceById, stripShadow } from "./dndReorder";
+import { baseDndOptions, moveById, replaceById, stripShadow } from "./dndReorder";
 
 const item = (id: string, extra: Record<string, unknown> = {}) => ({ id, ...extra });
 
@@ -56,97 +56,6 @@ describe("replaceById", () => {
 		const input = [item("a"), item("b")];
 		const out = replaceById(input, item("z", { v: 1 }));
 		expect(out.map((i) => i.id)).toEqual(["a", "b"]);
-	});
-});
-
-describe("applyOrder", () => {
-	const ids = (items: { id: string }[]) => items.map((i) => i.id);
-	const sameMultiset = (a: { id: string }[], b: { id: string }[]) => {
-		expect([...ids(a)].sort()).toEqual([...ids(b)].sort());
-		expect(a).toHaveLength(b.length);
-	};
-
-	it.each([
-		{
-			name: "keeps identity when reported matches current",
-			current: ["a", "b", "c"],
-			reported: ["a", "b", "c"],
-			expected: ["a", "b", "c"],
-		},
-		{
-			name: "applies a genuine reorder",
-			current: ["a", "b", "c"],
-			reported: ["b", "a", "c"],
-			expected: ["b", "a", "c"],
-		},
-		{
-			name: "restores an omitted item at its prior index, not appended",
-			current: ["a", "b", "c"],
-			reported: ["c", "a"],
-			expected: ["c", "b", "a"],
-		},
-		{
-			name: "restores several omitted items at their prior indexes",
-			current: ["a", "b", "c", "d"],
-			reported: ["d"],
-			expected: ["a", "b", "c", "d"],
-		},
-		{
-			name: "skips unknown ids",
-			current: ["a", "b"],
-			reported: ["x", "b", "a"],
-			expected: ["b", "a"],
-		},
-		{
-			name: "skips the shadow placeholder id",
-			current: ["a", "b", "c"],
-			reported: ["b", SHADOW_PLACEHOLDER_ITEM_ID, "c"],
-			expected: ["a", "b", "c"],
-		},
-		{
-			name: "takes each current id at most once when reported repeats it",
-			current: ["a", "b", "c"],
-			reported: ["c", "a", "c", "b"],
-			expected: ["c", "a", "b"],
-		},
-		{
-			name: "restores the full current list when reported is empty",
-			current: ["a", "b"],
-			reported: [],
-			expected: ["a", "b"],
-		},
-		{
-			name: "returns empty when current is empty",
-			current: [],
-			reported: ["a", "b"],
-			expected: [],
-		},
-	])("$name", ({ current, reported, expected }) => {
-		const currentItems = current.map((id) => item(id));
-		const reportedItems = reported.map((id) => item(id));
-		const out = applyOrder(currentItems, reportedItems);
-		expect(ids(out)).toEqual(expected);
-		sameMultiset(out, currentItems);
-	});
-
-	it("returns the current objects, not the reported copies", () => {
-		const a = item("a", { v: 1 });
-		const b = item("b", { v: 2 });
-		const reportedA = item("a", { v: 99 });
-		const out = applyOrder([a, b], [b, reportedA]);
-		expect(out).toEqual([b, a]);
-		expect(out[1]).toBe(a);
-		expect((out[1] as { v?: number }).v).toBe(1);
-	});
-
-	it("returns a NEW array without mutating either input", () => {
-		const current = [item("a"), item("b")];
-		const reported = [item("b"), item("a")];
-		const out = applyOrder(current, reported);
-		expect(out).not.toBe(current);
-		expect(out).not.toBe(reported);
-		expect(ids(current)).toEqual(["a", "b"]);
-		expect(ids(reported)).toEqual(["b", "a"]);
 	});
 });
 

--- a/src/gui/shared/dndReorder.ts
+++ b/src/gui/shared/dndReorder.ts
@@ -61,6 +61,60 @@ export function replaceById<T extends Reorderable>(
 }
 
 /**
+ * Treat `reported` as a ranking request over `current`. Skip unknown ids
+ * (including the library shadow). Take each current id at most once. Any
+ * current item omitted from reported is restored at its prior index, not
+ * appended, so a placeholder-window drop cannot drop membership.
+ * POSTCONDITION: the result is the same multiset as `current`.
+ */
+export function applyOrder<T extends Reorderable>(
+	current: readonly T[],
+	reported: readonly T[],
+): T[] {
+	const firstById = new Map<string, T>();
+	for (const item of current) {
+		if (!firstById.has(item.id)) firstById.set(item.id, item);
+	}
+
+	const usedIds = new Set<string>();
+	const ranked: T[] = [];
+	for (const item of reported) {
+		if (usedIds.has(item.id)) continue;
+		const match = firstById.get(item.id);
+		if (!match) continue;
+		ranked.push(match);
+		usedIds.add(item.id);
+	}
+
+	const usedItems = new Set(ranked);
+	const result = [...ranked];
+	current.forEach((item, priorIndex) => {
+		if (usedItems.has(item)) return;
+		result.splice(Math.min(priorIndex, result.length), 0, item);
+	});
+	return result;
+}
+
+/**
+ * Move the item with `id` by `delta` positions. Returns null when the id is
+ * unknown or the move would leave the list.
+ */
+export function moveById<T extends Reorderable>(
+	items: readonly T[],
+	id: string,
+	delta: number,
+): T[] | null {
+	const index = items.findIndex((item) => item.id === id);
+	if (index === -1) return null;
+	const target = index + delta;
+	if (target < 0 || target >= items.length || target === index) return null;
+	const next = [...items];
+	const [moved] = next.splice(index, 1);
+	next.splice(target, 0, moved);
+	return next;
+}
+
+/**
  * Shared svelte-dnd-action options for QuickAdd's two drag zones (choices view + macro
  * builder). These options are COUPLED and must move together (see dragPill.ts):
  *  - morphDisabled:true  <-> the custom pill (else the lib re-inflates the clone to

--- a/src/gui/shared/dndReorder.ts
+++ b/src/gui/shared/dndReorder.ts
@@ -61,41 +61,6 @@ export function replaceById<T extends Reorderable>(
 }
 
 /**
- * Treat `reported` as a ranking request over `current`. Skip unknown ids
- * (including the library shadow). Take each current id at most once. Any
- * current item omitted from reported is restored at its prior index, not
- * appended, so a placeholder-window drop cannot drop membership.
- * POSTCONDITION: the result is the same multiset as `current`.
- */
-export function applyOrder<T extends Reorderable>(
-	current: readonly T[],
-	reported: readonly T[],
-): T[] {
-	const firstById = new Map<string, T>();
-	for (const item of current) {
-		if (!firstById.has(item.id)) firstById.set(item.id, item);
-	}
-
-	const usedIds = new Set<string>();
-	const ranked: T[] = [];
-	for (const item of reported) {
-		if (usedIds.has(item.id)) continue;
-		const match = firstById.get(item.id);
-		if (!match) continue;
-		ranked.push(match);
-		usedIds.add(item.id);
-	}
-
-	const usedItems = new Set(ranked);
-	const result = [...ranked];
-	current.forEach((item, priorIndex) => {
-		if (usedItems.has(item)) return;
-		result.splice(Math.min(priorIndex, result.length), 0, item);
-	});
-	return result;
-}
-
-/**
  * Move the item with `id` by `delta` positions. Returns null when the id is
  * unknown or the move would leave the list.
  */

--- a/src/gui/shared/refocusDragHandle.ts
+++ b/src/gui/shared/refocusDragHandle.ts
@@ -12,7 +12,7 @@ export async function refocusDragHandle(
 	await tick();
 	if (!root) return;
 	const handle = root.querySelector(
-		`button[aria-label=${JSON.stringify(label)}]`,
+		`button[aria-label="${CSS.escape(label)}"]`,
 	) as HTMLButtonElement | null;
 	handle?.focus();
 }

--- a/src/gui/shared/refocusDragHandle.ts
+++ b/src/gui/shared/refocusDragHandle.ts
@@ -1,0 +1,18 @@
+import { tick } from "svelte";
+
+/**
+ * After a keyboard reorder the row's `<li>` is remounted and Chromium blurs
+ * the handle, so a second ArrowUp/Down is a no-op. Wait a tick, then put
+ * focus back on the handle that still owns `label`.
+ */
+export async function refocusDragHandle(
+	root: ParentNode | null | undefined,
+	label: string,
+): Promise<void> {
+	await tick();
+	if (!root) return;
+	const handle = root.querySelector(
+		`button[aria-label=${JSON.stringify(label)}]`,
+	) as HTMLButtonElement | null;
+	handle?.focus();
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -563,8 +563,10 @@
 .quickAddModal .qa-folder-mode-warning {
 	color: var(--text-warning);
 	font-size: var(--font-ui-smaller);
-	margin: 0 auto 12px;
-	max-width: 50%;
+	margin: 0 0 12px;
+	max-width: none;
+	width: 100%;
+	text-align: left;
 }
 
 .quickAddModal .qa-template-format-input {

--- a/src/utils/folder-sorting.test.ts
+++ b/src/utils/folder-sorting.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	filterFolderPathsWithinRoots,
 	isFolderPathWithinRoot,
+	orderFolderPathsByConfiguredRoots,
 	sortFolderPathsByTree,
 } from "./folder-sorting";
 
@@ -83,5 +84,35 @@ describe("filterFolderPathsWithinRoots", () => {
 				["A"],
 			),
 		).toEqual(["A", "A/B1", "A/B1/C1"]);
+	});
+});
+
+
+describe("orderFolderPathsByConfiguredRoots", () => {
+	it("emits each root's subtree in configured-root order", () => {
+		const treeSorted = [
+			"A",
+			"A/B1",
+			"A/B2",
+			"B",
+			"B/C1",
+			"B/C2",
+			"C",
+		];
+		expect(orderFolderPathsByConfiguredRoots(treeSorted, ["B", "A"])).toEqual([
+			"B",
+			"B/C1",
+			"B/C2",
+			"A",
+			"A/B1",
+			"A/B2",
+		]);
+	});
+
+	it("skips paths already emitted when roots overlap", () => {
+		const treeSorted = ["A", "A/B1", "A/B1/C1", "A/B2"];
+		expect(
+			orderFolderPathsByConfiguredRoots(treeSorted, ["A/B1", "A"]),
+		).toEqual(["A/B1", "A/B1/C1", "A", "A/B2"]);
 	});
 });

--- a/src/utils/folder-sorting.test.ts
+++ b/src/utils/folder-sorting.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-	filterFolderPathsWithinRoots,
 	isFolderPathWithinRoot,
 	orderFolderPathsByConfiguredRoots,
 	sortFolderPathsByTree,
@@ -75,18 +74,6 @@ describe("isFolderPathWithinRoot", () => {
 		expect(isFolderPathWithinRoot("/A2/B1/", "A/")).toBe(false);
 	});
 });
-
-describe("filterFolderPathsWithinRoots", () => {
-	it("keeps only roots and descendants without leaking sibling prefixes", () => {
-		expect(
-			filterFolderPathsWithinRoots(
-				["A", "A/B1", "A/B1/C1", "A2", "A2/B1", "B/B1"],
-				["A"],
-			),
-		).toEqual(["A", "A/B1", "A/B1/C1"]);
-	});
-});
-
 
 describe("orderFolderPathsByConfiguredRoots", () => {
 	it("emits each root's subtree in configured-root order", () => {

--- a/src/utils/folder-sorting.ts
+++ b/src/utils/folder-sorting.ts
@@ -62,3 +62,24 @@ export function filterFolderPathsWithinRoots(
 		roots.some((root) => isFolderPathWithinRoot(path, root)),
 	);
 }
+
+/**
+ * Keep each root's subtree in vault tree order, but emit those blocks in
+ * configured-root order. Overlapping roots skip paths already emitted.
+ */
+export function orderFolderPathsByConfiguredRoots(
+	treeSortedPaths: readonly string[],
+	roots: readonly string[],
+): string[] {
+	const result: string[] = [];
+	const seen = new Set<string>();
+	for (const root of roots) {
+		for (const path of treeSortedPaths) {
+			if (seen.has(path)) continue;
+			if (!isFolderPathWithinRoot(path, root)) continue;
+			result.push(path);
+			seen.add(path);
+		}
+	}
+	return result;
+}

--- a/src/utils/folder-sorting.ts
+++ b/src/utils/folder-sorting.ts
@@ -54,15 +54,6 @@ export function isFolderPathWithinRoot(path: string, root: string): boolean {
 	);
 }
 
-export function filterFolderPathsWithinRoots(
-	paths: string[],
-	roots: string[],
-): string[] {
-	return paths.filter((path) =>
-		roots.some((root) => isFolderPathWithinRoot(path, root)),
-	);
-}
-
 /**
  * Keep each root's subtree in vault tree order, but emit those blocks in
  * configured-root order. Overlapping roots skip paths already emitted.


### PR DESCRIPTION
## Why

Template choices that create notes in a specific folder store an ordered `folder.folders` path list. Users could only append or delete. Macro command lists and the choices list already support drag and keyboard reorder. [#1734](https://github.com/chhoumann/quickadd/issues/1734) asks for the same on this list so frequency-based order matches the runtime folder suggester.

## Scope

- Add `applyOrder` and `moveById` in `src/gui/shared/dndReorder.ts`.
- Rewrite `FolderList.svelte` as a controlled list: `folders` + `onChange`, local mid-drag preview, unique `folder:${id}` zone type, `DragHandle` + trash, single-column layout (drops the two-column 50% grid).
- Wire `TemplateChoiceForm.svelte` through `onChange`; remove `deleteFolder` and unused `createFolderListProps`.
- Tests for helpers, consider/finalize (including placeholder-window recovery), keyboard, zone isolation, and form proxy write-through.
- Docs one-liner under Template choice folder location.

Out of scope: `CommandList` / `ChoiceList` migration, schema change, settings-tab template folder paths.

## Tradeoffs

- Persist still happens on builder close (existing form proxy snapshot). Mid-drag never writes `choice.folder.folders`.
- `applyOrder` treats the library payload as a ranking request over current membership so a placeholder-window drop cannot drop a path. An omitted item restores at its prior index.
- No generic reorder session for one consumer.

## Blast Radius

Touches Template choice settings UI only when folder mode is "specific folder". Runtime `buildFolderSuggestions` already walks `folder.folders` in array order. No data migration. Mobile keeps whole-row long-press and hides the handle via existing `.quickAddCommandControls` CSS.

## Verification

- `pnpm exec vitest run` on FolderList + `dndReorder` suites: 46 passed.
- Full `pnpm test`: 5277 passed.
- `pnpm run build-with-lint`: tsc, ESLint, production esbuild succeeded.
- Obsidian 1.13.7 e2e: ArrowDown on `Reorder Alpha` then Done persisted `["Bravo","Alpha","Charlie"]`; trash removed Charlie. Log: `/opt/cursor/artifacts/folder-list-reorder-obsidian.log`.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Linked #1734
- [x] No release/migration impact (UI + pure helpers only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop and keyboard controls for reordering folders when configuring note locations.
  * Added folder removal controls and screen-reader feedback.
  * Preserved focus on drag handles after keyboard reordering.
  * Applied consistent keyboard reordering behavior to command and choice lists.
  * Folder suggestions now follow configured folder order, with subfolders sorted within each folder.

* **Documentation**
  * Clarified folder reordering controls and subfolder inclusion behavior.

* **Style**
  * Improved folder-mode warning layout for better readability.

* **Tests**
  * Added coverage for reordering, removal, keyboard navigation, focus retention, and folder ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->