### PR TITLE
fix(settings): prevent background model sync from overwriting newer data.json (#1749)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { deepClone } from "./utils/deepClone";
 import {
 	reconcileSettingsPersistPlan,
 	settingsValuesEqual,
+	threeWayMergeSettings,
 } from "./utils/settingsPersistMerge";
 import { interactivePromptServer } from "./interactive/interactivePromptServer";
 import { parseSemver } from "./utils/semver";
@@ -609,27 +610,54 @@ export default class QuickAdd extends Plugin {
 	 * since `lastPersistedSettings` (another device/sync, hand edit, …), local
 	 * mutations are three-way-merged onto the on-disk value instead of replacing
 	 * the file with a stale in-memory snapshot (#1749).
+	 *
+	 * Obsidian's `loadData` / `saveData` expose no compare-and-swap, file lock, or
+	 * version token, so a TOCTOU window remains between the final re-read below
+	 * and `saveData`. We narrow that window with a last-look revalidation; we
+	 * cannot close it with the public Plugin API alone.
 	 */
 	private persistSettings(): Promise<void> {
 		const run = async () => {
 			const base = this.lastPersistedSettings;
-			let disk: QuickAddSettings | null = null;
 
-			if (base) {
-				const loadedData = await this.loadData();
-				disk = this.normalizeLoadedSettings(loadedData);
-			}
+			const readDisk = async (): Promise<QuickAddSettings | null> => {
+				if (!base) return null;
+				return this.normalizeLoadedSettings(await this.loadData());
+			};
 
-			// Capture the local merge leg AFTER the disk read so updates that landed
-			// while loadData() was in flight are included. Then reconcile again
-			// against the live store before any replaceState (Codex P1 on #1750).
-			const local = deepClone(this.settings);
-			const plan = reconcileSettingsPersistPlan({
-				base,
-				disk,
-				local,
-				currentStore: this.settings,
-			});
+			let disk = await readDisk();
+
+			const buildPlan = (diskSnapshot: QuickAddSettings | null) => {
+				// Capture local AFTER the disk read so updates that landed while
+				// loadData() was in flight are included, then fold any further
+				// live-store drift onto that plan (Codex P1 / CodeRabbit on #1750).
+				const local = deepClone(this.settings);
+				return reconcileSettingsPersistPlan({
+					base,
+					disk: diskSnapshot,
+					local,
+					currentStore: this.settings,
+				});
+			};
+
+			const applyStoreReplace = (
+				plan: ReturnType<typeof reconcileSettingsPersistPlan<QuickAddSettings>>,
+			) => {
+				if (
+					plan.shouldReplaceStore &&
+					settingsValuesEqual(this.settings, plan.local)
+				) {
+					this.suppressSettingsSave = true;
+					try {
+						settingsStore.replaceState(plan.toWrite);
+						this.settings = plan.toWrite;
+					} finally {
+						this.suppressSettingsSave = false;
+					}
+				}
+			};
+
+			let plan = buildPlan(disk);
 
 			if (plan.didMerge) {
 				log.logMessage(
@@ -637,29 +665,35 @@ export default class QuickAdd extends Plugin {
 				);
 			}
 
-			if (
-				plan.shouldReplaceStore &&
-				settingsValuesEqual(this.settings, plan.local)
-			) {
-				this.suppressSettingsSave = true;
-				try {
-					settingsStore.replaceState(plan.toWrite);
-					this.settings = plan.toWrite;
-				} finally {
-					this.suppressSettingsSave = false;
+			applyStoreReplace(plan);
+
+			// Last-look disk revalidation before saveData. Still racy without CAS
+			// (see method doc); this only shrinks the window after the first merge.
+			if (base) {
+				const freshDisk = await readDisk();
+				if (
+					freshDisk &&
+					(!disk || !settingsValuesEqual(freshDisk, disk))
+				) {
+					log.logMessage(
+						"[Settings] data.json changed again before save; re-merging with the fresher on-disk snapshot.",
+					);
+					disk = freshDisk;
+					plan = buildPlan(disk);
+					applyStoreReplace(plan);
 				}
 			}
 
-			// If the store advanced after the plan was built, write a fresh merge
-			// so the file includes those edits instead of the stale toWrite.
-			const toWrite = settingsValuesEqual(this.settings, plan.local)
-				? plan.toWrite
-				: reconcileSettingsPersistPlan({
-						base,
-						disk,
-						local: deepClone(this.settings),
-						currentStore: this.settings,
-					}).toWrite;
+			// Fold any last-moment store drift onto the planned write, using the
+			// plan's local snapshot as the 3-way base so disk-only fields survive.
+			let toWrite = plan.toWrite;
+			if (!settingsValuesEqual(this.settings, plan.local)) {
+				toWrite = threeWayMergeSettings(
+					plan.local,
+					this.settings,
+					plan.toWrite,
+				);
+			}
 
 			await this.saveData(toWrite);
 			this.lastPersistedSettings = deepClone(toWrite);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,11 @@ import migrate from "./migrations/migrate";
 import { settingsStore } from "./settingsStore";
 import { UpdateModal } from "./gui/UpdateModal/UpdateModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
+import { deepClone } from "./utils/deepClone";
+import {
+	resolveSettingsToPersist,
+	settingsValuesEqual,
+} from "./utils/settingsPersistMerge";
 import { interactivePromptServer } from "./interactive/interactivePromptServer";
 import { parseSemver } from "./utils/semver";
 import {
@@ -96,6 +101,20 @@ const SETTINGS_SAVE_DEBOUNCE_MS = 1000;
 export default class QuickAdd extends Plugin {
 	settings: QuickAddSettings;
 	private unsubscribeSettingsStore: () => void;
+	/**
+	 * Snapshot of settings as of the last successful load/save. Used as the
+	 * 3-way-merge base so a whole-file write cannot clobber newer on-disk fields
+	 * that this instance never edited (see #1749 / background model sync).
+	 */
+	private lastPersistedSettings: QuickAddSettings | null = null;
+	/**
+	 * When true, the settingsStore subscriber updates `this.settings` but does
+	 * not schedule a disk write. Set while applying a conflict-merge result back
+	 * into the store after that result has already been (or is about to be) saved.
+	 */
+	private suppressSettingsSave = false;
+	/** Serialize persist calls so overlapping debounced/immediate saves cannot race. */
+	private persistChain: Promise<void> = Promise.resolve();
 	// Debounced disk write for the store subscriber. saveSettings() stays immediate
 	// (migrations await it) and cancels this; onunload flushes it.
 	//
@@ -107,7 +126,7 @@ export default class QuickAdd extends Plugin {
 	// silently did not persist. Awaiting inside a QuickAdd frame puts us on the stack.
 	private requestSave: Debouncer<[], void> = debounce(() => {
 		void (async () => {
-			await this.saveData(this.settings);
+			await this.persistSettings();
 		})();
 	}, SETTINGS_SAVE_DEBOUNCE_MS);
 
@@ -131,7 +150,9 @@ export default class QuickAdd extends Plugin {
 		settingsStore.replaceState(this.settings);
 		this.unsubscribeSettingsStore = settingsStore.subscribe((settings) => {
 			this.settings = settings;
-			this.requestSave();
+			if (!this.suppressSettingsSave) {
+				this.requestSave();
+			}
 		});
 
 		this.addCommand({
@@ -535,12 +556,16 @@ export default class QuickAdd extends Plugin {
 		PromptPeekSession.getActive()?.cancel();
 	}
 
-	async loadSettings() {
-		const loadedData = await this.loadData();
+	/**
+	 * Normalize raw `data.json` into the in-memory settings shape. Shared by the
+	 * initial load and by conflict-aware saves so the 3-way-merge base/disk legs
+	 * use the same defaults / coerce / id-heal rules.
+	 */
+	private normalizeLoadedSettings(loadedData: unknown): QuickAddSettings {
 		const settings = Object.assign(
 			{},
 			DEFAULT_SETTINGS,
-			loadedData,
+			loadedData ?? {},
 		) as QuickAddSettings & {
 			announceUpdates: QuickAddSettings["announceUpdates"] | boolean;
 		};
@@ -561,14 +586,68 @@ export default class QuickAdd extends Plugin {
 			settings.choices = dedupeChoicesById(settings.choices);
 		}
 
+		return settings as QuickAddSettings;
+	}
+
+	async loadSettings() {
+		const loadedData = await this.loadData();
+		const settings = this.normalizeLoadedSettings(loadedData);
 		this.settings = settings;
+		// Deep-clone so later in-place store edits cannot mutate the merge base.
+		this.lastPersistedSettings = deepClone(settings);
 	}
 
 	async saveSettings() {
 		// Immediate, awaitable write (migrations rely on this). Supersede any pending
 		// debounced write so the same settings aren't redundantly rewritten after.
 		this.requestSave.cancel();
-		await this.saveData(this.settings);
+		await this.persistSettings();
+	}
+
+	/**
+	 * Whole-file settings write with a disk-aware merge. If `data.json` changed
+	 * since `lastPersistedSettings` (another device/sync, hand edit, …), local
+	 * mutations are three-way-merged onto the on-disk value instead of replacing
+	 * the file with a stale in-memory snapshot (#1749).
+	 */
+	private persistSettings(): Promise<void> {
+		const run = async () => {
+			const local = deepClone(this.settings);
+			const base = this.lastPersistedSettings;
+			let disk: QuickAddSettings | null = null;
+
+			if (base) {
+				const loadedData = await this.loadData();
+				disk = this.normalizeLoadedSettings(loadedData);
+			}
+
+			const { toWrite, didMerge } = resolveSettingsToPersist(
+				base,
+				local,
+				disk,
+			);
+
+			if (didMerge) {
+				log.logMessage(
+					"[Settings] data.json changed on disk since the last QuickAdd write; merged in-memory changes with on-disk settings before saving.",
+				);
+				if (!settingsValuesEqual(toWrite, this.settings)) {
+					this.suppressSettingsSave = true;
+					try {
+						settingsStore.replaceState(toWrite);
+						this.settings = toWrite;
+					} finally {
+						this.suppressSettingsSave = false;
+					}
+				}
+			}
+
+			await this.saveData(toWrite);
+			this.lastPersistedSettings = deepClone(toWrite);
+		};
+
+		this.persistChain = this.persistChain.then(run, run);
+		return this.persistChain;
 	}
 
 	private addCommandsForChoices(choices: IChoice[]) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { deepClone } from "./utils/deepClone";
 import {
 	reconcileSettingsPersistPlan,
 	settingsValuesEqual,
+	shouldApplyPersistedWriteToStore,
 	threeWayMergeSettings,
 } from "./utils/settingsPersistMerge";
 import { interactivePromptServer } from "./interactive/interactivePromptServer";
@@ -686,13 +687,33 @@ export default class QuickAdd extends Plugin {
 
 			// Fold any last-moment store drift onto the planned write, using the
 			// plan's local snapshot as the 3-way base so disk-only fields survive.
+			const storeAtFinalMerge = deepClone(this.settings);
 			let toWrite = plan.toWrite;
-			if (!settingsValuesEqual(this.settings, plan.local)) {
+			if (!settingsValuesEqual(storeAtFinalMerge, plan.local)) {
 				toWrite = threeWayMergeSettings(
 					plan.local,
-					this.settings,
+					storeAtFinalMerge,
 					plan.toWrite,
 				);
+			}
+
+			// Keep the live store aligned with what we persist. Otherwise disk-only
+			// fields preserved in toWrite stay missing from this.settings, and the
+			// next save treats that gap as a local deletion (CodeRabbit on #1750).
+			if (
+				shouldApplyPersistedWriteToStore(
+					toWrite,
+					this.settings,
+					storeAtFinalMerge,
+				)
+			) {
+				this.suppressSettingsSave = true;
+				try {
+					settingsStore.replaceState(toWrite);
+					this.settings = toWrite;
+				} finally {
+					this.suppressSettingsSave = false;
+				}
 			}
 
 			await this.saveData(toWrite);

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import { UpdateModal } from "./gui/UpdateModal/UpdateModal";
 import { FieldSuggestionCache } from "./utils/FieldSuggestionCache";
 import { deepClone } from "./utils/deepClone";
 import {
-	resolveSettingsToPersist,
+	reconcileSettingsPersistPlan,
 	settingsValuesEqual,
 } from "./utils/settingsPersistMerge";
 import { interactivePromptServer } from "./interactive/interactivePromptServer";
@@ -612,7 +612,6 @@ export default class QuickAdd extends Plugin {
 	 */
 	private persistSettings(): Promise<void> {
 		const run = async () => {
-			const local = deepClone(this.settings);
 			const base = this.lastPersistedSettings;
 			let disk: QuickAddSettings | null = null;
 
@@ -621,26 +620,46 @@ export default class QuickAdd extends Plugin {
 				disk = this.normalizeLoadedSettings(loadedData);
 			}
 
-			const { toWrite, didMerge } = resolveSettingsToPersist(
+			// Capture the local merge leg AFTER the disk read so updates that landed
+			// while loadData() was in flight are included. Then reconcile again
+			// against the live store before any replaceState (Codex P1 on #1750).
+			const local = deepClone(this.settings);
+			const plan = reconcileSettingsPersistPlan({
 				base,
-				local,
 				disk,
-			);
+				local,
+				currentStore: this.settings,
+			});
 
-			if (didMerge) {
+			if (plan.didMerge) {
 				log.logMessage(
 					"[Settings] data.json changed on disk since the last QuickAdd write; merged in-memory changes with on-disk settings before saving.",
 				);
-				if (!settingsValuesEqual(toWrite, this.settings)) {
-					this.suppressSettingsSave = true;
-					try {
-						settingsStore.replaceState(toWrite);
-						this.settings = toWrite;
-					} finally {
-						this.suppressSettingsSave = false;
-					}
+			}
+
+			if (
+				plan.shouldReplaceStore &&
+				settingsValuesEqual(this.settings, plan.local)
+			) {
+				this.suppressSettingsSave = true;
+				try {
+					settingsStore.replaceState(plan.toWrite);
+					this.settings = plan.toWrite;
+				} finally {
+					this.suppressSettingsSave = false;
 				}
 			}
+
+			// If the store advanced after the plan was built, write a fresh merge
+			// so the file includes those edits instead of the stale toWrite.
+			const toWrite = settingsValuesEqual(this.settings, plan.local)
+				? plan.toWrite
+				: reconcileSettingsPersistPlan({
+						base,
+						disk,
+						local: deepClone(this.settings),
+						currentStore: this.settings,
+					}).toWrite;
 
 			await this.saveData(toWrite);
 			this.lastPersistedSettings = deepClone(toWrite);

--- a/src/utils/settingsPersistMerge.test.ts
+++ b/src/utils/settingsPersistMerge.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { deepClone } from "./deepClone";
+import {
+	diskSettingsDivergedFromBase,
+	resolveSettingsToPersist,
+	settingsValuesEqual,
+	threeWayMergeSettings,
+} from "./settingsPersistMerge";
+
+describe("settingsValuesEqual", () => {
+	it("treats key order as irrelevant for plain objects", () => {
+		expect(settingsValuesEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+	});
+
+	it("treats array order as significant", () => {
+		expect(settingsValuesEqual([1, 2], [2, 1])).toBe(false);
+	});
+});
+
+describe("threeWayMergeSettings", () => {
+	it("preserves newer on-disk user fields while keeping local model-sync edits (#1749)", () => {
+		const base = {
+			globalVariables: { syncMarker: "device-b-stale" },
+			ai: {
+				providers: [
+					{
+						name: "mock",
+						models: [{ name: "mock-model-v1", maxTokens: 1 }],
+					},
+				],
+				lastModelAutoSyncAt: undefined as number | undefined,
+			},
+		};
+
+		const local = deepClone(base);
+		local.ai.providers[0].models.push({
+			name: "mock-model-v2",
+			maxTokens: 32768,
+		});
+		local.ai.lastModelAutoSyncAt = 1788982813069;
+
+		const disk = deepClone(base);
+		disk.globalVariables.syncMarker = "device-a-newer";
+
+		const merged = threeWayMergeSettings(base, local, disk);
+
+		expect(merged.globalVariables.syncMarker).toBe("device-a-newer");
+		expect(merged.ai.lastModelAutoSyncAt).toBe(1788982813069);
+		expect(merged.ai.providers[0].models.map((m) => m.name)).toEqual([
+			"mock-model-v1",
+			"mock-model-v2",
+		]);
+	});
+
+	it("keeps local when disk matches base", () => {
+		const base = { choices: [{ id: "a" }], version: "1" };
+		const local = { choices: [{ id: "a" }, { id: "b" }], version: "1" };
+		const disk = deepClone(base);
+
+		expect(threeWayMergeSettings(base, local, disk)).toEqual(local);
+	});
+
+	it("keeps disk when local matches base", () => {
+		const base = { globalVariables: { x: "1" } };
+		const local = deepClone(base);
+		const disk = { globalVariables: { x: "2" } };
+
+		expect(threeWayMergeSettings(base, local, disk)).toEqual(disk);
+	});
+
+	it("prefers local on irreducible leaf conflicts", () => {
+		const base = { version: "1" };
+		const local = { version: "2-local" };
+		const disk = { version: "2-disk" };
+
+		expect(threeWayMergeSettings(base, local, disk)).toEqual(local);
+	});
+
+	it("recurses into nested objects when both sides edit different keys", () => {
+		const base = { ai: { lastModelAutoSyncAt: 1, showAssistant: true } };
+		const local = { ai: { lastModelAutoSyncAt: 99, showAssistant: true } };
+		const disk = { ai: { lastModelAutoSyncAt: 1, showAssistant: false } };
+
+		expect(threeWayMergeSettings(base, local, disk)).toEqual({
+			ai: { lastModelAutoSyncAt: 99, showAssistant: false },
+		});
+	});
+});
+
+describe("diskSettingsDivergedFromBase", () => {
+	it("detects external divergence", () => {
+		expect(
+			diskSettingsDivergedFromBase(
+				{ globalVariables: { syncMarker: "a" } },
+				{ globalVariables: { syncMarker: "b" } },
+			),
+		).toBe(true);
+		expect(
+			diskSettingsDivergedFromBase(
+				{ globalVariables: { syncMarker: "a" } },
+				{ globalVariables: { syncMarker: "a" } },
+			),
+		).toBe(false);
+	});
+});
+
+describe("resolveSettingsToPersist", () => {
+	it("writes local unchanged when disk still matches the last persist", () => {
+		const base = { globalVariables: { syncMarker: "stale" }, ai: { t: 0 } };
+		const local = { globalVariables: { syncMarker: "stale" }, ai: { t: 1 } };
+		const disk = deepClone(base);
+
+		expect(resolveSettingsToPersist(base, local, disk)).toEqual({
+			toWrite: local,
+			didMerge: false,
+		});
+	});
+
+	it("merges when disk moved on under a model-sync-style local edit", () => {
+		const base = {
+			globalVariables: { syncMarker: "device-b-stale" },
+			ai: { lastModelAutoSyncAt: undefined as number | undefined },
+		};
+		const local = {
+			globalVariables: { syncMarker: "device-b-stale" },
+			ai: { lastModelAutoSyncAt: 99 },
+		};
+		const disk = {
+			globalVariables: { syncMarker: "device-a-newer" },
+			ai: { lastModelAutoSyncAt: undefined as number | undefined },
+		};
+
+		expect(resolveSettingsToPersist(base, local, disk)).toEqual({
+			toWrite: {
+				globalVariables: { syncMarker: "device-a-newer" },
+				ai: { lastModelAutoSyncAt: 99 },
+			},
+			didMerge: true,
+		});
+	});
+
+	it("skips merge when base or disk is missing", () => {
+		const local = { version: "1" };
+		expect(resolveSettingsToPersist(null, local, local)).toEqual({
+			toWrite: local,
+			didMerge: false,
+		});
+		expect(resolveSettingsToPersist(local, local, null)).toEqual({
+			toWrite: local,
+			didMerge: false,
+		});
+	});
+});

--- a/src/utils/settingsPersistMerge.test.ts
+++ b/src/utils/settingsPersistMerge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { deepClone } from "./deepClone";
 import {
 	diskSettingsDivergedFromBase,
+	reconcileSettingsPersistPlan,
 	resolveSettingsToPersist,
 	settingsValuesEqual,
 	threeWayMergeSettings,
@@ -149,5 +150,90 @@ describe("resolveSettingsToPersist", () => {
 			toWrite: local,
 			didMerge: false,
 		});
+	});
+});
+
+describe("reconcileSettingsPersistPlan", () => {
+	it("re-merges when the store advanced during the disk read (Codex P1 / #1750)", () => {
+		const base = {
+			globalVariables: { syncMarker: "device-b-stale" },
+			ai: {
+				lastModelAutoSyncAt: undefined as number | undefined,
+				prompt: "old",
+			},
+		};
+		const localAtStart = {
+			globalVariables: { syncMarker: "device-b-stale" },
+			ai: { lastModelAutoSyncAt: 99, prompt: "old" },
+		};
+		const disk = {
+			globalVariables: { syncMarker: "device-a-newer" },
+			ai: {
+				lastModelAutoSyncAt: undefined as number | undefined,
+				prompt: "old",
+			},
+		};
+		// While loadData() was pending, a user edit landed in the store.
+		const currentStore = {
+			globalVariables: { syncMarker: "device-b-stale" },
+			ai: { lastModelAutoSyncAt: 99, prompt: "user-edit-during-read" },
+		};
+
+		const plan = reconcileSettingsPersistPlan({
+			base,
+			disk,
+			local: localAtStart,
+			currentStore,
+		});
+
+		expect(plan.didMerge).toBe(true);
+		expect(plan.toWrite).toEqual({
+			globalVariables: { syncMarker: "device-a-newer" },
+			ai: { lastModelAutoSyncAt: 99, prompt: "user-edit-during-read" },
+		});
+		expect(plan.shouldReplaceStore).toBe(true);
+		expect(plan.local).toEqual(currentStore);
+	});
+
+	it("does not recommend replaceState when the store no longer matches the merge local", () => {
+		const base = { version: "1", note: "base" };
+		const local = { version: "2", note: "base" };
+		const disk = { version: "1", note: "disk" };
+		const currentStore = { version: "3", note: "even-newer" };
+
+		// Force the "no re-merge from currentStore" path by passing currentStore
+		// that differs — reconcile will re-merge, so shouldReplace becomes true
+		// against the refreshed local. To assert the guard itself, call with
+		// local === currentStore for the merge, then imagine a later drift:
+		const plan = reconcileSettingsPersistPlan({
+			base,
+			disk,
+			local,
+			currentStore: local,
+		});
+		expect(plan.shouldReplaceStore).toBe(true);
+		expect(plan.toWrite).toEqual({ version: "2", note: "disk" });
+
+		// After planning, a newer store value must not be replaced by the old plan.
+		expect(
+			settingsValuesEqual(currentStore, plan.local) &&
+				plan.shouldReplaceStore,
+		).toBe(false);
+	});
+
+	it("skips store replace when merge is a no-op relative to the current store", () => {
+		const base = { version: "1" };
+		const local = { version: "1" };
+		const disk = { version: "1" };
+
+		const plan = reconcileSettingsPersistPlan({
+			base,
+			disk,
+			local,
+			currentStore: local,
+		});
+		expect(plan.didMerge).toBe(false);
+		expect(plan.shouldReplaceStore).toBe(false);
+		expect(plan.toWrite).toEqual(local);
 	});
 });

--- a/src/utils/settingsPersistMerge.test.ts
+++ b/src/utils/settingsPersistMerge.test.ts
@@ -5,6 +5,7 @@ import {
 	reconcileSettingsPersistPlan,
 	resolveSettingsToPersist,
 	settingsValuesEqual,
+	shouldApplyPersistedWriteToStore,
 	threeWayMergeSettings,
 } from "./settingsPersistMerge";
 
@@ -378,7 +379,7 @@ describe("reconcileSettingsPersistPlan", () => {
 		const currentStore = { version: "3", note: "even-newer" };
 
 		// Force the "no re-merge from currentStore" path by passing currentStore
-		// that differs — reconcile will re-merge, so shouldReplace becomes true
+		// that differs; reconcile will re-merge, so shouldReplace becomes true
 		// against the refreshed local. To assert the guard itself, call with
 		// local === currentStore for the merge, then imagine a later drift:
 		const plan = reconcileSettingsPersistPlan({
@@ -411,5 +412,47 @@ describe("reconcileSettingsPersistPlan", () => {
 		expect(plan.didMerge).toBe(false);
 		expect(plan.shouldReplaceStore).toBe(false);
 		expect(plan.toWrite).toEqual(local);
+	});
+});
+
+describe("shouldApplyPersistedWriteToStore", () => {
+	it("applies when toWrite kept disk-only fields the live store lacks", () => {
+		const storeSnapshot = {
+			globalVariables: { syncMarker: "stale" },
+			ai: { lastModelAutoSyncAt: 99 },
+		};
+		const toWrite = {
+			globalVariables: { syncMarker: "from-disk" },
+			ai: { lastModelAutoSyncAt: 99 },
+		};
+
+		expect(
+			shouldApplyPersistedWriteToStore(
+				toWrite,
+				storeSnapshot,
+				storeSnapshot,
+			),
+		).toBe(true);
+	});
+
+	it("skips when the store already matches toWrite", () => {
+		const value = { globalVariables: { syncMarker: "from-disk" } };
+		expect(shouldApplyPersistedWriteToStore(value, value, value)).toBe(
+			false,
+		);
+	});
+
+	it("skips when the store moved after the final-merge snapshot", () => {
+		const storeSnapshot = { note: "merged-from" };
+		const currentStore = { note: "even-newer" };
+		const toWrite = { note: "from-disk", extra: true };
+
+		expect(
+			shouldApplyPersistedWriteToStore(
+				toWrite,
+				currentStore,
+				storeSnapshot,
+			),
+		).toBe(false);
 	});
 });

--- a/src/utils/settingsPersistMerge.test.ts
+++ b/src/utils/settingsPersistMerge.test.ts
@@ -86,6 +86,164 @@ describe("threeWayMergeSettings", () => {
 			ai: { lastModelAutoSyncAt: 99, showAssistant: false },
 		});
 	});
+
+	it("merges ai.providers by id so concurrent provider edits both survive", () => {
+		const base = {
+			ai: {
+				providers: [
+					{
+						id: "openai",
+						name: "OpenAI",
+						endpoint: "https://api.openai.com",
+						models: [{ name: "gpt-4o", maxTokens: 128000 }],
+					},
+					{
+						id: "anthropic",
+						name: "Anthropic",
+						endpoint: "https://api.anthropic.com",
+						models: [{ name: "claude-sonnet", maxTokens: 200000 }],
+					},
+				],
+			},
+		};
+
+		const local = deepClone(base);
+		// Background model sync discovers a new OpenAI model.
+		local.ai.providers[0].models.push({
+			name: "gpt-5.5",
+			maxTokens: 1050000,
+		});
+
+		const disk = deepClone(base);
+		// External edit changes the Anthropic endpoint on another device.
+		disk.ai.providers[1].endpoint = "https://anthropic.example/v1";
+
+		const merged = threeWayMergeSettings(base, local, disk);
+
+		expect(merged.ai.providers).toHaveLength(2);
+		const openai = merged.ai.providers.find((p) => p.id === "openai");
+		const anthropic = merged.ai.providers.find((p) => p.id === "anthropic");
+		expect(openai?.models.map((m) => m.name)).toEqual([
+			"gpt-4o",
+			"gpt-5.5",
+		]);
+		expect(anthropic?.endpoint).toBe("https://anthropic.example/v1");
+	});
+
+	it("keeps an externally added provider when local model sync only touches another provider", () => {
+		// CodeRabbit outside-diff Major on #1750: whole-array prefer-local used to
+		// drop a disk-added provider whenever background sync rewrote providers[].
+		const base = {
+			ai: {
+				providers: [
+					{
+						id: "openai",
+						name: "OpenAI",
+						endpoint: "https://api.openai.com",
+						models: [{ name: "gpt-4o", maxTokens: 128000 }],
+					},
+				],
+				lastModelAutoSyncAt: undefined as number | undefined,
+			},
+		};
+
+		const local = deepClone(base);
+		local.ai.providers[0].models.push({
+			name: "gpt-5.5",
+			maxTokens: 1050000,
+		});
+		local.ai.lastModelAutoSyncAt = 1788982813069;
+
+		const disk = deepClone(base);
+		disk.ai.providers.push({
+			id: "ollama",
+			name: "Ollama",
+			endpoint: "http://127.0.0.1:11434",
+			models: [{ name: "llama3", maxTokens: 8192 }],
+		});
+
+		const merged = resolveSettingsToPersist(base, local, disk).toWrite;
+
+		expect(merged.ai.lastModelAutoSyncAt).toBe(1788982813069);
+		expect(merged.ai.providers.map((p) => p.id)).toEqual([
+			"openai",
+			"ollama",
+		]);
+		expect(
+			merged.ai.providers
+				.find((p) => p.id === "openai")
+				?.models.map((m) => m.name),
+		).toEqual(["gpt-4o", "gpt-5.5"]);
+		expect(
+			merged.ai.providers.find((p) => p.id === "ollama")?.endpoint,
+		).toBe("http://127.0.0.1:11434");
+	});
+
+	it("merges provider models by name so sync and external metadata edits both survive", () => {
+		const base = {
+			ai: {
+				providers: [
+					{
+						id: "openai",
+						name: "OpenAI",
+						endpoint: "https://api.openai.com",
+						models: [{ name: "gpt-4o", maxTokens: 128000 }],
+					},
+				],
+			},
+		};
+
+		const local = deepClone(base);
+		local.ai.providers[0].models.push({
+			name: "gpt-5.5",
+			maxTokens: 1050000,
+		});
+
+		const disk = deepClone(base);
+		disk.ai.providers[0].models[0].maxTokens = 200000;
+
+		const merged = threeWayMergeSettings(base, local, disk);
+		const models = merged.ai.providers[0].models;
+
+		expect(models.map((m) => m.name)).toEqual(["gpt-4o", "gpt-5.5"]);
+		expect(models.find((m) => m.name === "gpt-4o")?.maxTokens).toBe(200000);
+		expect(models.find((m) => m.name === "gpt-5.5")?.maxTokens).toBe(
+			1050000,
+		);
+	});
+
+	it("falls back to name+endpoint when provider id is missing", () => {
+		const base = {
+			ai: {
+				providers: [
+					{
+						name: "Custom",
+						endpoint: "http://localhost:8080",
+						models: [{ name: "a", maxTokens: 1 }],
+					},
+				],
+			},
+		};
+		const local = deepClone(base);
+		local.ai.providers[0].models.push({ name: "b", maxTokens: 2 });
+		const disk = deepClone(base);
+		disk.ai.providers[0].endpoint = "http://localhost:9090";
+
+		const merged = threeWayMergeSettings(base, local, disk);
+		// Same name but endpoint changed on disk → treated as a different key
+		// once name+endpoint is the identity, so local keep + disk add.
+		expect(merged.ai.providers.length).toBeGreaterThanOrEqual(1);
+		expect(
+			merged.ai.providers.some((p) =>
+				p.models.some((m) => m.name === "b"),
+			),
+		).toBe(true);
+		expect(
+			merged.ai.providers.some(
+				(p) => p.endpoint === "http://localhost:9090",
+			),
+		).toBe(true);
+	});
 });
 
 describe("diskSettingsDivergedFromBase", () => {
@@ -154,7 +312,7 @@ describe("resolveSettingsToPersist", () => {
 });
 
 describe("reconcileSettingsPersistPlan", () => {
-	it("re-merges when the store advanced during the disk read (Codex P1 / #1750)", () => {
+	it("folds store mutations during loadData onto the disk merge via three-way (Codex P1 / CodeRabbit #1750)", () => {
 		const base = {
 			globalVariables: { syncMarker: "device-b-stale" },
 			ai: {
@@ -187,6 +345,7 @@ describe("reconcileSettingsPersistPlan", () => {
 		});
 
 		expect(plan.didMerge).toBe(true);
+		// Disk-only syncMarker + in-flight prompt edit + local lastModelAutoSyncAt.
 		expect(plan.toWrite).toEqual({
 			globalVariables: { syncMarker: "device-a-newer" },
 			ai: { lastModelAutoSyncAt: 99, prompt: "user-edit-during-read" },
@@ -195,6 +354,23 @@ describe("reconcileSettingsPersistPlan", () => {
 		expect(plan.local).toEqual(currentStore);
 	});
 
+	it("three-way merges current store onto toWrite using local as base before replace/save", () => {
+		const base = { a: 1, b: 1, c: 1 };
+		const local = { a: 2, b: 1, c: 1 };
+		const disk = { a: 1, b: 2, c: 1 };
+		// Store advanced after local was captured: c edited in memory.
+		const currentStore = { a: 2, b: 1, c: 3 };
+
+		const plan = reconcileSettingsPersistPlan({
+			base,
+			disk,
+			local,
+			currentStore,
+		});
+
+		expect(plan.toWrite).toEqual({ a: 2, b: 2, c: 3 });
+		expect(plan.shouldReplaceStore).toBe(true);
+	});
 	it("does not recommend replaceState when the store no longer matches the merge local", () => {
 		const base = { version: "1", note: "base" };
 		const local = { version: "2", note: "base" };

--- a/src/utils/settingsPersistMerge.test.ts
+++ b/src/utils/settingsPersistMerge.test.ts
@@ -245,6 +245,67 @@ describe("threeWayMergeSettings", () => {
 			),
 		).toBe(true);
 	});
+
+	it("does not name-merge choices arrays (duplicate display names must survive)", () => {
+		// Regression: isModelLike used to match any `{ name }` object, so choices
+		// were keyed by display name and a second "Journal" was dropped.
+		const base = {
+			choices: [
+				{ id: "1", name: "Journal", type: "Capture", command: false },
+				{ id: "2", name: "Journal", type: "Template", command: false },
+			],
+		};
+		const local = deepClone(base);
+		local.choices[0] = { ...local.choices[0], command: true };
+		const disk = deepClone(base);
+		disk.choices.push({
+			id: "3",
+			name: "Other",
+			type: "Macro",
+			command: false,
+		});
+
+		const merged = threeWayMergeSettings(base, local, disk);
+		// Irreducible choices[] conflict prefers local (documented policy).
+		expect(merged.choices).toEqual(local.choices);
+		expect(merged.choices).toHaveLength(2);
+		expect(merged.choices.map((c) => c.id)).toEqual(["1", "2"]);
+	});
+
+	it("still preserves disk choices when local only changed ai (the #1749 shape)", () => {
+		const base = {
+			choices: [
+				{ id: "1", name: "Journal", type: "Capture" },
+				{ id: "2", name: "Journal", type: "Template" },
+			],
+			ai: {
+				lastModelAutoSyncAt: undefined as number | undefined,
+				providers: [
+					{
+						id: "openai",
+						name: "OpenAI",
+						endpoint: "https://api.openai.com",
+						models: [{ name: "gpt-4o", maxTokens: 128000 }],
+					},
+				],
+			},
+		};
+		const local = deepClone(base);
+		local.ai.providers[0].models.push({
+			name: "gpt-5.5",
+			maxTokens: 1050000,
+		});
+		local.ai.lastModelAutoSyncAt = 99;
+		const disk = deepClone(base);
+		disk.choices.push({ id: "3", name: "Other", type: "Macro" });
+
+		const merged = resolveSettingsToPersist(base, local, disk).toWrite;
+		expect(merged.choices.map((c) => c.id)).toEqual(["1", "2", "3"]);
+		expect(merged.ai.lastModelAutoSyncAt).toBe(99);
+		expect(
+			merged.ai.providers[0].models.map((m) => m.name),
+		).toEqual(["gpt-4o", "gpt-5.5"]);
+	});
 });
 
 describe("diskSettingsDivergedFromBase", () => {

--- a/src/utils/settingsPersistMerge.ts
+++ b/src/utils/settingsPersistMerge.ts
@@ -50,14 +50,15 @@ function isProviderLike(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Model-shaped entries have a string `name` and are not providers. Prefer
- * `maxTokens` when present (the `Model` interface), but accept name-only stubs
- * used in tests and partial settings.
+ * Model-shaped entries look like `Model` (name + maxTokens). Do not treat bare
+ * `{ name }` objects as models: choices also have `name` and would otherwise be
+ * incorrectly merged by display name during conflict saves.
  */
 function isModelLike(value: unknown): value is Record<string, unknown> {
 	return (
 		isPlainObject(value) &&
 		typeof value.name === "string" &&
+		typeof value.maxTokens === "number" &&
 		!Array.isArray(value.models)
 	);
 }
@@ -106,6 +107,7 @@ function threeWayMergeKeyedArray(
 	local: unknown[],
 	disk: unknown[],
 	keyOf: (item: Record<string, unknown>) => string,
+	path: readonly string[],
 ): unknown[] {
 	const baseMap = indexByKey(base ?? [], keyOf);
 	const localMap = indexByKey(local, keyOf);
@@ -142,6 +144,7 @@ function threeWayMergeKeyedArray(
 				baseItem as Record<string, unknown> | undefined,
 				item,
 				diskItem,
+				path,
 			),
 		);
 	}
@@ -177,14 +180,21 @@ function everyItem<T>(
  * - If local is unchanged from base, take disk (preserves external edits).
  * - If disk is unchanged from base, take local (preserves in-memory edits).
  * - If both changed the same plain object, recurse per key.
- * - `ai.providers` arrays merge by `AIProvider.id` (fallback: name+endpoint);
- *   each provider's `models` merge by `Model.name`.
+ * - Arrays under an `providers` path merge by `AIProvider.id` (fallback:
+ *   name+endpoint); arrays under a `models` path merge by `Model.name`.
+ *   Path context matters: choice objects also have `name` and must not use
+ *   model-name identity.
  * - Other irreducible array/leaf conflicts prefer local.
  *
  * This is the data-integrity seam for #1749: a background model-sync write must
  * not clobber newer on-disk fields it never touched.
  */
-export function threeWayMergeSettings<T>(base: T, local: T, disk: T): T {
+export function threeWayMergeSettings<T>(
+	base: T,
+	local: T,
+	disk: T,
+	path: readonly string[] = [],
+): T {
 	if (settingsValuesEqual(local, disk)) return deepClone(local);
 	if (settingsValuesEqual(local, base)) return deepClone(disk);
 	if (settingsValuesEqual(disk, base)) return deepClone(local);
@@ -201,6 +211,7 @@ export function threeWayMergeSettings<T>(base: T, local: T, disk: T): T {
 				base[key],
 				local[key],
 				disk[key],
+				[...path, key],
 			);
 		}
 		return merged as T;
@@ -211,21 +222,32 @@ export function threeWayMergeSettings<T>(base: T, local: T, disk: T): T {
 	const diskArr = Array.isArray(disk) ? disk : undefined;
 
 	if (localArr && diskArr) {
+		const leaf = path[path.length - 1];
 		const sample = [...localArr, ...diskArr, ...(baseArr ?? [])];
-		if (everyItem(sample, isProviderLike)) {
+		// Keyed merges are path-gated. Shape checks alone are not enough:
+		// choices also have `name` and must fall through to prefer-local.
+		if (
+			leaf === "providers" &&
+			(sample.length === 0 || everyItem(sample, isProviderLike))
+		) {
 			return threeWayMergeKeyedArray(
 				baseArr,
 				localArr,
 				diskArr,
 				providerMergeKey,
+				path,
 			) as T;
 		}
-		if (everyItem(sample, isModelLike)) {
+		if (
+			leaf === "models" &&
+			(sample.length === 0 || everyItem(sample, isModelLike))
+		) {
 			return threeWayMergeKeyedArray(
 				baseArr,
 				localArr,
 				diskArr,
 				modelMergeKey,
+				path,
 			) as T;
 		}
 	}

--- a/src/utils/settingsPersistMerge.ts
+++ b/src/utils/settingsPersistMerge.ts
@@ -40,13 +40,146 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	);
 }
 
+/** Provider-shaped entries carry a `models` list (see `AIProvider`). */
+function isProviderLike(value: unknown): value is Record<string, unknown> {
+	return (
+		isPlainObject(value) &&
+		typeof value.name === "string" &&
+		Array.isArray(value.models)
+	);
+}
+
+/**
+ * Model-shaped entries have a string `name` and are not providers. Prefer
+ * `maxTokens` when present (the `Model` interface), but accept name-only stubs
+ * used in tests and partial settings.
+ */
+function isModelLike(value: unknown): value is Record<string, unknown> {
+	return (
+		isPlainObject(value) &&
+		typeof value.name === "string" &&
+		!Array.isArray(value.models)
+	);
+}
+
+function providerMergeKey(provider: Record<string, unknown>): string {
+	if (typeof provider.id === "string" && provider.id.trim().length > 0) {
+		return `id:${provider.id.trim().toLowerCase()}`;
+	}
+	const name = String(provider.name ?? "")
+		.trim()
+		.toLowerCase();
+	const endpoint = String(provider.endpoint ?? "")
+		.trim()
+		.toLowerCase()
+		.replace(/\/+$/, "");
+	return `name:${name}\u0000${endpoint}`;
+}
+
+function modelMergeKey(model: Record<string, unknown>): string {
+	return String(model.name ?? "")
+		.trim()
+		.toLowerCase();
+}
+
+function indexByKey(
+	items: unknown[],
+	keyOf: (item: Record<string, unknown>) => string,
+): Map<string, Record<string, unknown>> {
+	const map = new Map<string, Record<string, unknown>>();
+	for (const item of items) {
+		if (!isPlainObject(item)) continue;
+		const key = keyOf(item);
+		if (!key || key === "id:" || key === "name:\u0000") continue;
+		if (!map.has(key)) map.set(key, item);
+	}
+	return map;
+}
+
+/**
+ * Three-way merge of object arrays keyed by identity. Local order is preserved;
+ * disk-only additions are appended. Local deletions win over disk-only edits of
+ * the same key (same prefer-local conflict policy as leaf merges).
+ */
+function threeWayMergeKeyedArray(
+	base: unknown[] | undefined,
+	local: unknown[],
+	disk: unknown[],
+	keyOf: (item: Record<string, unknown>) => string,
+): unknown[] {
+	const baseMap = indexByKey(base ?? [], keyOf);
+	const localMap = indexByKey(local, keyOf);
+	const diskMap = indexByKey(disk, keyOf);
+	const result: unknown[] = [];
+	const seen = new Set<string>();
+
+	for (const item of local) {
+		if (!isPlainObject(item)) {
+			result.push(deepClone(item));
+			continue;
+		}
+		const key = keyOf(item);
+		if (seen.has(key)) continue;
+		seen.add(key);
+
+		const baseItem = baseMap.get(key);
+		const diskItem = diskMap.get(key);
+
+		if (!diskMap.has(key)) {
+			if (!baseMap.has(key)) {
+				// Local addition.
+				result.push(deepClone(item));
+			} else if (!settingsValuesEqual(item, baseItem)) {
+				// Local edit vs disk deletion — prefer keeping the local edit.
+				result.push(deepClone(item));
+			}
+			// else: unchanged locally and deleted on disk → drop.
+			continue;
+		}
+
+		result.push(
+			threeWayMergeSettings(
+				baseItem as Record<string, unknown> | undefined,
+				item,
+				diskItem,
+			),
+		);
+	}
+
+	for (const item of disk) {
+		if (!isPlainObject(item)) continue;
+		const key = keyOf(item);
+		if (seen.has(key)) continue;
+		seen.add(key);
+
+		if (!localMap.has(key)) {
+			if (!baseMap.has(key)) {
+				// Disk-only addition.
+				result.push(deepClone(item));
+			}
+			// else: present in base, absent locally → local deletion wins.
+		}
+	}
+
+	return result;
+}
+
+function everyItem<T>(
+	items: unknown[],
+	predicate: (value: unknown) => value is T,
+): items is T[] {
+	return items.length > 0 && items.every(predicate);
+}
+
 /**
  * Three-way merge for QuickAdd settings (and nested JSON-like values).
  *
  * - If local is unchanged from base, take disk (preserves external edits).
  * - If disk is unchanged from base, take local (preserves in-memory edits).
  * - If both changed the same plain object, recurse per key.
- * - On irreducible conflict (both sides diverged on a leaf/array), prefer local.
+ * - `ai.providers` arrays merge by `AIProvider.id` (fallback: name+endpoint);
+ *   each provider's `models` merge by `Model.name`.
+ * - Other irreducible array/leaf conflicts prefer local.
  *
  * This is the data-integrity seam for #1749: a background model-sync write must
  * not clobber newer on-disk fields it never touched.
@@ -73,7 +206,31 @@ export function threeWayMergeSettings<T>(base: T, local: T, disk: T): T {
 		return merged as T;
 	}
 
-	// Arrays and primitives: both sides diverged — keep the in-memory edit.
+	const baseArr = Array.isArray(base) ? base : undefined;
+	const localArr = Array.isArray(local) ? local : undefined;
+	const diskArr = Array.isArray(disk) ? disk : undefined;
+
+	if (localArr && diskArr) {
+		const sample = [...localArr, ...diskArr, ...(baseArr ?? [])];
+		if (everyItem(sample, isProviderLike)) {
+			return threeWayMergeKeyedArray(
+				baseArr,
+				localArr,
+				diskArr,
+				providerMergeKey,
+			) as T;
+		}
+		if (everyItem(sample, isModelLike)) {
+			return threeWayMergeKeyedArray(
+				baseArr,
+				localArr,
+				diskArr,
+				modelMergeKey,
+			) as T;
+		}
+	}
+
+	// Other arrays and primitives: both sides diverged — keep the in-memory edit.
 	return deepClone(local);
 }
 
@@ -116,10 +273,11 @@ export function resolveSettingsToPersist<T>(
 /**
  * Finalize a persist plan after an async disk read.
  *
- * `local` is the in-memory snapshot used for the merge. If `currentStore` has
- * moved on since that snapshot (another edit while `loadData()` was in flight),
- * re-merge against the newer store value so we neither write nor
- * `replaceState` a stale plan that would discard those edits (Codex P1 on #1750).
+ * `local` is the in-memory snapshot the disk-aware merge used. If `currentStore`
+ * has moved on since that snapshot (another edit while `loadData()` was in
+ * flight), fold those edits onto `toWrite` with a three-way merge that treats
+ * `local` as the base — so disk-only fields in `toWrite` survive while newer
+ * store fields win (Codex P1 / CodeRabbit on #1750).
  *
  * `shouldReplaceStore` is true only when publishing `toWrite` back into the
  * store would not clobber a concurrent update still equal to `local`.
@@ -132,7 +290,7 @@ export function reconcileSettingsPersistPlan<T>(options: {
 }): {
 	toWrite: T;
 	didMerge: boolean;
-	/** Local leg actually used for `toWrite` (may be `currentStore` after refresh). */
+	/** Local leg actually used for `toWrite` (may be `currentStore` after fold). */
 	local: T;
 	shouldReplaceStore: boolean;
 } {
@@ -144,12 +302,13 @@ export function reconcileSettingsPersistPlan<T>(options: {
 	);
 
 	if (!settingsValuesEqual(options.currentStore, local)) {
-		local = options.currentStore;
-		({ toWrite, didMerge } = resolveSettingsToPersist(
-			options.base,
+		toWrite = threeWayMergeSettings(
 			local,
-			options.disk,
-		));
+			options.currentStore,
+			toWrite,
+		);
+		local = options.currentStore;
+		didMerge = true;
 	}
 
 	const shouldReplaceStore =

--- a/src/utils/settingsPersistMerge.ts
+++ b/src/utils/settingsPersistMerge.ts
@@ -1,0 +1,114 @@
+import { deepClone } from "./deepClone";
+
+/**
+ * Structural equality for JSON-like settings values. Key order does not matter;
+ * array order does. Used to decide which side of a 3-way merge "changed".
+ */
+export function settingsValuesEqual(a: unknown, b: unknown): boolean {
+	if (Object.is(a, b)) return true;
+	if (a === null || b === null) return a === b;
+	if (typeof a !== typeof b) return false;
+
+	if (Array.isArray(a) || Array.isArray(b)) {
+		if (!Array.isArray(a) || !Array.isArray(b)) return false;
+		if (a.length !== b.length) return false;
+		return a.every((item, index) => settingsValuesEqual(item, b[index]));
+	}
+
+	if (typeof a === "object" && typeof b === "object") {
+		const aRecord = a as Record<string, unknown>;
+		const bRecord = b as Record<string, unknown>;
+		const aKeys = Object.keys(aRecord);
+		const bKeys = Object.keys(bRecord);
+		if (aKeys.length !== bKeys.length) return false;
+		return aKeys.every(
+			(key) =>
+				Object.prototype.hasOwnProperty.call(bRecord, key) &&
+				settingsValuesEqual(aRecord[key], bRecord[key]),
+		);
+	}
+
+	return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		Object.getPrototypeOf(value) === Object.prototype
+	);
+}
+
+/**
+ * Three-way merge for QuickAdd settings (and nested JSON-like values).
+ *
+ * - If local is unchanged from base, take disk (preserves external edits).
+ * - If disk is unchanged from base, take local (preserves in-memory edits).
+ * - If both changed the same plain object, recurse per key.
+ * - On irreducible conflict (both sides diverged on a leaf/array), prefer local.
+ *
+ * This is the data-integrity seam for #1749: a background model-sync write must
+ * not clobber newer on-disk fields it never touched.
+ */
+export function threeWayMergeSettings<T>(base: T, local: T, disk: T): T {
+	if (settingsValuesEqual(local, disk)) return deepClone(local);
+	if (settingsValuesEqual(local, base)) return deepClone(disk);
+	if (settingsValuesEqual(disk, base)) return deepClone(local);
+
+	if (isPlainObject(base) && isPlainObject(local) && isPlainObject(disk)) {
+		const keys = new Set([
+			...Object.keys(base),
+			...Object.keys(local),
+			...Object.keys(disk),
+		]);
+		const merged: Record<string, unknown> = {};
+		for (const key of keys) {
+			merged[key] = threeWayMergeSettings(
+				base[key],
+				local[key],
+				disk[key],
+			);
+		}
+		return merged as T;
+	}
+
+	// Arrays and primitives: both sides diverged — keep the in-memory edit.
+	return deepClone(local);
+}
+
+/**
+ * True when `disk` diverged from the last successfully persisted snapshot.
+ * Callers use this to decide whether a whole-file save needs a merge first.
+ */
+export function diskSettingsDivergedFromBase(
+	base: unknown,
+	disk: unknown,
+): boolean {
+	return !settingsValuesEqual(base, disk);
+}
+
+/**
+ * Decide what to write for a whole-file settings save.
+ *
+ * `base` is the last snapshot QuickAdd successfully loaded or wrote. When the
+ * on-disk file still matches that snapshot, the in-memory `local` value is
+ * written as-is. When disk has moved on (sync / external edit), local changes
+ * are three-way-merged onto disk so untouched fields are not clobbered (#1749).
+ */
+export function resolveSettingsToPersist<T>(
+	base: T | null | undefined,
+	local: T,
+	disk: T | null | undefined,
+): { toWrite: T; didMerge: boolean } {
+	if (base == null || disk == null) {
+		return { toWrite: local, didMerge: false };
+	}
+	if (!diskSettingsDivergedFromBase(base, disk)) {
+		return { toWrite: local, didMerge: false };
+	}
+	return {
+		toWrite: threeWayMergeSettings(base, local, disk),
+		didMerge: true,
+	};
+}

--- a/src/utils/settingsPersistMerge.ts
+++ b/src/utils/settingsPersistMerge.ts
@@ -112,3 +112,50 @@ export function resolveSettingsToPersist<T>(
 		didMerge: true,
 	};
 }
+
+/**
+ * Finalize a persist plan after an async disk read.
+ *
+ * `local` is the in-memory snapshot used for the merge. If `currentStore` has
+ * moved on since that snapshot (another edit while `loadData()` was in flight),
+ * re-merge against the newer store value so we neither write nor
+ * `replaceState` a stale plan that would discard those edits (Codex P1 on #1750).
+ *
+ * `shouldReplaceStore` is true only when publishing `toWrite` back into the
+ * store would not clobber a concurrent update still equal to `local`.
+ */
+export function reconcileSettingsPersistPlan<T>(options: {
+	base: T | null | undefined;
+	disk: T | null | undefined;
+	local: T;
+	currentStore: T;
+}): {
+	toWrite: T;
+	didMerge: boolean;
+	/** Local leg actually used for `toWrite` (may be `currentStore` after refresh). */
+	local: T;
+	shouldReplaceStore: boolean;
+} {
+	let local = options.local;
+	let { toWrite, didMerge } = resolveSettingsToPersist(
+		options.base,
+		local,
+		options.disk,
+	);
+
+	if (!settingsValuesEqual(options.currentStore, local)) {
+		local = options.currentStore;
+		({ toWrite, didMerge } = resolveSettingsToPersist(
+			options.base,
+			local,
+			options.disk,
+		));
+	}
+
+	const shouldReplaceStore =
+		didMerge &&
+		settingsValuesEqual(options.currentStore, local) &&
+		!settingsValuesEqual(toWrite, options.currentStore);
+
+	return { toWrite, didMerge, local, shouldReplaceStore };
+}

--- a/src/utils/settingsPersistMerge.ts
+++ b/src/utils/settingsPersistMerge.ts
@@ -318,3 +318,21 @@ export function reconcileSettingsPersistPlan<T>(options: {
 
 	return { toWrite, didMerge, local, shouldReplaceStore };
 }
+
+/**
+ * Whether the live settings store should be replaced with the value about to be
+ * written to disk. True when `toWrite` differs from the store (e.g. it still
+ * carries disk-only fields from a merge) and the store has not moved past the
+ * snapshot used to compute that write. Skipping the replace would leave the
+ * store stale so the next save treats those disk-only fields as local deletions.
+ */
+export function shouldApplyPersistedWriteToStore<T>(
+	toWrite: T,
+	currentStore: T,
+	storeSnapshotUsedForMerge: T,
+): boolean {
+	return (
+		!settingsValuesEqual(toWrite, currentStore) &&
+		settingsValuesEqual(currentStore, storeSnapshotUsedForMerge)
+	);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1749: background AI model auto-sync updated the in-memory settings store, and the debounced whole-file `saveData` could silently replace newer on-disk `data.json` (for example from another device/sync) with stale in-memory values.

## Changes

- Track a deep-cloned `lastPersistedSettings` snapshot after each successful load/save.
- Before every settings write, re-read `data.json` and three-way-merge local changes onto disk when the file has diverged.
- Re-merge if the settings store advances while `loadData()` is in flight; only `replaceState` when the store still matches the merge snapshot.
- Merge `ai.providers` by `AIProvider.id` (name+endpoint fallback for legacy) and models by name so concurrent provider edits are not whole-array clobbered.
- After the final merge, apply `toWrite` back through `settingsStore.replaceState` under `suppressSettingsSave` so disk-only fields are not treated as local deletions on the next save.
- Last-look disk re-read before `saveData`. Residual TOCTOU remains: Obsidian Plugin `loadData`/`saveData` has no compare-and-swap.

## Testing / validation

- `pnpm run test` (settings persist merge coverage, including provider-id merge and store-sync guard)
- `pnpm run build-with-lint`
- Earlier Obsidian CLI race check for syncMarker preservation (prior commit)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Linked related issue (#1749)
- [x] Noted release/migration impact: none (behavior change on conflict only; no settings schema migration)

## Release / migration impact

None. No `data.json` schema change. Unchanged-disk saves behave as before; when disk moved under this instance, QuickAdd merges instead of clobbering.

## Residual risk

- Obsidian Plugin APIs have no CAS/lock; a writer can still interleave between the final re-read and `saveData`.
- Irreducible leaf/array conflicts (other than keyed providers/models) still prefer in-memory.
- Not auto-merging: settings persistence has non-trivial blast radius; needs Christian to merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4687a6cd-535b-5323-b9ff-466f2b215f0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4687a6cd-535b-5323-b9ff-466f2b215f0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings changes are now preserved more reliably when local and external updates occur simultaneously.
  * Compatible changes from multiple sources are retained while conflicts are resolved consistently.
  * Settings saves are serialized to prevent newer changes from being overwritten by earlier writes.
  * Settings remain synchronized when changes occur during an in-progress save.
  * Provider and model updates are merged more accurately, while duplicate choices remain intact.

* **Tests**
  * Added coverage for nested settings, conflict resolution, external changes, concurrent saves, and missing settings data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->