### PR TITLE
feat(template): apply templates to selected existing notes

### DIFF
--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -108,6 +108,11 @@ Values are passed through exactly as provided. If a choice should ignore an
 accidental leading or trailing space for a specific placeholder, use `|trim` in
 that format string, for example `{{VALUE:project|trim}}`.
 
+For Template choices, passing `value` supplies the new note's name. It does not
+select an existing note from the discovery picker. The generated path follows
+the choice's file-exists behavior. To use **When selecting an existing note**,
+run interactively and select the offered note in the discovery prompt.
+
 ### Names the CLI reserves {#reserved-flag-names}
 
 The bare `key=value` form (pattern 2) ignores names that a command already uses

--- a/docs/src/content/docs/docs/Advanced/onePageInputs.md
+++ b/docs/src/content/docs/docs/Advanced/onePageInputs.md
@@ -55,8 +55,11 @@ Nested Macros inherit the enclosing Macro's override unless they have their own.
 
 When a Template searches existing notes before creating, the one-page form includes
 its note picker alongside the Macro's Capture fields. Choose an existing note or
-create a new one. Template fields appear only when creating; switching between
-notes keeps your drafts. Each Capture's anonymous `{{VALUE}}` has its own answer,
+create a new one. With **Open note**, Template fields appear only when creating.
+With an [existing-note update action](/docs/Choices/TemplateChoice/#search-existing),
+inputs needed by the template remain visible for the selected note. Inputs used
+only in the new note's name or folder stay hidden. Switching between notes keeps
+your drafts. Each Capture's anonymous `{{VALUE}}` has its own answer,
 separate from the note title. Named inputs such as `{{VALUE:details}}` remain shared.
 
 If that Template's override is **Never**, QuickAdd shows its note picker first.

--- a/docs/src/content/docs/docs/Choices/TemplateChoice.md
+++ b/docs/src/content/docs/docs/Choices/TemplateChoice.md
@@ -1,11 +1,12 @@
 ---
 title: Template
-description: "Create a new note from a template file: dynamic paths and file names, a destination folder, linking, and what to do when the note already exists"
+description: "Create or update a note from a template file: dynamic paths and file names, a destination folder, linking, and actions for existing notes"
 slug: docs/Choices/TemplateChoice
 ---
 
-A Template choice creates a **new note from a template file**. Press a hotkey,
-answer any prompts, and QuickAdd builds the note - filling in dates, your
+A Template choice creates a **new note from a template file** or applies a
+template to an existing note. Press a hotkey, answer any prompts, and QuickAdd
+builds the note - filling in dates, your
 answers, and links as it goes. Use it to spin up a book note, a meeting note, or
 a project page from a layout you keep once and reuse everywhere.
 
@@ -190,9 +191,35 @@ the default note-title prompt. It opens the same discovery-first picker used by
 **New note from template**: matching notes and unresolved wikilink targets appear
 while you type, so you can open an existing note instead of creating a duplicate.
 
-Selecting an existing note opens it unchanged and does **not** apply the
-template, append template content, insert links, or copy links. Selecting the
-explicit **Create new note** row continues with normal Template creation.
+**When selecting an existing note** controls what selecting a match does:
+
+| Action | Result |
+| --- | --- |
+| **Open note** | Opens the note unchanged. This is the default. |
+| **Append template to bottom** | Adds the template at the end of the note. |
+| **Insert template at top** | Adds the template below the note's frontmatter. |
+| **Replace entire note** | Replaces all content, including frontmatter, with the template. |
+
+Append and insert use the same [frontmatter merging](#update-existing-file)
+as the other template update actions. Applying a template to a selected note
+requires a Markdown template.
+The picker names the action beside each existing note, so an update is visible
+before you select it.
+
+The selected note keeps its path and name. QuickAdd skips **File Name Format**,
+**New note location**, and the new-note collision setting. `{{TITLE}}` and the
+anonymous `{{VALUE}}` use the selected note's basename, and `{{FOLDER}}` uses its
+folder. The template's other inputs still appear, including in the
+[one-page form](/docs/Advanced/onePageInputs/#choose-or-create-a-note).
+
+An update finishes before the next Macro step runs and follows the choice's
+linking, clipboard, and **Open** settings. **Open note** always opens the selected
+note without applying the template, inserting links, or copying links.
+
+Selecting **Create new note** or an unresolved wikilink target continues with
+normal Template creation. **If a new note's path already exists** handles any
+collision at that generated path. The standalone **New note from template**
+command keeps the **Open note** behavior for existing matches.
 
 ## Which day `{{DATE}}` is about {#date-origin}
 
@@ -378,6 +405,10 @@ main hotkey keeps using Which day.
 the target name is already there. The setting works in two steps: first pick a
 high-level behavior, then a follow-up field appears for the two behaviors that
 need a detail.
+
+With **Search existing notes before creating** enabled, this setting is called
+**If a new note's path already exists**. It applies to new-note creation.
+[Selecting an existing match](#search-existing) has its own action.
 
 - **If the target file already exists** - choose **Ask every time**, **Update
   existing file**, **Create another file**, or **Keep existing file**.

--- a/src/choiceExecutor.ts
+++ b/src/choiceExecutor.ts
@@ -284,6 +284,7 @@ export class ChoiceExecutor implements IChoiceExecutor {
 	private async applyDateOrigin(choice: IChoice): Promise<void> {
 		if (
 			isTemplateChoice(choice) &&
+			(choice.existingNoteAction ?? "open") === "open" &&
 			getPreparedTemplateNoteSelection(this, choice.id)?.kind === "existing" &&
 			shouldRunTemplateNoteDiscovery(
 				choice,

--- a/src/engine/TemplateChoiceEngine.discovery.test.ts
+++ b/src/engine/TemplateChoiceEngine.discovery.test.ts
@@ -204,6 +204,22 @@ describe("TemplateChoiceEngine note discovery", () => {
 		setTargetFolderPathMock.mockReset();
 	});
 
+	it.each(["Templates/Project.md", "/Templates/Project", "  /Templates/Project.md  "])
+	("rejects the selected template source using the engine's path resolution: %s", async (templatePath) => {
+		const context = buildEngine(choice({ templatePath, existingNoteAction: "overwrite" }));
+		const source = file("Templates/Project.md");
+		context.files.set(source.path, source);
+		context.contents.set(source.path, "Reusable {{VALUE:owner}}");
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({ kind: "existing", file: source });
+		await context.engine.run();
+		expect(context.choiceExecutor.signalAbort).toHaveBeenCalledWith(expect.objectContaining({
+			message: expect.stringContaining("own template source"),
+		}));
+		expect(context.app.vault.modify).not.toHaveBeenCalled();
+		expect(formatFileContentMock).not.toHaveBeenCalled();
+		expect(context.contents.get(source.path)).toBe("Reusable {{VALUE:owner}}");
+	});
+
 	it("opens an existing discovery result unchanged and skips template side effects", async () => {
 		const existing = file("People/Alice.md");
 		promptForTemplateNoteDiscoveryMock.mockResolvedValue({

--- a/src/engine/TemplateChoiceEngine.discovery.test.ts
+++ b/src/engine/TemplateChoiceEngine.discovery.test.ts
@@ -9,6 +9,8 @@ const {
 	openFileMock,
 	insertFileLinkMock,
 	copyFileLinkMock,
+	setTitleMock,
+	setTargetFolderPathMock,
 } = vi.hoisted(() => ({
 	formatFileNameMock: vi.fn<(format: string, prompt: string) => Promise<string>>(),
 	formatFileContentMock: vi.fn<() => Promise<string>>(),
@@ -17,14 +19,20 @@ const {
 	openFileMock: vi.fn(),
 	insertFileLinkMock: vi.fn(),
 	copyFileLinkMock: vi.fn(),
+	setTitleMock: vi.fn(),
+	setTargetFolderPathMock: vi.fn(),
 }));
 
 vi.mock("../formatters/completeFormatter", () => {
 	class CompleteFormatterMock {
 		setLinkToCurrentFileBehavior() {}
-		setTitle() {}
+		setTitle(title: string) { setTitleMock(title); }
 		setPromptRunContext() {}
-		setTargetFolderPath() {}
+		setTargetFolderPath(path: string) { setTargetFolderPathMock(path); }
+		getAnonymousValue() { return undefined; }
+		async withPromptScope<T>(_scope: string, _input: string, work: () => Promise<T>) {
+			return await work();
+		}
 		async formatFileName(format: string, prompt: string) {
 			return formatFileNameMock(format, prompt);
 		}
@@ -57,6 +65,9 @@ vi.mock("../utilityObsidian", () => ({
 	getTemplater: vi.fn(() => ({})),
 	overwriteTemplaterOnce: vi.fn(),
 	getAllFolderPathsInVault: vi.fn(() => []),
+	getTemplateFile: (app: App, path: string) => app.vault.getAbstractFileByPath(path),
+	templaterParseTemplate: async (_app: App, content: string) => content,
+	jumpToNextTemplaterCursorIfPossible: vi.fn(),
 	insertFileLinkToActiveView: insertFileLinkMock,
 	openExistingFileTab: openExistingFileTabMock,
 	openFile: openFileMock,
@@ -84,6 +95,7 @@ import { TFile, type App } from "obsidian";
 import { TemplateChoiceEngine } from "./TemplateChoiceEngine";
 import type ITemplateChoice from "../types/choices/ITemplateChoice";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
+import { promptCancelled } from "../errors/UserCancelError";
 
 function file(path: string): TFile {
 	const tfile = new TFile();
@@ -130,6 +142,9 @@ function buildEngine(
 	variables = new Map<string, unknown>(),
 ) {
 	const created = file("Created.md");
+	const template = file(templateChoice.templatePath);
+	const files = new Map([[template.path, template]]);
+	const contents = new Map([[template.path, "Template source"]]);
 	const app = {
 		workspace: {
 			getActiveFile: vi.fn(() => null),
@@ -142,11 +157,17 @@ function buildEngine(
 			adapter: {
 				exists: vi.fn(async () => false),
 			},
-			getAbstractFileByPath: vi.fn(() => null),
-			getFiles: vi.fn(() => []),
+			getAbstractFileByPath: vi.fn((path: string) => files.get(path) ?? null),
+			getFiles: vi.fn(() => [...files.values()]),
+			cachedRead: vi.fn(async (target: TFile) => contents.get(target.path) ?? ""),
 			createFolder: vi.fn(),
 			create: vi.fn(async () => created),
-			modify: vi.fn(),
+			modify: vi.fn(async (target: TFile, content: string) => { contents.set(target.path, content); }),
+			process: vi.fn(async (target: TFile, update: (content: string) => string) => {
+				const content = update(contents.get(target.path) ?? "");
+				contents.set(target.path, content);
+				return content;
+			}),
 		},
 	} as unknown as App;
 	const choiceExecutor: IChoiceExecutor = {
@@ -164,7 +185,7 @@ function buildEngine(
 		templateChoice,
 		choiceExecutor,
 	);
-	return { engine, app, choiceExecutor, created };
+	return { engine, app, choiceExecutor, created, files, contents };
 }
 
 describe("TemplateChoiceEngine note discovery", () => {
@@ -179,12 +200,14 @@ describe("TemplateChoiceEngine note discovery", () => {
 		openFileMock.mockReset();
 		insertFileLinkMock.mockReset();
 		copyFileLinkMock.mockReset();
+		setTitleMock.mockReset();
+		setTargetFolderPathMock.mockReset();
 	});
 
 	it("opens an existing discovery result unchanged and skips template side effects", async () => {
 		const existing = file("People/Alice.md");
 		promptForTemplateNoteDiscoveryMock.mockResolvedValue({
-			kind: "openExisting",
+			kind: "existing",
 			file: existing,
 		});
 		const { engine, app, choiceExecutor } = buildEngine(
@@ -218,6 +241,96 @@ describe("TemplateChoiceEngine note discovery", () => {
 			file: existing,
 			effect: "unchanged",
 		});
+	});
+
+	it.each([
+		["appendBottom", "---\nstatus: active\n---\nOriginal body\nUpdate"],
+		["appendTop", "---\nstatus: active\n---\nUpdate\nOriginal body"],
+		["overwrite", "Update"],
+	] as const)("applies %s to the selected file without creating or rerouting a note", async (action, expected) => {
+		const existing = file("People/Alice.md");
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({ kind: "existing", file: existing });
+		const { engine, app, choiceExecutor, files, contents } = buildEngine(choice({
+			existingNoteAction: action,
+			fileNameFormat: { enabled: true, format: "{{VALUE}}" },
+			folder: { ...choice().folder, enabled: true, folders: ["Wrong/{{VALUE:folderOnly}}"] },
+			fileExistsBehavior: { kind: "apply", mode: "duplicateSuffix" },
+			appendLink: true,
+			copyLinkToClipboard: true,
+			openFile: true,
+		}));
+		files.set(existing.path, existing);
+		contents.set(existing.path, "---\nstatus: active\n---\nOriginal body");
+		formatFileContentMock.mockImplementation(async () => {
+			expect(choiceExecutor.variables.get("value")).toBe("Alice");
+			return "Update";
+		});
+
+		await engine.run();
+
+		expect(contents.get(existing.path)).toBe(expected);
+		expect(formatFileContentMock).toHaveBeenCalledTimes(1);
+		expect(formatFileNameMock).not.toHaveBeenCalled();
+		expect(app.vault.createFolder).not.toHaveBeenCalled();
+		expect(app.vault.create).not.toHaveBeenCalled();
+		expect(app.vault.adapter.exists).not.toHaveBeenCalled();
+		expect(setTitleMock).toHaveBeenCalledWith("Alice");
+		expect(setTargetFolderPathMock).toHaveBeenCalledWith("People");
+		expect(choiceExecutor.variables.has("value")).toBe(false);
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledExactlyOnceWith({
+			status: "success", file: existing, effect: "changed",
+		});
+		expect(insertFileLinkMock).toHaveBeenCalledTimes(1);
+		expect(copyFileLinkMock).toHaveBeenCalledExactlyOnceWith(existing);
+		expect(openFileMock).toHaveBeenCalledWith(app, existing, expect.anything());
+	});
+
+	it.each(["appendBottom", "appendTop", "overwrite"] as const)("cancels %s before writing or running post-commit actions", async (action) => {
+		const existing = file("People/Alice.md");
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({ kind: "existing", file: existing });
+		const { engine, app, choiceExecutor, files, contents } = buildEngine(choice({
+			existingNoteAction: action, appendLink: true, copyLinkToClipboard: true, openFile: true,
+		}));
+		files.set(existing.path, existing);
+		contents.set(existing.path, "Keep this body");
+		const cancellation = promptCancelled();
+		formatFileContentMock.mockRejectedValue(cancellation);
+
+		await engine.run();
+
+		expect(contents.get(existing.path)).toBe("Keep this body");
+		expect(app.vault.modify).not.toHaveBeenCalled();
+		expect(app.vault.process).not.toHaveBeenCalled();
+		expect(app.vault.create).not.toHaveBeenCalled();
+		expect(choiceExecutor.signalAbort).toHaveBeenCalledExactlyOnceWith(cancellation);
+		expect(choiceExecutor.recordExecutionResult).not.toHaveBeenCalled();
+		expect(choiceExecutor.variables.has("value")).toBe(false);
+		expect(insertFileLinkMock).not.toHaveBeenCalled();
+		expect(copyFileLinkMock).not.toHaveBeenCalled();
+		expect(openFileMock).not.toHaveBeenCalled();
+	});
+
+	it.each(["appendBottom", "overwrite"] as const)("records a failed %s without post-commit actions", async (action) => {
+		const existing = file("People/Alice.md");
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({ kind: "existing", file: existing });
+		const { engine, app, choiceExecutor, contents } = buildEngine(choice({
+			existingNoteAction: action, appendLink: true, copyLinkToClipboard: true, openFile: true,
+		}));
+		contents.set(existing.path, "Keep this body");
+		formatFileContentMock.mockResolvedValue("Update");
+		vi.mocked(app.vault.modify).mockRejectedValue(new Error("Disk is read-only"));
+		vi.mocked(app.vault.process).mockRejectedValue(new Error("Disk is read-only"));
+
+		await engine.run();
+
+		expect(contents.get(existing.path)).toBe("Keep this body");
+		expect(choiceExecutor.recordExecutionResult).toHaveBeenCalledExactlyOnceWith({
+			status: "error", reason: expect.stringContaining("Disk is read-only"),
+		});
+		expect(choiceExecutor.variables.has("value")).toBe(false);
+		expect(insertFileLinkMock).not.toHaveBeenCalled();
+		expect(copyFileLinkMock).not.toHaveBeenCalled();
+		expect(openFileMock).not.toHaveBeenCalled();
 	});
 
 	it("seeds VALUE and continues through normal template creation for create rows", async () => {

--- a/src/engine/TemplateChoiceEngine.discovery.test.ts
+++ b/src/engine/TemplateChoiceEngine.discovery.test.ts
@@ -75,6 +75,7 @@ vi.mock("../utilityObsidian", () => ({
 
 vi.mock("../utils/fileLinks", () => ({
 	copyFileLinkToClipboard: copyFileLinkMock,
+	getAppendLinkDestinationFile: () => null,
 }));
 
 vi.mock("../gui/GenericSuggester/genericSuggester", () => ({
@@ -202,6 +203,25 @@ describe("TemplateChoiceEngine note discovery", () => {
 		copyFileLinkMock.mockReset();
 		setTitleMock.mockReset();
 		setTargetFolderPathMock.mockReset();
+	});
+
+	it.each(["open", "appendBottom"] as const)("validates a missing append-link target only when the selected action needs it: %s", async (action) => {
+		const context = buildEngine(choice({
+			existingNoteAction: action,
+			appendLink: { enabled: true, placement: "newLine", requireActiveFile: false, destination: { type: "specifiedFile", path: "Missing.md" } },
+		}));
+		const selected = file("Existing.md");
+		promptForTemplateNoteDiscoveryMock.mockResolvedValue({ kind: "existing", file: selected });
+		await context.engine.run();
+		if (action === "open") {
+			expect(openFileMock).toHaveBeenCalledWith(context.app, selected, expect.anything());
+			expect(context.choiceExecutor.recordExecutionResult).toHaveBeenCalledWith({ status: "success", file: selected, effect: "unchanged" });
+		} else {
+			expect(openFileMock).not.toHaveBeenCalled();
+			expect(context.choiceExecutor.recordExecutionResult).toHaveBeenCalledWith(expect.objectContaining({ status: "error", reason: expect.stringContaining("Append link target") }));
+		}
+		expect(formatFileContentMock).not.toHaveBeenCalled();
+		expect(context.app.vault.modify).not.toHaveBeenCalled();
 	});
 
 	it.each(["Templates/Project.md", "/Templates/Project", "  /Templates/Project.md  "])

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -103,7 +103,6 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					? "optional"
 					: "required",
 			);
-			if (!this.validateAppendLinkDestination(linkOptions)) return;
 
 			const format = this.choice.fileNameFormat.enabled
 				? this.choice.fileNameFormat.format
@@ -138,6 +137,8 @@ export class TemplateChoiceEngine extends TemplateEngine {
 					discoveryVaultRelativePath = discovery.vaultRelativePath ?? null;
 				}
 			}
+
+			if (!this.validateAppendLinkDestination(linkOptions)) return;
 
 			// Open-only discovery returns before evaluating the template source.
 			const templatePath = await this.resolveTemplateSourcePath(

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -57,6 +57,7 @@ import { MacroAbortError } from "../errors/MacroAbortError";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { handleMacroAbort } from "../utils/macroAbortHandler";
 import { parentFolderPath } from "../utils/pathUtils";
+import { getTemplateFile } from "../utils/templateFolderUtils";
 
 type NormalizedAppendLinkOptions = ReturnType<typeof normalizeAppendLinkOptions>;
 
@@ -142,6 +143,9 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			const templatePath = await this.resolveTemplateSourcePath(
 				this.choice.templatePath,
 			);
+			if (selectedUpdate && getTemplateFile(this.app, templatePath)?.path === selectedUpdate.file.path) {
+				throw new ChoiceAbortError("Cannot apply a template to its own template source.");
+			}
 
 			const targetFilePath = selectedUpdate?.file.path ?? await this.resolveNewNotePath({
 				templatePath, format, discoveryVaultRelativePath,

--- a/src/engine/TemplateChoiceEngine.ts
+++ b/src/engine/TemplateChoiceEngine.ts
@@ -1,13 +1,15 @@
 import type { App, WorkspaceLeaf } from "obsidian";
 import { Notice, TFile } from "obsidian";
 import invariant from "src/utils/invariant";
-import { VALUE_SYNTAX } from "../constants";
+import { VALUE_SYNTAX, BASE_FILE_EXTENSION_REGEX, CANVAS_FILE_EXTENSION_REGEX } from "../constants";
 import GenericSuggester from "../gui/GenericSuggester/genericSuggester";
 import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
 import type QuickAdd from "../main";
 import {
 	getFileExistsMode,
+	getExistingNoteAction,
+	type TemplateExistingNoteAction,
 	getPromptModes,
 	resolveCreateNewCollisionFilePath,
 	type FileExistsModeId,
@@ -84,6 +86,7 @@ export class TemplateChoiceEngine extends TemplateEngine {
 	public async run(): Promise<void> {
 		let restoreDiscoveryValue: (() => void) | null = null;
 		let discoveryVaultRelativePath: string | null = null;
+		let selectedUpdate: { file: TFile; mode: Exclude<TemplateExistingNoteAction, "open"> } | null = null;
 
 		try {
 			invariant(this.choice.templatePath, () => {
@@ -120,78 +123,29 @@ export class TemplateChoiceEngine extends TemplateEngine {
 						this.choice,
 						this.choiceExecutor,
 					);
-				if (discovery.kind === "openExisting") {
-					await this.openDiscoveredExistingNote(discovery.file);
-					// Opening a note is not writing one: this path exists precisely to
-					// AVOID creating a duplicate, so it leaves the vault byte-identical
-					// (#1615).
-					this.outcome.success(discovery.file, "unchanged");
-					return;
+				if (discovery.kind === "existing") {
+					const action = getExistingNoteAction(this.choice.existingNoteAction);
+					if (action === "open") {
+						await this.openDiscoveredExistingNote(discovery.file);
+						this.outcome.success(discovery.file, "unchanged");
+						return;
+					}
+					selectedUpdate = { file: discovery.file, mode: action };
+					restoreDiscoveryValue = this.setTemporaryValueVariable(discovery.file.basename);
+				} else {
+					restoreDiscoveryValue = this.setTemporaryValueVariable(discovery.title);
+					discoveryVaultRelativePath = discovery.vaultRelativePath ?? null;
 				}
-
-				restoreDiscoveryValue = this.setTemporaryValueVariable(discovery.title);
-				discoveryVaultRelativePath = discovery.vaultRelativePath ?? null;
 			}
 
-			// Resolve format tokens in the template path ONCE, after discovery has
-			// either selected "create" or been skipped. Existing-note discovery exits
-			// before any template-path prompt, folder creation, or template side effect.
+			// Open-only discovery returns before evaluating the template source.
 			const templatePath = await this.resolveTemplateSourcePath(
 				this.choice.templatePath,
 			);
 
-			let folderPath = "";
-
-			if (discoveryVaultRelativePath) {
-				folderPath = parentFolderPath(discoveryVaultRelativePath);
-			} else if (this.choice.folder.enabled) {
-				folderPath = await this.getFolderPath();
-			} else {
-				// Respect Obsidian's "Default location for new notes" setting
-				const parent = this.app.fileManager.getNewFileParent(
-					this.app.workspace.getActiveFile()?.path ?? "",
-				);
-				folderPath = parent === this.app.vault.getRoot() ? "" : parent.path;
-			}
-
-			// Make the resolved folder available to {{FOLDER}} in the file name.
-			this.formatter.setTargetFolderPath(folderPath);
-			// The title prompt below can say where the note will be created only
-			// when a folder is actually configured. With folder settings off the
-			// formatted name can reroute the note from the vault root
-			// (shouldTreatFormattedNameAsVaultRelativePath returns false as soon
-			// as folderEnabled), and the answer that reroutes it is the very one
-			// being typed - so Obsidian's default location is not something this
-			// prompt can promise.
-			if (this.choice.folder.enabled) {
-				this.formatter.setPromptRunContext({
-					destination: folderPath,
-					destinationKind: "folder",
-				});
-			}
-
-			const formattedName = discoveryVaultRelativePath
-				? discoveryVaultRelativePath
-				: await this.formatter.formatFileName(format, "noteTitle");
-			const routedName = normalizeGeneratedFilePath(formattedName, "File name");
-			const { fileName, strippedPrefix } = discoveryVaultRelativePath
-				? { fileName: routedName, strippedPrefix: false }
-				: this.stripDuplicateFolderPrefix(
-					routedName,
-					folderPath,
-				);
-			const treatAsVaultRelativePath =
-				this.shouldTreatFormattedNameAsVaultRelativePath(
-					routedName,
-					strippedPrefix,
-					this.choice.folder.enabled,
-				);
-
-			const targetFilePath = this.normalizeTemplateFilePath(
-				discoveryVaultRelativePath || treatAsVaultRelativePath ? "" : folderPath,
-				fileName,
-				templatePath,
-			);
+			const targetFilePath = selectedUpdate?.file.path ?? await this.resolveNewNotePath({
+				templatePath, format, discoveryVaultRelativePath,
+			});
 
 			let createdFile: TFile | null;
 			let shouldAutoOpen = false;
@@ -204,7 +158,19 @@ export class TemplateChoiceEngine extends TemplateEngine {
 			// inferred: it always writes, so `changed` can in principle over-report a
 			// write whose bytes happened to match, which is the harmless direction.
 			let effect: ChoiceEffect = "created";
-			if (await this.app.vault.adapter.exists(targetFilePath)) {
+			if (selectedUpdate) {
+				if (BASE_FILE_EXTENSION_REGEX.test(templatePath) || CANVAS_FILE_EXTENSION_REGEX.test(templatePath)) {
+					throw new ChoiceAbortError("Only Markdown templates can be applied to a selected note.");
+				}
+				createdFile = await this.applyExistingFileUpdate(
+					selectedUpdate.mode, selectedUpdate.file, templatePath, linkOptions,
+				);
+				if (!createdFile) {
+					this.failRun(this.lastTemplateFileFailure ?? `Could not apply template to '${targetFilePath}'.`, "none");
+					return;
+				}
+				effect = "changed";
+			} else if (await this.app.vault.adapter.exists(targetFilePath)) {
 				const modeId = await this.getSelectedFileExistsMode();
 				const mode = getFileExistsMode(modeId);
 				effect =
@@ -395,6 +361,65 @@ export class TemplateChoiceEngine extends TemplateEngine {
 		if (level === "warning") log.logWarning(message);
 		else if (level === "error") log.logError(message);
 		this.outcome.failure(message);
+	}
+
+	private async resolveNewNotePath({ templatePath, format, discoveryVaultRelativePath }: {
+		templatePath: string;
+		format: string;
+		discoveryVaultRelativePath: string | null;
+	}): Promise<string> {
+		let folderPath = "";
+
+		if (discoveryVaultRelativePath) {
+			folderPath = parentFolderPath(discoveryVaultRelativePath);
+		} else if (this.choice.folder.enabled) {
+			folderPath = await this.getFolderPath();
+		} else {
+			// Respect Obsidian's "Default location for new notes" setting
+			const parent = this.app.fileManager.getNewFileParent(
+				this.app.workspace.getActiveFile()?.path ?? "",
+			);
+			folderPath = parent === this.app.vault.getRoot() ? "" : parent.path;
+		}
+
+		// Make the resolved folder available to {{FOLDER}} in the file name.
+		this.formatter.setTargetFolderPath(folderPath);
+		// The title prompt below can say where the note will be created only
+		// when a folder is actually configured. With folder settings off the
+		// formatted name can reroute the note from the vault root
+		// (shouldTreatFormattedNameAsVaultRelativePath returns false as soon
+		// as folderEnabled), and the answer that reroutes it is the very one
+		// being typed - so Obsidian's default location is not something this
+		// prompt can promise.
+		if (this.choice.folder.enabled) {
+			this.formatter.setPromptRunContext({
+				destination: folderPath,
+				destinationKind: "folder",
+			});
+		}
+
+		const formattedName = discoveryVaultRelativePath
+			? discoveryVaultRelativePath
+			: await this.formatter.formatFileName(format, "noteTitle");
+		const routedName = normalizeGeneratedFilePath(formattedName, "File name");
+		const { fileName, strippedPrefix } = discoveryVaultRelativePath
+			? { fileName: routedName, strippedPrefix: false }
+			: this.stripDuplicateFolderPrefix(
+				routedName,
+				folderPath,
+			);
+		const treatAsVaultRelativePath =
+			this.shouldTreatFormattedNameAsVaultRelativePath(
+				routedName,
+				strippedPrefix,
+				this.choice.folder.enabled,
+			);
+
+		return this.normalizeTemplateFilePath(
+			discoveryVaultRelativePath || treatAsVaultRelativePath ? "" : folderPath,
+			fileName,
+			templatePath,
+		);
 	}
 
 	private setTemporaryValueVariable(value: string): () => void {

--- a/src/engine/promptForTemplateNoteDiscovery.ts
+++ b/src/engine/promptForTemplateNoteDiscovery.ts
@@ -10,9 +10,11 @@ import { renderNotePathSuggestion } from "src/gui/InputSuggester/renderNotePathS
 import { isCancellationError } from "src/utils/errorUtils";
 import { UserCancelError } from "src/errors/UserCancelError";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+import { existingNoteActionVerb } from "src/template/fileExistsPolicy";
 
 import {
 	buildDiscoveryCandidates,
+	createTemplateNoteSelection,
 	decodeTemplateNoteSelection,
 	resolveTemplateNoteSelection,
 	normalizedKey,
@@ -49,21 +51,23 @@ export async function promptForTemplateNoteDiscovery(
 	);
 
 	const placeholder = `Search notes or create ${choice.name}`;
+	const action = existingNoteActionVerb(choice.existingNoteAction);
 
 	try {
-		const selected = String(
-			await routePrompt(executor, {
-				remote: (provider) =>
-					promptEngineChoice(provider, {
+		const selected = await routePrompt(executor, {
+				remote: async (provider) => {
+					const result = await promptEngineChoice(provider, {
 						items: candidates.map((candidate) => ({
-							value: candidate.item,
-							title: candidate.title,
+							value: decodeTemplateNoteSelection(candidate.item),
+							title: candidate.renderPath && action !== "Open" ? `${action}: ${candidate.title}` : candidate.title,
 						})),
 						placeholder,
 						// "Create new note" - the whole point of the picker.
 						allowCustomInput: true,
 						what: "the note-discovery picker",
-					}),
+					});
+					return typeof result === "string" ? createTemplateNoteSelection(result) : result;
+				},
 				// A headless run never reaches here: `shouldRunTemplateNoteDiscovery`
 				// needs an unresolved `value`, which the CLI refuses up front as a
 				// missing input. Guarded anyway, so the branch cannot become a hang.
@@ -73,8 +77,8 @@ export async function promptForTemplateNoteDiscovery(
 							`Pass the note name (e.g. value-value=<name>), or re-run with the ui flag.`,
 					);
 				},
-				app: () =>
-					InputSuggester.Suggest(
+				app: async () => {
+					const result = await InputSuggester.Suggest(
 			app,
 			candidates.map((candidate) => candidate.display),
 			candidates.map((candidate) => candidate.item),
@@ -102,6 +106,7 @@ export async function promptForTemplateNoteDiscovery(
 							candidate.renderPath,
 							candidate.renderAlias,
 						);
+						if (action !== "Open") el.querySelector(".suggestion-title")?.prepend(`${action}: `);
 						return;
 					}
 					if (candidate.unresolvedTitle) {
@@ -109,11 +114,12 @@ export async function promptForTemplateNoteDiscovery(
 					}
 				},
 			},
-					),
-			}),
-		);
+					);
+					return candidateByItem.has(result) ? decodeTemplateNoteSelection(result) : createTemplateNoteSelection(result);
+				},
+			});
 
-		return resolveTemplateNoteSelection(app, decodeTemplateNoteSelection(selected));
+		return resolveTemplateNoteSelection(app, selected);
 	} catch (error) {
 		if (isCancellationError(error)) {
 			throw new UserCancelError("Input cancelled by user");

--- a/src/engine/promptForTemplateNoteDiscovery.ts
+++ b/src/engine/promptForTemplateNoteDiscovery.ts
@@ -1,12 +1,11 @@
 import type { App } from "obsidian";
-import InputSuggester from "src/gui/InputSuggester/inputSuggester";
+import { TemplateNoteDiscoveryModal } from "src/gui/TemplateNoteDiscoveryModal";
 import {
 	routePrompt,
 	type PromptRoutingContext,
 } from "../interactive/routePrompt";
 import { promptEngineChoice } from "../interactive/engineChoice";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
-import { renderNotePathSuggestion } from "src/gui/InputSuggester/renderNotePathSuggestion";
 import { isCancellationError } from "src/utils/errorUtils";
 import { UserCancelError } from "src/errors/UserCancelError";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
@@ -17,107 +16,45 @@ import {
 	createTemplateNoteSelection,
 	decodeTemplateNoteSelection,
 	resolveTemplateNoteSelection,
-	normalizedKey,
 	type TemplateNoteDiscoveryResult,
 } from "src/utils/templateNoteDiscovery";
-
-function renderUnresolvedSuggestion(el: HTMLElement, title: string): void {
-	el.addClass("mod-complex");
-	const content = el.createDiv({ cls: "suggestion-content" });
-	content.createDiv({ cls: "suggestion-title", text: title });
-	content.createDiv({ cls: "suggestion-note", text: "Unresolved link" });
-}
-
-function renderExistingSuggestion(
-	el: HTMLElement,
-	path: string,
-	alias?: string,
-): void {
-	renderNotePathSuggestion(el, path);
-	if (!alias) return;
-
-	const content = el.querySelector(".suggestion-content");
-	content?.createDiv({ cls: "suggestion-note", text: `Alias: ${alias}` });
-}
 
 export async function promptForTemplateNoteDiscovery(
 	app: App,
 	choice: ITemplateChoice,
 	executor: PromptRoutingContext,
 ): Promise<TemplateNoteDiscoveryResult> {
-	const { candidates, existingKeys } = buildDiscoveryCandidates(app, choice);
-	const candidateByItem = new Map(
-		candidates.map((candidate) => [candidate.item, candidate]),
-	);
+	const { candidates } = buildDiscoveryCandidates(app, choice);
 
 	const placeholder = `Search notes or create ${choice.name}`;
 	const action = existingNoteActionVerb(choice.existingNoteAction);
 
 	try {
 		const selected = await routePrompt(executor, {
-				remote: async (provider) => {
-					const result = await promptEngineChoice(provider, {
-						items: candidates.map((candidate) => ({
-							value: decodeTemplateNoteSelection(candidate.item),
-							title: candidate.renderPath && action !== "Open" ? `${action}: ${candidate.title}` : candidate.title,
-						})),
-						placeholder,
-						// "Create new note" - the whole point of the picker.
-						allowCustomInput: true,
-						what: "the note-discovery picker",
-					});
-					return typeof result === "string" ? createTemplateNoteSelection(result) : result;
-				},
-				// A headless run never reaches here: `shouldRunTemplateNoteDiscovery`
-				// needs an unresolved `value`, which the CLI refuses up front as a
-				// missing input. Guarded anyway, so the branch cannot become a hang.
-				headless: () => {
-					throw new ChoiceAbortError(
-						`'${choice.name}' needs to ask which note to open or create, but this run is non-interactive. ` +
-							`Pass the note name (e.g. value-value=<name>), or re-run with the ui flag.`,
-					);
-				},
-				app: async () => {
-					const result = await InputSuggester.Suggest(
-			app,
-			candidates.map((candidate) => candidate.display),
-			candidates.map((candidate) => candidate.item),
-			{
-				placeholder,
-				allowCustomValue: true,
-				customValueLabel: (value) => `Create new note: ${value}`,
-				valueExists: (value) => {
-					const key = normalizedKey(value);
-					return (
-						existingKeys.has(key) ||
-						candidates.some(
-							(candidate) =>
-								candidate.unresolvedTitle &&
-								normalizedKey(candidate.unresolvedTitle) === key,
-						)
-					);
-				},
-				renderItem: (item, el) => {
-					const candidate = candidateByItem.get(item);
-					if (!candidate) return;
-					if (candidate.renderPath) {
-						renderExistingSuggestion(
-							el,
-							candidate.renderPath,
-							candidate.renderAlias,
-						);
-						if (action !== "Open") el.querySelector(".suggestion-title")?.prepend(`${action}: `);
-						return;
-					}
-					if (candidate.unresolvedTitle) {
-						renderUnresolvedSuggestion(el, candidate.unresolvedTitle);
-					}
-				},
+			remote: async (provider) => {
+				const result = await promptEngineChoice(provider, {
+					items: candidates.map((candidate) => ({
+						value: decodeTemplateNoteSelection(candidate.item),
+						title: candidate.renderPath && action !== "Open" ? `${action}: ${candidate.title}` : candidate.title,
+					})),
+					placeholder,
+					// "Create new note" - the whole point of the picker.
+					allowCustomInput: true,
+					what: "the note-discovery picker",
+				});
+				return typeof result === "string" ? createTemplateNoteSelection(result) : result;
 			},
-					);
-					return candidateByItem.has(result) ? decodeTemplateNoteSelection(result) : createTemplateNoteSelection(result);
-				},
-			});
+			// A headless run never reaches here: `shouldRunTemplateNoteDiscovery`
+			// needs an unresolved `value`, which the CLI refuses up front as a
+			// missing input. Guarded anyway, so the branch cannot become a hang.
+			headless: () => {
+				throw new ChoiceAbortError(
+					`'${choice.name}' needs to ask which note to open or create, but this run is non-interactive. ` +
+						`Pass the note name (e.g. value-value=<name>), or re-run with the ui flag.`,
+				);
+			},
+			app: () => new TemplateNoteDiscoveryModal(app, choice, candidates).promise,
+		});
 
 		return resolveTemplateNoteSelection(app, selected);
 	} catch (error) {

--- a/src/engine/templateNoteDiscovery.audit-template.test.ts
+++ b/src/engine/templateNoteDiscovery.audit-template.test.ts
@@ -4,9 +4,9 @@ const { inputSuggestMock } = vi.hoisted(() => ({
 	inputSuggestMock: vi.fn(),
 }));
 
-vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
-	default: {
-		Suggest: inputSuggestMock,
+vi.mock("src/gui/TemplateNoteDiscoveryModal", () => ({
+	TemplateNoteDiscoveryModal: class {
+		promise = inputSuggestMock();
 	},
 }));
 
@@ -70,7 +70,7 @@ function app(files: TFile[] = []): App {
 	} as unknown as App;
 }
 
-describe("template note discovery — typed name vault-relative parity (audit)", () => {
+describe("template note discovery - typed name vault-relative parity (audit)", () => {
 	beforeEach(() => {
 		inputSuggestMock.mockReset();
 	});
@@ -80,7 +80,7 @@ describe("template note discovery — typed name vault-relative parity (audit)",
 		// existing note or unresolved link, so it flows through the typed
 		// custom-value branch. It must resolve like the unresolved-link branch
 		// (vault-relative), not anchor under the configured/default folder.
-		inputSuggestMock.mockResolvedValue("Projects/My New Note");
+		inputSuggestMock.mockResolvedValue({ kind: "create", title: "Projects/My New Note" });
 
 		const result = await promptForTemplateNoteDiscovery(app([]), choice(), IN_APP_RUN);
 
@@ -92,7 +92,7 @@ describe("template note discovery — typed name vault-relative parity (audit)",
 	});
 
 	it("leaves a plain typed name without a vault-relative path", async () => {
-		inputSuggestMock.mockResolvedValue("My New Note");
+		inputSuggestMock.mockResolvedValue({ kind: "create", title: "My New Note" });
 
 		const result = await promptForTemplateNoteDiscovery(app([]), choice(), IN_APP_RUN);
 

--- a/src/engine/templateNoteDiscovery.test.ts
+++ b/src/engine/templateNoteDiscovery.test.ts
@@ -19,6 +19,7 @@ import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { promptForTemplateNoteDiscovery } from "./promptForTemplateNoteDiscovery";
 import { shouldRunTemplateNoteDiscovery } from "src/utils/templateNoteDiscoveryEligibility";
 import { resolveTemplateNoteSelection, selectionForDiscoveryCandidate, testExports } from "src/utils/templateNoteDiscovery";
+import type { PromptProvider } from "src/interactive/promptProvider";
 // An ordinary in-app run: no interactive client attached and not headless, so the
 // picker opens the Obsidian modal - exactly the path these tests exercise.
 const IN_APP_RUN = {} as never;
@@ -106,7 +107,7 @@ describe("template note discovery", () => {
 		const files = [existing];
 		const obsidianApp = app(files);
 		const selection = selectionForDiscoveryCandidate(obsidianApp, "@quickadd-existing-note:Existing/Alice.md");
-		expect(resolveTemplateNoteSelection(obsidianApp, selection)).toEqual({ kind: "openExisting", file: existing });
+		expect(resolveTemplateNoteSelection(obsidianApp, selection)).toEqual({ kind: "existing", file: existing });
 		files.length = 0;
 		expect(() => resolveTemplateNoteSelection(obsidianApp, selection)).toThrow("Selected note no longer exists");
 	});
@@ -116,6 +117,32 @@ describe("template note discovery", () => {
 			.toEqual({ kind: "create", title: "Projects/Roadmap", vaultRelativePath: "Projects/Roadmap" });
 		expect(() => resolveTemplateNoteSelection(app(), { kind: "create", title: "../outside" }))
 			.toThrow();
+	});
+
+	it.each(["canvas", "base", "png"])("rejects a selected %s target", (extension) => {
+		const target = file(`Target.${extension}`);
+		target.extension = extension;
+		expect(() => resolveTemplateNoteSelection(app([target]), { kind: "existing", path: target.path }))
+			.toThrow("Select a Markdown note");
+	});
+
+	it("does not interpret a custom title as an unoffered existing-note handle", async () => {
+		inputSuggestMock.mockResolvedValue("@quickadd-existing-note:Templates/Project.md");
+		await expect(promptForTemplateNoteDiscovery(app([file("Templates/Project.md")]), choice(), IN_APP_RUN))
+			.resolves.toMatchObject({ kind: "create", title: "@quickadd-existing-note:Templates/Project.md" });
+	});
+
+	it("distinguishes a remote selected note from custom text matching its internal value", async () => {
+		const target = file("Existing/Alice.md");
+		const suggester = vi.fn<PromptProvider["suggester"]>();
+		const executor = { promptProvider: { suggester } as unknown as PromptProvider };
+		suggester.mockImplementation(async (_labels, items) => items[0]);
+		await expect(promptForTemplateNoteDiscovery(app([target]), choice({ existingNoteAction: "overwrite" }), executor))
+			.resolves.toEqual({ kind: "existing", file: target });
+		expect(suggester.mock.calls[0][0]).toEqual(expect.arrayContaining(["Replace: Alice (Existing/Alice.md)"]));
+		suggester.mockResolvedValue("@quickadd-existing-note:Existing/Alice.md");
+		await expect(promptForTemplateNoteDiscovery(app([target]), choice(), executor))
+			.resolves.toMatchObject({ kind: "create", title: "@quickadd-existing-note:Existing/Alice.md" });
 	});
 
 	it("only runs for opted-in default title prompts with no seeded value", () => {
@@ -212,7 +239,7 @@ describe("template note discovery", () => {
 
 		const result = await promptForTemplateNoteDiscovery(app([alice]), choice(), IN_APP_RUN);
 
-		expect(result).toEqual({ kind: "openExisting", file: alice });
+		expect(result).toEqual({ kind: "existing", file: alice });
 	});
 
 	it("returns a create result for unresolved-link rows", async () => {

--- a/src/engine/templateNoteDiscovery.test.ts
+++ b/src/engine/templateNoteDiscovery.test.ts
@@ -4,9 +4,10 @@ const { inputSuggestMock } = vi.hoisted(() => ({
 	inputSuggestMock: vi.fn(),
 }));
 
-vi.mock("src/gui/InputSuggester/inputSuggester", () => ({
-	default: {
-		Suggest: inputSuggestMock,
+vi.mock("src/gui/TemplateNoteDiscoveryModal", () => ({
+	TemplateNoteDiscoveryModal: class {
+		promise: Promise<unknown>;
+		constructor(...args: unknown[]) { this.promise = inputSuggestMock(...args); }
 	},
 }));
 
@@ -18,7 +19,7 @@ import { TFile, type App } from "obsidian";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { promptForTemplateNoteDiscovery } from "./promptForTemplateNoteDiscovery";
 import { shouldRunTemplateNoteDiscovery } from "src/utils/templateNoteDiscoveryEligibility";
-import { resolveTemplateNoteSelection, selectionForDiscoveryCandidate, testExports } from "src/utils/templateNoteDiscovery";
+import { decodeTemplateNoteSelection, resolveTemplateNoteSelection, selectionForDiscoveryCandidate, testExports, type DiscoveryCandidate } from "src/utils/templateNoteDiscovery";
 import type { PromptProvider } from "src/interactive/promptProvider";
 // An ordinary in-app run: no interactive client attached and not headless, so the
 // picker opens the Obsidian modal - exactly the path these tests exercise.
@@ -127,7 +128,7 @@ describe("template note discovery", () => {
 	});
 
 	it("does not interpret a custom title as an unoffered existing-note handle", async () => {
-		inputSuggestMock.mockResolvedValue("@quickadd-existing-note:Templates/Project.md");
+		inputSuggestMock.mockResolvedValue({ kind: "create", title: "@quickadd-existing-note:Templates/Project.md" });
 		await expect(promptForTemplateNoteDiscovery(app([file("Templates/Project.md")]), choice(), IN_APP_RUN))
 			.resolves.toMatchObject({ kind: "create", title: "@quickadd-existing-note:Templates/Project.md" });
 	});
@@ -235,7 +236,7 @@ describe("template note discovery", () => {
 
 	it("returns a tagged existing-file result when an existing row is selected", async () => {
 		const alice = file("People/Alice.md");
-		inputSuggestMock.mockImplementation(async (_app, _display, items) => items[0]);
+		inputSuggestMock.mockImplementation(async (_app, _choice, candidates: DiscoveryCandidate[]) => decodeTemplateNoteSelection(candidates[0].item));
 
 		const result = await promptForTemplateNoteDiscovery(app([alice]), choice(), IN_APP_RUN);
 
@@ -244,8 +245,8 @@ describe("template note discovery", () => {
 
 	it("returns a create result for unresolved-link rows", async () => {
 		const alice = file("People/Alice.md");
-		inputSuggestMock.mockImplementation(async (_app, _display, items) =>
-			items.find((item: string) => item.includes("Missing Project")),
+		inputSuggestMock.mockImplementation(async (_app, _choice, candidates: DiscoveryCandidate[]) =>
+			decodeTemplateNoteSelection(candidates.find(candidate => candidate.unresolvedTitle === "Missing Project")!.item),
 		);
 
 		const result = await promptForTemplateNoteDiscovery(app([alice]), choice(), IN_APP_RUN);
@@ -255,8 +256,8 @@ describe("template note discovery", () => {
 
 	it("tags foldered unresolved-link rows with a vault-relative target path", async () => {
 		const alice = file("People/Alice.md");
-		inputSuggestMock.mockImplementation(async (_app, _display, items) =>
-			items.find((item: string) => item.includes("Projects/Missing Roadmap")),
+		inputSuggestMock.mockImplementation(async (_app, _choice, candidates: DiscoveryCandidate[]) =>
+			decodeTemplateNoteSelection(candidates.find(candidate => candidate.unresolvedTitle === "Projects/Missing Roadmap")!.item),
 		);
 
 		const result = await promptForTemplateNoteDiscovery(app([alice]), choice(), IN_APP_RUN);
@@ -273,23 +274,11 @@ describe("template note discovery", () => {
 		const staleApp = app([alice]);
 		(staleApp.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>)
 			.mockReturnValueOnce(null);
-		inputSuggestMock.mockImplementation(async (_app, _display, items) => items[0]);
+		inputSuggestMock.mockImplementation(async (_app, _choice, candidates: DiscoveryCandidate[]) => decodeTemplateNoteSelection(candidates[0].item));
 
 		await expect(
 			promptForTemplateNoteDiscovery(staleApp, choice(), IN_APP_RUN),
 		).rejects.toThrow("Selected note no longer exists");
 	});
 
-	it("suppresses the generic create row for exact existing or unresolved names", async () => {
-		const alice = file("People/Alice.md");
-		inputSuggestMock.mockResolvedValue("Fresh Idea");
-
-		await promptForTemplateNoteDiscovery(app([alice]), choice(), IN_APP_RUN);
-
-		const options = inputSuggestMock.mock.calls[0]?.[3];
-		expect(options.valueExists("Alice")).toBe(true);
-		expect(options.valueExists("People/Alice")).toBe(true);
-		expect(options.valueExists("Missing Project")).toBe(true);
-		expect(options.valueExists("Fresh Idea")).toBe(false);
-	});
 });

--- a/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/TemplateChoiceForm.svelte
@@ -12,6 +12,7 @@ import {
 	getDefaultBehaviorForCategory,
 	getFileExistsMode,
 	getModesForCategory,
+	existingNoteActions,
 } from "../../template/fileExistsPolicy";
 import { log } from "../../logger/logManager";
 import { getAllFolderPathsInVault, getTemplateFile } from "../../utilityObsidian";
@@ -100,7 +101,7 @@ const discoverySupported = $derived(
 );
 const discoveryDescription = $derived(
 	discoverySupported
-		? "For the default note-title prompt, show matching notes first. Choosing one opens it unchanged; choosing the create row continues with this template."
+		? "Show matching notes and unresolved links in the note-title prompt."
 		: "Only available when the file name prompt is the default note title: no custom format, {{VALUE}}, or {{NAME}}.",
 );
 
@@ -319,8 +320,25 @@ function onModeChange(value: string) {
 	{/snippet}
 </SettingItem>
 
+{#if discoverySupported && choice.discoverExistingNotesBeforeCreate}
+	<SettingItem name="When selecting an existing note">
+		{#snippet control()}
+			<Dropdown
+				value={choice.existingNoteAction ?? "open"}
+				options={existingNoteActions.map((action) => ({ value: action.id, label: action.label }))}
+				onchange={(value) => {
+					const action = existingNoteActions.find((action) => action.id === value);
+					if (action) choice.existingNoteAction = action.id;
+				}}
+			/>
+		{/snippet}
+	</SettingItem>
+{/if}
+
 <SettingItem
-	name="If the target file already exists"
+	name={discoverySupported && choice.discoverExistingNotesBeforeCreate
+		? "If a new note's path already exists"
+		: "If the target file already exists"}
 	desc="Choose whether QuickAdd should ask what to do, update the existing file, create another file, or keep the existing file."
 >
 	{#snippet control()}

--- a/src/gui/TemplateNoteDiscoveryModal.test.ts
+++ b/src/gui/TemplateNoteDiscoveryModal.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { App } from "obsidian";
+import { TemplateChoice } from "src/types/choices/TemplateChoice";
+import type { DiscoveryCandidate } from "src/utils/templateNoteDiscovery";
+import { TemplateNoteDiscoveryModal } from "./TemplateNoteDiscoveryModal";
+
+const candidates: DiscoveryCandidate[] = [
+	{ item: "@quickadd-existing-note:Existing/Alice.md", title: "Alice", display: "Alice Existing/Alice.md A. Example", exactKeys: ["alice", "existing/alice", "a. example"], renderPath: "Existing/Alice.md" },
+	{ item: "@quickadd-unresolved-note:Projects/Missing Roadmap", title: "Missing Roadmap", display: "Projects/Missing Roadmap", exactKeys: ["projects/missing roadmap"], unresolvedTitle: "Projects/Missing Roadmap" },
+];
+
+function modal() {
+	return new TemplateNoteDiscoveryModal({} as App, new TemplateChoice("Project"), candidates);
+}
+
+describe("native Template discovery rows", () => {
+	it.each(candidates)("keeps a typed internal identifier separate from its candidate: $item", async (candidate) => {
+		const picker = modal();
+		const suggestions = picker.getSuggestions(candidate.item);
+		expect(suggestions[0].item).toEqual({ kind: "create", title: candidate.item });
+		picker.selectSuggestion(suggestions[0], new KeyboardEvent("keydown", { key: "Enter" }));
+		await expect(picker.promise).resolves.toMatchObject({ kind: "create", title: candidate.item });
+	});
+
+	it.each([
+		["Alice", { kind: "existing", path: "Existing/Alice.md" }],
+		["Projects/Missing Roadmap", { kind: "create", title: "Projects/Missing Roadmap", vaultRelativePath: "Projects/Missing Roadmap" }],
+	])("preserves selected candidate identity for %s", async (query, expected) => {
+		const picker = modal();
+		const suggestions = picker.getSuggestions(String(query));
+		expect(suggestions[0].item.kind).toBe("candidate");
+		picker.selectSuggestion(suggestions[0], new MouseEvent("click"));
+		await expect(picker.promise).resolves.toEqual(expected);
+	});
+
+	it.each(["Alice", "Existing/Alice.md", "A. Example", "Projects/Missing Roadmap"])("does not offer duplicate creation for exact public key %s", (query) => {
+		const picker = modal();
+		void picker.promise.catch(() => {});
+		expect(picker.getSuggestions(query).some(match => match.item.kind === "create")).toBe(false);
+		picker.close();
+	});
+
+	it("does not insert internal identifiers when Tab is pressed", () => {
+		const picker = modal();
+		void picker.promise.catch(() => {});
+		picker.inputEl.value = "Alice";
+		picker.getSuggestions("Alice");
+		picker.inputEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", code: "Tab", bubbles: true }));
+		expect(picker.inputEl.value).toBe("Alice");
+		picker.close();
+	});
+
+	it("settles cancellation when dismissed without a selection", async () => {
+		const picker = modal();
+		picker.close();
+		await expect(picker.promise).rejects.toThrow("cancelled");
+	});
+
+	it("rejects an invalid custom title without leaving the promise pending", async () => {
+		const picker = modal();
+		picker.onChooseItem({ kind: "create", title: "../outside" });
+		await expect(picker.promise).rejects.toThrow();
+	});
+});

--- a/src/gui/TemplateNoteDiscoveryModal.ts
+++ b/src/gui/TemplateNoteDiscoveryModal.ts
@@ -1,0 +1,90 @@
+import { FuzzySuggestModal, setIcon, type App, type FuzzyMatch } from "obsidian";
+import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+import { promptCancelled } from "src/errors/UserCancelError";
+import { existingNoteActionVerb } from "src/template/fileExistsPolicy";
+import {
+	createTemplateNoteSelection,
+	decodeTemplateNoteSelection,
+	normalizedKey,
+	type DiscoveryCandidate,
+	type TemplateNoteSelection,
+} from "src/utils/templateNoteDiscovery";
+import { renderNotePathSuggestion } from "./InputSuggester/renderNotePathSuggestion";
+
+type DiscoveryRow =
+	| { kind: "candidate"; candidate: DiscoveryCandidate }
+	| { kind: "create"; title: string };
+
+export class TemplateNoteDiscoveryModal extends FuzzySuggestModal<DiscoveryRow> {
+	readonly promise: Promise<TemplateNoteSelection>;
+	private resolvePromise!: (row: DiscoveryRow) => void;
+	private rejectPromise!: (reason: unknown) => void;
+	private settled = false;
+	private readonly rows: DiscoveryRow[];
+	private readonly action: string;
+
+	constructor(app: App, choice: ITemplateChoice, candidates: DiscoveryCandidate[]) {
+		super(app);
+		this.rows = candidates.map(candidate => ({ kind: "candidate", candidate }));
+		this.action = existingNoteActionVerb(choice.existingNoteAction);
+		this.promise = new Promise<DiscoveryRow>((resolve, reject) => {
+			this.resolvePromise = resolve;
+			this.rejectPromise = reject;
+		}).then(row => row.kind === "candidate"
+			? decodeTemplateNoteSelection(row.candidate.item)
+			: createTemplateNoteSelection(row.title));
+		this.setPlaceholder(`Search notes or create ${choice.name}`);
+		this.open();
+	}
+
+	getItems(): DiscoveryRow[] { return this.rows; }
+
+	getItemText(row: DiscoveryRow): string {
+		return row.kind === "candidate" ? row.candidate.display : row.title;
+	}
+
+	getSuggestions(query: string): FuzzyMatch<DiscoveryRow>[] {
+		const title = query.trim();
+		const key = normalizedKey(title);
+		const exact = (row: DiscoveryRow) => row.kind === "candidate" && row.candidate.exactKeys.includes(key);
+		const suggestions = super.getSuggestions(title)
+			.sort((a, b) => Number(exact(b.item)) - Number(exact(a.item)));
+		if (title && !this.rows.some(exact)) {
+			suggestions.unshift({ item: { kind: "create", title }, match: { score: Number.NEGATIVE_INFINITY, matches: [] } });
+		}
+		return suggestions;
+	}
+
+	renderSuggestion({ item: row }: FuzzyMatch<DiscoveryRow>, el: HTMLElement): void {
+		if (row.kind === "candidate" && row.candidate.renderPath) {
+			const candidate = row.candidate;
+			renderNotePathSuggestion(el, row.candidate.renderPath);
+			if (this.action !== "Open") el.querySelector(".suggestion-title")?.prepend(`${this.action}: `);
+			if (candidate.renderAlias) el.querySelector(".suggestion-content")?.createDiv({ cls: "suggestion-note", text: `Alias: ${candidate.renderAlias}` });
+			return;
+		}
+		el.addClass("mod-complex");
+		const content = el.createDiv({ cls: "suggestion-content" });
+		content.createDiv({ cls: "suggestion-title", text: row.kind === "create" ? `Create new note: ${row.title}` : row.candidate.unresolvedTitle ?? row.candidate.title });
+		if (row.kind === "create") {
+			setIcon(el.createDiv({ cls: "suggestion-aux" }).createSpan({ cls: "suggestion-flair" }), "file-plus");
+		} else {
+			content.createDiv({ cls: "suggestion-note", text: "Unresolved link" });
+		}
+	}
+
+	selectSuggestion(value: FuzzyMatch<DiscoveryRow>, event: MouseEvent | KeyboardEvent): void {
+		this.settled = true;
+		super.selectSuggestion(value, event);
+	}
+
+	onChooseItem(row: DiscoveryRow): void {
+		this.settled = true;
+		this.resolvePromise(row);
+	}
+
+	onClose(): void {
+		super.onClose();
+		if (!this.settled) this.rejectPromise(promptCancelled());
+	}
+}

--- a/src/gui/suggesters/NoteDiscoveryInputSuggest.test.ts
+++ b/src/gui/suggesters/NoteDiscoveryInputSuggest.test.ts
@@ -67,4 +67,15 @@ describe("NoteDiscoveryInputSuggest", () => {
 		expect(() => suggester.resolveInput("../outside")).toThrow();
 		expect(suggester.resolveInput("Unresolved link")).toEqual({ kind: "create", title: "Unresolved link" });
 	});
+
+	it("never interprets a custom create row as an encoded existing-note selection", () => {
+		const { suggester, selected } = createSuggest();
+		const text = "@quickadd-existing-note:Projects/Project Atlas.md";
+		const custom = suggester.getSuggestions(text).find((option) => option.label.startsWith("Create new note:"));
+		expect(custom).toBeDefined();
+		if (!custom) throw new Error("Expected a custom title row");
+		suggester.selectSuggestion(custom);
+		expect(selected).toHaveBeenCalledWith({ kind: "create", title: text, vaultRelativePath: text });
+		expect(suggester.resolveInput(text)).toEqual({ kind: "create", title: text, vaultRelativePath: text });
+	});
 });

--- a/src/gui/suggesters/NoteDiscoveryInputSuggest.ts
+++ b/src/gui/suggesters/NoteDiscoveryInputSuggest.ts
@@ -1,7 +1,9 @@
 import { Notice, prepareFuzzySearch, type App, type Scope } from "obsidian";
 import type ITemplateChoice from "src/types/choices/ITemplateChoice";
+import { existingNoteActionVerb } from "src/template/fileExistsPolicy";
 import {
 	buildDiscoveryCandidates,
+	createTemplateNoteSelection,
 	normalizedKey,
 	selectionForDiscoveryCandidate,
 	type TemplateNoteSelection,
@@ -30,10 +32,13 @@ export class NoteDiscoveryInputSuggest extends TextInputSuggest<NoteOption> {
 		const { candidates, existingKeys } = buildDiscoveryCandidates(obsidianApp, choice);
 		super(obsidianApp, input, parentScope);
 		this.existingKeys = existingKeys;
+		const action = existingNoteActionVerb(choice.existingNoteAction);
 		this.options = candidates.map((candidate) => ({
 			item: candidate.item,
 			exactKeys: candidate.exactKeys,
-			label: candidate.renderPath?.split("/").at(-1)?.replace(/\.md$/i, "") ?? candidate.unresolvedTitle ?? candidate.title,
+			label: candidate.renderPath
+				? `${action === "Open" ? "" : `${action}: `}${candidate.renderPath.split("/").at(-1)?.replace(/\.md$/i, "")}`
+				: candidate.unresolvedTitle ?? candidate.title,
 			detail: candidate.renderPath ?? "Unresolved link",
 			search: candidate.display,
 		}));
@@ -60,7 +65,7 @@ export class NoteDiscoveryInputSuggest extends TextInputSuggest<NoteOption> {
 	resolveInput(text: string): TemplateNoteSelection {
 		const key = normalizedKey(text);
 		const exact = this.options.find((option) => option.exactKeys.includes(key));
-		return selectionForDiscoveryCandidate(this.obsidianApp, exact?.item ?? text);
+		return exact ? selectionForDiscoveryCandidate(this.obsidianApp, exact.item) : createTemplateNoteSelection(text);
 	}
 
 	renderSuggestion(option: NoteOption, el: HTMLElement): void {
@@ -72,7 +77,9 @@ export class NoteDiscoveryInputSuggest extends TextInputSuggest<NoteOption> {
 
 	selectSuggestion(option: NoteOption): void {
 		try {
-			const selection = selectionForDiscoveryCandidate(this.obsidianApp, option.item);
+			const selection = this.options.includes(option)
+				? selectionForDiscoveryCandidate(this.obsidianApp, option.item)
+				: createTemplateNoteSelection(option.item);
 			this.inputEl.value = "";
 			this.close();
 			this.onSelect(selection);

--- a/src/gui/suggesters/suggest.test.ts
+++ b/src/gui/suggesters/suggest.test.ts
@@ -249,6 +249,20 @@ describe("TextInputSuggest resource lifecycle", () => {
 		suggest.destroy();
 	});
 
+	it("discards a lookup after its field is closed and shown again", async () => {
+		const suggest = new DeferredSuggest(app, input);
+		input.value = "a";
+		const inFlight = suggest.onInputChanged();
+		input.hidden = true;
+		suggest.close();
+		input.hidden = false;
+		suggest.resolvePending?.(["a", "ab"]);
+		await inFlight;
+		expect(app.keymap.pushScope).not.toHaveBeenCalled();
+		expect(createPopperMock).not.toHaveBeenCalled();
+		suggest.destroy();
+	});
+
 	it("ignores delayed input updates inside a hidden form field", async () => {
 		const field = document.createElement("div");
 		field.hidden = true;

--- a/src/gui/suggesters/suggest.ts
+++ b/src/gui/suggesters/suggest.ts
@@ -476,6 +476,7 @@ export abstract class TextInputSuggest<T> implements ISuggestOwner<T> {
 	}
 
 	close(): void {
+		this.currentRequestId++;
 		if (!this.isOpen) return;
 
 		this.app.keymap.popScope(this.scope);

--- a/src/preflight/OnePageInputModal.linkSuggesters.test.ts
+++ b/src/preflight/OnePageInputModal.linkSuggesters.test.ts
@@ -47,11 +47,11 @@ vi.mock("src/gui/suggesters/tagSuggester", () => ({
 }));
 
 vi.mock("src/gui/suggesters/FieldValueInputSuggest", () => ({
-	FieldValueInputSuggest: class {},
+	FieldValueInputSuggest: class { destroy = vi.fn(); },
 }));
 
 vi.mock("src/gui/suggesters/SuggesterInputSuggest", () => ({
-	SuggesterInputSuggest: class {},
+	SuggesterInputSuggest: class { destroy = vi.fn(); },
 }));
 
 vi.mock("src/gui/suggesters/FilePickerInputSuggest", () => ({

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -51,12 +51,14 @@ vi.mock("src/gui/imagePasteHandler", () => ({
 
 vi.mock("src/gui/suggesters/fileSuggester", () => ({
 	FileSuggester: class {
+		close = vi.fn();
 		destroy = vi.fn();
 	},
 }));
 
 vi.mock("src/gui/suggesters/tagSuggester", () => ({
 	TagSuggester: class {
+		close = vi.fn();
 		destroy = vi.fn();
 	},
 }));
@@ -248,7 +250,7 @@ vi.mock("obsidian", () => {
 });
 
 vi.mock("src/gui/date-picker/datePicker", () => ({
-	createDatePicker: () => ({ setSelectedIso: vi.fn() }),
+	createDatePicker: () => ({ setSelectedIso: vi.fn(), destroy: vi.fn() }),
 }));
 
 const { fieldSuggestConstructorArgs } = vi.hoisted(() => ({
@@ -257,6 +259,8 @@ const { fieldSuggestConstructorArgs } = vi.hoisted(() => ({
 
 vi.mock("src/gui/suggesters/FieldValueInputSuggest", () => ({
 	FieldValueInputSuggest: class {
+		close = vi.fn();
+		destroy = vi.fn();
 		constructor(...args: unknown[]) {
 			fieldSuggestConstructorArgs.push(args);
 		}
@@ -264,11 +268,12 @@ vi.mock("src/gui/suggesters/FieldValueInputSuggest", () => ({
 }));
 
 vi.mock("src/gui/suggesters/SuggesterInputSuggest", () => ({
-	SuggesterInputSuggest: class {},
+	SuggesterInputSuggest: class { close = vi.fn(); destroy = vi.fn(); },
 }));
 
 vi.mock("src/gui/suggesters/FilePickerInputSuggest", () => ({
 	FilePickerInputSuggest: class {
+		close = vi.fn();
 		destroy = vi.fn();
 
 		constructor(
@@ -344,6 +349,16 @@ function ensureObsidianDomPolyfills(): void {
 	};
 }
 
+function discoveryModal(create: FieldRequirement, existing: FieldRequirement) {
+	return new OnePageInputModal({} as App, [
+		{ id: "note", label: "Note", type: "text" }, create,
+	], undefined, undefined, {
+		notes: [{ id: "note", choice: new TemplateChoice("Project"), group: { id: "project", label: "Project" } }],
+		visibleForNotes: new Map([[create.id, [{ noteId: "note", includeExisting: true }]]]),
+		fieldUsages: new Map([[create.id, [{ kind: "note", noteId: "note", create, existing }]]]),
+	});
+}
+
 describe("OnePageInputModal", () => {
 	beforeEach(() => {
 		ensureObsidianDomPolyfills();
@@ -351,6 +366,97 @@ describe("OnePageInputModal", () => {
 		noteSelections.length = 0;
 		noteSuggesterSetup.mockReset();
 		attachImagePasteHandlerMock.mockClear();
+	});
+
+	it("keeps each control's default and draft when switching between dropdown and text", async () => {
+		const modal = discoveryModal(
+			{ id: "detail", label: "Folder", type: "dropdown", options: ["a", "b"], defaultValue: "b" },
+			{ id: "detail", label: "Description", type: "text", defaultValue: "Body default", placeholder: "Describe it" },
+		);
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		const input = modal.contentEl.querySelector<HTMLInputElement>('input[placeholder="Describe it"]')!;
+		expect(input.value).toBe("Body default");
+		input.value = "Free text draft";
+		input.dispatchEvent(new Event("input"));
+		noteSelections[0]({ kind: "create", title: "New project" });
+		const dropdown = modal.contentEl.querySelector("select")!;
+		expect(dropdown.value).toBe("b");
+		dropdown.value = "a";
+		dropdown.dispatchEvent(new Event("change"));
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		expect(modal.contentEl.querySelector('input[placeholder="Describe it"]')).toBe(input);
+		expect(input.value).toBe("Free text draft");
+		noteSelections[0]({ kind: "create", title: "New project" });
+		expect(modal.contentEl.querySelector("select")).toBe(dropdown);
+		expect(dropdown.value).toBe("a");
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		Array.from(modal.contentEl.querySelectorAll("button")).find(button => button.textContent === "Submit")!.click();
+		await expect(modal.waitForClose).resolves.toEqual({ detail: "Free text draft" });
+	});
+
+	it("changes same-type options and retains an explicitly blank optional dropdown", () => {
+		const modal = discoveryModal(
+			{ id: "detail", label: "Detail", type: "dropdown", options: ["a", "b"], optional: true },
+			{ id: "detail", label: "Detail", type: "dropdown", options: ["x", "y"], displayOptions: ["X label", "Y label"], defaultValue: "y" },
+		);
+		noteSelections[0]({ kind: "create", title: "New" });
+		const create = modal.contentEl.querySelector("select")!;
+		create.value = "";
+		create.dispatchEvent(new Event("change"));
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		const existing = modal.contentEl.querySelector("select")!;
+		expect(existing.value).toBe("y");
+		expect(Array.from(existing.options, option => option.textContent)).toEqual(["X label", "Y label"]);
+		noteSelections[0]({ kind: "create", title: "New" });
+		expect(modal.contentEl.querySelector("select")!.value).toBe("");
+	});
+
+	it("retains invalid date text without blocking a different active text control", async () => {
+		const modal = discoveryModal(
+			{ id: "detail", label: "Date", type: "date" },
+			{ id: "detail", label: "Description", type: "text", placeholder: "Body" },
+		);
+		noteSelections[0]({ kind: "create", title: "New" });
+		const date = modal.contentEl.querySelector<HTMLInputElement>(".qa-date-input input")!;
+		date.value = "not-a-valid-date";
+		date.dispatchEvent(new Event("input"));
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		const text = modal.contentEl.querySelector<HTMLInputElement>('input[placeholder="Body"]')!;
+		text.value = "No date needed";
+		text.dispatchEvent(new Event("input"));
+		noteSelections[0]({ kind: "create", title: "New" });
+		expect(modal.contentEl.querySelector(".qa-date-input input")).toBe(date);
+		expect(date.value).toBe("not-a-valid-date");
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		Array.from(modal.contentEl.querySelectorAll("button")).find(button => button.textContent === "Submit")!.click();
+		await expect(modal.waitForClose).resolves.toEqual({ detail: "No date needed" });
+	});
+
+	it("keeps structured file picks with commas in their names in their own control", () => {
+		const modal = discoveryModal(
+			{ id: "detail", label: "People", type: "file-picker", options: ["@file:People/Doe, Jane.md"], displayOptions: ["Doe, Jane"], suggesterConfig: { multiSelect: true, allowCustomInput: true } },
+			{ id: "detail", label: "Description", type: "text" },
+		);
+		noteSelections[0]({ kind: "create", title: "New" });
+		filePickerSuggesters[0].onSelect({ value: "@file:People/Doe, Jane.md", label: "Doe, Jane", path: "People/Doe, Jane.md" });
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		expect(modal.fileSelections.has("detail")).toBe(false);
+		noteSelections[0]({ kind: "create", title: "New" });
+		expect(modal.fileSelections.get("detail")).toEqual(["@file:People/Doe, Jane.md"]);
+		expect(Array.from(modal.contentEl.querySelectorAll(".qa-onepage-file-picker__chip-label"), el => el.textContent)).toContain("Doe, Jane");
+	});
+
+	it("reveals a renderable control after an inactive runtime-only definition", async () => {
+		const modal = discoveryModal(
+			{ id: "detail", label: "Detail", type: "text", runtimeOnly: true },
+			{ id: "detail", label: "Detail", type: "text", defaultValue: "Existing body" },
+		);
+		noteSelections[0]({ kind: "create", title: "New" });
+		expect(modal.activeRequirements.some(req => req.id === "detail")).toBe(false);
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		expect(modal.activeRequirements.find(req => req.id === "detail")?.defaultValue).toBe("Existing body");
+		Array.from(modal.contentEl.querySelectorAll("button")).find(button => button.textContent === "Submit")!.click();
+		await expect(modal.waitForClose).resolves.toEqual({ detail: "Existing body" });
 	});
 
 	it("retains create-only drafts while changing notes and omits them when opening an existing note", async () => {
@@ -400,8 +506,8 @@ describe("OnePageInputModal", () => {
 			]),
 			fieldUsages: new Map([["detail", [{
 				kind: "note", noteId: "note",
-				create: { optional: false, pathContext: true },
-				existing: { optional: true, pathContext: false },
+				create: { id: "detail", label: "Detail", type: "text", optional: false, pathContext: true },
+				existing: { id: "detail", label: "Detail", type: "text", optional: true, pathContext: false },
 			}]]]),
 		});
 		const [, detail, folder] = modal.contentEl.querySelectorAll("input");
@@ -470,6 +576,32 @@ describe("OnePageInputModal", () => {
 		Array.from(modal.contentEl.querySelectorAll("button")).find((button) => button.textContent === "Submit")!.click();
 		await expect(modal.waitForClose).resolves.toEqual({});
 		expect(modal.discoverySelections.get("note")).toEqual({ kind: "create", title: "Project At" });
+	});
+
+	it("uses the newly revealed definition when submitting a pending title", async () => {
+		const modal = new OnePageInputModal({} as App, [
+			{ id: "note", label: "Note", type: "text" },
+			{ id: "detail", label: "Detail", type: "text", optional: true },
+		], undefined, undefined, {
+			notes: [{ id: "note", choice: new TemplateChoice("Project"), group: { id: "project", label: "Project" } }],
+			visibleForNotes: new Map([["detail", [{ noteId: "note", includeExisting: false }]]]),
+			fieldUsages: new Map([["detail", [{ kind: "note", noteId: "note", create: { id: "detail", label: "Description", type: "textarea" }, existing: null }]]]),
+		});
+		document.body.appendChild(modal.containerEl);
+		modal.contentEl.querySelector("input")!.value = "New project";
+		const submitted = vi.fn();
+		void modal.waitForClose.then(submitted);
+		const submit = Array.from(modal.contentEl.querySelectorAll("button")).find(button => button.textContent === "Submit")!;
+		submit.click();
+		await Promise.resolve();
+		expect(submitted).not.toHaveBeenCalled();
+		const detail = modal.contentEl.querySelector("textarea")!;
+		expect(document.activeElement).toBe(detail);
+		detail.value = "Required description";
+		detail.dispatchEvent(new Event("input"));
+		submit.click();
+		await expect(modal.waitForClose).resolves.toEqual({ detail: "Required description" });
+		modal.containerEl.remove();
 	});
 
 	it("reveals required creation fields before saving a pending new title", async () => {

--- a/src/preflight/OnePageInputModal.test.ts
+++ b/src/preflight/OnePageInputModal.test.ts
@@ -205,6 +205,7 @@ vi.mock("obsidian", () => {
 			settingEl.classList.add("setting-item");
 			this.infoEl = document.createElement("div");
 			this.nameEl = document.createElement("div");
+			this.nameEl.classList.add("setting-item-name");
 			this.descEl = document.createElement("div");
 			this.controlEl = document.createElement("div");
 			settingEl.appendChild(this.infoEl);
@@ -349,6 +350,7 @@ describe("OnePageInputModal", () => {
 		filePickerSuggesters.length = 0;
 		noteSelections.length = 0;
 		noteSuggesterSetup.mockReset();
+		attachImagePasteHandlerMock.mockClear();
 	});
 
 	it("retains create-only drafts while changing notes and omits them when opening an existing note", async () => {
@@ -359,7 +361,8 @@ describe("OnePageInputModal", () => {
 		];
 		const modal = new OnePageInputModal({} as App, requirements, undefined, undefined, {
 			notes: [{ id: "note", choice: new TemplateChoice("Project"), group: { id: "project", label: "Project" } }],
-			visibleWhenCreating: new Map([["owner", ["note"]]]),
+			fieldUsages: new Map(),
+			visibleForNotes: new Map([["owner", [{ noteId: "note", includeExisting: false }]]]),
 		});
 		const owner = modal.contentEl.querySelectorAll<HTMLInputElement>("input")[1];
 		const ownerRow = owner.closest<HTMLElement>(".setting-item")!;
@@ -381,6 +384,61 @@ describe("OnePageInputModal", () => {
 		expect(modal.discoverySelections.get("note")).toEqual({ kind: "existing", path: "Atlas.md" });
 	});
 
+	it("updates optional input and image-paste behavior when choosing an existing note", async () => {
+		const choice = new TemplateChoice("Project");
+		choice.existingNoteAction = "appendBottom";
+		const requirements: FieldRequirement[] = [
+			{ id: "note", label: "Note", type: "text" },
+			{ id: "detail", label: "Detail", type: "text", pathContext: true },
+			{ id: "folder", label: "Folder", type: "text", pathContext: true },
+		];
+		const modal = new OnePageInputModal({} as App, requirements, undefined, undefined, {
+			notes: [{ id: "note", choice, group: { id: "project", label: "Project" } }],
+			visibleForNotes: new Map([
+				["detail", [{ noteId: "note", includeExisting: true }]],
+				["folder", [{ noteId: "note", includeExisting: false }]],
+			]),
+			fieldUsages: new Map([["detail", [{
+				kind: "note", noteId: "note",
+				create: { optional: false, pathContext: true },
+				existing: { optional: true, pathContext: false },
+			}]]]),
+		});
+		const [, detail, folder] = modal.contentEl.querySelectorAll("input");
+		const detailRow = detail.closest<HTMLElement>(".setting-item")!;
+		const folderRow = folder.closest<HTMLElement>(".setting-item")!;
+		noteSelections[0]({ kind: "create", title: "New project" });
+		expect(detailRow.hidden).toBe(false);
+		expect(folderRow.hidden).toBe(false);
+		expect(detailRow.querySelector(".qa-onepage-optional-badge")).toBeNull();
+		expect(attachImagePasteHandlerMock).not.toHaveBeenCalled();
+		detail.value = "Draft description";
+		detail.dispatchEvent(new Event("input"));
+		folder.value = "Archive";
+		folder.dispatchEvent(new Event("input"));
+
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		expect(detailRow.hidden).toBe(false);
+		expect(folderRow.hidden).toBe(true);
+		expect(detailRow.querySelector(".qa-onepage-optional-badge")).not.toBeNull();
+		expect(detailRow.querySelector("input")).toBe(detail);
+		expect(detail.value).toBe("Draft description");
+		expect(modal.contentEl.textContent).toContain("Append to: Atlas");
+		expect(attachImagePasteHandlerMock).toHaveBeenCalledTimes(1);
+		const pasteHandle = attachImagePasteHandlerMock.mock.results[0].value;
+
+		noteSelections[0]({ kind: "create", title: "New project" });
+		expect(pasteHandle.detach).toHaveBeenCalledTimes(1);
+		expect(detailRow.querySelector(".qa-onepage-optional-badge")).toBeNull();
+		expect(folder.value).toBe("Archive");
+		noteSelections[0]({ kind: "existing", path: "Atlas.md" });
+		detail.value = "";
+		detail.dispatchEvent(new Event("input"));
+		Array.from(modal.contentEl.querySelectorAll("button"))
+			.find((button) => button.textContent === "Submit")!.click();
+		await expect(modal.waitForClose).resolves.toEqual({ detail: "" });
+	});
+
 	it("keeps a shared field visible when any create-note consumer needs it", () => {
 		const requirements: FieldRequirement[] = [
 			{ id: "first", label: "First", type: "text" },
@@ -389,7 +447,8 @@ describe("OnePageInputModal", () => {
 		];
 		const modal = new OnePageInputModal({} as App, requirements, undefined, undefined, {
 			notes: ["first", "second"].map((id) => ({ id, choice: new TemplateChoice(id), group: { id, label: id } })),
-			visibleWhenCreating: new Map([["owner", ["first", "second"]]]),
+			fieldUsages: new Map(),
+			visibleForNotes: new Map([["owner", ["first", "second"].map((noteId) => ({ noteId, includeExisting: false }))]]),
 		});
 		void modal.waitForClose.catch(() => {});
 		const ownerRow = modal.contentEl.querySelectorAll("input")[2].closest<HTMLElement>(".setting-item")!;
@@ -404,7 +463,8 @@ describe("OnePageInputModal", () => {
 	it("accepts a pending new title on submit", async () => {
 		const modal = new OnePageInputModal({} as App, [{ id: "note", label: "Note", type: "text" }], undefined, undefined, {
 			notes: [{ id: "note", choice: new TemplateChoice("Project"), group: { id: "project", label: "Project" } }],
-			visibleWhenCreating: new Map(),
+			fieldUsages: new Map(),
+			visibleForNotes: new Map(),
 		});
 		modal.contentEl.querySelector("input")!.value = "Project At";
 		Array.from(modal.contentEl.querySelectorAll("button")).find((button) => button.textContent === "Submit")!.click();
@@ -418,7 +478,8 @@ describe("OnePageInputModal", () => {
 			{ id: "owner", label: "Owner", type: "text" },
 		], undefined, undefined, {
 			notes: [{ id: "note", choice: new TemplateChoice("Project"), group: { id: "project", label: "Project" } }],
-			visibleWhenCreating: new Map([["owner", ["note"]]]),
+			fieldUsages: new Map(),
+			visibleForNotes: new Map([["owner", [{ noteId: "note", includeExisting: false }]]]),
 		});
 		document.body.appendChild(modal.containerEl);
 		const [note, owner] = modal.contentEl.querySelectorAll("input");
@@ -442,7 +503,8 @@ describe("OnePageInputModal", () => {
 		noteSuggesterSetup.mockImplementation(() => { throw new Error("Metadata unavailable"); });
 		const modal = new OnePageInputModal({} as App, [{ id: "note", label: "Note", type: "text" }], undefined, undefined, {
 			notes: [{ id: "note", choice: new TemplateChoice("Project"), group: { id: "project", label: "Project" } }],
-			visibleWhenCreating: new Map(),
+			fieldUsages: new Map(),
+			visibleForNotes: new Map(),
 		});
 		const input = modal.contentEl.querySelector("input")!;
 		const submit = Array.from(modal.contentEl.querySelectorAll("button")).find((button) => button.textContent === "Submit")!;
@@ -461,7 +523,7 @@ describe("OnePageInputModal", () => {
 			{ id: "meeting", label: "Next meeting", type: "text", group: { id: "meeting", label: "Next meeting" } },
 		];
 		const modal = new OnePageInputModal({} as App, requirements, undefined, undefined,
-			discovery ? { notes: [], visibleWhenCreating: new Map() } : undefined);
+			discovery ? { notes: [], visibleForNotes: new Map(), fieldUsages: new Map() } : undefined);
 		void modal.waitForClose.catch(() => {});
 		expect(modal.contentEl.querySelectorAll(".qa-onepage-section")).toHaveLength(discovery ? 0 : 2);
 		modal.onClose();

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -47,7 +47,7 @@ import type { PreviewDiagnostic } from "src/formatters/previewDiagnostics";
 import { decodeFileValue } from "src/utils/fileSyntax";
 import { NoteDiscoveryInputSuggest } from "src/gui/suggesters/NoteDiscoveryInputSuggest";
 import { createTemplateNoteSelection, type TemplateNoteSelection } from "src/utils/templateNoteDiscovery";
-import { acceptsDiscoverySelection, resolveDiscoveryFieldMetadata, type DiscoveryFormConfig, type DiscoveryNoteField } from "./discoveryFormPlan";
+import { acceptsDiscoverySelection, resolveDiscoveryFieldRequirement, type DiscoveryFormConfig, type DiscoveryNoteField } from "./discoveryFormPlan";
 import { existingNoteActionVerb } from "src/template/fileExistsPolicy";
 
 type CompletionInputEvent = Event & {
@@ -106,6 +106,23 @@ type PreviewComputer = (
 	values: Record<string, unknown>,
 ) => Promise<PreviewRow[]> | PreviewRow[];
 
+interface FieldControl {
+	requirement: FieldRequirement;
+	elements: HTMLElement[];
+	value: string;
+	multiSelections?: string[];
+	fileSelections?: string[];
+	dateParseError: boolean;
+	suggesters: Array<{ close(): void; destroy(): void }>;
+	dispose: Array<() => void>;
+}
+
+function controlDefinition(requirement: FieldRequirement): string {
+	return JSON.stringify(Object.entries(requirement)
+		.filter(([key, value]) => value !== undefined && !["id", "group", "optional", "pathContext", "runtimeOnly"].includes(key))
+		.sort(([a], [b]) => a.localeCompare(b)));
+}
+
 export class OnePageInputModal extends Modal {
 	private readonly requirements: FieldRequirement[];
 	private readonly initialValues: Map<string, string>;
@@ -123,6 +140,8 @@ export class OnePageInputModal extends Modal {
 	public readonly discoverySelections = new Map<string, TemplateNoteSelection>();
 	private readonly discoverySuggesters: NoteDiscoveryInputSuggest[] = [];
 	private readonly fieldElements = new Map<string, HTMLElement[]>();
+	private readonly fieldAnchors = new Map<string, Comment>();
+	private readonly fieldControls = new Map<FieldRequirement, FieldControl>();
 	private readonly discoveryInputs = new Map<string, {
 		input: HTMLInputElement;
 		select: (selection: TemplateNoteSelection) => void;
@@ -136,11 +155,10 @@ export class OnePageInputModal extends Modal {
 	private previewToken = 0;
 	private updatePreviewDebounced: () => void;
 	private settled = false;
-	private readonly imagePasteHandles = new Map<string, ImagePasteHandle>();
-	private readonly imagePasteInputs = new Map<string, HTMLInputElement | HTMLTextAreaElement>();
+	private readonly imagePasteHandles = new Map<FieldRequirement, ImagePasteHandle>();
+	private readonly imagePasteInputs = new Map<FieldRequirement, HTMLInputElement | HTMLTextAreaElement>();
 	private readonly freeTextFields: OnePageFreeTextField[] = [];
 	private lastFocusedFreeText: OnePageFreeTextField | undefined;
-	private readonly filePickerSuggesters: FilePickerInputSuggest[] = [];
 	private readonly peek: InputPromptPeek;
 
 	public waitForClose: Promise<Record<string, string>>;
@@ -303,11 +321,48 @@ export class OnePageInputModal extends Modal {
 		const note = this.discoveryForm?.notes.find((field) => field.id === req.id);
 		if (note) this.renderNoteField(note);
 		else this.renderFieldControl(req);
-		this.fieldElements.set(req.id, Array.from(this.contentEl.children)
-			.filter((element): element is HTMLElement => element instanceof HTMLElement && !before.has(element)));
+		const elements = Array.from(this.contentEl.children)
+			.filter((element): element is HTMLElement => element instanceof HTMLElement && !before.has(element));
+		this.fieldElements.set(req.id, elements);
+		if (!note) {
+			this.controlFor(req).elements = elements;
+			let anchor = this.fieldAnchors.get(req.id);
+			if (!anchor) {
+				anchor = this.contentEl.ownerDocument.createComment(req.id);
+				this.contentEl.append(anchor);
+				this.fieldAnchors.set(req.id, anchor);
+			}
+			for (const element of elements) this.contentEl.insertBefore(element, anchor);
+		}
+	}
+
+	private controlFor(requirement: FieldRequirement): FieldControl {
+		let control = this.fieldControls.get(requirement);
+		if (!control) {
+			control = { requirement, elements: [], value: "", dateParseError: false, suggesters: [], dispose: [] };
+			this.fieldControls.set(requirement, control);
+		}
+		return control;
+	}
+
+	private publishControl(control: FieldControl): void {
+		const req = control.requirement;
+		if (this.settled || !this.requirements.includes(req)) return;
+		this.result.set(req.id, control.value);
+		if (control.multiSelections) this.multiSelections.set(req.id, control.multiSelections);
+		else this.multiSelections.delete(req.id);
+		if (control.fileSelections) this.fileSelections.set(req.id, control.fileSelections);
+		else this.fileSelections.delete(req.id);
+		if (control.dateParseError) this.dateParseErrors.add(req.id);
+		else this.dateParseErrors.delete(req.id);
+	}
+
+	public get activeRequirements(): readonly FieldRequirement[] {
+		return this.requirements.filter((req) => this.isFieldVisible(req.id));
 	}
 
 	private isFieldVisible(id: string): boolean {
+		if (this.requirements.find((req) => req.id === id)?.runtimeOnly) return false;
 		const conditions = this.discoveryForm?.visibleForNotes.get(id);
 		return !conditions || conditions.some((condition) => acceptsDiscoverySelection(condition, this.discoverySelections));
 	}
@@ -317,18 +372,51 @@ export class OnePageInputModal extends Modal {
 		for (const [id, elements] of this.fieldElements) {
 			for (const element of elements) element.hidden = !this.isFieldVisible(id);
 		}
-		for (const requirement of this.requirements) {
-			const input = this.imagePasteInputs.get(requirement.id);
-			if (input) this.syncImagePaste(requirement, input);
+		for (const control of this.fieldControls.values()) {
+			if (this.requirements.includes(control.requirement) && this.isFieldVisible(control.requirement.id)) continue;
+			for (const suggester of control.suggesters) suggester.close();
+		}
+		for (const [requirement, input] of this.imagePasteInputs) {
+			this.syncImagePaste(requirement, input);
 		}
 		if (updatePreview) this.updatePreviewDebounced();
 	}
 
 	private updateFieldMetadata(): void {
-		for (const req of this.requirements) {
+		for (let index = 0; index < this.requirements.length; index++) {
+			let req = this.requirements[index];
 			const usages = this.discoveryForm?.fieldUsages.get(req.id);
 			if (!usages) continue;
-			Object.assign(req, resolveDiscoveryFieldMetadata(usages, this.discoverySelections));
+			const resolved = resolveDiscoveryFieldRequirement(usages, this.discoverySelections);
+			if (!resolved) continue;
+			const next = { ...resolved, id: req.id, group: req.group };
+			if (!this.fieldElements.has(req.id)) {
+				this.requirements[index] = next;
+				continue;
+			}
+			if (controlDefinition(req) !== controlDefinition(next)) {
+				const previous = this.controlFor(req);
+				previous.value = this.result.get(req.id) ?? previous.value;
+				for (const suggester of previous.suggesters) suggester.close();
+				for (const element of previous.elements) {
+					element.hidden = true;
+					element.remove();
+				}
+				const cached = Array.from(this.fieldControls.values()).find((control) =>
+					control.requirement.id === req.id && controlDefinition(control.requirement) === controlDefinition(next));
+				req = cached?.requirement ?? next;
+				this.requirements[index] = req;
+				if (cached) {
+					for (const element of cached.elements) {
+						this.contentEl.insertBefore(element, this.fieldAnchors.get(req.id) ?? null);
+					}
+					this.fieldElements.set(req.id, cached.elements);
+					this.publishControl(cached);
+				} else {
+					this.renderField(req);
+				}
+			}
+			Object.assign(req, { optional: next.optional, pathContext: next.pathContext, runtimeOnly: next.runtimeOnly });
 			for (const element of this.fieldElements.get(req.id) ?? []) {
 				element.querySelector(".setting-item-name")?.replaceChildren(this.decorateLabel(req));
 				if (req.type !== "dropdown") continue;
@@ -342,7 +430,9 @@ export class OnePageInputModal extends Modal {
 					select.prepend(option);
 				} else if (!req.optional && skip) {
 					skip.remove();
-					this.result.set(req.id, select.value);
+					const control = this.controlFor(req);
+					control.value = select.value;
+					this.publishControl(control);
 				}
 			}
 		}
@@ -398,11 +488,14 @@ export class OnePageInputModal extends Modal {
 	}
 
 	private renderFieldControl(req: FieldRequirement) {
-		const setValue = (id: string, value: string) => {
-			this.result.set(id, value);
+		const control = this.controlFor(req);
+		const setValue = (_id: string, value: string) => {
+			control.value = value;
+			this.publishControl(control);
 			this.updatePreviewDebounced();
 		};
 		const starting = this.initialValues.get(req.id) ?? req.defaultValue ?? "";
+		control.value = starting;
 
 		switch (req.type) {
 			case "textarea": {
@@ -417,7 +510,7 @@ export class OnePageInputModal extends Modal {
 					.onChange((v) => setValue(req.id, v));
 				input.inputEl.addClass("qa-onepage-textarea");
 				this.enableImagePaste(req, input.inputEl);
-				this.attachFreeTextBehaviors(req.id, input.inputEl, setting);
+				this.attachFreeTextBehaviors(req, input.inputEl, setting);
 				break;
 			}
 			case "text": {
@@ -431,7 +524,7 @@ export class OnePageInputModal extends Modal {
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
 				this.enableImagePaste(req, input.inputEl);
-				this.attachFreeTextBehaviors(req.id, input.inputEl, setting);
+				this.attachFreeTextBehaviors(req, input.inputEl, setting);
 				break;
 			}
 			case "number": {
@@ -592,6 +685,8 @@ export class OnePageInputModal extends Modal {
 					},
 				});
 
+				control.dispose.push(() => datePicker.destroy());
+
 				const aliasEntries = getOrderedDateAliases(
 					settingsStore.getState().dateAliases,
 				);
@@ -630,7 +725,7 @@ export class OnePageInputModal extends Modal {
 
 				const applyPickerSelection = (iso: string) => {
 					selectedIso = iso;
-					this.dateParseErrors.delete(req.id);
+					control.dateParseError = false;
 					const display = formatIsoForDisplay(iso);
 					input.inputEl.value = display;
 					setValue(req.id, `@date:${iso}`);
@@ -654,7 +749,7 @@ export class OnePageInputModal extends Modal {
 						);
 						if (parsed.isValid && parsed.isoString) {
 							selectedIso = parsed.isoString;
-							this.dateParseErrors.delete(req.id);
+							control.dateParseError = false;
 							setValue(req.id, `@date:${parsed.isoString}`);
 							syncSelection(parsed.isoString);
 							const formatted =
@@ -664,14 +759,14 @@ export class OnePageInputModal extends Modal {
 							return;
 						}
 						renderPreview(parsed.error || "Unable to parse date", true);
-						this.dateParseErrors.add(req.id);
+						control.dateParseError = true;
 						setValue(req.id, "");
 						syncSelection();
 						return;
 					}
 					if (!inputVal) {
 						selectedIso = undefined;
-						this.dateParseErrors.delete(req.id);
+						control.dateParseError = false;
 						setValue(req.id, "");
 						syncSelection();
 						renderPreview(
@@ -686,7 +781,7 @@ export class OnePageInputModal extends Modal {
 					if (inputVal.startsWith("@date:")) {
 						const iso = inputVal.slice(6).trim();
 						if (iso) {
-							this.dateParseErrors.delete(req.id);
+							control.dateParseError = false;
 							applyPickerSelection(iso);
 							return;
 						}
@@ -695,7 +790,7 @@ export class OnePageInputModal extends Modal {
 					const parsed = parseNaturalLanguageDate(inputVal, req.dateFormat);
 					if (parsed.isValid && parsed.isoString) {
 						selectedIso = parsed.isoString;
-						this.dateParseErrors.delete(req.id);
+						control.dateParseError = false;
 						setValue(req.id, `@date:${parsed.isoString}`);
 						syncSelection(parsed.isoString);
 						const formatted =
@@ -703,7 +798,7 @@ export class OnePageInputModal extends Modal {
 						renderPreview(formatted, false);
 					} else {
 						selectedIso = undefined;
-						this.dateParseErrors.add(req.id);
+						control.dateParseError = true;
 						setValue(req.id, "");
 						syncSelection();
 						renderPreview(parsed.error || "Unable to parse date", true);
@@ -736,7 +831,7 @@ export class OnePageInputModal extends Modal {
 					? req.id.slice(FIELD_VARIABLE_PREFIX.length)
 					: req.id;
 				try {
-					new FieldValueInputSuggest(this.app, input.inputEl, fieldSpecifier);
+					control.suggesters.push(new FieldValueInputSuggest(this.app, input.inputEl, fieldSpecifier));
 				} catch {
 					// Non-fatal; leave as plain input if suggester fails
 				}
@@ -783,7 +878,7 @@ export class OnePageInputModal extends Modal {
 					try {
 						const caseSensitive = req.suggesterConfig?.caseSensitive ?? false;
 						const multiSelect = req.suggesterConfig?.multiSelect ?? false;
-						new SuggesterInputSuggest(
+						control.suggesters.push(new SuggesterInputSuggest(
 							this.app,
 							input.inputEl,
 							displayOptions,
@@ -791,12 +886,13 @@ export class OnePageInputModal extends Modal {
 							multiSelect,
 							multiSelect
 								? (item) => {
-										const arr = this.multiSelections.get(req.id) ?? [];
+										const arr = control.multiSelections ?? [];
 										arr.push(item);
-										this.multiSelections.set(req.id, arr);
+										control.multiSelections = arr;
+										this.publishControl(control);
 									}
 								: undefined,
-						);
+						));
 					} catch {
 						// Non-fatal; falls back to plain text input
 					}
@@ -817,12 +913,12 @@ export class OnePageInputModal extends Modal {
 					.setValue(starting)
 					.onChange((v) => setValue(req.id, v));
 				this.enableImagePaste(req, input.inputEl);
-				this.attachFreeTextBehaviors(req.id, input.inputEl, setting);
+				this.attachFreeTextBehaviors(req, input.inputEl, setting);
 			}
 		}
 
 		// Initialize stored value for empty inputs to ensure presence
-		if (!this.result.has(req.id)) this.result.set(req.id, starting);
+		this.publishControl(control);
 	}
 
 	private renderFilePickerField(
@@ -909,7 +1005,7 @@ export class OnePageInputModal extends Modal {
 		const sync = () => {
 			const picked = orderedSelections();
 			const pickedValues = picked.map((option) => option.value);
-			this.fileSelections.set(req.id, pickedValues);
+			this.controlFor(req).fileSelections = pickedValues;
 			setValue(
 				req.id,
 				multiSelect ? pickedValues.join(", ") : (pickedValues[0] ?? ""),
@@ -973,7 +1069,7 @@ export class OnePageInputModal extends Modal {
 				multiSelect,
 				allowCustomInput,
 			);
-			this.filePickerSuggesters.push(suggester);
+			this.controlFor(req).suggesters.push(suggester);
 		} catch {
 			// A failed suggester should not break the rest of the one-page form.
 			input.setDisabled(true);
@@ -983,10 +1079,11 @@ export class OnePageInputModal extends Modal {
 	}
 
 	private attachFreeTextBehaviors(
-		id: string,
+		req: FieldRequirement,
 		el: HTMLInputElement | HTMLTextAreaElement,
 		setting: Setting,
 	): void {
+		const id = req.id;
 		if (!setting.nameEl.id) {
 			setting.nameEl.id = `qa-onepage-label-${id}`;
 		}
@@ -1001,14 +1098,15 @@ export class OnePageInputModal extends Modal {
 			}),
 		};
 		this.freeTextFields.push(field);
+		this.controlFor(req).suggesters.push(field.fileSuggester, field.tagSuggester);
 		el.addEventListener("focus", () => {
 			this.lastFocusedFreeText = field;
 		});
 	}
 
 	private insertTarget(): OnePageFreeTextField | undefined {
-		if (this.lastFocusedFreeText && this.isFieldVisible(this.lastFocusedFreeText.id)) return this.lastFocusedFreeText;
-		return this.freeTextFields.find((field) => this.isFieldVisible(field.id));
+		if (this.lastFocusedFreeText && this.contentEl.contains(this.lastFocusedFreeText.el) && this.isFieldVisible(this.lastFocusedFreeText.id)) return this.lastFocusedFreeText;
+		return this.freeTextFields.find((field) => this.contentEl.contains(field.el) && this.isFieldVisible(field.id));
 	}
 
 	/**
@@ -1023,7 +1121,7 @@ export class OnePageInputModal extends Modal {
 		req: FieldRequirement,
 		inputEl: HTMLInputElement | HTMLTextAreaElement,
 	): void {
-		this.imagePasteInputs.set(req.id, inputEl);
+		this.imagePasteInputs.set(req, inputEl);
 		this.syncImagePaste(req, inputEl);
 	}
 
@@ -1031,12 +1129,16 @@ export class OnePageInputModal extends Modal {
 		req: FieldRequirement,
 		inputEl: HTMLInputElement | HTMLTextAreaElement,
 	): void {
-		const handle = this.imagePasteHandles.get(req.id);
-		if (req.pathContext || !this.isFieldVisible(req.id)) {
+		const handle = this.imagePasteHandles.get(req);
+		if (this.settled || req.pathContext || !this.requirements.includes(req) || !this.isFieldVisible(req.id)) {
+			if (!this.settled && !req.pathContext && handle?.isBusy()) {
+				void handle.whenIdle().then(() => this.syncImagePaste(req, inputEl));
+				return;
+			}
 			handle?.detach();
-			this.imagePasteHandles.delete(req.id);
+			this.imagePasteHandles.delete(req);
 		} else if (!handle) {
-			this.imagePasteHandles.set(req.id, attachImagePasteHandler(this.app, inputEl, {}));
+			this.imagePasteHandles.set(req, attachImagePasteHandler(this.app, inputEl, {}));
 		}
 	}
 
@@ -1056,7 +1158,8 @@ export class OnePageInputModal extends Modal {
 
 	private submit() {
 		if (this.settled) return;
-		const previouslyHidden = this.requirements.filter((req) => !this.isFieldVisible(req.id));
+		const previouslyHidden = new Set(this.requirements
+			.filter((req) => !this.isFieldVisible(req.id)).map((req) => req.id));
 		for (const note of this.discoveryForm?.notes ?? []) {
 			if (this.discoverySelections.has(note.id)) continue;
 			const field = this.discoveryInputs.get(note.id);
@@ -1074,7 +1177,7 @@ export class OnePageInputModal extends Modal {
 				return;
 			}
 		}
-		const revealed = previouslyHidden.find((req) => this.isFieldVisible(req.id) &&
+		const revealed = this.requirements.find((req) => previouslyHidden.has(req.id) && this.isFieldVisible(req.id) &&
 			!req.optional && !(this.result.get(req.id) ?? this.initialValues.get(req.id) ?? req.defaultValue));
 		if (revealed) {
 			this.fieldElements.get(revealed.id)?.[0]?.querySelector<HTMLElement>("input, textarea, select")?.focus();
@@ -1186,14 +1289,12 @@ export class OnePageInputModal extends Modal {
 		for (const handle of this.imagePasteHandles.values()) handle.detach();
 		this.imagePasteHandles.clear();
 		this.imagePasteInputs.clear();
-		for (const field of this.freeTextFields) {
-			field.fileSuggester.destroy();
-			field.tagSuggester.destroy();
+		for (const control of this.fieldControls.values()) {
+			for (const suggester of control.suggesters) suggester.destroy();
+			for (const dispose of control.dispose) dispose();
 		}
 		this.freeTextFields.length = 0;
 		this.lastFocusedFreeText = undefined;
-		for (const suggester of this.filePickerSuggesters) suggester.destroy();
-		this.filePickerSuggesters.length = 0;
 		for (const suggester of this.discoverySuggesters) suggester.destroy();
 		this.discoverySuggesters.length = 0;
 		// Esc (or any close that isn't submit/cancel) must settle the promise,

--- a/src/preflight/OnePageInputModal.ts
+++ b/src/preflight/OnePageInputModal.ts
@@ -46,8 +46,9 @@ import { promptCancelled } from "../errors/UserCancelError";
 import type { PreviewDiagnostic } from "src/formatters/previewDiagnostics";
 import { decodeFileValue } from "src/utils/fileSyntax";
 import { NoteDiscoveryInputSuggest } from "src/gui/suggesters/NoteDiscoveryInputSuggest";
-import { selectionForDiscoveryCandidate, type TemplateNoteSelection } from "src/utils/templateNoteDiscovery";
-import type { DiscoveryFormConfig, DiscoveryNoteField } from "./discoveryFormPlan";
+import { createTemplateNoteSelection, type TemplateNoteSelection } from "src/utils/templateNoteDiscovery";
+import { acceptsDiscoverySelection, resolveDiscoveryFieldMetadata, type DiscoveryFormConfig, type DiscoveryNoteField } from "./discoveryFormPlan";
+import { existingNoteActionVerb } from "src/template/fileExistsPolicy";
 
 type CompletionInputEvent = Event & {
 	fromCompletion?: boolean;
@@ -135,7 +136,8 @@ export class OnePageInputModal extends Modal {
 	private previewToken = 0;
 	private updatePreviewDebounced: () => void;
 	private settled = false;
-	private readonly imagePasteHandles: ImagePasteHandle[] = [];
+	private readonly imagePasteHandles = new Map<string, ImagePasteHandle>();
+	private readonly imagePasteInputs = new Map<string, HTMLInputElement | HTMLTextAreaElement>();
 	private readonly freeTextFields: OnePageFreeTextField[] = [];
 	private lastFocusedFreeText: OnePageFreeTextField | undefined;
 	private readonly filePickerSuggesters: FilePickerInputSuggest[] = [];
@@ -153,7 +155,8 @@ export class OnePageInputModal extends Modal {
 		private readonly discoveryForm?: DiscoveryFormConfig,
 	) {
 		super(app);
-		this.requirements = requirements;
+		this.requirements = requirements.map((requirement) => ({ ...requirement }));
+		this.updateFieldMetadata();
 		this.initialValues = new Map<string, string>();
 		this.computePreview = computePreview;
 		initial?.forEach((v, k) => {
@@ -305,15 +308,44 @@ export class OnePageInputModal extends Modal {
 	}
 
 	private isFieldVisible(id: string): boolean {
-		const conditions = this.discoveryForm?.visibleWhenCreating.get(id);
-		return !conditions || conditions.some((noteId) => this.discoverySelections.get(noteId)?.kind === "create");
+		const conditions = this.discoveryForm?.visibleForNotes.get(id);
+		return !conditions || conditions.some((condition) => acceptsDiscoverySelection(condition, this.discoverySelections));
 	}
 
 	private updateFieldVisibility(updatePreview = true): void {
+		this.updateFieldMetadata();
 		for (const [id, elements] of this.fieldElements) {
 			for (const element of elements) element.hidden = !this.isFieldVisible(id);
 		}
+		for (const requirement of this.requirements) {
+			const input = this.imagePasteInputs.get(requirement.id);
+			if (input) this.syncImagePaste(requirement, input);
+		}
 		if (updatePreview) this.updatePreviewDebounced();
+	}
+
+	private updateFieldMetadata(): void {
+		for (const req of this.requirements) {
+			const usages = this.discoveryForm?.fieldUsages.get(req.id);
+			if (!usages) continue;
+			Object.assign(req, resolveDiscoveryFieldMetadata(usages, this.discoverySelections));
+			for (const element of this.fieldElements.get(req.id) ?? []) {
+				element.querySelector(".setting-item-name")?.replaceChildren(this.decorateLabel(req));
+				if (req.type !== "dropdown") continue;
+				const select = element.querySelector("select");
+				if (!select || req.options?.includes("")) continue;
+				const skip = Array.from(select.options).find((option) => option.value === "");
+				if (req.optional && !skip) {
+					const option = select.ownerDocument.createElement("option");
+					option.value = "";
+					option.textContent = "Skip (leave empty)";
+					select.prepend(option);
+				} else if (!req.optional && skip) {
+					skip.remove();
+					this.result.set(req.id, select.value);
+				}
+			}
+		}
 	}
 
 	private renderNoteField(note: DiscoveryNoteField): void {
@@ -330,7 +362,10 @@ export class OnePageInputModal extends Modal {
 			suggester?.close();
 			this.discoverySelections.set(note.id, selection);
 			selected.empty();
-			const label = selection.kind === "existing" ? selection.path.replace(/\.md$/i, "") : `Create: ${selection.title}`;
+			const action = existingNoteActionVerb(note.choice.existingNoteAction);
+			const label = selection.kind === "existing"
+				? `${action === "Open" ? "" : `${action}: `}${selection.path.replace(/\.md$/i, "")}`
+				: `Create: ${selection.title}`;
 			const chip = selected.createDiv({ cls: "qa-onepage-file-picker__chip" });
 			chip.createSpan({ cls: "qa-onepage-file-picker__chip-label", text: label });
 			const change = chip.createEl("button", { cls: "qa-onepage-file-picker__remove", text: "×" });
@@ -358,7 +393,7 @@ export class OnePageInputModal extends Modal {
 			select: showSelection,
 			resolve: () => suggester
 				? suggester.resolveInput(input.inputEl.value)
-				: selectionForDiscoveryCandidate(this.app, input.inputEl.value),
+				: createTemplateNoteSelection(input.inputEl.value),
 		});
 	}
 
@@ -988,8 +1023,21 @@ export class OnePageInputModal extends Modal {
 		req: FieldRequirement,
 		inputEl: HTMLInputElement | HTMLTextAreaElement,
 	): void {
-		if (req.pathContext) return;
-		this.imagePasteHandles.push(attachImagePasteHandler(this.app, inputEl, {}));
+		this.imagePasteInputs.set(req.id, inputEl);
+		this.syncImagePaste(req, inputEl);
+	}
+
+	private syncImagePaste(
+		req: FieldRequirement,
+		inputEl: HTMLInputElement | HTMLTextAreaElement,
+	): void {
+		const handle = this.imagePasteHandles.get(req.id);
+		if (req.pathContext || !this.isFieldVisible(req.id)) {
+			handle?.detach();
+			this.imagePasteHandles.delete(req.id);
+		} else if (!handle) {
+			this.imagePasteHandles.set(req.id, attachImagePasteHandler(this.app, inputEl, {}));
+		}
 	}
 
 	private decorateLabel(req: FieldRequirement): string | DocumentFragment {
@@ -1034,7 +1082,7 @@ export class OnePageInputModal extends Modal {
 		}
 		// A pasted image may still be saving in one of the fields; defer so
 		// paste-then-Mod+Enter submits WITH the embed link.
-		const busyHandle = this.imagePasteHandles.find((handle) =>
+		const busyHandle = Array.from(this.imagePasteHandles.values()).find((handle) =>
 			handle.isBusy(),
 		);
 		if (busyHandle) {
@@ -1135,8 +1183,9 @@ export class OnePageInputModal extends Modal {
 
 	onClose() {
 		this.peek.onHostClosed();
-		for (const handle of this.imagePasteHandles) handle.detach();
-		this.imagePasteHandles.length = 0;
+		for (const handle of this.imagePasteHandles.values()) handle.detach();
+		this.imagePasteHandles.clear();
+		this.imagePasteInputs.clear();
 		for (const field of this.freeTextFields) {
 			field.fileSuggester.destroy();
 			field.tagSuggester.destroy();

--- a/src/preflight/discoveryFormPlan.test.ts
+++ b/src/preflight/discoveryFormPlan.test.ts
@@ -11,7 +11,7 @@ import type { ICommand } from "src/types/macros/ICommand";
 import type { INestedChoiceCommand } from "src/types/macros/QuickCommands/INestedChoiceCommand";
 import { CommandType } from "src/types/macros/CommandType";
 import { QA_INTERNAL_DATE_ORIGIN } from "src/constants";
-import { buildDiscoveryFormPlan, resolveDiscoveryFieldMetadata, storeDiscoveryFormAnswers } from "./discoveryFormPlan";
+import { buildDiscoveryFormPlan, resolveDiscoveryFieldRequirement, storeDiscoveryFormAnswers } from "./discoveryFormPlan";
 import { getPreparedTemplateNoteSelection, withPreparedChoiceInputs } from "./preparedChoiceInputs";
 
 vi.mock("src/utilityObsidian", () => ({
@@ -149,12 +149,12 @@ describe("discovery form planning", () => {
 		const noteId = plan.config.notes[0].id;
 		const usages = plan.config.fieldUsages.get("detail");
 		if (!usages) throw new Error("Expected shared field usages");
-		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+		expect(resolveDiscoveryFieldRequirement(usages, new Map([
 			[noteId, { kind: "existing", path: "Projects/Atlas.md" }],
-		]))).toEqual({ optional: true, pathContext: false });
-		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+		]))).toMatchObject({ optional: true, pathContext: false });
+		expect(resolveDiscoveryFieldRequirement(usages, new Map([
 			[noteId, { kind: "create", title: "Borealis" }],
-		]))).toEqual({ optional: false, pathContext: true });
+		]))).toMatchObject({ optional: false, pathContext: true });
 	});
 
 	it("does not let a skipped open-only Template restrict a shared Capture field", async () => {
@@ -167,12 +167,12 @@ describe("discovery form planning", () => {
 		expect(plan.config.visibleForNotes.has("detail")).toBe(false);
 		const usages = plan.config.fieldUsages.get("detail");
 		if (!usages) throw new Error("Expected shared field usages");
-		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+		expect(resolveDiscoveryFieldRequirement(usages, new Map([
 			["__qa.note.note", { kind: "existing", path: "Projects/Atlas.md" }],
-		]))).toEqual({ optional: true, pathContext: false });
-		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+		]))).toMatchObject({ optional: true, pathContext: false });
+		expect(resolveDiscoveryFieldRequirement(usages, new Map([
 			["__qa.note.note", { kind: "create", title: "Borealis" }],
-		]))).toEqual({ optional: false, pathContext: true });
+		]))).toMatchObject({ optional: false, pathContext: true });
 	});
 
 	it("prepares creation-only answers per occurrence when the same Template creates and updates", async () => {

--- a/src/preflight/discoveryFormPlan.test.ts
+++ b/src/preflight/discoveryFormPlan.test.ts
@@ -11,7 +11,7 @@ import type { ICommand } from "src/types/macros/ICommand";
 import type { INestedChoiceCommand } from "src/types/macros/QuickCommands/INestedChoiceCommand";
 import { CommandType } from "src/types/macros/CommandType";
 import { QA_INTERNAL_DATE_ORIGIN } from "src/constants";
-import { buildDiscoveryFormPlan, storeDiscoveryFormAnswers } from "./discoveryFormPlan";
+import { buildDiscoveryFormPlan, resolveDiscoveryFieldMetadata, storeDiscoveryFormAnswers } from "./discoveryFormPlan";
 import { getPreparedTemplateNoteSelection, withPreparedChoiceInputs } from "./preparedChoiceInputs";
 
 vi.mock("src/utilityObsidian", () => ({
@@ -36,9 +36,10 @@ describe("discovery form planning", () => {
 	let capture: CaptureChoice;
 	let executor: IChoiceExecutor;
 	let selectedText: string;
+	let templateContent: string;
 	const app = {
 		vault: {
-			cachedRead: async () => "{{VALUE}} {{VALUE:shared}} {{VALUE:templateOnly}}",
+			cachedRead: async () => templateContent,
 			getAbstractFileByPath: () => null,
 		},
 		metadataCache: { getFileCache: () => null },
@@ -58,6 +59,7 @@ describe("discovery form planning", () => {
 		capture.format = { enabled: true, format: "{{VALUE}} {{VALUE:shared}}" };
 		executor = { ...createChoiceExecutor(), execute: vi.fn(), variables: new Map() };
 		selectedText = "";
+		templateContent = "{{VALUE}} {{VALUE:shared}} {{VALUE:templateOnly}}";
 	});
 
 	it("separates note selection from repeated Capture answers and keeps shared fields visible", async () => {
@@ -68,8 +70,8 @@ describe("discovery form planning", () => {
 		expect(plan.requirements.map((field) => field.id)).toEqual([
 			"__qa.note.note", "shared", "templateOnly", "__qa.value.first", "__qa.value.second",
 		]);
-		expect(plan.config.visibleWhenCreating.get("templateOnly")).toEqual(["__qa.note.note"]);
-		expect(plan.config.visibleWhenCreating.has("shared")).toBe(false);
+		expect(plan.config.visibleForNotes.get("templateOnly")).toEqual([{ noteId: "__qa.note.note", includeExisting: false }]);
+		expect(plan.config.visibleForNotes.has("shared")).toBe(false);
 		expect(plan.requirements.filter((field) => field.id.startsWith("__qa.value."))
 			.map((field) => field.group?.id)).toEqual(["first", "second"]);
 
@@ -82,6 +84,7 @@ describe("discovery form planning", () => {
 			expect(getPreparedTemplateNoteSelection(executor, template.id))
 				.toEqual({ kind: "existing", path: "Existing.md" });
 			expect(executor.variables.has("templateOnly")).toBe(false);
+			expect(executor.variables.has("shared")).toBe(false);
 		});
 		const results: unknown[] = [];
 		for (const id of ["first", "second"]) {
@@ -91,6 +94,118 @@ describe("discovery form planning", () => {
 			});
 		}
 		expect(results).toEqual(["First answer", "Second answer"]);
+		expect(executor.variables.has("value")).toBe(false);
+	});
+
+	it.each(["appendBottom", "appendTop", "overwrite"] as const)("prepares template inputs for %s without asking creation-only inputs", async (action) => {
+		template.existingNoteAction = action;
+		template.folder = { ...template.folder, enabled: true, folders: ["{{VALUE:folderOnly}}/{{VALUE:shared}}"] };
+		template.dateOrigin = { kind: "ask" };
+		const plan = await buildDiscoveryFormPlan(app, plugin, executor, template);
+		if (!plan) throw new Error("Expected discovery form");
+		const noteId = plan.config.notes[0].id;
+		for (const id of ["shared", "templateOnly", QA_INTERNAL_DATE_ORIGIN]) {
+			expect(plan.config.visibleForNotes.get(id), id).toEqual([{ noteId, includeExisting: true }]);
+		}
+		expect(plan.config.visibleForNotes.get("folderOnly")).toEqual([{ noteId, includeExisting: false }]);
+
+		storeDiscoveryFormAnswers(executor, plan, new Map([
+			["shared", "Ada"], ["templateOnly", "Ship Friday"],
+			[QA_INTERNAL_DATE_ORIGIN, "@date:2026-09-07"], ["folderOnly", "Unused folder draft"],
+		]), new Map([[noteId, { kind: "existing", path: "Projects/Atlas.md" }]]));
+		await withPreparedChoiceInputs(executor, template.id, async () => {
+			expect([...executor.variables]).toEqual(expect.arrayContaining([
+				["shared", "Ada"], ["templateOnly", "Ship Friday"],
+				[QA_INTERNAL_DATE_ORIGIN, "@date:2026-09-07"],
+			]));
+			expect(executor.variables.has("folderOnly")).toBe(false);
+			expect(executor.variables.has("value")).toBe(false);
+			expect(getPreparedTemplateNoteSelection(executor, template.id))
+				.toEqual({ kind: "existing", path: "Projects/Atlas.md" });
+		});
+		expect(executor.variables.has("value")).toBe(false);
+	});
+
+	it("retains source-path answers when applying a dynamically selected template", async () => {
+		template.existingNoteAction = "overwrite";
+		template.templatePath = "Templates/{{VALUE:source}}.md";
+		const plan = await buildDiscoveryFormPlan(app, plugin, executor, template);
+		if (!plan) throw new Error("Expected discovery form");
+		const noteId = plan.config.notes[0].id;
+		expect(plan.config.visibleForNotes.get("source")).toEqual([{ noteId, includeExisting: true }]);
+		storeDiscoveryFormAnswers(executor, plan, new Map([["source", "Project"]]),
+			new Map([[noteId, { kind: "existing", path: "Projects/Atlas.md" }]]));
+		await withPreparedChoiceInputs(executor, template.id, async () => {
+			expect(executor.variables.get("source")).toBe("Project");
+		});
+	});
+
+	it("uses only active template purposes to decide whether a shared field is optional and accepts images", async () => {
+		template.existingNoteAction = "appendBottom";
+		template.folder = { ...template.folder, enabled: true, folders: ["Archive/{{VALUE:detail}}"] };
+		templateContent = "Description: {{VALUE:detail|optional}}";
+		const plan = await buildDiscoveryFormPlan(app, plugin, executor, template);
+		if (!plan) throw new Error("Expected discovery form");
+		const noteId = plan.config.notes[0].id;
+		const usages = plan.config.fieldUsages.get("detail");
+		if (!usages) throw new Error("Expected shared field usages");
+		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+			[noteId, { kind: "existing", path: "Projects/Atlas.md" }],
+		]))).toEqual({ optional: true, pathContext: false });
+		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+			[noteId, { kind: "create", title: "Borealis" }],
+		]))).toEqual({ optional: false, pathContext: true });
+	});
+
+	it("does not let a skipped open-only Template restrict a shared Capture field", async () => {
+		template.folder = { ...template.folder, enabled: true, folders: ["Archive/{{VALUE:detail}}"] };
+		templateContent = "{{VALUE:detail}}";
+		capture.format = { enabled: true, format: "{{VALUE:detail|optional}}" };
+		const plan = await buildDiscoveryFormPlan(app, plugin, executor,
+			macro(nested(template, "note"), nested(capture, "capture")));
+		if (!plan) throw new Error("Expected discovery form");
+		expect(plan.config.visibleForNotes.has("detail")).toBe(false);
+		const usages = plan.config.fieldUsages.get("detail");
+		if (!usages) throw new Error("Expected shared field usages");
+		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+			["__qa.note.note", { kind: "existing", path: "Projects/Atlas.md" }],
+		]))).toEqual({ optional: true, pathContext: false });
+		expect(resolveDiscoveryFieldMetadata(usages, new Map([
+			["__qa.note.note", { kind: "create", title: "Borealis" }],
+		]))).toEqual({ optional: false, pathContext: true });
+	});
+
+	it("prepares creation-only answers per occurrence when the same Template creates and updates", async () => {
+		template.existingNoteAction = "appendBottom";
+		template.folder = { ...template.folder, enabled: true, folders: ["{{VALUE:folderOnly}}"] };
+		const plan = await buildDiscoveryFormPlan(app, plugin, executor,
+			macro(nested(template, "update"), nested(template, "create"), nested(capture, "capture")));
+		if (!plan) throw new Error("Expected discovery form");
+		storeDiscoveryFormAnswers(executor, plan, new Map([
+			["shared", "Ada"], ["templateOnly", "Template text"], ["folderOnly", "Projects"],
+			["__qa.value.capture", "Capture text"],
+		]), new Map([
+			["__qa.note.update", { kind: "existing", path: "Archive/Atlas.md" }],
+			["__qa.note.create", { kind: "create", title: "Borealis" }],
+		]));
+		await withPreparedChoiceInputs(executor, "update", async () => {
+			expect(executor.variables.get("shared")).toBe("Ada");
+			expect(executor.variables.get("templateOnly")).toBe("Template text");
+			expect(executor.variables.has("folderOnly")).toBe(false);
+			expect(getPreparedTemplateNoteSelection(executor, template.id))
+				.toEqual({ kind: "existing", path: "Archive/Atlas.md" });
+		});
+		await withPreparedChoiceInputs(executor, "create", async () => {
+			expect(executor.variables.get("folderOnly")).toBe("Projects");
+			expect(executor.variables.get("shared")).toBe("Ada");
+			expect(getPreparedTemplateNoteSelection(executor, template.id))
+				.toEqual({ kind: "create", title: "Borealis" });
+		});
+		await withPreparedChoiceInputs(executor, "capture", async () => {
+			expect(executor.variables.get("shared")).toBe("Ada");
+			expect(executor.variables.get("value")).toBe("Capture text");
+			expect(executor.preparedInputs.active?.values.has("templateOnly")).toBe(false);
+		});
 		expect(executor.variables.has("value")).toBe(false);
 	});
 

--- a/src/preflight/discoveryFormPlan.ts
+++ b/src/preflight/discoveryFormPlan.ts
@@ -29,7 +29,7 @@ export interface DiscoveryFormConfig {
 	fieldUsages: Map<string, DiscoveryFieldUsage[]>;
 }
 
-type DiscoveryFieldMetadata = Pick<FieldRequirement, "optional" | "pathContext">;
+type DiscoveryFieldMetadata = FieldRequirement;
 
 export type DiscoveryFieldUsage =
 	| { kind: "always"; metadata: DiscoveryFieldMetadata }
@@ -40,24 +40,27 @@ export type DiscoveryFieldUsage =
 		existing: DiscoveryFieldMetadata | null;
 	};
 
-export function resolveDiscoveryFieldMetadata(
+export function resolveDiscoveryFieldRequirement(
 	usages: readonly DiscoveryFieldUsage[],
 	selections: ReadonlyMap<string, TemplateNoteSelection>,
-): Required<DiscoveryFieldMetadata> {
+): FieldRequirement | null {
 	const active = usages.flatMap((usage) => {
 		if (usage.kind === "always") return [usage.metadata];
 		const selection = selections.get(usage.noteId);
 		if (selection?.kind === "create") return [usage.create];
 		return selection?.kind === "existing" && usage.existing ? [usage.existing] : [];
 	});
+	if (active.length === 0) return null;
 	return {
+		...active[0],
 		optional: active.length > 0 && active.every((metadata) => metadata.optional),
 		pathContext: active.some((metadata) => metadata.pathContext),
+		runtimeOnly: active.some((metadata) => metadata.runtimeOnly),
 	};
 }
 
 function fieldMetadata(requirement: FieldRequirement): DiscoveryFieldMetadata {
-	return { optional: requirement.optional, pathContext: requirement.pathContext };
+	return { ...requirement };
 }
 
 export interface DiscoveryInputCondition {
@@ -188,10 +191,15 @@ export async function buildDiscoveryFormPlan(
 			step.bindings.set(id, { variable: requirement.id, condition });
 			const usages = config.fieldUsages.get(id) ?? [];
 			const existingNoteRequirement = existingNoteInputs.get(requirement.id);
+			const field: FieldRequirement = {
+				...requirement, id, group,
+				...(requirement.id === "value" && captureSelection.trim()
+					? { defaultValue: captureSelection } : {}),
+			};
 			usages.push(noteId ? {
-				kind: "note", noteId, create: fieldMetadata(requirement),
+				kind: "note", noteId, create: fieldMetadata(field),
 				existing: existingNoteRequirement ? fieldMetadata(existingNoteRequirement) : null,
-			} : { kind: "always", metadata: fieldMetadata(requirement) });
+			} : { kind: "always", metadata: fieldMetadata(field) });
 			config.fieldUsages.set(id, usages);
 			const existing = requirements.get(id);
 			if (existing) {
@@ -199,12 +207,7 @@ export async function buildDiscoveryFormPlan(
 				if (requirement.pathContext) existing.pathContext = true;
 				if (requirement.runtimeOnly) existing.runtimeOnly = true;
 			} else {
-				requirements.set(id, {
-					...requirement, id, group,
-					...(requirement.id === "value" && captureSelection.trim()
-						? { defaultValue: captureSelection }
-						: {}),
-				});
+				requirements.set(id, field);
 			}
 			const owners = consumers.get(id) ?? [];
 			owners.push(condition);

--- a/src/preflight/discoveryFormPlan.ts
+++ b/src/preflight/discoveryFormPlan.ts
@@ -8,6 +8,7 @@ import type ITemplateChoice from "src/types/choices/ITemplateChoice";
 import { VALUE_SYNTAX } from "src/constants";
 import type { TemplateNoteSelection } from "src/utils/templateNoteDiscovery";
 import { shouldRunTemplateNoteDiscovery } from "src/utils/templateNoteDiscoveryEligibility";
+import { getExistingNoteAction } from "src/template/fileExistsPolicy";
 import { commandListOf, isCommandLike } from "src/utils/macroUtils";
 import { getActiveEditorSelection } from "src/utils/activeMarkdownEditor";
 import { classifyStep, isCaptureChoice, isTemplateChoice } from "./macroCommandRole";
@@ -24,14 +25,59 @@ export interface DiscoveryNoteField {
 
 export interface DiscoveryFormConfig {
 	notes: DiscoveryNoteField[];
-	visibleWhenCreating: Map<string, string[]>;
+	visibleForNotes: Map<string, DiscoveryInputCondition[]>;
+	fieldUsages: Map<string, DiscoveryFieldUsage[]>;
+}
+
+type DiscoveryFieldMetadata = Pick<FieldRequirement, "optional" | "pathContext">;
+
+export type DiscoveryFieldUsage =
+	| { kind: "always"; metadata: DiscoveryFieldMetadata }
+	| {
+		kind: "note";
+		noteId: string;
+		create: DiscoveryFieldMetadata;
+		existing: DiscoveryFieldMetadata | null;
+	};
+
+export function resolveDiscoveryFieldMetadata(
+	usages: readonly DiscoveryFieldUsage[],
+	selections: ReadonlyMap<string, TemplateNoteSelection>,
+): Required<DiscoveryFieldMetadata> {
+	const active = usages.flatMap((usage) => {
+		if (usage.kind === "always") return [usage.metadata];
+		const selection = selections.get(usage.noteId);
+		if (selection?.kind === "create") return [usage.create];
+		return selection?.kind === "existing" && usage.existing ? [usage.existing] : [];
+	});
+	return {
+		optional: active.length > 0 && active.every((metadata) => metadata.optional),
+		pathContext: active.some((metadata) => metadata.pathContext),
+	};
+}
+
+function fieldMetadata(requirement: FieldRequirement): DiscoveryFieldMetadata {
+	return { optional: requirement.optional, pathContext: requirement.pathContext };
+}
+
+export interface DiscoveryInputCondition {
+	noteId: string;
+	includeExisting: boolean;
+}
+
+export function acceptsDiscoverySelection(
+	condition: DiscoveryInputCondition,
+	selections: ReadonlyMap<string, TemplateNoteSelection>,
+): boolean {
+	const selection = selections.get(condition.noteId);
+	return selection?.kind === "create" || (condition.includeExisting && selection?.kind === "existing");
 }
 
 interface DiscoveryFormStep {
 	occurrenceId: string;
 	choiceId: string;
 	noteId: string | null;
-	bindings: Map<string, string>;
+	bindings: Map<string, { variable: string; condition: DiscoveryInputCondition | null }>;
 }
 
 export interface DiscoveryFormPlan {
@@ -77,8 +123,8 @@ export async function buildDiscoveryFormPlan(
 	}
 
 	const requirements = new Map<string, FieldRequirement>();
-	const consumers = new Map<string, Array<string | null>>();
-	const config: DiscoveryFormConfig = { notes: [], visibleWhenCreating: new Map() };
+	const consumers = new Map<string, Array<DiscoveryInputCondition | null>>();
+	const config: DiscoveryFormConfig = { notes: [], visibleForNotes: new Map(), fieldUsages: new Map() };
 	const steps: DiscoveryFormStep[] = [];
 	if (isMacroChoice(choice)) {
 		const macroWithoutCommands: IMacroChoice = { ...choice, macro: { ...choice.macro, commands: [] } };
@@ -86,11 +132,12 @@ export async function buildDiscoveryFormPlan(
 			app, plugin, executor, macroWithoutCommands,
 		), executor.variables);
 		if (macroRequirements.length > 0) {
-			const bindings = new Map<string, string>();
+			const bindings: DiscoveryFormStep["bindings"] = new Map();
 			for (const requirement of macroRequirements) {
 				requirements.set(requirement.id, requirement);
-				bindings.set(requirement.id, requirement.id);
+				bindings.set(requirement.id, { variable: requirement.id, condition: null });
 				consumers.set(requirement.id, [null]);
+				config.fieldUsages.set(requirement.id, [{ kind: "always", metadata: fieldMetadata(requirement) }]);
 			}
 			steps.push({ occurrenceId: choice.id, choiceId: choice.id, noteId: null, bindings });
 		}
@@ -119,6 +166,17 @@ export async function buildDiscoveryFormPlan(
 			app, plugin, executor, collectable,
 			{ preloadedUserScripts: executor.preloadedUserScripts },
 		), executor.variables);
+		const existingNoteInputs = new Map<string, FieldRequirement>();
+		if (discovery && getExistingNoteAction(discovery.existingNoteAction) !== "open") {
+			const existingTarget: ITemplateChoice = {
+				...discovery,
+				fileNameFormat: { enabled: false, format: "" },
+				folder: { ...discovery.folder, enabled: false },
+			};
+			for (const requirement of await collectChoiceRequirements(app, plugin, executor, existingTarget)) {
+				existingNoteInputs.set(requirement.id, requirement);
+			}
+		}
 		const captureSelection = child && isCaptureChoice(child) &&
 			(child.useSelectionAsCaptureValue ?? plugin.settings.useSelectionAsCaptureValue ?? true)
 			? getActiveEditorSelection(app)
@@ -126,7 +184,15 @@ export async function buildDiscoveryFormPlan(
 		for (const requirement of collected) {
 			if (discovery && requirement.id === "value") continue;
 			const id = requirement.id === "value" ? `__qa.value.${entry.occurrenceId}` : requirement.id;
-			step.bindings.set(id, requirement.id);
+			const condition = noteId ? { noteId, includeExisting: existingNoteInputs.has(requirement.id) } : null;
+			step.bindings.set(id, { variable: requirement.id, condition });
+			const usages = config.fieldUsages.get(id) ?? [];
+			const existingNoteRequirement = existingNoteInputs.get(requirement.id);
+			usages.push(noteId ? {
+				kind: "note", noteId, create: fieldMetadata(requirement),
+				existing: existingNoteRequirement ? fieldMetadata(existingNoteRequirement) : null,
+			} : { kind: "always", metadata: fieldMetadata(requirement) });
+			config.fieldUsages.set(id, usages);
 			const existing = requirements.get(id);
 			if (existing) {
 				existing.optional = Boolean(existing.optional && requirement.optional);
@@ -141,13 +207,13 @@ export async function buildDiscoveryFormPlan(
 				});
 			}
 			const owners = consumers.get(id) ?? [];
-			owners.push(noteId);
+			owners.push(condition);
 			consumers.set(id, owners);
 		}
 	}
 	for (const [id, owners] of consumers) {
 		if (!owners.includes(null)) {
-			config.visibleWhenCreating.set(id, owners.filter((owner): owner is string => owner !== null));
+			config.visibleForNotes.set(id, owners.filter((owner): owner is DiscoveryInputCondition => owner !== null));
 		}
 	}
 	return { requirements: [...requirements.values()], config, steps };
@@ -162,9 +228,9 @@ export function storeDiscoveryFormAnswers(
 	for (const step of plan.steps) {
 		const discovery = step.noteId ? selections.get(step.noteId) ?? null : null;
 		const values = new Map<string, unknown>();
-		if (discovery?.kind !== "existing") {
-			for (const [fieldId, variable] of step.bindings) {
-				if (answers.has(fieldId)) values.set(variable, answers.get(fieldId));
+		for (const [fieldId, { variable, condition }] of step.bindings) {
+			if ((!condition || acceptsDiscoverySelection(condition, selections)) && answers.has(fieldId)) {
+				values.set(variable, answers.get(fieldId));
 			}
 		}
 		setPreparedChoiceInputs(executor, step.occurrenceId, { choiceId: step.choiceId, values, discovery });

--- a/src/preflight/runOnePagePreflight.ts
+++ b/src/preflight/runOnePagePreflight.ts
@@ -155,7 +155,7 @@ export async function runOnePagePreflight(
 		if (unresolved.length === 0) return false; // Everything prefilled, skip modal
 
 		const modalRequirements = unresolved.filter(
-			(requirement) => !requirement.runtimeOnly,
+			(requirement) => !requirement.runtimeOnly || discoveryPlan?.config.fieldUsages.has(requirement.id),
 		);
 		if (modalRequirements.length === 0) return false;
 
@@ -262,7 +262,7 @@ export async function runOnePagePreflight(
 				displayToValue: Map<string, string>;
 			}
 		>();
-		for (const req of modalRequirements) {
+		for (const req of modal?.activeRequirements ?? modalRequirements) {
 			if (req.id.startsWith(FILE_VARIABLE_PREFIX)) {
 				const options = req.options ?? [];
 				const displayOptions = req.displayOptions ?? options;

--- a/src/template/fileExistsPolicy.test.ts
+++ b/src/template/fileExistsPolicy.test.ts
@@ -4,12 +4,26 @@ import {
 	getBehaviorCategory,
 	getDefaultBehaviorForCategory,
 	getFileExistsMode,
+	getExistingNoteAction,
 	getModesForCategory,
 	getPromptModes,
 	mapLegacyFileExistsModeToId,
 	resolveDuplicateSuffixCollisionPath,
 	resolveIncrementedCollisionPath,
 } from "./fileExistsPolicy";
+
+describe("existing-note action parsing", () => {
+	it("keeps saved choices without an action on the released open-only behavior", () => {
+		expect(getExistingNoteAction(undefined)).toBe("open");
+	});
+
+	it.each(["duplicateSuffix", "increment", "doNothing", "constructor", null, false])(
+		"rejects %s instead of silently changing a selected note's action",
+		(value) => {
+			expect(() => getExistingNoteAction(value)).toThrow("Unknown existing-note action");
+		},
+	);
+});
 
 describe("fileExistsPolicy registry", () => {
 	it("exposes stable behavior categories", () => {

--- a/src/template/fileExistsPolicy.ts
+++ b/src/template/fileExistsPolicy.ts
@@ -80,6 +80,32 @@ export type TemplateFileExistsBehavior =
 	| { kind: "prompt" }
 	| { kind: "apply"; mode: FileExistsModeId };
 
+export type TemplateExistingNoteAction = "open" | Extract<
+	FileExistsModeDefinition,
+	{ resolutionKind: "modifyExisting" }
+>["id"];
+
+export const existingNoteActions = [
+	{ id: "open", label: "Open note", verb: "Open" },
+	{ id: "appendBottom", label: "Append template to bottom", verb: "Append to" },
+	{ id: "appendTop", label: "Insert template at top", verb: "Insert into" },
+	{ id: "overwrite", label: "Replace entire note", verb: "Replace" },
+] satisfies Array<{ id: TemplateExistingNoteAction; label: string; verb: string }>;
+
+function existingNoteActionDefinition(value: unknown) {
+	const action = existingNoteActions.find((action) => action.id === (value === undefined ? "open" : value));
+	if (!action) throw new Error(`Unknown existing-note action: ${String(value)}`);
+	return action;
+}
+
+export function getExistingNoteAction(value: unknown): TemplateExistingNoteAction {
+	return existingNoteActionDefinition(value).id;
+}
+
+export function existingNoteActionVerb(value: TemplateExistingNoteAction | undefined): string {
+	return existingNoteActionDefinition(value).verb;
+}
+
 type ExistsFn = (path: string) => Promise<boolean>;
 type CreateNewModeId = Extract<
 	FileExistsModeDefinition,

--- a/src/types/choices/ITemplateChoice.ts
+++ b/src/types/choices/ITemplateChoice.ts
@@ -1,7 +1,7 @@
 import type IChoice from "./IChoice";
 import type { AppendLinkOptions } from "../linkPlacement";
 import type { OpenLocation, FileViewMode2 } from "../fileOpening";
-import type { TemplateFileExistsBehavior } from "../../template/fileExistsPolicy";
+import type { TemplateExistingNoteAction, TemplateFileExistsBehavior } from "../../template/fileExistsPolicy";
 
 /**
  * Destination configuration for a Template choice. These four booleans encode a
@@ -26,6 +26,7 @@ export default interface ITemplateChoice extends IChoice {
 	 * before committing to creating a new one.
 	 */
 	discoverExistingNotesBeforeCreate?: boolean;
+	existingNoteAction?: TemplateExistingNoteAction;
 	/** 
 	 * Configure link appending behavior. 
 	 * - boolean: Legacy format for backward compatibility (true = enabled with default placement)

--- a/src/types/choices/TemplateChoice.ts
+++ b/src/types/choices/TemplateChoice.ts
@@ -4,12 +4,13 @@ import { Choice } from "./Choice";
 import type { OpenLocation, FileViewMode2 } from "../fileOpening";
 import type { AppendLinkOptions } from "../linkPlacement";
 import { normalizeFileOpening } from "../../utils/fileOpeningDefaults";
-import type { TemplateFileExistsBehavior } from "../../template/fileExistsPolicy";
+import type { TemplateExistingNoteAction, TemplateFileExistsBehavior } from "../../template/fileExistsPolicy";
 
 export class TemplateChoice extends Choice implements ITemplateChoice {
 	appendLink: boolean | AppendLinkOptions;
 	copyLinkToClipboard: boolean;
 	discoverExistingNotesBeforeCreate: boolean;
+	existingNoteAction?: TemplateExistingNoteAction;
 	fileNameFormat: { enabled: boolean; format: string };
 	folder: TemplateFolderConfig;
 	openFile: boolean;

--- a/src/utils/templateNoteDiscovery.ts
+++ b/src/utils/templateNoteDiscovery.ts
@@ -10,7 +10,7 @@ const UNRESOLVED_PREFIX = "@quickadd-unresolved-note:";
 
 export type TemplateNoteDiscoveryResult =
 	| { kind: "create"; title: string; vaultRelativePath?: string }
-	| { kind: "openExisting"; file: TFile };
+	| { kind: "existing"; file: TFile };
 
 export type TemplateNoteSelection =
 	| { kind: "existing"; path: string }
@@ -194,10 +194,11 @@ export function decodeTemplateNoteSelection(selected: string): TemplateNoteSelec
 	if (isExistingItem(selected)) {
 		return { kind: "existing", path: decodeExistingPath(selected) };
 	}
-	const title = normalizeGeneratedFilePath(
-		isUnresolvedItem(selected) ? decodeUnresolvedTitle(selected) : selected,
-		"Note title",
-	);
+	return createTemplateNoteSelection(isUnresolvedItem(selected) ? decodeUnresolvedTitle(selected) : selected);
+}
+
+export function createTemplateNoteSelection(input: string): TemplateNoteSelection {
+	const title = normalizeGeneratedFilePath(input, "Note title");
 	return {
 		kind: "create",
 		title,
@@ -223,7 +224,10 @@ export function resolveTemplateNoteSelection(
 		if (!(file instanceof TFile)) {
 			throw new Error("Selected note no longer exists. Please run QuickAdd again.");
 		}
-		return { kind: "openExisting", file };
+		if (file.extension.toLowerCase() !== "md") {
+			throw new Error("Select a Markdown note to use with this Template choice.");
+		}
+		return { kind: "existing", file };
 	}
 	const title = normalizeGeneratedFilePath(selection.title, "Note title");
 	return { kind: "create", title, ...(title.includes("/") ? { vaultRelativePath: title } : {}) };

--- a/tests/e2e/template-discovery-actions.test.ts
+++ b/tests/e2e/template-discovery-actions.test.ts
@@ -135,6 +135,21 @@ async function notePaths(workflow: Awaited<ReturnType<typeof seedTemplate>>) {
 }
 
 describe("Template actions for discovered existing notes", () => {
+	it("opens a selected note when an unused append-link destination is missing", async () => {
+		const workflow = await seedTemplate("open-with-missing-link", { action: "open" });
+		workflow.template.appendLink = {
+			enabled: true,
+			placement: "newLine",
+			requireActiveFile: false,
+			destination: { type: "specifiedFile", path: workflow.sandbox.path("Missing link destination.md") },
+		};
+		await runChoice(workflow.template, false);
+		await chooseExisting(workflow, false);
+		await expectNoPrompt(workflow.obsidian);
+		await expect.poll(() => workflow.obsidian.dev.evalJson<string>("app.workspace.getActiveFile()?.path ?? ''"), POLL_OPTS).toBe(workflow.targetPath);
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+	});
+
 	it("rejects a dynamic template source that resolves to the selected note", async () => {
 		const workflow = await seedTemplate("dynamic-source", { action: "appendBottom" });
 		workflow.template.templatePath = "{{VALUE:source}}";

--- a/tests/e2e/template-discovery-actions.test.ts
+++ b/tests/e2e/template-discovery-actions.test.ts
@@ -135,6 +135,17 @@ async function notePaths(workflow: Awaited<ReturnType<typeof seedTemplate>>) {
 }
 
 describe("Template actions for discovered existing notes", () => {
+	it("does not treat a typed internal candidate identifier as a selected note", async () => {
+		const workflow = await seedTemplate("typed-candidate-identity", { action: "overwrite", body: "Replacement body\n" });
+		await runChoice(workflow.template, false);
+		const input = `input[placeholder=${JSON.stringify(`Search notes or create ${workflow.template.name}`)}]`;
+		await waitForElement(workflow.obsidian, input);
+		await typeInto(workflow.obsidian, input, `@quickadd-existing-note:${workflow.targetPath}`);
+		await pressKey(workflow.obsidian, "Enter");
+		await expectNoPrompt(workflow.obsidian);
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+	});
+
 	it("opens a selected note when an unused append-link destination is missing", async () => {
 		const workflow = await seedTemplate("open-with-missing-link", { action: "open" });
 		workflow.template.appendLink = {

--- a/tests/e2e/template-discovery-actions.test.ts
+++ b/tests/e2e/template-discovery-actions.test.ts
@@ -135,6 +135,56 @@ async function notePaths(workflow: Awaited<ReturnType<typeof seedTemplate>>) {
 }
 
 describe("Template actions for discovered existing notes", () => {
+	it("rejects a dynamic template source that resolves to the selected note", async () => {
+		const workflow = await seedTemplate("dynamic-source", { action: "appendBottom" });
+		workflow.template.templatePath = "{{VALUE:source}}";
+		const { plugin } = getContext();
+		await plugin.data<QuickAddData>().patch((data) => {
+			data.onePageInputEnabled = false;
+			data.choices.push(workflow.template);
+		});
+		await plugin.reload({ waitUntilReady: true });
+		const completed = workflow.obsidian.execJson("quickadd:run", {
+			id: workflow.template.id, ui: true, verify: true,
+			vars: JSON.stringify({ source: workflow.targetPath }),
+		});
+		await chooseExisting(workflow, false, "Append to");
+		const outcome = await completed;
+		expect(outcome).toMatchObject({ ok: false, error: expect.stringContaining("template source") });
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+	});
+
+	it("switches a creation dropdown to the existing note's free-text body field", async () => {
+		const workflow = await seedTemplate("shared-control", {
+			action: "appendBottom", body: "Description: {{VALUE:detail}}\n",
+			folder: "{{VALUE:a,b|name:detail}}",
+		});
+		await runChoice(workflow.template, true);
+		await chooseExisting(workflow, true);
+		await waitForElement(workflow.obsidian, formField("detail"));
+		await typeInto(workflow.obsidian, formField("detail"), "An unrestricted description");
+		await workflow.obsidian.dev.evalJson(`document.querySelector('[aria-label="Change note"]').click()`);
+		const noteInput = `[aria-label=${JSON.stringify(`Note for ${workflow.template.name}`)}]`;
+		await typeInto(workflow.obsidian, noteInput, "New control draft");
+		await expect.poll(() => workflow.obsidian.dev.evalJson<string>(
+			'document.querySelector(".qa-onepage-file-suggestion__label")?.textContent ?? ""',
+		), POLL_OPTS).toBe("Create new note: New control draft");
+		await pressKey(workflow.obsidian, "Enter");
+		expect(await workflow.obsidian.dev.evalJson<string[]>(
+			'Array.from(document.querySelector(".onePageInputModal select").options, option => option.value)',
+		)).toEqual(["a", "b"]);
+		await workflow.obsidian.dev.evalJson(`document.querySelector('[aria-label="Change note"]').click()`);
+		await chooseExisting(workflow, true);
+		expect(await workflow.obsidian.dev.evalJson<string>(
+			`document.querySelector(${JSON.stringify(formField("detail"))}).value`,
+		)).toBe("An unrestricted description");
+		await pressKey(workflow.obsidian, "Enter", true);
+		const content = await workflow.sandbox.waitForContent(workflow.relativePath,
+			(text) => text.includes("Description: An unrestricted description"), WAIT_OPTS);
+		expect(content).toBe(`${INITIAL_CONTENT}\nDescription: An unrestricted description\n`);
+		await expectNoPrompt(workflow.obsidian);
+	});
+
 	it.each([
 		{ action: "appendBottom", verb: "Append to", expected: `${INITIAL_CONTENT}\nOwner: Ada\n` },
 		{ action: "appendTop", verb: "Insert into", expected: "---\nstatus: active\n---\nOwner: Ada\n\n# Existing note\n" },
@@ -155,7 +205,7 @@ describe("Template actions for discovered existing notes", () => {
 		const content = await workflow.sandbox.waitForContent(workflow.relativePath, (text) => text.includes("Owner: Ada"), WAIT_OPTS);
 		expect(content).toBe(scenario.expected);
 		await expectNoPrompt(workflow.obsidian);
-		expect(await workflow.obsidian.dev.evalJson<string | null>("app.workspace.getActiveFile()?.path ?? null"))
+		await expect.poll(() => workflow.obsidian.dev.evalJson<string | null>("app.workspace.getActiveFile()?.path ?? null"), POLL_OPTS)
 			.toBe(workflow.targetPath);
 		expect(await notePaths(workflow)).toEqual(pathsBefore);
 	});

--- a/tests/e2e/template-discovery-actions.test.ts
+++ b/tests/e2e/template-discovery-actions.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ObsidianClient } from "obsidian-e2e";
+import { CaptureChoice } from "../../src/types/choices/CaptureChoice";
+import type IChoice from "../../src/types/choices/IChoice";
+import { MacroChoice } from "../../src/types/choices/MacroChoice";
+import { TemplateChoice } from "../../src/types/choices/TemplateChoice";
+import { NestedChoiceCommand } from "../../src/types/macros/QuickCommands/NestedChoiceCommand";
+import { createQuickAddE2EHarness, seedVaultFile } from "./e2eVault";
+
+const getContext = createQuickAddE2EHarness("template-discovery-actions");
+const WAIT_OPTS = { timeoutMs: 10_000, intervalMs: 200 };
+const POLL_OPTS = { timeout: 10_000, interval: 200 };
+const INITIAL_CONTENT = "---\nstatus: active\n---\n# Existing note\n";
+const VALUE_INPUT = '.qaInputPrompt input[type="text"], .qaInputPrompt textarea';
+
+type QuickAddData = {
+	choices: IChoice[];
+	onePageInputEnabled: boolean;
+};
+
+async function waitForElement(obsidian: ObsidianClient, selector: string) {
+	await expect.poll(() => obsidian.dev.evalJson<boolean>(
+		`Boolean(document.querySelector(${JSON.stringify(selector)})?.getClientRects().length)`,
+	), POLL_OPTS).toBe(true);
+}
+
+async function typeInto(obsidian: ObsidianClient, selector: string, text: string) {
+	expect(await obsidian.dev.evalJson<boolean>(`(() => {
+		const input = document.querySelector(${JSON.stringify(selector)});
+		if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return false;
+		input.focus();
+		input.select();
+		return true;
+	})()`)).toBe(true);
+	await obsidian.exec("dev:cdp", {
+		method: "Input.insertText",
+		params: JSON.stringify({ text }),
+	});
+}
+
+async function pressKey(obsidian: ObsidianClient, key: "Enter" | "Escape", modified = false) {
+	const modifiers = modified
+		? (await obsidian.dev.evalJson<string>("process.platform")) === "darwin" ? 4 : 2
+		: 0;
+	for (const type of ["keyDown", "keyUp"]) {
+		await obsidian.exec("dev:cdp", {
+			method: "Input.dispatchKeyEvent",
+			params: JSON.stringify({ type, key, code: key, windowsVirtualKeyCode: key === "Enter" ? 13 : 27, modifiers }),
+		});
+	}
+}
+
+async function expectNoPrompt(obsidian: ObsidianClient) {
+	await expect.poll(() => obsidian.dev.evalJson<boolean>(
+		'Boolean(document.querySelector(".modal-container, .prompt"))',
+	), POLL_OPTS).toBe(false);
+}
+
+async function closeOpenPrompts() {
+	const { obsidian } = getContext();
+	for (let remaining = 10; remaining > 0; remaining--) {
+		if (!await obsidian.dev.evalJson<boolean>('Boolean(document.querySelector(".modal-container, .prompt"))')) break;
+		await pressKey(obsidian, "Escape");
+	}
+	await expectNoPrompt(obsidian);
+}
+
+beforeEach(closeOpenPrompts);
+afterEach(closeOpenPrompts);
+
+function formField(id: string) {
+	return `.onePageInputModal [aria-labelledby=${JSON.stringify(`qa-onepage-label-${id}`)}]`;
+}
+
+async function seedTemplate(name: string, options: {
+	action?: TemplateChoice["existingNoteAction"];
+	body?: string;
+	folder?: string;
+} = {}) {
+	const { obsidian, sandbox } = getContext();
+	const noteName = `Existing ${name}`;
+	const relativePath = `${name}/original/${noteName}.md`;
+	const targetPath = await seedVaultFile(obsidian, sandbox, relativePath, INITIAL_CONTENT);
+	const template = new TemplateChoice(`Discover ${name}`);
+	template.command = true;
+	template.discoverExistingNotesBeforeCreate = true;
+	template.existingNoteAction = options.action;
+	template.templatePath = await seedVaultFile(
+		obsidian, sandbox, `${name}/template.md`, options.body ?? "Owner: {{VALUE:owner}}\n",
+	);
+	template.fileNameFormat = { enabled: true, format: "{{VALUE}}" };
+	template.folder = {
+		...template.folder,
+		enabled: true,
+		folders: [sandbox.path(`${name}/new/${options.folder ?? "{{VALUE:creationFolder}}"}`)],
+	};
+	template.fileExistsBehavior = { kind: "apply", mode: "overwrite" };
+	template.openFile = true;
+	return { obsidian, sandbox, template, noteName, relativePath, targetPath, name };
+}
+
+async function runChoice(choice: IChoice, onePage: boolean) {
+	const { obsidian, plugin } = getContext();
+	await plugin.data<QuickAddData>().patch((data) => {
+		data.onePageInputEnabled = onePage;
+		data.choices.push(choice);
+	});
+	await plugin.reload({ waitUntilReady: true });
+	await obsidian.exec("command", { id: `quickadd:choice:${choice.id}` });
+}
+
+async function chooseExisting(workflow: Awaited<ReturnType<typeof seedTemplate>>, onePage: boolean, verb?: string) {
+	const { obsidian, template, noteName, targetPath } = workflow;
+	const input = onePage
+		? `[aria-label=${JSON.stringify(`Note for ${template.name}`)}]`
+		: `input[placeholder=${JSON.stringify(`Search notes or create ${template.name}`)}]`;
+	await waitForElement(obsidian, input);
+	await typeInto(obsidian, input, noteName);
+	if (onePage) {
+		await expect.poll(() => obsidian.dev.evalJson<string>(
+			'document.querySelector(".qa-onepage-file-suggestion__path")?.textContent ?? ""',
+		), POLL_OPTS).toBe(targetPath);
+	} else {
+		await expect.poll(() => obsidian.dev.evalJson<string>(
+			'document.querySelector(".suggestion-item .suggestion-title")?.textContent ?? ""',
+		), POLL_OPTS).toContain(verb ? `${verb}: ${noteName}` : noteName);
+	}
+	await pressKey(obsidian, "Enter");
+}
+
+async function notePaths(workflow: Awaited<ReturnType<typeof seedTemplate>>) {
+	return workflow.obsidian.dev.evalJson<string[]>(`app.vault.getFiles()
+		.filter((file) => file.path.startsWith(${JSON.stringify(`${workflow.sandbox.path(workflow.name)}/`)}))
+		.map((file) => file.path).sort()`);
+}
+
+describe("Template actions for discovered existing notes", () => {
+	it.each([
+		{ action: "appendBottom", verb: "Append to", expected: `${INITIAL_CONTENT}\nOwner: Ada\n` },
+		{ action: "appendTop", verb: "Insert into", expected: "---\nstatus: active\n---\nOwner: Ada\n\n# Existing note\n" },
+		{ action: "overwrite", verb: "Replace", expected: "Owner: Ada\n" },
+	] satisfies Array<{ action: TemplateChoice["existingNoteAction"]; verb: string; expected: string }>)
+	("persists $action and updates the selected path without asking where to create", async (scenario) => {
+		const workflow = await seedTemplate(`action-${scenario.action}`, { action: scenario.action });
+		const pathsBefore = await notePaths(workflow);
+		await runChoice(workflow.template, false);
+		await chooseExisting(workflow, false, scenario.verb);
+		await waitForElement(workflow.obsidian, VALUE_INPUT);
+		expect(await workflow.obsidian.dev.evalJson<string>(
+			'document.querySelector(".qaInputPrompt")?.textContent ?? ""',
+		)).toContain("owner");
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+		await typeInto(workflow.obsidian, VALUE_INPUT, "Ada");
+		await pressKey(workflow.obsidian, "Enter");
+		const content = await workflow.sandbox.waitForContent(workflow.relativePath, (text) => text.includes("Owner: Ada"), WAIT_OPTS);
+		expect(content).toBe(scenario.expected);
+		await expectNoPrompt(workflow.obsidian);
+		expect(await workflow.obsidian.dev.evalJson<string | null>("app.workspace.getActiveFile()?.path ?? null"))
+			.toBe(workflow.targetPath);
+		expect(await notePaths(workflow)).toEqual(pathsBefore);
+	});
+
+	it("cancels replacement at a template question without changing or creating a note", async () => {
+		const workflow = await seedTemplate("cancel-replacement", { action: "overwrite" });
+		const pathsBefore = await notePaths(workflow);
+		await runChoice(workflow.template, false);
+		await chooseExisting(workflow, false, "Replace");
+		await waitForElement(workflow.obsidian, VALUE_INPUT);
+		await typeInto(workflow.obsidian, VALUE_INPUT, "Unsubmitted owner");
+		await pressKey(workflow.obsidian, "Escape");
+		await expectNoPrompt(workflow.obsidian);
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+		expect(await notePaths(workflow)).toEqual(pathsBefore);
+	});
+
+	it("makes a shared folder and body field optional when switching from creation to an existing note", async () => {
+		const workflow = await seedTemplate("optional-shared-field", {
+			action: "appendBottom",
+			body: "Description: {{VALUE:detail|optional}}\n",
+			folder: "{{VALUE:detail}}",
+		});
+		const pathsBefore = await notePaths(workflow);
+		await runChoice(workflow.template, true);
+		const noteInput = `[aria-label=${JSON.stringify(`Note for ${workflow.template.name}`)}]`;
+		await waitForElement(workflow.obsidian, noteInput);
+		await typeInto(workflow.obsidian, noteInput, "New optionality test note");
+			await expect.poll(() => workflow.obsidian.dev.evalJson<string>(
+				'document.querySelector(".qa-onepage-file-suggestion__label")?.textContent ?? ""',
+			), POLL_OPTS).toBe("Create new note: New optionality test note");
+		await pressKey(workflow.obsidian, "Enter");
+		await waitForElement(workflow.obsidian, formField("detail"));
+		const hasOptionalBadge = () => workflow.obsidian.dev.evalJson<boolean>(
+			`Boolean(document.querySelector(${JSON.stringify(formField("detail"))})?.closest(".setting-item")?.querySelector(".qa-onepage-optional-badge"))`,
+		);
+		expect(await hasOptionalBadge()).toBe(false);
+		expect(await workflow.obsidian.dev.evalJson<boolean>(`(() => {
+			const button = document.querySelector('[aria-label="Change note"]');
+			if (!button) return false;
+			button.click();
+			return true;
+		})()`)).toBe(true);
+		await chooseExisting(workflow, true);
+		await expect.poll(hasOptionalBadge, POLL_OPTS).toBe(true);
+		expect(await workflow.obsidian.dev.evalJson<string>(
+			`document.querySelector(${JSON.stringify(formField("detail"))})?.value ?? "missing"`,
+		)).toBe("");
+		await pressKey(workflow.obsidian, "Enter", true);
+		const content = await workflow.sandbox.waitForContent(workflow.relativePath, (text) => text.includes("Description:"), WAIT_OPTS);
+		expect(content.trimEnd()).toBe(`${INITIAL_CONTENT}\nDescription:`);
+		await expectNoPrompt(workflow.obsidian);
+		expect(await notePaths(workflow)).toEqual(pathsBefore);
+	});
+
+	it("submits one combined form, applies the template once, and continues Capture with its own value", async () => {
+		const workflow = await seedTemplate("macro-append", { action: "appendBottom" });
+		const capture = new CaptureChoice("Capture after applying template");
+		capture.captureToActiveFile = true;
+		capture.activeFileWritePosition = "bottom";
+		capture.useSelectionAsCaptureValue = false;
+		capture.format = { enabled: true, format: "{{VALUE}} ({{VALUE:owner}})" };
+		const captureCommand = new NestedChoiceCommand(capture);
+		const macro = new MacroChoice("Apply discovered template then capture");
+		macro.command = true;
+		macro.macro.commands = [new NestedChoiceCommand(workflow.template), captureCommand];
+		await runChoice(macro, true);
+		await chooseExisting(workflow, true);
+		await waitForElement(workflow.obsidian, formField("owner"));
+		expect(await workflow.obsidian.dev.evalJson<boolean>(
+			`Boolean(document.querySelector(${JSON.stringify(formField("creationFolder"))})?.getClientRects().length)`,
+		)).toBe(false);
+		await typeInto(workflow.obsidian, formField("owner"), "Ada");
+		await typeInto(workflow.obsidian, formField(`__qa.value.${captureCommand.id}`), "Follow-up");
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+		await pressKey(workflow.obsidian, "Enter", true);
+		const content = await workflow.sandbox.waitForContent(workflow.relativePath, (text) => text.includes("Follow-up (Ada)"), WAIT_OPTS);
+		expect(content.trimEnd()).toBe(`${INITIAL_CONTENT}\nOwner: Ada\n\nFollow-up (Ada)`);
+		await expectNoPrompt(workflow.obsidian);
+		expect(await workflow.obsidian.dev.evalJson<string | null>("app.workspace.getActiveFile()?.path ?? null"))
+			.toBe(workflow.targetPath);
+	});
+
+	it("keeps the released open-only default even when the collision policy replaces files", async () => {
+		const workflow = await seedTemplate("default-open");
+		const pathsBefore = await notePaths(workflow);
+		await runChoice(workflow.template, true);
+		await chooseExisting(workflow, true);
+		expect(await workflow.obsidian.dev.evalJson<boolean>(
+			`Boolean(document.querySelector(${JSON.stringify(formField("owner"))})?.getClientRects().length)`,
+		)).toBe(false);
+		await pressKey(workflow.obsidian, "Enter", true);
+		await expectNoPrompt(workflow.obsidian);
+		await expect.poll(() => workflow.obsidian.dev.evalJson<string | null>(
+			"app.workspace.getActiveFile()?.path ?? null",
+		), POLL_OPTS).toBe(workflow.targetPath);
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+		expect(await notePaths(workflow)).toEqual(pathsBefore);
+	});
+
+	it("does not interpret custom text as a reserved selection that replaces a canvas", async () => {
+		const workflow = await seedTemplate("reserved-selection", {
+			action: "overwrite", body: "THIS MUST NOT REPLACE THE CANVAS\n", folder: "created",
+		});
+		const canvasRelativePath = `${workflow.name}/Protected.canvas`;
+		const canvasContent = JSON.stringify({ nodes: [], edges: [] });
+		const canvasPath = await seedVaultFile(workflow.obsidian, workflow.sandbox, canvasRelativePath, canvasContent);
+		await runChoice(workflow.template, false);
+		const input = `input[placeholder=${JSON.stringify(`Search notes or create ${workflow.template.name}`)}]`;
+		await waitForElement(workflow.obsidian, input);
+		await typeInto(workflow.obsidian, input, `@quickadd-existing-note:${canvasPath}`);
+		await pressKey(workflow.obsidian, "Enter");
+		await expectNoPrompt(workflow.obsidian);
+		await expect.poll(() => workflow.obsidian.dev.evalJson<string>(
+			'Array.from(document.querySelectorAll(".notice"), (notice) => notice.textContent).join("\\n")',
+		), POLL_OPTS).toMatch(/cannot create|cannot contain|Markdown note/i);
+		expect(await workflow.sandbox.read(canvasRelativePath)).toBe(canvasContent);
+		expect(await workflow.sandbox.read(workflow.relativePath)).toBe(INITIAL_CONTENT);
+	});
+});


### PR DESCRIPTION
Selecting an existing note can now open it, append or prepend the template, or replace the note. The new "When selecting an existing note" setting keeps this deliberate selection separate from a new note's filename collision policy. Combined forms use the selected action's complete field definition and preserve drafts when switching between create and existing notes. Creation-only inputs disappear when updating an existing note.

Existing choices retain "Open note" by default. No migration or version-file change is needed. Open-only selections bypass unused link-destination validation. The native picker no longer copies internal identifiers into the title on Tab. The native picker preserves selected-row identity, so typed titles cannot impersonate selected-file handles, template updates require Markdown targets, and dynamically resolved templates cannot update their own source.

To verify in Obsidian, enable "Search existing notes before creating", choose an existing-note action, and run the choice against a note with known content. Check the result using Enter and Mod+Enter, then repeat inside a one-page macro. Existing open-only choices should leave the note unchanged.

Validation: Template-only build, lint, Svelte checks, and full unit suite passed with 5,363 tests and 37 existing skips. The native Obsidian 1.13.7 Linux discovery and adjacent template suites passed with 63 tests. Documentation is included.

![Existing-note action setting](https://files.bagerbach.com/template-action-settings-eq4qu8r6dcb3.png)

![Combined form after selecting an existing note](https://files.bagerbach.com/template-combined-selected-wiyb875ja7c2.png)

Fixes #1739


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Template choices can apply templates to existing notes by opening, appending, inserting, or replacing content.
  - Added a configuration option for actions on discovered existing notes.
  - Input forms now show relevant fields and preserve drafts when switching notes.
  - Added a dedicated note-discovery interface with create-new-note support.

- **Bug Fixes**
  - Prevented invalid file types, self-referential templates, stale suggestions, and missing destinations from causing unintended actions.
  - Improved cancellation, validation, and error handling.

- **Documentation**
  - Clarified existing-note selection, template actions, and file-exists behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->