### PR TITLE
ci: clear CodeQL unpinned-workflow and insecure-temp alerts

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -40,7 +40,7 @@ jobs:
         permissions:
             contents: write
             pull-requests: write
-        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@v4
+        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-prepare.yml@ebcf84b80dc48ba15e0eec1f3575d41519a78ed5 # v4
         with:
             plugin-name: quickadd
             package-manager: pnpm

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -39,7 +39,7 @@ jobs:
             actions: write
             contents: write
             pull-requests: read
-        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@v4
+        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release-validate.yml@ebcf84b80dc48ba15e0eec1f3575d41519a78ed5 # v4
         with:
             pr-number: ${{ github.event.pull_request.number || inputs.pr-number }}
             plugin-name: quickadd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             contents: write
             id-token: write
             pull-requests: read
-        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@v4
+        uses: chhoumann/obsidian-plugin-workflows/.github/workflows/release.yml@ebcf84b80dc48ba15e0eec1f3575d41519a78ed5 # v4
         with:
             release-pr: ${{ inputs.releasePr }}
             plugin-name: quickadd

--- a/tests/orb-setup.test.ts
+++ b/tests/orb-setup.test.ts
@@ -223,15 +223,19 @@ describe.skipIf(!runningOnLinux)("Linux Obsidian launcher validation", () => {
 	});
 
 	it("accepts only the runner's exact canonical argv", () => {
-		const instanceName = `orb-script-test-${process.pid}-${Date.now()}`;
 		const initialRoot = prepareProfileRoot();
-		const validHome = path.join(profileRoot, instanceName, "home");
+		const instanceDir = fs.mkdtempSync(path.join(profileRoot, "orb-script-test-"));
+		const instanceName = path.basename(instanceDir);
+		const validHome = path.join(instanceDir, "home");
 		const args = validArgs(validHome);
 		const escapedHome = temporaryDirectory("quickadd-obsidian-escaped-home-");
 		const linkName = `orb-script-link-${process.pid}-${Date.now()}`;
 		const linkPath = path.join(profileRoot, linkName);
-		fs.mkdirSync(validHome, { recursive: true });
-		fs.writeFileSync(path.join(validHome, "..", "obsidian-e2e-instance.json"), "{}");
+		fs.mkdirSync(validHome, { recursive: true, mode: 0o700 });
+		fs.writeFileSync(path.join(instanceDir, "obsidian-e2e-instance.json"), "{}", {
+			mode: 0o600,
+			flag: "wx",
+		});
 		try {
 			expect(validate(args).status).toBe(0);
 			const adversarial = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clears four open CodeQL Security-tab alerts that the earlier triage pass could not see (alert APIs return 403; analyze jobs reported zero annotations).

- **#18–#20** (medium, CWE-829): pin the three `obsidian-plugin-workflows` reusable release callers to the immutable commit currently at `v4` instead of the floating `@v4` tag.
- **#17** (high, CWE-377/378): create the orb-setup test instance directory with `mkdtempSync` and write `obsidian-e2e-instance.json` exclusively with mode `0600`, keeping the real `/tmp/quickadd-obsidian-e2e` PROFILE_ROOT contract.

Do **not** dismiss the alerts in the GitHub UI; they should auto-close after the default-branch CodeQL upload lands.

## Changes

- `.github/workflows/release-prepare.yml`, `release-trigger.yml`, `release.yml`: `@v4` → `@ebcf84b80dc48ba15e0eec1f3575d41519a78ed5 # v4` (current tip of `v4` on `chhoumann/obsidian-plugin-workflows`).
- Sibling scan: those three were the only unpinned reusable-workflow tags in this repo; first-party actions were already SHA-pinned.
- `tests/orb-setup.test.ts`: `mkdtempSync` under the profile root + `flag: "wx"` / `mode: 0o600` for the instance marker file.

## Testing / validation

- `pnpm exec vitest run tests/orb-setup.test.ts` — **6 passed** (including Linux launcher validation / canonical argv).
- Full suite via `pnpm run test` — **5475 passed**, 37 skipped.

## Checklist

- [x] PR title follows Conventional Commits (`ci:` — no user-facing release bump)
- [ ] Linked any related issue(s) — CodeQL alerts #17–#20 (Security tab; no GitHub issues)
- [x] Noted release/migration impact: **none for users**. Residual: Dependabot must bump the workflow SHA when `obsidian-plugin-workflows` cuts a new `v4` tip; floating `@v4` no longer auto-follows.

## Residual risk

SHA pins stop mutable-tag supply-chain moves, but also stop automatic pickup of non-breaking toolkit fixes until Dependabot (or a maintainer) bumps the three identical SHAs together.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc631bb3-6f41-5f01-89aa-0d5f3157b866?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc631bb3-6f41-5f01-89aa-0d5f3157b866&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned release automation workflows to a specific version for more predictable and secure execution.

* **Tests**
  * Improved test isolation by using unique temporary directories.
  * Strengthened test fixture file and directory creation safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->