### PR TITLE
feat(capture): write native note properties

### DIFF
--- a/docs/src/content/docs/docs/Advanced/CLI.md
+++ b/docs/src/content/docs/docs/Advanced/CLI.md
@@ -108,6 +108,17 @@ Values are passed through exactly as provided. If a choice should ignore an
 accidental leading or trailing space for a specific placeholder, use `|trim` in
 that format string, for example `{{VALUE:project|trim}}`.
 
+For [property captures](/docs/Choices/CaptureChoice/#property), `vars` preserves
+native numbers, checkboxes, and lists when the Capture format is one whole token:
+
+```bash
+obsidian vault=dev quickadd choice="Add project tags" \
+  vars='{"tags":["Research, writing","work"]}' verify=true
+```
+
+`verify=true` includes the engine's [confirmed outcome](#verified-and-effect),
+so automation can distinguish a changed property from an unchanged capture.
+
 For Template choices, passing `value` supplies the new note's name. It does not
 select an existing note from the discovery picker. The generated path follows
 the choice's file-exists behavior. To use **When selecting an existing note**,
@@ -265,4 +276,3 @@ Good to know:
 - **Desktop only.** The bridge binds to `127.0.0.1`, is gated by the per-session `token`, rejects browser (`Origin`/`Referer`) and non-loopback `Host` requests, and the server is ephemeral - it starts on the first session and stops when the last one ends.
 - **Concurrency.** Each run gets its own `sessionId` + `token`; many can run at once without interfering.
 - If no client attaches within ~30s the run is aborted so a prompt can't hang forever.
-

--- a/docs/src/content/docs/docs/Advanced/onePageInputs.md
+++ b/docs/src/content/docs/docs/Advanced/onePageInputs.md
@@ -70,12 +70,18 @@ in one form. Scripts and conditional steps retain their execution boundaries.
 
 QuickAdd scans the choice for placeholders and turns each one into a field:
 
-- Placeholders in file names, templates, and capture content: `{{VALUE}}`, `{{VALUE:name}}`, `{{VDATE:name, YYYY-MM-DD}}`, `{{FIELD:name|...}}`, and `{{FILE:folder|...}}`.
+- Placeholders in file names, templates, capture content, and capture property names: `{{VALUE}}`, `{{VALUE:name}}`, `{{VDATE:name, YYYY-MM-DD}}`, `{{FIELD:name|...}}`, and `{{FILE:folder|...}}`.
 - Nested `{{TEMPLATE:path}}` includes are scanned recursively, so their prompts show up too.
 - `{{VALUE|type:multiline}}` and `{{VALUE:name|type:multiline}}` become textareas.
 - `{{VALUE:name|type:number|min:1|max:10}}` becomes a bounded numeric input, and `{{VALUE:name|type:slider|min:0|max:100|step:5}}` becomes a slider plus numeric input.
 - The capture target file, when you are capturing to a folder or a tag.
 - Inputs declared by a user script inside a macro, if the script provides them.
+
+For [property captures](/docs/Choices/CaptureChoice/#property), a plain `VALUE`
+input uses the property's Number or Checkbox widget when its type is known.
+If the property or its type is not known yet, QuickAdd asks for that value after
+resolving the target note and property. **Choose when capturing** also opens its
+property picker at runtime.
 
 Text and textarea fields support `[[` file links and `#` tags. **Peek at note**
 hides the whole form while you read or select text in the open note. **Insert

--- a/docs/src/content/docs/docs/Choices/CaptureChoice.md
+++ b/docs/src/content/docs/docs/Choices/CaptureChoice.md
@@ -1,11 +1,11 @@
 ---
 title: Capture
-description: "Add text to any note without opening it: append to your journal, log entries under headings, save links, and capture to Canvas cards"
+description: "Capture to a note without opening it: add journal entries, update properties, save links, and capture to Canvas cards"
 slug: docs/Choices/CaptureChoice
 ---
 
-A Capture choice adds text to a note **without opening it**. Press a hotkey,
-type your entry, and QuickAdd files it exactly where it belongs - while you
+A Capture choice adds text or updates a property **without opening the note**.
+Press a hotkey, type your entry, and QuickAdd files it exactly where it belongs - while you
 stay right where you are. Use it to:
 
 - Add timestamped entries to your daily note
@@ -74,7 +74,7 @@ value decides what happens:
 | `Projects/` (trailing slash) | Opens a picker confined to that folder |
 | `Projects` (existing folder, no extension) | Same picker, unless `Projects.md` exists - then the file wins |
 | `#people` | Picker with notes carrying that tag |
-| `property:type=draft` | Picker with notes whose frontmatter matches - see [capturing to a property](#capturing-to-a-property) |
+| `property:type=draft` | Picker with notes whose frontmatter matches - see [filtering by a property](#capturing-to-a-property) |
 
 Paths are vault-relative; a leading `/` is ignored (except a lone `/`, which
 opens the whole-vault picker).
@@ -133,6 +133,9 @@ placeholder in the capture format instead.
 Type `property:<field>=<value>` to limit the picker to notes whose frontmatter
 matches. If your notes have a `type` field, `property:type=draft` opens a
 picker containing only the notes whose `type` is `draft`.
+
+This selects the destination note. [**Write position → Property**](#property)
+controls whether the capture updates one of that note's properties.
 
 - `property:type=draft` - notes whose `type` equals `draft`.
 - `property:type` - notes that **have** a `type` field, whatever the value.
@@ -237,8 +240,8 @@ edit, version, and reuse a complete capture format as a normal note. The
 referenced template files too, so their prompts appear up front.
 
 :::note
-A capture inserts included content as-is. If the referenced template starts
-with its own `---` frontmatter block and the target note already has one, you
+A capture into the note body inserts included content as-is. If the referenced
+template starts with its own `---` frontmatter block and the target note already has one, you
 get a literal second block - use
 [Apply Template to Note](/docs/ApplyTemplateToNote/) when frontmatter should
 merge.
@@ -309,6 +312,92 @@ depend on whether **Capture to active file** is enabled:
 - **After line…** - insert after a target line you specify, or pick a heading at run time. The workhorse for structured notes - see [Insert after](#insert-after).
 - **Before line…** - see [Insert before](#insert-before)
 - **Bottom of file**
+- **Property** - set a frontmatter value or add items to a list.
+
+### Capture into a property {#property}
+
+**Write position → Property** writes the Capture format to one frontmatter
+property in a Markdown note. The note's body and unrelated property values stay
+intact. QuickAdd uses Obsidian's frontmatter writer, so YAML formatting can change.
+
+**Property** selects the key:
+
+- **Named property** uses a fixed name such as `status`, or a formatted name such
+  as `{{VALUE:property}}`.
+- **Choose when capturing** opens a picker with the target note's properties.
+  With **Create property if missing** enabled, you can also enter a new name.
+
+Property names match case-insensitively and keep the note's existing spelling.
+An exact match wins. If several keys differ only in case and none matches exactly,
+QuickAdd stops the capture instead of choosing one.
+
+**Action** controls the update:
+
+- **Set value** replaces the property's value. For a List property, text becomes
+  one item, and a typed list replaces the whole list. An empty text value clears
+  the list. Commas and line breaks inside text do not split it into several items.
+- **Add to list** adds one text value or a list of text values. Existing items
+  keep their order, and exact duplicates are skipped. An existing text, number,
+  or checkbox value causes an error.
+
+Neither action converts an existing text, number, or checkbox property into a
+list. An empty text value or empty list with **Add to list** leaves the note
+unchanged. It does not create a missing note, write properties, insert links,
+or copy links.
+
+**Create property if missing** permits a new key. When disabled, a missing key
+stops the capture. **Create file if it doesn't exist** separately controls
+whether QuickAdd can create the destination note.
+
+The Capture format supplies the value. A format made entirely of one `VALUE`,
+`FIELD`, or `FILE` token preserves a typed number, checkbox, or list. Combining
+a token with other text produces text. An explicit multi-select output format,
+such as `|format:spaced`, also produces the requested text representation.
+
+For a Number or Checkbox property, a plain `{{VALUE}}` or `{{VALUE:rating}}`
+automatically uses the matching input widget and value type. This also applies
+to a missing property whose type is already set in Obsidian. An explicit
+`|type:` option takes precedence.
+
+| Property | Action | Capture format | Result |
+| --- | --- | --- | --- |
+| `status` | **Set value** | `{{VALUE:status}}` | The entered text. |
+| `rating` | **Set value** | `{{VALUE:rating\|type:number}}` | A Number property. |
+| `done` | **Set value** | `{{VALUE:done\|type:checkbox}}` | A Checkbox property. |
+| `tags` | **Add to list** | `{{VALUE:work,personal\|multi}}` | Adds the selected tags. |
+| `people` | **Set value** | `{{FILE:People\|multi\|link}}` | Replaces the list with links to the selected notes. |
+
+The value must match the property's Obsidian type, or its existing value when
+no type is known. A Number property can receive a script value of `42` or the
+text `"42"` through a plain `VALUE` token. Literal formats and composite text
+are not parsed as YAML: `true` and `[work, personal]` remain text. Text properties
+also preserve values such as `001`. Commas in text remain part of one value.
+Objects and lists containing non-text values are rejected. **Set value** removes
+exact duplicate list items while preserving their order.
+
+For a new property without a known type, the captured value determines the type.
+Date properties accept `YYYY-MM-DD`, and date-time properties accept ISO date-time
+text such as `2026-09-07T14:30`. An intentional empty text value or empty list
+clears a matching property with **Set value**. Use `|optional` to allow an empty
+prompt answer. Cancelling a prompt stops the capture.
+
+QuickAdd collects and validates the property inputs before writing or creating
+the note. **Task** and **Run Templater on entire destination file after capture**
+are hidden and do not apply to property captures.
+
+Scripts can supply native values through `executeChoice`. With **Add to list**,
+property `tags`, and format `{{VALUE:tags}}`, this adds two complete items.
+The comma inside the first item stays part of that item:
+
+```js
+await quickAddApi.executeChoice("Add project tags", {
+	tags: ["Research, writing", "work"],
+});
+```
+
+For a non-interactive CLI run, use **Named property**, optionally with a variable
+in its name, and pass typed values through [`vars`](/docs/Advanced/CLI/#passing-variables).
+**Choose when capturing** requires an interactive run.
 
 ### Link back to the captured note {#link-to-captured-file}
 
@@ -389,8 +478,8 @@ _Open_ toggle. Enabling it reveals:
 - _View mode_ - **Source**, **Preview**, **Live Preview**, or **Default**
 - _Focus new pane_ - focus the opened tab immediately (shown for every location except **Reuse current tab**)
 
-When QuickAdd opens and focuses a Markdown target in an editable mode, it
-places the cursor at the end of the inserted capture so you can keep typing.
+When QuickAdd opens and focuses a Markdown target in an editable mode after a
+body capture, it places the cursor at the end of the inserted text so you can keep typing.
 This is skipped for preview/unfocused opens and when Templater cursor markers
 take over.
 
@@ -412,7 +501,7 @@ whole-file pass.
 
 ### Templater and newly created notes {#templater-and-newly-created-files}
 
-Capture has two Templater paths when it creates a missing Markdown file:
+Body captures have two Templater paths when they create a missing Markdown file:
 
 - **Create file if it doesn't exist** without a QuickAdd template: QuickAdd creates a blank file first. If Templater's new-file trigger applies to that location, QuickAdd waits for Templater to finish before inserting the capture.
 - **Create with template**: QuickAdd owns the initial content. It renders the selected QuickAdd template, suppresses Templater's new-file/directory trigger for that creation, then runs Templater once on the content QuickAdd wrote.
@@ -420,6 +509,10 @@ Capture has two Templater paths when it creates a missing Markdown file:
 So a blank Capture-created file can receive Templater's directory template
 first, while a template-created file runs Templater on QuickAdd's template
 content instead.
+
+Property captures prepare the property value before creating the file. After a
+new-file Templater pass, QuickAdd applies the property update to the resulting
+frontmatter so the template does not discard the capture.
 
 ## Insert after {#insert-after}
 

--- a/docs/src/content/docs/docs/FormatSyntax.md
+++ b/docs/src/content/docs/docs/FormatSyntax.md
@@ -423,7 +423,7 @@ wikilinks.
 Good to know:
 
 - The picks become a real YAML list **inside front matter**. In a note body they become comma-separated text.
-- In a **Capture**, multi-select becomes a list only when capturing into a brand-new note's front matter (Create file if it doesn't exist, without a template). Other capture shapes write comma-separated text.
+- In a **Capture**, a whole multi-select token with the default `|format:auto` stays a list with [**Write position → Property**](/docs/Choices/CaptureChoice/#property). Capturing into a brand-new note's frontmatter also produces a list when **Create file if it doesn't exist** is enabled without a template. Captures into an existing note's body write comma-separated text.
 - With the [one-page input form](/docs/Advanced/onePageInputs/), avoid commas inside a single option (like `|text:"High, urgent"`) on a `|multi` placeholder - the one-page picker can't round-trip them. The default one-prompt-at-a-time picker handles them correctly.
 
 #### Reuse the pick elsewhere: `|name:` {#value-name}
@@ -755,7 +755,10 @@ topics:
 ```
 
 Inside front matter, `|multi` writes a real YAML list when the placeholder is
-the property's whole value. In note bodies, file names, and other text
+the property's whole value. With the default `|format:auto`, it also stays a
+list when the entire Capture format is the token and
+[**Write position → Property**](/docs/Choices/CaptureChoice/#property) is selected.
+In note bodies, file names, and other text
 positions it writes comma-separated text. Combines with the same filters and
 defaults as single-value FIELD prompts:
 `{{FIELD:topic|multi|folder:Projects|tag:active|default:Inbox}}`.
@@ -885,7 +888,7 @@ Options:
 
 - `|optional` - allow skipping the pick (becomes nothing).
 - `|custom` - also allow typing a value that isn't in the folder.
-- `|multi` - pick several files. In frontmatter/property positions QuickAdd writes a YAML list; in note bodies, file names, existing-note captures, and other text positions it writes comma-separated text. Combine with `|link` or `|path` to write links or paths for every pick.
+- `|multi` - pick several files. In frontmatter property positions, including a whole-token [property capture](/docs/Choices/CaptureChoice/#property), QuickAdd writes a YAML list. In note bodies, file names, and other text positions it writes comma-separated text. Combine with `|link` or `|path` to write links or paths for every pick.
 - `|label:Pick a person` - set the picker's placeholder text.
 - `|name:<id>` - share one pick between placeholders. FILE placeholders are cached by their full definition: placeholders that differ (folder, filters, mode, or `|label:`) prompt independently, while identical ones reuse one pick. To pick **two different** people, give the placeholders different labels (`{{FILE:People|label:Author}}` and `{{FILE:People|label:Reviewer}}`). To reuse **the same** pick - say, a name in one place and a link in another - give them the same `|name:`. Placeholders sharing an id should target the same folder and filters; the shared pick is required if *any* occurrence omits `|optional`.
 - Filters reuse the FIELD syntax: `|tag:`, `|exclude-folder:`, `|exclude-tag:`, `|exclude-file:` (each repeatable).

--- a/src/engine/CaptureChoiceEngine.property.test.ts
+++ b/src/engine/CaptureChoiceEngine.property.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TFile, type App } from "obsidian";
+import type QuickAdd from "../main";
+import type * as Obsidian from "obsidian";
+import { CaptureChoice } from "../types/choices/CaptureChoice";
+import { createChoiceExecutor } from "../../tests/helpers/createChoiceExecutor";
+import { UserCancelError } from "../errors/UserCancelError";
+import { CaptureChoiceEngine } from "./CaptureChoiceEngine";
+import { readCaptureFrontmatter, serializeCaptureFrontmatter } from "./captureProperty";
+
+const mocks = vi.hoisted(() => ({
+	value: vi.fn<() => Promise<unknown>>(),
+	template: vi.fn<() => Promise<string>>(),
+	picker: vi.fn<() => Promise<string>>(),
+	templaterEnabled: false,
+	afterCreate: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("obsidian", async (importOriginal) => ({
+	...await importOriginal<typeof Obsidian>(),
+	stringifyYaml: (value: Record<string, unknown>) => Object.entries(value).map(([key, item]) => `${key}: ${JSON.stringify(item)}\n`).join(""),
+}));
+vi.mock("../main", () => ({ default: class {} }));
+vi.mock("obsidian-dataview", () => ({ getAPI: vi.fn() }));
+vi.mock("../logger/logManager", () => ({ log: { logError: vi.fn(), logWarning: vi.fn(), logMessage: vi.fn() } }));
+vi.mock("src/gui/InputSuggester/inputSuggester", () => ({ default: { Suggest: mocks.picker } }));
+vi.mock("../formatters/captureChoiceFormatter", () => ({
+	CaptureChoiceFormatter: class {
+		setPromptRunContext() {}
+		setLinkToCurrentFileBehavior() {}
+		setUseSelectionAsCaptureValue() {}
+		setDestinationSourcePath() {}
+		setDestinationFile() {}
+		setTargetFolderPath() {}
+		setTitle() {}
+		consumeCreatedClipboardAttachmentPaths() { return []; }
+		async formatFileName(value: string) { return value; }
+		async formatPropertyName(value: string) { return value; }
+		formatPropertyValue() { return mocks.value(); }
+	},
+}));
+vi.mock("./SingleTemplateEngine", () => ({
+	SingleTemplateEngine: class {
+		setDestinationPath() {}
+		setPromptRunContext() {}
+		setLinkToCurrentFileBehavior() {}
+		getAndClearTemplatePropertyVars() { return new Map(); }
+		run() { return mocks.template(); }
+	},
+}));
+vi.mock("../utilityObsidian", () => ({
+	isFolder: () => false,
+	openExistingFileTab: () => null,
+	openFile: vi.fn(),
+	overwriteTemplaterOnce: vi.fn(),
+	isTemplaterTriggerOnCreateEnabled: () => mocks.templaterEnabled,
+	waitForTemplaterTriggerOnCreateToComplete: mocks.afterCreate,
+	withTemplaterFileCreationSuppressed: async (_app: unknown, _path: string, work: () => Promise<unknown>) => await work(),
+}));
+
+function fixture(content?: string) {
+	const choice = new CaptureChoice("Set status");
+	choice.captureTo = "Inbox.md";
+	choice.propertyCapture = { property: { kind: "named", format: "status" }, action: "set", createIfMissing: true };
+	const executor = { ...createChoiceExecutor(), interactive: false, recordExecutionResult: vi.fn(), signalAbort: vi.fn() };
+	const file = Object.assign(new TFile(), { path: "Inbox.md", basename: "Inbox", name: "Inbox.md", extension: "md" });
+	let stored = content;
+	let beforeCallback: (() => void) | undefined;
+	const create = vi.fn(async (_path: string, input: string) => { stored = input; return file; });
+	const createFolder = vi.fn(async () => {});
+	const processFrontMatter = vi.fn(async (_file: TFile, callback: (data: Record<string, unknown>) => void) => {
+		beforeCallback?.();
+		const current = readCaptureFrontmatter(stored ?? "");
+		callback(current);
+		stored = serializeCaptureFrontmatter(stored ?? "", current);
+	});
+	const app = {
+		vault: {
+			adapter: { exists: async (path: string) => path === "" || stored !== undefined },
+			getAbstractFileByPath: (path: string) => path === file.path && stored !== undefined ? file : null,
+			read: async () => stored ?? "",
+			create, createFolder,
+		},
+		workspace: { getActiveFile: () => stored === undefined ? null : file, getActiveViewOfType: () => null },
+		fileManager: { processFrontMatter },
+	};
+	const plugin = { settings: { useSelectionAsCaptureValue: false, showCaptureNotification: false } } as QuickAdd;
+	return {
+		choice, executor, file, create, createFolder, processFrontMatter,
+		read: () => stored,
+		overwrite: (content: string) => { stored = content; },
+		race: (content: string) => { beforeCallback = () => { stored = content; }; },
+		run: () => new CaptureChoiceEngine(app as unknown as App, plugin, choice, executor).run(),
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.value.mockResolvedValue("done");
+	mocks.template.mockResolvedValue("---\nstatus: active\n---\nTemplate body\n");
+	mocks.templaterEnabled = false;
+	mocks.afterCreate.mockResolvedValue(undefined);
+});
+
+describe("Capture property writes", () => {
+	it("writes a configured property while preserving unrelated properties and body", async () => {
+		const test = fixture("---\nstatus: active\nother: 42\n---\nBody\n");
+		test.choice.task = true;
+		test.choice.insertAfter.enabled = true;
+		test.choice.insertAfter.promptHeading = true;
+		await test.run();
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ status: "done", other: 42 });
+		expect(test.read()).toMatch(/---\nBody\n$/);
+		expect(test.executor.recordExecutionResult).toHaveBeenCalledWith({ status: "success", file: test.file, effect: "changed" });
+		expect(mocks.picker).not.toHaveBeenCalled();
+	});
+
+	it("uses the active Markdown file without requiring an editor insertion", async () => {
+		const test = fixture("Body\n");
+		test.choice.captureToActiveFile = true;
+		await test.run();
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ status: "done" });
+	});
+
+	it("preserves the existing property's casing with creation disabled", async () => {
+		const test = fixture("---\nStatus: active\n---\nBody\n");
+		test.choice.propertyCapture!.createIfMissing = false;
+		await test.run();
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ Status: "done" });
+	});
+
+	it("resolves property casing again against the callback's current values", async () => {
+		const test = fixture("---\nstatus: active\n---\nBody\n");
+		test.choice.propertyCapture!.createIfMissing = false;
+		test.race("---\nSTATUS: active\n---\nBody\n");
+		await test.run();
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ STATUS: "done" });
+	});
+
+	it("adds to the callback's current list and keeps a concurrent unrelated edit", async () => {
+		const test = fixture("---\nstatus: [old]\nother: before\n---\nBody\n");
+		test.choice.propertyCapture!.action = "addToList";
+		test.race("---\nstatus: [old, concurrent]\nother: after\n---\nNew body\n");
+		await test.run();
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ status: ["old", "concurrent", "done"], other: "after" });
+		expect(test.read()).toMatch(/---\nNew body\n$/);
+	});
+
+	it("validates again when the selected property's type changes during input", async () => {
+		const test = fixture("---\nstatus: active\n---\nBody\n");
+		test.race("---\nstatus: 7\n---\nConcurrent body\n");
+		await test.run();
+		expect(test.read()).toBe("---\nstatus: 7\n---\nConcurrent body\n");
+		expect(test.executor.recordExecutionResult).toHaveBeenCalledWith(expect.objectContaining({ status: "error", reason: expect.stringContaining("requires number") }));
+	});
+
+	it("reports unchanged from persisted bytes after setting the same value", async () => {
+		const test = fixture('---\nstatus: "done"\n---\nBody\n');
+		await test.run();
+		expect(test.executor.recordExecutionResult).toHaveBeenCalledWith(expect.objectContaining({ status: "success", effect: "unchanged" }));
+	});
+
+	it("does not create a target when value input is cancelled", async () => {
+		const test = fixture();
+		test.choice.createFileIfItDoesntExist.enabled = true;
+		mocks.value.mockRejectedValue(new UserCancelError("Input cancelled by user"));
+		await test.run();
+		expect(test.create).not.toHaveBeenCalled();
+		expect(test.createFolder).not.toHaveBeenCalled();
+		expect(test.executor.signalAbort).toHaveBeenCalledWith(expect.any(UserCancelError));
+	});
+
+	it.each(["", []])("does not write or create a note for an empty list addition %j", async (value) => {
+		for (const content of [undefined, "---\nstatus: [old]\n---\nBody\n"]) {
+			const test = fixture(content);
+			test.choice.createFileIfItDoesntExist.enabled = true;
+			test.choice.propertyCapture!.action = "addToList";
+			mocks.value.mockResolvedValue(value);
+			await test.run();
+			expect(test.read()).toBe(content);
+			expect(test.create).not.toHaveBeenCalled();
+			expect(test.processFrontMatter).not.toHaveBeenCalled();
+			expect(test.executor.recordExecutionResult).toHaveBeenCalledWith({ status: "success", file: content === undefined ? undefined : test.file, effect: "unchanged" });
+		}
+	});
+
+	it("still rejects an empty Add against a scalar property", async () => {
+		const test = fixture("---\nstatus: active\n---\nBody\n");
+		test.choice.propertyCapture!.action = "addToList";
+		mocks.value.mockResolvedValue("");
+		await test.run();
+		expect(test.processFrontMatter).not.toHaveBeenCalled();
+		expect(test.executor.recordExecutionResult).toHaveBeenCalledWith(expect.objectContaining({ status: "error", reason: expect.stringContaining("requires a list") }));
+	});
+
+	it("validates against a prepared template before creating once", async () => {
+		const test = fixture();
+		test.choice.createFileIfItDoesntExist = { enabled: true, createWithTemplate: true, template: "Template.md" };
+		await test.run();
+		expect(test.create).toHaveBeenCalledTimes(1);
+		expect(test.processFrontMatter).toHaveBeenCalledTimes(1);
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ status: "done" });
+		expect(test.read()).toMatch(/---\nTemplate body\n$/);
+	});
+
+	it("rejects a type mismatch with the template before creating a note", async () => {
+		const test = fixture();
+		test.choice.createFileIfItDoesntExist = { enabled: true, createWithTemplate: true, template: "Template.md" };
+		mocks.template.mockResolvedValue("---\nstatus: 7\n---\nBody");
+		await test.run();
+		expect(test.create).not.toHaveBeenCalled();
+		expect(test.createFolder).not.toHaveBeenCalled();
+	});
+
+	it("applies the prepared value after a create-time Templater trigger", async () => {
+		const test = fixture();
+		test.choice.createFileIfItDoesntExist.enabled = true;
+		mocks.templaterEnabled = true;
+		mocks.afterCreate.mockImplementation(async () => { test.overwrite("---\nstatus: trigger\n---\nTemplater body\n"); });
+		await test.run();
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ status: "done" });
+		expect(test.read()).toMatch(/---\nTemplater body\n$/);
+		expect(test.create).toHaveBeenCalledTimes(1);
+	});
+
+	it("aborts a headless runtime property picker before target creation", async () => {
+		const test = fixture();
+		test.choice.createFileIfItDoesntExist.enabled = true;
+		test.choice.propertyCapture!.property = { kind: "prompt" };
+		await test.run();
+		expect(test.create).not.toHaveBeenCalled();
+		expect(mocks.value).not.toHaveBeenCalled();
+		expect(test.executor.signalAbort).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("Configure a named property") }));
+	});
+
+	it("routes runtime property selection through the connected prompt provider", async () => {
+		const test = fixture("---\nstatus: active\n---\nBody\n");
+		test.choice.propertyCapture!.property = { kind: "prompt" };
+		test.executor.interactive = true;
+		Object.assign(test.executor, { promptProvider: { suggester: vi.fn(async (_labels: string[], handles: string[]) => handles[0]) } });
+		await test.run();
+		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ status: "done" });
+		expect(mocks.picker).not.toHaveBeenCalled();
+	});
+});

--- a/src/engine/CaptureChoiceEngine.property.test.ts
+++ b/src/engine/CaptureChoiceEngine.property.test.ts
@@ -221,6 +221,27 @@ describe("Capture property writes", () => {
 		expect(readCaptureFrontmatter(test.read() ?? "")).toEqual({ status: "done" });
 		expect(test.read()).toMatch(/---\nTemplater body\n$/);
 		expect(test.create).toHaveBeenCalledTimes(1);
+		expect(test.executor.recordExecutionResult).toHaveBeenCalledWith({ status: "success", file: test.file, effect: "created" });
+	});
+
+	it("reports failure when Templater makes the final property update invalid", async () => {
+		const test = fixture();
+		test.choice.createFileIfItDoesntExist.enabled = true;
+		test.choice.propertyCapture!.action = "addToList";
+		mocks.templaterEnabled = true;
+		mocks.afterCreate.mockImplementation(async () => {
+			expect(test.executor.recordExecutionResult).not.toHaveBeenCalled();
+			test.overwrite("---\nstatus: [{nested: value}]\n---\nTemplater body\n");
+		});
+		test.processFrontMatter.mockImplementationOnce(async (_file, update) => {
+			update({ status: [{ nested: "value" }] });
+		});
+		await test.run();
+		expect(test.processFrontMatter).toHaveBeenCalledTimes(1);
+		expect(test.read()).toBe("---\nstatus: [{nested: value}]\n---\nTemplater body\n");
+		expect(test.executor.recordExecutionResult).toHaveBeenCalledExactlyOnceWith({
+			status: "error", reason: expect.stringContaining("lists of text only"),
+		});
 	});
 
 	it("aborts a headless runtime property picker before target creation", async () => {

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -26,6 +26,18 @@ import { getLinesInString } from "../utility";
 import { log } from "../logger/logManager";
 import type QuickAdd from "../main";
 import type ICaptureChoice from "../types/choices/ICaptureChoice";
+import { parsePropertyCapture, type PropertyCapture } from "../types/choices/ICaptureChoice";
+import {
+	planPropertyUpdate,
+	readCaptureFrontmatter,
+	resolveCapturePropertyKey,
+	serializeCaptureFrontmatter,
+	validatePropertyName,
+} from "./captureProperty";
+import { resolveObsidianPropertyType } from "../utils/obsidianPropertyTypes";
+import { TemplatePropertyCollector } from "../utils/TemplatePropertyCollector";
+import { coerceYamlValue } from "../utils/yamlValues";
+import { inheritPropertyValueType } from "../utils/propertyCaptureFormat";
 import {
 	normalizeAppendLinkOptions,
 	placementSupportsFrontmatter,
@@ -84,6 +96,7 @@ import { QuickAddChoiceEngine } from "./QuickAddChoiceEngine";
 import {
 	postProcessFrontMatter,
 	shouldPostProcessFrontMatter,
+	assignFrontmatterValue,
 } from "./helpers/frontmatterPostProcessor";
 import { ChoiceAbortError } from "../errors/ChoiceAbortError";
 import { assertCreatableFilePath } from "./assertCreatableFilePath";
@@ -390,7 +403,10 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 					: globalSelectionAsValue;
 			this.formatter.setUseSelectionAsCaptureValue(useSelectionAsCaptureValue);
 
-			const action = getCaptureAction(this.choice);
+			const propertyCapture = this.choice.propertyCapture === undefined
+				? undefined
+				: parsePropertyCapture(this.choice.propertyCapture);
+			const action = propertyCapture ? "append" : getCaptureAction(this.choice);
 			const isEditorInsertionAction =
 				action === "currentLine" ||
 				action === "newLineAbove" ||
@@ -403,6 +419,9 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			const canvasTarget = activeCanvasTarget ?? configuredCanvasTarget;
 
 			if (canvasTarget?.kind === "text") {
+				if (propertyCapture) {
+					throw new ChoiceAbortError("Property capture requires a Markdown note. Canvas text cards do not have note properties.");
+				}
 				await this.handleCanvasTextCapture(
 					canvasTarget,
 					action,
@@ -415,7 +434,7 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			}
 
 			if (
-				canvasTarget?.kind === "file" &&
+				!propertyCapture && canvasTarget?.kind === "file" &&
 				((action === "insertAfter" &&
 					this.choice.insertAfter?.createIfNotFound &&
 					this.choice.insertAfter?.createIfNotFoundLocation === "cursor") ||
@@ -465,6 +484,14 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			// heading for a note that cannot be created.
 			if (!fileAlreadyExists && this.choice?.createFileIfItDoesntExist?.enabled) {
 				assertCreatableFilePath(filePath);
+			}
+			if (propertyCapture) {
+				await this.captureToProperty({
+					filePath, fileAlreadyExists, config: propertyCapture, linkOptions,
+					isCanvasTriggered: !!canvasTarget,
+					onCommit: () => { contentCommitted = true; },
+				});
+				return;
 			}
 
 			// "Choose heading when capturing" (After line…): prompt for a heading from the resolved
@@ -710,6 +737,125 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				this.formatter.consumeCreatedClipboardAttachmentPaths();
 			}
 		}
+	}
+
+	private async captureToProperty(args: {
+		filePath: string;
+		fileAlreadyExists: boolean;
+		config: PropertyCapture;
+		linkOptions: NormalizedAppendLinkOptions;
+		isCanvasTriggered: boolean;
+		onCommit: () => void;
+	}): Promise<void> {
+		const { filePath, fileAlreadyExists, config, linkOptions } = args;
+		if (!MARKDOWN_FILE_EXTENSION_REGEX.test(filePath)) {
+			throw new ChoiceAbortError("Property capture requires a Markdown note.");
+		}
+		if (!fileAlreadyExists && !this.choice.createFileIfItDoesntExist.enabled) {
+			throw new ChoiceAbortError(`Target file missing: ${filePath}. Enable "Create file if it doesn't exist" or choose an existing file.`);
+		}
+		let file = fileAlreadyExists ? this.getFileByPath(filePath) : undefined;
+		this.formatter.setTitle(basenameWithoutMdOrCanvas(filePath));
+		this.formatter.setTargetFolderPath(parentFolderPath(filePath));
+		this.formatter.setDestinationSourcePath(filePath);
+		if (file) this.formatter.setDestinationFile(file);
+		this.formatter.setPromptRunContext({
+			draftScopeId: this.choice.id, choiceName: this.choice.name,
+			destination: filePath, destinationKind: "file",
+		});
+
+		let initialContent = file ? await this.app.vault.read(file) : "";
+		const createWithTemplate = !file && this.choice.createFileIfItDoesntExist.createWithTemplate;
+		let templateVars = new Map<string, unknown>();
+		if (createWithTemplate) {
+			const template = new SingleTemplateEngine(this.app, this.plugin,
+				this.choice.createFileIfItDoesntExist.template, this.choiceExecutor);
+			template.setDestinationPath(filePath);
+			template.setPromptRunContext({
+				draftScopeId: `${this.choice.id}#${this.choice.createFileIfItDoesntExist.template}`,
+				choiceName: this.choice.name, destination: filePath, destinationKind: "file",
+			});
+			if (linkOptions.enabled && !linkOptions.requireActiveFile) template.setLinkToCurrentFileBehavior("optional");
+			initialContent = await template.run();
+			templateVars = template.getAndClearTemplatePropertyVars();
+		}
+		const frontmatter = readCaptureFrontmatter(initialContent);
+		for (const [key, value] of templateVars) {
+			assignFrontmatterValue(frontmatter, key.split(TemplatePropertyCollector.PATH_SEPARATOR), coerceYamlValue(value));
+		}
+		const key = resolveCapturePropertyKey(frontmatter, validatePropertyName(config.property.kind === "named"
+			? await this.formatter.formatPropertyName(config.property.format)
+			: await this.promptForCaptureProperty(frontmatter, config.createIfMissing)));
+		const registeredType = resolveObsidianPropertyType(this.app, key, { registeredOnly: true });
+		const existingValue = Object.prototype.hasOwnProperty.call(frontmatter, key) ? frontmatter[key] : undefined;
+		const inputType = registeredType ?? (typeof existingValue === "number" ? "number" : typeof existingValue === "boolean" ? "checkbox" : null);
+		const value = await this.formatter.formatPropertyValue(inheritPropertyValueType(
+			this.choice.format.enabled ? this.choice.format.format : VALUE_SYNTAX, inputType,
+		));
+		const plan = (current: Record<string, unknown>) => planPropertyUpdate({
+			frontmatter: current, key, value, config,
+			registeredType: resolveObsidianPropertyType(this.app, key, { registeredOnly: true }),
+		});
+		const prepared = plan(frontmatter);
+		if (config.action === "addToList" && (value === "" || (Array.isArray(value) && value.length === 0))) {
+			this.outcome.success(file, "unchanged");
+			return;
+		}
+
+		let priorContent = "";
+		if (file) {
+			priorContent = await this.app.vault.read(file);
+			await this.app.fileManager.processFrontMatter(file, (current: Record<string, unknown>) => {
+				current[resolveCapturePropertyKey(current, key)] = plan(current);
+			});
+		} else {
+			frontmatter[key] = prepared;
+			file = await this.createFileWithInput(filePath, serializeCaptureFrontmatter(initialContent, frontmatter), {
+				suppressTemplaterOnCreate: createWithTemplate,
+			});
+		}
+		args.onCommit();
+		const persistedContent = await this.app.vault.read(file);
+		this.outcome.success(file, !fileAlreadyExists ? "created" : persistedContent === priorContent ? "unchanged" : "changed");
+		if (!fileAlreadyExists && (createWithTemplate || isTemplaterTriggerOnCreateEnabled(this.app))) {
+			if (createWithTemplate) await overwriteTemplaterOnce(this.app, file);
+			else await waitForTemplaterTriggerOnCreateToComplete(this.app, file);
+			await this.app.fileManager.processFrontMatter(file, (current: Record<string, unknown>) => {
+				current[resolveCapturePropertyKey(current, key)] = plan(current);
+			});
+		}
+		if (this.plugin.settings.showCaptureNotification) {
+			new Notice(`Captured to '${key}' in '${file.basename}'`, DEFAULT_NOTICE_DURATION);
+		}
+		await this.copyCapturedFileLinkToClipboard(file);
+		await this.insertCaptureLink(file, linkOptions, { isCanvasTriggered: args.isCanvasTriggered });
+		if (this.choice.openFile) {
+			const fileOpening = normalizeFileOpening(this.choice.fileOpening);
+			if (!openExistingFileTab(this.app, file, fileOpening.focus ?? true)) {
+				await openFile(this.app, file, { ...fileOpening, originLeaf: this.originLeaf });
+			}
+		}
+	}
+
+	private async promptForCaptureProperty(frontmatter: Record<string, unknown>, allowCreate: boolean): Promise<string> {
+		const keys = Object.keys(frontmatter).filter((key) => key !== "__proto__").sort((a, b) => a.localeCompare(b));
+		if (!allowCreate && keys.length === 0) {
+			throw new ChoiceAbortError("The capture target has no properties. Enable 'Create property if missing' to add one.");
+		}
+		return await routePrompt(this.choiceExecutor, {
+			remote: (provider) => promptEngineChoice(provider, {
+				items: keys.map((key) => ({ value: key, title: key })),
+				placeholder: "Property", allowCustomInput: allowCreate, what: "the property picker",
+			}),
+			headless: async () => {
+				throw new ChoiceAbortError("Property capture needs a property selection. Configure a named property or run with the ui flag.");
+			},
+			app: () => InputSuggester.Suggest(this.app, keys, keys, {
+				placeholder: "Property", allowCustomValue: allowCreate,
+				customValueLabel: (key) => `Create property: ${key}`,
+				valueExists: (key) => keys.some((existing) => existing.trim().toLowerCase() === key.trim().toLowerCase()),
+			}),
+		});
 	}
 
 	/**

--- a/src/engine/CaptureChoiceEngine.ts
+++ b/src/engine/CaptureChoiceEngine.ts
@@ -815,8 +815,6 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 			});
 		}
 		args.onCommit();
-		const persistedContent = await this.app.vault.read(file);
-		this.outcome.success(file, !fileAlreadyExists ? "created" : persistedContent === priorContent ? "unchanged" : "changed");
 		if (!fileAlreadyExists && (createWithTemplate || isTemplaterTriggerOnCreateEnabled(this.app))) {
 			if (createWithTemplate) await overwriteTemplaterOnce(this.app, file);
 			else await waitForTemplaterTriggerOnCreateToComplete(this.app, file);
@@ -824,6 +822,8 @@ export class CaptureChoiceEngine extends QuickAddChoiceEngine {
 				current[resolveCapturePropertyKey(current, key)] = plan(current);
 			});
 		}
+		const persistedContent = await this.app.vault.read(file);
+		this.outcome.success(file, !fileAlreadyExists ? "created" : persistedContent === priorContent ? "unchanged" : "changed");
 		if (this.plugin.settings.showCaptureNotification) {
 			new Notice(`Captured to '${key}' in '${file.basename}'`, DEFAULT_NOTICE_DURATION);
 		}

--- a/src/engine/SingleTemplateEngine.ts
+++ b/src/engine/SingleTemplateEngine.ts
@@ -5,6 +5,7 @@ import type { IChoiceExecutor } from "../IChoiceExecutor";
 import { log } from "../logger/logManager";
 import type { TemplateInclusionState } from "../formatters/formatter";
 import type { PromptScopeKind } from "../formatters/promptScope";
+import { basenameWithoutMdOrCanvas, parentFolderPath } from "../utils/pathUtils";
 
 export class SingleTemplateEngine extends TemplateEngine {
 	/**
@@ -26,6 +27,10 @@ export class SingleTemplateEngine extends TemplateEngine {
 
 	public setPromptScope(scope: PromptScopeKind): void {
 		this.promptScope = scope;
+	}
+	public setDestinationPath(path: string): void {
+		this.formatter.setTitle(basenameWithoutMdOrCanvas(path));
+		this.formatter.setTargetFolderPath(parentFolderPath(path));
 	}
 	public async run(): Promise<string> {
 		// Resolve format tokens in the template path (issue #620) before reading.

--- a/src/engine/captureProperty.test.ts
+++ b/src/engine/captureProperty.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { planPropertyUpdate, resolveCapturePropertyKey, validatePropertyName } from "./captureProperty";
+import { parsePropertyCapture } from "../types/choices/ICaptureChoice";
+
+const set = { action: "set", createIfMissing: true } as const;
+const add = { action: "addToList", createIfMissing: true } as const;
+
+describe("property capture values", () => {
+	it.each(["001", "false", "2026-09-07", "[a, b]", "a,b", "", "a\nb"])("keeps plain text %j as text", (value) => {
+		expect(planPropertyUpdate({ frontmatter: { status: "active" }, key: "status", value, config: set, registeredType: "text" })).toBe(value);
+	});
+	it.each([0, false, [], ["one", "two"]])("preserves a new typed value %j", (value) => {
+		expect(planPropertyUpdate({ frontmatter: {}, key: "property", value, config: set, registeredType: null })).toEqual(value);
+	});
+	it("adds distinct items in order without splitting text or changing existing data", () => {
+		const frontmatter = { sources: ["a,b", "old"], status: "active" };
+		expect(planPropertyUpdate({ frontmatter, key: "sources", value: ["old", "new", "new"], config: add, registeredType: "multitext" })).toEqual(["a,b", "old", "new"]);
+		expect(planPropertyUpdate({ frontmatter, key: "sources", value: "one,two\nthree", config: add, registeredType: null })).toEqual(["a,b", "old", "one,two\nthree"]);
+		expect(frontmatter).toEqual({ sources: ["a,b", "old"], status: "active" });
+	});
+	it("can replace and explicitly clear a list", () => {
+		expect(planPropertyUpdate({ frontmatter: { tags: ["old"] }, key: "tags", value: [], config: set, registeredType: "tags" })).toEqual([]);
+	});
+	it.each(["", []])("keeps an empty addition %j from changing the list", (value) => {
+		expect(planPropertyUpdate({ frontmatter: { items: ["old", "old"] }, key: "items", value, config: add, registeredType: null })).toEqual(["old", "old"]);
+	});
+	it("uses registered types even for missing and null properties", () => {
+		for (const frontmatter of [{}, { done: null }]) {
+			expect(() => planPropertyUpdate({ frontmatter, key: "done", value: "false", config: set, registeredType: "checkbox" })).toThrow("requires checkbox");
+			expect(planPropertyUpdate({ frontmatter, key: "done", value: false, config: set, registeredType: "checkbox" })).toBe(false);
+		}
+	});
+	it("infers an existing type without a registry and rejects mismatches", () => {
+		expect(() => planPropertyUpdate({ frontmatter: { count: 3 }, key: "count", value: "0", config: set, registeredType: null })).toThrow("requires number");
+		expect(planPropertyUpdate({ frontmatter: { count: 3 }, key: "count", value: 0, config: set, registeredType: null })).toBe(0);
+	});
+	it("rejects scalar-to-list conversion", () => {
+		expect(() => planPropertyUpdate({ frontmatter: { tags: "old" }, key: "tags", value: "new", config: add, registeredType: "tags" })).toThrow("requires a list");
+		expect(() => planPropertyUpdate({ frontmatter: { tags: "old" }, key: "tags", value: ["new"], config: set, registeredType: "tags" })).toThrow("correcting the existing property to a list");
+	});
+	it("sets one literal list item from text and clears a list from empty text", () => {
+		expect(planPropertyUpdate({ frontmatter: { sources: ["old"] }, key: "sources", value: "one,two", config: set, registeredType: null })).toEqual(["one,two"]);
+		expect(planPropertyUpdate({ frontmatter: { sources: ["old"] }, key: "sources", value: "", config: set, registeredType: null })).toEqual([]);
+		expect(planPropertyUpdate({ frontmatter: {}, key: "sources", value: "one,two", config: set, registeredType: "multitext" })).toEqual(["one,two"]);
+	});
+	it.each([{ nested: true }, ["a", 2], null, undefined, Number.NaN, Infinity])("rejects unsupported captured value %j", (value) => {
+		expect(() => planPropertyUpdate({ frontmatter: {}, key: "x", value, config: set, registeredType: null })).toThrow("supports text");
+	});
+	it.each([{ nested: true }, ["a", 2]])("protects unsupported existing value %j even during Set", (value) => {
+		expect(() => planPropertyUpdate({ frontmatter: { x: value }, key: "x", value: "replacement", config: set, registeredType: null })).toThrow("supports text");
+	});
+	it("distinguishes a missing own property from inherited and null values", () => {
+		const config = { ...set, createIfMissing: false };
+		expect(() => planPropertyUpdate({ frontmatter: {}, key: "constructor", value: "x", config, registeredType: null })).toThrow("is missing");
+		expect(planPropertyUpdate({ frontmatter: { constructor: null }, key: "constructor", value: "x", config, registeredType: null })).toBe("x");
+	});
+	it("resolves existing property names without case-sensitive duplicate creation", () => {
+		expect(resolveCapturePropertyKey({ Status: "active" }, "status")).toBe("Status");
+		expect(resolveCapturePropertyKey({ Status: "active", status: "done" }, "status")).toBe("status");
+		expect(() => resolveCapturePropertyKey({ Status: "active", STATUS: "done" }, "status")).toThrow("multiple properties");
+		expect(planPropertyUpdate({ frontmatter: { Status: "active" }, key: "status", value: "done", config: { ...set, createIfMissing: false }, registeredType: null })).toBe("done");
+	});
+	it("rejects malformed settings instead of falling back to body capture", () => {
+		expect(() => parsePropertyCapture({ property: { kind: "named", format: "status" }, action: "append" })).toThrow("Invalid property");
+		expect(() => parsePropertyCapture(null)).toThrow("Invalid property");
+	});
+	it.each(["", "  ", "a\nb", "__proto__"])("rejects unsafe property name %j", (name) => {
+		expect(() => validatePropertyName(name)).toThrow("Property name");
+	});
+});

--- a/src/engine/captureProperty.ts
+++ b/src/engine/captureProperty.ts
@@ -1,0 +1,121 @@
+import { getFrontMatterInfo, parseYaml, stringifyYaml } from "obsidian";
+import type { PropertyCapture } from "../types/choices/ICaptureChoice";
+
+export type CapturePropertyValue = string | number | boolean | string[];
+
+export function validatePropertyName(input: string): string {
+	const key = input.trim();
+	if (!key || /[\r\n\0]/.test(key) || key === "__proto__") {
+		throw new Error("Property name must be nonempty and contain no line breaks or unsafe keys.");
+	}
+	return key;
+}
+
+export function resolveCapturePropertyKey(frontmatter: Record<string, unknown>, requested: string): string {
+	if (Object.prototype.hasOwnProperty.call(frontmatter, requested)) return requested;
+	const matches = Object.keys(frontmatter).filter((key) => key.trim().toLowerCase() === requested.trim().toLowerCase());
+	if (matches.length > 1) throw new Error(`Property '${requested}' matches multiple properties in the target note.`);
+	return matches[0] ?? requested;
+}
+
+function propertyValue(value: unknown, key: string): CapturePropertyValue {
+	if (typeof value === "string" || typeof value === "boolean") return value;
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (Array.isArray(value) && value.every((item): item is string => typeof item === "string")) return [...value];
+	throw new Error(`Property '${key}' supports text, finite numbers, checkboxes, and lists of text only.`);
+}
+
+type PropertyType = "text" | "number" | "checkbox" | "list" | "date" | "datetime";
+
+function propertyType(type: string | null, key: string): PropertyType | null {
+	if (type === null && ["tags", "aliases", "cssclasses"].includes(key.toLowerCase())) return "list";
+	if (type === null) return null;
+	switch (type.toLowerCase()) {
+		case "text": return "text";
+		case "number": return "number";
+		case "checkbox": case "boolean": return "checkbox";
+		case "list": case "multitext": case "tags": case "aliases": return "list";
+		case "date": return "date";
+		case "datetime": return "datetime";
+		default: throw new Error(`Property '${key}' has unsupported type '${type}'.`);
+	}
+}
+
+function inferType(value: CapturePropertyValue): PropertyType {
+	if (Array.isArray(value)) return "list";
+	if (typeof value === "boolean") return "checkbox";
+	if (typeof value === "number") return "number";
+	return "text";
+}
+
+function validateType(value: CapturePropertyValue, type: PropertyType, key: string): void {
+	const actual = inferType(value);
+	if (type === "date" || type === "datetime") {
+		const pattern = type === "date"
+			? /^\d{4}-\d{2}-\d{2}$/
+			: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?$/;
+		if (typeof value === "string" && (value === "" || (
+			pattern.test(value) && Number.isFinite(Date.parse(value)) &&
+			new Date(value.slice(0, 10)).toISOString().slice(0, 10) === value.slice(0, 10)
+		))) return;
+	} else if (actual === type) {
+		return;
+	}
+	throw new Error(`Property '${key}' requires ${type}; the capture is ${actual}. Use a matching typed VALUE token or value.`);
+}
+
+export function planPropertyUpdate(args: {
+	frontmatter: Record<string, unknown>;
+	key: string;
+	value: unknown;
+	config: Pick<PropertyCapture, "action" | "createIfMissing">;
+	registeredType: string | null;
+}): CapturePropertyValue {
+	const { frontmatter, config } = args;
+	const key = resolveCapturePropertyKey(frontmatter, args.key);
+	const exists = Object.prototype.hasOwnProperty.call(frontmatter, key);
+	if (!exists && !config.createIfMissing) {
+		throw new Error(`Property '${key}' is missing. Enable 'Create property if missing' to add it.`);
+	}
+	const existing = exists ? frontmatter[key] : undefined;
+	const captured = propertyValue(args.value, key);
+	const current = existing == null ? null : propertyValue(existing, key);
+	const type = propertyType(args.registeredType, key) ?? (current === null ? null : inferType(current));
+	if (config.action === "addToList") {
+		if (current !== null && !Array.isArray(current)) {
+			throw new Error(`Property '${key}' is ${inferType(current)}. 'Add to list' requires a list.`);
+		}
+		if (type !== null && type !== "list") {
+			throw new Error(`Property '${key}' is ${type}. 'Add to list' requires a list.`);
+		}
+		const items = typeof captured === "string" ? captured === "" ? [] : [captured] : captured;
+		if (!Array.isArray(items)) throw new Error(`Property '${key}' requires text or a list of text to add.`);
+		if (items.length === 0) return current ?? [];
+		return [...new Set([...(current ?? []), ...items])];
+	}
+	if (type === "list" && current !== null && !Array.isArray(current)) {
+		throw new Error(`Property '${key}' contains ${inferType(current)}. Set a list only after correcting the existing property to a list.`);
+	}
+	const next = type === "list" && typeof captured === "string"
+		? captured === "" ? [] : [captured]
+		: captured;
+	if (type !== null) validateType(next, type, key);
+	return Array.isArray(next) ? [...new Set(next)] : next;
+}
+
+export function readCaptureFrontmatter(content: string): Record<string, unknown> {
+	const info = getFrontMatterInfo(content);
+	if (!info.exists || !info.frontmatter.trim()) return {};
+	const parsed: unknown = parseYaml(info.frontmatter);
+	if (parsed === null) return {};
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("The capture target's frontmatter must be a property mapping.");
+	}
+	return Object.fromEntries(Object.entries(parsed));
+}
+
+export function serializeCaptureFrontmatter(content: string, frontmatter: Record<string, unknown>): string {
+	const info = getFrontMatterInfo(content);
+	const body = info.exists ? content.slice(info.contentStart) : content;
+	return `---\n${stringifyYaml(frontmatter)}---\n${body}`;
+}

--- a/src/formatters/completeFormatter.test.ts
+++ b/src/formatters/completeFormatter.test.ts
@@ -1,4 +1,5 @@
 import { createChoiceExecutor } from "../../tests/helpers/createChoiceExecutor";
+import { inheritPropertyValueType } from "../utils/propertyCaptureFormat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TemplateInclusionState } from "./formatter";
 import type { FieldValueProcessor as FieldValueProcessorType } from "../utils/FieldValueProcessor";
@@ -1876,5 +1877,83 @@ describe("CompleteFormatter - remote prompt provider routing", () => {
 			false,
 		);
 		expect(mocks.genericSuggesterSuggest).not.toHaveBeenCalled();
+	});
+});
+
+describe("property value formatting", () => {
+	function formatterWithValue(value: unknown) {
+		const executor = createChoiceExecutor();
+		executor.variables.set("input", value);
+		executor.variables.set("value", value);
+		return new CompleteFormatter(makeApp({ activeFile: null, selection: null, generatedLink: "" }) as any, makePlugin() as any, executor);
+	}
+
+	it.each([0, false, ["a,b", "c"], [], { nested: true }])("retains whole-token native values for validation: %j", async (value) => {
+		expect(await formatterWithValue(value).formatPropertyValue("{{VALUE:input}}")).toEqual(value);
+		expect(await formatterWithValue(value).formatPropertyValue("{{VALUE}}")).toEqual(value);
+	});
+
+	it.each(["001", "false", "[a,b]", "a,b", ""]) ("leaves ordinary token text %j unchanged", async (value) => {
+		expect(await formatterWithValue(value).formatPropertyValue("{{VALUE:input}}")).toBe(value);
+	});
+
+	it.each([false, 0, ["one", "two"], []])("preserves anonymous native values with label and optional options: %j", async (value) => {
+		expect(await formatterWithValue(value).formatPropertyValue("{{VALUE|label:Property value|optional}}")).toEqual(value);
+		expect(await formatterWithValue(value).formatPropertyValue("{{VALUE:input|label:Property value|optional}}")).toEqual(value);
+	});
+
+	it("trims anonymous typed list items without flattening the list", async () => {
+		expect(await formatterWithValue([" one ", " two "]).formatPropertyValue("{{VALUE|trim}}")).toEqual(["one", "two"]);
+	});
+
+	it.each([
+		["{{VALUE:input|type:number}}", "0", 0],
+		["{{VALUE:input|type:checkbox}}", "false", false],
+		["{{VALUE|type:number}}", "0", 0],
+		["{{VALUE|type:checkbox}}", "false", false],
+		["{{VALUE:input|type:text}}", false, "false"],
+	])("uses explicit native input types: %s", async (format, input, expected) => {
+		expect(await formatterWithValue(input).formatPropertyValue(String(format))).toBe(expected);
+	});
+
+	it("keeps a mixed format and explicit list formatting as text", async () => {
+		expect(await formatterWithValue(["one", "two"]).formatPropertyValue("Sources: {{VALUE:input}}")).toBe("Sources: one,two");
+		expect(await formatterWithValue(["one", "two"]).formatPropertyValue("{{VALUE:one,two|name:input|multi|format:spaced}}")).toBe("one, two");
+		expect(await formatterWithValue(false).formatPropertyValue("{{VALUE:input}} literal")).toBe("false literal");
+	});
+
+	it("does not leak typed values into later body formatting or plain-text properties", async () => {
+		const formatter = formatterWithValue(["one", "two"]);
+		expect(await formatter.formatPropertyValue("{{VALUE:input}}")).toEqual(["one", "two"]);
+		expect(await formatter.formatFileContent("{{VALUE:input}}")).toBe("one,two");
+		expect(await formatter.formatPropertyValue("literal")).toBe("literal");
+	});
+
+	it("uses inherited native widgets for prefilled number and checkbox strings", async () => {
+		expect(await formatterWithValue("42").formatPropertyValue(inheritPropertyValueType("{{VALUE:input}}", "number"))).toBe(42);
+		expect(await formatterWithValue("false").formatPropertyValue(inheritPropertyValueType("{{VALUE}}", "checkbox"))).toBe(false);
+	});
+
+	it.each(["auto", "yaml"])("preserves FIELD lists only without an explicit %s rendering format", async (multiFormat) => {
+		mocks.fieldParse.mockReturnValue({ fieldName: "topics", filters: {}, multiSelect: true, multiFormat });
+		mocks.collectProcessedDetailed.mockResolvedValue({ values: ["Alpha", "Beta"], hasDefaultValue: false });
+		mocks.multiSuggesterSuggest.mockResolvedValue(["Alpha", "Beta"]);
+		const value = await defaultFormatter().formatPropertyValue(`{{FIELD:topics|multi|format:${multiFormat}}}`);
+		expect(value).toEqual(multiFormat === "auto" ? ["Alpha", "Beta"] : '["Alpha", "Beta"]');
+	});
+
+	it("validates typed inputs supplied by scripts as strictly as prompt inputs", async () => {
+		await expect(formatterWithValue("false-ish").formatPropertyValue("{{VALUE:input|type:checkbox}}")).rejects.toThrow("true or false");
+		await expect(formatterWithValue("0x12").formatPropertyValue("{{VALUE:input|type:number}}")).rejects.toThrow("finite number");
+	});
+
+	it.each([false, ["1"], Number.NaN, Infinity])("rejects a non-number %j for an explicitly numeric token", async (value) => {
+		await expect(formatterWithValue(value).formatPropertyValue("{{VALUE:input|type:number}}")).rejects.toThrow("finite number");
+		await expect(formatterWithValue(value).formatPropertyValue("{{VALUE|type:number}}")).rejects.toThrow("finite number");
+	});
+
+	it.each([7, ["false"]])("rejects a non-boolean %j for an explicitly checkbox token", async (value) => {
+		await expect(formatterWithValue(value).formatPropertyValue("{{VALUE:input|type:checkbox}}")).rejects.toThrow("true or false");
+		await expect(formatterWithValue(value).formatPropertyValue("{{VALUE|type:checkbox}}")).rejects.toThrow("true or false");
 	});
 });

--- a/src/formatters/completeFormatter.ts
+++ b/src/formatters/completeFormatter.ts
@@ -167,6 +167,24 @@ export class CompleteFormatter extends Formatter {
 		return output;
 	}
 
+	async formatPropertyName(input: string): Promise<string> {
+		return await this.withPromptScope("propertyName", input, async () =>
+			this.replaceCurrentFileTokensInString(await this.format(input), {
+				links: true, fileName: true, folder: true, activeFolder: "content", title: true,
+			}),
+		);
+	}
+
+	async formatPropertyValue(input: string): Promise<unknown> {
+		return await this.preserveSingleTokenValue(input, () =>
+			this.withPromptScope("propertyValue", input, async () =>
+				this.replaceCurrentFileTokensInString(await this.format(input), {
+					links: true, fileName: true, folder: true, activeFolder: "content", title: true,
+				}),
+			),
+		);
+	}
+
 	async formatFileContent(input: string): Promise<string> {
 		let output: string = input;
 

--- a/src/formatters/formatter-file.test.ts
+++ b/src/formatters/formatter-file.test.ts
@@ -64,6 +64,10 @@ class FileTestFormatter extends Formatter {
 		return this.replaceFileInString(input);
 	}
 
+	public runPropertyValue(input: string): Promise<unknown> {
+		return this.preserveSingleTokenValue(input, () => this.replaceFileInString(input));
+	}
+
 	public runWithPropertyCollection(input: string): Promise<string> {
 		return this.withTemplatePropertyCollection(() =>
 			this.replaceFileInString(input),
@@ -303,5 +307,14 @@ describe("Formatter {{FILE:...}} token", () => {
 
 		expect(output).toBe("---\npeople: []\n---\n");
 		expect(vars.get("people")).toEqual(["[[Tom@]]", "[[Jack@]]"]);
+	});
+});
+
+describe("FILE tokens as property values", () => {
+	it("keeps selected file paths as a native list unless rendering was explicitly requested", async () => {
+		const formatter = new FileTestFormatter(makeApp([]), () => ["@file:Projects/Alpha.md", "@file:Projects/Beta.md"]);
+		expect(await formatter.runPropertyValue("{{FILE:Projects|path|multi}}")).toEqual(["Projects/Alpha.md", "Projects/Beta.md"]);
+		expect(await formatter.runPropertyValue("{{FILE:Projects|path|multi|format:yaml}}")).toBe('["Projects/Alpha.md", "Projects/Beta.md"]');
+		expect(await formatter.runPropertyValue("Files: {{FILE:Projects|path|multi}}" )).toBe("Files: Projects/Alpha.md,Projects/Beta.md");
 	});
 });

--- a/src/formatters/formatter.ts
+++ b/src/formatters/formatter.ts
@@ -333,6 +333,45 @@ export abstract class Formatter {
 	// Tracks variables collected for YAML property post-processing
 	private readonly propertyCollector: TemplatePropertyCollector;
 	private templatePropertyCollectionDepth = 0;
+	private singleTokenValue?: { input: string; result?: { value: unknown } };
+
+	protected async preserveSingleTokenValue(input: string, work: () => Promise<string>): Promise<unknown> {
+		const previous = this.singleTokenValue;
+		const capture: typeof this.singleTokenValue = /^(?:\{\{(?:VALUE|NAME)(?::[^{}]+|\|[^{}]+)?\}\}|\{\{(?:FIELD|FILE):[^{}]+\}\})$/i.test(input)
+			? { input }
+			: undefined;
+		this.singleTokenValue = capture;
+		try {
+			const text = await work();
+			return capture?.result && typeof capture.result.value !== "string" ? capture.result.value : text;
+		} finally {
+			this.singleTokenValue = previous;
+		}
+	}
+
+	private retainSingleTokenValue(input: string, start: number, end: number, value: unknown): void {
+		if (this.singleTokenValue?.input === input && start === 0 && end === input.length) {
+			this.singleTokenValue.result = { value };
+		}
+	}
+
+	private propertyTokenValue(value: unknown, inputType?: string): unknown {
+		if (inputType === "text") return formatUnknownValue(value);
+		if (inputType === "checkbox") {
+			if (typeof value === "boolean") return value;
+			if (value === "true") return true;
+			if (value === "false") return false;
+			throw new Error("A checkbox property value must be true or false.");
+		}
+		if (inputType === "number" || inputType === "slider") {
+			if (typeof value === "number" && Number.isFinite(value)) return value;
+			if (typeof value !== "string" || !/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(value.trim()) || !Number.isFinite(Number(value))) {
+				throw new Error("A number property value must be a finite number.");
+			}
+			return Number(value);
+		}
+		return value;
+	}
 
 	// Detects the same |name being defined with conflicting option lists across
 	// one execution (filename + body share this instance). Keyed name -> option
@@ -598,6 +637,8 @@ export abstract class Formatter {
 			const inner = token.slice(2, -2);
 			const optionsIndex = inner.indexOf("|");
 			if (optionsIndex === -1) {
+				this.retainSingleTokenValue(source, offset, offset + token.length,
+					this.hasConcreteVariable("value") ? this.variables.get("value") : this.value);
 				return escapeValueInsideQuotedYamlScalar(
 					source,
 					offset,
@@ -618,6 +659,13 @@ export abstract class Formatter {
 					? parsed.defaultValue
 					: this.value;
 			const transformed = this.applyValueTextOptions(effectiveValue, parsed);
+			if (this.singleTokenValue) {
+				const rawValue = this.value === "" && parsed.defaultValue && !parsed.optional
+					? parsed.defaultValue
+					: this.hasConcreteVariable("value") ? this.variables.get("value") : this.value;
+				this.retainSingleTokenValue(source, offset, offset + token.length,
+					this.propertyTokenValue(this.applyValueTokenOptions(rawValue, parsed), parsed.inputTypeOverride));
+			}
 			// |type:text on the anonymous {{VALUE|...}} form quotes the same way
 			// as the named form (see replaceVariableInString).
 			if (
@@ -651,7 +699,7 @@ export abstract class Formatter {
 
 	private applyValueTokenOptions(
 		value: unknown,
-		parsed: ParsedValueToken,
+		parsed: Pick<ParsedValueToken, "trim" | "caseStyle">,
 	): unknown {
 		if (Array.isArray(value)) {
 			return parsed.trim
@@ -1070,6 +1118,9 @@ export abstract class Formatter {
 		heuristicEnabled: boolean;
 		multiFormat?: MultiValueFormat;
 	}): string | undefined {
+		if (!args.multiFormat || args.multiFormat === "auto") {
+			this.retainSingleTokenValue(args.input, args.matchStart, args.matchEnd, args.rawValue);
+		}
 		if (Array.isArray(args.rawValue) && args.multiFormat) {
 			const explicit = renderExplicitMultiValue({
 				input: args.input,
@@ -1359,6 +1410,10 @@ export abstract class Formatter {
 			// Get the raw value from variables
 			const rawValue = this.variables.get(effectiveKey);
 			const effectiveRawValue = this.applyValueTokenOptions(rawValue, parsed);
+			if (this.singleTokenValue && (!parsed.multiFormat || parsed.multiFormat === "auto")) {
+				this.retainSingleTokenValue(output, match.index, match.index + match[0].length,
+					this.propertyTokenValue(effectiveRawValue, parsed.inputTypeOverride));
+			}
 
 			// Offer this variable to the property collector for YAML post-processing.
 			// Collecting structured values (arrays/objects/numbers/booleans) into a
@@ -1369,7 +1424,7 @@ export abstract class Formatter {
 				input: output,
 				matchStart: match.index,
 				matchEnd: match.index + match[0].length,
-				rawValue: effectiveRawValue,
+				rawValue: this.singleTokenValue?.result ? this.singleTokenValue.result.value : effectiveRawValue,
 				fallbackKey: variableName,
 				// |type:text forces a string: never run the string->structured
 				// heuristic on it, or a comma/bracket value (`a,b`, `[x]`) would be
@@ -1483,6 +1538,9 @@ export abstract class Formatter {
 				const rawValue = this.hasConcreteVariable(fieldVariableKey)
 					? this.variables.get(fieldVariableKey)
 					: this.getVariableValue(fieldVariableKey);
+				if (!parsed.multiFormat || parsed.multiFormat === "auto") {
+					this.retainSingleTokenValue(input, match.index, match.index + match[0].length, rawValue);
+				}
 				let replacement: string;
 
 				if (Array.isArray(rawValue)) {

--- a/src/formatters/promptScope.ts
+++ b/src/formatters/promptScope.ts
@@ -17,6 +17,8 @@ export type PromptScopeKind =
 	| "noteTitle"
 	| "captureTarget"
 	| "captureText"
+	| "propertyName"
+	| "propertyValue"
 	| "noteBody"
 	| "folder"
 	| "templatePath"
@@ -93,6 +95,16 @@ const SCOPE_COPY: Record<Exclude<PromptScopeKind, "generic">, ScopeCopy> = {
 		ask: "Text to capture",
 		hint: "Text to add to the note",
 		partOf: "Part of the text added to the note",
+	},
+	propertyName: {
+		ask: "Property",
+		hint: "Property name",
+		partOf: "Part of the property name",
+	},
+	propertyValue: {
+		ask: "Property value",
+		hint: "Value to capture",
+		partOf: "Part of the property value",
 	},
 	noteBody: {
 		ask: "Note content",
@@ -179,6 +191,8 @@ export function isPathScope(scope: PromptScopeKind): boolean {
 	return (
 		scope === "noteTitle" ||
 		scope === "captureTarget" ||
+		scope === "propertyName" ||
+		scope === "propertyValue" ||
 		scope === "folder" ||
 		scope === "templatePath" ||
 		scope === "lineTarget" ||

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.svelte
@@ -149,11 +149,13 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 </SettingItem>
 
 <SettingItem name="Content" heading />
+{#if !choice.propertyCapture}
 <SettingItem name="Task" desc="Formats the value as a task.">
 	{#snippet control()}
 		<Toggle bind:checked={choice.task} />
 	{/snippet}
 </SettingItem>
+{/if}
 
 <LabeledField
 	name="Capture format"
@@ -199,6 +201,7 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 	{/snippet}
 </SettingItem>
 
+{#if !choice.propertyCapture}
 <SettingItem
 	name="Run Templater on entire destination file after capture"
 	desc="Advanced / legacy: this executes any <% %> anywhere in the destination file (including inside code blocks)."
@@ -210,6 +213,7 @@ function onTemplaterAfterCaptureChange(value: boolean) {
 		/>
 	{/snippet}
 </SettingItem>
+{/if}
 
 <DateOriginSetting bind:dateOrigin={choice.dateOrigin} />
 

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -127,6 +127,29 @@ function previewRows(container: HTMLElement): HTMLElement[] {
 }
 
 describe("CaptureChoiceForm", () => {
+	it("persists property settings and hides dormant body controls until switching back", async () => {
+		const { container, props, getByLabelText } = mountForm();
+		props.choice.insertAfter.enabled = true;
+		props.choice.task = true;
+		flushSync();
+		await fireEvent.change(selectUnderSetting(container, "Write position"), { target: { value: "property" } });
+		flushSync();
+		expect(settingNames(container)).not.toContain("Insert after");
+		expect(settingNames(container)).not.toContain("Task");
+		expect(settingNames(container)).toContain("Create property if missing");
+		await fireEvent.input(getByLabelText("Property"), { target: { value: "{{VALUE:property}}" } });
+		await fireEvent.change(selectUnderSetting(container, "Action"), { target: { value: "addToList" } });
+		flushSync();
+		expect(props.choice.propertyCapture).toEqual({ property: { kind: "named", format: "{{VALUE:property}}" }, action: "addToList", createIfMissing: true });
+		await fireEvent.change(selectUnderSetting(container, "Property"), { target: { value: "prompt" } });
+		flushSync();
+		expect(props.choice.propertyCapture?.property).toEqual({ kind: "prompt" });
+		await fireEvent.change(selectUnderSetting(container, "Write position"), { target: { value: "bottom" } });
+		flushSync();
+		expect(props.choice.propertyCapture).toBeUndefined();
+		expect(settingNames(container)).toContain("Task");
+	});
+
 	it("reveals insert-after / insert-before fields by write position, mutually exclusive, without remounting", async () => {
 		const { container } = mountForm();
 		const headerBefore = container.querySelector(".choiceNameHeaderButton");

--- a/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
+++ b/src/gui/ChoiceBuilder/CaptureChoiceForm.test.ts
@@ -144,6 +144,15 @@ describe("CaptureChoiceForm", () => {
 		await fireEvent.change(selectUnderSetting(container, "Property"), { target: { value: "prompt" } });
 		flushSync();
 		expect(props.choice.propertyCapture?.property).toEqual({ kind: "prompt" });
+		await fireEvent.change(selectUnderSetting(container, "Property"), { target: { value: "named" } });
+		flushSync();
+		expect(getByLabelText("Property")).toHaveValue("{{VALUE:property}}");
+		expect(props.choice.propertyCapture?.property).toEqual({ kind: "named", format: "{{VALUE:property}}" });
+		await fireEvent.input(getByLabelText("Property"), { target: { value: "status" } });
+		await fireEvent.change(selectUnderSetting(container, "Property"), { target: { value: "prompt" } });
+		await fireEvent.change(selectUnderSetting(container, "Property"), { target: { value: "named" } });
+		flushSync();
+		expect(getByLabelText("Property")).toHaveValue("status");
 		await fireEvent.change(selectUnderSetting(container, "Write position"), { target: { value: "bottom" } });
 		flushSync();
 		expect(props.choice.propertyCapture).toBeUndefined();

--- a/src/gui/ChoiceBuilder/components/PropertyCaptureFields.svelte
+++ b/src/gui/ChoiceBuilder/components/PropertyCaptureFields.svelte
@@ -32,7 +32,9 @@ const suggesters = [(el: HTMLInputElement | HTMLTextAreaElement) => new FormatSy
 	{/snippet}
 </LabeledField>
 
-<SettingItem name="Action">
+<SettingItem name="Action" desc={config.action === "addToList"
+	? "Add captured values to the property's list, keeping existing items and skipping duplicates."
+	: "Replace the property's value with the captured value."}>
 	{#snippet control()}
 		<Dropdown value={config.action}
 			options={[{ value: "set", label: "Set value" }, { value: "addToList", label: "Add to list" }]}

--- a/src/gui/ChoiceBuilder/components/PropertyCaptureFields.svelte
+++ b/src/gui/ChoiceBuilder/components/PropertyCaptureFields.svelte
@@ -16,13 +16,17 @@ let { config = $bindable(), app, plugin }: {
 } = $props();
 
 const suggesters = [(el: HTMLInputElement | HTMLTextAreaElement) => new FormatSyntaxSuggester(app, el, plugin)];
+let lastNamedFormat = "";
 </script>
 
 <LabeledField name="Property" bodyVisible={config.property.kind === "named"}>
 	{#snippet control()}
 		<Dropdown value={config.property.kind}
 			options={[{ value: "named", label: "Named property" }, { value: "prompt", label: "Choose when capturing" }]}
-			onchange={(value) => { config.property = value === "prompt" ? { kind: "prompt" } : { kind: "named", format: "" }; }} />
+			onchange={(value) => {
+				if (config.property.kind === "named") lastNamedFormat = config.property.format;
+				config.property = value === "prompt" ? { kind: "prompt" } : { kind: "named", format: lastNamedFormat };
+			}} />
 	{/snippet}
 	{#snippet children(id)}
 		{#if config.property.kind === "named"}

--- a/src/gui/ChoiceBuilder/components/PropertyCaptureFields.svelte
+++ b/src/gui/ChoiceBuilder/components/PropertyCaptureFields.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+import type { App } from "obsidian";
+import type QuickAdd from "../../../main";
+import type { PropertyCapture } from "../../../types/choices/ICaptureChoice";
+import { FormatSyntaxSuggester } from "../../suggesters/formatSyntaxSuggester";
+import SettingItem from "../../components/SettingItem.svelte";
+import Dropdown from "../../components/Dropdown.svelte";
+import Toggle from "../../components/Toggle.svelte";
+import LabeledField from "./LabeledField.svelte";
+import ValidatedInput from "./ValidatedInput.svelte";
+
+let { config = $bindable(), app, plugin }: {
+	config: PropertyCapture;
+	app: App;
+	plugin: QuickAdd;
+} = $props();
+
+const suggesters = [(el: HTMLInputElement | HTMLTextAreaElement) => new FormatSyntaxSuggester(app, el, plugin)];
+</script>
+
+<LabeledField name="Property" bodyVisible={config.property.kind === "named"}>
+	{#snippet control()}
+		<Dropdown value={config.property.kind}
+			options={[{ value: "named", label: "Named property" }, { value: "prompt", label: "Choose when capturing" }]}
+			onchange={(value) => { config.property = value === "prompt" ? { kind: "prompt" } : { kind: "named", format: "" }; }} />
+	{/snippet}
+	{#snippet children(id)}
+		{#if config.property.kind === "named"}
+			<ValidatedInput {id} bind:value={config.property.format} placeholder="Property name"
+				required requiredMessage="Property name is required" makeSuggesters={suggesters} />
+		{/if}
+	{/snippet}
+</LabeledField>
+
+<SettingItem name="Action">
+	{#snippet control()}
+		<Dropdown value={config.action}
+			options={[{ value: "set", label: "Set value" }, { value: "addToList", label: "Add to list" }]}
+			onchange={(value) => { config.action = value === "addToList" ? "addToList" : "set"; }} />
+	{/snippet}
+</SettingItem>
+
+<SettingItem name="Create property if missing">
+	{#snippet control()}
+		<Toggle bind:checked={config.createIfMissing} />
+	{/snippet}
+</SettingItem>

--- a/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
+++ b/src/gui/ChoiceBuilder/components/WritePositionSetting.svelte
@@ -8,6 +8,7 @@ import SettingItem from "../../components/SettingItem.svelte";
 import Dropdown from "../../components/Dropdown.svelte";
 import InsertAfterFields from "./InsertAfterFields.svelte";
 import InsertBeforeFields from "./InsertBeforeFields.svelte";
+import PropertyCaptureFields from "./PropertyCaptureFields.svelte";
 
 /**
  * Reactive port of captureChoiceBuilder.addWritePositionSetting. The write-position
@@ -28,6 +29,7 @@ let {
 const isActiveFile = $derived(!!choice.captureToActiveFile);
 
 const current = $derived.by(() => {
+	if (choice.propertyCapture) return "property";
 	if (choice.insertAfter?.enabled) return "after";
 	if (choice.insertBefore?.enabled) return "before";
 	if (choice.newLineCapture?.enabled)
@@ -55,9 +57,19 @@ const options = $derived([
 	{ value: "after", label: "After line…" },
 	{ value: "before", label: "Before line…" },
 	{ value: "bottom", label: "Bottom of file" },
+	{ value: "property", label: "Property" },
 ]);
 
 function onWritePositionChange(value: string) {
+	if (value === "property") {
+		choice.propertyCapture ??= {
+			property: { kind: "named", format: "" },
+			action: "set",
+			createIfMissing: true,
+		};
+		return;
+	}
+	delete choice.propertyCapture;
 	// Reset every mutually-exclusive position flag, then set the chosen one
 	// (verbatim order from the imperative builder, captureChoiceBuilder.ts:941-999).
 	choice.prepend = false;
@@ -115,6 +127,7 @@ function onWritePositionChange(value: string) {
 }
 
 const showCanvasNotice = $derived.by(() => {
+	if (choice.propertyCapture) return false;
 	const obviousCanvasTarget =
 		typeof choice.captureTo === "string" && isCanvasTargetPath(choice.captureTo);
 	const hasActiveCanvasView =
@@ -145,11 +158,15 @@ const showCanvasNotice = $derived.by(() => {
 	{/snippet}
 </SettingItem>
 
-{#if choice.insertAfter.enabled}
+{#if choice.propertyCapture}
+	<PropertyCaptureFields bind:config={choice.propertyCapture} {app} {plugin} />
+{/if}
+
+{#if !choice.propertyCapture && choice.insertAfter.enabled}
 	<InsertAfterFields bind:insertAfter={choice.insertAfter} {app} {plugin} />
 {/if}
 
-{#if choice.insertBefore?.enabled}
+{#if !choice.propertyCapture && choice.insertBefore?.enabled}
 	<InsertBeforeFields bind:insertBefore={choice.insertBefore} {app} {plugin} />
 {/if}
 

--- a/src/preflight/collectChoiceRequirements.test.ts
+++ b/src/preflight/collectChoiceRequirements.test.ts
@@ -2447,3 +2447,42 @@ describe("collectChoiceRequirements - macro form roster", () => {
 		).resolves.toEqual([]);
 	});
 });
+
+describe("property capture requirements", () => {
+	it.each(["number", "checkbox"])("uses a known property's %s widget in the one-page form", async (type) => {
+		const choice = createCaptureChoice("Inbox.md");
+		choice.propertyCapture = { property: { kind: "named", format: "rating" }, action: "set", createIfMissing: true };
+		choice.format = { enabled: true, format: "{{VALUE:ratingInput}}" };
+		const requirements = await collectChoiceRequirements({
+			vault: { getAbstractFileByPath: () => null },
+			metadataTypeManager: { getAllProperties: () => ({ rating: {} }), getTypeInfo: () => ({ expected: { type } }) },
+		} as unknown as App, { settings: { inputPrompt: "single-line", globalVariables: {}, useSelectionAsCaptureValue: false } } as any, createChoiceExecutor(), choice);
+		expect(requirements).toEqual([expect.objectContaining({ id: "ratingInput", type: type === "checkbox" ? "dropdown" : type })]);
+		expect(requirements[0].runtimeOnly).not.toBe(true);
+	});
+
+	it("defers only the value whose native property type depends on the runtime selection", async () => {
+		const choice = createCaptureChoice("Inbox.md");
+		choice.propertyCapture = { property: { kind: "named", format: "{{VALUE:propertyName}}" }, action: "set", createIfMissing: true };
+		choice.format = { enabled: true, format: "{{VALUE:propertyInput}}" };
+		const requirements = await collectChoiceRequirements({ vault: { getAbstractFileByPath: () => null } } as unknown as App,
+			{ settings: { inputPrompt: "single-line", globalVariables: {}, useSelectionAsCaptureValue: false } } as any, createChoiceExecutor(), choice);
+		expect(requirements.find((requirement) => requirement.id === "propertyInput")?.runtimeOnly).toBe(true);
+		expect(requirements.find((requirement) => requirement.id === "propertyName")?.runtimeOnly).not.toBe(true);
+	});
+
+	it("collects property-name and value formats while ignoring dormant body-position fields", async () => {
+		const choice = createCaptureChoice("Inbox.md");
+		choice.propertyCapture = { property: { kind: "named", format: "{{VALUE:property}}" }, action: "set", createIfMissing: true };
+		choice.format = { enabled: true, format: "{{VALUE:amount|type:number}}" };
+		choice.insertAfter.enabled = true;
+		choice.insertAfter.after = "{{VALUE:dormantAfter}}";
+		choice.insertBefore = { enabled: true, before: "{{VALUE:dormantBefore}}", createIfNotFound: false, createIfNotFoundLocation: "top" };
+		const requirements = await collectChoiceRequirements({ vault: { getAbstractFileByPath: () => null }, workspace: { getActiveViewOfType: () => null } } as unknown as App,
+			{ settings: { inputPrompt: "single-line", globalVariables: {}, useSelectionAsCaptureValue: false } } as any,
+			createChoiceExecutor(), choice);
+		expect(requirements.map((requirement) => requirement.id)).toEqual(["property", "amount"]);
+		expect(requirements.find((requirement) => requirement.id === "amount")?.type).toBe("number");
+		expect(requirements.every((requirement) => requirement.pathContext)).toBe(true);
+	});
+});

--- a/src/preflight/collectChoiceRequirements.ts
+++ b/src/preflight/collectChoiceRequirements.ts
@@ -41,6 +41,8 @@ import { orderFilesForPicker } from "src/utils/fileOrdering";
 import { buildFileDisplayLabels } from "src/utils/fileSyntax";
 import { buildPickerOrderingDeps } from "src/utils/pickerOrderingDeps";
 import { resolveExistingVariableKey } from "src/utils/valueSyntax";
+import { inheritPropertyValueType, untypedPropertyValueVariable } from "src/utils/propertyCaptureFormat";
+import { resolveObsidianPropertyType } from "src/utils/obsidianPropertyTypes";
 import {
 	RequirementCollector,
 	type FieldRequirement,
@@ -373,19 +375,35 @@ async function collectForCaptureChoice(
 		// Scanned BEFORE content so a dual-use {{VALUE}} is marked as path context.
 		"captureTarget",
 	);
-
-	if (choice.format?.enabled) {
+	if (choice.propertyCapture?.property.kind === "named") {
 		await scanContentWithTemplateIncludes(
-			app,
-			collector,
-			choice.format.format,
-			undefined,
-			0,
-			"captureText",
+			app, collector, choice.propertyCapture.property.format, undefined, 0, "propertyName",
 		);
 	}
 
-	if (choice.insertAfter?.enabled && !choice.insertAfter.promptHeading) {
+	const captureFormat = choice.format?.enabled ? choice.format.format : VALUE_SYNTAX;
+	const propertyName = choice.propertyCapture?.property.kind === "named"
+		? choice.propertyCapture.property.format.trim() : null;
+	const knownPropertyType = propertyName && !hasTemplatePathSyntax(propertyName)
+		? resolveObsidianPropertyType(app, propertyName, { registeredOnly: true }) : null;
+	if (choice.format?.enabled || choice.propertyCapture) {
+		await scanContentWithTemplateIncludes(
+			app,
+			collector,
+			choice.propertyCapture ? inheritPropertyValueType(captureFormat, knownPropertyType) : captureFormat,
+			undefined,
+			0,
+			choice.propertyCapture ? "propertyValue" : "captureText",
+		);
+	}
+
+	if (choice.propertyCapture && knownPropertyType === null) {
+		const key = untypedPropertyValueVariable(captureFormat);
+		const requirement = key === null ? undefined : collector.requirements.get(key);
+		if (requirement) requirement.runtimeOnly = true;
+	}
+
+	if (!choice.propertyCapture && choice.insertAfter?.enabled && !choice.insertAfter.promptHeading) {
 		await scanContentWithTemplateIncludes(
 			app,
 			collector,
@@ -397,7 +415,7 @@ async function collectForCaptureChoice(
 		);
 	}
 
-	if (choice.insertBefore?.enabled) {
+	if (!choice.propertyCapture && choice.insertBefore?.enabled) {
 		await scanContentWithTemplateIncludes(
 			app,
 			collector,

--- a/src/types/choices/CaptureChoice.ts
+++ b/src/types/choices/CaptureChoice.ts
@@ -8,8 +8,10 @@ import { CREATE_IF_NOT_FOUND_ORDERED } from "../../constants";
 import type { OpenLocation, FileViewMode2 } from "../fileOpening";
 import type { AppendLinkOptions } from "../linkPlacement";
 import { normalizeFileOpening } from "../../utils/fileOpeningDefaults";
+import { parsePropertyCapture } from "./ICaptureChoice";
 
 export class CaptureChoice extends Choice implements ICaptureChoice {
+	propertyCapture?: ICaptureChoice["propertyCapture"];
 	appendLink: boolean | AppendLinkOptions;
 	copyLinkToClipboard: boolean;
 	captureTo: string;
@@ -107,6 +109,9 @@ export class CaptureChoice extends Choice implements ICaptureChoice {
 
 	public static Load(choice: ICaptureChoice): CaptureChoice {
 		const loaded = choice as CaptureChoice;
+		if (loaded.propertyCapture !== undefined) {
+			loaded.propertyCapture = parsePropertyCapture(loaded.propertyCapture);
+		}
 		// Ensure backward compatibility: default to "cursor" if not set
 		if (
 			loaded.activeFileWritePosition !== "cursor" &&

--- a/src/types/choices/ICaptureChoice.ts
+++ b/src/types/choices/ICaptureChoice.ts
@@ -4,6 +4,12 @@ import type { OpenLocation, FileViewMode2 } from "../fileOpening";
 
 export type BlankLineAfterMatchMode = "auto" | "skip" | "none";
 
+export interface PropertyCapture {
+	property: { kind: "named"; format: string } | { kind: "prompt" };
+	action: "set" | "addToList";
+	createIfMissing: boolean;
+}
+
 /** How to derive a sort key from a section heading's text (issue #481). */
 export type SectionOrderBy =
 	| "insertion"
@@ -28,6 +34,7 @@ export interface SectionOrdering {
 }
 
 export default interface ICaptureChoice extends IChoice {
+	propertyCapture?: PropertyCapture;
 	captureTo: string;
 	captureToActiveFile: boolean;
 	captureToCanvasNodeId?: string;
@@ -99,4 +106,24 @@ export default interface ICaptureChoice extends IChoice {
 	templater?: {
 		afterCapture?: "none" | "wholeFile";
 	};
+}
+
+export function parsePropertyCapture(input: unknown): PropertyCapture {
+	if (
+		!input || typeof input !== "object" ||
+		!("property" in input) || !input.property ||
+		typeof input.property !== "object" || !("kind" in input.property) ||
+		!("action" in input) || (input.action !== "set" && input.action !== "addToList") ||
+		!("createIfMissing" in input) || typeof input.createIfMissing !== "boolean"
+	) {
+		throw new Error("Invalid property capture settings. Choose a property and action in the Capture settings.");
+	}
+	const property = input.property;
+	if (property.kind === "prompt") {
+		return { property: { kind: "prompt" }, action: input.action, createIfMissing: input.createIfMissing };
+	}
+	if (property.kind === "named" && "format" in property && typeof property.format === "string") {
+		return { property: { kind: "named", format: property.format }, action: input.action, createIfMissing: input.createIfMissing };
+	}
+	throw new Error("Invalid property capture selector.");
 }

--- a/src/utilityObsidian.templater-binding.test.ts
+++ b/src/utilityObsidian.templater-binding.test.ts
@@ -1,6 +1,51 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { App, TFile } from "obsidian";
-import { jumpToNextTemplaterCursorIfPossible, templaterParseTemplate } from "./utilityObsidian";
+import { isTemplaterTriggerOnCreateEnabled, jumpToNextTemplaterCursorIfPossible, templaterParseTemplate } from "./utilityObsidian";
+
+describe("isTemplaterTriggerOnCreateEnabled", () => {
+	it.each([true, false])("reads the current local setting: %s", (enabled) => {
+		const app = new App();
+		Object.assign(app.plugins.plugins, {
+			"templater-obsidian": {
+				settings: { data_version: 2, trigger_on_file_creation_mode: "folder" },
+			},
+		});
+		app.loadLocalStorage = vi.fn(() => ({ trigger_on_file_creation: enabled }));
+
+		expect(isTemplaterTriggerOnCreateEnabled(app)).toBe(enabled);
+		expect(app.loadLocalStorage).toHaveBeenCalledWith("templater-local-settings");
+	});
+
+	it.each([true, false])("preserves the legacy setting over local storage: %s", (enabled) => {
+		const app = new App();
+		Object.assign(app.plugins.plugins, {
+			"templater-obsidian": { settings: { trigger_on_file_creation: enabled } },
+		});
+		app.loadLocalStorage = vi.fn(() => ({ trigger_on_file_creation: !enabled }));
+
+		expect(isTemplaterTriggerOnCreateEnabled(app)).toBe(enabled);
+		expect(app.loadLocalStorage).not.toHaveBeenCalled();
+	});
+
+	it.each([undefined, null, {}, [], "true", { trigger_on_file_creation: "true" }])(
+		"ignores absent or malformed local settings: %j",
+		(localSettings) => {
+			const app = new App();
+			Object.assign(app.plugins.plugins, { "templater-obsidian": { settings: {} } });
+			app.loadLocalStorage = () => localSettings;
+
+			expect(isTemplaterTriggerOnCreateEnabled(app)).toBe(false);
+		},
+	);
+
+	it("requires the Templater plugin to be loaded", () => {
+		const app = new App();
+		app.loadLocalStorage = vi.fn(() => ({ trigger_on_file_creation: true }));
+
+		expect(isTemplaterTriggerOnCreateEnabled(app)).toBe(false);
+		expect(app.loadLocalStorage).not.toHaveBeenCalled();
+	});
+});
 
 describe("templaterParseTemplate", () => {
 	it("calls parse_template with the correct `this` context", async () => {

--- a/src/utils/obsidianPropertyTypes.ts
+++ b/src/utils/obsidianPropertyTypes.ts
@@ -7,6 +7,7 @@ type MetadataTypeInfo = {
 
 type MetadataTypeManager = {
 	getTypeInfo?: (key: string) => unknown;
+	getAllProperties?: () => unknown;
 };
 
 const SET_LIKE_PROPERTY_TYPES = new Set([
@@ -31,6 +32,7 @@ const SET_LIKE_RESERVED_KEYS = new Set([
 export function resolveObsidianPropertyType(
 	app: App | undefined,
 	propertyKey: string | undefined,
+	options: { registeredOnly?: boolean } = {},
 ): string | null {
 	if (!app || !propertyKey) return null;
 
@@ -48,6 +50,13 @@ export function resolveObsidianPropertyType(
 
 	if (!manager || typeof manager.getTypeInfo !== "function") {
 		return null;
+	}
+	if (options.registeredOnly) {
+		const properties = manager.getAllProperties?.();
+		if (!properties || typeof properties !== "object" ||
+			!Object.keys(properties).some((key) => key.toLowerCase() === propertyKey.toLowerCase())) {
+			return null;
+		}
 	}
 
 	const info = manager.getTypeInfo(propertyKey) as MetadataTypeInfo | undefined;

--- a/src/utils/propertyCaptureFormat.test.ts
+++ b/src/utils/propertyCaptureFormat.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { inheritPropertyValueType, untypedPropertyValueVariable } from "./propertyCaptureFormat";
+
+describe("property input type inheritance", () => {
+	it.each(["{{VALUE}}", "{{NAME}}", "{{VALUE:rating}}", "{{VALUE:rating|optional}}"])("inherits the native widget for %s", (format) => {
+		expect(inheritPropertyValueType(format, "number")).toBe(`${format.slice(0, -2)}|type:number}}`);
+		expect(inheritPropertyValueType(format, "checkbox")).toBe(`${format.slice(0, -2)}|type:checkbox}}`);
+	});
+	it.each(["{{VALUE:rating|type:text}}", "{{VALUE:rating|type:number}}", "{{VALUE:rating}} points", "{{VALUE:a,b|multi}}", "{{VALUE:rating|case:upper}}", "{{FIELD:rating}}", "42"])("keeps an explicit or composite format %s", (format) => {
+		expect(inheritPropertyValueType(format, "number")).toBe(format);
+		expect(untypedPropertyValueVariable(format)).toBeNull();
+	});
+	it("keeps an unregistered property as plain text and retains named variable identity", () => {
+		expect(inheritPropertyValueType("{{VALUE:rating}}", null)).toBe("{{VALUE:rating}}");
+		expect(untypedPropertyValueVariable("{{VALUE:rating|label:Score}}" )).toBe("rating");
+	});
+});

--- a/src/utils/propertyCaptureFormat.ts
+++ b/src/utils/propertyCaptureFormat.ts
@@ -1,0 +1,22 @@
+import { parseAnonymousValueOptions, parseValueToken } from "./valueSyntax";
+
+export function untypedPropertyValueVariable(format: string): string | null {
+	const named = /^\{\{VALUE:([^{}]+)\}\}$/i.exec(format);
+	if (named) {
+		const parsed = parseValueToken(named[1]);
+		return parsed && !parsed.inputTypeOverride && !parsed.hasOptions && !parsed.caseStyle
+			? parsed.variableKey : null;
+	}
+	const anonymous = /^\{\{(?:VALUE|NAME)(\|[^{}]+)?\}\}$/i.exec(format);
+	if (!anonymous) return null;
+	const parsed = parseAnonymousValueOptions(anonymous[1] ?? "");
+	return !parsed.inputTypeOverride && !parsed.caseStyle ? "value" : null;
+}
+
+export function inheritPropertyValueType(format: string, propertyType: string | null): string {
+	const type = propertyType === "boolean" ? "checkbox" : propertyType;
+	if ((type !== "number" && type !== "checkbox") || untypedPropertyValueVariable(format) === null) {
+		return format;
+	}
+	return `${format.slice(0, -2)}|type:${type}}}`;
+}

--- a/src/utils/templaterIntegration.ts
+++ b/src/utils/templaterIntegration.ts
@@ -154,7 +154,20 @@ export function getTemplaterPlugin(app: App): TemplaterPluginLike | null {
 }
 
 export function isTemplaterTriggerOnCreateEnabled(app: App): boolean {
-	return !!getTemplaterPlugin(app)?.settings?.trigger_on_file_creation;
+	const plugin = getTemplaterPlugin(app);
+	if (!plugin) return false;
+
+	const legacySetting = plugin.settings?.trigger_on_file_creation;
+	if (typeof legacySetting === "boolean") return legacySetting;
+
+	const localSettings: unknown = app.loadLocalStorage?.("templater-local-settings");
+	return (
+		typeof localSettings === "object" &&
+		localSettings !== null &&
+		!Array.isArray(localSettings) &&
+		"trigger_on_file_creation" in localSettings &&
+		localSettings.trigger_on_file_creation === true
+	);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/tests/e2e/property-capture-ui.test.ts
+++ b/tests/e2e/property-capture-ui.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ObsidianClient } from "obsidian-e2e";
+import { CaptureChoice } from "../../src/types/choices/CaptureChoice";
+import type IChoice from "../../src/types/choices/IChoice";
+import { MacroChoice } from "../../src/types/choices/MacroChoice";
+import { TemplateChoice } from "../../src/types/choices/TemplateChoice";
+import { NestedChoiceCommand } from "../../src/types/macros/QuickCommands/NestedChoiceCommand";
+import { createQuickAddE2EHarness, seedVaultFile } from "./e2eVault";
+
+const getContext = createQuickAddE2EHarness("property-capture-ui");
+const POLL_OPTS = { timeout: 10_000, interval: 200 };
+const BODY = "\n# Project\n\nKeep the body unchanged.\n";
+const NUMBER_INPUT = '.qaInputPrompt input[type="number"]';
+const TEXT_INPUT = '.qaInputPrompt input[type="text"], .qaInputPrompt textarea';
+const PROPERTY_INPUT = '.prompt input[placeholder="Property"]';
+
+type QuickAddData = { choices: IChoice[]; onePageInputEnabled: boolean };
+
+async function waitForElement(obsidian: ObsidianClient, selector: string) {
+	await expect.poll(() => obsidian.dev.evalJson<boolean>(
+		`Boolean(document.querySelector(${JSON.stringify(selector)})?.getClientRects().length)`,
+	), POLL_OPTS).toBe(true);
+}
+
+async function pressKey(obsidian: ObsidianClient, key: "Enter" | "Escape" | "F8", modified = false) {
+	const mod = (await obsidian.dev.evalJson<string>("process.platform")) === "darwin" ? 4 : 2;
+	const codes = { Enter: 13, Escape: 27, F8: 119 };
+	for (const type of ["keyDown", "keyUp"]) {
+		await obsidian.exec("dev:cdp", {
+			method: "Input.dispatchKeyEvent",
+			params: JSON.stringify({
+				type, key, code: key, windowsVirtualKeyCode: codes[key],
+				modifiers: modified ? mod | (key === "F8" ? 8 : 0) : 0,
+			}),
+		});
+	}
+}
+
+async function typeInto(obsidian: ObsidianClient, selector: string, text: string) {
+	await waitForElement(obsidian, selector);
+	expect(await obsidian.dev.evalJson<boolean>(`(() => {
+		const input = document.querySelector(${JSON.stringify(selector)});
+		if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return false;
+		input.focus();
+		input.select();
+		return true;
+	})()`)).toBe(true);
+	await obsidian.exec("dev:cdp", {
+		method: "Input.insertText", params: JSON.stringify({ text }),
+	});
+	await expect.poll(() => obsidian.dev.evalJson<string>(
+		`document.querySelector(${JSON.stringify(selector)})?.value ?? ""`,
+	), POLL_OPTS).toBe(text);
+}
+
+async function expectNoPrompt(obsidian: ObsidianClient) {
+	await expect.poll(() => obsidian.dev.evalJson<boolean>(
+		'Boolean(document.querySelector(".modal-container, .prompt"))',
+	), POLL_OPTS).toBe(false);
+}
+
+async function closeOpenPrompts() {
+	const { obsidian } = getContext();
+	for (let remaining = 5; remaining > 0; remaining--) {
+		if (!await obsidian.dev.evalJson<boolean>('Boolean(document.querySelector(".modal-container, .prompt"))')) break;
+		await pressKey(obsidian, "Escape");
+	}
+	await expectNoPrompt(obsidian);
+}
+
+beforeEach(closeOpenPrompts);
+afterEach(closeOpenPrompts);
+
+function choiceFor(name: string, path: string, property: string) {
+	const choice = new CaptureChoice(name);
+	choice.command = true;
+	choice.captureTo = path;
+	choice.onePageInput = "never";
+	choice.useSelectionAsCaptureValue = false;
+	choice.propertyCapture = {
+		property: { kind: "named", format: property }, action: "set", createIfMissing: true,
+	};
+	return choice;
+}
+
+async function saveChoice(choice: IChoice, onePage = false) {
+	const { plugin } = getContext();
+	await plugin.data<QuickAddData>().patch((data) => {
+		data.choices.push(choice);
+		data.onePageInputEnabled = onePage;
+	});
+	await plugin.reload({ waitUntilReady: true });
+}
+
+async function readNote(path: string) {
+	const { obsidian } = getContext();
+	const content = await obsidian.dev.evalJsonAsync<string>(
+		`app.vault.read(app.vault.getAbstractFileByPath(${JSON.stringify(path)}))`,
+	);
+	const properties = await obsidian.metadata.frontmatter(path);
+	return {
+		properties: properties ?? {},
+		body: content.replace(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/, ""),
+	};
+}
+
+describe("property capture through native keyboard prompts", () => {
+	it("uses a numeric input for default VALUE and stores zero through a hotkey", async () => {
+		const { obsidian, sandbox } = getContext();
+		const property = "qa_ui_capture_count";
+		const path = await seedVaultFile(obsidian, sandbox, "number.md", `---\n${property}: 7\nkeep: unchanged\n---\n${BODY}`);
+		const choice = choiceFor("Capture number by hotkey", path, property);
+		await saveChoice(choice);
+		const commandId = `quickadd:choice:${choice.id}`;
+		expect(await obsidian.dev.evalJson<boolean>(`(() => {
+			const commandId = ${JSON.stringify(commandId)};
+			app.hotkeyManager.setHotkeys(commandId, [{ modifiers: ["Mod", "Shift"], key: "F8" }]);
+			return Boolean(app.commands.commands[commandId]);
+		})()`)).toBe(true);
+		try {
+			await pressKey(obsidian, "F8", true);
+			await waitForElement(obsidian, NUMBER_INPUT);
+		} finally {
+			await obsidian.dev.evalJson<boolean>(`(() => {
+				app.hotkeyManager.removeHotkeys(${JSON.stringify(commandId)});
+				return true;
+			})()`);
+		}
+		await typeInto(obsidian, NUMBER_INPUT, "0");
+		await pressKey(obsidian, "Enter");
+		await expectNoPrompt(obsidian);
+		await expect.poll(() => readNote(path), POLL_OPTS).toEqual({
+			properties: { [property]: 0, keep: "unchanged" }, body: BODY,
+		});
+	});
+
+	it("offers true and false for a checkbox property and stores false through a direct command", async () => {
+		const { obsidian, sandbox } = getContext();
+		const property = "qa_ui_capture_done";
+		const path = await seedVaultFile(obsidian, sandbox, "checkbox.md", `---\n${property}: true\n---\n${BODY}`);
+		const choice = choiceFor("Capture checkbox by command", path, property);
+		await saveChoice(choice);
+		await obsidian.exec("command", { id: `quickadd:choice:${choice.id}` });
+		const input = '.prompt input.prompt-input';
+		await waitForElement(obsidian, input);
+		await expect.poll(() => obsidian.dev.evalJson<string[]>(
+			'Array.from(document.querySelectorAll(".prompt .suggestion-item")).map((item) => item.textContent.trim())',
+		), POLL_OPTS).toEqual(["true", "false"]);
+		await typeInto(obsidian, input, "false");
+		await expect.poll(() => obsidian.dev.evalJson<string>(
+			'document.querySelector(".prompt .suggestion-item.is-selected")?.textContent.trim() ?? ""',
+		), POLL_OPTS).toBe("false");
+		await pressKey(obsidian, "Enter");
+		await expectNoPrompt(obsidian);
+		await expect.poll(() => readNote(path), POLL_OPTS).toEqual({
+			properties: { [property]: false }, body: BODY,
+		});
+	});
+
+	it("defers a runtime property value with one-page input enabled and stores commas as one list item", async () => {
+		const { obsidian, sandbox } = getContext();
+		const path = await seedVaultFile(obsidian, sandbox, "runtime-list.md", `---\ntags: [original]\nstatus: active\n---\n${BODY}`);
+		const choice = choiceFor("Choose a property then capture", path, "unused");
+		choice.onePageInput = "always";
+		choice.propertyCapture = { property: { kind: "prompt" }, action: "set", createIfMissing: false };
+		await saveChoice(choice, true);
+		await obsidian.exec("command", { id: `quickadd:choice:${choice.id}` });
+		await waitForElement(obsidian, PROPERTY_INPUT);
+		expect(await obsidian.dev.evalJson<boolean>(
+			'Boolean(document.querySelector(".onePageInputModal, .qaInputPrompt"))',
+		)).toBe(false);
+		await typeInto(obsidian, PROPERTY_INPUT, "tags");
+		await expect.poll(() => obsidian.dev.evalJson<string>(
+			'document.querySelector(".prompt .suggestion-item.is-selected")?.textContent.trim() ?? ""',
+		), POLL_OPTS).toBe("tags");
+		await pressKey(obsidian, "Enter");
+		await typeInto(obsidian, TEXT_INPUT, "a,b");
+		expect((await readNote(path)).properties).toEqual({ tags: ["original"], status: "active" });
+		await pressKey(obsidian, "Enter");
+		await expectNoPrompt(obsidian);
+		await expect.poll(() => readNote(path), POLL_OPTS).toEqual({
+			properties: { tags: ["a,b"], status: "active" }, body: BODY,
+		});
+	});
+
+	it("cancels the default value prompt before creating a configured target", async () => {
+		const { obsidian, sandbox } = getContext();
+		const path = sandbox.path("cancelled/new-note.md");
+		const choice = choiceFor("Cancel before creating a property capture", path, "qa_ui_capture_new_text");
+		choice.createFileIfItDoesntExist.enabled = true;
+		await saveChoice(choice);
+		await obsidian.exec("command", { id: `quickadd:choice:${choice.id}` });
+		await typeInto(obsidian, TEXT_INPUT, "Unsubmitted value");
+		const exists = () => obsidian.dev.evalJson<boolean>(
+			`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(path)}))`,
+		);
+		expect(await exists()).toBe(false);
+		await pressKey(obsidian, "Escape");
+		await expectNoPrompt(obsidian);
+		expect(await exists()).toBe(false);
+		expect(await obsidian.dev.evalJson<boolean>(
+			`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(sandbox.path("cancelled"))}))`,
+		)).toBe(false);
+	});
+
+	it("keeps the native number widget in the combined form for a known property", async () => {
+		const { obsidian, sandbox } = getContext();
+		const property = "qa_ui_capture_form_count";
+		const path = await seedVaultFile(obsidian, sandbox, "one-page-number.md", `---\n${property}: 8\n---\n${BODY}`);
+		await expect.poll(() => obsidian.metadata.frontmatter(path), POLL_OPTS)
+			.toEqual({ [property]: 8 });
+		await expect.poll(() => obsidian.dev.evalJson<string | null>(
+			`app.metadataTypeManager.getAllProperties()[${JSON.stringify(property)}]?.widget ?? null`,
+		), POLL_OPTS).toBe("number");
+		const choice = choiceFor("Capture a number in one form", path, property);
+		choice.onePageInput = "always";
+		await saveChoice(choice, true);
+		await obsidian.exec("command", { id: `quickadd:choice:${choice.id}` });
+		const input = '.onePageInputModal input[type="number"]';
+		await typeInto(obsidian, input, "0");
+		expect((await readNote(path)).properties).toEqual({ [property]: 8 });
+		await pressKey(obsidian, "Enter", true);
+		await expectNoPrompt(obsidian);
+		await expect.poll(() => readNote(path), POLL_OPTS).toEqual({
+			properties: { [property]: 0 }, body: BODY,
+		});
+	});
+
+	it("submits one form to append a discovered template and update that note's property", async () => {
+		const { obsidian, sandbox } = getContext();
+		const template = new TemplateChoice("Discover a project and append its owner");
+		const noteName = `Combined property project ${template.id}`;
+		const path = await seedVaultFile(obsidian, sandbox, `${noteName}.md`, `---\nstatus: active\nkeep: unchanged\n---\n${BODY}`);
+		template.templatePath = await seedVaultFile(obsidian, sandbox, "owner-template.md", "Owner: {{VALUE:owner}}\n");
+		template.fileNameFormat = { enabled: true, format: "{{VALUE}}" };
+		template.discoverExistingNotesBeforeCreate = true;
+		template.existingNoteAction = "appendBottom";
+		template.openFile = true;
+		const capture = new CaptureChoice("Update the selected project's status");
+		capture.captureToActiveFile = true;
+		capture.useSelectionAsCaptureValue = false;
+		capture.format = { enabled: true, format: "{{VALUE:state}}" };
+		capture.propertyCapture = {
+			property: { kind: "named", format: "status" }, action: "set", createIfMissing: false,
+		};
+		const macro = new MacroChoice("Append project owner and update status");
+		macro.command = true;
+		macro.onePageInput = "always";
+		macro.macro.commands = [new NestedChoiceCommand(template), new NestedChoiceCommand(capture)];
+		await expect.poll(() => obsidian.metadata.frontmatter(path), POLL_OPTS)
+			.toEqual({ status: "active", keep: "unchanged" });
+		await saveChoice(macro, true);
+		await obsidian.exec("command", { id: `quickadd:choice:${macro.id}` });
+		const noteInput = `[aria-label=${JSON.stringify(`Note for ${template.name}`)}]`;
+		await typeInto(obsidian, noteInput, noteName);
+		await expect.poll(() => obsidian.dev.evalJson<string>(
+			'document.querySelector(".qa-onepage-file-suggestion__path")?.textContent ?? ""',
+		), POLL_OPTS).toBe(path);
+		await pressKey(obsidian, "Enter");
+		await typeInto(obsidian, '.onePageInputModal [aria-labelledby="qa-onepage-label-owner"]', "Ada");
+		await typeInto(obsidian, '.onePageInputModal [aria-labelledby="qa-onepage-label-state"]', "done");
+		expect(await readNote(path)).toEqual({
+			properties: { status: "active", keep: "unchanged" }, body: BODY,
+		});
+		await pressKey(obsidian, "Enter", true);
+		await expect.poll(() => readNote(path), POLL_OPTS).toEqual({
+			properties: { status: "done", keep: "unchanged" }, body: `${BODY}\nOwner: Ada\n`,
+		});
+		await expectNoPrompt(obsidian);
+		expect(await obsidian.dev.evalJson<string | null>("app.workspace.getActiveFile()?.path ?? null"))
+			.toBe(path);
+	});
+});

--- a/tests/e2e/property-capture.test.ts
+++ b/tests/e2e/property-capture.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { CaptureChoice } from "../../src/types/choices/CaptureChoice";
+import type IChoice from "../../src/types/choices/IChoice";
+import { createQuickAddE2EHarness, seedVaultFile } from "./e2eVault";
+
+const getContext = createQuickAddE2EHarness("property-capture");
+const BODY = "\n# Project\n\nBody stays exactly here.\n";
+
+async function saveChoice(choice: CaptureChoice) {
+	const { plugin } = getContext();
+	await plugin.data<{ choices: IChoice[] }>().patch((data) => { data.choices.push(choice); });
+	await plugin.reload({ waitUntilReady: true });
+}
+
+function choiceFor(path: string) {
+	const choice = new CaptureChoice("Property capture E2E");
+	choice.captureTo = path;
+	choice.onePageInput = "never";
+	choice.format = { enabled: true, format: "{{VALUE:input}}" };
+	choice.propertyCapture = { property: { kind: "named", format: "{{VALUE:property}}" }, action: "set", createIfMissing: true };
+	return choice;
+}
+
+async function readNote(path: string) {
+	const { obsidian } = getContext();
+	const content = await obsidian.dev.evalJsonAsync<string>(`app.vault.read(app.vault.getAbstractFileByPath(${JSON.stringify(path)}))`);
+	const properties = await obsidian.metadata.frontmatter(path);
+	return { properties: properties ?? {}, body: content.replace(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/, "") };
+}
+
+describe("property capture in native Obsidian", () => {
+	it("sets text, zero, false and arrays through CLI vars without altering the body", async () => {
+		const { obsidian, sandbox } = getContext();
+		const path = await seedVaultFile(obsidian, sandbox, "types.md", `---\nstatus: active\nqa_capture_count: 7\nqa_capture_done: true\nqa_capture_sources: [old]\nkeep: unchanged\n---\n${BODY}`);
+		const choice = choiceFor(path);
+		choice.task = true;
+		choice.insertAfter.enabled = true;
+		choice.insertAfter.after = "{{VALUE:dormant}}";
+		await saveChoice(choice);
+		for (const [property, input] of Object.entries({ status: "001", qa_capture_count: 0, qa_capture_done: false, qa_capture_sources: ["a,b", "c"] })) {
+			const outcome = await obsidian.execJson<{ ok: boolean }>("quickadd:run", { id: choice.id, verify: true, vars: JSON.stringify({ property, input }) });
+			expect(outcome).toMatchObject({ ok: true, verified: true });
+		}
+		await expect.poll(() => readNote(path), { timeout: 10000, interval: 100 }).toEqual({ properties: { status: "001", qa_capture_count: 0, qa_capture_done: false, qa_capture_sources: ["a,b", "c"], keep: "unchanged" }, body: BODY });
+	});
+
+	it("adds a whole typed list through executeChoice and skips exact duplicates", async () => {
+		const { obsidian, sandbox } = getContext();
+		const path = await seedVaultFile(obsidian, sandbox, "list.md", `---\nqa_capture_sources: [old]\n---\n${BODY}`);
+		const choice = choiceFor(path);
+		choice.propertyCapture = { property: { kind: "named", format: "qa_capture_sources" }, action: "addToList", createIfMissing: true };
+		await saveChoice(choice);
+		await obsidian.dev.evalJsonAsync(`(async () => {
+			await app.plugins.plugins.quickadd.api.executeChoice(${JSON.stringify(choice.name)}, { input: ["old", "a,b", "new", "new"] });
+			return true;
+		})()`);
+		await expect.poll(() => readNote(path), { timeout: 10000, interval: 100 }).toEqual({ properties: { qa_capture_sources: ["old", "a,b", "new"] }, body: BODY });
+		const outcome = await obsidian.execJson<{ ok: boolean; effect: string }>("quickadd:run", { id: choice.id, verify: true, vars: JSON.stringify({ input: ["old", "a,b", "new"] }) });
+		expect(outcome).toMatchObject({ ok: true, effect: "unchanged" });
+	});
+
+	it("creates a new typed property and preserves a prepared template", async () => {
+		const { obsidian, sandbox } = getContext();
+		const template = await seedVaultFile(obsidian, sandbox, "template.md", `---\nkeep: template\n---\n${BODY}`);
+		const path = sandbox.path("created.md");
+		const choice = choiceFor(path);
+		choice.createFileIfItDoesntExist = { enabled: true, createWithTemplate: true, template };
+		await saveChoice(choice);
+		const outcome = await obsidian.execJson<{ ok: boolean; effect: string }>("quickadd:run", { id: choice.id, verify: true, vars: JSON.stringify({ property: "qa_capture_new_typed_number", input: 0 }) });
+		expect(outcome).toMatchObject({ ok: true, effect: "created" });
+		await expect.poll(() => readNote(path), { timeout: 10000, interval: 100 }).toEqual({ properties: { keep: "template", qa_capture_new_typed_number: 0 }, body: BODY });
+	});
+
+	it("rejects a runtime property picker headlessly without creating its target", async () => {
+		const { obsidian, sandbox } = getContext();
+		const path = sandbox.path("must-not-exist.md");
+		const choice = choiceFor(path);
+		choice.propertyCapture = { property: { kind: "prompt" }, action: "set", createIfMissing: true };
+		choice.createFileIfItDoesntExist.enabled = true;
+		await saveChoice(choice);
+		const outcome = await obsidian.execJson<{ ok: boolean; error?: string }>("quickadd:run", { id: choice.id, verify: true, vars: JSON.stringify({ input: "done" }) });
+		expect(outcome).toMatchObject({ ok: false, error: expect.stringContaining("property selection") });
+		expect(await obsidian.dev.evalJson<boolean>(`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(path)}))`)).toBe(false);
+	});
+
+	it("updates the existing property spelling when its configured name differs in case", async () => {
+		const { obsidian, sandbox } = getContext();
+		const path = await seedVaultFile(obsidian, sandbox, "casing.md", `---\nStatus: active\n---\n${BODY}`);
+		const choice = choiceFor(path);
+		choice.propertyCapture = { property: { kind: "named", format: "status" }, action: "set", createIfMissing: false };
+		await saveChoice(choice);
+		const outcome = await obsidian.execJson("quickadd:run", { id: choice.id, verify: true, vars: JSON.stringify({ input: "done" }) });
+		expect(outcome).toMatchObject({ ok: true, verified: true, effect: "changed" });
+		await expect.poll(() => readNote(path), { timeout: 10000, interval: 100 })
+			.toEqual({ properties: { Status: "done" }, body: BODY });
+	});
+
+	it.each([{ input: "" }, { input: [] }])("leaves a missing target absent for an empty Add value $input", async ({ input }) => {
+		const { obsidian, sandbox } = getContext();
+		const path = sandbox.path("empty-add/absent.md");
+		const choice = choiceFor(path);
+		choice.propertyCapture = { property: { kind: "named", format: "tags" }, action: "addToList", createIfMissing: true };
+		choice.createFileIfItDoesntExist.enabled = true;
+		await saveChoice(choice);
+		const outcome = await obsidian.execJson("quickadd:run", { id: choice.id, verify: true, vars: JSON.stringify({ input }) });
+		expect(outcome).toMatchObject({ ok: true, verified: true, effect: "unchanged" });
+		expect(await obsidian.dev.evalJson<boolean>(`Boolean(app.vault.getAbstractFileByPath(${JSON.stringify(sandbox.path("empty-add"))}))`)).toBe(false);
+	});
+});


### PR DESCRIPTION
Capture can now write to a native note property using "Set value" or "Add to list". Choose a named property or select one when capturing, with an explicit create-if-missing option. Native property types guide inputs and validation; list values keep their order and drop exact duplicates.

QuickAdd collects its inputs before creating the target and preserves the note body and unrelated properties. Templater 2.25 creation triggers are detected through their current setting so a delayed folder template cannot overwrite the captured value. Success is reported only after the final property write succeeds, including post-Templater validation. Existing body captures retain their behavior; no migration or version-file change is needed.

To verify in Obsidian, select "Write position: Property", capture into text, number, checkbox, and list properties, and read back the properties and body. Repeat with the runtime property picker, cancellation, CLI variables, and a combined Template-to-Capture macro.

Validation: build, lint, Svelte checks, 5,475 unit tests with 37 existing skips, and 76 native Obsidian 1.13.7 Linux tests passed. The 76 native tests passed before the final help text change; both action descriptions and the property-mode round trip were subsequently verified in native Obsidian, and all 13 native Property Capture tests passed after the settings fix. Native Templater 2.25 integration was also verified. Documentation and regression tests are included.

The shared Template integration landed in #1746. The Action setting explains what the selected operation does directly below its label. Switching between a named property and the runtime picker preserves the last entered name within the open form.

![Set value action and explanation](https://files.bagerbach.com/property-action-help-set-0pb11rb3cj4w.png)

![Add to list action and explanation](https://files.bagerbach.com/property-action-help-list-kew343n36alo.png)

Fixes #1736


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Capture Choice can now write captured values directly to note properties.
  - Set property values or add items to lists, with optional creation of missing properties.
  - Property types such as numbers, checkboxes, and lists are preserved automatically.
  - Choose a property interactively or specify one using formatted input.
  - Property captures preserve existing note content and support template-based note creation.

- **Documentation**
  - Added guidance for configuring property captures, CLI usage, one-page inputs, formatting, and supported property behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->